### PR TITLE
fix(uploadprogress): drop Safari skip — make Delete/MagicShelves/preferences work in Safari

### DIFF
--- a/cps/static/js/uploadprogress.js
+++ b/cps/static/js/uploadprogress.js
@@ -16,7 +16,7 @@
     var ua = (navigator && navigator.userAgent) ? navigator.userAgent : "";
     var isSafari = /safari/i.test(ua) && !/chrome|chromium|crios|android/i.test(ua);
 
-    if (!$.support.xhrFileUpload || !$.support.xhrFormData || isSafari) {
+    if (!$.support.xhrFileUpload || !$.support.xhrFormData) {
         // skip decorating form
         return;
     }


### PR DESCRIPTION
Fixes the Safari uploadprogress halt that breaks Delete Book / Magic Shelves / preferences in Safari.

The bundled `cps/static/js/uploadprogress.js` returns early on Safari, which prevents `\$.fn.uploadprogress` from being assigned. `cps/static/js/main.js` then calls `.uploadprogress()` at module top-level, throws `TypeError`, and halts execution of the rest of the file — including every later jQuery binding (Delete Book, Magic Shelves, preferences).

Repro: open `/book/<id>` in Safari, click trash icon, confirm in modal — nothing happens. Console shows `TypeError: \$("#form-upload").uploadprogress is not a function` at `main.js:153`.

## Diff

One line in `cps/static/js/uploadprogress.js`:

\`\`\`diff
-    if (!\$.support.xhrFileUpload || !\$.support.xhrFormData || isSafari) {
+    if (!\$.support.xhrFileUpload || !\$.support.xhrFormData) {
\`\`\`

Matches upstream \`janeczku/calibre-web\` behavior.

## Verify
- [ ] Read the diff (it's one line)
- [ ] Reproduce the Safari TypeError before merge
- [ ] After merge: hard-refresh in Safari, click Delete on a book, confirm POST fires + book is removed