### PR TITLE
ci(translations): skip wiki sync when GH_PAT secret is missing

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -70,17 +70,32 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/actions/workflows/docker-image-build-dev.yml/dispatches \
             -d "{\"ref\":\"main\",\"inputs\":{\"ref\":\"${DEV_BUILD_SHA}\",\"branch\":\"main\"}}"
 
+      - name: Detect wiki PAT
+        id: wiki_pat
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          if [ -n "${GH_PAT}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GH_PAT secret not set; skipping wiki status sync."
+          fi
+
       - name: Clone wiki repo
+        if: steps.wiki_pat.outputs.available == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           git clone https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git wiki-tmp
 
       - name: Generate translation status table (in wiki repo)
+        if: steps.wiki_pat.outputs.available == 'true'
         run: |
           python scripts/generate_translation_status.py wiki-tmp/Contributing-Translations.md
 
       - name: Commit and push wiki update
+        if: steps.wiki_pat.outputs.available == 'true'
         run: |
           cd wiki-tmp
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## Why

`Update Translations and Wiki Status` workflow fails on **every** push to `main` that touches `cps/**`. Failure happens at the trailing "Clone wiki repo" step because:

- `secrets.GH_PAT` is not set in this repo (we never carried it over after detaching from the upstream fork).
- The `*.wiki.git` repo doesn't exist on this fork yet — no wiki pages have been published.
- `secrets.GITHUB_TOKEN` cannot push to wiki repos.

Result: every translation drain reds main, which makes it impossible to use main CI status as a signal for actual regressions.

## What

Adds a `Detect wiki PAT` step that probes `secrets.GH_PAT` and writes `available={true|false}` to step outputs. The three wiki steps (`Clone wiki repo`, `Generate translation status table`, `Commit and push wiki update`) gain a matching `if:` guard.

When a PAT is later added to repo secrets, those steps resume automatically.

The translation generation/commit/push steps and the dev-build trigger are **unchanged** — the failure was purely in trailing wiki sync.

## Test plan

- [ ] Merge to main; observe `Update Translations and Wiki Status` workflow run on the next push touching `cps/**` (or `workflow_dispatch`).
- [ ] Verify the run is green with the wiki steps shown as skipped.
- [ ] (Future) When `GH_PAT` is configured + a wiki page exists, verify the wiki steps run normally.