### PR TITLE
fix(ci): resolve PRs on workflow_run via .pull_requests[]

### DIFF
--- a/.github/workflows/auto-merge-tier1.yml
+++ b/.github/workflows/auto-merge-tier1.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          EVENT_PATH: ${{ github.event_path }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -57,13 +58,22 @@ jobs:
             fi
             echo "numbers=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
+            # workflow_run path: read related PRs from the event payload's
+            # workflow_run.pull_requests[].number. The earlier
+            # implementation searched PRs by SHA via gh pr list, which
+            # silently returned nothing because the gh search filter for
+            # "head" matches a branch name, not a SHA. The whole
+            # workflow_run branch no-op'd on every CI completion; three
+            # tier-1 PRs had to be manually nudged on 2026-05-02 because
+            # of this. Fall back to the commits/<SHA>/pulls API if the
+            # event array is empty (rare — happens for non-PR triggered
+            # runs).
             HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
-            if [ -z "$HEAD_SHA" ]; then
-              echo "numbers=" >> "$GITHUB_OUTPUT"
-              exit 0
+            NUMBERS=$(jq -r '.workflow_run.pull_requests[]?.number' "$EVENT_PATH" 2>/dev/null | tr '\n' ' ' || true)
+            if [ -z "${NUMBERS// }" ] && [ -n "$HEAD_SHA" ]; then
+              NUMBERS=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+                --jq '.[] | select(.state == "open") | .number' 2>/dev/null | tr '\n' ' ' || true)
             fi
-            # Find every open PR whose head matches this run's SHA.
-            NUMBERS=$(gh pr list --repo "$REPO" --state open --search "head:$HEAD_SHA" --json number --jq '.[].number' | tr '\n' ' ')
             echo "numbers=$NUMBERS" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Bug

The `workflow_run`-triggered branch of `auto-merge-tier1.yml` used:

```bash
NUMBERS=$(gh pr list --repo "$REPO" --state open \
    --search "head:$HEAD_SHA" --json number --jq '.[].number')
```

But GitHub's PR search filter `head:` matches a **branch name**, not a
commit SHA, so this query always returned empty. The workflow_run branch
silently no-op'd on every Test Suite / validate-author completion.

This bit us on 2026-05-02 draining 3 tier-1 i18n PRs (#7, #8, #9): all
went green on every required check, but auto-merge only fired on the
`pull_request: labeled` trigger. Two PRs needed remove+re-add of the
label to retrigger; one had to be merged manually.

## Fix

Read related PRs straight from the event payload's
`workflow_run.pull_requests[].number` field, which is exactly what we
need. Cheapest possible change — no extra API roundtrip. Fall back to
`gh api repos/{repo}/commits/{sha}/pulls` if the array is empty (rare —
happens for non-PR triggered workflow runs).

## Why no test of the fix in CI

The bug is in workflow YAML behavior, which we can't easily exercise
without firing live workflow_run events. Instead this PR adds a static
guard in `tests/autopilot/test_workflows.sh` (the autopilot-tick gate):
a regression test that **forbids** `gh pr list --search "head:\$..."` and
**requires** either `workflow_run.pull_requests` or `commits/<SHA>/pulls`.

## Verification

- `bash scripts/test-autopilot.sh` — 14 files / all green.
- Functional verification will happen on the next tier-1 drain — if
  re-evaluation now happens on workflow_run completion (without needing
  the label remove+re-add), the fix works.

## Root-cause record

`notes/auto-merge-workflow-run-sha-bug.md` has the long-form analysis,
the exact log line that revealed the no-op, and Option A vs B fix
comparison.