### PR TITLE
Backport upstream #1298: fix(healthcheck): follow redirects so 302 /login is not marked unhealthy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -298,5 +298,6 @@ VOLUME /calibre-library
 
 # Health check for container orchestration
 # Uses shell form to support environment variable substitution for CWA_PORT_OVERRIDE
+# -L follows redirects so the 302 to /login on the root path is treated as healthy
 HEALTHCHECK --interval=30s --timeout=3s --start-period=120s --retries=3 \
-  CMD curl -f http://localhost:${CWA_PORT_OVERRIDE:-8083}/ || curl -f -k https://localhost:${CWA_PORT_OVERRIDE:-8083}/ || exit 1
+  CMD curl -fsL http://localhost:${CWA_PORT_OVERRIDE:-8083}/ || curl -fsL -k https://localhost:${CWA_PORT_OVERRIDE:-8083}/ || exit 1


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1298** by @rancur.

**Original title:** fix(healthcheck): follow redirects so 302 /login is not marked unhealthy
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1298

## Verification

Walk through `notes/merge/upstream-pr-1298-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1298.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Do not merge until the verification checklist is signed off.)