### PR TITLE
Backport upstream #1096: fix(metadata-search): address safari metadata search failure #1055

### DIFF
--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -238,7 +238,10 @@ $(function () {
       $.ajax({
         url: getPath() + "/metadata/search",
         type: "POST",
-        data: { query: keyword },
+        data: {
+          query: keyword,
+          'csrf_token': $('input[name="csrf_token"]').val()
+        },
         dataType: "json",
         success: function success(data) {
           if (data.length) {


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1096** by @SethMilliken.

**Original title:** fix(metadata-search): address safari metadata search failure #1055
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1096

## Verification

Walk through `notes/merge/upstream-pr-1096-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1096.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Do not merge until the verification checklist is signed off.)