### PR TITLE
Backport upstream #1213: Fix crash when Kobo bookmark has no Location data

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -945,11 +945,12 @@ def HandleStateRequest(book_uuid):
                 current_bookmark = kobo_reading_state.current_bookmark
                 current_bookmark.progress_percent = request_bookmark["ProgressPercent"]
                 current_bookmark.content_source_progress_percent = request_bookmark["ContentSourceProgressPercent"]
-                location = request_bookmark["Location"]
+                location = request_bookmark.get("Location")
                 if location:
                     current_bookmark.location_value = location["Value"]
                     current_bookmark.location_type = location["Type"]
                     current_bookmark.location_source = location["Source"]
+                current_bookmark.last_modified = datetime.now(timezone.utc)
                 update_results_response["CurrentBookmarkResult"] = {"Result": "Success"}
 
             request_statistics = request_reading_state["Statistics"]


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1213** by @hsttlrjeff.

**Original title:** Fix crash when Kobo bookmark has no Location data
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1213

## Verification

Walk through `notes/merge/upstream-pr-1213-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1213.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Do not merge until the verification checklist is signed off.)