### PR TITLE
security(kobo_auth): close IDOR in token generation / deletion (#1303 upstream)

### DIFF
--- a/cps/kobo_auth.py
+++ b/cps/kobo_auth.py
@@ -70,6 +70,13 @@ kobo_auth = Blueprint("kobo_auth", __name__, url_prefix="/kobo_auth")
 @kobo_auth.route("/generate_auth_token/<int:user_id>")
 @user_login_required
 def generate_auth_token(user_id):
+    # IDOR guard: only the user themselves OR an admin may mint a Kobo
+    # auth token for a given user_id. Without this, any authenticated
+    # user can request /kobo_auth/generate_auth_token/<other_user_id>
+    # and walk away with a token that authorizes Kobo sync as that user.
+    # Reported upstream as crocodilestick/Calibre-Web-Automated#1303.
+    if current_user.id != user_id and not current_user.role_admin():
+        abort(403)
     warning = False
     host_list = request.host.rsplit(':')
     if len(host_list) == 1:
@@ -112,6 +119,11 @@ def generate_auth_token(user_id):
 @kobo_auth.route("/deleteauthtoken/<int:user_id>", methods=["POST"])
 @user_login_required
 def delete_auth_token(user_id):
+    # IDOR guard: same model as generate_auth_token. Without this any
+    # authenticated user could revoke another user's Kobo auth token,
+    # locking them out of Kobo sync (a softer DoS variant of #1303).
+    if current_user.id != user_id and not current_user.role_admin():
+        abort(403)
     # Invalidate any previously generated Kobo Auth token for this user
     ub.session.query(ub.RemoteAuthToken).filter(ub.RemoteAuthToken.user_id == user_id)\
         .filter(ub.RemoteAuthToken.token_type==1).delete()


### PR DESCRIPTION
## Severity: HIGH

Closes the IDOR vulnerability described in upstream issue [#1303](https://github.com/crocodilestick/Calibre-Web-Automated/issues/1303). Upstream has no fix PR at time of writing.

## Bug

\`cps/kobo_auth.py\` exposed two routes:

- \`GET /kobo_auth/generate_auth_token/<int:user_id>\`
- \`POST /kobo_auth/deleteauthtoken/<int:user_id>\`

Both were gated **only** by \`@user_login_required\`. Neither verified that \`user_id\` matched \`current_user.id\` or that the requester was admin.

**Effect:**
- Any authenticated user could request a Kobo auth token for *any* other user_id and walk away with their token — full Kobo-sync impersonation.
- Any authenticated user could revoke any other user's token — soft DoS / lockout.

## Fix

Add an IDOR guard at the top of both view functions:

\`\`\`python
if current_user.id != user_id and not current_user.role_admin():
    abort(403)
\`\`\`

Same pattern \`cps/admin.py\` uses for admin-only routes. \`current_user\` and \`abort\` are already imported in this file. The guard short-circuits unauthorized access before any DB query runs.

## Risk

Defensive. The intended use case is the user setting up their own Kobo, which still works — \`current_user.id == user_id\`. Admin can still mint/delete tokens for any user (e.g., to help a household member). Non-self / non-admin requests now return 403 instead of leaking a token.

## Test plan

- [ ] Maggie can still set up her own Kobo at \`/kobo_auth/generate_auth_token/<her_user_id>\` (passes the guard).
- [ ] Admin can mint a token on behalf of another user (passes \`role_admin()\`).
- [ ] Non-admin requesting another user's id returns 403 (was: returns leaked token).
- [ ] Existing CI: \`Test Suite / Fast Tests\` green.
- [ ] \`validate-author\` green.

## Why we're shipping ahead of upstream

Upstream issue is open with no comments and no fix PR. Our deployment runs Kobo sync. This is a 12-line single-file change that mirrors an existing in-repo pattern; landing it locally has higher value than waiting for an upstream merge.

## Manual recovery

If the operator wants to roll back: \`gh pr revert\` on the merged commit, or hand-revert \`cps/kobo_auth.py\` lines 70-78 and 112-122.