### PR TITLE
security(cwa): require auth on 14 unauthenticated CWA routes

### DIFF
--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -1648,6 +1648,8 @@ def cwa_flash_status():
 ##————————————————————————————————————————————————————————————————————————————##
 
 @cwa_logs.route('/cwa-logs/download/<log_filename>')
+@login_required_if_no_ano
+@admin_required
 def download_log(log_filename):
     try:
         # Secure the filename to prevent directory traversal (e.g., '..')
@@ -1672,6 +1674,8 @@ def download_log(log_filename):
         abort(400)  # Bad request for malformed or unsafe file paths
 
 @cwa_logs.route('/cwa-logs/read/<log_filename>')
+@login_required_if_no_ano
+@admin_required
 def read_log(log_filename):
     try:
         # Secure the filename to prevent directory traversal (e.g., '..')
@@ -1807,6 +1811,8 @@ def kill_convert_library(queue):
             break
 
 @convert_library.route('/cwa-convert-library-overview', methods=["GET"])
+@login_required_if_no_ano
+@admin_required
 def show_convert_library_page():
     return render_title_template('cwa_convert_library.html', title=_("Calibre-Web Automated - Convert Library"), page="cwa-library-convert",
                                 target_format=CWA_DB().cwa_settings['auto_convert_target_format'].upper())
@@ -1831,6 +1837,8 @@ def schedule_convert_library(delay: int):
     return redirect(url_for('convert_library.show_convert_library_page'))
 
 @convert_library.route('/cwa-convert-library/log-archive', methods=["GET"])
+@login_required_if_no_ano
+@admin_required
 def show_convert_library_logs():
     logs=get_logs_from_archive("convert-library")
     log_dates = get_log_dates(logs)
@@ -1838,6 +1846,8 @@ def show_convert_library_logs():
                                 logs=logs, log_dates=log_dates)
 
 @convert_library.route('/cwa-convert-library/download-current-log/<log_filename>')
+@login_required_if_no_ano
+@admin_required
 def download_current_log(log_filename):
     log_filename = "convert-library.log"
     LOG_DIR = "/config"
@@ -1864,6 +1874,8 @@ def download_current_log(log_filename):
         abort(400)  # Bad request for malformed or unsafe file paths
 
 @convert_library.route('/cwa-convert-library-start', methods=["GET"])
+@login_required_if_no_ano
+@admin_required
 def start_conversion():
     # Wipe conversion log from previous runs
     open('/config/convert-library.log', 'w').close()
@@ -1883,12 +1895,16 @@ def start_conversion():
     return redirect(url_for('convert_library.show_convert_library_page'))
 
 @convert_library.route('/convert-library-cancel', methods=["GET"])
+@login_required_if_no_ano
+@admin_required
 def cancel_convert_library():
     # Create kill trigger file
     open(tempfile.gettempdir() + "/.kill_convert_library_trigger", 'w').close()
     return redirect(url_for('convert_library.show_convert_library_page'))
 
 @convert_library.route('/convert-library-status', methods=["GET"])
+@login_required_if_no_ano
+@admin_required
 def get_status():
     with open("/config/convert-library.log", 'r') as f:
         status = f.read()
@@ -1949,6 +1965,8 @@ def kill_epub_fixer(queue):
             break
 
 @epub_fixer.route('/cwa-epub-fixer-overview', methods=["GET"])
+@login_required_if_no_ano
+@admin_required
 def show_epub_fixer_page():
     return render_title_template('cwa_epub_fixer.html', title=_("Calibre-Web Automated - EPUB Fixer Service"), page="cwa-epub-fixer")
 
@@ -1971,6 +1989,8 @@ def schedule_epub_fixer(delay: int):
     return redirect(url_for('epub_fixer.show_epub_fixer_page'))
 
 @epub_fixer.route('/cwa-epub-fixer/log-archive', methods=["GET"])
+@login_required_if_no_ano
+@admin_required
 def show_epub_fixer_logs():
     logs = get_logs_from_archive("epub-fixer")
     log_dates = get_log_dates(logs)
@@ -1978,6 +1998,8 @@ def show_epub_fixer_logs():
                                 logs=logs, log_dates=log_dates)
 
 @epub_fixer.route('/cwa-epub-fixer/download-current-log/<log_filename>')
+@login_required_if_no_ano
+@admin_required
 def download_current_log(log_filename):
     log_filename = "epub-fixer.log"
     LOG_DIR = "/config"
@@ -2004,6 +2026,8 @@ def download_current_log(log_filename):
         abort(400)  # Bad request for malformed or unsafe file paths
 
 @epub_fixer.route('/cwa-epub-fixer-start', methods=["GET"])
+@login_required_if_no_ano
+@admin_required
 def start_epub_fixer():
     # Wipe conversion log from previous runs
     open('/config/epub-fixer.log', 'w').close()
@@ -2072,6 +2096,8 @@ def run_epub_fixer_for_book():
         return jsonify({"success": False, "error": _("Failed to start EPUB Fixer for selected book.")}), 500
 
 @epub_fixer.route('/epub-fixer-cancel', methods=["GET"])
+@login_required_if_no_ano
+@admin_required
 def cancel_epub_fixer():
     # Create kill trigger file
     open(tempfile.gettempdir() + "/.kill_epub_fixer_trigger", 'w').close()
@@ -2086,6 +2112,8 @@ def cancel_epub_fixer():
     return redirect(url_for('epub_fixer.show_epub_fixer_page'))
 
 @epub_fixer.route('/epub-fixer-status', methods=["GET"])
+@login_required_if_no_ano
+@admin_required
 def get_status():
     with open("/config/epub-fixer.log", 'r') as f:
         status = f.read()


### PR DESCRIPTION
## Severity: HIGH (multiple)

Found during the post-#1303 IDOR audit (see \`notes/SECURITY-kobo-idor-1303.md\`). The audit pivoted from \`cps/kobo_auth.py\` to a sweep of all \`cps/cwa_functions.py\` routes for missing decorators.

## Bug

14 routes across the \`cwa_logs\`, \`convert_library\`, and \`epub_fixer\` blueprints had **no authentication decorator** at all. Most sibling routes in the same file are properly gated with \`@login_required_if_no_ano\` + \`@admin_required\` — these 14 are clear omissions.

## Effect

With \`config_anonbrowse=False\`, an unauthenticated visitor who knows the URL could:

- **Read or download CWA log files** (\`cwa_logs.download/read\`, \`convert_library.download_current_log\`, \`epub_fixer.download_current_log\`). Logs leak paths, error stacks, book titles, admin actions.
- **Trigger destructive operations**: \`start_conversion\` (kicks off a library-wide format conversion), \`start_epub_fixer\` (runs the fixer across the library), \`cancel_*\` (interrupt running jobs).
- **Query operational status / scheduler queue contents** (\`get_status\` x2, \`log-archive\` x2, \`*-overview\` x2).

## Fix

Add the standard decorator chain to each of the 14 routes:

\`\`\`python
@<bp>.route(\"/...\")
@login_required_if_no_ano    # NEW
@admin_required              # NEW
def view():
    ...
\`\`\`

Pattern matches what's already in use on \`cwa_settings\`, \`cwa_stats\`, \`cwa_check_status\`, \`cwa_scheduled\`, etc. — the imports for both decorators are already at the top of \`cps/cwa_functions.py\`.

28 added lines, 0 removed. Single file diff.

## Routes modified

| Blueprint | Route |
|---|---|
| \`cwa_logs\` | \`/cwa-logs/download/<log_filename>\` |
| \`cwa_logs\` | \`/cwa-logs/read/<log_filename>\` |
| \`convert_library\` | \`/cwa-convert-library-overview\` |
| \`convert_library\` | \`/cwa-convert-library/log-archive\` |
| \`convert_library\` | \`/cwa-convert-library/download-current-log/<log_filename>\` |
| \`convert_library\` | \`/cwa-convert-library-start\` |
| \`convert_library\` | \`/convert-library-cancel\` |
| \`convert_library\` | \`/convert-library-status\` |
| \`epub_fixer\` | \`/cwa-epub-fixer-overview\` |
| \`epub_fixer\` | \`/cwa-epub-fixer/log-archive\` |
| \`epub_fixer\` | \`/cwa-epub-fixer/download-current-log/<log_filename>\` |
| \`epub_fixer\` | \`/cwa-epub-fixer-start\` |
| \`epub_fixer\` | \`/epub-fixer-cancel\` |
| \`epub_fixer\` | \`/epub-fixer-status\` |

## Out of scope

\`cwa_internal\` blueprint (5 routes) is intentionally localhost-only by design — each handler explicitly checks \`request.remote_addr in ('127.0.0.1', '::1')\` against the trusted-proxy-resolved client IP. There IS a follow-up: the same handlers fall back to \`X-Forwarded-For\` first, which can be spoofed by clients if \`TRUSTED_PROXY_COUNT\` doesn't strip enough hops. Tracked separately in \`notes/SECURITY-cwa-routes-unauth.md\`.

## Risk

Defensive. No happy-path behaviour change for authenticated admins — they were the intended audience already. Unauthenticated requests now redirect to \`/login\` per the standard \`login_required_if_no_ano\` semantics (or 403 for admin-only paths if anon-browse is on).

## Test plan

- [ ] Authenticated admin: every operation (start/cancel conversion, view logs, start/cancel epub fixer, schedule, etc.) still works.
- [ ] Authenticated non-admin: access to these 14 routes returns 403.
- [ ] Unauthenticated, \`config_anonbrowse=False\`: all 14 routes redirect to \`/login\`.
- [ ] CI: \`Test Suite / Fast Tests\` green; \`validate-author\` green.

## Why ahead of upstream

These routes don't appear to be guarded in upstream either. Filing a parallel issue / PR upstream is a follow-up; for our deployment we ship the fix locally now.