### PR TITLE
security(cover_enforcer): replace os.system shell-interpolation with shutil

### DIFF
--- a/scripts/cover_enforcer.py
+++ b/scripts/cover_enforcer.py
@@ -9,6 +9,7 @@ import atexit
 import json
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -623,8 +624,15 @@ class Enforcer:
 
 
     def replace_old_metadata(self, old_metadata: str, new_metadata: str) -> None:
-        """Switches the metadata in metadata_temp with the metadata in the Calibre-Library"""
-        os.system(f'cp "{new_metadata}" "{old_metadata}"')
+        """Switches the metadata in metadata_temp with the metadata in the Calibre-Library.
+
+        Uses shutil.copy (no shell) to avoid command-injection if a book's
+        directory or filename ever contains shell metacharacters that
+        survive Calibre's title sanitization (quotes, semicolons,
+        backticks, dollar signs). The previous implementation interpolated
+        these paths into an os.system 'cp "..." "..."' call.
+        """
+        shutil.copy(new_metadata, old_metadata)
 
 
     def print_library_list(self) -> None:
@@ -693,8 +701,24 @@ class Enforcer:
 
 
     def empty_metadata_temp(self):
-        """Empties the metadata_temp folder"""
-        os.system(f"rm -r {metadata_temp_dir}/*")
+        """Empties the metadata_temp folder.
+
+        Uses shutil instead of os.system 'rm -r' so the operation is
+        independent of shell semantics and the path is not interpolated
+        into a command line. metadata_temp_dir is currently a hardcoded
+        constant, but defense-in-depth in case that ever changes.
+        """
+        if not os.path.isdir(metadata_temp_dir):
+            return
+        for entry in os.listdir(metadata_temp_dir):
+            path = os.path.join(metadata_temp_dir, entry)
+            if os.path.isdir(path) and not os.path.islink(path):
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
 
 
     def check_for_other_logs(self, processed_book_ids: set | None = None):


### PR DESCRIPTION
## Severity: MEDIUM (defense-in-depth)

Found during the \`scripts/\` audit recommended in \`notes/SECURITY-audit-summary.md\` (follow-up to PR #18 / PR #19).

## Bug

\`scripts/cover_enforcer.py\` had two \`os.system\` calls that interpolated paths into a shell command line:

\`\`\`python
os.system(f'cp \"{new_metadata}\" \"{old_metadata}\"')   # line 627
os.system(f\"rm -r {metadata_temp_dir}/*\")            # line 697
\`\`\`

The first one is the real concern. \`old_metadata\` / \`new_metadata\` derive from \`book.book_dir\`, which Calibre constructs as:

\`\`\`
<calibre_library>/<author>/<title> (<id>)/metadata.opf
\`\`\`

\`<author>\` and \`<title>\` come from book metadata (uploaded EPUB tags or set via the admin UI). If either ever contains shell metacharacters that survive Calibre's title sanitization — quotes, semicolons, backticks, \`$\` — the surrounding \`\"...\"\` quoting breaks and we get arbitrary command execution as the \`abc\` user (UID 1000).

The second \`os.system\` uses \`metadata_temp_dir\`, which is currently hardcoded to \`/app/calibre-web-automated/metadata_temp\`, so no current attacker control. But it's bad form — \`rm -rf\` interpolated into shell text, and we lose if the constant ever moves to config.

## Fix

Switch both to stdlib \`shutil\`:

- \`replace_old_metadata\` → \`shutil.copy(new_metadata, old_metadata)\` (no shell).
- \`empty_metadata_temp\` → iterate \`os.listdir\`; \`shutil.rmtree\` for dirs (skip symlinks), \`os.unlink\` for files. Same observable effect as \`rm -r .../*\`.

\`shutil\` is in stdlib; just added the import. 28 added / 4 removed, single-file diff.

## Risk

Defensive. Happy-path behaviour unchanged. Edge case improvements:

- Filenames with shell metacharacters now copy correctly instead of failing or executing unintended commands.
- The empty-temp path now skips symlinks rather than following them (avoids one class of surprise where a symlink in the temp dir leaks deletion outside of it).

## Test plan

- [ ] Cover/metadata enforcer continues to work on books with normal titles.
- [ ] Try a book with a quote in the title (already broken under the old shell-interpolation path) — should now succeed.
- [ ] CI: \`Test Suite / Fast Tests\` green.

## Why ahead of upstream

Same pattern as PR #18 / PR #19: upstream has not addressed it; the fix is small, isolated, and ships as defense-in-depth for our deployment.