### PR TITLE
fix(updater): point release check at Calibre-Web-NextGen + fix downgrade banner

### DIFF
--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -118,13 +118,29 @@ def cwa_update_available() -> tuple[bool, str, str]:
         def _normalize_version(value: str) -> str:
             return (value or "").lstrip("vV")
 
+        def _version_tuple(value: str) -> tuple:
+            # Best-effort numeric parse; non-numeric segments sort lower.
+            parts = []
+            for seg in value.split("."):
+                num = ""
+                for ch in seg:
+                    if ch.isdigit():
+                        num += ch
+                    else:
+                        break
+                parts.append(int(num) if num else 0)
+            return tuple(parts)
+
         current_normalized = _normalize_version(current_version)
         tag_normalized = _normalize_version(tag_name)
 
         if current_normalized in ("", "0.0.0") or tag_normalized in ("", "0.0.0"):
             return False, "0.0.0", "0.0.0"
 
-        return (tag_normalized != current_normalized), current_version, tag_name
+        # Only flag an update when the published tag is strictly newer than
+        # what's installed; a downgrade or equal version is not an update.
+        is_newer = _version_tuple(tag_normalized) > _version_tuple(current_normalized)
+        return is_newer, current_version, tag_name
     except Exception as e:
         print(f"[cwa-update-notification-service] Error checking for CWA updates: {e}", flush=True)
         return False, "0.0.0", "0.0.0"

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -392,9 +392,16 @@ echo "[cwa-init] Installed version: $CWA_INSTALLED_VERSION"
 echo "[cwa-init] Attempting to fetch latest stable version from GitHub..."
 CWA_STABLE_VERSION=""
 
+# Repo to query for the latest release tag. Defaults to the
+# Calibre-Web-NextGen fork; override with CWA_RELEASE_REPO=owner/name
+# to track upstream or any other downstream.
+: "${CWA_RELEASE_REPO:=new-usemame/Calibre-Web-NextGen}"
+CWA_RELEASE_API_URL="https://api.github.com/repos/${CWA_RELEASE_REPO}/releases/latest"
+echo "[cwa-init] Release source: $CWA_RELEASE_REPO"
+
 if command -v jq >/dev/null 2>&1; then
   echo "[cwa-init] Using jq for JSON parsing..."
-  if CWA_STABLE_VERSION="$(timeout 5 curl -sS --max-time 3 --connect-timeout 2 https://api.github.com/repos/crocodilestick/calibre-web-automated/releases/latest 2>/dev/null | timeout 2 jq -r '.tag_name' 2>/dev/null)"; then
+  if CWA_STABLE_VERSION="$(timeout 5 curl -sS --max-time 3 --connect-timeout 2 "$CWA_RELEASE_API_URL" 2>/dev/null | timeout 2 jq -r '.tag_name' 2>/dev/null)"; then
     echo "[cwa-init] Successfully fetched stable version via jq: $CWA_STABLE_VERSION"
   else
     echo "[cwa-init] Failed to fetch stable version via jq (network/timeout issue)"
@@ -402,7 +409,7 @@ if command -v jq >/dev/null 2>&1; then
   fi
 else
   echo "[cwa-init] jq not available, using fallback parsing..."
-  if CWA_STABLE_VERSION="$(timeout 5 curl -sS --max-time 3 --connect-timeout 2 https://api.github.com/repos/crocodilestick/calibre-web-automated/releases/latest 2>/dev/null | timeout 2 sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"; then
+  if CWA_STABLE_VERSION="$(timeout 5 curl -sS --max-time 3 --connect-timeout 2 "$CWA_RELEASE_API_URL" 2>/dev/null | timeout 2 sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"; then
     echo "[cwa-init] Successfully fetched stable version via sed: $CWA_STABLE_VERSION"
   else
     echo "[cwa-init] Failed to fetch stable version via sed (network/timeout issue)"


### PR DESCRIPTION
## What

Two bugs in the in-app update banner:

1. **Wrong source repo.** The s6 init script queries
   \`api.github.com/repos/crocodilestick/calibre-web-automated/releases/latest\` —
   so installs of NextGen check upstream's release feed, not ours. As soon
   as upstream cuts a tag we don't carry, we banner users to "re-pull the
   image" toward upstream.

2. **\`!=\` comparator.** \`cps/render_template.py:cwa_update_available\`
   flags an update on any inequality. When the installed version is
   *ahead* of the queried tag we still banner — that's how the nonsensical
   \`Current v4.0.7 | Newest v4.0.6\` flash happened in production.

## Fix

- s6 init now points at \`new-usemame/Calibre-Web-NextGen\` for the
  latest-release lookup. Overridable via \`CWA_RELEASE_REPO=owner/name\`
  if a downstream wants to track upstream or another fork.
- Comparator parses both versions into integer tuples and only fires when
  the queried tag is **strictly newer** than the installed version.
- Non-numeric / pre-release suffixes parse to 0 — conservative: we'd
  rather miss a notification than flap a downgrade warning.

## Risk

Low. Both edits are isolated. Worst case: someone running an env where
GitHub API is unreachable continues to see no banner (same as today).