### PR TITLE
feat(covers): bump cover resolution for high-DPI e-readers

### DIFF
--- a/cps/metadata_provider/amazon.py
+++ b/cps/metadata_provider/amazon.py
@@ -149,8 +149,17 @@ class Amazon(Metadata):
                             cover_src = m.group(1)
                             break
                     if not cover_src:
-                        # Fallback to the standard image
+                        # Try data-old-hires (Amazon's pre-rendered hi-res variant)
+                        landing = soup2.find("img", attrs={"id": "landingImage"})
+                        if landing:
+                            cover_src = landing.get("data-old-hires", "") or landing.get("src", "") or ""
+                    if not cover_src:
+                        # Last resort: a-dynamic-image src is always small (e.g. _SY475_)
                         cover_src = soup2.find("img", attrs={"class": "a-dynamic-image"})["src"]
+                    # Strip Amazon's dynamic-sizing token (e.g. ._SY475_.) so we
+                    # serve the original full-resolution variant.
+                    if cover_src:
+                        cover_src = re.sub(r'(\._[A-Z0-9,_]+_\.)', '.', cover_src)
                     match.cover = cover_src
                 except (AttributeError, TypeError):
                     match.cover = ""

--- a/cps/metadata_provider/google.py
+++ b/cps/metadata_provider/google.py
@@ -105,8 +105,10 @@ class Google(Metadata):
             # strip curl in cover
             cover_url = cover_url.replace("&edge=curl", "")
             
-            # request 800x900 cover image (higher resolution)
-            cover_url += "&fife=w800-h900"
+            # Request a cover sized for high-DPI e-readers (Kobo Libra Color
+            # is 1264x1680). Google Books returns the source image when the
+            # requested fife dimensions exceed what's available.
+            cover_url += "&fife=w1280-h1920"
             
             return cover_url.replace("http://", "https://")
         return generic_cover

--- a/cps/tasks/thumbnail.py
+++ b/cps/tasks/thumbnail.py
@@ -23,8 +23,14 @@ except (ImportError, RuntimeError) as e:
     use_IM = False
 
 
+_BASE_THUMBNAIL_HEIGHT = int(os.environ.get("CWA_THUMBNAIL_BASE_HEIGHT", "420"))
+
+
 def get_resize_height(resolution):
-    return int(255 * resolution)
+    # Heights at the three resolution multipliers (small=1, medium=2, large=4):
+    #   default 420 -> 420 / 840 / 1680  (matches Kobo Libra Color long axis)
+    #   override via CWA_THUMBNAIL_BASE_HEIGHT for low-storage deployments.
+    return int(_BASE_THUMBNAIL_HEIGHT * resolution)
 
 
 def get_resize_width(resolution, original_width, original_height):


### PR DESCRIPTION
## Why

On a Kobo Libra Color (1264×1680) — and any high-DPI e-reader — covers
look low quality. Three independent caps stack to limit y-axis to
~500 px:

1. Thumbnail cache base height = 255 px (medium = 510 → matches user
   report). Source: \`cps/tasks/thumbnail.py:27\`.
2. Google Books URL pinned at \`&fife=w800-h900\` (max 900 y).
3. Amazon US falls back to \`a-dynamic-image src\` which is Amazon's
   \`_SY475_\` thumbnail (~475 y).

The original \`cover.jpg\` in the library is *not* capped — the issue is
purely (a) the URL the metadata provider hands back, and (b) the
in-app thumbnail downscale used for browser grid + Kobo sync.

## What

| File | Change |
|---|---|
| \`cps/tasks/thumbnail.py\` | \`255 * resolution\` → \`420 * resolution\`. New ladder: 420 / 840 / **1680** (Libra Color long axis). Override via \`CWA_THUMBNAIL_BASE_HEIGHT\` env. |
| \`cps/metadata_provider/google.py\` | \`&fife=w800-h900\` → \`&fife=w1280-h1920\`. Google serves the source image when fife exceeds available — no-op for small originals, strict win otherwise. |
| \`cps/metadata_provider/amazon.py\` | (a) try \`data-old-hires\` before falling back to \`src\`. (b) strip Amazon's dynamic sizing token (\`._SY475_.\`, \`._AC_UL320_SR320,320_.\`, etc.) from whatever URL we land on. Same approach as \`amazonjp.py:138\`. |

## Verified

- All three modules compile.
- 5/5 Amazon URL-strip cases pass (incl. unaffected hi-res URLs).
- Resize formula: 1×=420, 2×=840, 4×=1680.
- Override path \`CWA_THUMBNAIL_BASE_HEIGHT=300\` correctly produces 300/600/1200 ladder for low-storage deployments.
- 16/16 autopilot test files pass.

## After merge — deployment

Operators should run **Admin → Refresh Thumbnail Cache** once after
container restart so existing covers regenerate at the new resolutions.
New metadata-search results are high-res with no further action.

## Risk

Low. The thumbnail cache will roughly **2.7× per book** in disk space
(linear scaling factor squared on bitmap pixels: (420/255)² ≈ 2.7).
For a 10k-book library: ~3-4 GB extra cache disk. Operators on tight
storage can opt out with \`CWA_THUMBNAIL_BASE_HEIGHT=255\`.