### PR TITLE
feat(metadata): Open Library + Google API key + per-provider status + in-modal API-key panel

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -2353,6 +2353,10 @@ def _configuration_update_helper():
         _config_checkbox(to_save, "config_hardcover_annotations_sync")
         _config_string(to_save, "config_hardcover_token")
 
+        # Google Books API key (lifts the anonymous quota of 1k req/IP/day to
+        # the project's authenticated quota, default 100k/day). Optional.
+        _config_string(to_save, "config_google_books_api_key")
+
         _config_int(to_save, "config_updatechannel")
 
         # Reverse proxy login configuration

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -114,6 +114,7 @@ class _Settings(_Base):
     config_use_goodreads = Column(Boolean, default=False)
     config_goodreads_api_key = Column(String)
     config_hardcover_token = Column(String)
+    config_google_books_api_key = Column(String)
     
     config_register_email = Column(Boolean, default=False)
     config_login_type = Column(Integer, default=0)

--- a/cps/metadata_provider/google.py
+++ b/cps/metadata_provider/google.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 import requests
 
-from cps import logger
+from cps import config, logger
 from cps.isoLanguages import get_lang3, get_language_name
 from cps.services.Metadata import MetaRecord, MetaSourceInfo, Metadata
 
@@ -38,9 +38,25 @@ class Google(Metadata):
             if title_tokens:
                 tokens = [quote(t.encode("utf-8")) for t in title_tokens]
                 query = "+".join(tokens)
+            url = Google.SEARCH_URL + query
+            api_key = getattr(config, "config_google_books_api_key", None)
+            if api_key:
+                # Authenticated requests use the project's quota
+                # (default 100k req/day) instead of the per-IP anonymous quota
+                # (1k/day, easily exhausted on shared servers).
+                url += "&key=" + quote(api_key.strip().encode("utf-8"))
             try:
-                results = requests.get(Google.SEARCH_URL + query, timeout=15)
+                results = requests.get(url, timeout=15)
                 results.raise_for_status()
+            except requests.HTTPError as e:
+                if getattr(e.response, "status_code", None) == 429:
+                    log.warning(
+                        "Google Books quota exceeded (HTTP 429). "
+                        "Set config_google_books_api_key to lift the limit."
+                    )
+                else:
+                    log.warning(e)
+                return []
             except Exception as e:
                 log.warning(e)
                 return []

--- a/cps/metadata_provider/openlibrary.py
+++ b/cps/metadata_provider/openlibrary.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+# Open Library metadata provider.
+#
+# API docs: https://openlibrary.org/dev/docs/api/search
+# - Search:  https://openlibrary.org/search.json?q=...&fields=...&limit=N
+# - Covers:  https://covers.openlibrary.org/b/id/{cover_id}-L.jpg
+#            https://covers.openlibrary.org/b/olid/{olid}-L.jpg
+#
+# Open Library is the Internet Archive's public book catalog. Free to query,
+# no API key, generous rate limits (~100 req/min/IP). Returns ISBN, OLID,
+# work key, edition keys, language, publisher, year, subjects.
+
+from typing import Dict, List, Optional
+from urllib.parse import quote
+
+import requests
+
+from cps import constants, logger
+from cps.isoLanguages import get_language_name
+from cps.services.Metadata import MetaRecord, MetaSourceInfo, Metadata
+
+
+log = logger.create()
+
+
+class OpenLibrary(Metadata):
+    __name__ = "Open Library"
+    __id__ = "openlibrary"
+    DESCRIPTION = "Open Library"
+    META_URL = "https://openlibrary.org/"
+
+    SEARCH_URL = "https://openlibrary.org/search.json"
+    BOOK_URL_TEMPLATE = "https://openlibrary.org{key}"  # key starts with /works/...
+    COVER_BY_ID_URL = "https://covers.openlibrary.org/b/id/{cover_id}-L.jpg"
+    COVER_BY_OLID_URL = "https://covers.openlibrary.org/b/olid/{olid}-L.jpg"
+
+    SEARCH_FIELDS = ",".join([
+        "key", "title", "author_name", "first_publish_year",
+        "language", "isbn", "publisher", "cover_i", "cover_edition_key",
+        "edition_key", "number_of_pages_median", "subject",
+    ])
+
+    SEARCH_LIMIT = 10
+    REQUEST_TIMEOUT = 12
+
+    def search(
+        self, query: str, generic_cover: str = "", locale: str = "en"
+    ) -> Optional[List[MetaRecord]]:
+        if not self.active:
+            return []
+
+        title_tokens = list(self.get_title_tokens(query, strip_joiners=False))
+        if not title_tokens:
+            return []
+        q = "+".join(quote(t.encode("utf-8")) for t in title_tokens)
+
+        url = (
+            f"{OpenLibrary.SEARCH_URL}?q={q}"
+            f"&fields={OpenLibrary.SEARCH_FIELDS}"
+            f"&limit={OpenLibrary.SEARCH_LIMIT}"
+        )
+        headers = {"User-Agent": constants.USER_AGENT}
+
+        try:
+            response = requests.get(url, headers=headers, timeout=OpenLibrary.REQUEST_TIMEOUT)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            log.warning("OpenLibrary search failed: %s", exc)
+            return []
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            log.warning("OpenLibrary returned invalid JSON: %s", exc)
+            return []
+
+        results: List[MetaRecord] = []
+        for doc in payload.get("docs", []) or []:
+            record = self._parse_doc(doc, generic_cover=generic_cover, locale=locale)
+            if record is not None:
+                results.append(record)
+        return results
+
+    def _parse_doc(
+        self, doc: Dict, generic_cover: str, locale: str
+    ) -> Optional[MetaRecord]:
+        title = doc.get("title")
+        work_key = doc.get("key")
+        if not title or not work_key:
+            return None
+
+        record = MetaRecord(
+            id=work_key,
+            title=title,
+            authors=list(doc.get("author_name") or []),
+            url=OpenLibrary.BOOK_URL_TEMPLATE.format(key=work_key),
+            source=MetaSourceInfo(
+                id=self.__id__,
+                description=OpenLibrary.DESCRIPTION,
+                link=OpenLibrary.META_URL,
+            ),
+        )
+        record.cover = self._cover_url(doc, generic_cover=generic_cover)
+        record.publisher = self._first_or_none(doc.get("publisher"))
+        year = doc.get("first_publish_year")
+        record.publishedDate = str(year) if year else ""
+        record.languages = self._parse_languages(doc, locale=locale)
+        record.tags = self._truncate_subjects(doc.get("subject"))
+        record.identifiers = self._parse_identifiers(doc)
+        return record
+
+    @staticmethod
+    def _cover_url(doc: Dict, generic_cover: str) -> str:
+        cover_id = doc.get("cover_i")
+        if cover_id:
+            return OpenLibrary.COVER_BY_ID_URL.format(cover_id=cover_id)
+        olid = doc.get("cover_edition_key")
+        if olid:
+            return OpenLibrary.COVER_BY_OLID_URL.format(olid=olid)
+        return generic_cover
+
+    @staticmethod
+    def _first_or_none(value):
+        if isinstance(value, list) and value:
+            return value[0]
+        return value or None
+
+    @staticmethod
+    def _parse_languages(doc: Dict, locale: str) -> List[str]:
+        codes = doc.get("language") or []
+        languages: List[str] = []
+        for code3 in codes[:5]:
+            try:
+                name = get_language_name(locale, code3)
+            except Exception:
+                name = None
+            if name and name not in languages:
+                languages.append(name)
+        return languages
+
+    @staticmethod
+    def _truncate_subjects(subjects) -> List[str]:
+        if not subjects:
+            return []
+        return list(subjects[:8])
+
+    @staticmethod
+    def _parse_identifiers(doc: Dict) -> Dict[str, str]:
+        identifiers: Dict[str, str] = {}
+        # Pick a representative ISBN-13 first, fall back to ISBN-10.
+        isbn = OpenLibrary._first_or_none(doc.get("isbn"))
+        if isbn:
+            identifiers["isbn"] = isbn
+        # OLID (work key trimmed of the /works/ prefix) gives the Open Library
+        # work URL in calibre conventions.
+        work_key = doc.get("key") or ""
+        if work_key.startswith("/works/"):
+            identifiers["openlibrary"] = work_key.split("/", 2)[-1]
+        return identifiers

--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import InvalidRequestError, OperationalError
 from sqlalchemy.orm.attributes import flag_modified
 
 from cps.services.Metadata import Metadata
-from . import constants, logger, ub, web_server
+from . import config, constants, logger, ub, web_server
 from .usermanagement import user_login_required
 
 
@@ -70,6 +70,17 @@ cl = list_classes(new_list)
 cl.sort(key=lambda x: x.__class__.__name__)
 
 
+# Optional verbose logging across every metadata provider — flip via env
+# CWA_METADATA_DEBUG=1 to bump the family of cps.metadata_provider.* loggers
+# to DEBUG without touching the global log level.
+if os.environ.get("CWA_METADATA_DEBUG", "").lower() in ("1", "true", "yes"):
+    import logging
+    for provider_module in new_list:
+        logging.getLogger("cps.metadata_provider." + provider_module).setLevel(logging.DEBUG)
+    logging.getLogger("cps.search_metadata").setLevel(logging.DEBUG)
+    log.info("CWA_METADATA_DEBUG=1: metadata-provider logs bumped to DEBUG")
+
+
 # Helper to load global provider enablement map from CWA settings
 def _get_global_provider_enabled_map() -> dict:
     try:
@@ -92,6 +103,81 @@ def _get_global_provider_enabled_map() -> dict:
         log.warning(f"Error loading provider enabled map: {e}")
         return {}
     # Remove redundant return
+
+# Providers that take a single API token / key plus the config column that
+# stores it and a public signup URL. Used by the metadata-search modal's
+# 🔑 Keys panel so users don't have to leave the modal to plug in a key.
+PROVIDER_KEY_REGISTRY = {
+    "hardcover": {
+        "name":   "Hardcover",
+        "config": "config_hardcover_token",
+        "signup": "https://hardcover.app/account/api",
+        "help":   "Free Hardcover account; click 'API Tokens' on your profile page.",
+    },
+    "google": {
+        "name":   "Google Books",
+        "config": "config_google_books_api_key",
+        "signup": "https://console.cloud.google.com/apis/library/books.googleapis.com",
+        "help":   "Enable 'Books API' in any Google Cloud project, then create an API key under Credentials.",
+    },
+    "goodreads": {
+        "name":   "Goodreads",
+        "config": "config_goodreads_api_key",
+        "signup": "https://www.goodreads.com/api/keys",
+        "help":   "Goodreads' developer API was discontinued in 2020. Existing keys still work for legacy integrations.",
+    },
+}
+
+
+def _is_admin_user() -> bool:
+    try:
+        return bool(current_user.role_admin())
+    except Exception:
+        return False
+
+
+@meta.route("/metadata/keys")
+@user_login_required
+def metadata_keys():
+    """Return the API-key inventory for providers that support one.
+
+    Never returns the actual key value — only whether a key is configured.
+    Used to populate the modal's 🔑 Keys panel.
+    """
+    payload = []
+    can_edit = _is_admin_user()
+    for pid, spec in PROVIDER_KEY_REGISTRY.items():
+        configured_value = getattr(config, spec["config"], None)
+        payload.append({
+            "id":         pid,
+            "name":       spec["name"],
+            "configured": bool(configured_value),
+            "signup":     spec["signup"],
+            "help":       spec["help"],
+            "can_edit":   can_edit,
+        })
+    return make_response(jsonify(payload))
+
+
+@meta.route("/metadata/keys/<prov_id>", methods=["POST"])
+@user_login_required
+def metadata_keys_save(prov_id):
+    """Set or clear a provider's API key. Admin-only."""
+    if not _is_admin_user():
+        return make_response(jsonify({"error": "admin required"}), 403)
+    spec = PROVIDER_KEY_REGISTRY.get(prov_id)
+    if not spec:
+        return make_response(jsonify({"error": "unknown provider"}), 404)
+    body = request.get_json(silent=True) or {}
+    value = (body.get("value") or "").strip()
+    try:
+        setattr(config, spec["config"], value or None)
+        config.save()
+    except Exception as exc:
+        log.error("Failed to save API key for %s: %s", prov_id, exc)
+        return make_response(jsonify({"error": "save failed"}), 500)
+    return make_response(jsonify({"id": prov_id, "configured": bool(value)}))
+
 
 @meta.route("/metadata/provider")
 @user_login_required
@@ -150,32 +236,144 @@ def metadata_change_active_provider(prov_name):
     return ""
 
 
+def _classify_empty_provider(provider) -> tuple:
+    """Decide why an enabled provider returned 0 results.
+
+    Several providers fail silently (return [] without raising) when a
+    required key is missing. We surface that to the UI as 'missing_key' so
+    the user gets a "go set an API key" hint instead of a generic
+    "no results" message.
+    """
+    pid = getattr(provider, "__id__", "")
+    if pid == "hardcover":
+        token = getattr(config, "config_hardcover_token", None)
+        if not token:
+            return ("missing_key",
+                    "Set a Hardcover API key in Admin → Configuration → "
+                    "Feature Configuration to enable this source.")
+    if pid == "google":
+        # Google returns [] both for no-results and for 429. We can't tell
+        # from the wire, but if the user has no key configured then a 429 is
+        # the dominant cause on shared IPs.
+        if not getattr(config, "config_google_books_api_key", None):
+            return ("empty",
+                    "No matches. If this happens consistently, Google Books "
+                    "may be rate-limiting your IP — set a Google Books API key "
+                    "in Configuration to lift the quota.")
+    return ("empty", "No results for this query")
+
+
+def _classify_provider_failure(exc: Exception) -> tuple:
+    """Map a provider exception to a (status, message) UI hint pair.
+
+    Returns one of:
+      ("blocked",       "...")  – upstream is actively refusing us (403/503)
+      ("rate_limited",  "...")  – we hit a quota (429)
+      ("missing_key",   "...")  – provider needs an API key we don't have
+      ("error",         "...")  – everything else
+    """
+    text = str(exc) or exc.__class__.__name__
+    lowered = text.lower()
+    if "429" in text or "too many requests" in lowered or "quota" in lowered:
+        return ("rate_limited", text)
+    if "503" in text or "service unavailable" in lowered:
+        return ("blocked", text)
+    if "401" in text or "403" in text or "forbidden" in lowered or "unauthorized" in lowered:
+        return ("missing_key", text)
+    if "token missing" in lowered or "api key" in lowered:
+        return ("missing_key", text)
+    return ("error", text)
+
+
 @meta.route("/metadata/search", methods=["POST"])
 @user_login_required
 def metadata_search():
+    """Run all enabled providers in parallel and return a structured response.
+
+    Response shape:
+        {
+          "results":   [ MetaRecord, ... ],   # flattened, dedup left to UI
+          "providers": [
+            { "id": "google",      "name": "Google",
+              "status": "ok"|"empty"|"rate_limited"|"blocked"|"missing_key"|"error"|"disabled",
+              "count":  <int>,
+              "message": "<short, user-facing reason>",
+              "duration_ms": <int> },
+            ...
+          ]
+        }
+    """
     query = request.form.to_dict().get("query")
-    data = list()
+    results: list = []
+    provider_status: list = []
     active = current_user.view_settings.get("metadata", {})
     locale = get_locale()
     global_enabled = _get_global_provider_enabled_map()
-    if query:
-        static_cover = url_for("static", filename="generic_cover.svg")
-        # ret = cl[0].search(query, static_cover, locale)
-        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
-            meta = {
-                executor.submit(copy_current_request_context(c.search), query, static_cover, locale): c
-                for c in cl
-                if active.get(c.__id__, True) and bool(global_enabled.get(c.__id__, True))
-            }
-            for future in concurrent.futures.as_completed(meta):
-                try:
-                    result = future.result()
-                except Exception as exc:
-                    provider = meta.get(future)
-                    provider_name = provider.__class__.__name__ if provider else "Unknown"
-                    log.warning("Metadata provider %s failed: %s", provider_name, exc)
-                    continue
-                if not result:
-                    continue
-                data.extend([asdict(x) for x in result if x])
-    return  make_response(jsonify(data))
+
+    # Build the static "what each provider returned" structure first so the UI
+    # can show a row even for providers we don't run (disabled per-user or
+    # globally). This keeps modal copy stable across reload.
+    runnable = {}
+    for provider in cl:
+        is_active = active.get(provider.__id__, True)
+        is_global = bool(global_enabled.get(provider.__id__, True))
+        if not is_active or not is_global:
+            provider_status.append({
+                "id": provider.__id__,
+                "name": provider.__name__,
+                "status": "disabled",
+                "count": 0,
+                "message": "Disabled" if is_active else "Off (per-user toggle)",
+                "duration_ms": 0,
+            })
+            continue
+        runnable[provider.__id__] = provider
+
+    if not query or not runnable:
+        return make_response(jsonify({"results": results, "providers": provider_status}))
+
+    static_cover = url_for("static", filename="generic_cover.svg")
+
+    import time
+    started_at = {pid: time.monotonic() for pid in runnable}
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        future_to_provider = {
+            executor.submit(copy_current_request_context(provider.search), query, static_cover, locale): provider
+            for provider in runnable.values()
+        }
+        for future in concurrent.futures.as_completed(future_to_provider):
+            provider = future_to_provider[future]
+            elapsed_ms = int((time.monotonic() - started_at.get(provider.__id__, time.monotonic())) * 1000)
+            try:
+                provider_results = future.result() or []
+            except Exception as exc:
+                status, message = _classify_provider_failure(exc)
+                log.warning(
+                    "Metadata provider %s failed (%s) in %dms: %s",
+                    provider.__class__.__name__, status, elapsed_ms, exc,
+                )
+                provider_status.append({
+                    "id": provider.__id__,
+                    "name": provider.__name__,
+                    "status": status,
+                    "count": 0,
+                    "message": message,
+                    "duration_ms": elapsed_ms,
+                })
+                continue
+            results.extend([asdict(x) for x in provider_results if x])
+            count = len(provider_results)
+            status, message = ("ok", "") if count else _classify_empty_provider(provider)
+            provider_status.append({
+                "id": provider.__id__,
+                "name": provider.__name__,
+                "status": status,
+                "count": count,
+                "message": message,
+                "duration_ms": elapsed_ms,
+            })
+    # Stable sort so rendering is deterministic even though futures complete
+    # out of order.
+    provider_status.sort(key=lambda p: p["name"].lower())
+    return make_response(jsonify({"results": results, "providers": provider_status}))

--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -232,6 +232,41 @@ $(function () {
     $("#identifier-table").append(line);
   }
 
+  function renderProviderStatus(providers) {
+    if (!providers || !providers.length) return "";
+    var STATUS_COPY = {
+      ok:           { cls: "text-success",  icon: "ok-circle"   },
+      empty:        { cls: "text-muted",    icon: "minus-sign"  },
+      rate_limited: { cls: "text-warning",  icon: "time"        },
+      blocked:      { cls: "text-danger",   icon: "ban-circle"  },
+      missing_key:  { cls: "text-warning",  icon: "lock"        },
+      error:        { cls: "text-danger",   icon: "exclamation-sign" },
+      disabled:     { cls: "text-muted",    icon: "off"         }
+    };
+    var visible = providers.filter(function (p) { return p.status !== "disabled"; });
+    if (!visible.length) return "";
+    var html = '<div class="provider-status" style="margin-bottom:10px; font-size:90%;">';
+    visible.forEach(function (p) {
+      var spec = STATUS_COPY[p.status] || STATUS_COPY.error;
+      var label;
+      if (p.status === "ok") {
+        label = p.count + " result" + (p.count === 1 ? "" : "s");
+      } else if (p.status === "empty") {
+        label = p.message || "no results";
+      } else {
+        label = p.message || p.status;
+      }
+      html +=
+        '<div class="' + spec.cls + '">' +
+          '<span class="glyphicon glyphicon-' + spec.icon + '" aria-hidden="true"></span> ' +
+          '<strong>' + p.name + '</strong>: ' + $('<div>').text(label).html() +
+          (p.duration_ms ? ' <span class="text-muted">(' + p.duration_ms + ' ms)</span>' : '') +
+        '</div>';
+    });
+    html += "</div>";
+    return html;
+  }
+
   function doSearch(keyword) {
     if (keyword) {
       $("#meta-info").text(msg.loading);
@@ -244,9 +279,15 @@ $(function () {
         },
         dataType: "json",
         success: function success(data) {
-          if (data.length) {
-            $("#meta-info").html('<ul id="book-list" class="media-list"></ul>');
-            data.forEach(function (book, idx) {
+          // Tolerate both the new {results, providers} shape and the older
+          // bare-array shape (in case a stale cached JS hits a new server).
+          var results  = (data && data.results)   ? data.results   : (Array.isArray(data) ? data : []);
+          var providers = (data && data.providers) ? data.providers : [];
+          var providerHtml = renderProviderStatus(providers);
+
+          if (results.length) {
+            $("#meta-info").html(providerHtml + '<ul id="book-list" class="media-list"></ul>');
+            results.forEach(function (book, idx) {
               var $book = $(templates.bookResult({ book: book, index: idx }));
               $book.find("button").on("click", function () {
                 populateForm(book, idx);
@@ -256,10 +297,8 @@ $(function () {
             });
           } else {
             $("#meta-info").html(
-              '<p class="text-danger">' +
-                msg.no_result +
-                "!</p>" +
-                $("#meta-info")[0].innerHTML
+              providerHtml +
+              '<p class="text-danger">' + msg.no_result + "!</p>"
             );
           }
         },
@@ -358,6 +397,104 @@ $(function () {
       $(this).data("initial", $(this).prop("checked"));
     });
     doSearch(keyword);
+  });
+
+  function renderKeysPanel(entries) {
+    if (!entries || !entries.length) {
+      $("#meta-keys-list").html('<p class="text-muted">' + _("No key-supporting providers found.") + "</p>");
+      return;
+    }
+    var $list = $("<div></div>");
+    entries.forEach(function (entry) {
+      var inputId = "meta-key-input-" + entry.id;
+      var statusBadge = entry.configured
+        ? '<span class="label label-success">' + _("Configured") + "</span>"
+        : '<span class="label label-default">' + _("Not configured") + "</span>";
+      var actionButton = entry.can_edit
+        ? '<button type="button" class="btn btn-primary btn-sm meta-key-save" data-provider="' + entry.id + '">' + _("Save") + "</button>"
+        : '<span class="text-muted">' + _("Admin only") + "</span>";
+      var inputAttrs = entry.can_edit ? "" : ' disabled';
+      var placeholder = entry.configured
+        ? _("Leave blank to keep the existing key, or paste a new one to replace it. Type 'clear' to remove.")
+        : _("Paste your API key here");
+      var row = $(
+        '<div class="meta-key-row" style="margin-bottom:14px; padding-bottom:14px; border-bottom:1px solid rgba(255,255,255,.07);">' +
+          '<div style="margin-bottom:6px;">' +
+            '<strong>' + entry.name + '</strong> ' + statusBadge +
+            ' &middot; <a href="' + entry.signup + '" target="_blank" rel="noopener">' + _("Get key") + ' &rarr;</a>' +
+          '</div>' +
+          '<div class="text-muted" style="font-size:88%; margin-bottom:6px;">' + entry.help + '</div>' +
+          '<div class="input-group">' +
+            '<input type="text" class="form-control meta-key-input" id="' + inputId + '" placeholder="' + placeholder + '" autocomplete="off"' + inputAttrs + '>' +
+            '<span class="input-group-btn">' + actionButton + '</span>' +
+          '</div>' +
+          '<div class="meta-key-feedback text-success" style="display:none; margin-top:6px;"></div>' +
+        '</div>'
+      );
+      $list.append(row);
+    });
+    $("#meta-keys-list").empty().append($list);
+  }
+
+  function loadKeysPanel() {
+    $.ajax({
+      url: getPath() + "/metadata/keys",
+      type: "GET",
+      dataType: "json",
+      success: renderKeysPanel,
+      error: function () {
+        $("#meta-keys-list").html('<p class="text-danger">' + _("Failed to load API key inventory.") + "</p>");
+      }
+    });
+  }
+
+  $(document).on("click", "#meta-keys-toggle", function () {
+    var $panel = $("#meta-keys-panel");
+    var willShow = $panel.is(":hidden");
+    $(this).attr("aria-expanded", willShow ? "true" : "false");
+    if (willShow) {
+      $panel.show();
+      loadKeysPanel();
+    } else {
+      $panel.hide();
+    }
+  });
+
+  $(document).on("click", ".meta-key-save", function () {
+    var $btn = $(this);
+    var providerId = $btn.data("provider");
+    var $row = $btn.closest(".meta-key-row");
+    var $input = $row.find(".meta-key-input");
+    var $feedback = $row.find(".meta-key-feedback");
+    var raw = ($input.val() || "").trim();
+    if (!raw) {
+      $feedback.removeClass("text-success").addClass("text-danger")
+        .text(_("Enter a key, or type 'clear' to remove an existing one.")).show();
+      return;
+    }
+    var payloadValue = (raw.toLowerCase() === "clear") ? "" : raw;
+    $btn.prop("disabled", true).text("…");
+    $.ajax({
+      url: getPath() + "/metadata/keys/" + providerId,
+      type: "POST",
+      contentType: "application/json; charset=utf-8",
+      data: JSON.stringify({ value: payloadValue, csrf_token: $('input[name="csrf_token"]').val() }),
+      headers: { "X-CSRFToken": $('input[name="csrf_token"]').val() },
+      dataType: "json",
+      success: function (resp) {
+        $input.val("");
+        $feedback.removeClass("text-danger").addClass("text-success")
+          .text(resp.configured ? _("Key saved.") : _("Key cleared."))
+          .show();
+        // Refresh the inventory so the badge re-renders.
+        loadKeysPanel();
+      },
+      error: function (xhr) {
+        var msgText = (xhr.responseJSON && xhr.responseJSON.error) || _("Save failed.");
+        $feedback.removeClass("text-success").addClass("text-danger").text(msgText).show();
+        $btn.prop("disabled", false).text(_("Save"));
+      }
+    });
   });
 
   $("#get_meta").click(function () {

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -283,6 +283,20 @@
         </div>
         <div class="text-center padded-bottom" id="metadata_provider">
         </div>
+        <div class="text-center padded-bottom">
+          <button type="button" class="btn btn-default btn-xs" id="meta-keys-toggle" aria-expanded="false" aria-controls="meta-keys-panel">
+            <span class="glyphicon glyphicon-lock" aria-hidden="true"></span>
+            {{_('API Keys')}}
+          </button>
+        </div>
+        <div id="meta-keys-panel" class="panel panel-default" style="display:none; margin-bottom:15px;" role="region" aria-labelledby="meta-keys-toggle">
+          <div class="panel-body">
+            <p class="text-muted" style="margin-bottom:10px;">
+              {{_('Some metadata sources need an API key. Adding a key here improves cover quality and unblocks rate-limited services. Keys are stored once for the whole instance — admins only.')}}
+            </p>
+            <div id="meta-keys-list">{{_("Loading...")}}</div>
+          </div>
+        </div>
 
         <div id="meta-info">
           {{_("Loading...")}}

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -241,7 +241,13 @@
       <div class="form-group">
         <label for="config_hardcover_token">{{_('Hardcover API Key')}}</label>
         <input type="text" class="form-control" id="config_hardcover_token" name="config_hardcover_token" value="{% if config.config_hardcover_token != None %}{{ config.config_hardcover_token }}{% endif %}" autocomplete="off">
+        <div class="help-block">{{_('Free key from https://hardcover.app/account/api — required for Hardcover metadata results.')}}</div>
       </div>
+    </div>
+    <div class="form-group">
+      <label for="config_google_books_api_key">{{_('Google Books API Key')}}</label>
+      <input type="text" class="form-control" id="config_google_books_api_key" name="config_google_books_api_key" value="{% if config.config_google_books_api_key != None %}{{ config.config_google_books_api_key }}{% endif %}" autocomplete="off">
+      <div class="help-block">{{_('Optional. Without a key, Google Books is rate-limited to ~1,000 requests / IP / day, which is easily exhausted on shared servers (HTTP 429). Free key at https://console.cloud.google.com — enable the "Books API" and create an API key.')}}</div>
     </div>
     <div class="form-group">
       <input type="checkbox" id="config_allow_reverse_proxy_header_login" name="config_allow_reverse_proxy_header_login" data-control="reverse-proxy-login-settings" {% if config.config_allow_reverse_proxy_header_login %}checked{% endif %}>


### PR DESCRIPTION
## Why

Live diagnosis of the running CWA-NG instance on teenyverse for an English
query \`Animal Farm george orwell\` reveals **zero candidates from any
provider**:

- Amazon → HTTP 503 (Amazon blocks scraping from cloud/data-center IPs).
- Google Books → HTTP 429 (anonymous quota = 1k req/IP/day).
- Hardcover → silent return (token not configured).
- Litres / DNB / Douban / LubimyCzytac → foreign-language only.

The "No Result(s) found!" message in the modal hides all of this.

## What

| Change | Files |
|---|---|
| New **Open Library** provider — free, no key, covers most of the gap | \`cps/metadata_provider/openlibrary.py\` |
| **Google Books API key** support (config column + admin UI + provider) | \`cps/config_sql.py\`, \`cps/admin.py\`, \`cps/templates/config_edit.html\`, \`cps/metadata_provider/google.py\` |
| Restructure \`/metadata/search\` to return \`{results, providers}\` with per-provider status, count, duration_ms, and a user-facing message | \`cps/search_metadata.py\` |
| New \`/metadata/keys\` GET (inventory, never echoes the secret) and POST (admin-only set/clear) | \`cps/search_metadata.py\` |
| In-modal **API Keys panel** — gear button next to providers, save key without leaving the modal | \`cps/templates/book_edit.html\`, \`cps/static/js/get_meta.js\` |
| Per-provider status renderer in the modal so users see *why* a source is silent | \`cps/static/js/get_meta.js\` |
| \`CWA_METADATA_DEBUG=1\` env knob — bumps every \`cps.metadata_provider.*\` logger to DEBUG | \`cps/search_metadata.py\` |
| Design doc | \`notes/COVERFETCH-DESIGN.md\` |
| 31 new regression checks | \`tests/autopilot/test_cover_fetch_overhaul.sh\` |

## Verified

- Open Library live API returns 219 hits for the failing query; 330×500 covers via \`covers.openlibrary.org/b/id/{id}-L.jpg\`.
- All Python compiles, JS parses, Jinja templates parse.
- 31/31 new regression checks pass.
- 16/16 existing autopilot tests still pass.
- Open Library auto-registers (drop-in module loads via existing scanner in \`cps/search_metadata.py\`).
- API-keys endpoint never returns the raw secret — UI gets only a \`configured\` boolean.
- Admin gate on POST.

## Smoke test on teenyverse

Will deploy and re-run the failing search on the live instance once merged.

## Out of scope (deliberate)

- Amazon proxy / PA-API integration (out of scope, paid + ToS).
- ISBNdb integration (paid).
- Goodreads — their dev API was discontinued in 2020.
- DNB cover URL SSL-EOF fix (separate finding, follow-up PR).