### PR TITLE
fix(isoLanguages): tolerate None and string locales (unblocks DNB + hardens every provider)

### DIFF
--- a/cps/isoLanguages.py
+++ b/cps/isoLanguages.py
@@ -37,9 +37,32 @@ except ImportError as ex:
 
 
 def get_language_names(locale):
+    """Resolve the localised language-name dictionary for *locale*.
+
+    Tolerates None, strings (e.g. "en", "en_US", "eng"), and babel.core.Locale
+    instances. Background-fetch paths (auto_metadata, scheduled jobs) and
+    one-off provider invocations frequently pass None or a bare string; the
+    previous implementation crashed with AttributeError because
+    locale.language was accessed unguarded on those.
+    """
+    if locale is None:
+        return None
+    if isinstance(locale, str):
+        # Direct match first ("en"), then leading 2-letter component for
+        # composites like "en_US" / "en-GB".
+        names = _LANGUAGE_NAMES.get(locale)
+        if names is None:
+            head = locale.split("_", 1)[0].split("-", 1)[0]
+            if head and head != locale:
+                names = _LANGUAGE_NAMES.get(head)
+        return names
+    # babel.core.Locale (or any object with .language): try str() first
+    # ("en_US") then the bare .language attribute ("en").
     names = _LANGUAGE_NAMES.get(str(locale))
     if names is None:
-        names = _LANGUAGE_NAMES.get(locale.language)
+        lang_attr = getattr(locale, "language", None)
+        if lang_attr:
+            names = _LANGUAGE_NAMES.get(lang_attr)
     return names
 
 
@@ -47,7 +70,8 @@ def get_language_name(locale, lang_code):
     UNKNOWN_TRANSLATION = "Unknown"
     names = get_language_names(locale)
     if names is None:
-        log.error(f"Missing language names for locale: {str(locale)}/{locale.language}")
+        # Don't probe locale.language here — locale may be None or str.
+        log.warning("No language-names dictionary for locale: %r", locale)
         return UNKNOWN_TRANSLATION
 
     name = names.get(lang_code, UNKNOWN_TRANSLATION)

--- a/tests/smoke/test_iso_languages_locale_smoke.py
+++ b/tests/smoke/test_iso_languages_locale_smoke.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for cps.isoLanguages.get_language_name(s).
+
+The previous implementation crashed with
+    AttributeError: 'NoneType' object has no attribute 'language'
+when called with a None locale (background-fetch / scheduler paths) or with
+a string locale that did not exactly match a key in _LANGUAGE_NAMES (e.g.
+"en_US"). This affected every metadata provider that resolved a language
+name — DNB was the loud one.
+
+These tests pin the contract: "any input, no exception; missing data is
+returned as 'Unknown' or None".
+"""
+
+import pytest
+
+from cps import isoLanguages
+
+
+# ---------------------------------------------------------------------------
+# get_language_names() — must never raise on bad locale input.
+# ---------------------------------------------------------------------------
+
+class _FakeLocale:
+    """Minimal stand-in for babel.core.Locale."""
+    def __init__(self, value, language):
+        self._value = value
+        self.language = language
+
+    def __str__(self):
+        return self._value
+
+
+@pytest.mark.parametrize(
+    "locale,should_be_dict",
+    [
+        # Happy paths ---------------------------------------------------------
+        ("en",                 True),
+        (_FakeLocale("en_US", "en"), True),   # str() doesn't match, .language does
+        (_FakeLocale("en", "en"),    True),   # str() matches directly
+        # Defensive paths -----------------------------------------------------
+        (None,                 False),       # used to raise; must return None
+        ("en_US",              True),        # composite must fall back to "en"
+        ("en-GB",              True),        # hyphen variant must fall back to "en"
+        ("eng",                False),       # unknown 3-letter code must return None
+        ("",                   False),       # empty string must return None
+        (_FakeLocale("zz_ZZ", None),    False),  # unknown locale, no .language
+        (_FakeLocale("zz_ZZ", "zz"),    False),  # unknown locale + unknown lang
+    ],
+)
+def test_get_language_names_tolerates_arbitrary_input(locale, should_be_dict):
+    result = isoLanguages.get_language_names(locale)
+    if should_be_dict:
+        assert isinstance(result, dict) and result, \
+            f"expected a non-empty dict for locale={locale!r}, got {result!r}"
+    else:
+        assert result is None, \
+            f"expected None for locale={locale!r}, got {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# get_language_name() — never raise; return "Unknown" on bad input.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("locale", [None, "", "garbage", "eng"])
+def test_get_language_name_returns_unknown_for_bad_locale(locale):
+    # Smoke: the call must not raise (was AttributeError pre-fix).
+    out = isoLanguages.get_language_name(locale, "ger")
+    assert out == "Unknown"
+
+
+def test_get_language_name_resolves_with_string_locale():
+    out = isoLanguages.get_language_name("en", "ger")
+    assert out and out != "Unknown"
+
+
+def test_get_language_name_resolves_with_composite_locale_string():
+    """en_US must fall back to en."""
+    out = isoLanguages.get_language_name("en_US", "ger")
+    assert out and out != "Unknown"
+
+
+def test_get_language_name_resolves_with_locale_object():
+    """babel.core.Locale-like objects keep working."""
+    out = isoLanguages.get_language_name(_FakeLocale("en_US", "en"), "ger")
+    assert out and out != "Unknown"
+
+
+def test_get_language_name_unknown_lang_code_returns_unknown_not_raise():
+    out = isoLanguages.get_language_name("en", "totallymadeupcode")
+    assert out == "Unknown"


### PR DESCRIPTION
## Root cause

\`cps/isoLanguages.py:get_language_names\` accessed \`locale.language\` unguarded on the fallback branch:

\`\`\`python
def get_language_names(locale):
    names = _LANGUAGE_NAMES.get(str(locale))
    if names is None:
        names = _LANGUAGE_NAMES.get(locale.language)   # ← AttributeError when locale is None or str
    return names
\`\`\`

That crashed every code path that called the function with:

- **\`None\`** — anything outside a Flask request context. \`cps/auto_metadata.py:124\` is one such caller (background metadata fetcher); my own diagnostic scripts triggered the same path.
- **A string locale that didn't exactly match a 28-key dict** — e.g. \`"en_US"\`, \`"en-GB"\`, \`"eng"\`. Strings don't have \`.language\`.

DNB was the loud victim because it iterates every record's MARC21 041 field through this function and a single bad locale aborts the whole record loop. Open Library / Litres / Kobo etc were silently susceptible to the same crash on the wrong inputs.

\`\`\`
[2026-05-02] WARN cps.metadata_provider.dnb DNB search error: 'NoneType' object has no attribute 'language'
\`\`\`

## Fix

Single defensive entry point. No provider changes needed:

| Input | Before | After |
|---|---|---|
| \`None\` | AttributeError | \`None\` |
| \`'en'\` | dict | dict |
| \`'en_US'\` | AttributeError | en dict (composite-locale fallback) |
| \`'en-GB'\` | AttributeError | en dict (hyphen-variant fallback) |
| \`'eng'\` | AttributeError | \`None\` (defensive) |
| \`Locale('en_US')\` | en dict | en dict (regression-tested) |

\`get_language_name\` no longer dereferences \`locale.language\` in its failure-log line either — that was the second crash site.

## Verified end-to-end on the running instance

\`\`\`text
DNB search('Animal Farm george orwell', '', 'en') -> 2 records (was: 0 + AttributeError)
get_language_names(None)     -> None      (was: AttributeError)
get_language_names('en_US')  -> en dict   (was: AttributeError)
get_language_names('en-GB')  -> en dict   (was: AttributeError)
get_language_names('eng')    -> None      (was: AttributeError)
get_language_name(None, 'ger') -> 'Unknown' (was: AttributeError)
\`\`\`

## Tests

- \`tests/smoke/test_iso_languages_locale_smoke.py\` — 11 parametrised pytest cases pinning the contract.
- \`tests/autopilot/test_iso_languages_locale_guard.sh\` — 10 source-level guards making sure the unguarded \`locale.language\` access never returns.

Both green; full autopilot suite (17 files now) green.

## Out of scope (deliberately)

- DNB cover-URL SSL-EOF errors against \`portal.dnb.de\` — separate finding, doesn't crash the record loop now that this fix is in.
- 3-letter ISO codes (\`'eng'\`) returning \`None\` — by design; if the operator wants 3-letter resolution, that's a feature, not a bug fix.