### PR TITLE
feat(metadata): cover-resolution booster + sort-by-cover-size in fetch dialog

### DIFF
--- a/cps/metadata_provider/google.py
+++ b/cps/metadata_provider/google.py
@@ -6,6 +6,7 @@
 # See CONTRIBUTORS for full list of authors.
 
 # Google Books api document: https://developers.google.com/books/docs/v1/using
+import re
 from typing import Dict, List, Optional
 from urllib.parse import quote
 from datetime import datetime
@@ -115,19 +116,41 @@ class Google(Metadata):
 
     @staticmethod
     def _parse_cover(result: Dict, generic_cover: str) -> str:
-        if result["volumeInfo"].get("imageLinks"):
-            cover_url = result["volumeInfo"]["imageLinks"]["thumbnail"]
-            
-            # strip curl in cover
-            cover_url = cover_url.replace("&edge=curl", "")
-            
-            # Request a cover sized for high-DPI e-readers (Kobo Libra Color
-            # is 1264x1680). Google Books returns the source image when the
-            # requested fife dimensions exceed what's available.
-            cover_url += "&fife=w1280-h1920"
-            
-            return cover_url.replace("http://", "https://")
-        return generic_cover
+        image_links = result["volumeInfo"].get("imageLinks") or {}
+        if not image_links:
+            return generic_cover
+
+        # Prefer the largest source URL Google supplies; thumbnail is the
+        # smallest. extraLarge is rarely present but worth checking when it is.
+        cover_url = (
+            image_links.get("extraLarge")
+            or image_links.get("large")
+            or image_links.get("medium")
+            or image_links.get("small")
+            or image_links.get("thumbnail")
+            or image_links.get("smallThumbnail")
+        )
+        if not cover_url:
+            return generic_cover
+
+        # Strip the small-thumbnail decorations Google injects by default.
+        cover_url = cover_url.replace("&edge=curl", "")
+        cover_url = re.sub(r"&zoom=\d+", "", cover_url)
+
+        # fife=w<W>-h<H> asks the Google Books image proxy for that size.
+        # Google returns the source image when the requested dimensions
+        # exceed what's available, so a generous request is a strict win.
+        # 1600x2400 covers the Kobo Libra Color (1264x1680) plus 2x retina
+        # phone/tablet displays without forcing a browser upscale.
+        if "fife=" in cover_url:
+            cover_url = re.sub(
+                r"fife=w\d+(?:-h\d+)?", "fife=w1600-h2400", cover_url
+            )
+        else:
+            sep = "&" if "?" in cover_url else "?"
+            cover_url = f"{cover_url}{sep}fife=w1600-h2400"
+
+        return cover_url.replace("http://", "https://")
 
     @staticmethod
     def _parse_languages(result: Dict, locale: str) -> List[str]:

--- a/cps/metadata_provider/hardcover.py
+++ b/cps/metadata_provider/hardcover.py
@@ -184,6 +184,18 @@ class Hardcover(Metadata):
             if "data" not in response_data:
                 log.warning("Invalid response structure: missing 'data' field")
                 return []
+        except requests.exceptions.HTTPError as e:
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            if status == 401:
+                log.warning(
+                    "Hardcover rejected the saved token (HTTP 401 'Unable to verify token'). "
+                    "The configured value is not a valid Hardcover API token. "
+                    "Generate a fresh one at https://hardcover.app/account/api and paste it "
+                    "into Admin > Basic Configuration > Hardcover API Key (or the per-user field)."
+                )
+            else:
+                log.warning(f"HTTP request failed: {e}")
+            return []
         except requests.exceptions.RequestException as e:
             log.warning(f"HTTP request failed: {e}")
             return []

--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -19,6 +19,7 @@ from sqlalchemy.exc import InvalidRequestError, OperationalError
 from sqlalchemy.orm.attributes import flag_modified
 
 from cps.services.Metadata import Metadata
+from cps.services.cover_booster import boost_covers
 from . import config, constants, logger, ub, web_server
 from .usermanagement import user_login_required
 
@@ -376,4 +377,13 @@ def metadata_search():
     # Stable sort so rendering is deterministic even though futures complete
     # out of order.
     provider_status.sort(key=lambda p: p["name"].lower())
+
+    # Upgrade thumbnail-sized covers to high-DPI variants (Kobo Libra Color
+    # etc.) by ISBN/title lookup against iTunes Search API. No-op when the
+    # cover is already known to be high-res or no ISBN/title match exists.
+    try:
+        boost_covers(results)
+    except Exception as exc:  # pragma: no cover - defensive: never break search
+        log.warning("cover boost pass failed: %s", exc)
+
     return make_response(jsonify({"results": results, "providers": provider_status}))

--- a/cps/services/cover_booster.py
+++ b/cps/services/cover_booster.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Cover-resolution booster for metadata-search results.
+
+Many providers serve thumbnail-sized cover URLs (Hardcover ~290x475, Open
+Library "-L" ~500x..., Google Books default ~128 wide). High-DPI e-readers
+like the Kobo Libra Color (1264x1680) need ~1500px-wide covers to render
+crisply. This module takes the aggregated MetaRecord list from
+search_metadata.metadata_search() and, in parallel, looks up a higher-res
+alternative for each record, replacing record.cover when one is found.
+
+Sources tried, in order, per record:
+
+  1. iTunes Search API (https://itunes.apple.com/lookup or /search) -
+     free, no API key, returns artworkUrl100 which we rewrite to
+     1500x1500bb.jpg. Works for the long tail of trade fiction / non-
+     fiction sold on Apple Books.
+  2. Amazon `_SL1500_` URL rewrite - if the record cover is already an
+     Amazon m.media-amazon.com asset with a sizing token, swap to
+     _SL1500_ to pull the full-resolution variant.
+
+Disable globally with env CWA_COVER_BOOST=0. Tuning knobs:
+
+  CWA_COVER_BOOST_TIMEOUT  - per-lookup HTTP timeout, seconds (default 4)
+  CWA_COVER_BOOST_WORKERS  - thread pool size for parallel lookups (default 8)
+  CWA_COVER_BOOST_MAX      - cap on records boosted per request (default 30)
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import os
+import re
+from typing import Dict, Iterable, List, Optional
+from urllib.parse import quote_plus
+
+import requests
+
+from .. import constants, logger
+
+
+log = logger.create()
+
+
+_DEFAULT_TIMEOUT = float(os.environ.get("CWA_COVER_BOOST_TIMEOUT", "4"))
+_DEFAULT_WORKERS = int(os.environ.get("CWA_COVER_BOOST_WORKERS", "8"))
+_DEFAULT_MAX = int(os.environ.get("CWA_COVER_BOOST_MAX", "30"))
+
+# Patterns that indicate the cover URL is already high-res - skip work.
+_HIGHRES_HINTS = (
+    "_SL1500_", "_SL2000_", "1500x1500bb", "2400x2400bb", "fife=w1600",
+    "fife=w2000", "fife=w2400",
+)
+
+# Amazon dynamic-image sizing token: ._SX475_., ._SY450_., ._UL320_., etc.
+_AMAZON_SIZE_TOKEN = re.compile(r"\._(?:S[XLY]|UL|UY|UX|CR|AC|FM)\d+(?:_,\d+,\d+,\d+,\d+)?_\.")
+
+
+def boost_covers(records: List[Dict]) -> List[Dict]:
+    """Mutate each MetaRecord-as-dict in place, upgrading record["cover"] when a
+    higher-resolution variant can be found. Returns the same list for chaining.
+
+    Inputs are dicts (post-asdict()) keyed like MetaRecord: title, authors,
+    identifiers (with optional 'isbn'), cover, source, etc. Records with no
+    title or no cover are skipped.
+    """
+    if os.environ.get("CWA_COVER_BOOST", "1").lower() in ("0", "false", "no", "off"):
+        return records
+    if not records:
+        return records
+
+    candidates: List[Dict] = []
+    for rec in records:
+        if not isinstance(rec, dict):
+            continue
+        cover = rec.get("cover") or ""
+        if not rec.get("title") or not cover:
+            continue
+        if any(h in cover for h in _HIGHRES_HINTS):
+            continue
+        candidates.append(rec)
+        if len(candidates) >= _DEFAULT_MAX:
+            break
+
+    if not candidates:
+        return records
+
+    workers = max(1, min(_DEFAULT_WORKERS, len(candidates)))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(_boosted_cover_for, rec): rec for rec in candidates}
+        for future in concurrent.futures.as_completed(futures):
+            rec = futures[future]
+            try:
+                upgraded = future.result()
+            except Exception as exc:  # pragma: no cover - defensive
+                log.debug("cover boost: lookup failed for %r: %s", rec.get("title"), exc)
+                continue
+            if upgraded:
+                log.debug(
+                    "cover boost: %s -> %s (was %s)",
+                    rec.get("title"), upgraded, rec.get("cover"),
+                )
+                rec["cover"] = upgraded
+    return records
+
+
+def _boosted_cover_for(record: Dict) -> Optional[str]:
+    """Return a higher-resolution cover URL for ``record`` or None."""
+    title = (record.get("title") or "").strip()
+    authors = record.get("authors") or []
+    primary_author = (authors[0] if authors else "") or ""
+    isbn = _isbn_from(record.get("identifiers") or {})
+
+    # Path 1: iTunes lookup by ISBN. Apple's catalog occasionally cross-
+    # references unrelated books to the same ISBN (collections, omnibuses,
+    # mis-tagged anthologies), so we still verify the returned trackName
+    # matches the record's title before swapping the cover.
+    if isbn and title:
+        result = _itunes_lookup_isbn(isbn)
+        if result and _itunes_result_matches(title, primary_author, result):
+            url = _itunes_artwork(result)
+            if url:
+                return url
+
+    # Path 2: iTunes search by title + first author.
+    if title:
+        result = _itunes_search(title, primary_author)
+        if result and _itunes_result_matches(title, primary_author, result):
+            url = _itunes_artwork(result)
+            if url:
+                return url
+
+    # Path 3: Amazon URL rewrite (works only if the current cover is already
+    # an Amazon image but at a small sizing token).
+    current = record.get("cover") or ""
+    if "m.media-amazon.com/images/" in current or "ssl-images-amazon.com/images/" in current:
+        rewritten = _AMAZON_SIZE_TOKEN.sub("._SL1500_.", current)
+        if rewritten != current:
+            return rewritten
+
+    return None
+
+
+def _isbn_from(identifiers: Dict) -> Optional[str]:
+    for key in ("isbn", "isbn_13", "isbn13", "isbn_10", "isbn10"):
+        val = identifiers.get(key)
+        if val:
+            digits = re.sub(r"[^0-9Xx]", "", str(val))
+            if len(digits) in (10, 13):
+                return digits
+    return None
+
+
+def _itunes_lookup_isbn(isbn: str) -> Optional[Dict]:
+    try:
+        resp = requests.get(
+            "https://itunes.apple.com/lookup",
+            params={"isbn": isbn, "country": "us", "media": "ebook"},
+            headers={"User-Agent": getattr(constants, "USER_AGENT", "Calibre-Web")},
+            timeout=_DEFAULT_TIMEOUT,
+        )
+        resp.raise_for_status()
+        payload = resp.json() or {}
+    except (requests.RequestException, ValueError):
+        return None
+    results = payload.get("results") or []
+    return results[0] if results else None
+
+
+def _itunes_search(title: str, author: str) -> Optional[Dict]:
+    term = f"{title} {author}".strip()
+    if not term:
+        return None
+    try:
+        resp = requests.get(
+            "https://itunes.apple.com/search",
+            params={
+                "term": term,
+                "country": "us",
+                "media": "ebook",
+                "entity": "ebook",
+                "limit": 3,
+            },
+            headers={"User-Agent": getattr(constants, "USER_AGENT", "Calibre-Web")},
+            timeout=_DEFAULT_TIMEOUT,
+        )
+        resp.raise_for_status()
+        payload = resp.json() or {}
+    except (requests.RequestException, ValueError):
+        return None
+    # Apple occasionally returns audiobook/wrapper entries despite media=ebook.
+    for result in payload.get("results") or []:
+        kind = result.get("kind") or result.get("wrapperType")
+        if kind in ("ebook", "audiobook"):
+            return result
+    return None
+
+
+def _itunes_result_matches(query_title: str, query_author: str, result: Dict) -> bool:
+    """Conservative fuzzy check that the iTunes hit is for the same book.
+
+    Avoids replacing covers with unrelated images when the search engine
+    returns a loose match. Title token overlap >=70% with first 6 tokens.
+    """
+    if not result:
+        return False
+    track = (result.get("trackName") or result.get("collectionName") or "").lower()
+    if not track:
+        return False
+    qtokens = _tokenize(query_title)[:6]
+    if not qtokens:
+        return False
+    rtokens = set(_tokenize(track))
+    overlap = sum(1 for t in qtokens if t in rtokens) / float(len(qtokens))
+    if overlap < 0.7:
+        return False
+    if query_author:
+        artist = (result.get("artistName") or "").lower()
+        atokens = _tokenize(query_author)
+        if atokens and not any(t in artist for t in atokens):
+            return False
+    return True
+
+
+def _tokenize(text: str) -> List[str]:
+    return [tok for tok in re.split(r"[^a-z0-9]+", (text or "").lower()) if len(tok) > 2]
+
+
+def _itunes_artwork(result: Optional[Dict]) -> Optional[str]:
+    """Extract artwork URL from an iTunes result and upgrade to 1500px.
+
+    iTunes returns artworkUrl100 / artworkUrl60 with a path segment like
+    ``100x100bb.jpg``; their CDN serves arbitrary sizes when you replace
+    that segment. 1500x1500bb is the sweet spot for Kobo Libra Color.
+    """
+    if not result:
+        return None
+    art = (
+        result.get("artworkUrl100")
+        or result.get("artworkUrl512")
+        or result.get("artworkUrl60")
+        or result.get("artworkUrl30")
+    )
+    if not art:
+        return None
+    upgraded = re.sub(r"/\d+x\d+bb\.jpg$", "/1500x1500bb.jpg", art)
+    upgraded = re.sub(r"/\d+x\d+bb\.png$", "/1500x1500bb.png", upgraded)
+    return upgraded if upgraded.startswith("http") else None

--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -295,7 +295,13 @@ $(function () {
               applyMetaSelections($book);
               $("#book-list").append($book);
             });
+            // Reveal the sort dropdown and reset to default ordering on every
+            // fresh search so users start from a known state.
+            $("#meta-sort").val("default");
+            window.__metaSortMode = "default";
+            $("#meta-sort-bar").show();
           } else {
+            $("#meta-sort-bar").hide();
             $("#meta-info").html(
               providerHtml +
               '<p class="text-danger">' + msg.no_result + "!</p>"

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -298,6 +298,15 @@
           </div>
         </div>
 
+        <div id="meta-sort-bar" class="text-right" style="display:none; margin-bottom:8px;">
+          <label for="meta-sort" style="margin-right:6px; font-weight:normal;">{{_('Sort by:')}}</label>
+          <select id="meta-sort" class="form-control input-sm" style="display:inline-block; width:auto;">
+            <option value="default">{{_('Provider order (default)')}}</option>
+            <option value="cover_desc">{{_('Cover size — largest first')}}</option>
+            <option value="cover_asc">{{_('Cover size — smallest first')}}</option>
+          </select>
+        </div>
+
         <div id="meta-info">
           {{_("Loading...")}}
         </div>
@@ -312,7 +321,7 @@
 
 {% block js %}
 <script type="text/template" id="template-book-result">
-  <li class="media" data-related="<%= book.source.id %>">
+  <li class="media" data-related="<%= book.source.id %>" data-meta-index="<%= index %>">
     <div class="media-image">
       <div class="media-image-wrapper">
         <img
@@ -408,12 +417,47 @@
   function coverDimensions(el) {
     var existing_cover = document.querySelector("#detailcover")
     el.nextElementSibling.innerText = el.naturalWidth + 'x' + el.naturalHeight
-    if (existing_cover.naturalHeight*existing_cover.naturalWidth >  el.naturalWidth * el.naturalHeight){
+    if (existing_cover && existing_cover.naturalHeight*existing_cover.naturalWidth >  el.naturalWidth * el.naturalHeight){
       el.nextElementSibling.classList.add("smaller")
-    } else if (existing_cover.naturalHeight*existing_cover.naturalWidth < el.naturalWidth * el.naturalHeight){
+    } else if (existing_cover && existing_cover.naturalHeight*existing_cover.naturalWidth < el.naturalWidth * el.naturalHeight){
       el.nextElementSibling.classList.add("larger")
     }
+    var li = el.closest('li.media');
+    if (li) {
+      li.dataset.coverPixels = el.naturalWidth * el.naturalHeight;
+      // If the modal is currently sorted by cover size, re-apply on each
+      // image-load so cards float into place as their dimensions resolve.
+      if (window.__metaSortMode && window.__metaSortMode !== 'default') {
+        applyMetaSort();
+      }
+    }
   }
+  function applyMetaSort() {
+    var mode = window.__metaSortMode || 'default';
+    var list = document.getElementById('book-list');
+    if (!list) return;
+    var items = Array.prototype.slice.call(list.querySelectorAll('li.media'));
+    if (!items.length) return;
+    if (mode === 'default') {
+      items.sort(function (a, b) {
+        return parseInt(a.dataset.metaIndex || '0', 10) - parseInt(b.dataset.metaIndex || '0', 10);
+      });
+    } else {
+      items.sort(function (a, b) {
+        var ap = parseInt(a.dataset.coverPixels || '0', 10);
+        var bp = parseInt(b.dataset.coverPixels || '0', 10);
+        // Items missing a cover (pixels=0) always sink to the bottom.
+        if (ap === 0 && bp !== 0) return 1;
+        if (bp === 0 && ap !== 0) return -1;
+        return mode === 'cover_desc' ? (bp - ap) : (ap - bp);
+      });
+    }
+    items.forEach(function (li) { list.appendChild(li); });
+  }
+  $(document).on('change', '#meta-sort', function () {
+    window.__metaSortMode = this.value;
+    applyMetaSort();
+  });
   $(document).on('click','.meta_identifier a',
     function (e) {
       e.preventDefault()


### PR DESCRIPTION
Cover booster (iTunes Search API + Amazon SL1500 rewrite), Google Books fife=w1600-h2400, Hardcover 401 hint, and a sort-by-cover-size dropdown in the Fetch Metadata modal. See commit message for full details and test notes.