### PR TITLE
docs: governance + contributing + changes-vs-upstream + extend security

### DIFF
--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -1,0 +1,69 @@
+# Changes vs upstream Calibre-Web-Automated
+
+Tracks every divergence between this fork and `crocodilestick/Calibre-Web-Automated@main` since the fork point. Updated per release.
+
+Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), with a one-line description and the squash-merge SHA.
+
+## Backports (upstream PRs we merged ahead of upstream review)
+
+| Fork PR | Upstream | Author | Description | SHA | Release |
+|---|---|---|---|---|---|
+| #4 | [#1313](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1313) | @ikuma-hiroyuki | i18n(ja) fill empty msgstr + fix existing | `f5fc59a` | v4.0.6 |
+| #5 | [#1291](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1291) | @sinyawskiy | i18n update messages.po | `67dce95` | v4.0.6 |
+| #7 | [#1274](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1274) | @cu0uz | i18n update messages.po | `65ffc90` | v4.0.6 |
+| #8 | [#1305](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1305) | @RFrens | i18n update messages.po | `f1dc937` | v4.0.6 |
+| #9 | [#1267](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1267) | @area57 | i18n update messages.po | `4ebb7ae` | v4.0.6 |
+| #11 | [#1296](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1296) | @julien-noblet | i18n(fr) fix lang | `1e1eca9` | v4.0.6 |
+| #12 | [#1257](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1257) | @lexis11mob | i18n update messages.po | `188a854` | v4.0.6 |
+| #13 | [#1298](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1298) | @rancur | Docker healthcheck `curl -fsL` so `/ → /login` 302 doesn't fail | `653a516` | v4.0.7 |
+| #14 | [#1283](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1283) | @chloeroform | user-profile `fetch()` → `getPath()` for reverse-proxy path prefixes | `a5dd59c` | v4.0.7 |
+| #15 | [#1322](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1322) | @Sycha | `.cbr` / `.cbz` → IANA mimetypes | `fc8ba00` | v4.0.7 |
+| #16 | [#1096](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1096) | @SethMilliken | Safari metadata-search CSRF token | `6721638` | v4.0.7 |
+| #17 | [#1213](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1213) | @hsttlrjeff | Kobo `HandleStateRequest` `.get("Location")` + `last_modified` | `1fd6c50` | v4.0.7 |
+
+## Original fork patches (no upstream PR existed)
+
+### Bug fixes
+
+| Fork PR | Upstream issue | Description | SHA | Release |
+|---|---|---|---|---|
+| #1 | (audit; user-reported #1206 / #1078 / #1097 / #1270 / #1329) | Revert hardcoded Safari skip in `uploadprogress.js` so `$.fn.uploadprogress` stays defined and `main.js` doesn't crash on Safari | `3b7d70c` | v4.0.6 |
+
+### Security
+
+| Fork PR | Upstream issue | Description | SHA | Release |
+|---|---|---|---|---|
+| #18 | [#1303](https://github.com/crocodilestick/Calibre-Web-Automated/issues/1303) | Kobo IDOR: `/kobo_auth/generate_auth_token` + `/deleteauthtoken` reject `current_user.id != user_id` and not admin | `9f50bb2` | v4.0.7 |
+| #19 | (fork audit; private disclosure to upstream) | 14 CWA routes (cwa_logs, convert_library, epub_fixer) gated with `@login_required_if_no_ano + @admin_required` | `09bf581` | v4.0.7 |
+| #20 | (fork audit; private disclosure to upstream) | `cover_enforcer.py` shell-injection: `os.system(f'cp "{title}" ...')` → `shutil.copy` / `shutil.rmtree` | `b70fb53` | v4.0.7 |
+
+### Infrastructure
+
+| Fork PR | Description | SHA | Release |
+|---|---|---|---|
+| #6 | CI: rewrite gating so auto-merge actually waits for green CI | `d7e22c6` | v4.0.6 |
+| #10 | CI: resolve PRs on `workflow_run` via `.pull_requests[]` | `f8fb1ed` | v4.0.6 |
+| #21 | Production-ready GHCR multi-arch release pipeline | `7a26106` | v4.0.7 |
+| #27 | Drop deadsnakes PPA, install Python 3.13 from python-build-standalone | `2e5d781` | v4.0.7 |
+| #28 | Updater: point release check at this fork; only flag true upgrades | `5997519` | v4.0.8 |
+
+### Features (fork-original, not yet upstream)
+
+| Fork PR | Description | SHA | Release |
+|---|---|---|---|
+| #29 | Bump cover resolution for high-DPI e-readers (Libra Color etc.) | `630ee22` | v4.0.9 |
+| #30 | Metadata: Open Library + Google Books API key + per-provider status + in-modal API-key panel | `428530c` | v4.0.9 |
+| #31 | `isoLanguages.get_language_names`: tolerate `None` / string locales (unblocks DNB) | `491af54` | v4.0.10 |
+| #32 | DNB: drop synchronous cover-validation; switch to `<img onerror>` graceful fallback | `dab1589` | v4.0.11 |
+| #33 | Metadata: cover-resolution booster + sort-by-cover-size in fetch dialog | `e5b7666` | v4.0.12 |
+| #34 | docs(readme): user-facing fork front-matter | `aa89fd7` | (docs only) |
+
+## Container image
+
+Published to `ghcr.io/new-usemame/calibre-web-nextgen` instead of upstream's `crocodilestick/calibre-web-automated`. Same data layout, same compose file shape — drop-in swap.
+
+## Mergeable-back guarantee
+
+Every entry in this file's "Backports" section is a clean cherry-pick of an upstream PR with the original author preserved as committer in the squash-merge message. If upstream coordination resumes and the maintainer wants to take any of these back, they can `git cherry-pick <sha>` from this fork's main and the patch will apply cleanly.
+
+For "Original fork patches": the diffs are small and isolated; PR descriptions in this fork link the line-by-line rationale. Upstream is welcome to take them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+Bug reports, fixes, translations, and small features welcome.
+
+## Reporting a bug
+
+[Open an issue](https://github.com/new-usemame/Calibre-Web-NextGen/issues/new). Useful template:
+
+```
+**Version**: v4.0.x (from container env or `/about`)
+**Browser / client**: Safari 17 / Chrome 124 / KOReader 2024.04 / Kobo Libra Color
+**Reverse proxy**: yes/no, with path prefix?
+**Repro steps**:
+1. ...
+2. ...
+**Expected vs actual**: ...
+**Container logs (last 50 lines)**: ...
+```
+
+Bug reports without a version + repro are still useful — we'll just ask follow-ups before we can act on them.
+
+## Submitting a PR
+
+1. Fork → branch off `main` → commit → push → open PR against `main`.
+2. Keep PRs focused on one logical change. A 200-line PR with one purpose merges; a 200-line PR with five purposes stalls.
+3. CI must pass: `Fast Tests`, `validate-author`, `evaluate`, `Test Suite Summary`. Integration + E2E run on Docker-touching changes.
+4. If touching `cps/` Python: add a unit test for the change (look at `cps/tests/` for the pattern).
+5. If touching `cps/static/js/` or templates: include a one-line "tested in <browser>" note in the PR description.
+6. If touching `cps/translations/`: just the `.po` is enough; CI runs `i18n-validate`.
+
+Don't introduce new dependencies, license changes, or external service URLs without flagging in the PR description and tagging `@new-usemame` for approval.
+
+## Backporting an upstream PR
+
+If you spot a useful PR sitting unmerged on `crocodilestick/Calibre-Web-Automated`:
+
+1. `git remote add upstream https://github.com/crocodilestick/Calibre-Web-Automated.git && git fetch upstream pull/<N>/head:upstream-pr-<N>`
+2. `git checkout -b merge/upstream-pr-<N>` from current `main`
+3. `git cherry-pick upstream-pr-<N>` (or rebase if it conflicts on refreshed `messages.pot`)
+4. Re-author the commit so the author email is yours, not upstream's: `git commit --amend --reset-author`
+5. Push, open PR, mention the upstream PR number + author in the PR title/body. Release notes will credit `@upstream-author`.
+
+The autopilot script does this automatically (`scripts/draft-cherry-pick.sh <N>`), so check `notes/merge/` first to see if it's already in flight.
+
+## Tier policy (which PRs auto-merge)
+
+`safe-tier-1` (translations / docs only) auto-merge once CI is green.
+`safe-tier-2` (≤50 LOC isolated single-file code, no security-adjacent paths) auto-merge after a 7-day clean tier-1 history.
+`needs-review` (everything else) waits for project lead.
+
+Full tier definitions in [`CLAUDE.md`](CLAUDE.md#tier-policy).
+
+## Style
+
+Follow the existing code style of the file you're editing. CWA is mostly Flask + SQLAlchemy + jQuery + Bootstrap; we're not doing a rewrite. New code that fits the existing patterns merges; new code that introduces a new framework or paradigm gets bounced.
+
+## Getting commit access
+
+See [`GOVERNANCE.md`](GOVERNANCE.md#becoming-a-maintainer). Short version: ~3 quality merged PRs + ask.
+
+## Credit
+
+Every backported upstream PR credits the original author by handle in the release notes. Direct contributions are credited the same way. We don't squash credit out.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,50 @@
+# Governance
+
+## Stewardship
+
+- **Project lead**: [@new-usemame](https://github.com/new-usemame). Final call on releases, security policy, and commit access.
+- **Maintainers**: trusted contributors with commit + merge rights. Earned through ~3 quality PRs + a clean track record. Mostly merge in their own subsystems; escalate cross-cutting changes to the project lead.
+- **Contributors**: anyone with a PR. Credited by handle in release notes.
+
+## Relationship to upstream
+
+This fork exists because review on `crocodilestick/Calibre-Web-Automated` has been paused and the PR + issue queue accumulated. The fork is a **continuation, not a takeover**. Operating principles:
+
+- We do not own upstream. We comment on existing threads, never edit, never close.
+- Every backported patch is mergeable back if upstream review resumes.
+- Original PR authors are credited by handle in release notes.
+- If the upstream maintainer returns and wants to coordinate, repo is public, branches are public, all squash-merge SHAs trace to upstream PR numbers in their commit messages.
+
+## Becoming a maintainer
+
+1. Open ~3 PRs that get merged without major rewrites.
+2. Ask in an issue or DM `@new-usemame`.
+3. If accepted, you get write on the repo + the `maintainer` GitHub team. No paperwork, no CLA.
+
+If you previously had a PR ghosted on upstream and want commit access here to keep your work moving — reach out. That's exactly what this fork is for.
+
+## Decision process
+
+- **Bug fixes / security**: any maintainer can merge under the tier policy in `CLAUDE.md`. Security fixes follow the disclosure flow in `SECURITY.md`.
+- **Features / refactors / dep changes**: project lead approval required. Open as a PR with a design note in the description (or a markdown file under `notes/`).
+- **Disagreements**: discuss in the PR or an issue. If unresolved after a week, project lead decides. Decisions are reversible with new evidence.
+
+## Succession
+
+If `@new-usemame` is unreachable for 90 consecutive days (no commits, no responses on issues, no responses to direct contact):
+
+1. The longest-tenured active maintainer becomes acting project lead.
+2. They coordinate with other active maintainers to confirm the role within 2 weeks.
+3. The fork's repo settings (admin, secrets, package permissions) get rotated — see `notes/SUCCESSION-PLAYBOOK.md` *(to be written when there's a second maintainer)*.
+
+The fork should never go dark just because one person stops showing up. That's the whole point.
+
+## Code of conduct
+
+Be respectful in PRs, issues, and Discussions. No personal attacks, no harassment, no off-topic political flame wars. Disagree on the technical question, not the person. Project lead can lock or remove abusive comments and ban repeat offenders.
+
+Specific to this fork: **no hostility toward upstream or its maintainer**. We are guests in their ecosystem. If you can't keep that tone, don't post here.
+
+## License
+
+Same as upstream CWA (GPL-3.0). Contributions are accepted under the same license. No CLA.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,71 @@ Report suspected vulnerabilities by opening a private security advisory at
 
 Please do not file public issues for vulnerabilities.
 
+Include affected version (container tag / commit SHA), reproduction steps or PoC,
+impact assessment, and a suggested fix if you have one.
+
+## Response timeline
+
+- **Acknowledgement**: within 72 hours.
+- **Initial assessment + severity**: within 7 days.
+- **Patch + release**: within 30 days for High/Critical, 90 days for Medium/Low.
+- **Public advisory**: published with the patch release once users have had time to update.
+
+## Coordinated disclosure with upstream
+
+Because this fork tracks `crocodilestick/Calibre-Web-Automated`, a vulnerability we
+find in shared code may also affect upstream users. Default flow:
+
+1. Patch the fork.
+2. Notify upstream privately (GitHub security advisory or maintainer email)
+   with the patch link + technical detail. Same 30/90-day window before public.
+3. Publish our advisory after the disclosure window — even if upstream
+   hasn't acted, so users on the upstream image know to upgrade.
+
+If a vulnerability is already public (e.g. an unprivileged user filed a public
+bug describing it before reporting privately), we patch and disclose immediately
+— withholding a public fix from a public bug helps no one.
+
+## Scope
+
+**In scope**: authentication bypass, privilege escalation, IDOR, RCE,
+command injection, path traversal, SQLi, SSRF, XXE, stored/reflected XSS
+affecting other users, sensitive-data exposure, container escape.
+
+**Out of scope**: physical access required, third-party software vulnerabilities
+not exposed by our usage, self-XSS, clickjacking on pages with no sensitive
+actions, DoS requiring authenticated admin, automated-scanner output without
+analysis.
+
+## Resolved security advisories
+
+### v4.0.7
+
+- **Kobo IDOR** (closes upstream issue [#1303](https://github.com/crocodilestick/Calibre-Web-Automated/issues/1303)):
+  `/kobo_auth/generate_auth_token` and `/deleteauthtoken` accepted arbitrary
+  `user_id` in the request body, allowing any authenticated user to mint or
+  revoke another user's Kobo auth token. Patched in
+  [`9f50bb2`](https://github.com/new-usemame/Calibre-Web-NextGen/commit/9f50bb2).
+  Severity: HIGH.
+- **14 unauthenticated CWA admin/log routes** (fork audit): the `cwa_logs`,
+  `convert_library`, and `epub_fixer` blueprints exposed log download/read,
+  conversion start/cancel/status, and epub-fixer start/cancel/status routes
+  without auth decorators. Patched in
+  [`09bf581`](https://github.com/new-usemame/Calibre-Web-NextGen/commit/09bf581).
+  Severity: HIGH. Privately disclosed to upstream.
+- **`cover_enforcer.py` shell injection** (fork audit):
+  `os.system(f'cp "{path}" "{dst}"')` interpolated Calibre book paths
+  (containing user-controlled titles) into a shell, allowing command execution
+  as the `abc` user via crafted book metadata. Patched in
+  [`b70fb53`](https://github.com/new-usemame/Calibre-Web-NextGen/commit/b70fb53).
+  Severity: MEDIUM. Privately disclosed to upstream.
+
+## Credit
+
+Reporters credited by handle in advisories unless they request otherwise.
+Researchers who follow responsible disclosure get credited; public 0-day drops
+get patched but not credited.
+
 ## Verifying release artifacts
 
 Every released image is signed with [cosign](https://github.com/sigstore/cosign)


### PR DESCRIPTION
Lands the four docs the new README front-matter (PR #34) references:

- `GOVERNANCE.md` — project lead, maintainer path (~3 PRs + ask), succession (90-day rule), code of conduct, non-hostile-to-upstream principle
- `CONTRIBUTING.md` — bug-report template, PR rules, **backport-an-upstream-PR workflow**, tier policy pointer
- `CHANGES-vs-upstream.md` — every divergence as a table: backports (12 entries with author + upstream PR + SHA + release), original fork patches (Safari fix + 3 security fixes), infra (CI + release pipeline + Python 3.13), features (covers + metadata providers). Establishes mergeable-back guarantee.
- `SECURITY.md` — extends existing cosign+SBOM verification with disclosure timeline (72h ack / 7d assess / 30-90d patch), coordinated-disclosure flow with upstream, scope, and v4.0.7 resolved advisories (Kobo IDOR, 14-route auth gap, cover_enforcer shell injection)

These remove the `(coming soon)` placeholders in README.md and make every contributor-facing link resolve.

No code changes. Lands ahead of Wave 2b (private security email to upstream) so the disclosure flow this commits to is documented before we exercise it.