### PR TITLE
fix(dependabot): route bumps to needs-review (not safe-tier-1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(deps)"
+    # Dependabot PRs cannot satisfy the safe-tier-1 auto-merge gate:
+    #   1. Tier policy (CLAUDE.md) restricts safe-tier-1 to .po/.md/README*;
+    #      .github/workflows/*.yml bumps don't qualify.
+    #   2. validate-author requires committer == new-usemame, but
+    #      dependabot's commits use noreply@github.com.
+    # Route them to operator review so the version jump gets a human eye.
     labels:
-      - safe-tier-1
+      - needs-review
+      - dependabot
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Why

Five open dependabot PRs (#22–#26) all show red CI. Single root cause: dependabot.yml auto-labels every bump `safe-tier-1`, which immediately disqualifies them on two independent checks:

1. **Tier policy mismatch** — CLAUDE.md restricts `safe-tier-1` to `.po`, `.md`, `README*`. Dependabot bumps touch `.github/workflows/*.yml` (CI config), which is outside that scope.
2. **Identity gate** — `validate-author` requires committer = `new-usemame`. Dependabot's commits use `noreply@github.com`, which is not in the allowlist. Will never pass.

## What

- Replace `safe-tier-1` label with `needs-review` + `dependabot` in `.github/dependabot.yml`
- Add an inline comment explaining why so future me / contributors don't re-promote
- The 5 currently-open PRs were demoted manually in the same autopilot tick

## Test plan

- [x] Single-file config change, no logic
- [x] Comment added explaining the constraint
- [ ] Future dependabot run (next weekly cycle) opens PR with the new labels