### PR TITLE
Backport upstream #1290: Run ingest service python workers as abc, not root

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -111,7 +111,7 @@ wait_for_stable_file() {
 
 run_fallback() {
         echo "[cwa-ingest-service] Falling back to polling watcher" >&2
-        python3 /app/calibre-web-automated/scripts/watch_fallback.py --path "$WATCH_FOLDER" --interval 5 |
+        s6-setuidgid abc python3 /app/calibre-web-automated/scripts/watch_fallback.py --path "$WATCH_FOLDER" --interval 5 |
         while read -r events filepath; do
                 handle_event "$filepath"
         done
@@ -155,7 +155,7 @@ process_retry_queue() {
                                 echo "[cwa-ingest-service] Retrying: $queued_file"
                                 local configured_timeout=$(get_timeout_from_db)  # Get configured timeout from database
                                 local safety_timeout=$((configured_timeout * 3))  # Safety timeout is 3x the configured timeout
-                                timeout $safety_timeout python3 /app/calibre-web-automated/scripts/ingest_processor.py "$queued_file"
+                                timeout $safety_timeout s6-setuidgid abc python3 /app/calibre-web-automated/scripts/ingest_processor.py "$queued_file"
                                 local retry_exit=$?
 
                                 if [ $retry_exit -eq 2 ]; then
@@ -213,7 +213,7 @@ handle_event() {
         echo "processing:$filename:$(date '+%Y-%m-%d %H:%M:%S')" > "$STATUS_FILE"
 
         # Use safety timeout as last resort - processor should handle its own timeout internally
-        timeout $safety_timeout python3 /app/calibre-web-automated/scripts/ingest_processor.py "$filepath"
+        timeout $safety_timeout s6-setuidgid abc python3 /app/calibre-web-automated/scripts/ingest_processor.py "$filepath"
         local exit_code=$?
 
         if [ $exit_code -eq 124 ]; then


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1290** by @haraldpdl.

**Original title:** Run ingest service python workers as abc, not root
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1290

## Verification

Walk through `notes/merge/upstream-pr-1290-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1290.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Do not merge until the verification checklist is signed off.)