### PR TITLE
Backport upstream #1233: Fix: magic shelf author sort returning no books

### DIFF
--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -594,10 +594,22 @@ def get_books_for_magic_shelf(shelf_id, page=1, page_size=None, sort_order=None,
         # Build base query
         query = cdb.session.query(db.Books)
         query = query.filter(query_filter)
-        
+
         # Apply standard user permissions filters
         query = query.filter(cdb.common_filters())
-        
+
+        # Join Series table if sort order references it (e.g. author sort
+        # includes series name for sub-sorting within each author).
+        # Without this join, ORDER BY series.name produces empty results.
+        if sort_order is not None:
+            order_list = sort_order if isinstance(sort_order, list) else [sort_order]
+            needs_series_join = any(
+                'series' in str(getattr(expr, 'element', expr)).lower()
+                for expr in order_list
+            )
+            if needs_series_join:
+                query = query.outerjoin(db.books_series_link).outerjoin(db.Series)
+
         # Apply sorting
         if sort_order is not None:
             if isinstance(sort_order, list):
@@ -605,7 +617,7 @@ def get_books_for_magic_shelf(shelf_id, page=1, page_size=None, sort_order=None,
                     query = query.order_by(order_expr)
             else:
                 query = query.order_by(sort_order)
-        
+
         # Execute Full Query for Cache
         try:
             # Fetch ALL IDs


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1233** by @scottjamesrogers.

**Original title:** Fix: magic shelf author sort returning no books
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1233

## Verification

Walk through `notes/merge/upstream-pr-1233-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1233.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Re-created after a 504 swallowed the original `gh pr create` call. Do not merge until the verification checklist is signed off.)