### PR TITLE
Backport upstream #1231: fix: restore missing back button in epub reader

### DIFF
--- a/cps/static/css/reader.css
+++ b/cps/static/css/reader.css
@@ -46,6 +46,11 @@
     font-size: 16px;
 }
 
+#back-button {
+  width: 50px !important;
+  right: 50px;
+}
+
 .reader-error {
     padding: 24px;
     margin: 24px;

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -29,6 +29,7 @@
             <!--a id="show-Search" class="show_view icon-search" data-view="Search">Search</a-->
             <a id="show-Toc" class="show_view icon-list-1 active" data-view="Toc">TOC</a>
             <a id="show-Bookmarks" class="show_view icon-bookmark" data-view="Bookmarks">Bookmarks</a>
+            <a id="back-button" data-view="Back to Books" href="{{ url_for('web.index') }}">Books</a>
             <!--a id="show-Notes" class="show_view icon-edit" data-view="Notes">Notes</a-->
 
         </div>


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1231** by @burakemirsezen.

**Original title:** fix: restore missing back button in epub reader
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1231

## Verification

Walk through `notes/merge/upstream-pr-1231-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1231.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Do not merge until the verification checklist is signed off.)