### PR TITLE
Backport upstream #1226: Do not use `install` to create the ingest directory, use mkdir

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -107,7 +107,7 @@ PY
 )
 if [ -n "$INGEST_DIR" ]; then
   # Create directory if missing
-  install -d -o abc -g abc "$INGEST_DIR" 2>/dev/null || mkdir -p "$INGEST_DIR" 2>/dev/null || true
+  mkdir -p "$INGEST_DIR" 2>/dev/null || true
   # Set ownership unless network share mode (only skip for /cwa-book-ingest)
   if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
     if [ "$INGEST_DIR" = "/cwa-book-ingest" ]; then
@@ -435,4 +435,3 @@ else
 fi
 
 echo "[cwa-init] Versions resolved: INSTALLED=$CWA_INSTALLED_VERSION, STABLE=$CWA_STABLE_VERSION"
-


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1226** by @antifuchs.

**Original title:** Do not use `install` to create the ingest directory, use mkdir
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1226

## Verification

Walk through `notes/merge/upstream-pr-1226-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1226.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Do not merge until the verification checklist is signed off.)