### PR TITLE
Backport upstream #1236: Fix email send failing when metadata export produces no file

### DIFF
--- a/cps/tasks/mail.py
+++ b/cps/tasks/mail.py
@@ -259,10 +259,15 @@ class TaskEmail(CalibreTask):
             try:
                 if config.config_binariesdir and config.config_embed_metadata:
                     data_path, data_file = do_calibre_export(self.book_id, extension)
-                    datafile = os.path.join(data_path, data_file + "." + extension)
+                    if data_path and data_file:
+                        export_file = os.path.join(data_path, data_file + "." + extension)
+                        if os.path.isfile(export_file):
+                            datafile = export_file
+                        else:
+                            log.warning('Metadata export produced no file, sending without embedded metadata')
                 with open(datafile, 'rb') as file_:
                     data = file_.read()
-                if config.config_binariesdir and config.config_embed_metadata:
+                if config.config_binariesdir and config.config_embed_metadata and datafile != os.path.join(calibre_path, book_path, filename):
                     os.remove(datafile)
             except IOError as e:
                 log.error_or_exception(e, stacklevel=3)


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1236** by @scottjamesrogers.

**Original title:** Fix email send failing when metadata export produces no file
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1236

## Verification

Walk through `notes/merge/upstream-pr-1236-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1236.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Do not merge until the verification checklist is signed off.)