### PR TITLE
Backport upstream #1229: fix: use valid zoneinfo timezone format in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,8 +377,8 @@ services:
       # Only change these if you know what you're doing
       - PUID=1000
       - PGID=1000
-      # Edit to match your current timezone https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-      - TZ=UTC
+      # Edit to match your current timezone e.g. Europe/London, America/New_York - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+      - TZ=Europe/London
       # Hardcover API Key required for Hardcover as a Metadata Provider, get one here: https://docs.hardcover.app/api/getting-started/
       - HARDCOVER_TOKEN=your_hardcover_api_key_here
       # If your library is on a network share (e.g., NFS/SMB), disable WAL to reduce locking issues

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       # Only change these if you know what you're doing
       - PUID=1000
       - PGID=1000
-      # Edit to match your current timezone https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-      - TZ=UTC
+      # Edit to match your current timezone e.g. Europe/London, America/New_York - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+      - TZ=Europe/London
       # Sets the listening port for the application. Defaults to 8083.
       # - CWA_PORT_OVERRIDE=8083
       # Hardcover API Key required for Hardcover as a Metadata Provider, get one here: https://docs.hardcover.app/api/getting-started/

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -7,8 +7,8 @@ services:
       # Only change these if you know what you're doing
       - PUID=1000
       - PGID=1000
-      # Edit to match your current timezone https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-      - TZ=UTC
+      # Edit to match your current timezone e.g. Europe/London, America/New_York - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+      - TZ=Europe/London
       # Sets the listening port for the application. Defaults to 8083.
       # - CWA_PORT_OVERRIDE=8083
       # Hardcover API Key required for Hardcover as a Metadata Provider, get one here: https://docs.hardcover.app/api/getting-started/


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1229** by @burakemirsezen.

**Original title:** fix: use valid zoneinfo timezone format in examples
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1229

## Verification

Walk through `notes/merge/upstream-pr-1229-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1229.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Do not merge until the verification checklist is signed off.)