### PR TITLE
Backport upstream #856: Update instructions for enabling uploads in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ And just like that, Calibre-Web Automated should be up and running! **HOWEVER** 
 2. Log in with the default admin credentials (_below_)
 3. Configure your Calibre-Web Automated instance via the Admin Page
   - If you need help with any of the settings, consult the CWA Wiki [here](https://github.com/crocodilestick/Calibre-Web-Automated/wiki)
-  - Make sure `Enable Uploads` is enabled in `Settings -> Basic Configuration -> Feature Configuration`
+  - Make sure `Enable Uploads` is enabled in `Admin -> Configuration -> Edit Basic Configuration -> Feature Configuration`
 4. Configure CWA to behave as you would like it to in the CWA Settings panel
   - Here you can turn certain features on and off, set your Target Format, which file formats should be ignored and which should be auto-converted ect.
 6. Drop a book into your ingest folder to check everything is working and enjoy!


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#856** by @bcsteeve.

**Original title:** Update instructions for enabling uploads in README
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/856

## Conflict resolution

Upstream's `README.md` line conflicted with our prior front-matter / wiki-link customization. Resolved by keeping our CWA-wiki link and accepting @bcsteeve's "Admin -> Configuration -> Edit Basic Configuration" path correction (the actual change his PR is making).

## Verification

Walk through `notes/merge/upstream-pr-856-verify.md` (auto-generated stub).

## Diff snapshot

See `notes/cherry-pick-856.diff` for upstream's original change.

---

(Prepared by an automation pipeline. Manual conflict resolve happened in tick-11. Do not merge until the verification checklist is signed off.)