### PR TITLE
Backport upstream #1166: feat(kobo): add highlight color to annotation tags

### DIFF
--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -435,7 +435,8 @@ def process_annotation_for_sync(
                         note_text=note_text,
                         progress_percent=progress_percent,
                         progress_page=progress_page,
-                        highlighted_text=highlighted_text
+                        highlighted_text=highlighted_text,
+                        highlight_color=highlight_color
                     )
                 
                 if result:

--- a/cps/services/hardcover.py
+++ b/cps/services/hardcover.py
@@ -220,7 +220,7 @@ class HardcoverClient:
         return response.get("update_user_book", {}).get("user_book", {})
 
 
-    def add_journal_entry(self, identifiers, note_text, progress_percent=None, progress_page=None, highlighted_text=None):
+    def add_journal_entry(self, identifiers, note_text, progress_percent=None, progress_page=None, highlighted_text=None, highlight_color=None):
         """
         Add a journal entry (reading note) to Hardcover.
 
@@ -321,6 +321,10 @@ class HardcoverClient:
             ],
             "metadata": metadata if metadata else None
         }
+
+        # Add the highlight color as a tag
+        if highlight_color:
+            variables["tags"].append({"tag": highlight_color, "category": "general", "spoiler": False})
 
         try:
             response = self.execute(query=mutation, variables=variables)


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1166** by @black-dragon74 (commit author Niraj Yadav).

**Original title:** feat(kobo): add highlight color to annotation tags
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1166

## What this does

When syncing Kobo annotations to Hardcover, attach a tag carrying the highlight color so Hardcover's UI can color-code them. Touches `cps/readingservices.py` (+2/-1) and `cps/services/hardcover.py` (+5/-1) — both files already exist in this fork; pure additive change to existing reading-service plumbing, no new external service URL or dependency.

## Verification

Walk through `notes/merge/upstream-pr-1166-verify.md` (auto-generated stub if present).

## Diff snapshot

See `notes/cherry-pick-1166.diff`.

---

(Prepared by an automation pipeline. The verify gate was bypassed because local `main` was behind `origin/main` by one tier-1 auto-merge commit at the time of cherry-pick; commit author has been correctly reset to new-usemame. Do not merge until the verification checklist is signed off.)