### PR TITLE
fix(covers): unblock metadata-cover saves + add diagnostics

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -1038,6 +1038,7 @@ def save_cover_from_url(url, book_path):
     max_cover_bytes, max_cover_mb = _get_cover_download_limit()
     img = None
     download_start = time.monotonic()
+    log.debug("Cover fetch start: url=%s", url)
     try:
         if cli_param.allow_localhost:
             img = requests.get(url, timeout=(10, 30), allow_redirects=False, stream=True)  # ToDo: Error Handling
@@ -1060,7 +1061,10 @@ def save_cover_from_url(url, book_path):
             if len(content) > max_cover_bytes:
                 return False, _("Cover image exceeds maximum size of %(size)s MB", size=max_cover_mb)
         img._content = bytes(content)
-        log.debug("Cover download ok: %s bytes in %.3fs", len(img._content), time.monotonic() - download_start)
+        log.info("Cover download ok: url=%s status=%s content-type=%s bytes=%s elapsed=%.3fs",
+                 url, getattr(img, "status_code", "?"),
+                 img.headers.get("content-type"), len(img._content),
+                 time.monotonic() - download_start)
         return save_cover(img, book_path)
     except (socket.gaierror,
             requests.exceptions.HTTPError,
@@ -1089,24 +1093,35 @@ def save_cover_from_filestorage(filepath, saved_filename, img):
     if not os.path.exists(filepath):
         try:
             os.makedirs(filepath)
-        except OSError:
-            log.error("Failed to create path for cover")
+        except OSError as e:
+            log.error("Failed to create cover path %s: %s", filepath, e)
             return False, _("Failed to create path for cover")
+    target = os.path.join(filepath, saved_filename)
     try:
         # upload of jpg file without wand
         if isinstance(img, requests.Response):
-            with open(os.path.join(filepath, saved_filename), 'wb') as f:
+            content_len = len(img.content) if img.content is not None else 0
+            ct = img.headers.get("content-type") if hasattr(img, "headers") else None
+            if content_len == 0:
+                log.error("Cover save aborted: empty response body (url=%s, content-type=%s, http=%s)",
+                          getattr(getattr(img, "request", None), "url", "?"), ct,
+                          getattr(img, "status_code", "?"))
+                return False, _("Cover-file is not a valid image file, or could not be stored")
+            with open(target, 'wb') as f:
                 f.write(img.content)
         else:
             if hasattr(img, "metadata"):
                 # upload of jpg/png... via url
-                img.save(filename=os.path.join(filepath, saved_filename))
+                img.save(filename=target)
                 img.close()
             else:
                 # upload of jpg/png... from hdd
-                img.save(os.path.join(filepath, saved_filename))
-    except (IOError, OSError):
-        log.error("Cover-file is not a valid image file, or could not be stored")
+                img.save(target)
+    except (IOError, OSError) as e:
+        log.error("Cover save failed (filesystem) target=%s: %s: %s", target, type(e).__name__, e)
+        return False, _("Cover-file is not a valid image file, or could not be stored")
+    except Exception as e:
+        log.error("Cover save failed (unexpected) target=%s: %s: %s", target, type(e).__name__, e)
         return False, _("Cover-file is not a valid image file, or could not be stored")
     return True, None
 
@@ -1136,8 +1151,15 @@ def save_cover(img, book_path):
                 imgc.format = 'jpeg'
                 imgc.transform_colorspace("srgb")
                 img = imgc
-            except (BlobError, MissingDelegateError):
-                log.error("Invalid cover file content")
+            except (BlobError, MissingDelegateError) as e:
+                log.error("Invalid cover file content (content-type=%s, bytes=%s): %s: %s",
+                          content_type, len(img.content) if hasattr(img, "content") else "?",
+                          type(e).__name__, e)
+                return False, _("Invalid cover file content")
+            except Exception as e:
+                log.error("Cover conversion failed (content-type=%s, bytes=%s): %s: %s",
+                          content_type, len(img.content) if hasattr(img, "content") else "?",
+                          type(e).__name__, e)
                 return False, _("Invalid cover file content")
     else:
         if content_type not in ['image/jpeg', 'image/jpg']:

--- a/scripts/cover_enforcer.py
+++ b/scripts/cover_enforcer.py
@@ -580,11 +580,38 @@ class Enforcer:
 
                 book_objects.append(book)
 
+            self._reset_book_dir_ownership(book_dir)
             return book_objects
         else:
             print(f"[cover-metadata-enforcer]: No supported file formats found in {book_dir}.", flush=True)
             print("[cover-metadata-enforcer]: *** NOTICE **** Only EPUB & AZW3 formats are currently supported.", flush=True)
             return []
+
+    @staticmethod
+    def _reset_book_dir_ownership(book_dir: str) -> None:
+        """Reset the book directory and its files to abc:abc (LinuxServer.io PUID/PGID) after running as root.
+
+        Why: this script runs under s6 as root so it can call calibredb/ebook-polish, but the
+        Calibre-Web Flask app runs as 'abc' (UID 1000). Files written here as root would be
+        unwritable for cover-from-URL saves later, surfacing as
+        'Cover-file is not a valid image file, or could not be stored'.
+        """
+        try:
+            uid = int(os.environ.get("PUID", "1000"))
+            gid = int(os.environ.get("PGID", "1000"))
+        except (TypeError, ValueError):
+            uid, gid = 1000, 1000
+        try:
+            if os.path.isdir(book_dir):
+                os.chown(book_dir, uid, gid)
+                for entry in os.listdir(book_dir):
+                    path = os.path.join(book_dir, entry)
+                    try:
+                        os.chown(path, uid, gid)
+                    except OSError:
+                        pass
+        except OSError as e:
+            print(f"[cover-metadata-enforcer] Warning: failed to chown {book_dir}: {e}", flush=True)
 
 
     def enforce_all_covers(self) -> tuple[int, float, int] | tuple[bool, bool, bool]:


### PR DESCRIPTION
## What

Fixes the **`Cover-file is not a valid image file, or could not be stored`** error users hit when saving a book cover from a Hardcover/Google Books/iTunes metadata-search result.

## Root cause

`cwa-ingest-service` and the `cover-metadata-enforcer` s6 services run as **root**, so `calibredb` / `ebook-polish` create the per-book directory and its files as `root:root`. Calibre-Web itself runs as **`abc` (PUID 1000)** and can't overwrite `cover.jpg` or create new files in those directories — the open() raises `PermissionError`, gets caught as `OSError` at `helper.py:1109`, and surfaces as the vague "not a valid image" message.

The chown step in `cwa-init/run` only fires at container startup, so any books ingested between restarts re-introduce the problem.

## Fixes

1. **`scripts/cover_enforcer.py`** — at the end of each per-book `enforce_cover()` pass, chown the book dir + its files back to `PUID:PGID` (defaults `1000:1000`, env-overridable for non-default LinuxServer.io users). Self-heals on every metadata-change cycle, no separate cron needed.
2. **`cps/helper.py`** — real diagnostics on cover-save failures:
   - log target path + exception class on filesystem errors
   - broaden the exception catch beyond `IOError`/`OSError` so wand/PIL errors no longer masquerade as filesystem issues
   - log URL + status + content-type + bytes on download success
   - abort early with a specific log line when the response body is 0 bytes (so a future `allow_redirects=False` regression surfaces clearly instead of silently writing 0-byte covers)

## Validation

Live-tested on the operator's instance (teenyverse): book 348 ("Animal Farm") had a `root:root 755` directory; cover save reproducibly failed via the UI. After applying the chown fix, abc can write the directory; after redeploying both files and restarting, the next `enforce_cover()` run keeps ownership at `abc:abc`.