### PR TITLE
fix(kobo_auth): eager-load formats + guard per-book convert

### DIFF
--- a/cps/kobo_auth.py
+++ b/cps/kobo_auth.py
@@ -56,6 +56,7 @@ from flask import g, Blueprint, abort, request
 from .cw_login import login_user, current_user
 from flask_babel import gettext as _
 from flask_limiter import RateLimitExceeded
+from sqlalchemy.orm import joinedload
 
 from . import logger, config, calibre_db, db, helper, ub, lm, limiter
 from .render_template import render_title_template
@@ -101,12 +102,22 @@ def generate_auth_token(user_id):
         ub.session.add(auth_token)
         ub.session_commit()
 
-    books = calibre_db.session.query(db.Books).join(db.Data).all()
+    if config.config_kepubifypath:
+        try:
+            books = (calibre_db.session.query(db.Books)
+                     .options(joinedload(db.Books.data))
+                     .all())
+        except Exception as ex:
+            log.warning("Could not enumerate books for kepub auto-conversion: %s", ex)
+            books = []
 
-    for book in books:
-        formats = [data.format for data in book.data]
-        if 'KEPUB' not in formats and config.config_kepubifypath and 'EPUB' in formats:
-            helper.convert_book_format(book.id, config.config_calibre_dir, 'EPUB', 'KEPUB', current_user.name)
+        for book in books:
+            try:
+                formats = [data.format for data in book.data]
+                if 'KEPUB' not in formats and 'EPUB' in formats:
+                    helper.convert_book_format(book.id, config.config_calibre_dir, 'EPUB', 'KEPUB', current_user.name)
+            except Exception as ex:
+                log.warning("Skipping kepub auto-conversion for book %s: %s", getattr(book, "id", "?"), ex)
 
     return render_title_template(
         "generate_kobo_auth_url.html",

--- a/tests/smoke/test_kobo_auth_eager_load_smoke.py
+++ b/tests/smoke/test_kobo_auth_eager_load_smoke.py
@@ -1,0 +1,79 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression test for upstream issue #1328 / fork issue #50.
+
+Symptom: Profile -> Create/View Kobo Auth Token returned a blank page with
+    sqlite3.InterfaceError: bad parameter or other API misuse
+    (cps/kobo_auth.py line ~104, lazy load of book.data)
+
+Root cause: `query(Books).join(Data).all()` returned duplicate book rows
+(one per format), then `book.data` lazy-loaded again per row -- N+1 queries
+on the request-scoped session. When a worker thread crashed mid-request
+(`worker:237 list index out of range` is in the original report just above
+the trace), subsequent lazy-loads hit a poisoned connection and raised the
+SQLite InterfaceError, blanking the page.
+
+This test pins the structural change so a future refactor can't reintroduce
+the lazy-load pattern: the kepub auto-conversion path must use joinedload,
+must skip the explicit JOIN-with-duplicates, and must wrap each per-book
+enqueue in a try/except so one bad book doesn't blank-page the user.
+"""
+
+import ast
+import pathlib
+import pytest
+
+
+KOBO_AUTH = pathlib.Path(__file__).resolve().parent.parent.parent / "cps" / "kobo_auth.py"
+
+
+@pytest.mark.smoke
+class TestKoboAuthGenerateAuthTokenEagerLoad:
+    def setup_method(self):
+        self.source = KOBO_AUTH.read_text()
+        self.tree = ast.parse(self.source)
+        self.fn = next(
+            (n for n in ast.walk(self.tree)
+             if isinstance(n, ast.FunctionDef) and n.name == "generate_auth_token"),
+            None,
+        )
+        assert self.fn is not None, "generate_auth_token function not found"
+
+    def test_imports_joinedload(self):
+        assert "from sqlalchemy.orm import joinedload" in self.source, \
+            "joinedload import is required to avoid the N+1 lazy-load that triggered #1328"
+
+    def test_uses_joinedload_on_books_data(self):
+        joinedload_calls = [
+            n for n in ast.walk(self.fn)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "joinedload"
+        ]
+        assert joinedload_calls, "generate_auth_token must call joinedload(...) on Books.data"
+
+    def test_no_explicit_join_data(self):
+        # The legacy `.join(db.Data)` pattern returned one row per (book, data)
+        # tuple, multiplying lazy loads -- that's exactly what crashed under load.
+        attr_chain_text = ast.unparse(self.fn)
+        assert ".join(db.Data)" not in attr_chain_text, \
+            "Stale .join(db.Data) — duplicates books N times where N=len(formats)"
+
+    def test_per_book_conversion_is_guarded(self):
+        # The kepub auto-conversion loop must wrap each book in try/except so
+        # a single bad book doesn't bubble up and blank-page the route.
+        for_nodes = [n for n in ast.walk(self.fn) if isinstance(n, ast.For)]
+        guarded = [
+            f for f in for_nodes
+            if any(isinstance(stmt, ast.Try) for stmt in f.body)
+        ]
+        assert guarded, "Per-book conversion loop must contain a try/except guard"
+
+    def test_kepub_check_short_circuits_when_disabled(self):
+        # When config_kepubifypath is unset there's nothing to convert; we shouldn't
+        # walk every book in the library at all (cheap perf + avoids the N+1 path).
+        attr_chain_text = ast.unparse(self.fn)
+        assert "config.config_kepubifypath" in attr_chain_text, \
+            "config_kepubifypath gate must be checked before the books query"


### PR DESCRIPTION
Closes #50 (mirror of upstream [crocodilestick/Calibre-Web-Automated#1328](https://github.com/crocodilestick/Calibre-Web-Automated/issues/1328), reporter @blahblah57).

## Symptom

Profile → Create/View Kobo Auth Token returned a blank page. Server logs:

```
ERROR cps.services.worker:237 list index out of range
ERROR /kobo_auth/generate_auth_token/5 [GET]
…
File "cps/kobo_auth.py", line 100, in generate_auth_token
    formats = [data.format for data in book.data]
…
sqlite3.InterfaceError: bad parameter or other API misuse
[SQL: SELECT … FROM calibre.data WHERE ? = calibre.data.book]
[parameters: (2005,)]
```

## Root cause

Old code:

```python
books = calibre_db.session.query(db.Books).join(db.Data).all()
for book in books:
    formats = [data.format for data in book.data]
    if 'KEPUB' not in formats and config.config_kepubifypath and 'EPUB' in formats:
        helper.convert_book_format(...)
```

`query(Books).join(Data).all()` returns one row per `(book, format)` tuple — books with N formats are duplicated N times. Each `book.data` access then **lazy-loads** that book's formats again, so we get N+1 queries on the request-scoped session.

When a worker thread crashed mid-request (`worker:237 list index out of range` is logged immediately before the trace), a connection from the shared pool ended up in a "bad parameter" state. The very next lazy-load from the request handler hit that connection and raised `sqlite3.InterfaceError`, blanking the page.

## Fix

- Replace `.join(Data).all()` + per-row lazy-load with a single `joinedload(Books.data)` query. One round trip, no lazy loads, no duplicates.
- Short-circuit when `config_kepubifypath` is unset so the route doesn't enumerate the library at all when there's nothing to convert.
- Wrap each per-book `convert_book_format` enqueue in `try/except`, so a single bad book never blank-pages the entire profile flow.

## Tests

`tests/smoke/test_kobo_auth_eager_load_smoke.py` (5 cases) pins the structural change so a refactor can't reintroduce `.join(Data).all()` or drop the per-book guard.

## Tier

`needs-review` — touches Kobo flow, ~10-line change.