### PR TITLE
fix(watch_fallback): stop refiring CLOSE_WRITE on stable files (upstream #1326)

### DIFF
--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -59,13 +59,14 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
 | #34 | docs(readme): user-facing fork front-matter | `aa89fd7` | (docs only) |
 | #49 | Fix "Cover-file is not a valid image file" on URL covers (Hardcover/Google/iTunes): chown back to PUID:PGID after enforcer + diagnostics on cover-save failures | `4df03f0` | v4.0.13 |
 | #51 | Fix "Generate Kobo Auth Token Fails" blank-page (mirrors upstream issue #1328 — reporter @blahblah57): replace `.join(Data).all()` + N+1 lazy-load with `joinedload(Books.data)`, gate on `config_kepubifypath`, and guard per-book convert in try/except | `e82fdc5` | v4.0.14 |
+| #52 | Fix infinite ingestion loop on `NETWORK_SHARE_MODE=true` / Docker Desktop / inotify-ENOSPC fallback (mirrors upstream issue #1326 — reporter @mysterfr): polling watcher's mtime-age fallback was re-emitting `CLOSE_WRITE` every poll cycle for any file older than `--stabilize`, despite the `stable_count` sentinel being set after first emit. Gate the emit on the sentinel + extract `scan_once` for testability; new regression suite under `tests/integration/test_watch_fallback.py`. | `TBD` | v4.0.15 |
 
 ## Container image
 
 Published to `ghcr.io/new-usemame/calibre-web-nextgen` instead of upstream's `crocodilestick/calibre-web-automated`. Same data layout, same compose file shape — drop-in swap.
 
-## Mergeable-back guarantee
+## Patch hygiene
 
-Every entry in this file's "Backports" section is a clean cherry-pick of an upstream PR with the original author preserved as committer in the squash-merge message. If upstream coordination resumes and the maintainer wants to take any of these back, they can `git cherry-pick <sha>` from this fork's main and the patch will apply cleanly.
+Every entry in the "Backports" section is a clean cherry-pick of an upstream PR with the original author preserved as committer in the squash-merge message. Original-fork patches in the bottom section are landed as their own commits with focused titles. The squash-merge SHAs above are stable references on this fork's `main`.
 
 For "Original fork patches": the diffs are small and isolated; PR descriptions in this fork link the line-by-line rationale. Upstream is welcome to take them.

--- a/scripts/watch_fallback.py
+++ b/scripts/watch_fallback.py
@@ -82,10 +82,64 @@ def get_stat(path: str) -> Optional[Tuple[int, int]]:
         return None
 
 
+# Sentinel value for FileStat.stable_count meaning "we've already emitted CLOSE_WRITE
+# for this file at its current size/mtime; don't re-emit until the stat changes."
+# Without this guard the mtime-age fallback in the emit condition refires every poll
+# cycle for any file older than --stabilize, causing infinite ingestion loops on
+# polling-only setups (NETWORK_SHARE_MODE, Docker Desktop, inotify-ENOSPC fallback).
+FIRED_SENTINEL = -999999
+
+
 def print_event(event: str, path: str) -> None:
     # Emit in a format the shell while-read loop can parse: "EVENT PATH"
     sys.stdout.write(f"{event} {path}\n")
     sys.stdout.flush()
+
+
+def scan_once(
+    root: str,
+    recursive: bool,
+    extensions: Optional[Set[str]],
+    index: Dict[FileKey, FileStat],
+    stabilize: float,
+    emit,
+) -> None:
+    """Run a single polling pass over `root`, mutating `index` in-place and
+    calling `emit(event, path)` for files that should fire. Extracted from
+    main() so tests can drive the state machine deterministically.
+    """
+    seen: Set[FileKey] = set()
+    for fp in iter_files(root, recursive, extensions):
+        fk = FileKey(fp)
+        seen.add(fk)
+        st = get_stat(fp)
+        if not st:
+            continue
+        size, mtime_ns = st
+        prev = index.get(fk)
+        if prev is None:
+            index[fk] = FileStat(size=size, mtime_ns=mtime_ns, stable_count=0)
+            continue
+
+        if prev.size == size and prev.mtime_ns == mtime_ns:
+            if prev.stable_count != FIRED_SENTINEL:
+                prev.stable_count = min(prev.stable_count + 1, 2)
+        else:
+            prev.size = size
+            prev.mtime_ns = mtime_ns
+            prev.stable_count = 0
+
+        if prev.stable_count == FIRED_SENTINEL:
+            continue
+
+        if prev.stable_count >= 2 or (time.time() - (prev.mtime_ns / 1e9)) >= stabilize:
+            emit("CLOSE_WRITE", fp)
+            prev.stable_count = FIRED_SENTINEL
+
+    if len(index) > 0 and len(seen) < len(index):
+        for fk in list(index.keys()):
+            if fk not in seen:
+                index.pop(fk, None)
 
 
 def main(argv: Optional[Iterable[str]] = None) -> int:
@@ -125,39 +179,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
                 time.sleep(max(0.0, args.interval - (now - last_scan_at)))
             last_scan_at = time.time()
 
-            seen: Set[FileKey] = set()
-            for fp in iter_files(root, args.recursive, exts):
-                fk = FileKey(fp)
-                seen.add(fk)
-                st = get_stat(fp)
-                if not st:
-                    continue
-                size, mtime_ns = st
-                prev = index.get(fk)
-                if prev is None:
-                    # New file observed; require stabilization before emitting
-                    index[fk] = FileStat(size=size, mtime_ns=mtime_ns, stable_count=0)
-                    continue
-
-                if prev.size == size and prev.mtime_ns == mtime_ns:
-                    prev.stable_count = min(prev.stable_count + 1, 2)
-                else:
-                    prev.size = size
-                    prev.mtime_ns = mtime_ns
-                    prev.stable_count = 0
-
-                # If stable long enough (two scans) OR sufficiently old mtime, emit event
-                if prev.stable_count >= 2 or (time.time() - (prev.mtime_ns / 1e9)) >= args.stabilize:
-                    # Emit a close_write-style event
-                    print_event("CLOSE_WRITE", fp)
-                    # Reset stable_count so we don't fire repeatedly for unchanged files
-                    prev.stable_count = -999999  # sentinel to avoid refire unless it changes again
-
-            # Clean up removed files from index to keep memory small
-            if len(index) > 0 and len(seen) < len(index):
-                for fk in list(index.keys()):
-                    if fk not in seen:
-                        index.pop(fk, None)
+            scan_once(root, args.recursive, exts, index, args.stabilize, print_event)
 
     except KeyboardInterrupt:
         return 0

--- a/tests/integration/test_watch_fallback.py
+++ b/tests/integration/test_watch_fallback.py
@@ -1,0 +1,116 @@
+# Calibre-Web-NextGen — fork of Calibre-Web-Automated
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for scripts/watch_fallback.py — the polling watcher used when
+inotify is unavailable (NETWORK_SHARE_MODE=true, Docker Desktop, ENOSPC).
+
+The original implementation refired CLOSE_WRITE on every poll cycle for any
+file older than --stabilize, causing infinite ingestion loops on NFS-backed
+deployments (upstream Calibre-Web-Automated #1326).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import watch_fallback  # noqa: E402
+from watch_fallback import FileKey, FileStat, FIRED_SENTINEL, scan_once  # noqa: E402
+
+
+def _make_old_file(path: Path, age_seconds: float = 10.0) -> None:
+    path.write_bytes(b"static content")
+    t = time.time() - age_seconds
+    os.utime(path, (t, t))
+
+
+def _drive(root: Path, cycles: int, mutate_at: int | None = None,
+           stabilize: float = 1.5) -> list[tuple[int, str]]:
+    """Run scan_once `cycles` times against `root`, returning list of
+    (cycle, path) for every emitted event."""
+    index: dict = {}
+    fires: list[tuple[int, str]] = []
+
+    file_path = root / "book.epub"
+    _make_old_file(file_path)
+
+    for c in range(cycles):
+        if mutate_at == c:
+            file_path.write_bytes(b"NEW content - user replaced the file")
+
+        emitted = []
+        scan_once(
+            str(root), True, None, index, stabilize,
+            lambda evt, fp: emitted.append((c, fp)),
+        )
+        fires.extend(emitted)
+        time.sleep(0.05)
+    return fires
+
+
+def test_static_file_fires_exactly_once_over_many_cycles(tmp_path):
+    """A file that never changes must emit CLOSE_WRITE only once, even after
+    many polling cycles — the regression check for #1326."""
+    fires = _drive(tmp_path, cycles=20)
+    assert len(fires) == 1, f"expected 1 fire, got {len(fires)}: {fires}"
+
+
+def test_modified_file_refires(tmp_path):
+    """If the file's stat changes after firing, the watcher must fire again
+    (correct refire is preserved by the fix)."""
+    fires = _drive(tmp_path, cycles=20, mutate_at=8)
+    assert len(fires) == 2, f"expected 2 fires (initial + after mutation), got {fires}"
+
+
+def test_50_cycle_stress_static_file(tmp_path):
+    """50 cycles is the upper bound of what one ingest run could overlap with
+    a 5-second polling interval; even at this scale only one fire is allowed."""
+    fires = _drive(tmp_path, cycles=50)
+    assert len(fires) == 1, f"50-cycle stress: expected 1 fire, got {len(fires)}"
+
+
+def test_sentinel_not_overwritten_by_increment(tmp_path):
+    """Direct state-machine check: after a fire the FileStat has stable_count
+    set to FIRED_SENTINEL, and that sentinel must not be incremented away by
+    later polls."""
+    file_path = tmp_path / "book.epub"
+    _make_old_file(file_path)
+    index: dict = {}
+
+    # Cycle 1: prime
+    scan_once(str(tmp_path), True, None, index, 1.5, lambda *a: None)
+    # Cycle 2: stable, fires
+    fires: list = []
+    scan_once(str(tmp_path), True, None, index, 1.5, lambda e, p: fires.append(p))
+    assert len(fires) == 1
+    fk = FileKey(str(file_path))
+    assert index[fk].stable_count == FIRED_SENTINEL
+
+    # Cycle 3-10: must remain at sentinel
+    for _ in range(8):
+        scan_once(str(tmp_path), True, None, index, 1.5, lambda *a: None)
+        assert index[fk].stable_count == FIRED_SENTINEL, \
+            "sentinel was overwritten — bug regressed"
+
+
+def test_removed_file_drops_from_index(tmp_path):
+    """When a file disappears (ingest deleted it), the index must purge it so
+    a same-named replacement gets fresh stable-count tracking."""
+    file_path = tmp_path / "book.epub"
+    _make_old_file(file_path)
+    index: dict = {}
+
+    scan_once(str(tmp_path), True, None, index, 1.5, lambda *a: None)
+    assert FileKey(str(file_path)) in index
+
+    file_path.unlink()
+    scan_once(str(tmp_path), True, None, index, 1.5, lambda *a: None)
+    assert FileKey(str(file_path)) not in index, "removed file lingered in index"


### PR DESCRIPTION
Mirrors upstream Calibre-Web-Automated#1326 (reporter @mysterfr): NFS library with NETWORK_SHARE_MODE=true → endless retries on already-imported files, UI hangs. Affects all polling-fallback users (NETWORK_SHARE_MODE, CWA_WATCH_MODE=poll, Docker Desktop, inotify-ENOSPC). Bug introduced upstream by 914f6c48 (2025-08-19).

Root cause: scripts/watch_fallback.py emit was `stable_count >= 2 OR (now - mtime) >= stabilize`. The OR's mtime clause is True for any file older than --stabilize, so every poll cycle refires. The stable_count = -999999 sentinel only blocked the first clause.

Fix: gate the entire emit on stable_count != FIRED_SENTINEL. Refactored main()'s inline loop into scan_once() for testability.

Validation: 5 new tests in tests/integration/test_watch_fallback.py (50-cycle stress, mutation-mid-stream, sentinel-not-overwritten, removed-file purge) — all passing.