### PR TITLE
revert: hold #40 (subquery loading) and #37 (s6-setuidgid abc) for thorough validation

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -404,15 +404,15 @@ class Books(Base):
     has_cover = Column(Integer, default=0)
     uuid = Column(String)
 
-    authors = relationship(Authors, secondary=books_authors_link, backref='books', lazy='subquery')
-    tags = relationship(Tags, secondary=books_tags_link, backref='books', order_by="Tags.name", lazy='subquery')
-    comments = relationship(Comments, backref='books', lazy='subquery')
-    data = relationship(Data, backref='books', lazy='subquery')
-    series = relationship(Series, secondary=books_series_link, backref='books', lazy='subquery')
-    ratings = relationship(Ratings, secondary=books_ratings_link, backref='books', lazy='subquery')
-    languages = relationship(Languages, secondary=books_languages_link, backref='books', lazy='subquery')
-    publishers = relationship(Publishers, secondary=books_publishers_link, backref='books', lazy='subquery')
-    identifiers = relationship(Identifiers, backref='books', lazy='subquery')
+    authors = relationship(Authors, secondary=books_authors_link, backref='books')
+    tags = relationship(Tags, secondary=books_tags_link, backref='books', order_by="Tags.name")
+    comments = relationship(Comments, backref='books')
+    data = relationship(Data, backref='books')
+    series = relationship(Series, secondary=books_series_link, backref='books')
+    ratings = relationship(Ratings, secondary=books_ratings_link, backref='books')
+    languages = relationship(Languages, secondary=books_languages_link, backref='books')
+    publishers = relationship(Publishers, secondary=books_publishers_link, backref='books')
+    identifiers = relationship(Identifiers, backref='books')
 
     def __init__(self, title, sort, author_sort, timestamp, pubdate, series_index, last_modified, path, has_cover,
                  authors, tags, languages=None):

--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -111,7 +111,7 @@ wait_for_stable_file() {
 
 run_fallback() {
         echo "[cwa-ingest-service] Falling back to polling watcher" >&2
-        s6-setuidgid abc python3 /app/calibre-web-automated/scripts/watch_fallback.py --path "$WATCH_FOLDER" --interval 5 |
+        python3 /app/calibre-web-automated/scripts/watch_fallback.py --path "$WATCH_FOLDER" --interval 5 |
         while read -r events filepath; do
                 handle_event "$filepath"
         done
@@ -155,7 +155,7 @@ process_retry_queue() {
                                 echo "[cwa-ingest-service] Retrying: $queued_file"
                                 local configured_timeout=$(get_timeout_from_db)  # Get configured timeout from database
                                 local safety_timeout=$((configured_timeout * 3))  # Safety timeout is 3x the configured timeout
-                                timeout $safety_timeout s6-setuidgid abc python3 /app/calibre-web-automated/scripts/ingest_processor.py "$queued_file"
+                                timeout $safety_timeout python3 /app/calibre-web-automated/scripts/ingest_processor.py "$queued_file"
                                 local retry_exit=$?
 
                                 if [ $retry_exit -eq 2 ]; then
@@ -213,7 +213,7 @@ handle_event() {
         echo "processing:$filename:$(date '+%Y-%m-%d %H:%M:%S')" > "$STATUS_FILE"
 
         # Use safety timeout as last resort - processor should handle its own timeout internally
-        timeout $safety_timeout s6-setuidgid abc python3 /app/calibre-web-automated/scripts/ingest_processor.py "$filepath"
+        timeout $safety_timeout python3 /app/calibre-web-automated/scripts/ingest_processor.py "$filepath"
         local exit_code=$?
 
         if [ $exit_code -eq 124 ]; then


### PR DESCRIPTION
Two of the eleven PRs that landed in the recent cleanup sweep need closed-loop integration testing before they ship to users. They are reverted on main here so v4.0.16 can ship the other 9 patches without delay; both will land again in v4.0.17 once the validation suites pass.

## Why hold #40 (`lazy='subquery'` on every Books relationship)

Sets eager loading on 9 collection relationships globally, not just at the call sites that actually need it. The original DetachedInstanceError it claims to fix has no reproduction in upstream PR #1279's body. Need to:
1. Demonstrate the actual DetachedInstanceError in a reproducible test against pre-#40 main
2. Confirm `lazy='subquery'` resolves it without regressing browse / OPDS / library-export latency or memory
3. Decide whether to scope the fix narrowly (`joinedload` at the affected callsite) or take the upstream-author's broad approach

## Why hold #37 (`s6-setuidgid abc` on ingest-service Python workers)

Architecturally correct, same direction as v4.0.13's cover-fix. But users on pre-v4.0.13 deployments may still have `root:root`-owned files in `/calibre-library` (especially NFS / NETWORK_SHARE_MODE users — exactly the audience just unblocked by v4.0.15 / #1326). Without a one-shot chown migration in the upgrade path, ingest will hit "Permission denied" the moment it tries to move a freshly-imported book into a root-owned author/series directory. Need to:
1. Build an integration test that simulates a pre-v4.0.13 library with `root:root`-owned subdirs, applies #37, and confirms ingest behavior
2. Either land a one-time chown migration alongside #37 or document a manual upgrade step
3. Confirm v4.0.13's cover-enforcer chown-back already heals the cover path; verify nothing else under `/calibre-library` stays root-owned post-upgrade

## Net effect

`v4.0.16` ships the other 9 backports without these two. `v4.0.17` reintroduces both with their validation suites and (for #37) any required migration. Original authors @dbraendle (#1279 / #40) and @haraldpdl (#1290 / #37) — the patches will be back in once we've closed the loop on the regressions they could trigger for the audience we're trying to help.