### PR TITLE
fix(test): drop sys.modules cps.* flush, was breaking cps.progress_syncing import

### DIFF
--- a/tests/integration/test_books_relationship_loading.py
+++ b/tests/integration/test_books_relationship_loading.py
@@ -113,15 +113,21 @@ def _make_engine_and_session(db_path: Path):
     runtime queries reference `calibre.books`, `calibre.data`, etc.
 
     Registers the same custom SQL functions Calibre defines so triggers
-    don't abort."""
+    don't abort.
+
+    NOTE: this fixture deliberately does NOT clear cps.* from sys.modules
+    before importing. Some modules under cps/ (notably
+    cps.progress_syncing.models) use a circular-import pattern that
+    resolves cleanly on the first package import but breaks if modules
+    are forcibly reloaded mid-suite — downstream tests fail with
+    `AttributeError: partially initialized module ... has no attribute
+    BookFormatChecksum`. The Books-relationship loading strategy is read
+    from whatever cps.db is committed on this branch, which is what the
+    runtime uses anyway."""
     from sqlalchemy import create_engine, event, text
     from sqlalchemy.orm import sessionmaker
     from sqlalchemy.pool import StaticPool
 
-    # Force re-import so cps.db reflects the current branch's strategy
-    for mod in list(sys.modules):
-        if mod.startswith("cps."):
-            del sys.modules[mod]
     from cps import db as cps_db  # noqa: E402
 
     engine = create_engine(


### PR DESCRIPTION
Test-only fix for the Integration Tests (Docker) job that's been failing on `main` since #55 landed.

## Why

`tests/integration/test_books_relationship_loading.py` (added in #55) cleared every `cps.*` module from `sys.modules` before importing `cps.db`, intending to capture whichever `lazy=...` strategy was committed on the branch. That flush broke the circular-import pattern in `cps.progress_syncing` — three downstream tests in `test_progress_syncing_kosync.py` started failing with:

```
AttributeError: partially initialized module 'cps.progress_syncing.models'
has no attribute 'BookFormatChecksum' (most likely due to a circular import)
```

cps modules are intentionally circular and rely on the package's first clean import to resolve. Forcing a reload mid-suite leaves the module graph half-built.

## Fix

Drop the `sys.modules` cleanup; just import `cps.db` once and read whichever loading strategy is committed. The whole point of the test is to validate the production-committed strategy, so re-importing was never necessary.

## Verified locally

```
============================= test session starts ==============================
tests/integration/test_books_relationship_loading.py ... 7 passed
tests/integration/test_progress_syncing_kosync.py::TestKOSyncHelperFunctions::test_get_book_by_checksum_function_exists PASSED
tests/integration/test_progress_syncing_kosync.py::TestKOSyncHelperFunctions::test_enrich_response_function_exists PASSED
tests/integration/test_progress_syncing_kosync.py::TestKOSyncHelperFunctions::test_enrich_response_with_no_match PASSED
======================== 10 passed, 9 warnings in 0.74s ========================
```