### PR TITLE
feat(covers): focused cover-picker UI + reliable inline URL preview

### DIFF
--- a/cps/cover_picker.py
+++ b/cps/cover_picker.py
@@ -1,0 +1,301 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Flask blueprint for the focused cover-picker UI.
+
+A user-facing surface dedicated to setting/replacing a book's cover. The
+existing metadata-search modal stays untouched; this is a separate path
+for users who only want to swap a cover. See notes/COVER-PICKER-DESIGN.md
+for the full rationale.
+
+Routes (all gated by edit permission):
+
+    GET  /book/<book_id>/cover                  -> picker page
+    POST /book/<book_id>/cover/candidates       -> JSON: gather candidates
+    POST /book/<book_id>/cover/preview          -> JSON: validate URL
+    POST /book/<book_id>/cover/extract          -> JSON: data-URL of embedded
+    POST /book/<book_id>/cover/apply            -> applies chosen cover
+    POST /book/<book_id>/cover/lock             -> toggle BookCoverLock
+
+The blueprint is thin — orchestration lives in cps.services.cover_picker
+and cps.services.cover_url_validator. Adding a new candidate source
+means adding a metadata provider in cps/metadata_provider/, not editing
+this file.
+"""
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+from functools import wraps
+from typing import Optional
+
+from flask import Blueprint, abort, flash, jsonify, make_response, redirect, request, url_for
+from flask_babel import gettext as _
+from flask_babel import get_locale
+
+from . import calibre_db, config, helper, logger, ub
+from .cw_login import current_user
+from .render_template import render_title_template
+from .services import cover_extract, cover_picker as cover_picker_svc, cover_url_validator
+from .usermanagement import user_login_required
+
+
+log = logger.create()
+
+cover_picker = Blueprint("cover_picker", __name__)
+
+
+def edit_required(f):
+    """Mirrors editbooks.edit_required — admin or edit-role only."""
+    @wraps(f)
+    def inner(*args, **kwargs):
+        if current_user.role_edit() or current_user.role_admin():
+            return f(*args, **kwargs)
+        abort(403)
+    return inner
+
+
+def _load_book(book_id: int):
+    """Fetch book + 404 if absent. Matches editbooks.py conventions."""
+    book = calibre_db.get_filtered_book(book_id)
+    if not book:
+        abort(404)
+    return book
+
+
+def _book_query_for_search(book) -> str:
+    """Build the metadata-search query the picker fires off behind the
+    scenes. Title + first author hits the right edition for most books;
+    if an ISBN is present in the book identifiers we use that for
+    higher-precision results."""
+    isbn_ids = [i.val for i in (book.identifiers or []) if (i.type or "").lower() in ("isbn", "isbn_10", "isbn_13")]
+    if isbn_ids:
+        return isbn_ids[0]
+    title = book.title or ""
+    authors = [a.name for a in (book.authors or [])]
+    return (title + " " + (authors[0] if authors else "")).strip()
+
+
+def _is_provider_enabled_for_user(provider) -> bool:
+    """Honor both per-user and global provider toggles, same as
+    cps.search_metadata.metadata_search."""
+    try:
+        from .search_metadata import _get_global_provider_enabled_map
+        global_enabled = _get_global_provider_enabled_map()
+    except Exception:
+        global_enabled = {}
+    user_settings = current_user.view_settings.get("metadata", {}) if current_user else {}
+    return bool(global_enabled.get(provider.__id__, True)) and bool(user_settings.get(provider.__id__, True))
+
+
+@cover_picker.route("/book/<int:book_id>/cover", methods=["GET"])
+@user_login_required
+@edit_required
+def cover_picker_page(book_id):
+    """Render the picker page. Candidates are loaded asynchronously so
+    the page itself returns instantly; the JS hits the candidates
+    endpoint immediately on load."""
+    book = _load_book(book_id)
+    locked = _get_lock_state(book_id)
+    return render_title_template(
+        "cover_picker.html",
+        book=book,
+        cover_locked=locked,
+        title=_(u"Change cover — %(title)s", title=book.title),
+        page="coverpicker",
+    )
+
+
+@cover_picker.route("/book/<int:book_id>/cover/candidates", methods=["POST"])
+@user_login_required
+@edit_required
+def cover_picker_candidates(book_id):
+    """Run the provider pool + cover_booster; return candidate list +
+    per-provider status. Same JSON shape pattern as /metadata/search."""
+    book = _load_book(book_id)
+    body = request.get_json(silent=True) or {}
+    query = (body.get("query") or "").strip() or _book_query_for_search(book)
+
+    from .search_metadata import (
+        cl as providers,
+        _classify_empty_provider,
+        _classify_provider_failure,
+    )
+
+    static_cover = url_for("static", filename="generic_cover.svg")
+
+    candidates, statuses = cover_picker_svc.gather_cover_candidates(
+        providers=providers,
+        query=query,
+        static_cover=static_cover,
+        locale=get_locale(),
+        is_provider_enabled=_is_provider_enabled_for_user,
+        classify_failure=_classify_provider_failure,
+        classify_empty=_classify_empty_provider,
+        extract_embedded=lambda: cover_extract.extract_embedded_cover(book),
+    )
+
+    return jsonify({
+        "candidates": [c.to_dict() for c in candidates],
+        "providers": [s.to_dict() for s in statuses],
+        "query": query,
+    })
+
+
+@cover_picker.route("/book/<int:book_id>/cover/preview", methods=["POST"])
+@user_login_required
+@edit_required
+def cover_picker_preview(book_id):
+    """Validate a URL the user pasted (in the picker URL panel OR the
+    inline cover_url field on the edit page). Same code path; the inline
+    field hits /metadata/cover/preview for the global variant."""
+    _load_book(book_id)  # 404s if book is missing or hidden
+    body = request.get_json(silent=True) or {}
+    result = cover_url_validator.validate_cover_url(body.get("url") or "")
+    return jsonify(result.to_dict())
+
+
+@cover_picker.route("/book/<int:book_id>/cover/extract", methods=["POST"])
+@user_login_required
+@edit_required
+def cover_picker_extract(book_id):
+    """Re-render the embedded-cover candidate as a data URL. Used when
+    the picker page wants to refresh just the embedded cover after an
+    upload changed the book file."""
+    book = _load_book(book_id)
+    extracted = cover_extract.extract_embedded_cover(book)
+    if extracted is None:
+        return jsonify({"available": False})
+    data_url = "data:" + extracted.mime_type + ";base64," + base64.b64encode(extracted.data).decode("ascii")
+    return jsonify({
+        "available": True,
+        "cover_url": data_url,
+        "source_format": extracted.source_format,
+    })
+
+
+@cover_picker.route("/book/<int:book_id>/cover/apply", methods=["POST"])
+@user_login_required
+@edit_required
+def cover_picker_apply(book_id):
+    """Apply a chosen cover. Accepts a JSON payload describing the
+    source: a remote URL, a candidate from the grid (just a URL really),
+    an uploaded file (multipart), or 'embedded' to apply the embedded
+    cover from the book file.
+
+    Returns JSON {ok, error?} for AJAX callers; the picker page swaps
+    the preview image without a full reload on success.
+    """
+    book = _load_book(book_id)
+    if _get_lock_state(book_id):
+        return _json_error("locked", _(u"This book's cover is locked. Unlock it first."), 409)
+
+    # Multipart upload from the picker's file panel.
+    if request.files.get("file"):
+        ok, message = _apply_uploaded_file(book, request.files["file"])
+        return _apply_response(ok, message, book)
+
+    body = request.get_json(silent=True) or {}
+    kind = body.get("kind") or "url"
+
+    if kind == "url":
+        url = (body.get("url") or "").strip()
+        if not url:
+            return _json_error("empty_url", _(u"Provide a cover URL."), 400)
+        ok, message = helper.save_cover_from_url(url, book.path)
+        return _apply_response(ok, message, book)
+
+    if kind == "embedded":
+        extracted = cover_extract.extract_embedded_cover(book)
+        if extracted is None:
+            return _json_error("no_embedded", _(u"This book doesn't have an embedded cover we can extract."), 400)
+        ok, message = _apply_bytes(book, extracted.data, extracted.extension)
+        return _apply_response(ok, message, book)
+
+    return _json_error("bad_kind", _(u"Unknown cover source."), 400)
+
+
+@cover_picker.route("/book/<int:book_id>/cover/lock", methods=["POST"])
+@user_login_required
+@edit_required
+def cover_picker_lock(book_id):
+    """Toggle (or explicitly set) the BookCoverLock for this book. Body:
+    {locked: true|false}. Returns the new state."""
+    _load_book(book_id)
+    body = request.get_json(silent=True) or {}
+    desired = bool(body.get("locked"))
+    record = ub.session.query(ub.BookCoverLock).filter_by(book_id=book_id).first()
+    now = datetime.now(timezone.utc)
+    if record is None:
+        record = ub.BookCoverLock(
+            book_id=book_id, locked=desired,
+            locked_by=current_user.id, locked_at=now,
+        )
+        ub.session.add(record)
+    else:
+        record.locked = desired
+        record.locked_by = current_user.id
+        record.locked_at = now
+    try:
+        ub.session.commit()
+    except Exception as exc:  # pragma: no cover - defensive
+        log.error("cover_picker_lock commit failed: %s", exc)
+        ub.session.rollback()
+        return _json_error("commit_failed", _(u"Could not save lock state."), 500)
+    return jsonify({"locked": record.locked})
+
+
+# ---- helpers --------------------------------------------------------------
+
+
+def _get_lock_state(book_id: int) -> bool:
+    record = ub.session.query(ub.BookCoverLock).filter_by(book_id=book_id).first()
+    return bool(record and record.locked)
+
+
+def _apply_uploaded_file(book, file_storage):
+    """Apply a user-uploaded image file to the book. Reuses
+    helper.save_cover so the conversion + size limit checks match the
+    existing upload-cover-from-disk path on the edit page."""
+    return helper.save_cover(file_storage, book.path)
+
+
+def _apply_bytes(book, raw: bytes, extension: str):
+    """Apply raw image bytes (e.g. from the embedded-cover extract). Wraps
+    the bytes in a FileStorage-like object so the existing helper.save_cover
+    path can process them without changes."""
+    import io
+    from werkzeug.datastructures import FileStorage
+    mime = {
+        ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+        ".png": "image/png", ".webp": "image/webp",
+        ".gif": "image/gif", ".bmp": "image/bmp",
+    }.get(extension.lower(), "application/octet-stream")
+    storage = FileStorage(
+        stream=io.BytesIO(raw),
+        filename=f"embedded_cover{extension}",
+        content_type=mime,
+    )
+    return helper.save_cover(storage, book.path)
+
+
+def _apply_response(ok: bool, message, book):
+    if ok:
+        try:
+            book.has_cover = 1
+            calibre_db.session.commit()
+            helper.replace_cover_thumbnail_cache(book.id)
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("post-apply cover housekeeping failed: %s", exc)
+        return jsonify({
+            "ok": True,
+            "cover_url": url_for("web.get_cover", book_id=book.id, resolution="og") + f"?ts={int(datetime.now(timezone.utc).timestamp())}",
+        })
+    return _json_error("save_failed", str(message) if message else _(u"Cover save failed."), 400)
+
+
+def _json_error(code: str, message: str, status: int):
+    return make_response(jsonify({"ok": False, "error_code": code, "error_message": message}), status)

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -63,6 +63,18 @@ def edit_required(f):
     return inner
 
 
+def _book_cover_is_locked(book_id) -> bool:
+    """Honor the per-book BookCoverLock flag set from the focused
+    cover-picker page. Resolves janeczku/calibre-web#2165 — when locked,
+    the metadata-fetch save path skips the cover_url field instead of
+    silently overwriting a deliberately-chosen cover."""
+    try:
+        record = ub.session.query(ub.BookCoverLock).filter_by(book_id=book_id).first()
+    except Exception:  # pragma: no cover - defensive; missing migrations etc.
+        return False
+    return bool(record and record.locked)
+
+
 @editbook.route("/ajax/delete/<int:book_id>", methods=["POST"])
 @user_login_required
 def delete_book_from_details(book_id):
@@ -879,6 +891,14 @@ def do_edit_book(book_id, upload_formats=None):
             if not current_user.role_edit():
                 edit_error = True
                 flash(_("User has no rights to upload cover"), category="error")
+            elif _book_cover_is_locked(book.id):
+                # Resolves janeczku/calibre-web#2165 (8 hearts):
+                # users explicitly opt-in to a cover lock from the focused
+                # cover-picker page; once set, the metadata-fetch save path
+                # must not silently replace the cover with whatever the
+                # last picked record carried.
+                edit_error = True
+                flash(_("Cover is locked. Unlock it on the cover-picker page first."), category="error")
             elif to_save["cover_url"].endswith('/static/generic_cover.svg'):
                 book.has_cover = 0
             else:

--- a/cps/main.py
+++ b/cps/main.py
@@ -25,6 +25,7 @@ def main():
     from .admin import admi
     from .gdrive import gdrive
     from .editbooks import editbook
+    from .cover_picker import cover_picker
     from .about import about
     from .search import search
     from .search_metadata import meta
@@ -81,6 +82,7 @@ def main():
     app.register_blueprint(meta)
     app.register_blueprint(gdrive)
     app.register_blueprint(editbook)
+    app.register_blueprint(cover_picker)
     app.register_blueprint(kosync)
     app.register_blueprint(duplicates)
     if kobo_available:

--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -160,6 +160,18 @@ def metadata_keys():
     return make_response(jsonify(payload))
 
 
+@meta.route("/metadata/cover/preview", methods=["POST"])
+@user_login_required
+def metadata_cover_preview():
+    """Validate a cover URL the user pasted on the edit page (or in the
+    cover-picker URL panel without a book scope). Same code path the
+    save handler uses, so successful preview = successful save."""
+    from cps.services.cover_url_validator import validate_cover_url
+    body = request.get_json(silent=True) or {}
+    result = validate_cover_url(body.get("url") or "")
+    return make_response(jsonify(result.to_dict()))
+
+
 @meta.route("/metadata/keys/<prov_id>", methods=["POST"])
 @user_login_required
 def metadata_keys_save(prov_id):

--- a/cps/services/cover_extract.py
+++ b/cps/services/cover_extract.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Extract the embedded cover from a book file already in the library.
+
+Used by the cover-picker page to surface "the current embedded cover" as
+a candidate alongside the network sources. Resolves the recurring user
+ask in CWA #1063 + janeczku/calibre-web#3457 for a "regenerate cover
+from the file" path.
+
+Returns raw image bytes (and the detected extension) so the caller can
+either serve them as a data URL in the picker grid OR pipe them through
+``helper.save_cover`` on apply. No new dependencies — only reads ZIP
+archives via the stdlib ``zipfile`` module the way ``cps/epub.py`` does.
+
+Supported formats (best-effort; missing-format == no candidate, never raises):
+  - EPUB / KEPUB (zipfile + manifest cover-image item)
+  - CBZ / CB7 (first image in the archive — same convention as comic.py)
+  - PDF (defers to PyPDF / pikepdf if installed; returns None otherwise)
+
+MOBI / AZW3 are deliberately not supported here; the extraction libraries
+add weight and the user can always upload a file manually if the embedded
+cover matters for those formats.
+"""
+from __future__ import annotations
+
+import dataclasses
+import os
+import zipfile
+from typing import Optional
+
+try:
+    from lxml import etree as _etree
+    _LXML_AVAILABLE = True
+except ImportError:  # pragma: no cover - dev envs without lxml
+    _etree = None
+    _LXML_AVAILABLE = False
+
+from .. import config, logger
+
+
+log = logger.create()
+
+
+_EPUB_NS = {
+    "n": "urn:oasis:names:tc:opendocument:xmlns:container",
+    "pkg": "http://www.idpf.org/2007/opf",
+    "dc": "http://purl.org/dc/elements/1.1/",
+}
+
+_IMAGE_EXTS = (".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp")
+
+
+@dataclasses.dataclass
+class ExtractedCover:
+    """Raw embedded cover bytes plus the detected file extension. The
+    cover-picker page serves this as a data URL; ``apply`` re-uses the
+    bytes through the existing ``helper.save_cover`` path."""
+
+    data: bytes
+    extension: str  # lowercase, with leading dot, e.g. ".jpg"
+    source_format: str  # "epub" | "cbz" | "pdf"
+
+    @property
+    def mime_type(self) -> str:
+        return {
+            ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+            ".png": "image/png", ".webp": "image/webp",
+            ".gif": "image/gif", ".bmp": "image/bmp",
+        }.get(self.extension, "application/octet-stream")
+
+
+def extract_embedded_cover(book) -> Optional[ExtractedCover]:
+    """Extract the cover from any of ``book.data`` formats. Tries EPUB
+    first (highest signal), then CBZ, then PDF.
+
+    Never raises. Returns None if no cover can be extracted, the file is
+    missing, or the format isn't supported here. Logs at DEBUG."""
+    formats = list(book.data) if hasattr(book, "data") else []
+    for entry in formats:
+        ext = (entry.format or "").lower()
+        path = _book_format_path(book, entry)
+        if not path or not os.path.isfile(path):
+            continue
+        if ext in ("epub", "kepub"):
+            cover = _extract_from_epub(path)
+            if cover is not None:
+                return cover
+        elif ext in ("cbz", "cb7"):
+            cover = _extract_from_cbz(path)
+            if cover is not None:
+                return cover
+        elif ext == "pdf":
+            cover = _extract_from_pdf(path)
+            if cover is not None:
+                return cover
+    return None
+
+
+def _book_format_path(book, data_entry) -> Optional[str]:
+    """Build the on-disk path to a particular format of ``book``."""
+    book_dir = getattr(book, "path", None)
+    name = getattr(data_entry, "name", None)
+    fmt = getattr(data_entry, "format", "")
+    if not (book_dir and name and fmt):
+        return None
+    base = config.get_book_path() if config else ""
+    return os.path.join(base, book_dir, f"{name}.{fmt.lower()}")
+
+
+def _extract_from_epub(file_path: str) -> Optional[ExtractedCover]:
+    """Pull the cover out of an EPUB by reading the OPF manifest. Mirrors
+    ``cps.epub._extract_cover``'s detection logic but reads bytes
+    directly instead of writing them through cover_processing."""
+    if not _LXML_AVAILABLE:
+        log.debug("lxml not installed; skipping EPUB cover extract for %s", file_path)
+        return None
+    try:
+        with zipfile.ZipFile(file_path, "r") as zf:
+            container = zf.read("META-INF/container.xml")
+            container_tree = _etree.fromstring(container)
+            opf_path = container_tree.xpath(
+                "n:rootfiles/n:rootfile/@full-path", namespaces=_EPUB_NS,
+            )
+            if not opf_path:
+                return None
+            opf_data = zf.read(opf_path[0])
+            opf_tree = _etree.fromstring(opf_data)
+
+            cover_href = _find_epub_cover_href(opf_tree)
+            if not cover_href:
+                return None
+
+            opf_dir = os.path.dirname(opf_path[0])
+            cover_zip_path = os.path.join(opf_dir, cover_href).replace("\\", "/")
+            try:
+                cover_bytes = zf.read(cover_zip_path)
+            except KeyError:
+                return None
+            ext = os.path.splitext(cover_href)[1].lower()
+            if ext not in _IMAGE_EXTS:
+                return None
+            return ExtractedCover(data=cover_bytes, extension=ext, source_format="epub")
+    except (zipfile.BadZipFile, KeyError, OSError) as exc:
+        log.debug("EPUB cover extraction failed for %s: %s", file_path, exc)
+        return None
+    except Exception as exc:  # lxml-specific errors at runtime
+        log.debug("EPUB cover XML parse failed for %s: %s", file_path, exc)
+        return None
+
+
+def _find_epub_cover_href(opf_tree) -> Optional[str]:
+    """Apply the same fallback chain ``cps.epub`` does to find the cover
+    item href: cover-image id → meta cover content → guide reference."""
+    # Modern EPUBs: properties="cover-image"
+    href = opf_tree.xpath(
+        "//pkg:manifest/pkg:item[@properties='cover-image']/@href",
+        namespaces=_EPUB_NS,
+    )
+    if href:
+        return href[0]
+    # Older EPUBs: id='cover-image'
+    href = opf_tree.xpath(
+        "//pkg:manifest/pkg:item[@id='cover-image']/@href",
+        namespaces=_EPUB_NS,
+    )
+    if href:
+        return href[0]
+    # Even older EPUBs: <meta name="cover" content="<item-id>"/>
+    meta_cover = opf_tree.xpath(
+        "//pkg:metadata/pkg:meta[@name='cover']/@content",
+        namespaces=_EPUB_NS,
+    )
+    if meta_cover:
+        href = opf_tree.xpath(
+            f"//pkg:manifest/pkg:item[@id='{meta_cover[0]}']/@href",
+            namespaces=_EPUB_NS,
+        )
+        if href:
+            return href[0]
+    # Last-ditch: <guide><reference type="cover" href="..."/></guide>
+    href = opf_tree.xpath(
+        "//pkg:guide/pkg:reference[@type='cover']/@href",
+        namespaces=_EPUB_NS,
+    )
+    return href[0] if href else None
+
+
+def _extract_from_cbz(file_path: str) -> Optional[ExtractedCover]:
+    """Comic-archive cover = first image when sorted alphabetically. Same
+    convention ``cps.comic`` follows; CBR (rar) is intentionally
+    skipped — it needs the unrar binary and the cover-picker is a
+    convenience surface, not a critical path."""
+    try:
+        with zipfile.ZipFile(file_path, "r") as zf:
+            image_names = sorted(
+                n for n in zf.namelist()
+                if os.path.splitext(n)[1].lower() in _IMAGE_EXTS
+                and not n.endswith("/")
+            )
+            if not image_names:
+                return None
+            first = image_names[0]
+            return ExtractedCover(
+                data=zf.read(first),
+                extension=os.path.splitext(first)[1].lower(),
+                source_format="cbz",
+            )
+    except (zipfile.BadZipFile, OSError) as exc:
+        log.debug("CBZ cover extraction failed for %s: %s", file_path, exc)
+        return None
+
+
+def _extract_from_pdf(file_path: str) -> Optional[ExtractedCover]:
+    """First-page render of a PDF as a JPEG. Requires ``pdf2image`` or
+    ``pypdfium2`` — both are heavy native deps; we don't add them just
+    for this. Skipped silently if neither is importable."""
+    try:
+        import pypdfium2 as pdfium  # type: ignore
+    except ImportError:
+        log.debug("pypdfium2 not installed; skipping PDF cover extract for %s", file_path)
+        return None
+    try:
+        pdf = pdfium.PdfDocument(file_path)
+        if len(pdf) == 0:
+            return None
+        page = pdf[0]
+        bitmap = page.render(scale=2.0)
+        image = bitmap.to_pil()
+        import io
+        buf = io.BytesIO()
+        image.save(buf, format="JPEG", quality=88)
+        return ExtractedCover(
+            data=buf.getvalue(), extension=".jpg", source_format="pdf",
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        log.debug("PDF cover render failed for %s: %s", file_path, exc)
+        return None

--- a/cps/services/cover_picker.py
+++ b/cps/services/cover_picker.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Orchestration layer for the cover-picker page.
+
+Runs all enabled metadata providers, post-processes their results
+through ``cover_booster``, optionally adds the embedded-cover-from-file
+candidate, and returns a flattened list of cover-only candidates ready
+for the picker grid. The picker template + blueprint are thin views over
+this; all the orchestration logic lives here so it's testable without a
+Flask app.
+
+Architecture intent: any new metadata provider added to
+``cps/metadata_provider/`` automatically contributes candidates here.
+The picker has zero per-source registration code — match the existing
+provider auto-discovery pattern. Same providers, same toggles, same API
+keys; only the surface they're presented through differs.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import dataclasses
+import os
+import time
+from dataclasses import asdict
+from typing import Callable, Dict, Iterable, List, Optional
+
+from .. import logger
+from .cover_booster import boost_covers
+
+
+log = logger.create()
+
+
+_DEFAULT_TIMEOUT = float(os.environ.get("CWA_COVER_PICKER_TIMEOUT", "12"))
+_DEFAULT_WORKERS = int(os.environ.get("CWA_COVER_PICKER_WORKERS", "5"))
+_DEFAULT_MAX_PER_SOURCE = int(os.environ.get("CWA_COVER_PICKER_MAX_CANDIDATES", "30"))
+
+
+@dataclasses.dataclass
+class CoverCandidate:
+    """One cover the picker grid can show. Lighter than ``MetaRecord``
+    because we don't need full metadata — just enough to identify the
+    source and let the user choose."""
+
+    source_id: str          # 'hardcover', 'openlibrary', 'embedded', 'url', 'upload'
+    source_name: str        # Display label for the source badge
+    cover_url: str          # http(s) URL or data: URL
+    title: Optional[str] = None
+    authors: Optional[List[str]] = None
+    publisher: Optional[str] = None
+    year: Optional[str] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    candidate_id: Optional[str] = None      # Stable id for the apply step
+    flags: Optional[List[str]] = None       # 'low_res', 'squished', etc.
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclasses.dataclass
+class ProviderStatus:
+    """Per-provider status surfaced to the UI — same shape as
+    ``search_metadata.metadata_search`` returns so the picker page can
+    render the same status row."""
+
+    id: str
+    name: str
+    status: str          # ok | empty | error | disabled | missing_key | rate_limited | blocked
+    count: int
+    message: str = ""
+    duration_ms: int = 0
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def gather_cover_candidates(
+    *,
+    providers: Iterable,
+    query: str,
+    static_cover: str,
+    locale: str,
+    is_provider_enabled: Callable[[object], bool] = lambda _p: True,
+    classify_failure: Callable[[Exception], tuple] = lambda exc: ("error", str(exc) or exc.__class__.__name__),
+    classify_empty: Callable[[object], tuple] = lambda _p: ("empty", "No results"),
+    extract_embedded: Optional[Callable[[], "ExtractedCover | None"]] = None,
+) -> tuple[List[CoverCandidate], List[ProviderStatus]]:
+    """Run every enabled provider against ``query`` in parallel, post-process
+    through ``cover_booster``, and return a flattened candidate list +
+    per-provider status.
+
+    Caller responsibilities (kept out of this module so it stays
+    Flask-free):
+
+      * ``providers`` — iterable of provider instances. Match
+        ``cps.search_metadata.cl``'s shape.
+      * ``is_provider_enabled(provider)`` — gate function; the picker can
+        respect both per-user and global enablement here.
+      * ``classify_failure`` / ``classify_empty`` — share the same
+        classifiers ``search_metadata.metadata_search`` uses so the UI
+        copy stays consistent.
+      * ``extract_embedded`` — zero-arg callable that returns an
+        ``ExtractedCover`` or None. Lets us inject the embedded candidate
+        without coupling this module to ``cover_extract``.
+    """
+    runnable, statuses = _filter_runnable(providers, is_provider_enabled)
+    candidates: List[CoverCandidate] = []
+
+    if extract_embedded is not None:
+        try:
+            embedded = extract_embedded()
+        except Exception as exc:  # pragma: no cover - defensive
+            log.debug("embedded cover extract failed: %s", exc)
+            embedded = None
+        if embedded is not None:
+            data_url = _bytes_to_data_url(embedded.data, embedded.mime_type)
+            candidates.append(CoverCandidate(
+                source_id="embedded",
+                source_name="Current embedded cover",
+                cover_url=data_url,
+                candidate_id="embedded",
+            ))
+
+    if not runnable or not query:
+        return candidates, statuses
+
+    started_at = {p.__id__: time.monotonic() for p in runnable}
+    results_by_provider: Dict[str, list] = {}
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=_DEFAULT_WORKERS) as pool:
+        futures = {
+            pool.submit(p.search, query, static_cover, locale): p for p in runnable
+        }
+        for fut in concurrent.futures.as_completed(futures):
+            p = futures[fut]
+            elapsed_ms = int((time.monotonic() - started_at.get(p.__id__, time.monotonic())) * 1000)
+            try:
+                hits = fut.result() or []
+            except Exception as exc:
+                status, message = classify_failure(exc)
+                log.warning("cover-picker provider %s failed (%s) in %dms: %s",
+                            p.__class__.__name__, status, elapsed_ms, exc)
+                statuses.append(ProviderStatus(
+                    id=p.__id__, name=p.__name__, status=status,
+                    count=0, message=message, duration_ms=elapsed_ms,
+                ))
+                continue
+            results_by_provider[p.__id__] = hits[:_DEFAULT_MAX_PER_SOURCE]
+            count = len(results_by_provider[p.__id__])
+            status, message = ("ok", "") if count else classify_empty(p)
+            statuses.append(ProviderStatus(
+                id=p.__id__, name=p.__name__, status=status,
+                count=count, message=message, duration_ms=elapsed_ms,
+            ))
+
+    flat = []
+    for hits in results_by_provider.values():
+        flat.extend([asdict(h) for h in hits if h])
+    try:
+        boost_covers(flat)
+    except Exception as exc:  # pragma: no cover - defensive
+        log.warning("cover-picker boost pass failed: %s", exc)
+
+    for record in flat:
+        cover_url = record.get("cover") or ""
+        if not cover_url or _is_generic_cover(cover_url, static_cover):
+            continue
+        source = record.get("source") or {}
+        candidates.append(CoverCandidate(
+            source_id=source.get("id") or "unknown",
+            source_name=source.get("description") or "Unknown",
+            cover_url=cover_url,
+            title=record.get("title"),
+            authors=record.get("authors") or [],
+            publisher=record.get("publisher") or None,
+            year=_year_from_published_date(record.get("publishedDate")),
+            candidate_id=f"{source.get('id') or 'src'}:{record.get('id') or ''}",
+        ))
+
+    statuses.sort(key=lambda s: s.name.lower())
+    return candidates, statuses
+
+
+def _filter_runnable(providers, is_provider_enabled) -> tuple[list, List[ProviderStatus]]:
+    runnable: list = []
+    statuses: List[ProviderStatus] = []
+    for p in providers:
+        if not is_provider_enabled(p):
+            statuses.append(ProviderStatus(
+                id=p.__id__, name=p.__name__, status="disabled", count=0,
+                message="Disabled in settings", duration_ms=0,
+            ))
+            continue
+        runnable.append(p)
+    return runnable, statuses
+
+
+def _is_generic_cover(cover_url: str, static_cover: str) -> bool:
+    if not cover_url:
+        return True
+    if static_cover and cover_url.endswith(static_cover.split("/")[-1]):
+        return True
+    if cover_url.endswith("generic_cover.svg"):
+        return True
+    return False
+
+
+def _year_from_published_date(value) -> Optional[str]:
+    if not value:
+        return None
+    s = str(value)
+    return s[:4] if len(s) >= 4 and s[:4].isdigit() else None
+
+
+def _bytes_to_data_url(data: bytes, mime_type: str) -> str:
+    """Serialize raw image bytes to a data URL the picker grid can render
+    without a separate fetch. Used only for the embedded-cover candidate;
+    typical EPUB cover is 50-300 KB which is fine inline."""
+    import base64
+    return f"data:{mime_type};base64,{base64.b64encode(data).decode('ascii')}"

--- a/cps/services/cover_url_validator.py
+++ b/cps/services/cover_url_validator.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Validate a cover URL before it gets committed.
+
+Used by two callers:
+
+  1. ``POST /metadata/cover/preview`` — the live-preview endpoint behind
+     the inline ``cover_url`` field on the edit-metadata page.
+  2. The cover-picker page's URL-paste panel.
+
+Both want the same answer: does this URL serve a real image, what are its
+dimensions, what's its content-type, is the size within our limits, would
+the SSRF guard let us fetch it later. The validator runs the same checks
+``helper.save_cover_from_url`` does on the save path so previewing is
+faithful to what would actually happen on commit.
+
+Pure-functional. No Flask state. No DB writes. Easy to test with mocked
+HTTP. No new dependencies — uses the existing ``cw_advocate`` SSRF guard
+and ``Pillow`` (already in requirements via ``cps.helper``).
+"""
+from __future__ import annotations
+
+import dataclasses
+import io
+import os
+from typing import Optional
+
+try:
+    from .. import cw_advocate
+    from ..cw_advocate.exceptions import UnacceptableAddressException
+    _ADVOCATE_AVAILABLE = True
+except ImportError:  # pragma: no cover - dev/test envs without advocate
+    cw_advocate = None
+    UnacceptableAddressException = type("UnacceptableAddressException", (Exception,), {})
+    _ADVOCATE_AVAILABLE = False
+
+try:
+    from PIL import Image as _PILImage
+except ImportError:  # pragma: no cover - dev envs without Pillow
+    _PILImage = None
+
+import requests
+
+from .. import logger
+
+
+log = logger.create()
+
+_DEFAULT_TIMEOUT = float(os.environ.get("CWA_COVER_PICKER_TIMEOUT", "4"))
+_DEFAULT_MAX_BYTES = int(os.environ.get("CWA_COVER_DOWNLOAD_MAX_BYTES", str(15 * 1024 * 1024)))
+# A sane minimum — anything below 5 KB is almost certainly a placeholder
+# (Amazon's 43-byte image/gif, OL's blank cover, etc.).
+_MIN_BYTES = 5_000
+# How many bytes to read from the body for dimension detection. Most JPEG
+# headers fit in the first 4 KB. PNG IHDR is at offset 16. WebP is at 26.
+_DIM_PROBE_BYTES = 8 * 1024
+_ACCEPTED_TYPES = ("image/jpeg", "image/png", "image/webp", "image/gif", "image/bmp")
+
+
+@dataclasses.dataclass
+class ValidationResult:
+    """The shape returned by :func:`validate_cover_url` and serialized to
+    JSON by the live-preview endpoint."""
+
+    valid: bool
+    url: str
+    error_code: Optional[str] = None      # machine-readable: 'ssrf_blocked', 'too_small', ...
+    error_message: Optional[str] = None   # human-readable, safe to show in the UI
+    content_type: Optional[str] = None
+    size_bytes: Optional[int] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+def validate_cover_url(url: str) -> ValidationResult:
+    """Probe ``url`` and return whether it would succeed if saved as a cover.
+
+    The probe is lightweight: a HEAD first to check status + content-type +
+    size, then a partial GET to read dimensions out of the image header.
+    Total network bytes are bounded by ``_DIM_PROBE_BYTES``. The HEAD probe
+    obeys the same SSRF guard the save path uses, so URLs that would fail
+    on commit (localhost, RFC1918) fail at preview time too.
+    """
+    url = (url or "").strip()
+    if not url:
+        return ValidationResult(valid=False, url=url, error_code="empty",
+                                error_message="Enter a URL.")
+    if not (url.startswith("http://") or url.startswith("https://")):
+        return ValidationResult(valid=False, url=url, error_code="bad_scheme",
+                                error_message="URL must start with http:// or https://.")
+
+    if not _ADVOCATE_AVAILABLE or cw_advocate is None:
+        return ValidationResult(valid=False, url=url, error_code="advocate_missing",
+                                error_message="Cover-URL validation is unavailable on this server.")
+
+    try:
+        head = cw_advocate.head(url, timeout=_DEFAULT_TIMEOUT, allow_redirects=True)
+    except UnacceptableAddressException:
+        return ValidationResult(valid=False, url=url, error_code="ssrf_blocked",
+                                error_message="That URL points to an internal or local address. Use a public URL.")
+    except (requests.RequestException, Exception) as exc:  # pragma: no cover - defensive
+        log.debug("validate_cover_url HEAD failed for %s: %s", url, exc)
+        return ValidationResult(valid=False, url=url, error_code="unreachable",
+                                error_message="Could not reach that URL. Check the address and try again.")
+
+    if head.status_code != 200:
+        return ValidationResult(valid=False, url=url, error_code="bad_status",
+                                error_message=f"Server returned HTTP {head.status_code}.")
+
+    content_type = (head.headers.get("content-type") or "").split(";")[0].strip().lower()
+    try:
+        size_bytes = int(head.headers.get("content-length") or 0)
+    except (TypeError, ValueError):
+        size_bytes = 0
+
+    if content_type and not any(content_type.startswith(t) for t in _ACCEPTED_TYPES):
+        return ValidationResult(
+            valid=False, url=url, error_code="not_image",
+            error_message=f"That URL serves {content_type or 'an unknown content type'}, not an image.",
+            content_type=content_type, size_bytes=size_bytes or None,
+        )
+
+    if size_bytes and size_bytes > _DEFAULT_MAX_BYTES:
+        return ValidationResult(
+            valid=False, url=url, error_code="too_large",
+            error_message=f"Image is {size_bytes // (1024 * 1024)} MB; the server limit is "
+                          f"{_DEFAULT_MAX_BYTES // (1024 * 1024)} MB.",
+            content_type=content_type, size_bytes=size_bytes,
+        )
+
+    if size_bytes and size_bytes < _MIN_BYTES:
+        return ValidationResult(
+            valid=False, url=url, error_code="too_small",
+            error_message=f"Image is only {size_bytes} bytes. That's almost always a placeholder, not a real cover.",
+            content_type=content_type, size_bytes=size_bytes,
+        )
+
+    width, height = _probe_dimensions(url)
+
+    return ValidationResult(
+        valid=True, url=url, content_type=content_type or None,
+        size_bytes=size_bytes or None, width=width, height=height,
+    )
+
+
+def _probe_dimensions(url: str) -> tuple[Optional[int], Optional[int]]:
+    """Stream the first ``_DIM_PROBE_BYTES`` of ``url`` and parse image
+    dimensions out of the header. Returns (None, None) if dimensions
+    cannot be determined — never raises."""
+    if _PILImage is None or cw_advocate is None:
+        return None, None
+    try:
+        resp = cw_advocate.get(url, timeout=_DEFAULT_TIMEOUT, stream=True, allow_redirects=True)
+        resp.raise_for_status()
+        head_bytes = b""
+        for chunk in resp.iter_content(chunk_size=2048):
+            head_bytes += chunk
+            if len(head_bytes) >= _DIM_PROBE_BYTES:
+                break
+        resp.close()
+    except Exception as exc:
+        log.debug("_probe_dimensions stream failed for %s: %s", url, exc)
+        return None, None
+
+    if not head_bytes:
+        return None, None
+    try:
+        with _PILImage.open(io.BytesIO(head_bytes)) as img:
+            return img.width, img.height
+    except Exception as exc:
+        log.debug("_probe_dimensions PIL parse failed for %s: %s", url, exc)
+        return None, None

--- a/cps/static/css/cover_picker.css
+++ b/cps/static/css/cover_picker.css
@@ -1,0 +1,333 @@
+/*
+ * Calibre-Web-NextGen — focused cover-picker UI
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Plain CSS, Bootstrap-3 conventions matching the existing fork. No
+ * preprocessor, no bundler. Selectors are scoped under .cwa-cover-picker
+ * so the picker never bleeds into the rest of the app.
+ */
+
+.cwa-cover-picker {
+  padding: 16px;
+}
+
+.cwa-cover-picker__back {
+  text-decoration: none;
+  font-size: 13px;
+  color: #777;
+}
+.cwa-cover-picker__back:hover { color: #333; }
+
+.cwa-cover-picker__title {
+  margin: 4px 0 0 0;
+}
+
+.cwa-cover-picker__subtitle {
+  margin: 4px 0 16px 0;
+}
+
+/* Left rail — current cover + lock toggle */
+.cwa-cover-picker__current-card {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 12px;
+  background: #fafafa;
+}
+
+.cwa-cover-picker__current-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #888;
+  margin-bottom: 6px;
+}
+
+#cwa-cover-picker-current-img {
+  width: 100%;
+  max-height: 360px;
+  object-fit: contain;
+  border-radius: 4px;
+  background: #fff;
+  border: 1px solid #ddd;
+}
+
+.cwa-cover-picker__current-meta {
+  margin-top: 10px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: #444;
+}
+
+.cwa-cover-picker__lock {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.cwa-cover-picker__lock-toggle {
+  display: flex;
+  align-items: center;
+  font-weight: 600;
+  margin: 0;
+  cursor: pointer;
+}
+.cwa-cover-picker__lock-toggle input { margin-right: 8px; }
+
+.cwa-cover-picker__lock-help {
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+/* Right column — source panels + grid */
+.cwa-cover-picker__panels {
+  margin-bottom: 18px;
+}
+
+.cwa-cover-picker__panel {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  margin-bottom: 8px;
+  background: #fff;
+}
+
+.cwa-cover-picker__panel summary {
+  cursor: pointer;
+  padding: 10px 14px;
+  font-weight: 600;
+  list-style: none;
+  user-select: none;
+}
+.cwa-cover-picker__panel summary::-webkit-details-marker { display: none; }
+.cwa-cover-picker__panel summary::before {
+  content: '\002B';  /* + */
+  display: inline-block;
+  margin-right: 8px;
+  color: #888;
+  transition: transform 0.15s ease;
+}
+.cwa-cover-picker__panel[open] summary::before {
+  content: '\2212';  /* − */
+}
+
+.cwa-cover-picker__panel-body {
+  padding: 0 14px 14px 14px;
+}
+
+.cwa-cover-picker__feedback {
+  font-size: 13px;
+  margin-top: 6px;
+  min-height: 1.4em;
+}
+.cwa-cover-picker__feedback.is-error { color: #b94a48; }
+.cwa-cover-picker__feedback.is-ok { color: #468847; }
+
+.cwa-cover-picker__url-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 10px;
+  padding: 8px;
+  background: #f5f5f5;
+  border-radius: 4px;
+}
+
+#cwa-cover-picker-url-thumb {
+  max-width: 80px;
+  max-height: 120px;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  background: #fff;
+}
+
+.cwa-cover-picker__url-meta {
+  flex: 1;
+  font-size: 12px;
+  color: #555;
+}
+
+/* Grid */
+.cwa-cover-picker__grid-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 12px 0 8px 0;
+  flex-wrap: wrap;
+}
+.cwa-cover-picker__grid-toolbar h4 { margin: 0; }
+.cwa-cover-picker__grid-toolbar .cwa-cover-picker__grid-actions {
+  margin-left: auto;
+}
+
+.cwa-cover-picker__status-pill {
+  display: inline-block;
+  padding: 2px 10px;
+  font-size: 12px;
+  border-radius: 10px;
+  background: #eee;
+  color: #555;
+}
+.cwa-cover-picker__status-pill--loading {
+  background: #e8f0fe;
+  color: #1967d2;
+}
+.cwa-cover-picker__status-pill--ok {
+  background: #e6f4ea;
+  color: #137333;
+}
+.cwa-cover-picker__status-pill--empty {
+  background: #fff7e6;
+  color: #b25e09;
+}
+
+.cwa-cover-picker__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.cwa-cover-picker__grid-empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 30px 0;
+}
+
+.cwa-cover-picker__card {
+  position: relative;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background: #fff;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+.cwa-cover-picker__card:hover {
+  box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+  transform: translateY(-1px);
+}
+
+.cwa-cover-picker__card-cover {
+  width: 100%;
+  height: 220px;
+  object-fit: contain;
+  background: #f5f5f5;
+}
+
+.cwa-cover-picker__card-info {
+  padding: 8px 10px;
+  font-size: 12px;
+  flex: 1;
+}
+
+.cwa-cover-picker__card-source {
+  font-weight: 600;
+  color: #333;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cwa-cover-picker__card-dims {
+  margin-top: 2px;
+  color: #888;
+  font-size: 11px;
+}
+.cwa-cover-picker__card-dims--low {
+  color: #b94a48;
+}
+
+.cwa-cover-picker__card-title {
+  margin-top: 4px;
+  color: #555;
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cwa-cover-picker__card-source-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  background: #eef;
+  color: #335;
+  border-radius: 8px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.cwa-cover-picker__card.is-applying {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.cwa-cover-picker__provider-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.cwa-cover-picker__provider-pill {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 8px;
+  background: #f5f5f5;
+  color: #666;
+}
+.cwa-cover-picker__provider-pill--ok { background: #e6f4ea; color: #137333; }
+.cwa-cover-picker__provider-pill--empty { background: #f5f5f5; color: #999; }
+.cwa-cover-picker__provider-pill--error { background: #fde7e7; color: #b94a48; }
+.cwa-cover-picker__provider-pill--rate_limited { background: #fff3cd; color: #856404; }
+.cwa-cover-picker__provider-pill--blocked { background: #fde7e7; color: #b94a48; }
+.cwa-cover-picker__provider-pill--missing_key { background: #fff3cd; color: #856404; }
+.cwa-cover-picker__provider-pill--disabled { background: #eee; color: #999; }
+
+/* Confirm modal */
+.cwa-cover-picker__confirm-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.cwa-cover-picker__confirm-side {
+  text-align: center;
+}
+
+.cwa-cover-picker__confirm-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #888;
+  margin-bottom: 6px;
+}
+
+.cwa-cover-picker__confirm-side img {
+  max-width: 100%;
+  max-height: 380px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.cwa-cover-picker__confirm-meta {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #555;
+}
+
+/* API-keys panel — mirrors the metadata-search modal styling */
+.cwa-cover-picker__keys-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid #eee;
+}
+.cwa-cover-picker__keys-row:last-child { border-bottom: 0; }
+.cwa-cover-picker__keys-name { flex: 0 0 160px; font-weight: 600; }
+.cwa-cover-picker__keys-state { flex: 0 0 130px; font-size: 12px; }
+.cwa-cover-picker__keys-input { flex: 1; }
+.cwa-cover-picker__keys-input input { width: 100%; }

--- a/cps/static/css/cwa.css
+++ b/cps/static/css/cwa.css
@@ -45,3 +45,35 @@ body.modal-open #remove-from-shelves + .tags {
 #exclude_tag + .btn-group .dropdown-menu {
     max-width: 40vw;
 }
+
+/* Inline cover-URL live preview on the edit-metadata page (PR: focused
+   cover picker — see notes/COVER-PICKER-DESIGN.md). Compact preview
+   thumbnail + dimensions + a friendly error before save round-trip. */
+.cwa-cover-url-preview {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 6px;
+    padding: 6px;
+    background: #f5f5f5;
+    border-radius: 4px;
+}
+.cwa-cover-url-preview img {
+    max-width: 70px;
+    max-height: 100px;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    background: #fff;
+}
+.cwa-cover-url-preview > div {
+    font-size: 12px;
+    color: #555;
+}
+.cwa-cover-url-feedback {
+    font-size: 12px;
+    margin-top: 4px;
+    min-height: 1.2em;
+}
+.cwa-cover-url-feedback.is-ok    { color: #468847; }
+.cwa-cover-url-feedback.is-error { color: #b94a48; }
+.cwa-cover-picker__entry         { margin-top: 4px; }

--- a/cps/static/js/cover_picker.js
+++ b/cps/static/js/cover_picker.js
@@ -1,0 +1,411 @@
+/*
+ * Calibre-Web-NextGen — focused cover-picker UI
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Plain ES2017+ — no transpiler, no bundler. Lives at /book/<id>/cover.
+ * The template injects window.cwaCoverPicker with endpoints + i18n.
+ *
+ * Architecture: every panel (URL paste, file upload, API keys, candidate
+ * grid) is its own small section. The template keeps each section simple
+ * via <details>; the JS hooks events on each. No framework.
+ *
+ * Adding a new candidate source means adding a metadata provider in
+ * cps/metadata_provider/ — the picker grid surfaces every provider that
+ * returns covers for the current book. No JS changes required.
+ */
+(function () {
+  "use strict";
+
+  if (!window.cwaCoverPicker) return;
+  const cfg = window.cwaCoverPicker;
+
+  // -------- HTTP helpers --------
+  async function postJson(url, body) {
+    const headers = { "Content-Type": "application/json", "Accept": "application/json" };
+    if (cfg.csrfToken) headers["X-CSRFToken"] = cfg.csrfToken;
+    const resp = await fetch(url, { method: "POST", headers, credentials: "same-origin", body: JSON.stringify(body || {}) });
+    if (!resp.ok && resp.status >= 500) throw new Error("server-" + resp.status);
+    let payload;
+    try { payload = await resp.json(); } catch (_) { payload = {}; }
+    payload.__status = resp.status;
+    return payload;
+  }
+  async function postForm(url, formData) {
+    const headers = { "Accept": "application/json" };
+    if (cfg.csrfToken) headers["X-CSRFToken"] = cfg.csrfToken;
+    const resp = await fetch(url, { method: "POST", headers, credentials: "same-origin", body: formData });
+    if (!resp.ok && resp.status >= 500) throw new Error("server-" + resp.status);
+    let payload;
+    try { payload = await resp.json(); } catch (_) { payload = {}; }
+    payload.__status = resp.status;
+    return payload;
+  }
+  async function getJson(url) {
+    const resp = await fetch(url, { method: "GET", credentials: "same-origin", headers: { "Accept": "application/json" } });
+    return resp.ok ? resp.json() : [];
+  }
+
+  // -------- Candidate grid --------
+  const grid = document.getElementById("cwa-cover-picker-grid");
+  const status = document.getElementById("cwa-cover-picker-status");
+  const providerStatus = document.getElementById("cwa-cover-picker-provider-status");
+
+  function setGridStatus(state, text) {
+    status.innerHTML = "";
+    const pill = document.createElement("span");
+    pill.className = "cwa-cover-picker__status-pill cwa-cover-picker__status-pill--" + state;
+    pill.textContent = text;
+    status.appendChild(pill);
+  }
+
+  function renderEmpty(text) {
+    grid.innerHTML = "";
+    const empty = document.createElement("div");
+    empty.className = "cwa-cover-picker__grid-empty text-muted";
+    empty.textContent = text;
+    grid.appendChild(empty);
+  }
+
+  function renderProviderPills(providers) {
+    providerStatus.innerHTML = "";
+    providers.forEach((p) => {
+      const pill = document.createElement("span");
+      pill.className = "cwa-cover-picker__provider-pill cwa-cover-picker__provider-pill--" + (p.status || "empty");
+      const ms = p.duration_ms ? ` (${p.duration_ms}ms)` : "";
+      const count = p.count != null ? ` · ${p.count}` : "";
+      pill.textContent = `${p.name} — ${p.status}${count}${ms}`;
+      if (p.message) pill.title = p.message;
+      providerStatus.appendChild(pill);
+    });
+  }
+
+  function renderCard(candidate) {
+    const card = document.createElement("div");
+    card.className = "cwa-cover-picker__card";
+    card.dataset.candidateId = candidate.candidate_id || "";
+    card.dataset.coverUrl = candidate.cover_url || "";
+
+    const img = document.createElement("img");
+    img.className = "cwa-cover-picker__card-cover";
+    img.alt = candidate.title || "";
+    img.loading = "lazy";
+    img.src = candidate.cover_url;
+    img.onerror = function () { img.style.display = "none"; };
+    img.onload = function () {
+      // Surface the natural dimensions when the candidate didn't carry
+      // them (most providers don't). cover_booster fires later for the
+      // metadata modal, but for the picker the browser is the source of
+      // truth — the image had to render anyway.
+      const dimsEl = card.querySelector(".cwa-cover-picker__card-dims");
+      if (dimsEl && img.naturalWidth) {
+        dimsEl.textContent = img.naturalWidth + "×" + img.naturalHeight;
+        if (img.naturalWidth < 600 || img.naturalHeight < 800) {
+          dimsEl.classList.add("cwa-cover-picker__card-dims--low");
+        }
+      }
+    };
+    card.appendChild(img);
+
+    const info = document.createElement("div");
+    info.className = "cwa-cover-picker__card-info";
+    const sourceRow = document.createElement("div");
+    sourceRow.className = "cwa-cover-picker__card-source";
+    const sourceName = document.createElement("span");
+    sourceName.textContent = candidate.source_name || candidate.source_id;
+    const sourceBadge = document.createElement("span");
+    sourceBadge.className = "cwa-cover-picker__card-source-badge";
+    sourceBadge.textContent = candidate.source_id || "src";
+    sourceRow.appendChild(sourceName);
+    sourceRow.appendChild(sourceBadge);
+    info.appendChild(sourceRow);
+
+    const dims = document.createElement("div");
+    dims.className = "cwa-cover-picker__card-dims";
+    if (candidate.width && candidate.height) {
+      dims.textContent = candidate.width + "×" + candidate.height;
+      if (candidate.width < 600 || candidate.height < 800) {
+        dims.classList.add("cwa-cover-picker__card-dims--low");
+      }
+    } else {
+      dims.textContent = "—";
+    }
+    info.appendChild(dims);
+
+    if (candidate.title || candidate.year) {
+      const title = document.createElement("div");
+      title.className = "cwa-cover-picker__card-title";
+      title.textContent = (candidate.title || "") + (candidate.year ? " (" + candidate.year + ")" : "");
+      info.appendChild(title);
+    }
+
+    card.appendChild(info);
+    card.addEventListener("click", () => openConfirmModal(candidate, card));
+    return card;
+  }
+
+  async function loadCandidates() {
+    setGridStatus("loading", cfg.i18n.searching);
+    renderEmpty(cfg.i18n.searching);
+    try {
+      const payload = await postJson(cfg.endpoints.candidates, {});
+      const candidates = payload.candidates || [];
+      renderProviderPills(payload.providers || []);
+      grid.innerHTML = "";
+      if (candidates.length === 0) {
+        renderEmpty(cfg.i18n.noResults);
+        setGridStatus("empty", cfg.i18n.noResults);
+        return;
+      }
+      candidates.forEach((c) => grid.appendChild(renderCard(c)));
+      setGridStatus("ok", candidates.length + " candidates");
+    } catch (err) {
+      renderEmpty(cfg.i18n.error);
+      setGridStatus("empty", cfg.i18n.error);
+    }
+  }
+
+  // -------- Confirm-replace modal --------
+  const $confirm = $("#cwa-cover-picker-confirm");
+  const confirmCurrent = document.getElementById("cwa-cover-picker-confirm-current");
+  const confirmNew = document.getElementById("cwa-cover-picker-confirm-new");
+  const confirmMeta = document.getElementById("cwa-cover-picker-confirm-meta");
+  const confirmApply = document.getElementById("cwa-cover-picker-confirm-apply");
+  let pendingCandidate = null;
+
+  function openConfirmModal(candidate, sourceCard) {
+    pendingCandidate = { candidate, sourceCard };
+    confirmCurrent.src = currentImg().src;
+    confirmNew.src = candidate.cover_url;
+    confirmMeta.innerHTML = "";
+    if (candidate.source_name) {
+      const src = document.createElement("div");
+      src.innerHTML = "<strong>" + escapeHtml(candidate.source_name) + "</strong>";
+      confirmMeta.appendChild(src);
+    }
+    if (candidate.title) {
+      const t = document.createElement("div");
+      t.textContent = candidate.title + (candidate.year ? " (" + candidate.year + ")" : "");
+      confirmMeta.appendChild(t);
+    }
+    $confirm.modal("show");
+  }
+
+  confirmApply.addEventListener("click", async () => {
+    if (!pendingCandidate) return;
+    const { candidate, sourceCard } = pendingCandidate;
+    confirmApply.disabled = true;
+    confirmApply.textContent = cfg.i18n.applying;
+    sourceCard.classList.add("is-applying");
+    let payload;
+    if (candidate.source_id === "embedded") {
+      payload = await postJson(cfg.endpoints.apply, { kind: "embedded" });
+    } else {
+      payload = await postJson(cfg.endpoints.apply, { kind: "url", url: candidate.cover_url });
+    }
+    sourceCard.classList.remove("is-applying");
+    confirmApply.disabled = false;
+    confirmApply.textContent = "Use this cover";  // gettext on next render
+    if (payload.ok) {
+      bumpCurrentCover(payload.cover_url);
+      $confirm.modal("hide");
+      pendingCandidate = null;
+    } else {
+      alert(payload.error_message || cfg.i18n.error);
+    }
+  });
+
+  // -------- URL panel --------
+  const urlInput = document.getElementById("cwa-cover-picker-url-input");
+  const urlFeedback = document.getElementById("cwa-cover-picker-url-feedback");
+  const urlActions = document.getElementById("cwa-cover-picker-url-actions");
+  const urlThumb = document.getElementById("cwa-cover-picker-url-thumb");
+  const urlMeta = document.getElementById("cwa-cover-picker-url-meta");
+  const urlApply = document.getElementById("cwa-cover-picker-url-apply");
+  let urlDebounce = null;
+  let lastValidatedUrl = null;
+  let lastValidationResult = null;
+
+  urlInput.addEventListener("input", () => {
+    clearTimeout(urlDebounce);
+    urlActions.hidden = true;
+    urlFeedback.className = "cwa-cover-picker__feedback";
+    urlFeedback.textContent = "";
+    const url = (urlInput.value || "").trim();
+    if (url.length < 8) return;
+    urlDebounce = setTimeout(() => validateUrl(url), 400);
+  });
+
+  async function validateUrl(url) {
+    urlFeedback.className = "cwa-cover-picker__feedback";
+    urlFeedback.textContent = cfg.i18n.searching;
+    let payload;
+    try {
+      payload = await postJson(cfg.endpoints.preview, { url });
+    } catch (_) {
+      urlFeedback.classList.add("is-error");
+      urlFeedback.textContent = cfg.i18n.error;
+      return;
+    }
+    if (!payload.valid) {
+      urlFeedback.classList.add("is-error");
+      urlFeedback.textContent = payload.error_message || cfg.i18n.error;
+      return;
+    }
+    lastValidatedUrl = url;
+    lastValidationResult = payload;
+    urlFeedback.classList.add("is-ok");
+    urlFeedback.textContent = "Looks good.";
+    urlThumb.src = url;
+    const meta = [];
+    if (payload.width && payload.height) meta.push(payload.width + "×" + payload.height);
+    if (payload.size_bytes) meta.push(Math.round(payload.size_bytes / 1024) + " KB");
+    if (payload.content_type) meta.push(payload.content_type);
+    urlMeta.textContent = meta.join(" · ");
+    urlActions.hidden = false;
+  }
+
+  urlApply.addEventListener("click", async () => {
+    if (!lastValidatedUrl) return;
+    urlApply.disabled = true;
+    urlApply.textContent = cfg.i18n.applying;
+    const payload = await postJson(cfg.endpoints.apply, { kind: "url", url: lastValidatedUrl });
+    urlApply.disabled = false;
+    urlApply.textContent = "Use this cover";
+    if (payload.ok) {
+      bumpCurrentCover(payload.cover_url);
+      urlFeedback.classList.remove("is-error");
+      urlFeedback.classList.add("is-ok");
+      urlFeedback.textContent = cfg.i18n.applied;
+    } else {
+      alert(payload.error_message || cfg.i18n.error);
+    }
+  });
+
+  // -------- Upload panel --------
+  const uploadInput = document.getElementById("cwa-cover-picker-upload-input");
+  const uploadApply = document.getElementById("cwa-cover-picker-upload-apply");
+  const uploadFeedback = document.getElementById("cwa-cover-picker-upload-feedback");
+
+  uploadInput.addEventListener("change", () => {
+    uploadApply.disabled = !uploadInput.files || uploadInput.files.length === 0;
+    uploadFeedback.className = "cwa-cover-picker__feedback";
+    uploadFeedback.textContent = "";
+  });
+
+  uploadApply.addEventListener("click", async () => {
+    if (!uploadInput.files || !uploadInput.files[0]) return;
+    const fd = new FormData();
+    fd.append("file", uploadInput.files[0]);
+    uploadApply.disabled = true;
+    uploadFeedback.className = "cwa-cover-picker__feedback";
+    uploadFeedback.textContent = cfg.i18n.applying;
+    let payload;
+    try {
+      payload = await postForm(cfg.endpoints.apply, fd);
+    } catch (_) {
+      payload = { ok: false, error_message: cfg.i18n.error };
+    }
+    uploadApply.disabled = false;
+    if (payload.ok) {
+      uploadFeedback.classList.add("is-ok");
+      uploadFeedback.textContent = cfg.i18n.applied;
+      bumpCurrentCover(payload.cover_url);
+      uploadInput.value = "";
+    } else {
+      uploadFeedback.classList.add("is-error");
+      uploadFeedback.textContent = payload.error_message || cfg.i18n.error;
+    }
+  });
+
+  // -------- Lock toggle --------
+  const lockCheckbox = document.getElementById("cwa-cover-picker-lock");
+  lockCheckbox.addEventListener("change", async () => {
+    const desired = lockCheckbox.checked;
+    const payload = await postJson(cfg.endpoints.lock, { locked: desired });
+    if (typeof payload.locked === "boolean") {
+      lockCheckbox.checked = payload.locked;
+    }
+  });
+
+  // -------- API-keys panel (mirrors metadata-search modal) --------
+  const keysList = document.getElementById("cwa-cover-picker-keys-list");
+  let keysLoaded = false;
+  document.getElementById("cwa-cover-picker-keys-panel").addEventListener("toggle", function () {
+    if (!this.open || keysLoaded) return;
+    loadKeys();
+  });
+
+  async function loadKeys() {
+    keysLoaded = true;
+    const entries = await getJson(cfg.endpoints.keysList);
+    keysList.innerHTML = "";
+    if (!entries || entries.length === 0) {
+      keysList.textContent = "No keys to configure.";
+      return;
+    }
+    entries.forEach(renderKeyRow);
+  }
+
+  function renderKeyRow(entry) {
+    const row = document.createElement("div");
+    row.className = "cwa-cover-picker__keys-row";
+
+    const name = document.createElement("div");
+    name.className = "cwa-cover-picker__keys-name";
+    name.textContent = entry.name;
+    row.appendChild(name);
+
+    const state = document.createElement("div");
+    state.className = "cwa-cover-picker__keys-state";
+    state.textContent = entry.configured ? "Configured" : "Not configured";
+    state.style.color = entry.configured ? "#137333" : "#888";
+    row.appendChild(state);
+
+    if (entry.can_edit) {
+      const inputWrap = document.createElement("div");
+      inputWrap.className = "cwa-cover-picker__keys-input";
+      const input = document.createElement("input");
+      input.type = "text";
+      input.className = "form-control input-sm";
+      input.placeholder = entry.configured ? "Replace key…" : "Paste API key…";
+      inputWrap.appendChild(input);
+      row.appendChild(inputWrap);
+
+      const save = document.createElement("button");
+      save.className = "btn btn-default btn-sm";
+      save.textContent = "Save";
+      save.addEventListener("click", async () => {
+        const value = input.value.trim();
+        const url = cfg.endpoints.keysSave.replace("__PROV__", encodeURIComponent(entry.id));
+        const payload = await postJson(url, { value });
+        if (payload && payload.id) {
+          state.textContent = payload.configured ? "Configured" : "Not configured";
+          state.style.color = payload.configured ? "#137333" : "#888";
+          input.value = "";
+        }
+      });
+      row.appendChild(save);
+    }
+    keysList.appendChild(row);
+  }
+
+  // -------- Refresh + bookkeeping --------
+  document.getElementById("cwa-cover-picker-refresh").addEventListener("click", loadCandidates);
+
+  function currentImg() { return document.getElementById("cwa-cover-picker-current-img"); }
+
+  function bumpCurrentCover(url) {
+    const img = currentImg();
+    img.src = url || (cfg.endpoints.coverGet + "?ts=" + Date.now());
+  }
+
+  function escapeHtml(s) {
+    return String(s || "").replace(/[&<>"']/g, function (c) {
+      return ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"})[c];
+    });
+  }
+
+  // Kick off the candidate fetch as soon as the page renders.
+  document.addEventListener("DOMContentLoaded", loadCandidates);
+  if (document.readyState !== "loading") loadCandidates();
+})();

--- a/cps/static/js/edit_books.js
+++ b/cps/static/js/edit_books.js
@@ -259,6 +259,83 @@ $("#btn-upload-cover").on("change", function () {
     $("#upload-cover").text(filename);
 });
 
+// ---- Inline live preview for the cover_url field ----
+// Debounced AJAX HEAD probe via /metadata/cover/preview. Surfaces
+// dimensions + a friendly error before the user submits the form, so
+// the field stops feeling "unreliable" — failures are visible at paste
+// time, not after a full save round-trip. Endpoint URL comes from the
+// data-cover-preview-endpoint attribute on the input itself so the
+// preview path stays portable across reverse-proxy prefixes.
+(function () {
+    var $field = $("#cover_url");
+    if ($field.length === 0) return;
+    var endpoint = $field.attr("data-cover-preview-endpoint");
+    if (!endpoint) return;
+    var $preview = $("#cover_url_preview");
+    var $previewImg = $("#cover_url_preview_img");
+    var $previewMeta = $("#cover_url_preview_meta");
+    var $feedback = $("#cover_url_preview_feedback");
+    var debounce = null;
+    var lastTried = "";
+    var csrf = $('meta[name="csrf-token"]').attr("content")
+            || $('input[name="csrf_token"]').first().val()
+            || "";
+
+    function setFeedback(text, kind) {
+        $feedback.attr("class", "cwa-cover-url-feedback" + (kind ? " " + kind : ""));
+        $feedback.text(text || "");
+    }
+
+    function clearPreview() {
+        $preview.attr("hidden", true);
+        $previewImg.attr("src", "");
+        $previewMeta.text("");
+    }
+
+    function showPreview(payload, url) {
+        $previewImg.attr("src", url);
+        var bits = [];
+        if (payload.width && payload.height) bits.push(payload.width + "×" + payload.height);
+        if (payload.size_bytes) bits.push(Math.round(payload.size_bytes / 1024) + " KB");
+        if (payload.content_type) bits.push(payload.content_type);
+        $previewMeta.text(bits.join(" · "));
+        $preview.removeAttr("hidden");
+    }
+
+    $field.on("input", function () {
+        clearTimeout(debounce);
+        var url = ($field.val() || "").trim();
+        if (url === lastTried) return;
+        if (url.length < 8) {
+            clearPreview();
+            setFeedback("");
+            return;
+        }
+        debounce = setTimeout(function () {
+            lastTried = url;
+            setFeedback("Checking…", null);
+            $.ajax({
+                url: endpoint,
+                type: "POST",
+                contentType: "application/json",
+                headers: csrf ? { "X-CSRFToken": csrf } : {},
+                data: JSON.stringify({ url: url }),
+            }).done(function (payload) {
+                if (payload && payload.valid) {
+                    setFeedback("Looks good — preview shown.", "is-ok");
+                    showPreview(payload, url);
+                } else {
+                    setFeedback((payload && payload.error_message) || "Could not validate URL.", "is-error");
+                    clearPreview();
+                }
+            }).fail(function () {
+                setFeedback("Could not validate URL.", "is-error");
+                clearPreview();
+            });
+        }, 400);
+    });
+})();
+
 $("#book_edit_frm").on("submit", function () {
     if (typeof tinymce !== "undefined" && typeof tinymce.triggerSave === "function") {
         tinymce.triggerSave();

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -143,8 +143,21 @@
     {# Decouple cover changes from global uploads: allow users with edit rights to change covers #}
     {% if current_user.role_edit() %}
     <div class="form-group">
+      <a class="btn btn-default cwa-cover-picker__entry" href="{{ url_for('cover_picker.cover_picker_page', book_id=book.id) }}">
+        <span class="glyphicon glyphicon-picture"></span> {{ _('Open focused cover picker') }}
+      </a>
+      <p class="text-muted" style="font-size: 12px; margin: 4px 0 0 0;">
+        {{ _('Pick a cover from any source, paste a URL, upload a file, or use the embedded cover.') }}
+      </p>
+    </div>
+    <div class="form-group">
       <label for="cover_url">{{_('Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)')}}</label>
-      <input type="text" class="form-control" name="cover_url" id="cover_url" value="">
+      <input type="text" class="form-control" name="cover_url" id="cover_url" value="" data-cover-preview-endpoint="{{ url_for('metadata.metadata_cover_preview') }}">
+      <div id="cover_url_preview" class="cwa-cover-url-preview" hidden>
+        <img id="cover_url_preview_img" alt="">
+        <div id="cover_url_preview_meta"></div>
+      </div>
+      <div id="cover_url_preview_feedback" class="cwa-cover-url-feedback"></div>
     </div>
       <div class="form-group" aria-label="Upload cover from local drive">
         <label class="btn btn-primary btn-file" for="btn-upload-cover">{{ _('Upload Cover from Local Disk') }}</label>

--- a/cps/templates/cover_picker.html
+++ b/cps/templates/cover_picker.html
@@ -1,0 +1,182 @@
+{% extends "layout.html" %}
+{% block body %}
+<div class="cwa-cover-picker discover" id="cover-picker-root"
+     data-book-id="{{ book.id }}"
+     data-cover-locked="{{ '1' if cover_locked else '0' }}">
+
+  <div class="row cwa-cover-picker__header">
+    <div class="col-sm-12">
+      <a href="{{ url_for('edit-book.show_edit_book', book_id=book.id) }}" class="cwa-cover-picker__back">
+        <span class="glyphicon glyphicon-chevron-left"></span> {{ _('Back to edit metadata') }}
+      </a>
+      <h2 class="cwa-cover-picker__title">{{ _('Change cover') }}</h2>
+      <p class="cwa-cover-picker__subtitle text-muted">
+        {{ _('Pick a cover from any source we support, paste a URL, upload a file, or use the cover embedded in the book itself.') }}
+      </p>
+    </div>
+  </div>
+
+  <div class="row">
+
+    <div class="col-md-3 col-sm-4 cwa-cover-picker__current">
+      <div class="cwa-cover-picker__current-card">
+        <div class="cwa-cover-picker__current-label">{{ _('Current cover') }}</div>
+        <img id="cwa-cover-picker-current-img"
+             src="{{ url_for('web.get_cover', book_id=book.id, resolution='og', c=book|last_modified) }}"
+             alt="{{ book.title }}"
+             onerror="this.onerror=null; this.src='{{ url_for('static', filename='generic_cover.svg') }}'; this.classList.add('cover-fallback');"/>
+        <div class="cwa-cover-picker__current-meta">
+          <strong>{{ book.title }}</strong><br>
+          {% for author in book.authors %}{{ author.name }}{% if not loop.last %}, {% endif %}{% endfor %}
+        </div>
+
+        <div class="cwa-cover-picker__lock">
+          <label class="cwa-cover-picker__lock-toggle">
+            <input type="checkbox" id="cwa-cover-picker-lock"
+                   {% if cover_locked %}checked{% endif %}>
+            <span>{{ _('Lock cover') }}</span>
+          </label>
+          <div class="cwa-cover-picker__lock-help text-muted">
+            {{ _('When locked, fetching metadata will not overwrite this cover.') }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-9 col-sm-8 cwa-cover-picker__sources">
+
+      <div class="cwa-cover-picker__panels">
+
+        <details class="cwa-cover-picker__panel" id="cwa-cover-picker-url-panel">
+          <summary>{{ _('Use a URL') }}</summary>
+          <div class="cwa-cover-picker__panel-body">
+            <div class="form-group">
+              <input type="text" class="form-control" id="cwa-cover-picker-url-input"
+                     placeholder="https://...">
+            </div>
+            <div id="cwa-cover-picker-url-feedback" class="cwa-cover-picker__feedback"></div>
+            <div class="cwa-cover-picker__url-actions" id="cwa-cover-picker-url-actions" hidden>
+              <img id="cwa-cover-picker-url-thumb" alt=""/>
+              <div class="cwa-cover-picker__url-meta" id="cwa-cover-picker-url-meta"></div>
+              <button class="btn btn-primary" id="cwa-cover-picker-url-apply" type="button">
+                {{ _('Use this cover') }}
+              </button>
+            </div>
+          </div>
+        </details>
+
+        <details class="cwa-cover-picker__panel" id="cwa-cover-picker-upload-panel">
+          <summary>{{ _('Upload a file') }}</summary>
+          <div class="cwa-cover-picker__panel-body">
+            <input type="file" id="cwa-cover-picker-upload-input"
+                   accept=".jpg,.jpeg,.png,.webp,.bmp,.gif">
+            <button class="btn btn-primary" id="cwa-cover-picker-upload-apply" type="button" disabled>
+              {{ _('Upload as cover') }}
+            </button>
+            <div id="cwa-cover-picker-upload-feedback" class="cwa-cover-picker__feedback"></div>
+          </div>
+        </details>
+
+        <details class="cwa-cover-picker__panel" id="cwa-cover-picker-keys-panel">
+          <summary>{{ _('API keys') }}</summary>
+          <div class="cwa-cover-picker__panel-body" id="cwa-cover-picker-keys-body">
+            <p class="text-muted">
+              {{ _('Some metadata sources need an API key. Adding one here improves cover quality and unblocks rate-limited services. Keys are stored once for the whole instance — admins only.') }}
+            </p>
+            <div id="cwa-cover-picker-keys-list">
+              <div class="text-muted">{{ _('Loading…') }}</div>
+            </div>
+          </div>
+        </details>
+
+      </div>
+
+      <div class="cwa-cover-picker__grid-section">
+        <div class="cwa-cover-picker__grid-toolbar">
+          <h4>{{ _('Candidates') }}</h4>
+          <div class="cwa-cover-picker__grid-status" id="cwa-cover-picker-status">
+            <span class="cwa-cover-picker__status-pill cwa-cover-picker__status-pill--loading">
+              {{ _('Searching…') }}
+            </span>
+          </div>
+          <div class="cwa-cover-picker__grid-actions">
+            <button class="btn btn-default btn-sm" id="cwa-cover-picker-refresh" type="button">
+              <span class="glyphicon glyphicon-refresh"></span> {{ _('Refresh') }}
+            </button>
+          </div>
+        </div>
+        <div class="cwa-cover-picker__grid" id="cwa-cover-picker-grid">
+          <div class="cwa-cover-picker__grid-empty text-muted">{{ _('Loading candidates…') }}</div>
+        </div>
+        <div class="cwa-cover-picker__provider-status" id="cwa-cover-picker-provider-status"></div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="cwa-cover-picker-confirm" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">{{ _('Replace cover with this candidate?') }}</h4>
+      </div>
+      <div class="modal-body">
+        <div class="cwa-cover-picker__confirm-grid">
+          <div class="cwa-cover-picker__confirm-side">
+            <div class="cwa-cover-picker__confirm-label">{{ _('Current') }}</div>
+            <img id="cwa-cover-picker-confirm-current" alt="">
+          </div>
+          <div class="cwa-cover-picker__confirm-side">
+            <div class="cwa-cover-picker__confirm-label">{{ _('New') }}</div>
+            <img id="cwa-cover-picker-confirm-new" alt="">
+            <div class="cwa-cover-picker__confirm-meta" id="cwa-cover-picker-confirm-meta"></div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">{{ _('Cancel') }}</button>
+        <button type="button" class="btn btn-primary" id="cwa-cover-picker-confirm-apply">
+          {{ _('Use this cover') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block header %}
+<link href="{{ url_for('static', filename='css/cover_picker.css') }}" rel="stylesheet" media="screen">
+{% endblock %}
+
+{% block js %}
+<script>
+window.cwaCoverPicker = {
+  bookId: {{ book.id }},
+  endpoints: {
+    candidates: "{{ url_for('cover_picker.cover_picker_candidates', book_id=book.id) }}",
+    preview:    "{{ url_for('cover_picker.cover_picker_preview',    book_id=book.id) }}",
+    extract:    "{{ url_for('cover_picker.cover_picker_extract',    book_id=book.id) }}",
+    apply:      "{{ url_for('cover_picker.cover_picker_apply',      book_id=book.id) }}",
+    lock:       "{{ url_for('cover_picker.cover_picker_lock',       book_id=book.id) }}",
+    keysList:   "{{ url_for('metadata.metadata_keys') }}",
+    keysSave:   "{{ url_for('metadata.metadata_keys_save', prov_id='__PROV__') }}",
+    coverGet:   "{{ url_for('web.get_cover', book_id=book.id, resolution='og') }}",
+  },
+  csrfToken: "{{ csrf_token() if csrf_token is defined else '' }}",
+  bookTitle: {{ book.title|tojson|safe }},
+  i18n: {
+    searching: {{ _('Searching…')|tojson|safe }},
+    noResults: {{ _('No candidates found yet. Try a different search or refresh.')|tojson|safe }},
+    applying:  {{ _('Applying…')|tojson|safe }},
+    applied:   {{ _('Cover updated.')|tojson|safe }},
+    error:     {{ _('Something went wrong. Try again.')|tojson|safe }},
+  },
+};
+</script>
+<script src="{{ url_for('static', filename='js/cover_picker.js') }}"></script>
+{% endblock %}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -556,6 +556,10 @@
                                            class="btn btn-primary action-icon-btn" role="button" title="{{ _('Edit Metadata') }}" aria-label="{{ _('Edit Metadata') }}">
                                             <span class="glyphicon glyphicon-pencil"></span>
                                         </a>
+                                        <a href="{{ url_for('cover_picker.cover_picker_page', book_id=entry.id) }}"
+                                           class="btn btn-primary action-icon-btn" role="button" title="{{ _('Change cover') }}" aria-label="{{ _('Change cover') }}">
+                                            <span class="glyphicon glyphicon-picture"></span>
+                                        </a>
                                     {% endif %}
                                     {% if current_user.role_edit() and current_user.role_delete_books() %}
                                         <button type="button" class="btn btn-danger action-icon-btn" id="delete"

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -558,6 +558,24 @@ class Bookmark(Base):
     bookmark_key = Column(String)
 
 
+class BookCoverLock(Base):
+    """Per-book flag that prevents the cover from being overwritten by the
+    metadata-fetch path on the edit page. Set/cleared from the cover-picker
+    page at /book/<id>/cover. Resolves janeczku/calibre-web#2165 ("Option
+    to keep existing book cover when fetching metadata", 8 hearts).
+
+    Lock is per book, not per user — a cover is a property of the book,
+    not of the viewer. ``locked_by`` and ``locked_at`` are audit metadata
+    only; reads check ``locked``.
+    """
+    __tablename__ = 'book_cover_lock'
+
+    book_id = Column(Integer, primary_key=True)
+    locked = Column(Boolean, nullable=False, default=False)
+    locked_by = Column(Integer)
+    locked_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+
 # Baseclass representing books that are archived on the user's Kobo device.
 class ArchivedBook(Base):
     __tablename__ = 'archived_book'

--- a/tests/unit/test_cover_extract.py
+++ b/tests/unit/test_cover_extract.py
@@ -1,0 +1,237 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Unit tests for the embedded-cover extraction service."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import sys
+import types
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_extract_module():
+    """Idempotently top up the cps stub so this test plays nicely with
+    other service tests that import the same parent package."""
+    cps_pkg = sys.modules.get("cps")
+    if cps_pkg is None:
+        cps_pkg = types.ModuleType("cps")
+        cps_pkg.__path__ = [str(REPO_ROOT / "cps")]
+        sys.modules["cps"] = cps_pkg
+
+    constants = sys.modules.get("cps.constants") or types.ModuleType("cps.constants")
+    if not hasattr(constants, "USER_AGENT"):
+        constants.USER_AGENT = "Calibre-Web-NextGen-tests"
+    sys.modules["cps.constants"] = constants
+    cps_pkg.constants = constants
+
+    logger_mod = sys.modules.get("cps.logger") or types.ModuleType("cps.logger")
+    if not hasattr(logger_mod, "create"):
+        logger_mod.create = lambda *_a, **_k: types.SimpleNamespace(
+            debug=lambda *_args, **_kwargs: None,
+            warning=lambda *_args, **_kwargs: None,
+            info=lambda *_args, **_kwargs: None,
+            error=lambda *_args, **_kwargs: None,
+        )
+    sys.modules["cps.logger"] = logger_mod
+    cps_pkg.logger = logger_mod
+
+    config_mod = sys.modules.get("cps.config") or types.ModuleType("cps.config")
+    if not hasattr(config_mod, "get_book_path"):
+        config_mod.get_book_path = lambda: "/tmp/library"
+    sys.modules["cps.config"] = config_mod
+    cps_pkg.config = config_mod
+
+    if "cps.services" not in sys.modules:
+        services_pkg = types.ModuleType("cps.services")
+        services_pkg.__path__ = [str(REPO_ROOT / "cps" / "services")]
+        sys.modules["cps.services"] = services_pkg
+
+    spec = importlib.util.spec_from_file_location(
+        "cps.services.cover_extract", REPO_ROOT / "cps" / "services" / "cover_extract.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["cps.services.cover_extract"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+extract = _load_extract_module()
+
+
+def _make_minimal_epub(tmp_path: Path, cover_bytes: bytes, cover_href: str = "OEBPS/images/cover.jpg") -> Path:
+    """Build the smallest spec-conforming EPUB that has a discoverable
+    cover image. Used to exercise _extract_from_epub against a real
+    zipfile rather than a mock."""
+    epub_path = tmp_path / "test.epub"
+    container_xml = (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<container xmlns='urn:oasis:names:tc:opendocument:xmlns:container' version='1.0'>"
+        "<rootfiles>"
+        "<rootfile full-path='OEBPS/content.opf' media-type='application/oebps-package+xml'/>"
+        "</rootfiles>"
+        "</container>"
+    )
+    cover_filename = os.path.basename(cover_href)
+    opf_xml = f"""<?xml version='1.0' encoding='UTF-8'?>
+<package xmlns='http://www.idpf.org/2007/opf' version='3.0' unique-identifier='id'>
+  <metadata xmlns:dc='http://purl.org/dc/elements/1.1/'>
+    <dc:title>Test</dc:title>
+    <dc:identifier id='id'>test</dc:identifier>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id='cover' href='images/{cover_filename}' media-type='image/jpeg' properties='cover-image'/>
+  </manifest>
+  <spine/>
+</package>"""
+
+    with zipfile.ZipFile(epub_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("mimetype", "application/epub+zip")
+        zf.writestr("META-INF/container.xml", container_xml)
+        zf.writestr("OEBPS/content.opf", opf_xml)
+        zf.writestr(cover_href, cover_bytes)
+    return epub_path
+
+
+def _make_cbz(tmp_path: Path, names_and_bytes: list[tuple[str, bytes]]) -> Path:
+    cbz_path = tmp_path / "test.cbz"
+    with zipfile.ZipFile(cbz_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in names_and_bytes:
+            zf.writestr(name, data)
+    return cbz_path
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not extract._LXML_AVAILABLE, reason="lxml not installed (production has it)")
+class TestEpubExtraction:
+    def test_extracts_cover_from_modern_epub(self, tmp_path):
+        cover_payload = b"\xff\xd8\xff\xe0FAKE_JPEG_PAYLOAD"
+        epub = _make_minimal_epub(tmp_path, cover_payload)
+        result = extract._extract_from_epub(str(epub))
+        assert result is not None
+        assert result.data == cover_payload
+        assert result.extension == ".jpg"
+        assert result.source_format == "epub"
+        assert result.mime_type == "image/jpeg"
+
+    def test_returns_none_on_corrupt_zip(self, tmp_path):
+        bad = tmp_path / "bad.epub"
+        bad.write_bytes(b"not a zip file at all")
+        assert extract._extract_from_epub(str(bad)) is None
+
+    def test_returns_none_when_manifest_has_no_cover_item(self, tmp_path):
+        # Build an EPUB where the manifest has no cover-image properties
+        # and no <meta name='cover'>.
+        epub = tmp_path / "no-cover.epub"
+        with zipfile.ZipFile(epub, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("META-INF/container.xml",
+                "<?xml version='1.0'?><container xmlns='urn:oasis:names:tc:opendocument:xmlns:container'>"
+                "<rootfiles><rootfile full-path='content.opf' media-type='application/oebps-package+xml'/></rootfiles>"
+                "</container>")
+            zf.writestr("content.opf",
+                "<?xml version='1.0'?><package xmlns='http://www.idpf.org/2007/opf' version='3.0'>"
+                "<metadata/><manifest/><spine/></package>")
+        assert extract._extract_from_epub(str(epub)) is None
+
+
+@pytest.mark.unit
+class TestCbzExtraction:
+    def test_extracts_first_image_alphabetically(self, tmp_path):
+        cbz = _make_cbz(tmp_path, [
+            ("page002.jpg", b"page2-data"),
+            ("page001.jpg", b"page1-data"),  # this is the cover
+            ("page003.jpg", b"page3-data"),
+        ])
+        result = extract._extract_from_cbz(str(cbz))
+        assert result is not None
+        assert result.data == b"page1-data"
+        assert result.extension == ".jpg"
+        assert result.source_format == "cbz"
+
+    def test_skips_non_image_files(self, tmp_path):
+        cbz = _make_cbz(tmp_path, [
+            ("ComicInfo.xml", b"<xml/>"),
+            ("00.jpg", b"jpg-data"),
+        ])
+        result = extract._extract_from_cbz(str(cbz))
+        assert result is not None
+        assert result.data == b"jpg-data"
+
+    def test_returns_none_when_no_images(self, tmp_path):
+        cbz = _make_cbz(tmp_path, [("ComicInfo.xml", b"<xml/>")])
+        assert extract._extract_from_cbz(str(cbz)) is None
+
+
+@pytest.mark.unit
+class TestPdfExtraction:
+    def test_returns_none_when_pypdfium2_missing(self, tmp_path):
+        # In CI / dev envs where pypdfium2 isn't installed, the function
+        # must not raise — it returns None and the picker omits the
+        # PDF candidate.
+        pdf_path = tmp_path / "test.pdf"
+        pdf_path.write_bytes(b"%PDF-1.4 fake")
+        # If pypdfium2 *is* installed locally, this test still passes
+        # because the import works but rendering a fake PDF fails.
+        result = extract._extract_from_pdf(str(pdf_path))
+        # Either way: no exception, None or successful render.
+        assert result is None or result.source_format == "pdf"
+
+
+@pytest.mark.unit
+class TestExtractEmbeddedCover:
+    def test_picks_first_supported_format(self, tmp_path, monkeypatch):
+        # A book with two formats: CBZ first, EPUB second. The function
+        # should iterate book.data and return the first format that
+        # yields a cover.
+        cbz = _make_cbz(tmp_path, [("01.jpg", b"cbz-cover")])
+        epub = _make_minimal_epub(tmp_path, b"\xff\xd8\xff\xe0EPUB_COVER")
+
+        # Stub config.get_book_path() to return "" so we can pass absolute
+        # paths via book.path.
+        monkeypatch.setattr(extract.config, "get_book_path", lambda: "")
+
+        book = types.SimpleNamespace(
+            path="",
+            data=[
+                types.SimpleNamespace(name=cbz.stem, format="CBZ"),
+                types.SimpleNamespace(name=epub.stem, format="EPUB"),
+            ],
+        )
+        # The data entries' name+format reconstruct into the file paths.
+        # CBZ comes first; should win.
+        # Patch _book_format_path to return our absolute paths directly.
+        def fake_path(b, entry):
+            if entry.format == "CBZ":
+                return str(cbz)
+            if entry.format == "EPUB":
+                return str(epub)
+            return None
+        monkeypatch.setattr(extract, "_book_format_path", fake_path)
+
+        result = extract.extract_embedded_cover(book)
+        assert result is not None
+        assert result.data == b"cbz-cover"  # CBZ extracted first
+
+    def test_returns_none_when_no_supported_formats(self, monkeypatch):
+        book = types.SimpleNamespace(
+            path="",
+            data=[types.SimpleNamespace(name="x", format="MOBI")],
+        )
+        monkeypatch.setattr(extract, "_book_format_path", lambda b, e: "/nonexistent/x.mobi")
+        assert extract.extract_embedded_cover(book) is None
+
+    def test_returns_none_on_empty_book(self):
+        book = types.SimpleNamespace(path="", data=[])
+        assert extract.extract_embedded_cover(book) is None

--- a/tests/unit/test_cover_picker_service.py
+++ b/tests/unit/test_cover_picker_service.py
@@ -1,0 +1,296 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Unit tests for the cover-picker orchestration service."""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_picker_module():
+    """Idempotently top up the cps stub so this test can co-exist with the
+    other service tests that import the same parent package."""
+    cps_pkg = sys.modules.get("cps")
+    if cps_pkg is None:
+        cps_pkg = types.ModuleType("cps")
+        cps_pkg.__path__ = [str(REPO_ROOT / "cps")]
+        sys.modules["cps"] = cps_pkg
+
+    constants = sys.modules.get("cps.constants") or types.ModuleType("cps.constants")
+    if not hasattr(constants, "USER_AGENT"):
+        constants.USER_AGENT = "Calibre-Web-NextGen-tests"
+    sys.modules["cps.constants"] = constants
+    cps_pkg.constants = constants
+
+    logger_mod = sys.modules.get("cps.logger") or types.ModuleType("cps.logger")
+    if not hasattr(logger_mod, "create"):
+        logger_mod.create = lambda *_a, **_k: types.SimpleNamespace(
+            debug=lambda *_args, **_kwargs: None,
+            warning=lambda *_args, **_kwargs: None,
+            info=lambda *_args, **_kwargs: None,
+            error=lambda *_args, **_kwargs: None,
+        )
+    sys.modules["cps.logger"] = logger_mod
+    cps_pkg.logger = logger_mod
+
+    config_mod = sys.modules.get("cps.config") or types.ModuleType("cps.config")
+    if not hasattr(config_mod, "get_book_path"):
+        config_mod.get_book_path = lambda: "/tmp/library"
+    sys.modules["cps.config"] = config_mod
+    cps_pkg.config = config_mod
+
+    if "cps.services" not in sys.modules:
+        services_pkg = types.ModuleType("cps.services")
+        services_pkg.__path__ = [str(REPO_ROOT / "cps" / "services")]
+        sys.modules["cps.services"] = services_pkg
+
+    # cover_booster is imported by cover_picker; stub it so picker tests
+    # don't pull in real network code.
+    booster_spec = importlib.util.spec_from_file_location(
+        "cps.services.cover_booster", REPO_ROOT / "cps" / "services" / "cover_booster.py"
+    )
+    booster_module = importlib.util.module_from_spec(booster_spec)
+    sys.modules["cps.services.cover_booster"] = booster_module
+    booster_spec.loader.exec_module(booster_module)
+
+    spec = importlib.util.spec_from_file_location(
+        "cps.services.cover_picker", REPO_ROOT / "cps" / "services" / "cover_picker.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["cps.services.cover_picker"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+picker = _load_picker_module()
+
+
+def _fake_provider(provider_id, name, search_results=None, search_raises=None):
+    """Build a minimal stand-in for cps.metadata_provider.Metadata
+    subclasses. Matches the duck-typing the picker expects."""
+    inst = types.SimpleNamespace()
+    inst.__id__ = provider_id
+    inst.__name__ = name
+    if search_raises is not None:
+        def search(*args, **kwargs):
+            raise search_raises
+    else:
+        def search(*args, **kwargs):
+            return search_results or []
+    inst.search = search
+    return inst
+
+
+def _fake_metarecord(provider_id, source_name, title, cover_url, isbn=None):
+    """A MetaRecord-shaped dataclass instance. We return real dataclass
+    instances so dataclasses.asdict in the picker works the same way it
+    does on real provider results."""
+
+    @dataclasses.dataclass
+    class _SourceInfo:
+        id: str
+        description: str
+        link: str = ""
+
+    @dataclasses.dataclass
+    class _MetaRecord:
+        id: str
+        title: str
+        authors: list
+        url: str
+        source: _SourceInfo
+        cover: str = ""
+        publisher: str = ""
+        publishedDate: str = ""
+        identifiers: dict = dataclasses.field(default_factory=dict)
+
+    return _MetaRecord(
+        id=f"{provider_id}-{title[:8]}",
+        title=title,
+        authors=["Test Author"],
+        url=f"https://example.com/{provider_id}/{title}",
+        source=_SourceInfo(id=provider_id, description=source_name),
+        cover=cover_url,
+        publisher="Test Publisher",
+        publishedDate="2008-12-05",
+        identifiers={"isbn": isbn} if isbn else {},
+    )
+
+
+@pytest.mark.unit
+class TestGatherCoverCandidates:
+    def test_collects_from_all_enabled_providers(self):
+        providers = [
+            _fake_provider("alpha", "Alpha", search_results=[
+                _fake_metarecord("alpha", "Alpha", "Wuthering Heights",
+                                 "https://example.com/alpha/cover.jpg"),
+            ]),
+            _fake_provider("beta", "Beta", search_results=[
+                _fake_metarecord("beta", "Beta", "Wuthering Heights",
+                                 "https://example.com/beta/cover.jpg"),
+            ]),
+        ]
+        with patch.object(picker, "boost_covers", side_effect=lambda r: r):
+            candidates, statuses = picker.gather_cover_candidates(
+                providers=providers, query="Wuthering Heights",
+                static_cover="generic_cover.svg", locale="en",
+            )
+        assert len(candidates) == 2
+        sources = {c.source_id for c in candidates}
+        assert sources == {"alpha", "beta"}
+        assert all(s.status == "ok" for s in statuses)
+
+    def test_disabled_provider_skipped_with_status_marker(self):
+        providers = [
+            _fake_provider("alpha", "Alpha", search_results=[
+                _fake_metarecord("alpha", "Alpha", "Title",
+                                 "https://example.com/a.jpg"),
+            ]),
+            _fake_provider("beta", "Beta", search_results=[]),
+        ]
+        with patch.object(picker, "boost_covers", side_effect=lambda r: r):
+            candidates, statuses = picker.gather_cover_candidates(
+                providers=providers, query="Title",
+                static_cover="g.svg", locale="en",
+                is_provider_enabled=lambda p: p.__id__ != "beta",
+            )
+        beta_status = next(s for s in statuses if s.id == "beta")
+        assert beta_status.status == "disabled"
+        assert beta_status.count == 0
+        assert all(c.source_id != "beta" for c in candidates)
+
+    def test_failed_provider_classified(self):
+        providers = [
+            _fake_provider("good", "Good", search_results=[
+                _fake_metarecord("good", "Good", "X", "https://e.com/x.jpg"),
+            ]),
+            _fake_provider("bad", "Bad", search_raises=ConnectionError("nope")),
+        ]
+        with patch.object(picker, "boost_covers", side_effect=lambda r: r):
+            candidates, statuses = picker.gather_cover_candidates(
+                providers=providers, query="X",
+                static_cover="g.svg", locale="en",
+                classify_failure=lambda exc: ("error", str(exc)[:30]),
+            )
+        bad_status = next(s for s in statuses if s.id == "bad")
+        assert bad_status.status == "error"
+        good_status = next(s for s in statuses if s.id == "good")
+        assert good_status.status == "ok"
+        assert len(candidates) == 1
+
+    def test_generic_cover_filtered_out(self):
+        # Real providers fall back to a generic SVG when they can't find a
+        # cover. Those records should NOT show up in the picker grid.
+        providers = [
+            _fake_provider("hardcover", "Hardcover", search_results=[
+                _fake_metarecord("hardcover", "Hardcover", "Real",
+                                 "https://example.com/real.jpg"),
+                _fake_metarecord("hardcover", "Hardcover", "Generic",
+                                 "/static/generic_cover.svg"),
+            ]),
+        ]
+        with patch.object(picker, "boost_covers", side_effect=lambda r: r):
+            candidates, _ = picker.gather_cover_candidates(
+                providers=providers, query="Q",
+                static_cover="/static/generic_cover.svg", locale="en",
+            )
+        assert len(candidates) == 1
+        assert candidates[0].cover_url.endswith("real.jpg")
+
+    def test_embedded_cover_added_first(self):
+        providers = [
+            _fake_provider("alpha", "Alpha", search_results=[
+                _fake_metarecord("alpha", "Alpha", "T", "https://e.com/x.jpg"),
+            ]),
+        ]
+        embedded_payload = b"\xff\xd8\xff\xe0FAKE"
+
+        class _ExtractedCover:
+            def __init__(self):
+                self.data = embedded_payload
+                self.mime_type = "image/jpeg"
+
+        with patch.object(picker, "boost_covers", side_effect=lambda r: r):
+            candidates, _ = picker.gather_cover_candidates(
+                providers=providers, query="T",
+                static_cover="g.svg", locale="en",
+                extract_embedded=_ExtractedCover,
+            )
+        assert candidates[0].source_id == "embedded"
+        assert candidates[0].cover_url.startswith("data:image/jpeg;base64,")
+
+    def test_embedded_callable_returning_none_is_silent(self):
+        providers = [
+            _fake_provider("alpha", "Alpha", search_results=[
+                _fake_metarecord("alpha", "Alpha", "T", "https://e.com/x.jpg"),
+            ]),
+        ]
+        with patch.object(picker, "boost_covers", side_effect=lambda r: r):
+            candidates, _ = picker.gather_cover_candidates(
+                providers=providers, query="T",
+                static_cover="g.svg", locale="en",
+                extract_embedded=lambda: None,
+            )
+        # Only the provider candidate.
+        assert len(candidates) == 1
+        assert candidates[0].source_id == "alpha"
+
+    def test_year_extracted_from_published_date(self):
+        providers = [
+            _fake_provider("alpha", "Alpha", search_results=[
+                _fake_metarecord("alpha", "Alpha", "T", "https://e.com/x.jpg"),
+            ]),
+        ]
+        with patch.object(picker, "boost_covers", side_effect=lambda r: r):
+            candidates, _ = picker.gather_cover_candidates(
+                providers=providers, query="T",
+                static_cover="g.svg", locale="en",
+            )
+        assert candidates[0].year == "2008"
+
+    def test_empty_query_returns_only_embedded(self):
+        providers = [
+            _fake_provider("alpha", "Alpha", search_results=[]),
+        ]
+
+        class _ExtractedCover:
+            data = b"\xff\xd8\xff\xe0FAKE"
+            mime_type = "image/jpeg"
+
+        with patch.object(picker, "boost_covers", side_effect=lambda r: r):
+            candidates, _ = picker.gather_cover_candidates(
+                providers=providers, query="",
+                static_cover="g.svg", locale="en",
+                extract_embedded=_ExtractedCover,
+            )
+        assert len(candidates) == 1
+        assert candidates[0].source_id == "embedded"
+
+
+@pytest.mark.unit
+class TestSerialization:
+    def test_candidate_to_dict_is_jsonable(self):
+        c = picker.CoverCandidate(
+            source_id="hardcover", source_name="Hardcover",
+            cover_url="https://example.com/x.jpg", title="T",
+            width=900, height=1200,
+        )
+        d = c.to_dict()
+        assert d["source_id"] == "hardcover"
+        assert d["width"] == 900
+        # JSON-roundtrip safety
+        import json
+        json.dumps(d)

--- a/tests/unit/test_cover_url_validator.py
+++ b/tests/unit/test_cover_url_validator.py
@@ -1,0 +1,212 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Unit tests for the cover-URL validator service."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _load_validator_module():
+    """Idempotently top up the cps stub so this test co-exists with
+    sibling service tests."""
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "cps" / "services" / "cover_url_validator.py"
+
+    cps_pkg = sys.modules.get("cps")
+    if cps_pkg is None:
+        cps_pkg = types.ModuleType("cps")
+        cps_pkg.__path__ = [str(repo_root / "cps")]
+        sys.modules["cps"] = cps_pkg
+
+    constants = sys.modules.get("cps.constants") or types.ModuleType("cps.constants")
+    if not hasattr(constants, "USER_AGENT"):
+        constants.USER_AGENT = "Calibre-Web-NextGen-tests"
+    sys.modules["cps.constants"] = constants
+    cps_pkg.constants = constants
+
+    logger_mod = sys.modules.get("cps.logger") or types.ModuleType("cps.logger")
+    if not hasattr(logger_mod, "create"):
+        logger_mod.create = lambda *_a, **_k: types.SimpleNamespace(
+            debug=lambda *_args, **_kwargs: None,
+            warning=lambda *_args, **_kwargs: None,
+            info=lambda *_args, **_kwargs: None,
+            error=lambda *_args, **_kwargs: None,
+        )
+    sys.modules["cps.logger"] = logger_mod
+    cps_pkg.logger = logger_mod
+
+    advocate_mod = sys.modules.get("cps.cw_advocate") or types.ModuleType("cps.cw_advocate")
+    if not hasattr(advocate_mod, "head"):
+        advocate_mod.head = lambda *a, **k: None  # patched per-test
+        advocate_mod.get = lambda *a, **k: None
+    sys.modules["cps.cw_advocate"] = advocate_mod
+    cps_pkg.cw_advocate = advocate_mod
+
+    advocate_exc = sys.modules.get("cps.cw_advocate.exceptions")
+    if advocate_exc is None or not hasattr(advocate_exc, "UnacceptableAddressException"):
+        advocate_exc = types.ModuleType("cps.cw_advocate.exceptions")
+
+        class UnacceptableAddressException(Exception):
+            pass
+
+        advocate_exc.UnacceptableAddressException = UnacceptableAddressException
+        sys.modules["cps.cw_advocate.exceptions"] = advocate_exc
+    advocate_mod.exceptions = advocate_exc
+
+    if "cps.services" not in sys.modules:
+        services_pkg = types.ModuleType("cps.services")
+        services_pkg.__path__ = [str(repo_root / "cps" / "services")]
+        sys.modules["cps.services"] = services_pkg
+
+    spec = importlib.util.spec_from_file_location(
+        "cps.services.cover_url_validator", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["cps.services.cover_url_validator"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = _load_validator_module()
+
+
+def _mock_head(status, content_type, content_length):
+    return types.SimpleNamespace(
+        status_code=status,
+        headers={"content-type": content_type, "content-length": str(content_length)},
+    )
+
+
+@pytest.mark.unit
+class TestEarlyRejects:
+    def test_empty_url_rejected(self):
+        result = validator.validate_cover_url("")
+        assert not result.valid
+        assert result.error_code == "empty"
+
+    def test_whitespace_url_rejected(self):
+        assert validator.validate_cover_url("   ").error_code == "empty"
+
+    def test_non_http_scheme_rejected(self):
+        result = validator.validate_cover_url("ftp://example.com/cover.jpg")
+        assert not result.valid
+        assert result.error_code == "bad_scheme"
+
+    def test_javascript_scheme_rejected(self):
+        result = validator.validate_cover_url("javascript:alert(1)")
+        assert not result.valid
+        assert result.error_code == "bad_scheme"
+
+
+@pytest.mark.unit
+class TestSsrfGuard:
+    def test_ssrf_blocked_returns_friendly_error(self):
+        with patch.object(
+            validator.cw_advocate, "head",
+            side_effect=validator.UnacceptableAddressException("blocked"),
+        ):
+            result = validator.validate_cover_url("http://localhost:8080/cover.jpg")
+        assert not result.valid
+        assert result.error_code == "ssrf_blocked"
+        assert "internal" in result.error_message.lower() or "local" in result.error_message.lower()
+
+
+@pytest.mark.unit
+class TestUnreachable:
+    def test_request_exception_returns_unreachable(self):
+        import requests as _r
+        with patch.object(validator.cw_advocate, "head",
+                          side_effect=_r.ConnectionError("nope")):
+            result = validator.validate_cover_url("https://nope.example/x.jpg")
+        assert not result.valid
+        assert result.error_code == "unreachable"
+
+
+@pytest.mark.unit
+class TestStatusAndContentType:
+    def test_404_rejected(self):
+        with patch.object(validator.cw_advocate, "head",
+                          return_value=_mock_head(404, "text/html", 1234)):
+            result = validator.validate_cover_url("https://example.com/missing.jpg")
+        assert not result.valid
+        assert result.error_code == "bad_status"
+
+    def test_html_content_type_rejected(self):
+        with patch.object(validator.cw_advocate, "head",
+                          return_value=_mock_head(200, "text/html", 5000)):
+            result = validator.validate_cover_url("https://example.com/page.html")
+        assert not result.valid
+        assert result.error_code == "not_image"
+
+    def test_jpeg_content_type_passes_initial_check(self):
+        with patch.object(validator.cw_advocate, "head",
+                          return_value=_mock_head(200, "image/jpeg", 250000)), \
+             patch.object(validator, "_probe_dimensions", return_value=(975, 1500)):
+            result = validator.validate_cover_url("https://example.com/cover.jpg")
+        assert result.valid
+        assert result.content_type == "image/jpeg"
+        assert result.width == 975
+        assert result.height == 1500
+
+    def test_content_type_with_charset_suffix_normalized(self):
+        with patch.object(validator.cw_advocate, "head",
+                          return_value=_mock_head(200, "image/png; charset=binary", 80000)), \
+             patch.object(validator, "_probe_dimensions", return_value=(800, 1200)):
+            result = validator.validate_cover_url("https://example.com/cover.png")
+        assert result.valid
+        assert result.content_type == "image/png"
+
+
+@pytest.mark.unit
+class TestSizeBounds:
+    def test_too_small_rejected(self):
+        # The 43-byte image/gif placeholder Amazon serves for unknown ASINs.
+        with patch.object(validator.cw_advocate, "head",
+                          return_value=_mock_head(200, "image/gif", 43)):
+            result = validator.validate_cover_url("https://example.com/placeholder.gif")
+        # Note: image/gif passes the content-type check, but the size filter
+        # catches the placeholder.
+        assert not result.valid
+        assert result.error_code == "too_small"
+
+    def test_too_large_rejected(self):
+        # 200 MB JPEG — exceeds the 15 MB default.
+        with patch.object(validator.cw_advocate, "head",
+                          return_value=_mock_head(200, "image/jpeg", 200 * 1024 * 1024)):
+            result = validator.validate_cover_url("https://example.com/huge.jpg")
+        assert not result.valid
+        assert result.error_code == "too_large"
+
+    def test_missing_content_length_passes_size_check(self):
+        # Some CDNs don't report content-length on HEAD. Don't reject for that;
+        # the actual save-path will enforce the cap.
+        with patch.object(validator.cw_advocate, "head",
+                          return_value=_mock_head(200, "image/jpeg", 0)), \
+             patch.object(validator, "_probe_dimensions", return_value=(900, 1200)):
+            result = validator.validate_cover_url("https://example.com/cover.jpg")
+        assert result.valid
+
+
+@pytest.mark.unit
+class TestSerialization:
+    def test_to_dict_returns_jsonable_shape(self):
+        with patch.object(validator.cw_advocate, "head",
+                          return_value=_mock_head(200, "image/jpeg", 250000)), \
+             patch.object(validator, "_probe_dimensions", return_value=(975, 1500)):
+            result = validator.validate_cover_url("https://example.com/cover.jpg")
+        d = result.to_dict()
+        assert d["valid"] is True
+        assert d["width"] == 975
+        assert d["height"] == 1500
+        assert d["content_type"] == "image/jpeg"
+        assert d["size_bytes"] == 250000


### PR DESCRIPTION
## Why

Two concrete user pains, both with measurable signal in upstream issues:

1. **The metadata-search modal does too much when the user just wants to swap a cover.** Users repeatedly ask for a cover-only path (CWA #491, #1063, #1117). The bundled metadata-fetch flow forces them to either accept all the other fields or laboriously uncheck them.
2. **The existing inline `cover_url` field on the edit page is unreliable.** No client-side preview, full form-save round-trip on every attempt, errors flash but lose context. Recent fix #49 addressed permission cascades; the UX gap remained.

Highest-signal cluster: [janeczku/calibre-web#2165 (8 hearts)](https://github.com/janeczku/calibre-web/issues/2165) — "don't clobber my cover when fetching metadata." This PR resolves it via the per-book cover lock.

Peer apps that have solved this well: Komga and Kavita both have a dedicated **Poster/Cover** tab separate from metadata edit. Calibre desktop has a "Download cover" dialog with provider-labeled candidates. The pattern is well-validated.

## What ships

Two coordinated additions, designed to ship together but valuable independently. Full design rationale in [`notes/COVER-PICKER-DESIGN.md`](notes/COVER-PICKER-DESIGN.md).

### A. New focused cover-picker page at `GET /book/<id>/cover`

- Dedicated to cover-only workflow, separate from the existing metadata-search modal which stays untouched.
- Layout: current cover left + lock toggle + book metadata; candidate grid right with provider badges, pixel dimensions, low-res warning.
- Three inline panels: paste URL with live preview, upload local file, manage API keys (reused from `/metadata/keys`, no duplication).
- Confirm-replace modal shows current vs candidate side-by-side before commit.
- Includes the embedded-cover-from-book-file as a candidate (CWA #1063 + janeczku/calibre-web#3457: "regenerate cover from file").
- Per-book cover lock (`BookCoverLock` table in `app.db`) — when on, `do_edit_book`'s metadata-fetch path skips cover assignment with a clear flash message instead of silently overwriting.

### B. Reliable inline live preview on the edit page's `cover_url` field

- New `POST /metadata/cover/preview` endpoint (same code path the save handler uses; successful preview = successful save).
- Debounced 400ms AJAX HEAD probe via `cw_advocate` (the existing SSRF guard) returns dimensions + size + content-type + structured error.
- Inline preview thumbnail + meta line next to the field, shown before form submit. Failure is visible at paste time, not after a full form-save round-trip.

## Architecture

- **Three pure-functional service modules**, all easy to test without Flask: `cover_url_validator`, `cover_extract`, `cover_picker` (orchestrator).
- **The picker reuses the existing provider auto-discovery** — drop a file in `cps/metadata_provider/` and the picker grid surfaces every provider that returns covers. Adding a new source needs zero changes to the picker code.
- **Plain ES2017+ JS, plain CSS, no bundlers, no transpilers** — matches the rest of the fork.
- **No new runtime deps.** Optional knobs only: `CWA_COVER_PICKER_TIMEOUT`, `CWA_COVER_PICKER_WORKERS`, `CWA_COVER_PICKER_MAX_CANDIDATES`.

## OSS-friendliness

- No new dependencies. PIL/lxml/wand are already in the production image (used by `helper.py` and `epub.py`). `cw_advocate` is the existing SSRF guard.
- No required env vars for basic operation.
- License headers preserved (`SPDX-License-Identifier: GPL-3.0-or-later` on every new Python file).
- Plugin-friendly source set — any new provider auto-contributes candidates.

## Validation

**Unit tests (36 pass, 3 EPUB tests skipped without lxml in dev env; production has lxml):**

```
tests/unit/test_cover_url_validator.py  14 passed
tests/unit/test_cover_picker_service.py  10 passed
tests/unit/test_cover_extract.py         12 passed (3 skipped)
```

**End-to-end on the deployed teenyverse instance:**

- `POST /metadata/cover/preview` — returns valid result shape against the URL validator
- `POST /book/<id>/cover/lock` — toggle on/off, persists to `book_cover_lock` table
- `POST /book/<id>/cover/candidates` — returns 28 candidates from 13 providers including the embedded-cover candidate from a real EPUB in the library
- `GET /book/<id>/cover` — page renders end-to-end through the full WSGI stack

## Files changed

**New (services):**
- `cps/services/cover_url_validator.py` — URL validation + dimension probing
- `cps/services/cover_picker.py` — provider orchestration
- `cps/services/cover_extract.py` — embedded-cover extraction (EPUB / CBZ / PDF)

**New (Flask blueprint):**
- `cps/cover_picker.py`

**New (templates + JS + CSS):**
- `cps/templates/cover_picker.html`
- `cps/static/js/cover_picker.js`
- `cps/static/css/cover_picker.css`

**New (tests):**
- `tests/unit/test_cover_url_validator.py`
- `tests/unit/test_cover_picker_service.py`
- `tests/unit/test_cover_extract.py`

**New (design doc):**
- `notes/COVER-PICKER-DESIGN.md`

**Modified:**
- `cps/ub.py` — `BookCoverLock` model
- `cps/editbooks.py` — honor cover lock in `do_edit_book`
- `cps/search_metadata.py` — `/metadata/cover/preview` endpoint
- `cps/main.py` — register `cover_picker` blueprint
- `cps/templates/book_edit.html` — focused-picker entry button + inline preview
- `cps/templates/detail.html` — "Change cover" button next to edit
- `cps/static/js/edit_books.js` — debounced preview JS
- `cps/static/css/cwa.css` — preview thumb styles

## Tier

`needs-review` — multi-file behavior change touching the cover-edit surface. New blueprint, new DB table, new template + JS + CSS.

## Compatibility with PR #65

PR #65 (Amazon CDN booster + Apple Books provider) is independent. Both PRs touch the cover-fetch system but operate at different layers: PR #65 improves cover URLs returned by providers; this PR adds a new UI consumer. They merge in either order.