### PR TITLE
fix(cover-picker): CSP whitelist + dark-theme contrast + cw_advocate.head bug

### DIFF
--- a/cps/services/cover_url_validator.py
+++ b/cps/services/cover_url_validator.py
@@ -101,7 +101,10 @@ def validate_cover_url(url: str) -> ValidationResult:
                                 error_message="Cover-URL validation is unavailable on this server.")
 
     try:
-        head = cw_advocate.head(url, timeout=_DEFAULT_TIMEOUT, allow_redirects=True)
+        # cw_advocate.api.py exports request/get/post/options but NOT a
+        # top-level head(); calling cw_advocate.head() raises AttributeError.
+        # Use the generic request() shim instead.
+        head = cw_advocate.request("HEAD", url, timeout=_DEFAULT_TIMEOUT, allow_redirects=True)
     except UnacceptableAddressException:
         return ValidationResult(valid=False, url=url, error_code="ssrf_blocked",
                                 error_message="That URL points to an internal or local address. Use a public URL.")

--- a/cps/static/css/cover_picker.css
+++ b/cps/static/css/cover_picker.css
@@ -2,43 +2,104 @@
  * Calibre-Web-NextGen — focused cover-picker UI
  * SPDX-License-Identifier: GPL-3.0-or-later
  *
- * Plain CSS, Bootstrap-3 conventions matching the existing fork. No
- * preprocessor, no bundler. Selectors are scoped under .cwa-cover-picker
- * so the picker never bleeds into the rest of the app.
+ * Theme-aware. The fork ships two themes: standard (light-Bootstrap-3)
+ * and caliBlur (dark; body gets the .blur class). All colors flow
+ * through CSS custom properties scoped to the picker so neither theme
+ * pollutes the other or pulls in light-on-light or dark-on-dark text.
+ *
+ * Selectors are scoped under .cwa-cover-picker so the picker never
+ * bleeds into the rest of the app.
  */
 
 .cwa-cover-picker {
+  /* Light-theme defaults — apply when body has no .blur class. */
+  --cp-bg:           transparent;
+  --cp-text:         #222;
+  --cp-text-muted:   #666;
+  --cp-text-strong:  #111;
+  --cp-card-bg:      #ffffff;
+  --cp-card-text:    #222;
+  --cp-card-border:  #d8d8d8;
+  --cp-card-elev-bg: #fafafa;
+  --cp-summary-bg:   #ffffff;
+  --cp-summary-text: #222;
+  --cp-input-bg:     #ffffff;
+  --cp-input-text:   #222;
+  --cp-input-border: #cccccc;
+  --cp-feedback-ok:  #2d7d35;
+  --cp-feedback-err: #b94a48;
+  --cp-thumb-bg:     #f0f0f0;
+  --cp-pill-bg:      #eeeeee;
+  --cp-pill-text:    #444;
+  --cp-source-badge-bg:   #e8eef9;
+  --cp-source-badge-text: #2c3e7a;
+  --cp-divider:      #e6e6e6;
+  --cp-shadow:       0 4px 12px rgba(0,0,0,0.10);
+  --cp-cover-fail-bg: #f0f0f0;
+  --cp-cover-fail-text: #666;
   padding: 16px;
+}
+
+/* Dark theme overrides for the caliBlur skin. The .blur class lives on
+   <body> when the user is on caliBlur (see cps/templates/layout.html). */
+body.blur .cwa-cover-picker {
+  --cp-bg:           transparent;
+  --cp-text:         #f0f0f0;
+  --cp-text-muted:   #b8b8b8;
+  --cp-text-strong:  #ffffff;
+  --cp-card-bg:      #2c2c2c;
+  --cp-card-text:    #f0f0f0;
+  --cp-card-border:  #404040;
+  --cp-card-elev-bg: #353535;
+  --cp-summary-bg:   #2c2c2c;
+  --cp-summary-text: #f0f0f0;
+  --cp-input-bg:     #1f1f1f;
+  --cp-input-text:   #f0f0f0;
+  --cp-input-border: #555555;
+  --cp-feedback-ok:  #6cd078;
+  --cp-feedback-err: #ff7676;
+  --cp-thumb-bg:     #1a1a1a;
+  --cp-pill-bg:      #404040;
+  --cp-pill-text:    #d0d0d0;
+  --cp-source-badge-bg:   #3a4665;
+  --cp-source-badge-text: #c8d4ff;
+  --cp-divider:      #404040;
+  --cp-shadow:       0 4px 12px rgba(0,0,0,0.45);
+  --cp-cover-fail-bg: #1a1a1a;
+  --cp-cover-fail-text: #888;
 }
 
 .cwa-cover-picker__back {
   text-decoration: none;
   font-size: 13px;
-  color: #777;
+  color: var(--cp-text-muted);
 }
-.cwa-cover-picker__back:hover { color: #333; }
+.cwa-cover-picker__back:hover { color: var(--cp-text); }
 
 .cwa-cover-picker__title {
   margin: 4px 0 0 0;
+  color: var(--cp-text-strong);
 }
 
 .cwa-cover-picker__subtitle {
   margin: 4px 0 16px 0;
+  color: var(--cp-text-muted) !important;  /* override Bootstrap text-muted */
 }
 
 /* Left rail — current cover + lock toggle */
 .cwa-cover-picker__current-card {
-  border: 1px solid #e0e0e0;
+  background: var(--cp-card-bg);
+  color: var(--cp-card-text);
+  border: 1px solid var(--cp-card-border);
   border-radius: 6px;
   padding: 12px;
-  background: #fafafa;
 }
 
 .cwa-cover-picker__current-label {
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #888;
+  color: var(--cp-text-muted);
   margin-bottom: 6px;
 }
 
@@ -47,21 +108,21 @@
   max-height: 360px;
   object-fit: contain;
   border-radius: 4px;
-  background: #fff;
-  border: 1px solid #ddd;
+  background: var(--cp-thumb-bg);
+  border: 1px solid var(--cp-card-border);
 }
 
 .cwa-cover-picker__current-meta {
   margin-top: 10px;
   font-size: 13px;
   line-height: 1.4;
-  color: #444;
+  color: var(--cp-card-text);
 }
 
 .cwa-cover-picker__lock {
   margin-top: 14px;
   padding-top: 12px;
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--cp-divider);
 }
 
 .cwa-cover-picker__lock-toggle {
@@ -70,12 +131,19 @@
   font-weight: 600;
   margin: 0;
   cursor: pointer;
+  color: var(--cp-card-text);
 }
-.cwa-cover-picker__lock-toggle input { margin-right: 8px; }
+.cwa-cover-picker__lock-toggle input {
+  margin-right: 8px;
+  /* Default browser checkboxes don't render well on dark — give them a
+     subtle border that's visible against either theme background. */
+  accent-color: #d77a00;  /* CWA brand orange */
+}
 
 .cwa-cover-picker__lock-help {
   font-size: 12px;
   margin-top: 4px;
+  color: var(--cp-text-muted);
 }
 
 /* Right column — source panels + grid */
@@ -84,10 +152,11 @@
 }
 
 .cwa-cover-picker__panel {
-  border: 1px solid #e0e0e0;
+  background: var(--cp-summary-bg);
+  border: 1px solid var(--cp-card-border);
   border-radius: 6px;
   margin-bottom: 8px;
-  background: #fff;
+  color: var(--cp-summary-text);
 }
 
 .cwa-cover-picker__panel summary {
@@ -96,13 +165,14 @@
   font-weight: 600;
   list-style: none;
   user-select: none;
+  color: var(--cp-summary-text);
 }
 .cwa-cover-picker__panel summary::-webkit-details-marker { display: none; }
 .cwa-cover-picker__panel summary::before {
   content: '\002B';  /* + */
   display: inline-block;
   margin-right: 8px;
-  color: #888;
+  color: var(--cp-text-muted);
   transition: transform 0.15s ease;
 }
 .cwa-cover-picker__panel[open] summary::before {
@@ -111,15 +181,24 @@
 
 .cwa-cover-picker__panel-body {
   padding: 0 14px 14px 14px;
+  color: var(--cp-summary-text);
+}
+
+.cwa-cover-picker__panel-body input[type="text"],
+.cwa-cover-picker__panel-body input[type="file"] {
+  background: var(--cp-input-bg);
+  color: var(--cp-input-text);
+  border: 1px solid var(--cp-input-border);
 }
 
 .cwa-cover-picker__feedback {
   font-size: 13px;
   margin-top: 6px;
   min-height: 1.4em;
+  color: var(--cp-text-muted);
 }
-.cwa-cover-picker__feedback.is-error { color: #b94a48; }
-.cwa-cover-picker__feedback.is-ok { color: #468847; }
+.cwa-cover-picker__feedback.is-error { color: var(--cp-feedback-err); }
+.cwa-cover-picker__feedback.is-ok    { color: var(--cp-feedback-ok); }
 
 .cwa-cover-picker__url-actions {
   display: flex;
@@ -127,22 +206,22 @@
   gap: 12px;
   margin-top: 10px;
   padding: 8px;
-  background: #f5f5f5;
+  background: var(--cp-card-elev-bg);
   border-radius: 4px;
 }
 
 #cwa-cover-picker-url-thumb {
   max-width: 80px;
   max-height: 120px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--cp-card-border);
   border-radius: 3px;
-  background: #fff;
+  background: var(--cp-thumb-bg);
 }
 
 .cwa-cover-picker__url-meta {
   flex: 1;
   font-size: 12px;
-  color: #555;
+  color: var(--cp-text-muted);
 }
 
 /* Grid */
@@ -153,7 +232,10 @@
   margin: 12px 0 8px 0;
   flex-wrap: wrap;
 }
-.cwa-cover-picker__grid-toolbar h4 { margin: 0; }
+.cwa-cover-picker__grid-toolbar h4 {
+  margin: 0;
+  color: var(--cp-text-strong);
+}
 .cwa-cover-picker__grid-toolbar .cwa-cover-picker__grid-actions {
   margin-left: auto;
 }
@@ -163,20 +245,20 @@
   padding: 2px 10px;
   font-size: 12px;
   border-radius: 10px;
-  background: #eee;
-  color: #555;
+  background: var(--cp-pill-bg);
+  color: var(--cp-pill-text);
 }
 .cwa-cover-picker__status-pill--loading {
-  background: #e8f0fe;
-  color: #1967d2;
+  background: #d99000;
+  color: #ffffff;
 }
 .cwa-cover-picker__status-pill--ok {
-  background: #e6f4ea;
-  color: #137333;
+  background: #2d7d35;
+  color: #ffffff;
 }
 .cwa-cover-picker__status-pill--empty {
-  background: #fff7e6;
-  color: #b25e09;
+  background: #b25e09;
+  color: #ffffff;
 }
 
 .cwa-cover-picker__grid {
@@ -190,13 +272,15 @@
   grid-column: 1 / -1;
   text-align: center;
   padding: 30px 0;
+  color: var(--cp-text-muted);
 }
 
 .cwa-cover-picker__card {
   position: relative;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--cp-card-border);
   border-radius: 6px;
-  background: #fff;
+  background: var(--cp-card-bg);
+  color: var(--cp-card-text);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -204,7 +288,7 @@
   transition: box-shadow 0.15s ease, transform 0.15s ease;
 }
 .cwa-cover-picker__card:hover {
-  box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+  box-shadow: var(--cp-shadow);
   transform: translateY(-1px);
 }
 
@@ -212,18 +296,47 @@
   width: 100%;
   height: 220px;
   object-fit: contain;
-  background: #f5f5f5;
+  background: var(--cp-thumb-bg);
+}
+
+/* Placeholder when an image fails to load (CSP, network, 404). The JS
+   sets a class on the card; the CSS replaces the broken thumb area
+   with a labeled fallback so the user understands the candidate
+   isn't reachable rather than seeing an empty white box. */
+.cwa-cover-picker__card.is-cover-failed .cwa-cover-picker__card-cover {
+  display: none;
+}
+.cwa-cover-picker__card-failed-msg {
+  display: none;
+  height: 220px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  background: var(--cp-cover-fail-bg);
+  color: var(--cp-cover-fail-text);
+  font-size: 12px;
+  text-align: center;
+  padding: 16px;
+}
+.cwa-cover-picker__card.is-cover-failed .cwa-cover-picker__card-failed-msg {
+  display: flex;
+}
+.cwa-cover-picker__card-failed-msg .glyphicon {
+  font-size: 24px;
+  opacity: 0.6;
+  margin-bottom: 6px;
 }
 
 .cwa-cover-picker__card-info {
   padding: 8px 10px;
   font-size: 12px;
   flex: 1;
+  color: var(--cp-card-text);
 }
 
 .cwa-cover-picker__card-source {
   font-weight: 600;
-  color: #333;
+  color: var(--cp-card-text);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -231,16 +344,16 @@
 
 .cwa-cover-picker__card-dims {
   margin-top: 2px;
-  color: #888;
+  color: var(--cp-text-muted);
   font-size: 11px;
 }
 .cwa-cover-picker__card-dims--low {
-  color: #b94a48;
+  color: var(--cp-feedback-err);
 }
 
 .cwa-cover-picker__card-title {
   margin-top: 4px;
-  color: #555;
+  color: var(--cp-text-muted);
   font-size: 11px;
   white-space: nowrap;
   overflow: hidden;
@@ -250,8 +363,8 @@
 .cwa-cover-picker__card-source-badge {
   display: inline-block;
   padding: 1px 6px;
-  background: #eef;
-  color: #335;
+  background: var(--cp-source-badge-bg);
+  color: var(--cp-source-badge-text);
   border-radius: 8px;
   font-size: 10px;
   text-transform: uppercase;
@@ -274,18 +387,19 @@
   font-size: 11px;
   padding: 2px 8px;
   border-radius: 8px;
-  background: #f5f5f5;
-  color: #666;
+  background: var(--cp-pill-bg);
+  color: var(--cp-pill-text);
 }
-.cwa-cover-picker__provider-pill--ok { background: #e6f4ea; color: #137333; }
-.cwa-cover-picker__provider-pill--empty { background: #f5f5f5; color: #999; }
-.cwa-cover-picker__provider-pill--error { background: #fde7e7; color: #b94a48; }
-.cwa-cover-picker__provider-pill--rate_limited { background: #fff3cd; color: #856404; }
-.cwa-cover-picker__provider-pill--blocked { background: #fde7e7; color: #b94a48; }
-.cwa-cover-picker__provider-pill--missing_key { background: #fff3cd; color: #856404; }
-.cwa-cover-picker__provider-pill--disabled { background: #eee; color: #999; }
+.cwa-cover-picker__provider-pill--ok           { background: #2d7d35; color: #fff; }
+.cwa-cover-picker__provider-pill--empty        { background: var(--cp-pill-bg); color: var(--cp-text-muted); }
+.cwa-cover-picker__provider-pill--error        { background: #b94a48; color: #fff; }
+.cwa-cover-picker__provider-pill--rate_limited { background: #d99000; color: #fff; }
+.cwa-cover-picker__provider-pill--blocked      { background: #b94a48; color: #fff; }
+.cwa-cover-picker__provider-pill--missing_key  { background: #d99000; color: #fff; }
+.cwa-cover-picker__provider-pill--disabled     { background: var(--cp-pill-bg); color: var(--cp-text-muted); opacity: 0.7; }
 
-/* Confirm modal */
+/* Confirm modal — Bootstrap 3 modals style themselves; only the inner
+   grid + image elements need our touch. */
 .cwa-cover-picker__confirm-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -300,34 +414,47 @@
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #888;
+  color: var(--cp-text-muted);
   margin-bottom: 6px;
 }
 
 .cwa-cover-picker__confirm-side img {
   max-width: 100%;
   max-height: 380px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--cp-card-border);
   border-radius: 4px;
-  background: #fff;
+  background: var(--cp-thumb-bg);
 }
 
 .cwa-cover-picker__confirm-meta {
   margin-top: 8px;
   font-size: 12px;
-  color: #555;
+  color: var(--cp-text-muted);
 }
 
-/* API-keys panel — mirrors the metadata-search modal styling */
+/* API-keys panel rows. Mirrors the metadata-search modal rhythm. */
 .cwa-cover-picker__keys-row {
   display: flex;
   align-items: center;
   gap: 10px;
   padding: 8px 0;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--cp-divider);
 }
 .cwa-cover-picker__keys-row:last-child { border-bottom: 0; }
-.cwa-cover-picker__keys-name { flex: 0 0 160px; font-weight: 600; }
-.cwa-cover-picker__keys-state { flex: 0 0 130px; font-size: 12px; }
+.cwa-cover-picker__keys-name {
+  flex: 0 0 160px;
+  font-weight: 600;
+  color: var(--cp-summary-text);
+}
+.cwa-cover-picker__keys-state {
+  flex: 0 0 130px;
+  font-size: 12px;
+  color: var(--cp-text-muted);
+}
 .cwa-cover-picker__keys-input { flex: 1; }
-.cwa-cover-picker__keys-input input { width: 100%; }
+.cwa-cover-picker__keys-input input {
+  width: 100%;
+  background: var(--cp-input-bg);
+  color: var(--cp-input-text);
+  border: 1px solid var(--cp-input-border);
+}

--- a/cps/static/css/cwa.css
+++ b/cps/static/css/cwa.css
@@ -48,26 +48,39 @@ body.modal-open #remove-from-shelves + .tags {
 
 /* Inline cover-URL live preview on the edit-metadata page (PR: focused
    cover picker — see notes/COVER-PICKER-DESIGN.md). Compact preview
-   thumbnail + dimensions + a friendly error before save round-trip. */
+   thumbnail + dimensions + a friendly error before save round-trip.
+   Theme-aware: caliBlur (body.blur) gets darker chrome, light theme
+   keeps the original light treatment. */
 .cwa-cover-url-preview {
+    --cup-bg: #f5f5f5;
+    --cup-text: #555;
+    --cup-thumb-border: #ddd;
+    --cup-thumb-bg: #fff;
     display: flex;
     align-items: center;
     gap: 10px;
     margin-top: 6px;
     padding: 6px;
-    background: #f5f5f5;
+    background: var(--cup-bg);
     border-radius: 4px;
+    color: var(--cup-text);
+}
+body.blur .cwa-cover-url-preview {
+    --cup-bg: #2c2c2c;
+    --cup-text: #d0d0d0;
+    --cup-thumb-border: #404040;
+    --cup-thumb-bg: #1a1a1a;
 }
 .cwa-cover-url-preview img {
     max-width: 70px;
     max-height: 100px;
-    border: 1px solid #ddd;
+    border: 1px solid var(--cup-thumb-border);
     border-radius: 3px;
-    background: #fff;
+    background: var(--cup-thumb-bg);
 }
 .cwa-cover-url-preview > div {
     font-size: 12px;
-    color: #555;
+    color: var(--cup-text);
 }
 .cwa-cover-url-feedback {
     font-size: 12px;
@@ -76,4 +89,6 @@ body.modal-open #remove-from-shelves + .tags {
 }
 .cwa-cover-url-feedback.is-ok    { color: #468847; }
 .cwa-cover-url-feedback.is-error { color: #b94a48; }
+body.blur .cwa-cover-url-feedback.is-ok    { color: #6cd078; }
+body.blur .cwa-cover-url-feedback.is-error { color: #ff7676; }
 .cwa-cover-picker__entry         { margin-top: 4px; }

--- a/cps/static/js/cover_picker.js
+++ b/cps/static/js/cover_picker.js
@@ -90,12 +90,18 @@
     img.alt = candidate.title || "";
     img.loading = "lazy";
     img.src = candidate.cover_url;
-    img.onerror = function () { img.style.display = "none"; };
+    img.onerror = function () {
+      // Network failure / CORS-strict provider / 404. Mark the card so
+      // the CSS-driven failure placeholder takes over the image area
+      // instead of showing an empty card. The candidate is still
+      // pickable — the user might know the URL is fine and want to apply
+      // it anyway.
+      card.classList.add("is-cover-failed");
+    };
     img.onload = function () {
       // Surface the natural dimensions when the candidate didn't carry
-      // them (most providers don't). cover_booster fires later for the
-      // metadata modal, but for the picker the browser is the source of
-      // truth — the image had to render anyway.
+      // them (most providers don't). For the picker the browser is the
+      // source of truth — the image had to render anyway.
       const dimsEl = card.querySelector(".cwa-cover-picker__card-dims");
       if (dimsEl && img.naturalWidth) {
         dimsEl.textContent = img.naturalWidth + "×" + img.naturalHeight;
@@ -105,6 +111,14 @@
       }
     };
     card.appendChild(img);
+
+    // Hidden by default — CSS reveals it when .is-cover-failed is set.
+    const failedMsg = document.createElement("div");
+    failedMsg.className = "cwa-cover-picker__card-failed-msg";
+    failedMsg.innerHTML =
+      '<span class="glyphicon glyphicon-picture" aria-hidden="true"></span>' +
+      '<div>Cover not reachable<br><small>Tap to apply anyway</small></div>';
+    card.appendChild(failedMsg);
 
     const info = document.createElement("div");
     info.className = "cwa-cover-picker__card-info";
@@ -249,6 +263,11 @@
     if (!payload.valid) {
       urlFeedback.classList.add("is-error");
       urlFeedback.textContent = payload.error_message || cfg.i18n.error;
+      // Make sure a previous successful preview's "Use this cover" button
+      // doesn't linger when the user types a worse URL afterwards.
+      urlActions.hidden = true;
+      lastValidatedUrl = null;
+      lastValidationResult = null;
       return;
     }
     lastValidatedUrl = url;

--- a/cps/web.py
+++ b/cps/web.py
@@ -125,7 +125,12 @@ def add_security_headers(resp):
     if request.endpoint == "admin.hardcover_review_matches":
         csp += " https:"
     csp += " data:"
-    if request.endpoint == "edit-book.show_edit_book" or config.config_use_google_drive:
+    if request.endpoint in ("edit-book.show_edit_book", "cover_picker.cover_picker_page") or config.config_use_google_drive:
+        # The metadata-search modal (edit-book) and the focused cover-picker
+        # page both render thumbnails directly from external provider CDNs
+        # (Hardcover, Apple Books, Amazon image CDN, OpenLibrary, Kobo,
+        # Douban, etc.). Allow those img-src origins for these two endpoints
+        # only — all other pages keep the strict same-origin policy.
         csp += " *"
     if request.endpoint == "web.read_book":
         csp += " blob: ; style-src-elem 'self' blob: 'unsafe-inline'"

--- a/tests/unit/test_cover_url_validator.py
+++ b/tests/unit/test_cover_url_validator.py
@@ -46,8 +46,8 @@ def _load_validator_module():
     cps_pkg.logger = logger_mod
 
     advocate_mod = sys.modules.get("cps.cw_advocate") or types.ModuleType("cps.cw_advocate")
-    if not hasattr(advocate_mod, "head"):
-        advocate_mod.head = lambda *a, **k: None  # patched per-test
+    if not hasattr(advocate_mod, "request"):
+        advocate_mod.request = lambda *a, **k: None  # patched per-test
         advocate_mod.get = lambda *a, **k: None
     sys.modules["cps.cw_advocate"] = advocate_mod
     cps_pkg.cw_advocate = advocate_mod
@@ -112,7 +112,7 @@ class TestEarlyRejects:
 class TestSsrfGuard:
     def test_ssrf_blocked_returns_friendly_error(self):
         with patch.object(
-            validator.cw_advocate, "head",
+            validator.cw_advocate, "request",
             side_effect=validator.UnacceptableAddressException("blocked"),
         ):
             result = validator.validate_cover_url("http://localhost:8080/cover.jpg")
@@ -125,7 +125,7 @@ class TestSsrfGuard:
 class TestUnreachable:
     def test_request_exception_returns_unreachable(self):
         import requests as _r
-        with patch.object(validator.cw_advocate, "head",
+        with patch.object(validator.cw_advocate, "request",
                           side_effect=_r.ConnectionError("nope")):
             result = validator.validate_cover_url("https://nope.example/x.jpg")
         assert not result.valid
@@ -135,21 +135,21 @@ class TestUnreachable:
 @pytest.mark.unit
 class TestStatusAndContentType:
     def test_404_rejected(self):
-        with patch.object(validator.cw_advocate, "head",
+        with patch.object(validator.cw_advocate, "request",
                           return_value=_mock_head(404, "text/html", 1234)):
             result = validator.validate_cover_url("https://example.com/missing.jpg")
         assert not result.valid
         assert result.error_code == "bad_status"
 
     def test_html_content_type_rejected(self):
-        with patch.object(validator.cw_advocate, "head",
+        with patch.object(validator.cw_advocate, "request",
                           return_value=_mock_head(200, "text/html", 5000)):
             result = validator.validate_cover_url("https://example.com/page.html")
         assert not result.valid
         assert result.error_code == "not_image"
 
     def test_jpeg_content_type_passes_initial_check(self):
-        with patch.object(validator.cw_advocate, "head",
+        with patch.object(validator.cw_advocate, "request",
                           return_value=_mock_head(200, "image/jpeg", 250000)), \
              patch.object(validator, "_probe_dimensions", return_value=(975, 1500)):
             result = validator.validate_cover_url("https://example.com/cover.jpg")
@@ -159,7 +159,7 @@ class TestStatusAndContentType:
         assert result.height == 1500
 
     def test_content_type_with_charset_suffix_normalized(self):
-        with patch.object(validator.cw_advocate, "head",
+        with patch.object(validator.cw_advocate, "request",
                           return_value=_mock_head(200, "image/png; charset=binary", 80000)), \
              patch.object(validator, "_probe_dimensions", return_value=(800, 1200)):
             result = validator.validate_cover_url("https://example.com/cover.png")
@@ -171,7 +171,7 @@ class TestStatusAndContentType:
 class TestSizeBounds:
     def test_too_small_rejected(self):
         # The 43-byte image/gif placeholder Amazon serves for unknown ASINs.
-        with patch.object(validator.cw_advocate, "head",
+        with patch.object(validator.cw_advocate, "request",
                           return_value=_mock_head(200, "image/gif", 43)):
             result = validator.validate_cover_url("https://example.com/placeholder.gif")
         # Note: image/gif passes the content-type check, but the size filter
@@ -181,7 +181,7 @@ class TestSizeBounds:
 
     def test_too_large_rejected(self):
         # 200 MB JPEG — exceeds the 15 MB default.
-        with patch.object(validator.cw_advocate, "head",
+        with patch.object(validator.cw_advocate, "request",
                           return_value=_mock_head(200, "image/jpeg", 200 * 1024 * 1024)):
             result = validator.validate_cover_url("https://example.com/huge.jpg")
         assert not result.valid
@@ -190,7 +190,7 @@ class TestSizeBounds:
     def test_missing_content_length_passes_size_check(self):
         # Some CDNs don't report content-length on HEAD. Don't reject for that;
         # the actual save-path will enforce the cap.
-        with patch.object(validator.cw_advocate, "head",
+        with patch.object(validator.cw_advocate, "request",
                           return_value=_mock_head(200, "image/jpeg", 0)), \
              patch.object(validator, "_probe_dimensions", return_value=(900, 1200)):
             result = validator.validate_cover_url("https://example.com/cover.jpg")
@@ -200,7 +200,7 @@ class TestSizeBounds:
 @pytest.mark.unit
 class TestSerialization:
     def test_to_dict_returns_jsonable_shape(self):
-        with patch.object(validator.cw_advocate, "head",
+        with patch.object(validator.cw_advocate, "request",
                           return_value=_mock_head(200, "image/jpeg", 250000)), \
              patch.object(validator, "_probe_dimensions", return_value=(975, 1500)):
             result = validator.validate_cover_url("https://example.com/cover.jpg")


### PR DESCRIPTION
Three follow-up fixes to the v4.0.19 cover-picker, caught only after end-to-end browser-driving the deployed instance under the caliBlur (dark) theme.

## Why

User reported "ui looks kinda bad — covers aren't even retrieved from services, and some colors are light on light and hard to see." End-to-end Playwright session confirmed all three root causes simultaneously. None showed up in unit tests because they're rendering-environment-specific (CSP, theme, runtime AttributeError swallowed by an over-broad except).

## What's broken

### 1. CSP blocked every external cover URL

`cps/web.py:128` adds `img-src *` only for the `edit-book.show_edit_book` endpoint. The focused cover-picker page (`cover_picker.cover_picker_page`) wasn't on the exception list, so the default `img-src 'self' data:` policy blocked all 14 providers' cover URLs (Apple Books, Hardcover, Amazon CDN, OpenLibrary, Kobo, Douban, etc.) at browser load time. **114 console errors** of the form:

```
Loading the image 'https://m.media-amazon.com/images/P/...' violates the
following Content Security Policy directive: "img-src 'self' data:".
```

Only the embedded-cover candidate (a `data:` URL) rendered. The candidate JSON was correct; the browser refused to fetch the images.

### 2. Picker CSS was light-theme-only — invisible on caliBlur

The fork's caliBlur theme adds `class="blur"` to `<body>` and uses a dark slate background (`#474747`) with near-white body text (`#f5f5f5`). My picker styles used hardcoded light colors (`#fafafa` cards, `#fff` panels, `#444` text). Text inside cards inherited body's near-white color while the cards stayed white — so titles, panel summaries ("Use a URL", "Upload a file", "API keys"), "Lock cover" label, help text, candidate metadata all rendered as **white-on-white**.

### 3. URL preview always returned "Could not reach that URL"

`cover_url_validator.validate_cover_url` called `cw_advocate.head(...)`, but `cps/cw_advocate/__init__.py` only exports `request`, `get`, `post`, etc. — **there is no top-level `head`**. The `AttributeError` got caught by the generic `except (requests.RequestException, Exception)` and surfaced as `error_code: unreachable`, so even known-good URLs (Amazon CDN, etc.) failed validation.

## What ships

### `cps/web.py` (1 line + comment)

Add `cover_picker.cover_picker_page` to the existing `img-src *` exception, alongside the metadata-search modal. Both surfaces render thumbnails directly from external provider CDNs; same exception applies.

### `cps/static/css/cover_picker.css` (full rewrite, theme-aware)

Every color flows through CSS custom properties scoped to `.cwa-cover-picker`. Light-theme defaults at the root, `body.blur` overrides for caliBlur. Selectors cover: backgrounds, borders, text, muted text, summaries, inputs, thumbs, source badges, status pills, the confirm-modal grid, the API-keys rows, and a new failure-placeholder area.

### `cps/static/css/cwa.css` (theme-aware addition for the inline preview)

The new inline `.cwa-cover-url-preview` block on the edit-metadata page got the same CSS-custom-properties treatment — light theme defaults, dark overrides under `body.blur`.

### `cps/static/js/cover_picker.js` (two fixes)

- Add a "Cover not reachable" placeholder for candidate cards whose images fail to load (network 4xx, SSL mismatch, anti-scraping HTTP 418 from Douban, etc.) instead of just hiding the broken `<img>` and leaving an empty card. Failed candidates remain pickable.
- When URL validation fails after a previous success, hide the lingering "Use this cover" action block and clear the cached validated URL so the user can't accidentally apply a stale-good URL.

### `cps/services/cover_url_validator.py` (one line + comment)

`cw_advocate.head(url, ...)` → `cw_advocate.request("HEAD", url, ...)`. The 14 existing unit tests now patch `cw_advocate.request` instead of `cw_advocate.head` and still all pass.

## Validation

End-to-end driven through Playwright against the deployed instance under the caliBlur theme:

- **67 candidate covers render** (Apple Books, Hardcover, OpenLibrary, Amazon CDN, Kobo, Douban, etc.)
- **URL preview validates** `https://m.media-amazon.com/images/P/1853260010.01._SCRM_SL2000_.jpg` → returns `valid: true`, dimensions `1300×2000`, size `359 KB`, content-type `image/jpeg`, displays the preview thumbnail (Wuthering Heights / Flaming June)
- **Panel toggles** (Use a URL / Upload a file / API keys) — all summary text readable
- **Lock toggle** — checkbox + "Lock cover" label + help text all readable
- **API-keys panel** — provider names, "Configured"/"Not configured" state, paste-key input, Save button — all properly contrasted
- **Console down to 1 error** (an HTTP 418 from Douban — anti-scraping signal, real network failure that triggers the new "Cover not reachable" placeholder; not a regression)

Unit tests:
```
tests/unit/test_cover_url_validator.py  14 passed in 0.18s
```

## Tier

`needs-review` — touches CSP allowlist + a Flask response header. CSP changes deserve a manual eyeball even when the change is one endpoint name.