### PR TITLE
feat(kobo-padding): default-on with kobo_sync + readonly color input + right-aligned secondary Cancel

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -2303,6 +2303,7 @@ def _configuration_update_helper():
                             and config.config_login_type == constants.LOGIN_LDAP)
         _config_checkbox_int(to_save, "config_public_reg")
         _config_checkbox_int(to_save, "config_register_email")
+        prev_kobo_sync = bool(config.config_kobo_sync)
         reboot_required |= _config_checkbox_int(to_save, "config_kobo_sync")
         _config_int(to_save, "config_external_port")
         _config_checkbox_int(to_save, "config_kobo_proxy")
@@ -2312,6 +2313,13 @@ def _configuration_update_helper():
         _config_string(to_save, "config_kobo_cover_padding_aspect")
         _config_string(to_save, "config_kobo_cover_padding_fill_mode")
         _config_string(to_save, "config_kobo_cover_padding_color")
+        # Default-on coupling: when the user first enables Kobo sync, auto-
+        # enable cover padding too (the padding section was hidden in the
+        # form they just submitted, so they couldn't have set it). They can
+        # untoggle padding on a later save while keeping kobo_sync on; the
+        # auto-enable only fires on the off→on transition.
+        if not prev_kobo_sync and bool(config.config_kobo_sync):
+            config.config_kobo_cover_padding_enabled = 1
 
         _config_checkbox_int(to_save, "config_hardcover_sync")
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -123,8 +123,9 @@ class _Settings(_Base):
 
     # Kobo cover aspect-ratio padding. Pads server-side so the device shows
     # full-screen artwork instead of letterboxing tall publisher covers.
-    # Defaults: off; Libra Color/2 ratio (1264:1680); edge-mirror fill.
-    config_kobo_cover_padding_enabled = Column(Boolean, default=False)
+    # Defaults: ON when kobo_sync is enabled (auto-applied on the kobo_sync
+    # off→on flip in admin.py); Libra Color/2 ratio; edge-mirror fill.
+    config_kobo_cover_padding_enabled = Column(Boolean, default=True)
     config_kobo_cover_padding_aspect = Column(String, default="kobo_libra_color")
     config_kobo_cover_padding_fill_mode = Column(String, default="edge_mirror")
     config_kobo_cover_padding_color = Column(String, default="")

--- a/cps/static/css/cwa.css
+++ b/cps/static/css/cwa.css
@@ -92,3 +92,41 @@ body.blur .cwa-cover-url-preview {
 body.blur .cwa-cover-url-feedback.is-ok    { color: #6cd078; }
 body.blur .cwa-cover-url-feedback.is-error { color: #ff7676; }
 .cwa-cover-picker__entry         { margin-top: 4px; }
+
+/* ------------------------------------------------------------------------
+   Form action footers (Save / Cancel button rows). Right-aligned, gap'd,
+   with Cancel using a distinguishable secondary style. Apply by wrapping
+   the buttons in `.cwa-form-actions` (or by hand-writing the flex). The
+   `.btn-secondary` class is used on the Cancel link so it stays light on
+   both Bootstrap-3 light and caliBlur dark.
+   ------------------------------------------------------------------------ */
+.cwa-form-actions {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.btn-secondary {
+    background-color: #ffffff;
+    color: #cc7b19;
+    border: 1px solid #cc7b19;
+}
+.btn-secondary:hover,
+.btn-secondary:focus,
+.btn-secondary:active {
+    background-color: #fdf3e7;
+    color: #cc7b19;
+    border-color: #cc7b19;
+    text-decoration: none;
+}
+body.blur .btn-secondary {
+    background-color: rgba(255, 255, 255, 0.92);
+}
+body.blur .btn-secondary:hover,
+body.blur .btn-secondary:focus,
+body.blur .btn-secondary:active {
+    background-color: #ffffff;
+}

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -99,6 +99,22 @@ $(document).on("click", ".postAction", function (event) {
 });
 
 
+// Dim + lock the Kobo cover-padding "custom border color" input when the
+// fill mode isn't "manual". Uses readonly (not disabled) so the typed
+// value is preserved across form submissions when the user toggles modes.
+// Layout does not shift; opacity halves to signal the disabled state.
+function _kobo_padding_color_sync() {
+    var $sel = $("#config_kobo_cover_padding_fill_mode");
+    var $color = $("#config_kobo_cover_padding_color");
+    if (!$sel.length || !$color.length) return;
+    var enabled = ($sel.val() === "manual");
+    $color.prop("readonly", !enabled);
+    $color.closest(".form-group").css("opacity", enabled ? "" : "0.5");
+}
+$(document).on("change", "#config_kobo_cover_padding_fill_mode", _kobo_padding_color_sync);
+$(_kobo_padding_color_sync);
+
+
 // Syntax has to be bind not on, otherwise problems with firefox
 $(".container-fluid").bind("dragenter dragover", function () {
     if($("#btn-upload").length && !$('body').hasClass('shelforder')) {

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -261,9 +261,13 @@
         <input name="detail_view" type="checkbox" checked> {{_('View Book on Save')}}
       </label>
     </div>
-    <a href="#" id="get_meta" class="btn btn-default" data-toggle="modal" data-target="#metaModal">{{_('Fetch Metadata')}}</a>
-    <button type="submit" id="submit" class="btn btn-default">{{_('Save')}}</button>
-    <a href="{{ url_for('web.show_book', book_id=book.id) }}" id="edit_cancel" class="btn btn-default">{{_('Cancel')}}</a>
+    <div style="display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: 0.75rem; margin-top: 1rem;">
+      <a href="#" id="get_meta" class="btn btn-default" data-toggle="modal" data-target="#metaModal">{{_('Fetch Metadata')}}</a>
+      <div class="cwa-form-actions" style="margin-bottom: 0;">
+        <a href="{{ url_for('web.show_book', book_id=book.id) }}" id="edit_cancel" class="btn btn-secondary">{{_('Cancel')}}</a>
+        <button type="submit" id="submit" class="btn btn-default">{{_('Save')}}</button>
+      </div>
+    </div>
   </div>
 </form>
 

--- a/cps/templates/config_db.html
+++ b/cps/templates/config_db.html
@@ -106,9 +106,9 @@
         {% endif %}
       {% endif %}
     {% endif %}
-    <div style="display: inline-flex; flex-direction: row; flex-wrap: wrap; align-items: flex-start; gap: 2rem; float: none; margin-bottom: 1rem; padding-left: 0px;" class="col-sm-12">
+    <div class="cwa-form-actions col-sm-12" style="padding-left: 0px;">
+      <a href="{{ url_for('admin.admin') }}" id="config_back" class="btn btn-secondary">{{_('Cancel')}}</a>
       <div id="db_submit" name="submit" class="btn btn-default">{{_('Save')}}</div>
-      <a href="{{ url_for('admin.admin') }}" id="config_back" class="btn btn-default">{{_('Cancel')}}</a>
     </div>
 
     <hr style="margin: 3rem 0;">

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -93,6 +93,31 @@
     padding: 10px 20px;
     font-size: 14px;
 }
+
+/* Secondary-style Cancel button on the config page: white bg, brand-orange
+   text + matching border. Hover darkens the background slightly without
+   changing the text. Works on both light + caliBlur dark themes. */
+.btn-secondary {
+    background-color: #ffffff;
+    color: #cc7b19;
+    border: 1px solid #cc7b19;
+}
+.btn-secondary:hover,
+.btn-secondary:focus,
+.btn-secondary:active {
+    background-color: #fdf3e7;
+    color: #cc7b19;
+    border-color: #cc7b19;
+    text-decoration: none;
+}
+body.blur .btn-secondary {
+    background-color: rgba(255, 255, 255, 0.92);
+}
+body.blur .btn-secondary:hover,
+body.blur .btn-secondary:focus,
+body.blur .btn-secondary:active {
+    background-color: #ffffff;
+}
 </style>
 {% endblock %}
 {% block body %}
@@ -653,9 +678,9 @@
             </div>
     </div>
 
-    <div style="max-width: 900px; justify-self: center; margin-bottom: 1rem; display: flex; flex-direction: row; flex-wrap: wrap; width: -webkit-fill-available; justify-content: space-between; margin-inline: 2rem;">
+    <div style="max-width: 900px; justify-self: center; margin-bottom: 1rem; display: flex; flex-direction: row; flex-wrap: wrap; width: -webkit-fill-available; justify-content: flex-end; gap: 0.75rem; margin-inline: 2rem;">
+      <a href="{{ url_for('admin.admin') }}" id="config_back" class="btn btn-secondary">{{_('Cancel')}}</a>
       <button type="button" name="submit" id="config_submit" class="btn btn-default">{{_('Save')}}</button>
-      <a href="{{ url_for('admin.admin') }}" id="config_back" class="btn btn-default">{{_('Cancel')}}</a>
     </div>
   </form>
 </div>

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -93,31 +93,6 @@
     padding: 10px 20px;
     font-size: 14px;
 }
-
-/* Secondary-style Cancel button on the config page: white bg, brand-orange
-   text + matching border. Hover darkens the background slightly without
-   changing the text. Works on both light + caliBlur dark themes. */
-.btn-secondary {
-    background-color: #ffffff;
-    color: #cc7b19;
-    border: 1px solid #cc7b19;
-}
-.btn-secondary:hover,
-.btn-secondary:focus,
-.btn-secondary:active {
-    background-color: #fdf3e7;
-    color: #cc7b19;
-    border-color: #cc7b19;
-    text-decoration: none;
-}
-body.blur .btn-secondary {
-    background-color: rgba(255, 255, 255, 0.92);
-}
-body.blur .btn-secondary:hover,
-body.blur .btn-secondary:focus,
-body.blur .btn-secondary:active {
-    background-color: #ffffff;
-}
 </style>
 {% endblock %}
 {% block body %}
@@ -678,7 +653,7 @@ body.blur .btn-secondary:active {
             </div>
     </div>
 
-    <div style="max-width: 900px; justify-self: center; margin-bottom: 1rem; display: flex; flex-direction: row; flex-wrap: wrap; width: -webkit-fill-available; justify-content: flex-end; gap: 0.75rem; margin-inline: 2rem;">
+    <div class="cwa-form-actions" style="max-width: 900px; justify-self: center; width: -webkit-fill-available; margin-inline: 2rem;">
       <a href="{{ url_for('admin.admin') }}" id="config_back" class="btn btn-secondary">{{_('Cancel')}}</a>
       <button type="button" name="submit" id="config_submit" class="btn btn-default">{{_('Save')}}</button>
     </div>

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -204,15 +204,9 @@
     </div>
     
     <!-- Action Buttons -->
-    <div style="max-width: 900px;
-                margin-left: 2rem;
-                margin-right: 2rem;
-                margin-bottom: 4rem;
-                justify-self: center;
-                width: -webkit-fill-available;
-                display: flex;">
-      <button type="submit" name="submit" class="btn btn-default" style="width: -webkit-fill-available;">{{_('Save')}}</button>
-      <a href="{{ url_for('admin.admin') }}" class="btn btn-default" style="width: -webkit-fill-available;">{{_('Cancel')}}</a>
+    <div class="cwa-form-actions" style="max-width: 900px; margin-left: 2rem; margin-right: 2rem; margin-bottom: 4rem; justify-self: center; width: -webkit-fill-available;">
+      <a href="{{ url_for('admin.admin') }}" class="btn btn-secondary">{{_('Cancel')}}</a>
+      <button type="submit" name="submit" class="btn btn-default">{{_('Save')}}</button>
     </div>
   </form>
 </div>

--- a/cps/templates/schedule_edit.html
+++ b/cps/templates/schedule_edit.html
@@ -42,8 +42,10 @@
       <label for="schedule_metadata_backup">{{_('Generate Metadata Backup Files')}}</label>
     </div>
 
-    <button type="submit" name="submit" value="submit" class="btn btn-default">{{_('Save')}}</button>
-    <a href="{{ url_for('admin.admin') }}" id="email_back" class="btn btn-default">{{_('Cancel')}}</a>
+    <div class="cwa-form-actions">
+      <a href="{{ url_for('admin.admin') }}" id="email_back" class="btn btn-secondary">{{_('Cancel')}}</a>
+      <button type="submit" name="submit" value="submit" class="btn btn-default">{{_('Save')}}</button>
+    </div>
   </form>
 </div>
 {% endblock %}

--- a/cps/templates/shelf_edit.html
+++ b/cps/templates/shelf_edit.html
@@ -22,10 +22,12 @@
           </label>
       </div>
     {% endif %}
-    <button type="submit" class="btn btn-default" id="submit">{{_('Save')}}</button>
-    {% if shelf.id != None %}
-      <a href="{{ url_for('shelf.show_shelf', shelf_id=shelf.id) }}" class="btn btn-default">{{_('Cancel')}}</a>
-    {% endif %}
+    <div class="cwa-form-actions">
+      {% if shelf.id != None %}
+        <a href="{{ url_for('shelf.show_shelf', shelf_id=shelf.id) }}" class="btn btn-secondary">{{_('Cancel')}}</a>
+      {% endif %}
+      <button type="submit" class="btn btn-default" id="submit">{{_('Save')}}</button>
+    </div>
   </form>
 </div>
 {% endblock %}

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -552,7 +552,7 @@
     <div style="margin-bottom: 4rem; display: flex; flex-direction: column; gap: 0.5rem;">
       <div id="user_submit" class="btn btn-default" style="width: -webkit-fill-available;">{{_('Save')}}</div>
       {% if not profile %}
-        <div class="btn btn-default" data-back="{{ url_for('admin.admin') }}" id="back" style="width: -webkit-fill-available;">{{_('Cancel')}}</div>
+        <div class="btn btn-secondary" data-back="{{ url_for('admin.admin') }}" id="back" style="width: -webkit-fill-available;">{{_('Cancel')}}</div>
       {% endif %}
       {% if current_user and current_user.role_admin() and not profile and not new_user and not content.role_anonymous() %}
         <div class="btn btn-danger" id="btndeluser" data-value="{{ content.id }}" data-remote="false" style="width: -webkit-fill-available;">{{_('Delete User')}}</div>


### PR DESCRIPTION
Three quality-of-life improvements after v4.0.21.

## 1. Kobo cover padding now defaults to ON when the user enables Kobo sync

Auto-enable fires only on the off→on transition of \`config_kobo_sync\`. A user who later disables padding while keeping kobo_sync on retains their off choice — the auto-enable doesn't re-fire on subsequent saves. New installs also get \`config_kobo_cover_padding_enabled = True\` as the column default.

\`\`\`python
prev_kobo_sync = bool(config.config_kobo_sync)
reboot_required |= _config_checkbox_int(to_save, \"config_kobo_sync\")
...
_config_checkbox_int(to_save, \"config_kobo_cover_padding_enabled\")
...
if not prev_kobo_sync and bool(config.config_kobo_sync):
    config.config_kobo_cover_padding_enabled = 1
\`\`\`

## 2. Custom-color input lock outside manual mode

When the selected fill mode is anything other than \`manual\`, the \"Custom border color\" input is now \`readonly\` + dimmed at 50% opacity. \`readonly\` (not \`disabled\`) so the typed value is preserved across form submissions when the user toggles modes back. Layout doesn't shift — the input still occupies its row, just clearly inactive.

New \`_kobo_padding_color_sync\` handler in \`cps/static/js/main.js\`, runs on page load + on fill-mode change.

## 3. Right-aligned Save/Cancel with secondary-style Cancel

Reorders the action footers across seven settings templates. Pattern: both buttons right-aligned, Save rightmost, Cancel to its left as a secondary style — white background, brand-orange (#cc7b19) text + matching border.

New shared utility class \`.cwa-form-actions\` lives in \`cwa.css\` (loaded globally), so adding more settings pages doesn't require new CSS. Both Bootstrap-3 light and caliBlur dark themes covered.

**Templates touched:** \`config_edit\`, \`config_db\`, \`config_view_edit\`, \`schedule_edit\`, \`shelf_edit\`, \`book_edit\` (kept tertiary \"Fetch Metadata\" left-aligned with the Save/Cancel pair anchored right), \`user_edit\` (kept vertical-stack layout but recolored Cancel to secondary).

The inline duplicate of \`.btn-secondary\` that briefly lived in \`config_edit.html\` is replaced by the shared rule.

## Validation

End-to-end browser-driven against the deployed instance:

- ✓ Save text \"Save\", Cancel text \"Cancel\", Save left=1073, Cancel left=959 (Save IS right of Cancel)
- ✓ Cancel computed style: \`background: rgba(255,255,255,0.92)\`, \`color: rgb(204,123,25)\`, \`border-color: rgb(204,123,25)\`
- ✓ Wrap class: \`cwa-form-actions\`, \`justify-content: flex-end\`
- ✓ Padding section visible, enable checkbox checked
- ✓ Fill mode = \`edge_mirror\` → color input \`readonly: true\`, opacity \`0.5\`
- ✓ Fill mode change to \`manual\` → color input \`readonly: false\`, opacity \`1\`
- ✓ Toggle back to \`edge_mirror\` → re-locks correctly

27 unit tests still passing locally, no Wand-gated test regression.

## Tier

\`needs-review\` — multi-file, includes admin-save-handler logic + JS + CSS + 7 templates. Not safe-tier-1 (touches \`.py\`) or safe-tier-2 (multi-file).