### PR TITLE
Backport upstream #1331: Fix fetched metadata not persisting on first save after title rename

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -870,7 +870,7 @@ def do_edit_book(book_id, upload_formats=None):
         title_author_error = None
         input_authors = [author.name for author in book.authors]
 
-        # Stage 1: Collect all metadata changes and apply them to the book object in the session
+        # Stage 1: Apply title/author changes before touching the remaining metadata fields.
         if "title" in to_save:
             title_change = handle_title_on_edit(book, to_save["title"])
 
@@ -878,6 +878,14 @@ def do_edit_book(book_id, upload_formats=None):
             new_input_authors, author_change = handle_author_on_edit(book, to_save["authors"])
             if author_change:
                 input_authors = new_input_authors
+            # Keep the filesystem path in sync before staging relationship-heavy metadata.
+            if title_change or author_change:
+                title_author_error = helper.update_dir_structure(book.id, config.get_book_path(), input_authors[0])
+                if title_author_error:
+                    flash(title_author_error, category="error")
+                    calibre_db.session.rollback()
+                    return render_edit_book(book_id)
+                modify_date = True
             modify_date |= edit_book_ratings(to_save, book)
         else:
             to_save, edit_error = upload_book_formats(upload_formats, book, book_id, book.has_cover)
@@ -915,6 +923,7 @@ def do_edit_book(book_id, upload_formats=None):
                     edit_error = True
                     flash(error, category="error")
 
+        # Stage 2: Apply the remaining metadata changes to the database session.
         modify_date |= edit_book_series_index(to_save.get("series_index"), book)
         modify_date |= edit_book_comments(Markup(to_save.get('comments')).unescape(), book)
 
@@ -954,16 +963,7 @@ def do_edit_book(book_id, upload_formats=None):
         else:
             book.pubdate = db.Books.DEFAULT_PUBDATE
 
-        # Stage 2: Perform filesystem operations if necessary
-        if title_change or author_change:
-            title_author_error = helper.update_dir_structure(book.id, config.get_book_path(), input_authors[0])
-            if title_author_error:
-                flash(title_author_error, category="error")
-                calibre_db.session.rollback()
-                return render_edit_book(book_id)
-            modify_date = True
-
-        # Stage 3: Commit all changes to the database
+        # Stage 3: Commit all changes to the database.
         if modify_date:
             book.last_modified = datetime.now(timezone.utc)
             kobo_sync_status.remove_synced_book(book.id, all=True)
@@ -1041,7 +1041,7 @@ def do_edit_book(book_id, upload_formats=None):
         except Exception as e:
             log.error_or_exception(f"Failed to write metadata change log for book {book.id}: {e}")
 
-        # Stage 4: Post-commit operations (like cloud sync)
+        # Stage 4: Post-commit operations.
         if config.config_use_google_drive:
             gdriveutils.updateGdriveCalibreFromLocal()
 

--- a/tests/unit/test_edit_book_save_order.py
+++ b/tests/unit/test_edit_book_save_order.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_directory_update_happens_before_comments_and_tags_are_staged():
+    source = (REPO_ROOT / "cps/editbooks.py").read_text(encoding="utf-8")
+    function_body = source[source.index("def do_edit_book") : source.index("def merge_metadata")]
+
+    directory_update = function_body.index("helper.update_dir_structure")
+    comments_update = function_body.index("edit_book_comments")
+    tags_update = function_body.index("edit_book_tags")
+
+    assert directory_update < comments_update
+    assert directory_update < tags_update


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1331** by @I-Would-Like-To-Report-A-Bug-Please.

**Original title:** Fix fetched metadata not persisting on first save after title rename
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1331

## Verification

Walk through `notes/merge/upstream-pr-1331-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1331.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Do not merge until the verification checklist is signed off.)