### PR TITLE
Backport upstream #1336: fix: sync applied metadata descriptions before save

### DIFF
--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -106,10 +106,12 @@ $(function () {
       )
     );
     if (updateItems.description) {
+      var description = book.description || "";
       if (typeof tinymce !== "undefined" && tinymce.get("comments")) {
-        tinymce.get("comments").setContent(book.description);
+        tinymce.get("comments").setContent(description);
+        tinymce.get("comments").save();
       } else {
-        $("#comments").val(book.description);
+        $("#comments").val(description);
       }
     }
     if (updateItems.tags) {

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -351,7 +351,7 @@
         <div class="image-dimensions"></div>
         <input type="checkbox" data-meta-index="<%= index %>" data-meta-value="cover" checked>
       </div>
-      <button class="btn btn-default">Save</button>
+      <button class="btn btn-default">{{_("Apply")}}</button>
       <div><a class="meta_source" href="<%= book.source.link %>" target="_blank" rel="noopener"><%= book.source.description %></a></div>
       <% if(book.format) { %>
       <div>Format: <%= book.format %></div>

--- a/tests/unit/test_metadata_ui_static.py
+++ b/tests/unit/test_metadata_ui_static.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_metadata_description_apply_syncs_tinymce_to_textarea():
+    js = (REPO_ROOT / "cps/static/js/get_meta.js").read_text(encoding="utf-8")
+
+    assert 'var description = book.description || "";' in js
+    assert 'tinymce.get("comments").setContent(description);' in js
+    assert 'tinymce.get("comments").save();' in js
+
+
+def test_metadata_result_button_is_apply_not_save():
+    template = (REPO_ROOT / "cps/templates/book_edit.html").read_text(encoding="utf-8")
+
+    assert '<button class="btn btn-default">{{_("Apply")}}</button>' in template


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1336** by @I-Would-Like-To-Report-A-Bug-Please.

**Original title:** fix: sync applied metadata descriptions before save
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1336

## Verification

Walk through `notes/merge/upstream-pr-1336-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1336.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Do not merge until the verification checklist is signed off.)