### PR TITLE
fix: scope kepub auto-convert to Kobo Sync shelves (#817)

### DIFF
--- a/cps/kobo_auth.py
+++ b/cps/kobo_auth.py
@@ -103,21 +103,41 @@ def generate_auth_token(user_id):
         ub.session_commit()
 
     if config.config_kepubifypath:
+        # Scope auto-convert to books on the user's Kobo Sync shelves only.
+        # Reported as crocodilestick/Calibre-Web-Automated#817: visiting this
+        # endpoint converted every EPUB in the library, queueing tens or
+        # hundreds of thousands of tasks and starving Kobo sync. Books not
+        # on a Kobo Sync shelf are still converted on-demand at sync time.
         try:
-            books = (calibre_db.session.query(db.Books)
-                     .options(joinedload(db.Books.data))
-                     .all())
+            synced_book_ids = [
+                row.book_id for row in
+                ub.session.query(ub.BookShelf)
+                .join(ub.Shelf, ub.Shelf.id == ub.BookShelf.shelf)
+                .filter(ub.Shelf.user_id == user_id)
+                .filter(ub.Shelf.kobo_sync == True)
+                .all()
+            ]
         except Exception as ex:
-            log.warning("Could not enumerate books for kepub auto-conversion: %s", ex)
-            books = []
+            log.warning("Could not enumerate Kobo Sync shelf books: %s", ex)
+            synced_book_ids = []
 
-        for book in books:
+        if synced_book_ids:
             try:
-                formats = [data.format for data in book.data]
-                if 'KEPUB' not in formats and 'EPUB' in formats:
-                    helper.convert_book_format(book.id, config.config_calibre_dir, 'EPUB', 'KEPUB', current_user.name)
+                books = (calibre_db.session.query(db.Books)
+                         .options(joinedload(db.Books.data))
+                         .filter(db.Books.id.in_(synced_book_ids))
+                         .all())
             except Exception as ex:
-                log.warning("Skipping kepub auto-conversion for book %s: %s", getattr(book, "id", "?"), ex)
+                log.warning("Could not enumerate books for kepub auto-conversion: %s", ex)
+                books = []
+
+            for book in books:
+                try:
+                    formats = [data.format for data in book.data]
+                    if 'KEPUB' not in formats and 'EPUB' in formats:
+                        helper.convert_book_format(book.id, config.config_calibre_dir, 'EPUB', 'KEPUB', current_user.name)
+                except Exception as ex:
+                    log.warning("Skipping kepub auto-conversion for book %s: %s", getattr(book, "id", "?"), ex)
 
     return render_title_template(
         "generate_kobo_auth_url.html",

--- a/tests/smoke/test_kobo_auth_shelf_scope_smoke.py
+++ b/tests/smoke/test_kobo_auth_shelf_scope_smoke.py
@@ -1,0 +1,79 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression test for upstream issue crocodilestick/Calibre-Web-Automated#817.
+
+Symptom: visiting Profile -> Create/View Kobo Auth Token enqueues a kepub
+conversion task for every EPUB in the library, regardless of whether the
+book is on a Kobo Sync shelf. On large libraries (200k+ books) this floods
+the worker queue, triggers a flood of `Skipping kepub auto-conversion`
+warnings for un-convertible files, and starves the actual /v1/library/sync
+calls until the container is marked unhealthy.
+
+Fix: scope the auto-conversion to books on the user's Kobo Sync shelves
+only. Books outside those shelves are still converted on-demand at sync
+time by the existing Kobo flow.
+
+This test pins the shelf-scope behavior so a refactor can't reintroduce
+the unbounded library walk.
+"""
+
+import ast
+import pathlib
+import pytest
+
+
+KOBO_AUTH = pathlib.Path(__file__).resolve().parent.parent.parent / "cps" / "kobo_auth.py"
+
+
+@pytest.mark.smoke
+class TestKoboAuthShelfScopedConvert:
+    def setup_method(self):
+        self.source = KOBO_AUTH.read_text()
+        self.tree = ast.parse(self.source)
+        self.fn = next(
+            (n for n in ast.walk(self.tree)
+             if isinstance(n, ast.FunctionDef) and n.name == "generate_auth_token"),
+            None,
+        )
+        assert self.fn is not None, "generate_auth_token function not found"
+        self.fn_text = ast.unparse(self.fn)
+
+    def test_filters_by_kobo_sync_shelf(self):
+        assert "kobo_sync" in self.fn_text, (
+            "generate_auth_token must filter by Shelf.kobo_sync to avoid "
+            "queuing a kepub convert for every book in the library"
+        )
+
+    def test_joins_book_shelf_link(self):
+        # The shelf scope is computed by joining BookShelf to Shelf and filtering
+        # by user_id + kobo_sync. Catching either name pins the structural change.
+        assert "BookShelf" in self.fn_text, (
+            "Must enumerate book_shelf_link rows to scope conversion to shelf members"
+        )
+        assert "Shelf" in self.fn_text
+
+    def test_no_unbounded_books_query(self):
+        # Legacy code did `query(Books).options(joinedload(...)).all()` with no
+        # filter, walking the entire library. Pin that exact pattern out.
+        for node in ast.walk(self.fn):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "all":
+                # Walk back through the chained call to find any .filter()
+                cursor = node.func.value
+                has_filter = False
+                while isinstance(cursor, ast.Call) and isinstance(cursor.func, ast.Attribute):
+                    if cursor.func.attr in ("filter", "filter_by"):
+                        has_filter = True
+                        break
+                    cursor = cursor.func.value
+                # Only enforce on calibre_db Books queries, not on the ub.session shelf query.
+                chain_text = ast.unparse(node)
+                if "db.Books" in chain_text:
+                    assert has_filter, (
+                        "calibre_db.session.query(db.Books).....all() must include a "
+                        ".filter(Books.id.in_(...)) to scope to shelf members; the "
+                        "unscoped .all() is the #817 regression."
+                    )


### PR DESCRIPTION
## Summary

- Scopes the kepub auto-conversion in `cps/kobo_auth.py::generate_auth_token` to books on the user's Kobo Sync shelves only, instead of walking every book in the library.
- Adds `tests/smoke/test_kobo_auth_shelf_scope_smoke.py` to pin the shelf-scope so a future refactor can't reintroduce the unbounded library walk.

## Problem

Reported as upstream issue [crocodilestick/Calibre-Web-Automated#817](https://github.com/crocodilestick/Calibre-Web-Automated/issues/817) by @jderuiter.

Visiting **Profile -> Create/View Kobo Auth Token** queued a kepub conversion task for **every** EPUB in the library, regardless of whether the book was on a Kobo Sync shelf. On a real-world 200k-book library this:

- Floods the in-memory worker queue with ~200k tasks the user never asked for.
- Spams `WARN cps.kobo_auth:120 Skipping kepub auto-conversion for book N: tuple index out of range` for every un-convertible file.
- Starves real `/v1/library/sync` calls so the Kobo device polls but gets nothing back.
- Eventually trips the container health check (observed `Up 42 minutes (unhealthy)`).

The user reporting #817 also noted disk usage doubling, since most of those books are not destined for the Kobo at all.

## Fix

Scope the auto-conversion query to books on the user's `Shelf.kobo_sync == True` shelves via `BookShelf -> Shelf` join. Books outside those shelves are still converted on demand at sync time by the existing Kobo flow in `cps/kobo.py`, so user-facing behavior for shelf-driven sync is unchanged — the library just isn't walked twice.

## Test plan

- [x] `pytest tests/smoke/test_kobo_auth_eager_load_smoke.py tests/smoke/test_kobo_auth_shelf_scope_smoke.py` — 8 passed locally.
- [x] Deployed to a 200k-book library: `WARN cps.kobo_auth:120` flood gone after restart; `/v1/library/sync` returns the expected `NewEntitlement` rows; only the user's actual shelf books are queued for conversion (1 book vs ~200k pre-fix).
- [ ] CI: Fast Tests, validate-author, evaluate, Test Suite Summary.

## Notes

- Per `CONTRIBUTING.md` §"Submitting a PR" item 4: added a smoke test alongside the existing `test_kobo_auth_eager_load_smoke.py`.
- No new dependencies, license changes, or external URLs.
- Credit to original reporter @jderuiter on `crocodilestick/Calibre-Web-Automated#817`.