### PR TITLE
ci: tier-policy single-source-of-truth + auto-merge consolidation + sync false-alarm fix

### DIFF
--- a/.github/policy/README.md
+++ b/.github/policy/README.md
@@ -1,0 +1,43 @@
+# `.github/policy/` — single source of truth for autopilot policy
+
+Policy values that multiple consumers (workflows, scripts, tests, docs) need to agree on live here. Each consumer reads from these files at run time; nobody hard-codes a value that's described in this directory.
+
+## Files
+
+### `tier-policy.env`
+
+Auto-merge tier policy. Sourceable shell with simple `KEY=VALUE` lines (no interpolation, no functions). Currently consumed by:
+
+- `.github/workflows/auto-merge.yml` — sources the file in the evaluate job and reads `$FORBIDDEN_PATHS_REGEX`, `$TIER2_MAX_ADDITIONS`, etc.
+- `scripts/triage-prs.sh` — parses the file for the same constants when classifying PRs into buckets.
+- `tests/autopilot/test_tier_policy.sh` — pins the file's existence + parseability + key fields.
+
+### `README.md` — this file.
+
+## Why this directory exists
+
+Before this consolidation, the same constants (LOC caps, forbidden paths, required CI checks) were declared inline in five different places — workflow, triage script, test file, CLAUDE.md, the autopilot SKILL.md. Three of those declarations had drifted: CLAUDE.md said tier-2 was capped at "<50 LOC" while the workflow enforced 80; the workflow forbidden-paths regex missed `cps/cw_login/` and `cps/usermanagement.py`; the triage script's auth path list didn't cover `cps/db.py`. Drift produced confusion ("why are we still tier-1?") and gaps (tier-2 PRs slipping past meant-to-be forbidden surfaces).
+
+Single source of truth here, doc references it by path-and-line. If a value needs to change, change it here — every consumer picks up the new value on next run.
+
+## How to add a new policy value
+
+1. Add the new `KEY=VALUE` line to the relevant `.env` file with a comment explaining what it gates.
+2. Update each consumer to read it. For shell consumers, that's `source .github/policy/tier-policy.env`. For Python (e.g., `triage-prs.sh`'s embedded Python), read the file with a small parser:
+   ```python
+   import os, re
+   policy = {}
+   with open(".github/policy/tier-policy.env") as fh:
+       for line in fh:
+           m = re.match(r"^([A-Z_]+)='?(.*?)'?$", line.strip())
+           if m: policy[m.group(1)] = m.group(2)
+   ```
+3. Add a test in `tests/autopilot/test_tier_policy.sh` asserting the key exists and parses.
+4. Update CLAUDE.md if the value is policy-level (gate semantics, what counts as tier-1 vs tier-2). Inline numeric values stay out of docs — they live here.
+
+## How to change an existing policy value
+
+1. Update the value in the `.env` file.
+2. Run `bash tests/autopilot/test_tier_policy.sh` to confirm parseability.
+3. Run `bash scripts/autopilot-tick.sh` (with `AUTOPILOT_NO_LLM=1`) to confirm the triage script still loads cleanly.
+4. Open a PR labeled `needs-review` — policy changes never auto-merge.

--- a/.github/policy/tier-policy.config
+++ b/.github/policy/tier-policy.config
@@ -1,0 +1,51 @@
+# Auto-merge tier policy — single source of truth.
+#
+# Every consumer of tier policy reads this file:
+#   .github/workflows/auto-merge.yml      — sources at job start
+#   scripts/triage-prs.sh                 — parses for LOC/file caps
+#   tests/autopilot/test_tier_policy.sh   — pins this file's invariants
+#
+# Format: shell key=value, single-quoted values, no interpolation, no
+# shell expansion (consumers parse via plain `source` or `awk '/=/'`).
+# Keep this file plain enough that a Python `for line in open(...)` parser
+# is enough; do NOT use bash arrays / heredocs / functions here.
+#
+# When changing a value here:
+#   1. Update CLAUDE.md tier policy section if the change is policy-level
+#      (LOC cap, file cap, gate semantics).
+#   2. Run `bash tests/autopilot/test_tier_policy.sh` and confirm green.
+#   3. Document the rationale in the PR body.
+
+# ─── Tier-1 ────────────────────────────────────────────────────────────
+# .po (translation), .pot (template), .md (docs), README* — no code at all.
+# These auto-merge on green CI without an operator opt-in.
+TIER1_PATHS_REGEX='\.(po|pot|md)$|^README'
+
+# ─── Tier-2 ────────────────────────────────────────────────────────────
+# Small isolated code change. Auto-merges only when the operator has set
+# the repo variable AUTOPILOT_TIER2_ENABLED=true (operator's explicit
+# opt-in; the policy of *when* to flip it on lives in CLAUDE.md, not here).
+TIER2_MAX_ADDITIONS=80
+TIER2_MAX_FILES=3
+
+# ─── Forbidden paths (filename check) ──────────────────────────────────
+# Any tier-N PR whose changed file paths match this regex is demoted to
+# needs-review and never auto-merges, regardless of size. Covers:
+#   - auth / oauth / admin / login subsystem
+#   - core data models (db, ub, config_sql) and blueprint registration
+#   - dependency files (requirements*.txt, package.json/package-lock.json)
+#   - container / orchestration files (Dockerfile, docker-compose*.yml)
+#   - migration directories
+FORBIDDEN_PATHS_REGEX='^(cps/(oauth|admin|usermanagement|cw_login/|main|db|ub|config_sql|kobo_auth|cwa_password)|.*/(auth|csrf|session|alembic)|migrations?/|.*/migrations?/|requirements.*\.txt|package\.json|package-lock\.json|Dockerfile|docker-compose.*\.ya?ml|optional-requirements\.txt)'
+
+# ─── Forbidden diff content (added-lines check) ────────────────────────
+# Filename-only filtering misses sensitive code added in allowed paths.
+# This regex runs against the added lines (those starting with `+`,
+# excluding the `+++` header). Matches demote the PR to needs-review.
+FORBIDDEN_DIFF_CONTENT_REGEX='\b(Authorization\s*[:=]|setattr\s*\(\s*request|app\.secret_key|csrf\.exempt|@csrf_exempt|generate_password_hash|check_password_hash|access_token|refresh_token|secret_key|migrations?\.create_all|metadata\.create_all|alembic|drop_table|alter_table|add_column|os\.execv|subprocess\.(call|run|Popen).*shell=True|eval\s*\(|exec\s*\()'
+
+# ─── Required CI checks for auto-merge ─────────────────────────────────
+# Comma-separated; consumers split. Tier-2 demands the integration
+# suite as a hard gate; tier-1 stops at fast tests + author validation.
+TIER1_REQUIRED_CHECKS='validate-author,Fast Tests (Smoke + Unit)'
+TIER2_REQUIRED_CHECKS='validate-author,Fast Tests (Smoke + Unit),Integration Tests (Docker)'

--- a/.github/workflows/auto-merge-tier1.yml
+++ b/.github/workflows/auto-merge-tier1.yml
@@ -87,7 +87,21 @@ jobs:
           set -euo pipefail
           # Forbidden path patterns — these PRs MUST go through human review,
           # regardless of the LOC heuristic that put a tier label on them.
-          FORBIDDEN_RE='^(cps/(oauth|admin)|.*/(auth|csrf|session|alembic)|migrations?/|.*/migrations?/)'
+          # Covers: auth/oauth/admin/login subsystem, settings/db/user models,
+          # blueprint registration, dependency files, container/orchestration
+          # files, migrations.
+          FORBIDDEN_RE='^(cps/(oauth|admin|usermanagement|cw_login/|main|db|ub|config_sql|kobo_auth|cwa_password)|.*/(auth|csrf|session|alembic)|migrations?/|.*/migrations?/|requirements.*\.txt|package\.json|package-lock\.json|Dockerfile|docker-compose.*\.ya?ml|optional-requirements\.txt)'
+
+          # Tier-2 hard caps — re-checked even though the triage script
+          # labeled the PR. Catches mis-labels and label-laundering.
+          TIER2_MAX_ADDITIONS=80
+          TIER2_MAX_FILES=3
+
+          # Sensitive-token regex run against the *diff content* (not
+          # filenames). Catches "PR touches an allowed path but adds
+          # auth/secret/migration code anyway" — the kind of thing the
+          # filename check misses.
+          DIFF_SENSITIVE_RE='\b(Authorization\s*[:=]|setattr\s*\(\s*request|app\.secret_key|csrf\.exempt|@csrf_exempt|generate_password_hash|check_password_hash|access_token|refresh_token|secret_key|migrations?\.create_all|metadata\.create_all|alembic|drop_table|alter_table|add_column|os\.execv|subprocess\.(call|run|Popen).*shell=True|eval\s*\(|exec\s*\()'
 
           comment_and_skip() {
             local n="$1" reason="$2"
@@ -133,13 +147,68 @@ jobs:
             if printf '%s\n' "$files" | grep -qiE "$FORBIDDEN_RE"; then
               echo "PR #$n touches forbidden paths; demoting label and skipping"
               gh pr edit "$n" --repo "$REPO" --remove-label safe-tier-1 --remove-label safe-tier-2 --add-label needs-review || true
-              comment_and_skip "$n" "PR touches forbidden paths (auth/csrf/session/admin/migrations); demoted to needs-review."
+              comment_and_skip "$n" "PR touches forbidden paths (auth/csrf/session/admin/migrations/deps/container); demoted to needs-review."
               continue
             fi
 
-            # Required checks must have run AND succeeded
+            # Tier-2 hard caps re-checked at merge time. The triage script
+            # may have applied the label based on stale data; re-verify.
+            if [ "$tier" = "safe-tier-2" ]; then
+              additions=$(gh pr view "$n" --repo "$REPO" --json additions --jq '.additions')
+              file_count=$(jq -r '.files | length' <<<"$META")
+              if [ "${additions:-0}" -gt "$TIER2_MAX_ADDITIONS" ] || [ "${file_count:-0}" -gt "$TIER2_MAX_FILES" ]; then
+                echo "PR #$n exceeds tier-2 caps (additions=$additions files=$file_count > $TIER2_MAX_ADDITIONS / $TIER2_MAX_FILES); demoting"
+                gh pr edit "$n" --repo "$REPO" --remove-label safe-tier-2 --add-label needs-review || true
+                comment_and_skip "$n" "PR is too large for safe-tier-2 (additions=$additions, files=$file_count; caps are $TIER2_MAX_ADDITIONS LOC / $TIER2_MAX_FILES files). Demoted to needs-review."
+                continue
+              fi
+            fi
+
+            # Diff-content scan: catch sensitive tokens added in the
+            # diff itself, not just the filename. cw_advocate/auth/etc
+            # surfaces can be touched indirectly.
+            DIFF=$(gh pr diff "$n" --repo "$REPO" 2>/dev/null || true)
+            # Only scan added lines (those starting with +, but not the +++ header)
+            ADDED=$(printf '%s\n' "$DIFF" | grep -E '^\+[^+]' || true)
+            if printf '%s\n' "$ADDED" | grep -qE "$DIFF_SENSITIVE_RE"; then
+              echo "PR #$n diff contains sensitive tokens; demoting label and skipping"
+              gh pr edit "$n" --repo "$REPO" --remove-label safe-tier-1 --remove-label safe-tier-2 --add-label needs-review || true
+              hit=$(printf '%s\n' "$ADDED" | grep -oE "$DIFF_SENSITIVE_RE" | sort -u | head -3 | paste -sd ', ' -)
+              comment_and_skip "$n" "PR diff contains sensitive token(s) — \`$hit\` — demoted to needs-review for human eyes."
+              continue
+            fi
+
+            # CHANGES-vs-upstream.md update required for non-trivial code
+            # PRs. Tier-1 (.po + *.md only) is exempt — translations don't
+            # need a CHANGES row. Tier-2 PRs that touch any non-doc, non-po
+            # file MUST also update CHANGES-vs-upstream.md.
+            if [ "$tier" = "safe-tier-2" ]; then
+              has_code=0
+              has_changes_update=0
+              while IFS= read -r f; do
+                case "$f" in
+                  *.po|*.pot) ;;
+                  *.md|README*) ;;
+                  CHANGES-vs-upstream.md) has_changes_update=1 ;;
+                  *) has_code=1 ;;
+                esac
+              done <<<"$files"
+              if [ "$has_code" = "1" ] && [ "$has_changes_update" = "0" ]; then
+                echo "PR #$n is tier-2 with code changes but no CHANGES-vs-upstream.md update"
+                comment_and_skip "$n" "tier-2 PRs with code changes must update CHANGES-vs-upstream.md to document the divergence. Add a row, push, and CI will re-evaluate."
+                continue
+              fi
+            fi
+
+            # Required checks must have run AND succeeded.
+            # Tier-2 adds Integration Tests as a hard gate — small code
+            # changes still need to clear the actual ingest/Calibre flow.
             CHECKS=$(gh api "repos/$REPO/commits/$head_sha/check-runs" --jq '.check_runs')
-            required=("validate-author" "Fast Tests (Smoke + Unit)")
+            if [ "$tier" = "safe-tier-2" ]; then
+              required=("validate-author" "Fast Tests (Smoke + Unit)" "Integration Tests (Docker)")
+            else
+              required=("validate-author" "Fast Tests (Smoke + Unit)")
+            fi
             all_ok=1
             for req in "${required[@]}"; do
               run=$(jq -c --arg n "$req" '.[] | select(.name == $n)' <<<"$CHECKS" | tail -1)

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,14 +11,14 @@ name: auto-merge
 #   1. State == OPEN, mergeable, no conflicts
 #   2. Has label `safe-tier-1` (or `safe-tier-2` and the operator has set
 #      repo variable AUTOPILOT_TIER2_ENABLED == 'true')
-#   3. Filename is NOT in FORBIDDEN_PATHS_REGEX (.github/policy/tier-policy.env)
+#   3. Filename is NOT in FORBIDDEN_PATHS_REGEX (.github/policy/tier-policy.config)
 #   4. Diff content does NOT match FORBIDDEN_DIFF_CONTENT_REGEX (same file)
 #   5. Tier-2 only: actual diff size <= TIER2_MAX_ADDITIONS LOC and
 #      <= TIER2_MAX_FILES files (re-checked at merge time)
 #   6. Tier-2 only: non-translation/docs PRs update CHANGES-vs-upstream.md
-#   7. TIER{1,2}_REQUIRED_CHECKS (tier-policy.env) all green
+#   7. TIER{1,2}_REQUIRED_CHECKS (tier-policy.config) all green
 #
-# All numeric/regex policy values live in .github/policy/tier-policy.env
+# All numeric/regex policy values live in .github/policy/tier-policy.config
 # — single source of truth shared with scripts/triage-prs.sh and the
 # autopilot test suite. To change them, edit that file, not this one.
 #
@@ -47,8 +47,8 @@ jobs:
   evaluate:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main (for tier-policy.env)
-        # The evaluate step sources .github/policy/tier-policy.env. We
+      - name: Checkout main (for tier-policy.config)
+        # The evaluate step sources .github/policy/tier-policy.config. We
         # check out main rather than the PR head so the policy values
         # used to gate the PR are always the ones currently on main —
         # a malicious PR can't widen its own auto-merge rules.
@@ -104,19 +104,19 @@ jobs:
 
           # Single source of truth for tier policy — values shared with
           # scripts/triage-prs.sh and tests/autopilot/test_tier_policy.sh.
-          # Edit .github/policy/tier-policy.env to change any of these.
-          if [ ! -f .github/policy/tier-policy.env ]; then
-            echo "::error::missing .github/policy/tier-policy.env — auto-merge cannot run safely"
+          # Edit .github/policy/tier-policy.config to change any of these.
+          if [ ! -f .github/policy/tier-policy.config ]; then
+            echo "::error::missing .github/policy/tier-policy.config — auto-merge cannot run safely"
             exit 1
           fi
           # shellcheck disable=SC1091
-          source .github/policy/tier-policy.env
-          : "${FORBIDDEN_PATHS_REGEX:?missing in tier-policy.env}"
-          : "${FORBIDDEN_DIFF_CONTENT_REGEX:?missing in tier-policy.env}"
-          : "${TIER2_MAX_ADDITIONS:?missing in tier-policy.env}"
-          : "${TIER2_MAX_FILES:?missing in tier-policy.env}"
-          : "${TIER1_REQUIRED_CHECKS:?missing in tier-policy.env}"
-          : "${TIER2_REQUIRED_CHECKS:?missing in tier-policy.env}"
+          source .github/policy/tier-policy.config
+          : "${FORBIDDEN_PATHS_REGEX:?missing in tier-policy.config}"
+          : "${FORBIDDEN_DIFF_CONTENT_REGEX:?missing in tier-policy.config}"
+          : "${TIER2_MAX_ADDITIONS:?missing in tier-policy.config}"
+          : "${TIER2_MAX_FILES:?missing in tier-policy.config}"
+          : "${TIER1_REQUIRED_CHECKS:?missing in tier-policy.config}"
+          : "${TIER2_REQUIRED_CHECKS:?missing in tier-policy.config}"
 
           # Aliases preserved so the rest of the script reads naturally.
           FORBIDDEN_RE="$FORBIDDEN_PATHS_REGEX"
@@ -222,7 +222,7 @@ jobs:
             # Required checks must have run AND succeeded.
             # Tier-2 adds Integration Tests as a hard gate — small code
             # changes still need to clear the actual ingest/Calibre flow.
-            # Lists come from .github/policy/tier-policy.env for parity
+            # Lists come from .github/policy/tier-policy.config for parity
             # with the triage script + tests.
             CHECKS=$(gh api "repos/$REPO/commits/$head_sha/check-runs" --jq '.check_runs')
             if [ "$tier" = "safe-tier-2" ]; then

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-name: auto-merge-tier1
+name: auto-merge
 
 # Tier-based auto-merge for safe-tier-1 / safe-tier-2 PRs.
 #
@@ -11,10 +11,16 @@ name: auto-merge-tier1
 #   1. State == OPEN, mergeable, no conflicts
 #   2. Has label `safe-tier-1` (or `safe-tier-2` and the operator has set
 #      repo variable AUTOPILOT_TIER2_ENABLED == 'true')
-#   3. Touches NO forbidden paths (auth/csrf/session/admin/migration/alembic)
-#   4. Every check on the head SHA reports a non-failing conclusion
-#      (success, skipped, or neutral). validate-author and Test Suite are
-#      both required to have run and reported success.
+#   3. Filename is NOT in FORBIDDEN_PATHS_REGEX (.github/policy/tier-policy.env)
+#   4. Diff content does NOT match FORBIDDEN_DIFF_CONTENT_REGEX (same file)
+#   5. Tier-2 only: actual diff size <= TIER2_MAX_ADDITIONS LOC and
+#      <= TIER2_MAX_FILES files (re-checked at merge time)
+#   6. Tier-2 only: non-translation/docs PRs update CHANGES-vs-upstream.md
+#   7. TIER{1,2}_REQUIRED_CHECKS (tier-policy.env) all green
+#
+# All numeric/regex policy values live in .github/policy/tier-policy.env
+# — single source of truth shared with scripts/triage-prs.sh and the
+# autopilot test suite. To change them, edit that file, not this one.
 #
 # Anything else: the workflow comments why and stops. It never bypasses
 # checks, never merges without a label, and will demote labels on a PR
@@ -41,6 +47,16 @@ jobs:
   evaluate:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout main (for tier-policy.env)
+        # The evaluate step sources .github/policy/tier-policy.env. We
+        # check out main rather than the PR head so the policy values
+        # used to gate the PR are always the ones currently on main —
+        # a malicious PR can't widen its own auto-merge rules.
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
       - name: Resolve candidate PR numbers
         id: prs
         env:
@@ -85,23 +101,26 @@ jobs:
           TIER2_ENABLED: ${{ vars.AUTOPILOT_TIER2_ENABLED }}
         run: |
           set -euo pipefail
-          # Forbidden path patterns — these PRs MUST go through human review,
-          # regardless of the LOC heuristic that put a tier label on them.
-          # Covers: auth/oauth/admin/login subsystem, settings/db/user models,
-          # blueprint registration, dependency files, container/orchestration
-          # files, migrations.
-          FORBIDDEN_RE='^(cps/(oauth|admin|usermanagement|cw_login/|main|db|ub|config_sql|kobo_auth|cwa_password)|.*/(auth|csrf|session|alembic)|migrations?/|.*/migrations?/|requirements.*\.txt|package\.json|package-lock\.json|Dockerfile|docker-compose.*\.ya?ml|optional-requirements\.txt)'
 
-          # Tier-2 hard caps — re-checked even though the triage script
-          # labeled the PR. Catches mis-labels and label-laundering.
-          TIER2_MAX_ADDITIONS=80
-          TIER2_MAX_FILES=3
+          # Single source of truth for tier policy — values shared with
+          # scripts/triage-prs.sh and tests/autopilot/test_tier_policy.sh.
+          # Edit .github/policy/tier-policy.env to change any of these.
+          if [ ! -f .github/policy/tier-policy.env ]; then
+            echo "::error::missing .github/policy/tier-policy.env — auto-merge cannot run safely"
+            exit 1
+          fi
+          # shellcheck disable=SC1091
+          source .github/policy/tier-policy.env
+          : "${FORBIDDEN_PATHS_REGEX:?missing in tier-policy.env}"
+          : "${FORBIDDEN_DIFF_CONTENT_REGEX:?missing in tier-policy.env}"
+          : "${TIER2_MAX_ADDITIONS:?missing in tier-policy.env}"
+          : "${TIER2_MAX_FILES:?missing in tier-policy.env}"
+          : "${TIER1_REQUIRED_CHECKS:?missing in tier-policy.env}"
+          : "${TIER2_REQUIRED_CHECKS:?missing in tier-policy.env}"
 
-          # Sensitive-token regex run against the *diff content* (not
-          # filenames). Catches "PR touches an allowed path but adds
-          # auth/secret/migration code anyway" — the kind of thing the
-          # filename check misses.
-          DIFF_SENSITIVE_RE='\b(Authorization\s*[:=]|setattr\s*\(\s*request|app\.secret_key|csrf\.exempt|@csrf_exempt|generate_password_hash|check_password_hash|access_token|refresh_token|secret_key|migrations?\.create_all|metadata\.create_all|alembic|drop_table|alter_table|add_column|os\.execv|subprocess\.(call|run|Popen).*shell=True|eval\s*\(|exec\s*\()'
+          # Aliases preserved so the rest of the script reads naturally.
+          FORBIDDEN_RE="$FORBIDDEN_PATHS_REGEX"
+          DIFF_SENSITIVE_RE="$FORBIDDEN_DIFF_CONTENT_REGEX"
 
           comment_and_skip() {
             local n="$1" reason="$2"
@@ -203,11 +222,13 @@ jobs:
             # Required checks must have run AND succeeded.
             # Tier-2 adds Integration Tests as a hard gate — small code
             # changes still need to clear the actual ingest/Calibre flow.
+            # Lists come from .github/policy/tier-policy.env for parity
+            # with the triage script + tests.
             CHECKS=$(gh api "repos/$REPO/commits/$head_sha/check-runs" --jq '.check_runs')
             if [ "$tier" = "safe-tier-2" ]; then
-              required=("validate-author" "Fast Tests (Smoke + Unit)" "Integration Tests (Docker)")
+              IFS=',' read -ra required <<< "$TIER2_REQUIRED_CHECKS"
             else
-              required=("validate-author" "Fast Tests (Smoke + Unit)")
+              IFS=',' read -ra required <<< "$TIER1_REQUIRED_CHECKS"
             fi
             all_ok=1
             for req in "${required[@]}"; do

--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -1,8 +1,14 @@
 name: Build & Push - Dev - Split Strategy
-# Automatically builds and pushes a multi-platform dev image based on commits involving key files in any branch
+# Builds + pushes a multi-platform dev image. Pushes to GHCR always;
+# also pushes to DockerHub when the operator has set the repo variable
+# DOCKERHUB_PUSH_ENABLED='true' AND the secrets DOCKERHUB_USERNAME +
+# DOCKERHUB_PA_TOKEN are present. Without those, the workflow runs in
+# GHCR-only mode — useful on the standalone fork where DockerHub
+# credentials don't exist. Earlier runs failed at the DockerHub login
+# step because the secrets were empty; this gating fixes that.
 
 on:
-  workflow_dispatch:  # disabled auto-trigger — needs DockerHub/Discord secrets we don't have on the standalone repo
+  workflow_dispatch:  # auto-trigger disabled by intent; operator dispatches manually
 jobs:
   # --------------------------------------------------------------------------------
   # JOB 1: Build Intel (amd64) on GitHub Runners
@@ -46,6 +52,9 @@ jobs:
 
       # --- 2. Logins ---
       - name: DockerHub Login
+        # Skipped on the standalone fork where DOCKERHUB secrets aren't set.
+        # Operator opts in by setting repo variable DOCKERHUB_PUSH_ENABLED='true'.
+        if: vars.DOCKERHUB_PUSH_ENABLED == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -64,6 +73,16 @@ jobs:
         with:
           driver-opts: network=host
 
+      - name: Compose docker outputs (GHCR always; DockerHub when opted-in)
+        run: |
+          GHCR_LINE="type=image,name=ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }},push-by-digest=true,name-canonical=true,push=true"
+          if [ "${{ vars.DOCKERHUB_PUSH_ENABLED }}" = "true" ]; then
+            DH_LINE="type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated,push-by-digest=true,name-canonical=true,push=true"
+            printf 'DOCKER_BUILD_OUTPUTS<<EOF\n%s\n%s\nEOF\n' "$DH_LINE" "$GHCR_LINE" >> "$GITHUB_ENV"
+          else
+            printf 'DOCKER_BUILD_OUTPUTS<<EOF\n%s\nEOF\n' "$GHCR_LINE" >> "$GITHUB_ENV"
+          fi
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v7
@@ -76,9 +95,10 @@ jobs:
           # CACHE STRATEGY: Use GitHub Actions Cache (Ephemeral Runner)
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: |
-            type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated,push-by-digest=true,name-canonical=true,push=true
-            type=image,name=ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }},push-by-digest=true,name-canonical=true,push=true
+          # GHCR is always a target. DockerHub is added by the
+          # "Compose docker outputs" step above, which conditionally
+          # includes the DockerHub image name when DOCKERHUB_PUSH_ENABLED.
+          outputs: ${{ env.DOCKER_BUILD_OUTPUTS }}
           build-args: |
             BUILD_DATE=${{ github.event.repository.updated_at }}
             VERSION=DEV_BUILD-${{ env.IMAGE_TAG }}-${{ vars.CURRENT_DEV_BUILD_NUM }}
@@ -141,6 +161,9 @@ jobs:
 
       # --- 2. Logins ---
       - name: DockerHub Login
+        # Skipped on the standalone fork where DOCKERHUB secrets aren't set.
+        # Operator opts in by setting repo variable DOCKERHUB_PUSH_ENABLED='true'.
+        if: vars.DOCKERHUB_PUSH_ENABLED == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -159,6 +182,16 @@ jobs:
         with:
           driver-opts: network=host
 
+      - name: Compose docker outputs (GHCR always; DockerHub when opted-in)
+        run: |
+          GHCR_LINE="type=image,name=ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }},push-by-digest=true,name-canonical=true,push=true"
+          if [ "${{ vars.DOCKERHUB_PUSH_ENABLED }}" = "true" ]; then
+            DH_LINE="type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated,push-by-digest=true,name-canonical=true,push=true"
+            printf 'DOCKER_BUILD_OUTPUTS<<EOF\n%s\n%s\nEOF\n' "$DH_LINE" "$GHCR_LINE" >> "$GITHUB_ENV"
+          else
+            printf 'DOCKER_BUILD_OUTPUTS<<EOF\n%s\nEOF\n' "$GHCR_LINE" >> "$GITHUB_ENV"
+          fi
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v7
@@ -172,9 +205,10 @@ jobs:
           # Saves bandwidth and time by storing cache directly on the Oracle VM
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          outputs: |
-            type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated,push-by-digest=true,name-canonical=true,push=true
-            type=image,name=ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }},push-by-digest=true,name-canonical=true,push=true
+          # GHCR is always a target. DockerHub is added by the
+          # "Compose docker outputs" step below, which conditionally
+          # includes the DockerHub image name when DOCKERHUB_PUSH_ENABLED.
+          outputs: ${{ env.DOCKER_BUILD_OUTPUTS }}
           build-args: |
             BUILD_DATE=${{ github.event.repository.updated_at }}
             VERSION=DEV_BUILD-${{ env.IMAGE_TAG }}-${{ vars.CURRENT_DEV_BUILD_NUM }}
@@ -259,6 +293,9 @@ jobs:
 
       # --- 2. Logins ---
       - name: DockerHub Login
+        # Skipped on the standalone fork where DOCKERHUB secrets aren't set.
+        # Operator opts in by setting repo variable DOCKERHUB_PUSH_ENABLED='true'.
+        if: vars.DOCKERHUB_PUSH_ENABLED == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -285,13 +322,17 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          # 1. Push to DockerHub (Both Tags)
-          docker buildx imagetools create \
-            -t ${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated:${{ env.FLOAT_TAG }} \
-            -t ${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated:${{ env.UNIQUE_TAG }} \
-            $(printf '${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated@sha256:%s ' *)
-          
-          # 2. Push to GHCR (Both Tags)
+          # 1. Push to DockerHub (only when DOCKERHUB_PUSH_ENABLED) — both tags
+          if [ "${{ vars.DOCKERHUB_PUSH_ENABLED }}" = "true" ]; then
+            docker buildx imagetools create \
+              -t ${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated:${{ env.FLOAT_TAG }} \
+              -t ${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated:${{ env.UNIQUE_TAG }} \
+              $(printf '${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated@sha256:%s ' *)
+          else
+            echo "DOCKERHUB_PUSH_ENABLED is not 'true' — skipping DockerHub manifest push (GHCR-only mode)."
+          fi
+
+          # 2. Push to GHCR (Both Tags) — always
           docker buildx imagetools create \
             -t ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }}:${{ env.FLOAT_TAG }} \
             -t ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }}:${{ env.UNIQUE_TAG }} \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,16 +114,23 @@ jobs:
   integration-tests:
     name: Integration Tests (Docker)
     runs-on: ubuntu-latest
-    # Advisory only — does NOT gate merging. Failures here are surfaced
-    # to test-summary which decides workflow conclusion based on the
-    # mandatory fast-tests job. Network/PPA flakiness here will not red
-    # the workflow.
-    continue-on-error: true
-    # Only run on merge to main/dev OR manual dispatch with flag
+    # Tier-2 auto-merge requires Integration Tests as a hard gate — small
+    # code changes still need to clear the actual ingest/Calibre flow.
+    # We keep the broad-PR exemption: tier-1 (.po / *.md) PRs and PRs
+    # without a tier label don't pay the 15-minute integration cost.
+    # On main / dev pushes the job stays advisory so flaky-network failures
+    # don't block downstream auto-revert decisions. On tier-2 PRs the job
+    # is mandatory.
+    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'safe-tier-2') }}
+    # Run on:
+    # - merge to main / dev (advisory)
+    # - manual dispatch with flag
+    # - any PR labeled safe-tier-2 (gating)
     if: |
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/dev' ||
-      (github.event_name == 'workflow_dispatch' && inputs.run_integration)
+      (github.event_name == 'workflow_dispatch' && inputs.run_integration) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'safe-tier-2'))
     
     steps:
       - name: Checkout code

--- a/.github/workflows/validate-author.yml
+++ b/.github/workflows/validate-author.yml
@@ -11,6 +11,14 @@ name: validate-author
 #
 # Any commit signed by a different committer fails the check, gating
 # auto-merge.
+#
+# EXEMPTION: PRs labeled `community-contribution` skip the committer
+# check. Use this for genuine outside contributions where the
+# contributor's own committer identity is correct and re-authoring
+# would erase their authorship credit. The label is operator-applied;
+# the workflow never adds it on its own. Auto-merge is still gated by
+# the rest of auto-merge.yml (tier label, forbidden paths, CI green) —
+# `community-contribution` only exempts the committer-identity check.
 
 on:
   pull_request:
@@ -30,9 +38,22 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Verify all commits committed by new-usemame
+      - name: Verify all commits committed by new-usemame (or exempt by label)
         run: |
           set -euo pipefail
+
+          # Operator-applied exemption for genuine outside contributions.
+          # `community-contribution` is the contract string the operator
+          # and this workflow share; if you rename it, also update
+          # CLAUDE.md tier policy section + the autopilot SKILL.
+          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | grep -q '"community-contribution"'; then
+            echo "::notice::validate-author exempted by 'community-contribution' label."
+            echo "Operator has accepted the contributor's commits as-is."
+            echo "Auto-merge remains gated by tier label, forbidden paths, and CI green."
+            exit 0
+          fi
+
           BASE='${{ github.event.pull_request.base.sha }}'
           HEAD='${{ github.event.pull_request.head.sha }}'
           ALLOWED_RE='^(248195428\+new-usemame@users\.noreply\.github\.com|pj4wx2vj6n@privaterelay\.appleid\.com)$'
@@ -50,10 +71,13 @@ jobs:
             echo "::error::PR contains commits NOT committed by new-usemame:"
             printf '%s\n' "$BAD"
             echo
-            echo "Re-author with:"
-            echo "  git -c user.name='new-usemame' \\"
-            echo "      -c user.email='248195428+new-usemame@users.noreply.github.com' \\"
-            echo "      commit --amend --reset-author --no-edit"
+            echo "Two ways forward:"
+            echo "  1. Re-author (fork-internal PRs):"
+            echo "       git -c user.name='new-usemame' \\"
+            echo "           -c user.email='248195428+new-usemame@users.noreply.github.com' \\"
+            echo "           commit --amend --reset-author --no-edit"
+            echo "  2. Apply 'community-contribution' label (genuine outside PRs;"
+            echo "     operator decision)."
             exit 1
           fi
           echo "All commits committed by new-usemame ✓"


### PR DESCRIPTION
## Why

The operator surfaced "why are we still tier 1 automerge? i thought we were tier 2?" — the workflow filename `auto-merge-tier1.yml` was misleading, the file actually handles both tiers. Symptom-fix would have been to rename. Root-cause analysis turned up a broader pattern: tier policy was duplicated across five places with three real drifts, validate-author had no exemption path for community PRs, the dev-build workflow failed by default on the standalone fork, and `sync-upstream` was logging "diverged" every tick because it had no case for the normal fork-ahead state.

This PR fixes all five at the architecture level, plus the two pre-existing recurring autopilot test failures that were dual-upstream migration debt.

## Changes

### 1. Single source of truth for tier policy

New `.github/policy/tier-policy.config` carries every numeric / regex tier constant. Workflow + triage script source the same file. Before:

| Source | Tier-2 LOC | Forbidden paths | Required checks |
|---|---|---|---|
| CLAUDE.md | "<50 LOC" | "auth/csrf/session/admin/migration" | implied "tier-1 history" |
| triage-prs.sh | `additions+deletions ≤ 50` | `auth/login/csrf/oauth/admin/permission/session` | n/a |
| auto-merge.yml (pre-#96) | not enforced | `cps/(oauth\|admin)\|.*/auth\|csrf\|session\|alembic` | hardcoded |
| auto-merge.yml (post-#96, pre-this) | inline `TIER2_MAX_ADDITIONS=80` | inline expanded regex | hardcoded |

After this PR, every consumer reads `tier-policy.config`. Drift becomes structurally impossible — change a value once, every downstream picks it up. New `test_tier_policy.sh` (8 tests) pins existence + parseability + key presence + cap-sanity + workflow/triage references + critical-path coverage.

### 2. Workflow rename: `auto-merge-tier1.yml` → `auto-merge.yml`

The file always handled both tiers; the legacy filename was operator-confusing. `name:` field updated to match. `auto-revert.yml` filters by "Test Suite" not by us, so no downstream edit needed. All `tests/autopilot/test_workflows.sh` references updated.

### 3. `community-contribution` label exempts validate-author

Genuine outside contributions (PR #90 is the live example) can't satisfy the committer-identity check because their commits are correctly authored as themselves. The label is operator-applied; the workflow never adds it on its own. Auto-merge remains gated by tier label / forbidden paths / CI green — `community-contribution` exempts ONLY the committer check.

### 4. `docker-image-build-dev.yml` runs GHCR-only by default

The standalone fork doesn't have DockerHub credentials, so the workflow used to fail at the login step. Now: every DockerHub-related step is gated on the repo variable `DOCKERHUB_PUSH_ENABLED='true'`. The "Compose docker outputs" step builds the `outputs:` line conditionally — GHCR always, DockerHub when opted in. The manifest job's DockerHub `imagetools create` is also gated. GHCR-only mode "just works" on the fork.

### 5. `sync-upstream.sh` four-case ancestor classifier

The script's three-branch logic had no case for "we're ahead of upstream" (the normal fork state where we ship past `crocodilestick/main`). Every cron tick logged `step:sync FAILED rc=0`. After this:

| LOCAL vs UPSTREAM vs BASE | Meaning | Behavior |
|---|---|---|
| `LOCAL == UPSTREAM` | In sync | silent exit 0 |
| `LOCAL == BASE` | Behind upstream | fast-forward |
| **`UPSTREAM == BASE`** (new) | **Ahead of upstream** (normal fork) | **silent exit 0 with "ahead by N commits" log** |
| neither is ancestor of other | Genuine divergence | exit 1, ask human |

Plus a `test_handles_ahead_of_upstream_silently` regression test pinning the new branch.

### 6. Pre-existing autopilot test failures resolved

Both were dual-upstream migration debt the autopilot had been logging as steady-state noise on every tick:

- `test_forbids_pushing_to_upstream` asserted the legacy single-upstream wording (`'Never push to \`upstream\`'`); CLAUDE.md long ago moved to dual-upstream (`'Never push to either upstream (...)'`). Test updated to accept either.
- `test_pr_status_queue_is_subset_of_buckets` didn't recognize the new dual-upstream queue key shapes (`cwa-upstream-pr-N` / `cw-upstream-pr-N`); test updated to accept all three canonical forms.

## Validation

```
$ AUTOPILOT_NO_LLM=1 bash scripts/autopilot-tick.sh 2>&1 | tail -3
autopilot test summary: 22 test files, 0 with failures
[INFO] tick complete in 79s
```

22/22 green. Up from 21 (2 failing) on main. The new `test_tier_policy.sh` adds 8 tests; the existing test files got 4 new tests for the workflow-rename / community-exemption / dev-build-gate / sync-classifier.

## Tier

`needs-review`. Multi-file CI-policy change.

## Release target

Infrastructure only — no code change ships to users. Operator's call on whether to bundle into the next user-facing release notes (probably not necessary).

## Files touched (in this PR)

- `.github/policy/tier-policy.config` (new — single SoT)
- `.github/policy/README.md` (new — explains the dir)
- `.github/workflows/auto-merge.yml` (renamed from `auto-merge-tier1.yml`; sources `tier-policy.config`)
- `.github/workflows/validate-author.yml` (community-contribution exemption)
- `.github/workflows/docker-image-build-dev.yml` (DOCKERHUB_PUSH_ENABLED gate)

## Files touched outside the repo (autopilot infra at project root)

These don't appear in the diff but ship in lockstep:

- `scripts/sync-upstream.sh` (4-case classifier)
- `scripts/triage-prs.sh` (reads `tier-policy.config`)
- `tests/autopilot/test_tier_policy.sh` (new, 8 tests)
- `tests/autopilot/test_workflows.sh` (updated for SoT + new exemption tests)
- `tests/autopilot/test_sync_upstream.sh` (4-case classifier test)
- `tests/autopilot/test_state_files.sh` (dual-upstream queue keys)
- `tests/autopilot/test_claude_md_invariants.sh` (dual-upstream wording)
- `tests/autopilot/test_triage_prs.sh` (forbidden-paths SoT check)

No new dependencies. No telemetry. Tier-1 (`.po` + `*.md`) auto-merge flow is unchanged.