### PR TITLE
docs(policy): fix tier-policy parser regex missing digits class

### DIFF
--- a/.github/policy/README.md
+++ b/.github/policy/README.md
@@ -29,7 +29,7 @@ Single source of truth here, doc references it by path-and-line. If a value need
    policy = {}
    with open(".github/policy/tier-policy.config") as fh:
        for line in fh:
-           m = re.match(r"^([A-Z_]+)='?(.*?)'?$", line.strip())
+           m = re.match(r"^([A-Z0-9_]+)='?(.*?)'?$", line.strip())
            if m: policy[m.group(1)] = m.group(2)
    ```
 3. Add a test in `tests/autopilot/test_tier_policy.sh` asserting the key exists and parses.


### PR DESCRIPTION
Doc-only follow-up. The Python parser snippet in `.github/policy/README.md` used `[A-Z_]+` for the key character class. `TIER2_*` keys contain a digit, so the regex didn't match them and triage silently fell back to historical defaults (`TIER2_MAX_ADDITIONS=50` instead of the configured `80`).

Fixes the regex to `[A-Z0-9_]+`. Aligns with the parser already corrected in `scripts/triage-prs.sh` (operator tooling at project root, not in this repo) and a new regression test in `tests/autopilot/test_tier_policy.sh` that asserts every uncommented `KEY=...` line in the policy file matches the documented parser.