### PR TITLE
Backport upstream #1324: feat: Push KOReader progress to Hardcover

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -996,7 +996,7 @@ def HandleStateRequest(book_uuid):
             ub.session.rollback()
             abort(400, description="Malformed request data is missing 'ReadingStates' key")
 
-        push_reading_state_to_hardcover(book, request_bookmark)
+        push_reading_state_to_hardcover(current_user, book, request_bookmark['ProgressPercent'])
 
         ub.session.merge(kobo_reading_state)
         ub.session_commit()
@@ -1006,7 +1006,7 @@ def HandleStateRequest(book_uuid):
         })
 
 
-def push_reading_state_to_hardcover(book: db.Books, request_bookmark: dict):
+def push_reading_state_to_hardcover(user, book: db.Books, progress_percentage: int):
     """
     Sync reading progress to Hardcover if enabled for the user and book is not blacklisted.
 
@@ -1014,7 +1014,7 @@ def push_reading_state_to_hardcover(book: db.Books, request_bookmark: dict):
     the Kobo from clearing its reading state sync queue.
 
     :param book: The book for which to sync reading progress.
-    :param request_bookmark: The bookmark data from the Kobo request.
+    :param progress_percentage: Reading progress percentage.
     :return: None
     """
 
@@ -1030,16 +1030,16 @@ def push_reading_state_to_hardcover(book: db.Books, request_bookmark: dict):
         return
 
     try:
-        hardcoverClient = hardcover.HardcoverClient(current_user.hardcover_token)
+        hardcoverClient = hardcover.HardcoverClient(user.hardcover_token)
     except hardcover.MissingHardcoverToken:
-        log.info(f"User {current_user.name} has no Hardcover token, not syncing reading progress to Hardcover")
+        log.info(f"User {user.name} has no Hardcover token, not syncing reading progress to Hardcover")
         return
     except Exception as e:
-        log.error(f"Failed to create Hardcover client for user {current_user.name}: {e}")
+        log.error(f"Failed to create Hardcover client for user {user.name}: {e}")
         return
 
     try:
-        hardcoverClient.update_reading_progress(book.identifiers, request_bookmark["ProgressPercent"])
+        hardcoverClient.update_reading_progress(book.identifiers, progress_percentage)
     except Exception as e:
         log.error(f"Failed to update reading progress for book {book.id} in Hardcover: {e}")
 

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -40,6 +40,9 @@ import base64
 from datetime import datetime, timezone
 from typing import Dict, Optional, Any, Tuple
 
+from ...services import SyncToken as SyncToken, hardcover
+from ...kobo import push_reading_state_to_hardcover
+
 from flask import Blueprint, request, jsonify
 from flask_babel import gettext as _
 from werkzeug.security import check_password_hash
@@ -326,7 +329,7 @@ def enrich_response_with_book_info(response_data: Dict[str, Any], document_check
     return response_data, book_id, book_format, book_title, checksum_version
 
 
-def update_book_read_status(user_id: int, book_id: int, percentage: float) -> None:
+def update_book_read_status(user, book_id: int, percentage: float) -> None:
     """
     Update the user's ReadBook status based on reading progress percentage.
 
@@ -359,6 +362,8 @@ def update_book_read_status(user_id: int, book_id: int, percentage: float) -> No
         new_status = ub.ReadBook.STATUS_IN_PROGRESS
     else:
         new_status = ub.ReadBook.STATUS_UNREAD
+
+    user_id = user.id
 
     log.debug(f"update_book_read_status: user {user_id}, book {book_id}, "
               f"percentage {percentage:.2f}% -> status {new_status}")
@@ -429,6 +434,17 @@ def update_book_read_status(user_id: int, book_id: int, percentage: float) -> No
 
     # Merge the record (caller commits)
     ub.session.merge(book_read)
+
+    # # Push to Hardcover
+    # # TODO: just pass in the user?
+    # from ... import calibre_db
+    # book = calibre_db.get_book(book_id)
+    
+    # if user is not None:
+    #     log.debug(f"Going to sync book {book_id} to Hardcover.")
+    #     push_reading_state_to_hardcover(user, book, int(percentage))
+    # else:
+    #     log.debug(f"Book {book_id} not syncing to Hardcover, no matched user.")
 
 
 def get_progress_record(user_id, document_checksum, book_id) -> KOSyncProgress:
@@ -747,10 +763,21 @@ def update_progress():
         # This is done AFTER kosync_progress is committed, so sync location is always safe
         if book_id:
             try:
-                update_book_read_status(user.id, book_id, percentage_float)
+                update_book_read_status(user, book_id, percentage_float)
                 ub.session.commit()
                 log.info(f"Updated ReadBook status: user={user.id}, book={book_id} "
                         f"({book_title}), status based on {percentage_float:.1f}%")
+                
+                # Push to Hardcover
+                from ... import calibre_db
+                book = calibre_db.get_book(book_id)
+                
+                if user is not None:
+                    log.debug(f"Going to sync book {book_id} to Hardcover.")
+                    push_reading_state_to_hardcover(user, book, int(percentage_float))
+                else:
+                    log.debug(f"Book {book_id} not syncing to Hardcover, no matched user.")
+
             except SQLAlchemyError as e:
                 log.error(f"Failed to update ReadBook status for book {book_id}: {e}")
                 # Rollback only affects the failed ReadBook update

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -435,17 +435,6 @@ def update_book_read_status(user, book_id: int, percentage: float) -> None:
     # Merge the record (caller commits)
     ub.session.merge(book_read)
 
-    # # Push to Hardcover
-    # # TODO: just pass in the user?
-    # from ... import calibre_db
-    # book = calibre_db.get_book(book_id)
-    
-    # if user is not None:
-    #     log.debug(f"Going to sync book {book_id} to Hardcover.")
-    #     push_reading_state_to_hardcover(user, book, int(percentage))
-    # else:
-    #     log.debug(f"Book {book_id} not syncing to Hardcover, no matched user.")
-
 
 def get_progress_record(user_id, document_checksum, book_id) -> KOSyncProgress:
     """
@@ -767,11 +756,11 @@ def update_progress():
                 ub.session.commit()
                 log.info(f"Updated ReadBook status: user={user.id}, book={book_id} "
                         f"({book_title}), status based on {percentage_float:.1f}%")
-                
+
                 # Push to Hardcover
                 from ... import calibre_db
                 book = calibre_db.get_book(book_id)
-                
+
                 if user is not None:
                     log.debug(f"Going to sync book {book_id} to Hardcover.")
                     push_reading_state_to_hardcover(user, book, int(percentage_float))

--- a/cps/services/hardcover.py
+++ b/cps/services/hardcover.py
@@ -155,12 +155,15 @@ class HardcoverClient:
             book = self.get_user_book(ids)
             # Book doesn't exist, add it in Reading status
             if not book:
+                log.debug(f'Book does not exist, add to reading status')
                 book = self.add_book(ids, status=STATUS_READING)
             # Book is either WTR or Read, and we aren't finished reading
             if book.get("status_id") != STATUS_READING and progress_percent != MAX_PROGRESS_PERCENTAGE:
+                log.debug(f'Book is in either want to read or read, not finished reading.')
                 book = self.change_book_status(book, STATUS_READING)
             # Book is already marked as read, and we are also done
             if book.get("status_id") == STATUS_READ and progress_percent == MAX_PROGRESS_PERCENTAGE:
+                log.debug(f'Book is already marked read and we are done.')
                 return
             pages = book.get("edition", {}).get("pages", 0)
             if pages:
@@ -169,8 +172,10 @@ class HardcoverClient:
                 if not read:
                     # read = self.add_read(book, pages_read)
                     # No read exists for some reason, return since we can't update anything.
+                    log.warning(f'No read status exists for book, not updating.')
                     return
                 else:
+                    log.info(f'Setting {pages_read} pages read at {progress_percent}% done.')
                     mutation = """
                     mutation ($readId: Int!, $pages: Int, $editionId: Int, $startedAt: date, $finishedAt: date) {
                         update_user_book_read(id: $readId, object: {
@@ -196,10 +201,12 @@ class HardcoverClient:
                         ),
                     }
                     if progress_percent == MAX_PROGRESS_PERCENTAGE:
+                        log.debug('Book finished, marking as read')
                         self.change_book_status(book, STATUS_READ)
                     self.execute(query=mutation, variables=variables)
             return
         else:
+            log.info('No Hardcover IDs associated with book, not updating.')
             return
 
     def change_book_status(self, book, status):

--- a/cps/services/hardcover.py
+++ b/cps/services/hardcover.py
@@ -155,15 +155,12 @@ class HardcoverClient:
             book = self.get_user_book(ids)
             # Book doesn't exist, add it in Reading status
             if not book:
-                log.debug(f'Book does not exist, add to reading status')
                 book = self.add_book(ids, status=STATUS_READING)
             # Book is either WTR or Read, and we aren't finished reading
             if book.get("status_id") != STATUS_READING and progress_percent != MAX_PROGRESS_PERCENTAGE:
-                log.debug(f'Book is in either want to read or read, not finished reading.')
                 book = self.change_book_status(book, STATUS_READING)
             # Book is already marked as read, and we are also done
             if book.get("status_id") == STATUS_READ and progress_percent == MAX_PROGRESS_PERCENTAGE:
-                log.debug(f'Book is already marked read and we are done.')
                 return
             pages = book.get("edition", {}).get("pages", 0)
             if pages:
@@ -172,10 +169,8 @@ class HardcoverClient:
                 if not read:
                     # read = self.add_read(book, pages_read)
                     # No read exists for some reason, return since we can't update anything.
-                    log.warning(f'No read status exists for book, not updating.')
                     return
                 else:
-                    log.info(f'Setting {pages_read} pages read at {progress_percent}% done.')
                     mutation = """
                     mutation ($readId: Int!, $pages: Int, $editionId: Int, $startedAt: date, $finishedAt: date) {
                         update_user_book_read(id: $readId, object: {
@@ -201,12 +196,10 @@ class HardcoverClient:
                         ),
                     }
                     if progress_percent == MAX_PROGRESS_PERCENTAGE:
-                        log.debug('Book finished, marking as read')
                         self.change_book_status(book, STATUS_READ)
                     self.execute(query=mutation, variables=variables)
             return
         else:
-            log.info('No Hardcover IDs associated with book, not updating.')
             return
 
     def change_book_status(self, book, status):

--- a/tests/unit/test_kosync_pushes_to_hardcover.py
+++ b/tests/unit/test_kosync_pushes_to_hardcover.py
@@ -1,0 +1,171 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for upstream CWA #1324 (fork PR #101) — KOReader sync
+must push reading progress to Hardcover, the same way the Kobo path does.
+
+Pre-fix: `push_reading_state_to_hardcover` was Kobo-only, signed
+`(book, request_bookmark)` and used `current_user`. KOReader sync (which
+runs without a `current_user` context) couldn't call it.
+
+Post-fix: signature is `(user, book, progress_percentage)` — explicit
+user passed in — and `kosync.update_progress` calls it after every
+successful progress update where `book_id` resolved to a Calibre book.
+"""
+
+import inspect
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _kosync_module():
+    """Fetch the kosync *module* (not the re-exported Blueprint) — the
+    package `__init__.py` shadows the submodule attribute. See the
+    matching helper in `test_kosync_book_id_keyed_lookup.py`."""
+    import cps.progress_syncing.protocols.kosync  # noqa: F401
+    return sys.modules["cps.progress_syncing.protocols.kosync"]
+
+
+@pytest.mark.unit
+class TestPushReadingStateToHardcoverSignature:
+    """Pin the new (user, book, progress_percentage) signature on
+    push_reading_state_to_hardcover. The kosync path has no Flask
+    `current_user`, so the function must accept an explicit user."""
+
+    def test_function_accepts_explicit_user_first_arg(self):
+        from cps.kobo import push_reading_state_to_hardcover
+        sig = inspect.signature(push_reading_state_to_hardcover)
+        params = list(sig.parameters.keys())
+        assert params[0] == "user", (
+            "first parameter must be `user` (was previously `book` + relied "
+            "on Flask current_user); kosync caller has no current_user"
+        )
+        assert "book" in sig.parameters
+        assert "progress_percentage" in sig.parameters, (
+            "function must accept progress_percentage directly, not extract "
+            "from a request_bookmark dict — kosync's caller doesn't have "
+            "the request_bookmark shape Kobo uses"
+        )
+
+
+@pytest.mark.unit
+class TestUpdateBookReadStatusSignature:
+    """Pin the (user, book_id, percentage) signature on update_book_read_status —
+    the call site that follows must hand off the same user object to
+    push_reading_state_to_hardcover."""
+
+    def test_function_accepts_user_object_not_just_user_id(self):
+        kosync_mod = _kosync_module()
+        sig = inspect.signature(kosync_mod.update_book_read_status)
+        params = list(sig.parameters.keys())
+        assert params[0] == "user", (
+            "must take user object so caller can pass the same user into "
+            "push_reading_state_to_hardcover without re-fetching"
+        )
+
+
+@pytest.mark.unit
+class TestKosyncUpdateProgressCallsHardcover:
+    """Pin the integration: when kosync.update_progress successfully writes
+    a progress record AND a Calibre book_id resolves, it must call
+    push_reading_state_to_hardcover. The Hardcover-sync path is the whole
+    point of the backport — silently dropping it is the regression."""
+
+    def test_update_progress_source_invokes_hardcover_push(self):
+        """Source-level pin so the call is preserved across edits."""
+        from pathlib import Path
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        src = (repo_root / "cps" / "progress_syncing" / "protocols" /
+               "kosync.py").read_text()
+        # find the update_progress function body up to next top-level def
+        import re
+        match = re.search(
+            r"def update_progress\(\).*?(?=\n(?:def |@)\w)",
+            src, re.DOTALL,
+        )
+        assert match is not None, "update_progress not found"
+        body = match.group(0)
+        assert "push_reading_state_to_hardcover" in body, (
+            "kosync.update_progress must call push_reading_state_to_hardcover "
+            "after a successful update — that's the whole point of fork PR #101"
+        )
+
+    def test_hardcover_push_imported_at_module_load(self):
+        kosync_mod = _kosync_module()
+        assert hasattr(kosync_mod, "push_reading_state_to_hardcover"), (
+            "import of push_reading_state_to_hardcover must be at module top "
+            "so the kosync update path can call it without a runtime import"
+        )
+
+    def test_hardcover_push_gated_on_book_id(self):
+        """No book_id resolution → no Hardcover push. Without this gate,
+        every KOReader sync of an un-ingested document would log a noisy
+        Hardcover-sync attempt."""
+        from pathlib import Path
+        import re
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        src = (repo_root / "cps" / "progress_syncing" / "protocols" /
+               "kosync.py").read_text()
+        match = re.search(
+            r"def update_progress\(\).*?(?=\n(?:def |@)\w)",
+            src, re.DOTALL,
+        )
+        body = match.group(0)
+        # Find the index of the if-book_id gate and the hardcover push call.
+        # The push must appear AFTER an `if book_id` check.
+        gate_pos = body.find("if book_id:")
+        push_pos = body.find("push_reading_state_to_hardcover")
+        assert gate_pos != -1, "missing `if book_id:` gate"
+        assert push_pos != -1, "missing push call"
+        assert push_pos > gate_pos, (
+            "push_reading_state_to_hardcover must be inside the `if book_id:` "
+            "block — calling it without a resolved book_id is a noisy regression"
+        )
+
+
+@pytest.mark.unit
+class TestPushReadingStateToHardcoverNoActiveContext:
+    """Behavioral pin: when push_reading_state_to_hardcover is called from
+    a context with no Flask `current_user` (i.e. the kosync path), it
+    must still resolve the user from the explicit argument, not crash."""
+
+    def test_works_without_flask_current_user(self):
+        """Hardcover client gets called with the explicit user (no
+        Flask current_user reference). Mocks model the real guards:
+        global config flag + per-book blacklist DB lookup."""
+        from cps.kobo import push_reading_state_to_hardcover
+        import cps.kobo as kobo_mod
+
+        user = MagicMock()
+        user.name = "alice"
+        user.hardcover_token = "fake-token"
+        user.id = 7
+
+        book = MagicMock()
+        book.id = 42
+        book.identifiers = []
+
+        # Mock the global config flag, the blacklist query, and the
+        # Hardcover client.
+        mock_config = MagicMock()
+        mock_config.config_hardcover_sync = True
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+
+        mock_ub = MagicMock(session=mock_session)
+        mock_hardcover = MagicMock()
+        mock_hardcover.__bool__ = lambda self: True
+
+        with patch.object(kobo_mod, "config", mock_config), \
+                patch.object(kobo_mod, "ub", mock_ub), \
+                patch.object(kobo_mod, "hardcover", mock_hardcover):
+            push_reading_state_to_hardcover(user, book, 42)
+            mock_hardcover.HardcoverClient.assert_called_once_with("fake-token")
+            mock_hardcover.HardcoverClient.return_value.update_reading_progress.\
+                assert_called_once_with(book.identifiers, 42)


### PR DESCRIPTION
Cherry-pick of upstream **crocodilestick/Calibre-Web-Automated#1324** by @frbncis.

**Original title:** feat: Push KOReader progress to Hardcover
**Original PR:** https://github.com/crocodilestick/Calibre-Web-Automated/pull/1324

## Verification

Walk through `notes/merge/upstream-pr-1324-verify.md` before merging.

## Diff snapshot

See `notes/cherry-pick-1324.diff` (captured at prep time; rebase if the upstream PR has moved).

---

(Prepared by an automation pipeline. Do not merge until the verification checklist is signed off.)