### PR TITLE
fix(db): rate-limit + demote author-sort drift warnings (fork #108)

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -44,6 +44,13 @@ from .string_helper import strip_whitespaces
 
 log = logger.create()
 
+# Rate-limit author-sort drift diagnostics. Books.author_sort is denormalized
+# from Authors.sort and can drift after an Authors edit; the divergence is
+# visual-only (within-book ordering falls back to Authors.id), but the log
+# fires from every page render. Module-level set so we warn once per process
+# per drifted sort string. See fork issue #108.
+_AUTHOR_SORT_DRIFT_WARNED: set = set()
+
 cc_exceptions = ['composite', 'series']
 cc_classes = {}
 
@@ -1120,11 +1127,21 @@ class CalibreDB:
                 if not auth:
                     continue
                 results = self.session.query(Authors).filter(Authors.sort == auth).all()
-                # ToDo: How to handle not found author name
                 if not len(results):
-                    log.error("Author '{}' not found to display name in right order".format(auth))
-                    # error = True
-                    break
+                    # Books.author_sort drifted from Authors.sort. Warn once
+                    # per process per author so the log doesn't fill on every
+                    # page render. The unmatched author still appears in the
+                    # book — it falls through to the Authors.id loop below
+                    # (continue, not break, so other authors on this same
+                    # book that DO have a valid sort still get ordered).
+                    if auth not in _AUTHOR_SORT_DRIFT_WARNED:
+                        _AUTHOR_SORT_DRIFT_WARNED.add(auth)
+                        log.warning(
+                            "Author sort '%s' from Books.author_sort has no "
+                            "match in Authors.sort. Falling back to Authors.id "
+                            "order for this author. To fix: edit the author in "
+                            "the admin UI so Authors.sort matches.", auth)
+                    continue
                 for r in results:
                     if r.id in ids:
                         authors_ordered.append(r)

--- a/tests/unit/test_author_sort_drift_log_dedup.py
+++ b/tests/unit/test_author_sort_drift_log_dedup.py
@@ -1,0 +1,263 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for fork issue #108 — Books.author_sort drift in
+`cps.db.CalibreDB.order_authors` was logging at ERROR level on every page
+render, with no dedup. Three Hungarian author names spammed Docker logs
+every 30 seconds because the OPDS / index page fired the lookup repeatedly.
+
+Pre-fix: log.error(...) on every miss, no dedup, `break` on first miss
+(meaning OTHER authors on the same book that DID have valid sort fell
+through to id-order too).
+
+Post-fix:
+- Module-level `_AUTHOR_SORT_DRIFT_WARNED` set rate-limits one warn per
+  process per drifted sort string.
+- Level demoted to WARNING (the situation is data drift, not an error;
+  the function gracefully recovers via the id-based fallback loop).
+- `continue` instead of `break` so other authors on the same book that
+  DO have valid sort entries still get correctly ordered.
+
+These tests pin all three guarantees. They use a stub session so we
+exercise the actual `order_authors` method, not just AST shape.
+"""
+
+import ast
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+DB_PY = (Path(__file__).resolve().parent.parent.parent / "cps" / "db.py")
+
+
+@pytest.mark.unit
+class TestAuthorSortDriftDedupSourcePins:
+    """Static pins on cps/db.py — these catch refactors that drop the
+    dedup or revert level/break semantics without a behavioral test
+    needing to import cps."""
+
+    def test_db_py_present(self):
+        assert DB_PY.is_file(), f"missing: {DB_PY}"
+
+    def test_module_level_drift_warned_set_exists(self):
+        src = DB_PY.read_text()
+        assert "_AUTHOR_SORT_DRIFT_WARNED" in src, (
+            "Expected module-level set _AUTHOR_SORT_DRIFT_WARNED for "
+            "rate-limiting author-sort drift warnings (fork #108). If "
+            "this rename is intentional, update this test too."
+        )
+        # Must be a set (not dict / list) — the dedup contract is set.add(auth)
+        # / 'auth in set'. Walk the AST to find the assignment and check.
+        tree = ast.parse(src)
+        found = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) \
+                    and node.target.id == "_AUTHOR_SORT_DRIFT_WARNED":
+                # `_AUTHOR_SORT_DRIFT_WARNED: set = set()`
+                found = True
+                assert isinstance(node.value, ast.Call), \
+                    "expected set() initializer"
+                assert isinstance(node.value.func, ast.Name) and \
+                    node.value.func.id == "set", \
+                    "expected initializer to be set()"
+            elif isinstance(node, ast.Assign):
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name) and tgt.id == "_AUTHOR_SORT_DRIFT_WARNED":
+                        found = True
+        assert found, "_AUTHOR_SORT_DRIFT_WARNED initializer not found at module level"
+
+    def test_order_authors_uses_continue_not_break_after_drift(self):
+        """Original code used `break` — meaning one drifted author short-
+        circuited the rest of the book's authors into id-order. Fork #108
+        replaced this with `continue`."""
+        src = DB_PY.read_text()
+        tree = ast.parse(src)
+        # Find the order_authors method body
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "order_authors":
+                src_segment = ast.get_source_segment(src, node) or ""
+                # The handler for the empty-results case should be a
+                # `continue` keyword, not `break`. Look at every Continue
+                # and Break inside this function and assert the dedup
+                # block ends with continue.
+                continues = [n for n in ast.walk(node) if isinstance(n, ast.Continue)]
+                breaks = [n for n in ast.walk(node) if isinstance(n, ast.Break)]
+                assert continues, (
+                    "order_authors should `continue` after warning about "
+                    "drift, so other authors on the same book still get "
+                    "ordered correctly. Found no Continue node."
+                )
+                # The fix should NOT have a `break` left over from the
+                # pre-fix code — break would short-circuit the rest of the
+                # author loop.
+                assert not breaks, (
+                    f"order_authors still contains a `break` statement: "
+                    f"{[ast.dump(b) for b in breaks]}. The fix for fork "
+                    f"#108 replaced break with continue so a single drifted "
+                    f"author doesn't short-circuit the rest of the book."
+                )
+                return
+        pytest.fail("order_authors method not found in cps/db.py")
+
+    def test_warning_level_not_error_level(self):
+        """ERROR was wrong — it implies actionable failure, but the
+        function recovers gracefully. WARNING is the right level for
+        recoverable drift diagnostics."""
+        src = DB_PY.read_text()
+        # The original error string has been intentionally rephrased to
+        # be more useful. Check the new wording uses log.warning (not
+        # log.error) for the drift-detected path.
+        assert "log.warning(" in src, "expected log.warning(...) for drift"
+        # And the old log.error spam string should be gone.
+        assert "Author '{}' not found to display name in right order" not in src, (
+            "old ERROR-level log line still present; fork #108 demotes it to "
+            "log.warning with rate-limited dedup"
+        )
+
+
+@pytest.mark.unit
+class TestAuthorSortDriftDedupBehavioral:
+    """Functional pin — instantiate a stub CalibreDB-like object with a
+    fake session and verify the dedup behavior across multiple
+    invocations. Importing cps.db is heavy (pulls SQLAlchemy app +
+    blueprints); use spec_from_file_location to load just the module
+    machinery we need."""
+
+    def test_drift_warned_set_grows_and_dedupes(self):
+        """The behavioral pin that matters: across many invocations with the
+        same drifted sort string, the set grows by exactly one entry per
+        unique drift name. (Log-volume assertions via caplog are flaky
+        because cps installs its own handler chain; the dedup-set state is
+        the actual contract this fix makes.)"""
+        from cps import db as cps_db
+
+        cps_db._AUTHOR_SORT_DRIFT_WARNED.clear()
+
+        instance = cps_db.CalibreDB.__new__(cps_db.CalibreDB)
+        fake_query = MagicMock()
+        fake_query.filter.return_value.all.return_value = []  # no Authors hit
+        fake_query.filter.return_value.first.return_value = None
+        instance.session = MagicMock()
+        instance.session.query.return_value = fake_query
+        instance.ensure_session = lambda: None
+
+        class _StubBook:
+            def __init__(self, sort_str, ids):
+                self.author_sort = sort_str
+                self.authors = [MagicMock(id=i) for i in ids]
+
+        # Reproduce the exact #108 set: 3 distinct drifted authors,
+        # invoked many times to simulate the per-30s page render storm.
+        for _ in range(10):
+            instance.order_authors([
+                _StubBook("Esterházy Péter", []),
+                _StubBook("Molnár, Ferenc", []),
+                _StubBook("Örkény István", []),
+            ], list_return=True, combined=False)
+
+        # Set should contain exactly the three drifted names — no growth
+        # past distinct-input cardinality regardless of invocation count.
+        assert cps_db._AUTHOR_SORT_DRIFT_WARNED == {
+            "Esterházy Péter", "Molnár, Ferenc", "Örkény István"
+        }, (
+            f"expected dedup set to contain exactly the three Hungarian "
+            f"drift names from fork #108; got {cps_db._AUTHOR_SORT_DRIFT_WARNED}"
+        )
+
+        # And a fresh drift name on the 11th call should grow the set by 1.
+        instance.order_authors([
+            _StubBook("Kosztolányi Dezső", []),
+        ], list_return=True, combined=False)
+        assert "Kosztolányi Dezső" in cps_db._AUTHOR_SORT_DRIFT_WARNED
+        assert len(cps_db._AUTHOR_SORT_DRIFT_WARNED) == 4
+
+    def test_continue_preserves_other_authors_ordering_for_same_book(self):
+        """A book with TWO authors — one drifted, one valid — should still
+        get the valid one ordered correctly. Pre-fix `break` would dump
+        BOTH into id-order; post-fix only the drifted one falls through."""
+        from cps import db as cps_db
+
+        cps_db._AUTHOR_SORT_DRIFT_WARNED.clear()
+
+        instance = cps_db.CalibreDB.__new__(cps_db.CalibreDB)
+
+        # Mock author rows. The fixture: book.author_sort = "Drift & Valid"
+        # → looking up "Drift" returns nothing; looking up "Valid" returns
+        # an Authors row whose id matches one of book.authors[].id.
+        valid_author = MagicMock()
+        valid_author.id = 42
+        valid_author.name = "Valid"
+        valid_author.sort = "Valid"
+
+        drift_id = 13
+
+        def filter_side_effect(expr):
+            """Crudely emulate the SQLAlchemy filter chain. We don't try
+            to parse the expression; instead, the .all() return value is
+            decided by which call it is."""
+            chain = MagicMock()
+            chain.all = MagicMock()
+            chain.first = MagicMock(return_value=None)
+            return chain
+
+        # We need .filter to vary by the filter expression. Easiest approach:
+        # track call count and dispatch on it. Two filter() calls happen for
+        # the sort lookups; then one filter() per remaining id (the fallback).
+        call_log = {"filter_calls": 0}
+
+        def smart_filter(expr):
+            call_log["filter_calls"] += 1
+            chain = MagicMock()
+            # First call: "Drift" — empty
+            # Second call: "Valid" — returns [valid_author]
+            # Third+: id fallbacks — return one MagicMock for whichever id
+            n = call_log["filter_calls"]
+            if n == 1:
+                chain.all = MagicMock(return_value=[])
+                chain.first = MagicMock(return_value=None)
+            elif n == 2:
+                chain.all = MagicMock(return_value=[valid_author])
+                chain.first = MagicMock(return_value=valid_author)
+            else:
+                fallback_author = MagicMock(id=drift_id, name="Drifted")
+                chain.all = MagicMock(return_value=[fallback_author])
+                chain.first = MagicMock(return_value=fallback_author)
+            return chain
+
+        fake_query = MagicMock()
+        fake_query.filter.side_effect = smart_filter
+        instance.session = MagicMock()
+        instance.session.query.return_value = fake_query
+        instance.ensure_session = lambda: None
+
+        class _StubBook:
+            pass
+
+        book = _StubBook()
+        book.author_sort = "Drift & Valid"
+        book.authors = [MagicMock(id=drift_id), MagicMock(id=42)]
+
+        instance.order_authors([book], list_return=True, combined=False)
+
+        # The valid author MUST appear in ordered_authors; pre-fix break
+        # would have bailed before reaching it.
+        ordered = book.ordered_authors
+        ordered_ids = [a.id for a in ordered]
+        assert 42 in ordered_ids, (
+            f"valid author (id=42) missing from ordered_authors {ordered_ids}; "
+            f"the post-#108 `continue` should let the loop reach 'Valid' "
+            f"after skipping 'Drift'"
+        )
+        # And valid_author should appear BEFORE the id-fallback drift author
+        # — the sort-order pass placed it; the id pass appends drift after.
+        assert ordered_ids.index(42) < ordered_ids.index(drift_id), (
+            f"valid author should be ordered first (it had a valid sort); "
+            f"got {ordered_ids}. Pre-fix `break` regressed this to drift-id "
+            f"order for the whole book."
+        )


### PR DESCRIPTION
Closes #108.

## What @droM4X saw

```
[2026-05-09 00:43:47,635] ERROR {cps.db:1125} Author 'Esterházy Péter' not found to display name in right order
[2026-05-09 00:44:18,191] ERROR {cps.db:1125} Author 'Molnár, Ferenc' not found to display name in right order
[2026-05-09 00:44:18,252] ERROR {cps.db:1125} Author 'Örkény István' not found to display name in right order
…repeating every ~30s indefinitely…
```

Three Hungarian authors filling the Docker log every page render.

## Root cause

`Books.author_sort` is a denormalized cache of `Authors.sort` from Calibre. After an author edit in the admin UI, the two columns can drift — the Books row keeps the old sort string, the Authors row gets the new one. `order_authors` then queries `Authors.sort == "<old string>"` and gets nothing back.

Three problems in the existing handler:

1. **Logged at ERROR** — implies actionable failure, but the function recovers automatically via the id-based fallback loop directly below. The only user-visible effect is within-book author ordering on a multi-author book. ERROR is the wrong level.
2. **No dedup** — every page render re-fires the lookup. With the OPDS poller + an open Safari tab, that's once every 30s. ERROR + no dedup = log spam.
3. **`break` on first miss** — short-circuits the rest of the per-book sort loop, so a book with one drifted author + four valid ones drops ALL FIVE into id-order, not just the drifted one.

## Fix

```diff
 results = self.session.query(Authors).filter(Authors.sort == auth).all()
-# ToDo: How to handle not found author name
 if not len(results):
-    log.error("Author '{}' not found to display name in right order".format(auth))
-    # error = True
-    break
+    if auth not in _AUTHOR_SORT_DRIFT_WARNED:
+        _AUTHOR_SORT_DRIFT_WARNED.add(auth)
+        log.warning(
+            "Author sort '%s' from Books.author_sort has no match in "
+            "Authors.sort. Falling back to Authors.id order for this "
+            "author. To fix: edit the author in the admin UI so "
+            "Authors.sort matches.", auth)
+    continue
```

Plus a module-level `_AUTHOR_SORT_DRIFT_WARNED: set = set()` that lives for the process lifetime.

Net effect for the user reporting this: the three Hungarian-author warnings fire **once each, ever**, after a process restart. Then silence.

## Why a name-based fallback wasn't added

Considered `Authors.name == auth` as a fallback before the warn. Rejected — `Books.author_sort` and `Authors.name` are different formats by design (Last, First vs First Last for non-Hungarian; both Last First for Hungarian). A naive name-fallback would silently misorder authors in cases that aren't drift, which is worse than the current "fall through to id-order" behavior. The right cleanup is the admin-UI path (edit author → re-sync sort), now surfaced in the warning text.

## Regression tests

`tests/unit/test_author_sort_drift_log_dedup.py` — 6 tests:

- AST walk verifies `order_authors` uses `continue` and contains zero `break` statements (catches reverts of fix #3)
- Source-pin on the dedup set + WARNING level (catches reverts of fixes #1 and #2)
- Behavioral test runs `order_authors` 10× over 3 drifted authors with a stub session, asserts the dedup set has exactly 3 entries (catches dedup regressions)
- Behavioral test on a 2-author book where one drifted, one valid: pin that the valid author still gets correctly sort-ordered (catches reverts of `continue`)

```
$ PYTHONPATH=scripts:. .venv/bin/python -m pytest tests/unit/test_author_sort_drift_log_dedup.py -v
============================== 6 passed in 0.51s ===============================
```

## Tier

`safe-tier-2` — code change in core db.py, but contained: 1 file, ~20 LOC of behavioral change, no auth/session/migration touched, recoverable behavior preserved exactly. Test files don't count toward the tier-2 size cap.

## Verification of user-visible flow

The bug surfaces in logs, not the UI — there is no user-visible flow to drive end-to-end. The fix makes the log line silent after first emission and improves correctness of within-book author ordering in the drift case. Both are exercised by the unit tests.

## Credit

Reported by @droM4X with a clean log excerpt that pinpointed the exact log line + frequency.