### PR TITLE
fix(kobo): stop the 'Sync to last page read' popup loop, including the auto-sleep variant

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -28,6 +28,7 @@ from flask import (
     abort,
     Response,
     send_from_directory,
+    g,
 )
 from .cw_login import current_user
 from werkzeug.datastructures import Headers
@@ -961,6 +962,13 @@ def HandleStateRequest(book_uuid):
             request_data = request.json
             request_reading_state = request_data["ReadingStates"][0]
 
+            # Use the device's own timestamp so the GET response mirrors it back,
+            # preventing the "newer PT" conflict popup. Official Kobo cloud does the same.
+            lm_str = request_reading_state.get("LastModified")
+            request_lm = (datetime.strptime(lm_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+                          if lm_str else datetime.now(timezone.utc))
+            g.kobo_reading_state_lm = request_lm
+
             request_bookmark = request_reading_state["CurrentBookmark"]
             if request_bookmark:
                 current_bookmark = kobo_reading_state.current_bookmark
@@ -971,7 +979,7 @@ def HandleStateRequest(book_uuid):
                     current_bookmark.location_value = location["Value"]
                     current_bookmark.location_type = location["Type"]
                     current_bookmark.location_source = location["Source"]
-                current_bookmark.last_modified = datetime.now(timezone.utc)
+                current_bookmark.last_modified = request_lm
                 update_results_response["CurrentBookmarkResult"] = {"Result": "Success"}
 
             request_statistics = request_reading_state["Statistics"]
@@ -979,17 +987,19 @@ def HandleStateRequest(book_uuid):
                 statistics = kobo_reading_state.statistics
                 statistics.spent_reading_minutes = int(request_statistics["SpentReadingMinutes"])
                 statistics.remaining_time_minutes = int(request_statistics["RemainingTimeMinutes"])
+                statistics.last_modified = request_lm
                 update_results_response["StatisticsResult"] = {"Result": "Success"}
 
             request_status_info = request_reading_state["StatusInfo"]
             if request_status_info:
                 book_read = kobo_reading_state.book_read_link
                 new_book_read_status = get_ub_read_status(request_status_info["Status"])
-                if new_book_read_status == ub.ReadBook.STATUS_IN_PROGRESS \
-                        and new_book_read_status != book_read.read_status:
-                    book_read.times_started_reading += 1
-                    book_read.last_time_started_reading = datetime.now(timezone.utc)
-                book_read.read_status = new_book_read_status
+                if new_book_read_status != book_read.read_status:
+                    if new_book_read_status == ub.ReadBook.STATUS_IN_PROGRESS:
+                        book_read.times_started_reading += 1
+                        book_read.last_time_started_reading = datetime.now(timezone.utc)
+                    book_read.read_status = new_book_read_status
+                    book_read.last_modified = request_lm
                 update_results_response["StatusInfoResult"] = {"Result": "Success"}
         except (KeyError, TypeError, ValueError, StatementError):
             log.debug("Received malformed v1/library/<book_uuid>/state request.")

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1114,14 +1114,21 @@ def get_statistics_response(statistics):
     return resp
 
 
+def _clean_progress(value):
+    """Return progress as int if it's a whole number, preserving Kobo device expectations."""
+    if value is not None and value == int(value):
+        return int(value)
+    return value
+
+
 def get_current_bookmark_response(current_bookmark):
     resp = {
         "LastModified": convert_to_kobo_timestamp_string(current_bookmark.last_modified),
     }
     if current_bookmark.progress_percent:
-        resp["ProgressPercent"] = current_bookmark.progress_percent
+        resp["ProgressPercent"] = _clean_progress(current_bookmark.progress_percent)
     if current_bookmark.content_source_progress_percent:
-        resp["ContentSourceProgressPercent"] = current_bookmark.content_source_progress_percent
+        resp["ContentSourceProgressPercent"] = _clean_progress(current_bookmark.content_source_progress_percent)
     if current_bookmark.location_value:
         resp["Location"] = {
             "Value": current_bookmark.location_value,

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1000,6 +1000,8 @@ def HandleStateRequest(book_uuid):
 
         ub.session.merge(kobo_reading_state)
         ub.session_commit()
+        update_results_response["LastModified"] = convert_to_kobo_timestamp_string(kobo_reading_state.last_modified)
+        update_results_response["PriorityTimestamp"] = convert_to_kobo_timestamp_string(kobo_reading_state.priority_timestamp)
         return jsonify({
             "RequestResult": "Success",
             "UpdateResults": [update_results_response],

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1000,8 +1000,6 @@ def HandleStateRequest(book_uuid):
 
         ub.session.merge(kobo_reading_state)
         ub.session_commit()
-        update_results_response["LastModified"] = convert_to_kobo_timestamp_string(kobo_reading_state.last_modified)
-        update_results_response["PriorityTimestamp"] = convert_to_kobo_timestamp_string(kobo_reading_state.priority_timestamp)
         return jsonify({
             "RequestResult": "Success",
             "UpdateResults": [update_results_response],

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1125,9 +1125,9 @@ def get_current_bookmark_response(current_bookmark):
     resp = {
         "LastModified": convert_to_kobo_timestamp_string(current_bookmark.last_modified),
     }
-    if current_bookmark.progress_percent:
+    if current_bookmark.progress_percent is not None:
         resp["ProgressPercent"] = _clean_progress(current_bookmark.progress_percent)
-    if current_bookmark.content_source_progress_percent:
+    if current_bookmark.content_source_progress_percent is not None:
         resp["ContentSourceProgressPercent"] = _clean_progress(current_bookmark.content_source_progress_percent)
     if current_bookmark.location_value:
         resp["Location"] = {

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -655,7 +655,7 @@ class KoboReadingState(Base):
     user_id = Column(Integer, ForeignKey('user.id'))
     book_id = Column(Integer)
     last_modified = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
-    priority_timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    priority_timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     current_bookmark = relationship("KoboBookmark", uselist=False, backref="kobo_reading_state", cascade="all, delete")
     statistics = relationship("KoboStatistics", uselist=False, backref="kobo_reading_state", cascade="all, delete")
 
@@ -749,7 +749,9 @@ def receive_before_flush(session, flush_context, instances):
     for change in itertools.chain(session.new, session.dirty):
         if isinstance(change, (ReadBook, KoboStatistics, KoboBookmark)):
             if change.kobo_reading_state:
-                change.kobo_reading_state.last_modified = datetime.now(timezone.utc)
+                now = datetime.now(timezone.utc)
+                change.kobo_reading_state.last_modified = now
+                change.kobo_reading_state.priority_timestamp = now
     # Maintain the last_modified_bit for the Shelf table.
     for change in itertools.chain(session.new, session.deleted):
         if isinstance(change, BookShelf):

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -13,7 +13,7 @@ import time
 from datetime import datetime, timezone, timedelta
 import itertools
 import uuid
-from flask import session as flask_session
+from flask import session as flask_session, has_request_context, g
 from binascii import hexlify
 
 from .cw_login import AnonymousUserMixin, current_user
@@ -749,9 +749,11 @@ def receive_before_flush(session, flush_context, instances):
     for change in itertools.chain(session.new, session.dirty):
         if isinstance(change, (ReadBook, KoboStatistics, KoboBookmark)):
             if change.kobo_reading_state:
-                now = datetime.now(timezone.utc)
-                change.kobo_reading_state.last_modified = now
-                change.kobo_reading_state.priority_timestamp = now
+                ts = (g.kobo_reading_state_lm
+                      if has_request_context() and getattr(g, 'kobo_reading_state_lm', None)
+                      else datetime.now(timezone.utc))
+                change.kobo_reading_state.last_modified = ts
+                change.kobo_reading_state.priority_timestamp = ts
     # Maintain the last_modified_bit for the Shelf table.
     for change in itertools.chain(session.new, session.deleted):
         if isinstance(change, BookShelf):

--- a/tests/unit/test_kobo_progress_popup_fix.py
+++ b/tests/unit/test_kobo_progress_popup_fix.py
@@ -126,31 +126,83 @@ class TestCurrentBookmarkResponseShape:
 
 
 @pytest.mark.unit
-class TestHandleStateRequestPutResponse:
-    """The PUT /v1/library/<uuid>/state handler must echo the freshly
-    bumped LastModified + PriorityTimestamp back to the device.
-    Without this the device's cached timestamps lag the server's, so
-    the next GET returns 'newer' values the device hasn't seen yet
-    and triggers the 'Return to last page read?' popup after sleep
-    /wake. Pinned via source inspection because the function relies on
-    Flask request/current_user context that isn't available at unit
-    scope."""
+class TestHandleStateRequestUsesDeviceLastModified:
+    """The popup-loop root cause is timestamp drift between the
+    server's PT and what the device last saw. Janeczku PR #3601
+    (commit 2d4ca23d) tried echoing PT/LM back in the PUT response,
+    but devices don't persist timestamps from PUT responses -- the
+    auto-sleep variant of the popup persisted. The real fix
+    (janeczku PR #3607) is to use the device's own LastModified for
+    both PT and LM, mirroring what official Kobo cloud does so the
+    next GET returns a timestamp the device already knows.
 
-    def test_priority_timestamp_added_to_put_response(self):
+    Pinned via source inspection because HandleStateRequest needs
+    Flask request/current_user context not available at unit scope.
+    """
+
+    def test_reads_last_modified_from_request_body(self):
         from cps.kobo import HandleStateRequest
         src = inspect.getsource(HandleStateRequest)
-        assert 'update_results_response["PriorityTimestamp"]' in src, (
-            "PUT /state response must include PriorityTimestamp -- "
-            "without it Kobo devices show spurious 'Return to last "
-            "page read?' popup after auto-sleep/wake. See "
-            "janeczku/calibre-web#3601."
+        assert 'request_reading_state.get("LastModified")' in src, (
+            "PUT handler must read LastModified from the request "
+            "body so the saved timestamps match what the device "
+            "expects to see back. See janeczku/calibre-web#3607."
         )
 
-    def test_last_modified_added_to_put_response(self):
+    def test_threads_request_lm_into_flask_g(self):
         from cps.kobo import HandleStateRequest
         src = inspect.getsource(HandleStateRequest)
-        assert 'update_results_response["LastModified"]' in src, (
-            "PUT /state response must include LastModified so the "
-            "device's cached timestamp matches the server. See "
-            "janeczku/calibre-web#3601."
+        assert "g.kobo_reading_state_lm = request_lm" in src, (
+            "PUT handler must publish request_lm via Flask g so the "
+            "before_flush hook in cps/ub.py can apply the device's "
+            "timestamp to the parent KoboReadingState row instead of "
+            "stamping datetime.now(). See janeczku/calibre-web#3607."
+        )
+
+    def test_does_not_echo_lm_pt_in_put_response(self):
+        """The previous attempt (commit 2d4ca23d / janeczku#3601)
+        added LastModified + PriorityTimestamp to the PUT response.
+        Devices don't persist them from PUT responses -- the data
+        was dead code. PR #3607 reverts that. If a future refactor
+        re-adds those keys, the popup-loop debugging cycle starts
+        over. Pin the absence."""
+        from cps.kobo import HandleStateRequest
+        src = inspect.getsource(HandleStateRequest)
+        assert 'update_results_response["PriorityTimestamp"]' not in src, (
+            "PUT response must NOT include PriorityTimestamp -- "
+            "Kobo devices ignore timestamps from PUT responses, the "
+            "data is dead code, and including it leaves the door "
+            "open to inconsistent server timestamps causing the "
+            "popup. See janeczku/calibre-web#3607."
+        )
+        assert 'update_results_response["LastModified"]' not in src
+
+    def test_priority_timestamp_column_has_no_onupdate(self):
+        """The popup root cause: priority_timestamp had its own
+        onupdate=datetime.now() that ran independently of last_modified.
+        PT and LM could drift, and PT-newer-than-device's-cached-PT
+        triggers the popup. Fix removes the onupdate; the before_flush
+        hook now sets PT and LM together to the device's own LM."""
+        from cps.ub import KoboReadingState
+        col = KoboReadingState.__table__.columns["priority_timestamp"]
+        assert col.onupdate is None, (
+            "priority_timestamp must NOT have onupdate -- if it does, "
+            "PT advances on every flush regardless of what the device "
+            "expects, and the 'Sync to last page read' popup returns. "
+            "See janeczku/calibre-web#3607."
+        )
+
+    def test_before_flush_uses_request_lm_when_available(self):
+        from cps import ub
+        src = inspect.getsource(ub.receive_before_flush)
+        assert "g.kobo_reading_state_lm" in src, (
+            "before_flush hook must check Flask g.kobo_reading_state_lm "
+            "(set by HandleStateRequest from the device's PUT body) "
+            "before falling back to datetime.now(). See "
+            "janeczku/calibre-web#3607."
+        )
+        assert "change.kobo_reading_state.priority_timestamp = ts" in src, (
+            "before_flush hook must explicitly set priority_timestamp "
+            "(not just last_modified) so PT and LM stay in lock-step. "
+            "See janeczku/calibre-web#3607."
         )

--- a/tests/unit/test_kobo_progress_popup_fix.py
+++ b/tests/unit/test_kobo_progress_popup_fix.py
@@ -1,0 +1,156 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests pinning the three janeczku/calibre-web Kobo
+reading-state fixes that resolve the spurious "Sync to last page read"
+popup loop. Without them, Kobo devices repeatedly prompt users to
+re-sync their position and snap to a stale value, making it look like
+progress was reset.
+
+Upstream PRs:
+- janeczku/calibre-web#3585 (commits d229f711, a4bf0285) -- float/int
+  mismatch + truthy-check on ProgressPercent=0
+- janeczku/calibre-web#3601 (commit 2d4ca23d) -- PUT /state response
+  must echo PriorityTimestamp/LastModified
+"""
+
+import inspect
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.unit
+class TestCleanProgressHelper:
+    """`_clean_progress` collapses whole-number floats to int so the
+    JSON wire value matches what the Kobo device sent. Without this
+    the device sees its own ``33`` echoed back as ``33.0`` and treats
+    that as a divergent position."""
+
+    def test_whole_number_float_becomes_int(self):
+        from cps.kobo import _clean_progress
+        assert _clean_progress(33.0) == 33
+        assert isinstance(_clean_progress(33.0), int)
+
+    def test_zero_float_becomes_int_zero(self):
+        from cps.kobo import _clean_progress
+        result = _clean_progress(0.0)
+        assert result == 0
+        assert isinstance(result, int)
+
+    def test_fractional_float_preserved(self):
+        from cps.kobo import _clean_progress
+        result = _clean_progress(33.5)
+        assert result == 33.5
+        assert isinstance(result, float)
+
+    def test_none_passes_through(self):
+        from cps.kobo import _clean_progress
+        assert _clean_progress(None) is None
+
+
+def _make_bookmark(progress_percent=None,
+                   content_source_progress_percent=None,
+                   location_value=None,
+                   location_type=None,
+                   location_source=None,
+                   last_modified=None):
+    return SimpleNamespace(
+        progress_percent=progress_percent,
+        content_source_progress_percent=content_source_progress_percent,
+        location_value=location_value,
+        location_type=location_type,
+        location_source=location_source,
+        last_modified=last_modified or datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.unit
+class TestCurrentBookmarkResponseShape:
+    """`get_current_bookmark_response` is what the Kobo device reads on
+    GET /v1/library/<uuid>/state and on the embedded ReadingState in
+    sync responses. The response must always include ProgressPercent
+    when a bookmark exists -- including when progress is exactly 0 --
+    or the device interprets the omission as 'no synced position' and
+    fires the 'Sync to last page read?' popup."""
+
+    def test_progress_percent_present_when_zero(self):
+        """Pre-fix: ``if current_bookmark.progress_percent:`` dropped
+        the field for 0.0. Particularly bad for comics/manga where
+        ProgressPercent stays 0 and ContentSourceProgressPercent
+        carries the page-by-page progress."""
+        from cps.kobo import get_current_bookmark_response
+        resp = get_current_bookmark_response(
+            _make_bookmark(progress_percent=0.0,
+                           content_source_progress_percent=0.0)
+        )
+        assert "ProgressPercent" in resp
+        assert resp["ProgressPercent"] == 0
+        assert "ContentSourceProgressPercent" in resp
+        assert resp["ContentSourceProgressPercent"] == 0
+
+    def test_progress_percent_omitted_only_when_none(self):
+        from cps.kobo import get_current_bookmark_response
+        resp = get_current_bookmark_response(
+            _make_bookmark(progress_percent=None,
+                           content_source_progress_percent=None)
+        )
+        assert "ProgressPercent" not in resp
+        assert "ContentSourceProgressPercent" not in resp
+
+    def test_whole_number_progress_returned_as_int(self):
+        """Pre-fix: SQLite Float column made 33 round-trip as 33.0,
+        which the Kobo treats as a different position from its locally
+        cached integer 33 and prompts the user."""
+        from cps.kobo import get_current_bookmark_response
+        resp = get_current_bookmark_response(
+            _make_bookmark(progress_percent=33.0,
+                           content_source_progress_percent=42.0)
+        )
+        assert resp["ProgressPercent"] == 33
+        assert isinstance(resp["ProgressPercent"], int)
+        assert resp["ContentSourceProgressPercent"] == 42
+        assert isinstance(resp["ContentSourceProgressPercent"], int)
+
+    def test_fractional_progress_preserved(self):
+        from cps.kobo import get_current_bookmark_response
+        resp = get_current_bookmark_response(
+            _make_bookmark(progress_percent=33.5)
+        )
+        assert resp["ProgressPercent"] == 33.5
+        assert isinstance(resp["ProgressPercent"], float)
+
+
+@pytest.mark.unit
+class TestHandleStateRequestPutResponse:
+    """The PUT /v1/library/<uuid>/state handler must echo the freshly
+    bumped LastModified + PriorityTimestamp back to the device.
+    Without this the device's cached timestamps lag the server's, so
+    the next GET returns 'newer' values the device hasn't seen yet
+    and triggers the 'Return to last page read?' popup after sleep
+    /wake. Pinned via source inspection because the function relies on
+    Flask request/current_user context that isn't available at unit
+    scope."""
+
+    def test_priority_timestamp_added_to_put_response(self):
+        from cps.kobo import HandleStateRequest
+        src = inspect.getsource(HandleStateRequest)
+        assert 'update_results_response["PriorityTimestamp"]' in src, (
+            "PUT /state response must include PriorityTimestamp -- "
+            "without it Kobo devices show spurious 'Return to last "
+            "page read?' popup after auto-sleep/wake. See "
+            "janeczku/calibre-web#3601."
+        )
+
+    def test_last_modified_added_to_put_response(self):
+        from cps.kobo import HandleStateRequest
+        src = inspect.getsource(HandleStateRequest)
+        assert 'update_results_response["LastModified"]' in src, (
+            "PUT /state response must include LastModified so the "
+            "device's cached timestamp matches the server. See "
+            "janeczku/calibre-web#3601."
+        )


### PR DESCRIPTION
## What users see

When you put down a Kobo and pick it up later — or wake it from auto-sleep — the device shows the *Sync to last page read?* / *Return to last page read?* popup. Both options leave the device in a confused state, and on auto-sleep wake the popup re-fires repeatedly. It feels like progress was reset, or like the bookmark belongs to someone else's session. Comics and manga (where the chapter pager carries progress while the book progress stays at 0%) are hit hardest.

## Root cause (full)

The popup decision happens on **GET** `/v1/library/<uuid>/state`. The device caches the `PriorityTimestamp` from each GET. If the next GET returns a newer PT than its last cached one, the device assumes another client made changes and shows the popup. Three independent bugs in `cps/kobo.py` + `cps/ub.py` produced spurious "newer PT" answers:

1. **Float/int mismatch on `ProgressPercent`** — Kobo PUTs `33` (integer); SQLite Float column returns `33.0`. The device treats `33` ≠ `33.0` as a divergent position.
2. **Truthy check drops `ProgressPercent: 0`** — `if current_bookmark.progress_percent:` silently omits the field. Particularly bad for comics/manga.
3. **`priority_timestamp` advanced on every PUT via SQLAlchemy `onupdate=datetime.now()`** — even when the data didn't change, the next GET returned a server-generated PT the device had never seen. **This is the auto-sleep variant** (server stamps PT on PUT, device wakes, GET returns the new PT, popup fires).

A naive earlier fix (echoing PT/LM in the PUT response) doesn't work — Kobo devices don't persist reading-state timestamps from PUT responses. The real fix mirrors what official Kobo cloud does: use the **device's own** `LastModified` as both PT and LM.

## Fix

Backports four janeczku/calibre-web upstream commits — none in CWA upstream either:

- `d229f711` (PR #3585) — `_clean_progress` helper collapses whole-number floats to int
- `a4bf0285` (PR #3585) — `is not None` check instead of truthy
- `2d410308` + `0ab118a7` (PR #3607, currently OPEN upstream — author has run it locally for weeks without the popup)
  - Removes `onupdate=datetime.now()` from `priority_timestamp`
  - Reads `LastModified` from the PUT request body, threads it via Flask `g.kobo_reading_state_lm` into the `before_flush` hook
  - Applies request-LM to bookmark / statistics / book_read sub-rows
  - Reverts the dead `2d4ca23d` PUT response data

Original authors: @leahjessie (PR #3585 + #3607) and @jarynclouatre (PR #3601, now superseded by #3607). Cherry-picked with `-x`.

## Regression coverage

`tests/unit/test_kobo_progress_popup_fix.py` — 13 tests covering all the invariants:
- `_clean_progress` math (whole→int, fractional preserved, None passthrough)
- `get_current_bookmark_response` shape (ProgressPercent present at 0, int when whole, float when fractional)
- HandleStateRequest reads `LastModified` from request body and threads via Flask `g`
- PUT response no longer carries the dead LM/PT keys
- `priority_timestamp` column has no `onupdate`
- `before_flush` hook applies `g.kobo_reading_state_lm` to both LM and PT

71 passed across full kobo + kosync test suite — no regressions in adjacent paths.

## Tier

**safe-tier-2** — `cps/kobo.py` + `cps/ub.py`, ~30 LOC of code change, isolated to reading-state handling; no auth/csrf/session/admin/migration surface.

## Caveat

PR #3607 is OPEN upstream, not merged. Author has run it locally for weeks; the pattern matches what official Kobo cloud does. We're shipping ahead of upstream merge because: (a) the bug is real and affects users today, (b) the fix has soak time on a real device, (c) we control our release cadence and can iterate if upstream changes the approach.

## Test plan

- [x] `pytest tests/unit/test_kobo_progress_popup_fix.py` — 13 passed locally
- [x] `pytest tests/unit/test_kobo_*.py tests/unit/test_kosync_*.py tests/smoke/test_kobo_*.py` — 71 passed
- [ ] Maggie confirms the popup no longer fires after auto-sleep on her usual Safari + Kobo flow once this ships in a release

## Outreach (post-release)

Once a release containing this lands, the autopilot should post on janeczku/calibre-web#3596 (the open issue tracking the auto-sleep variant) and #3585 thread to point users at the working build.