### PR TITLE
fix(kobo): rewrite library_sync URL in init response so reverse-proxy users can sync

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1457,6 +1457,8 @@ def HandleInitRequest():
                                                                isGreyscale='false'))
         if config.config_hardcover_annotations_sync and bool(hardcover):
             kobo_resources["reading_services_host"] = calibre_web_url
+        kobo_resources["library_sync"] = calibre_web_url + url_for("kobo.HandleSyncRequest",
+                                                                    auth_token=kobo_auth.get_auth_token())
     else:
         kobo_resources["image_host"] = url_for("web.index", _external=True).strip("/")
         kobo_resources["image_url_quality_template"] = unquote(url_for("kobo.HandleCoverImageRequest",
@@ -1476,6 +1478,9 @@ def HandleInitRequest():
                                                                _external=True))
         if config.config_hardcover_annotations_sync and bool(hardcover):
             kobo_resources["reading_services_host"] = url_for("web.index", _external=True).strip("/")
+        kobo_resources["library_sync"] = url_for("kobo.HandleSyncRequest",
+                                                  auth_token=kobo_auth.get_auth_token(),
+                                                  _external=True)
 
     # When not proxying Kobo Store requests, point oauth_host to CWA and
     # serve dummy OAuth responses for unregistered devices.

--- a/tests/unit/test_kobo_init_library_sync_rewrite.py
+++ b/tests/unit/test_kobo_init_library_sync_rewrite.py
@@ -1,0 +1,65 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression test pinning janeczku/calibre-web#3585's sister fix:
+``library_sync`` must be rewritten to point at the local Flask app in
+``HandleInitRequest``. Without it, Kobo devices behind a reverse proxy
+fetch sync from ``storeapi.kobo.com`` instead of our server, and no
+books are delivered.
+
+Upstream commit: a9713bd4 (Noé Sierra-Velasquez).
+
+The ``HandleInitRequest`` function rewrites a handful of Kobo resource
+URLs to point at the local server. ``image_host`` and the cover
+templates were already rewritten; ``library_sync`` was left at its
+``storeapi.kobo.com`` default. The fix adds the rewrite in both
+branches (proxied vs unproxied request shape).
+
+Source-inspection rather than live HTTP because ``HandleInitRequest``
+needs a Flask request context, kobo auth headers, and config setup
+that aren't available at unit scope. The point of this test is to
+ensure the assignment lines aren't accidentally removed in a future
+refactor of the resource-rewriting block.
+"""
+
+import inspect
+
+import pytest
+
+
+@pytest.mark.unit
+class TestHandleInitLibrarySyncRewrite:
+    def test_proxied_branch_rewrites_library_sync(self):
+        from cps.kobo import HandleInitRequest
+        src = inspect.getsource(HandleInitRequest)
+        assert (
+            'kobo_resources["library_sync"] = calibre_web_url + url_for(' in src
+        ), (
+            "Proxied branch of HandleInitRequest must rewrite "
+            "library_sync to point at the local HandleSyncRequest. "
+            "Without it Kobo devices behind a reverse proxy hit "
+            "storeapi.kobo.com and no books sync. See "
+            "janeczku/calibre-web a9713bd4."
+        )
+
+    def test_unproxied_branch_rewrites_library_sync(self):
+        from cps.kobo import HandleInitRequest
+        src = inspect.getsource(HandleInitRequest)
+        assert 'kobo_resources["library_sync"] = url_for(' in src, (
+            "Unproxied branch of HandleInitRequest must rewrite "
+            "library_sync to a local _external=True URL. See "
+            "janeczku/calibre-web a9713bd4."
+        )
+
+    def test_default_resource_table_still_has_storeapi_default(self):
+        """The default resource table is intentionally seeded with the
+        upstream Kobo URL -- this is the value that HandleInitRequest
+        overrides. If the default disappears, the upstream Kobo store
+        passthrough breaks for users who enable kobo_proxy."""
+        from cps.kobo import NATIVE_KOBO_RESOURCES
+        defaults = NATIVE_KOBO_RESOURCES()
+        assert defaults.get("library_sync") == (
+            "https://storeapi.kobo.com/v1/library/sync"
+        )


### PR DESCRIPTION
## What users see

Kobo behind a reverse proxy (nginx, Caddy, Traefik — most self-hosted setups) initializes against your CWA and gets the resource URL list back. Image hosts and cover URLs are correctly rewritten to point at your local instance, but `library_sync` is left at its default `https://storeapi.kobo.com/v1/library/sync`. The device dutifully calls Kobo's actual store API for sync, which has no idea what's in your local library — so no books arrive on the device.

## Root cause

`HandleInitRequest` in `cps/kobo.py` rewrites a handful of resource URLs (`image_host`, `image_url_quality_template`, `image_url_template`, `reading_services_host`, `oauth_host`) but leaves `library_sync` alone. The default `NATIVE_KOBO_RESOURCES()` table seeds it with the upstream Kobo store URL.

## Fix

Backports janeczku/calibre-web commit `a9713bd4` (@rakjlou). Adds the `library_sync` rewrite in both branches of the proxy/unproxied conditional. Cherry-picked with `-x`; one trivial conflict from our nearby hardcover/oauth additions, resolved to keep both sides.

## Regression coverage

`tests/unit/test_kobo_init_library_sync_rewrite.py` — 3 source-inspection tests. 2 fail on `main` and pass on this branch (verified by reverting the file locally). Source-inspection rather than live HTTP because `HandleInitRequest` needs a Flask request context, kobo auth headers, and config setup that aren't available at unit scope; the goal is to ensure a future refactor of the resource-rewriting block can't accidentally drop the assignments.

## Tier

**safe-tier-2** — `cps/kobo.py` only, +5/-0 LOC, isolated to the init resource-rewriting block; no auth/csrf/session/admin/migration surface.

## Test plan

- [x] `pytest tests/unit/test_kobo_init_library_sync_rewrite.py` — 3 passed locally
- [x] Verified 2 of 3 tests fail on `main` (the third is the default-table sanity check, correct on both sides)
- [ ] Reverse-proxy users confirm sync works after release

## Outreach (post-release)

Once a release containing this lands, the autopilot can post on janeczku/calibre-web#3585 and adjacent threads to point CW reverse-proxy users at the build that has the fix today.