### PR TITLE
fix(kobo): three PUT /state robustness bugs found in subsystem audit

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -985,8 +985,12 @@ def HandleStateRequest(book_uuid):
             request_statistics = request_reading_state["Statistics"]
             if request_statistics:
                 statistics = kobo_reading_state.statistics
-                statistics.spent_reading_minutes = int(request_statistics["SpentReadingMinutes"])
-                statistics.remaining_time_minutes = int(request_statistics["RemainingTimeMinutes"])
+                spent = request_statistics.get("SpentReadingMinutes")
+                if spent is not None:
+                    statistics.spent_reading_minutes = int(spent)
+                remaining = request_statistics.get("RemainingTimeMinutes")
+                if remaining is not None:
+                    statistics.remaining_time_minutes = int(remaining)
                 statistics.last_modified = request_lm
                 update_results_response["StatisticsResult"] = {"Result": "Success"}
 
@@ -1006,7 +1010,8 @@ def HandleStateRequest(book_uuid):
             ub.session.rollback()
             abort(400, description="Malformed request data is missing 'ReadingStates' key")
 
-        push_reading_state_to_hardcover(current_user, book, request_bookmark['ProgressPercent'])
+        if request_bookmark and request_bookmark.get("ProgressPercent") is not None:
+            push_reading_state_to_hardcover(current_user, book, request_bookmark["ProgressPercent"])
 
         ub.session.merge(kobo_reading_state)
         ub.session_commit()
@@ -1117,9 +1122,9 @@ def get_statistics_response(statistics):
     resp = {
         "LastModified": convert_to_kobo_timestamp_string(statistics.last_modified),
     }
-    if statistics.spent_reading_minutes:
+    if statistics.spent_reading_minutes is not None:
         resp["SpentReadingMinutes"] = statistics.spent_reading_minutes
-    if statistics.remaining_time_minutes:
+    if statistics.remaining_time_minutes is not None:
         resp["RemainingTimeMinutes"] = statistics.remaining_time_minutes
     return resp
 

--- a/tests/unit/test_kobo_state_put_robustness.py
+++ b/tests/unit/test_kobo_state_put_robustness.py
@@ -1,0 +1,119 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for HandleStateRequest PUT-path robustness.
+
+Three independent bugs surfaced during a Kobo subsystem audit on
+2026-05-10. None are large but each maps to a real user-visible
+failure mode:
+
+1. push_reading_state_to_hardcover called outside the request_bookmark
+   guard -> 500 when Kobo PUTs a Statistics-only or StatusInfo-only
+   payload (which devices legitimately do during a reading session).
+2. request_statistics["RemainingTimeMinutes"] / ["SpentReadingMinutes"]
+   accessed unconditionally -> KeyError + entire PUT rolled back when
+   the device sends partial stats. The bookmark + status_info updates
+   in the same request are lost.
+3. get_statistics_response uses falsy-check on integer fields -> drops
+   legitimate 0 values from the response, same class of bug as the
+   ProgressPercent=0 fix in PR #126.
+
+These are pinned via source inspection because HandleStateRequest
+needs Flask request + auth context not available at unit scope.
+"""
+
+import inspect
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+
+def _make_statistics(spent_reading_minutes=None,
+                     remaining_time_minutes=None,
+                     last_modified=None):
+    return SimpleNamespace(
+        spent_reading_minutes=spent_reading_minutes,
+        remaining_time_minutes=remaining_time_minutes,
+        last_modified=last_modified or datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.unit
+class TestStatisticsResponseFalsyCheck:
+    def test_zero_spent_reading_minutes_present(self):
+        from cps.kobo import get_statistics_response
+        resp = get_statistics_response(_make_statistics(
+            spent_reading_minutes=0,
+            remaining_time_minutes=42,
+        ))
+        assert resp["SpentReadingMinutes"] == 0
+        assert resp["RemainingTimeMinutes"] == 42
+
+    def test_zero_remaining_time_minutes_present(self):
+        from cps.kobo import get_statistics_response
+        resp = get_statistics_response(_make_statistics(
+            spent_reading_minutes=15,
+            remaining_time_minutes=0,
+        ))
+        assert resp["SpentReadingMinutes"] == 15
+        assert resp["RemainingTimeMinutes"] == 0
+
+    def test_none_omitted_from_response(self):
+        from cps.kobo import get_statistics_response
+        resp = get_statistics_response(_make_statistics(
+            spent_reading_minutes=None,
+            remaining_time_minutes=None,
+        ))
+        assert "SpentReadingMinutes" not in resp
+        assert "RemainingTimeMinutes" not in resp
+
+
+@pytest.mark.unit
+class TestHandleStateRequestPartialStatistics:
+    """When the device sends Statistics with only one of the two
+    minute fields (which it legitimately does between full updates),
+    we must not crash. Pre-fix, missing RemainingTimeMinutes raised
+    KeyError, the outer try/except returned 400, and the bookmark +
+    status_info updates in the same PUT were lost."""
+
+    def test_uses_get_for_spent_reading_minutes(self):
+        from cps.kobo import HandleStateRequest
+        src = inspect.getsource(HandleStateRequest)
+        assert 'request_statistics.get("SpentReadingMinutes")' in src, (
+            "PUT handler must use .get() for SpentReadingMinutes so "
+            "partial-stats payloads don't roll back the whole PUT."
+        )
+
+    def test_uses_get_for_remaining_time_minutes(self):
+        from cps.kobo import HandleStateRequest
+        src = inspect.getsource(HandleStateRequest)
+        assert 'request_statistics.get("RemainingTimeMinutes")' in src, (
+            "PUT handler must use .get() for RemainingTimeMinutes so "
+            "partial-stats payloads don't roll back the whole PUT."
+        )
+
+
+@pytest.mark.unit
+class TestPushReadingStateToHardcoverGuard:
+    """push_reading_state_to_hardcover used to be called
+    unconditionally with request_bookmark['ProgressPercent']. If the
+    device PUTs Statistics-only or StatusInfo-only payloads (no
+    CurrentBookmark), request_bookmark is None and the call raises
+    TypeError -> 500 to the device, which then retries forever.
+    Even when CurrentBookmark IS present, it might omit ProgressPercent
+    -> KeyError, same crash."""
+
+    def test_call_is_guarded_by_request_bookmark_truthy(self):
+        from cps.kobo import HandleStateRequest
+        src = inspect.getsource(HandleStateRequest)
+        assert (
+            'if request_bookmark and request_bookmark.get("ProgressPercent")'
+            in src
+        ), (
+            "push_reading_state_to_hardcover call must be guarded "
+            "behind `if request_bookmark and request_bookmark.get(...)` "
+            "so Statistics-only and StatusInfo-only PUTs don't crash."
+        )


### PR DESCRIPTION
## What users see

Three independent failure modes in PUT `/v1/library/<uuid>/state`. Each maps to a real Kobo bug surfaced in the 2026-05-10 subsystem audit:

1. **500 on Statistics-only / StatusInfo-only PUTs** — Kobo legitimately PUTs without `CurrentBookmark`. The hardcover-push call accessed `request_bookmark['ProgressPercent']` outside the `if request_bookmark:` guard, returning 500. Device retries forever.
2. **Partial Statistics rolls back the whole PUT** — Kobo sends `Statistics` with only `SpentReadingMinutes` when the book is just opened. Unconditional `request_statistics["RemainingTimeMinutes"]` raised KeyError, returned 400, lost bookmark + status updates in the same PUT.
3. **Falsy check drops 0 stats from response** — `if statistics.spent_reading_minutes:` omitted the field at 0. Same class as the `ProgressPercent=0` fix in PR #126; missing field reads as divergent state to the device.

(Reopened from #128 — original PR was auto-closed when its stacked base was merged.)

## Fix

- Guard hardcover push with `if request_bookmark and request_bookmark.get("ProgressPercent") is not None:`
- Switch `request_statistics["..."]` to `.get(...)` with None-guards
- Switch `get_statistics_response` falsy checks to `is not None`

## Regression coverage

`tests/unit/test_kobo_state_put_robustness.py` — 6 tests. 5 fail on baseline, all 6 pass on this branch.

## Tier

**safe-tier-2** — `cps/kobo.py` only, +9/-4 LOC.

## Test plan

- [x] `pytest tests/unit/test_kobo_state_put_robustness.py` — 6 passed
- [x] `pytest tests/unit/test_kobo_*.py tests/unit/test_kosync_*.py tests/smoke/test_kobo_*.py` — 77 passed
- [x] Verified each bug-class test fails without the corresponding fix