### PR TITLE
fix(kobo): race-free reading state via UNIQUE constraint + atomic upsert

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1080,18 +1080,73 @@ def get_ub_read_status(kobo_read_status):
 
 
 def get_or_create_reading_state(book_id):
-    book_read = ub.session.query(ub.ReadBook).filter(ub.ReadBook.book_id == book_id,
-                                                     ub.ReadBook.user_id == int(current_user.id)).one_or_none()
-    if not book_read:
-        book_read = ub.ReadBook(user_id=current_user.id, book_id=book_id)
+    """Return the canonical KoboReadingState row for (current_user, book_id),
+    creating ReadBook + KoboReadingState (+ child rows) if missing.
+
+    Concurrency-safe: two simultaneous PUTs to /v1/library/<uuid>/state from
+    the same device — which legitimately happen on wake-from-sleep — would
+    otherwise race past the read-then-write check and both insert. The
+    audit-2026-05-11 fix:
+
+    1. Bottom-row creation uses INSERT ... ON CONFLICT(user_id, book_id) DO
+       NOTHING via the sqlite dialect insert, so duplicate inserts no-op
+       at the SQL layer.
+    2. The (user_id, book_id) UNIQUE index added in
+       ``migrate_kobo_unique_constraints`` backs the ON CONFLICT clause
+       and guarantees post-insert SELECT returns exactly one row.
+    3. We commit each create separately so a concurrent winner's insert
+       is visible to our subsequent SELECT — the ON CONFLICT path makes
+       this safe (no spurious IntegrityError to recover from).
+    """
+    from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+    user_id = int(current_user.id)
+
+    # 1. ReadBook (book_read_link). Atomic insert-if-missing.
+    rb_stmt = (
+        sqlite_insert(ub.ReadBook)
+        .values(user_id=user_id, book_id=book_id,
+                read_status=ub.ReadBook.STATUS_UNREAD,
+                times_started_reading=0)
+        .on_conflict_do_nothing(index_elements=["user_id", "book_id"])
+    )
+    ub.session.execute(rb_stmt)
+    ub.session.commit()
+    book_read = (
+        ub.session.query(ub.ReadBook)
+        .filter(ub.ReadBook.user_id == user_id,
+                ub.ReadBook.book_id == book_id)
+        .one()
+    )
+
+    # 2. KoboReadingState. Same pattern — but we also need the matching
+    #    KoboBookmark + KoboStatistics child rows. We create the parent
+    #    first, then attach children via the ORM if they're missing.
     if not book_read.kobo_reading_state:
-        kobo_reading_state = ub.KoboReadingState(user_id=book_read.user_id, book_id=book_id)
+        krs_stmt = (
+            sqlite_insert(ub.KoboReadingState)
+            .values(user_id=user_id, book_id=book_id)
+            .on_conflict_do_nothing(index_elements=["user_id", "book_id"])
+        )
+        ub.session.execute(krs_stmt)
+        ub.session.commit()
+        # Re-fetch via the relationship so SQLAlchemy's identity map picks
+        # up the row just inserted (possibly by us, possibly by a racing
+        # request). ``book_read.kobo_reading_state`` is a primaryjoin on
+        # (user_id, book_id), so the row will resolve automatically.
+        ub.session.refresh(book_read)
+
+    kobo_reading_state = book_read.kobo_reading_state
+
+    # 3. Child rows. These have an FK to KoboReadingState.id, so they
+    #    can be created via ORM safely (the parent row is now stable).
+    if kobo_reading_state.current_bookmark is None:
         kobo_reading_state.current_bookmark = ub.KoboBookmark()
+    if kobo_reading_state.statistics is None:
         kobo_reading_state.statistics = ub.KoboStatistics()
-        book_read.kobo_reading_state = kobo_reading_state
-    ub.session.add(book_read)
-    ub.session_commit()
-    return book_read.kobo_reading_state
+    ub.session.commit()
+
+    return kobo_reading_state
 
 
 def get_kobo_reading_state_response(book, kobo_reading_state):

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -572,6 +572,13 @@ class ReadBook(Base):
     last_time_started_reading = Column(DateTime, nullable=True)
     times_started_reading = Column(Integer, default=0, nullable=False)
 
+    # Audit 2026-05-11: enforce per-(user, book) uniqueness so concurrent
+    # Kobo PUTs can't produce duplicate rows. The Kobo state handler reads
+    # via .one_or_none(); duplicates would surface as MultipleResultsFound.
+    __table_args__ = (
+        UniqueConstraint('user_id', 'book_id', name='uq_book_read_link_user_book'),
+    )
+
 
 class Bookmark(Base):
     __tablename__ = 'bookmark'
@@ -611,6 +618,13 @@ class ArchivedBook(Base):
     is_archived = Column(Boolean, unique=False)
     last_modified = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
+    # Audit 2026-05-11: enforce per-(user, book) uniqueness. Without it two
+    # concurrent Kobo PUTs could create duplicate rows; later reads
+    # (which use .one_or_none()) raise MultipleResultsFound -> 500.
+    __table_args__ = (
+        UniqueConstraint('user_id', 'book_id', name='uq_archived_book_user_book'),
+    )
+
 
 class UserHiddenBook(Base):
     """Per-user hidden books — fork issue #64.
@@ -644,6 +658,10 @@ class KoboSyncedBooks(Base):
     user_id = Column(Integer, ForeignKey('user.id'))
     book_id = Column(Integer)
 
+    __table_args__ = (
+        UniqueConstraint('user_id', 'book_id', name='uq_kobo_synced_books_user_book'),
+    )
+
 # The Kobo ReadingState API keeps track of 4 timestamped entities:
 #   ReadingState, StatusInfo, Statistics, CurrentBookmark
 # Which we map to the following 4 tables:
@@ -658,6 +676,10 @@ class KoboReadingState(Base):
     priority_timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     current_bookmark = relationship("KoboBookmark", uselist=False, backref="kobo_reading_state", cascade="all, delete")
     statistics = relationship("KoboStatistics", uselist=False, backref="kobo_reading_state", cascade="all, delete")
+
+    __table_args__ = (
+        UniqueConstraint('user_id', 'book_id', name='uq_kobo_reading_state_user_book'),
+    )
 
 
 class KoboBookmark(Base):
@@ -1110,6 +1132,293 @@ def migrate_magic_shelf_table(engine, _session):
         _run_ddl_with_retry(engine, "ALTER TABLE magic_shelf ADD column 'kobo_sync' Boolean DEFAULT 0")
 
 
+def migrate_kobo_unique_constraints(engine, _session):
+    """One-time migration: dedupe + uniquify (user_id, book_id) on Kobo
+    state tables (audit 2026-05-11).
+
+    Race condition: ``get_or_create_reading_state`` does read-then-write
+    without locking, so two concurrent Kobo PUTs to /v1/library/<uuid>/state
+    can both miss the existing row and both insert. The next read returns
+    multiple rows -> ``.one_or_none()`` raises MultipleResultsFound ->
+    500 to the device, which then retries forever.
+
+    The fix has two parts:
+
+    1. This migration: dedupe any existing duplicates, then create a
+       UNIQUE index on (user_id, book_id) so the DB rejects future races.
+       Winner per duplicate group is the row with the newest
+       ``last_modified`` (so the user's most recent reading position
+       survives). Child rows (KoboBookmark, KoboStatistics) are
+       reparented to the winning KoboReadingState; orphaned child rows
+       (the losers' children) are deleted only after their non-null
+       fields are merged into the winner's children — newest LM wins
+       per child too.
+
+    2. ``get_or_create_reading_state`` switches to an atomic
+       INSERT ... ON CONFLICT(user_id, book_id) DO NOTHING upsert so
+       the race itself can't produce a duplicate even before the DB
+       constraint trips.
+
+    Idempotent: gated by a marker file in CONFIG_DIR/.cwa_migrations/
+    so it runs at most once per install.
+    """
+    from sqlalchemy import inspect as sa_inspect
+    marker_path = os.path.join(constants.CONFIG_DIR, ".cwa_migrations",
+                               "kobo_unique_constraints_v1")
+    if os.path.isfile(marker_path):
+        return
+
+    inspector = sa_inspect(engine)
+    tables_present = set(inspector.get_table_names())
+
+    # All four tables share the (user_id, book_id) shape. Dedupe rules
+    # differ slightly per table; see _dedupe_* helpers below.
+    plan = [
+        ("kobo_reading_state", _dedupe_kobo_reading_state,
+         "uq_kobo_reading_state_user_book"),
+        ("book_read_link", _dedupe_book_read_link,
+         "uq_book_read_link_user_book"),
+        ("kobo_synced_books", _dedupe_kobo_synced_books,
+         "uq_kobo_synced_books_user_book"),
+        ("archived_book", _dedupe_archived_book,
+         "uq_archived_book_user_book"),
+    ]
+
+    try:
+        for table_name, dedupe_fn, index_name in plan:
+            if table_name not in tables_present:
+                continue
+            removed = dedupe_fn(_session)
+            if removed:
+                log.info(
+                    "[kobo-unique-migration] %s: merged %d duplicate row(s)",
+                    table_name, removed,
+                )
+        _session.commit()
+    except Exception as e:
+        log.error("[kobo-unique-migration] dedupe failed: %s", e)
+        _safe_session_rollback(_session, "kobo_unique_constraints/dedupe")
+        return
+
+    # Now that duplicates are gone, create the UNIQUE indexes. SQLite
+    # doesn't support ALTER TABLE ADD CONSTRAINT; a UNIQUE INDEX has
+    # equivalent semantics for INSERT ... ON CONFLICT routing and is
+    # what SQLAlchemy's UniqueConstraint generates on new installs.
+    ddl = [
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_kobo_reading_state_user_book "
+        "ON kobo_reading_state(user_id, book_id)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_book_read_link_user_book "
+        "ON book_read_link(user_id, book_id)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_kobo_synced_books_user_book "
+        "ON kobo_synced_books(user_id, book_id)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_archived_book_user_book "
+        "ON archived_book(user_id, book_id)",
+    ]
+    # Skip statements for tables that don't exist yet (fresh install path
+    # where add_missing_tables hasn't run create_all on a particular
+    # table — defensive only; current order has add_missing_tables first).
+    ddl = [s for s in ddl
+           if s.split(" ON ")[1].split("(")[0] in tables_present]
+    try:
+        _run_ddl_with_retry(engine, ddl)
+    except Exception as e:
+        log.error("[kobo-unique-migration] index creation failed: %s", e)
+        return
+
+    try:
+        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+        with open(marker_path, "w", encoding="utf-8") as fh:
+            fh.write(datetime.now(timezone.utc).isoformat())
+    except OSError as e:
+        # Marker is a perf optimization, not correctness — the migration
+        # is idempotent because the indexes already exist and dedupe is
+        # a no-op on a clean DB. Log but continue.
+        log.warning(
+            "[kobo-unique-migration] could not write marker %s: %s",
+            marker_path, e,
+        )
+
+
+def _dedupe_kobo_reading_state(_session):
+    """Pick winner per (user, book): newest last_modified. Reparent
+    KoboBookmark + KoboStatistics children to the winner, merging
+    non-null fields from losers' children (newest LM wins per child).
+    Returns count of losing rows deleted.
+    """
+    dup_groups = _find_duplicate_groups(_session, KoboReadingState)
+    deleted = 0
+    for (user_id, book_id), rows in dup_groups.items():
+        # Sort by last_modified DESC, NULL last; then id DESC as tiebreak.
+        rows.sort(
+            key=lambda r: (
+                r.last_modified or datetime.min.replace(tzinfo=timezone.utc),
+                r.id,
+            ),
+            reverse=True,
+        )
+        winner, losers = rows[0], rows[1:]
+        for loser in losers:
+            _merge_kobo_bookmark(_session, winner, loser)
+            _merge_kobo_statistics(_session, winner, loser)
+            _session.delete(loser)
+            deleted += 1
+    if deleted:
+        _session.flush()
+    return deleted
+
+
+def _merge_kobo_bookmark(_session, winner, loser):
+    """Merge loser.current_bookmark into winner.current_bookmark.
+    Newest last_modified wins per field; non-null beats null when LM
+    is missing. Loser's bookmark is left dangling (will be cascade-
+    deleted when loser KoboReadingState is deleted).
+    """
+    if loser.current_bookmark is None:
+        return
+    if winner.current_bookmark is None:
+        # Steal the row outright. Re-point its FK.
+        loser.current_bookmark.kobo_reading_state_id = winner.id
+        winner.current_bookmark = loser.current_bookmark
+        loser.current_bookmark = None
+        return
+    w, l = winner.current_bookmark, loser.current_bookmark
+    if _loser_wins_lm(l, w):
+        for attr in ("location_source", "location_type", "location_value",
+                     "progress_percent", "content_source_progress_percent",
+                     "last_modified"):
+            setattr(w, attr, getattr(l, attr))
+    else:
+        # Even if winner's bookmark is newer overall, prefer non-null
+        # losing fields if the winner has nulls there (defensive).
+        for attr in ("location_source", "location_type", "location_value",
+                     "progress_percent", "content_source_progress_percent"):
+            if getattr(w, attr) is None and getattr(l, attr) is not None:
+                setattr(w, attr, getattr(l, attr))
+
+
+def _merge_kobo_statistics(_session, winner, loser):
+    if loser.statistics is None:
+        return
+    if winner.statistics is None:
+        loser.statistics.kobo_reading_state_id = winner.id
+        winner.statistics = loser.statistics
+        loser.statistics = None
+        return
+    w, l = winner.statistics, loser.statistics
+    if _loser_wins_lm(l, w):
+        for attr in ("remaining_time_minutes", "spent_reading_minutes",
+                     "last_modified"):
+            setattr(w, attr, getattr(l, attr))
+    else:
+        for attr in ("remaining_time_minutes", "spent_reading_minutes"):
+            if getattr(w, attr) is None and getattr(l, attr) is not None:
+                setattr(w, attr, getattr(l, attr))
+
+
+def _dedupe_book_read_link(_session):
+    """ReadBook winner: prefer rows with the highest read_status (FINISHED
+    > IN_PROGRESS > UNREAD), tiebreak by newest last_modified, then by
+    highest times_started_reading. Sum times_started_reading from losers
+    into the winner so the user doesn't lose their read-counter total.
+    """
+    dup_groups = _find_duplicate_groups(_session, ReadBook)
+    deleted = 0
+    for (user_id, book_id), rows in dup_groups.items():
+        rows.sort(
+            key=lambda r: (
+                r.read_status or 0,
+                r.last_modified or datetime.min.replace(tzinfo=timezone.utc),
+                r.times_started_reading or 0,
+                r.id,
+            ),
+            reverse=True,
+        )
+        winner, losers = rows[0], rows[1:]
+        for loser in losers:
+            winner.times_started_reading = (
+                (winner.times_started_reading or 0)
+                + (loser.times_started_reading or 0)
+            )
+            if (loser.last_time_started_reading is not None and
+                (winner.last_time_started_reading is None or
+                 loser.last_time_started_reading > winner.last_time_started_reading)):
+                winner.last_time_started_reading = loser.last_time_started_reading
+            _session.delete(loser)
+            deleted += 1
+    if deleted:
+        _session.flush()
+    return deleted
+
+
+def _dedupe_kobo_synced_books(_session):
+    """No payload to merge — just keep one row (lowest id) per (user, book)."""
+    dup_groups = _find_duplicate_groups(_session, KoboSyncedBooks)
+    deleted = 0
+    for (user_id, book_id), rows in dup_groups.items():
+        rows.sort(key=lambda r: r.id)
+        for loser in rows[1:]:
+            _session.delete(loser)
+            deleted += 1
+    if deleted:
+        _session.flush()
+    return deleted
+
+
+def _dedupe_archived_book(_session):
+    """ArchivedBook winner: is_archived=True takes precedence over False
+    (archived is the more-recent semantic signal), then newest LM, then
+    highest id.
+    """
+    dup_groups = _find_duplicate_groups(_session, ArchivedBook)
+    deleted = 0
+    for (user_id, book_id), rows in dup_groups.items():
+        rows.sort(
+            key=lambda r: (
+                1 if r.is_archived else 0,
+                r.last_modified or datetime.min.replace(tzinfo=timezone.utc),
+                r.id,
+            ),
+            reverse=True,
+        )
+        for loser in rows[1:]:
+            _session.delete(loser)
+            deleted += 1
+    if deleted:
+        _session.flush()
+    return deleted
+
+
+def _find_duplicate_groups(_session, model):
+    """Return dict {(user_id, book_id): [rows]} for groups with size >= 2."""
+    from sqlalchemy import func as sa_func
+    dup_keys = (
+        _session.query(model.user_id, model.book_id)
+        .group_by(model.user_id, model.book_id)
+        .having(sa_func.count(model.id) > 1)
+        .all()
+    )
+    groups = {}
+    for user_id, book_id in dup_keys:
+        rows = (
+            _session.query(model)
+            .filter(model.user_id == user_id, model.book_id == book_id)
+            .all()
+        )
+        groups[(user_id, book_id)] = rows
+    return groups
+
+
+def _loser_wins_lm(loser, winner):
+    """True if loser.last_modified > winner.last_modified (strictly newer)."""
+    lo = getattr(loser, "last_modified", None)
+    wn = getattr(winner, "last_modified", None)
+    if lo is None:
+        return False
+    if wn is None:
+        return True
+    return lo > wn
+
+
 # Migrate database to current version, has to be updated after every database change. Currently migration from
 # maybe 4/5 versions back to current should work.
 # Migration is done by checking if relevant columns are existing, and then adding rows with SQL commands
@@ -1122,6 +1431,7 @@ def migrate_Database(_session):
     migrate_oauth_provider_table(engine, _session)
     migrate_config_table(engine, _session)
     migrate_magic_shelf_table(engine, _session)
+    migrate_kobo_unique_constraints(engine, _session)
 
     # Ensure progress syncing tables in app.db (user-related tables)
     from .progress_syncing.models import ensure_app_db_tables

--- a/tests/unit/test_kobo_state_concurrent_insert.py
+++ b/tests/unit/test_kobo_state_concurrent_insert.py
@@ -1,0 +1,177 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Concurrent-insert test for the Kobo reading-state race fix
+(audit 2026-05-11, item B2).
+
+The audit's specific concern: two simultaneous PUTs to
+``/v1/library/<uuid>/state`` from the same Kobo can race past the
+read-then-write check in ``get_or_create_reading_state`` and both
+insert, leaving the DB with duplicate (user_id, book_id) rows that
+later 500 the device with MultipleResultsFound.
+
+This test simulates the race directly. It fires N threads at the
+SQLite ``INSERT ... ON CONFLICT(user_id, book_id) DO NOTHING`` upsert
+path used by the fix and asserts that exactly one row exists
+afterwards, regardless of contention.
+
+We don't try to drive a full Flask request stack here — the ORM
+operations are what the fix changed, and they're what we want
+pinned. The test goes through ``sqlite_insert(...).on_conflict_do_nothing(...)``
+on a real SQLite DB to validate end-to-end behavior, not a mock.
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+
+@pytest.fixture
+def shared_file_db(tmp_path):
+    """File-backed (not :memory:) SQLite engine — threading semantics
+    on :memory: are connection-local, defeating the race we want to
+    actually exercise."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker, scoped_session
+    from cps import ub
+
+    db_path = tmp_path / "race.db"
+    # check_same_thread=False is needed because we share the engine
+    # across threads. Each thread gets its own connection from the pool.
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    with engine.connect() as conn:
+        conn.exec_driver_sql("PRAGMA foreign_keys = OFF")
+        conn.exec_driver_sql("PRAGMA journal_mode = WAL")
+        conn.commit()
+
+    ub.Base.metadata.create_all(engine)
+
+    Session = scoped_session(sessionmaker(bind=engine, future=True))
+    yield Session, engine
+    Session.remove()
+
+
+@pytest.mark.unit
+class TestConcurrentReadingStateInsert:
+    def test_n_threads_produce_exactly_one_row(self, shared_file_db):
+        from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+        from cps.ub import KoboReadingState
+
+        Session, _ = shared_file_db
+        user_id, book_id = 1, 42
+        n_threads = 16
+
+        barrier = threading.Barrier(n_threads)
+
+        def worker():
+            session = Session()
+            try:
+                barrier.wait()  # release all threads simultaneously
+                stmt = (
+                    sqlite_insert(KoboReadingState)
+                    .values(user_id=user_id, book_id=book_id)
+                    .on_conflict_do_nothing(
+                        index_elements=["user_id", "book_id"],
+                    )
+                )
+                session.execute(stmt)
+                session.commit()
+            finally:
+                Session.remove()
+
+        with ThreadPoolExecutor(max_workers=n_threads) as pool:
+            futures = [pool.submit(worker) for _ in range(n_threads)]
+            for f in futures:
+                f.result()  # raises if any worker raised
+
+        # Critical: exactly one row, no duplicates, no exception swallowed.
+        check_session = Session()
+        rows = check_session.query(KoboReadingState).filter_by(
+            user_id=user_id, book_id=book_id,
+        ).all()
+        assert len(rows) == 1, (
+            f"Race produced {len(rows)} rows; on_conflict_do_nothing "
+            f"with the (user_id, book_id) UNIQUE index must collapse "
+            f"to exactly one."
+        )
+
+    def test_n_threads_produce_exactly_one_read_book_row(self, shared_file_db):
+        from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+        from cps.ub import ReadBook
+
+        Session, _ = shared_file_db
+        user_id, book_id = 7, 99
+        n_threads = 16
+        barrier = threading.Barrier(n_threads)
+
+        def worker():
+            session = Session()
+            try:
+                barrier.wait()
+                stmt = (
+                    sqlite_insert(ReadBook)
+                    .values(user_id=user_id, book_id=book_id,
+                            read_status=ReadBook.STATUS_UNREAD,
+                            times_started_reading=0)
+                    .on_conflict_do_nothing(
+                        index_elements=["user_id", "book_id"],
+                    )
+                )
+                session.execute(stmt)
+                session.commit()
+            finally:
+                Session.remove()
+
+        with ThreadPoolExecutor(max_workers=n_threads) as pool:
+            for f in [pool.submit(worker) for _ in range(n_threads)]:
+                f.result()
+
+        check_session = Session()
+        rows = check_session.query(ReadBook).filter_by(
+            user_id=user_id, book_id=book_id,
+        ).all()
+        assert len(rows) == 1
+
+    def test_different_books_dont_collide(self, shared_file_db):
+        from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+        from cps.ub import KoboReadingState
+
+        Session, _ = shared_file_db
+        # Each thread tries a different (user, book) pair.
+        n_threads = 8
+        barrier = threading.Barrier(n_threads)
+
+        def worker(thread_idx):
+            session = Session()
+            try:
+                barrier.wait()
+                stmt = (
+                    sqlite_insert(KoboReadingState)
+                    .values(user_id=1, book_id=thread_idx)
+                    .on_conflict_do_nothing(
+                        index_elements=["user_id", "book_id"],
+                    )
+                )
+                session.execute(stmt)
+                session.commit()
+            finally:
+                Session.remove()
+
+        with ThreadPoolExecutor(max_workers=n_threads) as pool:
+            for f in [pool.submit(worker, i) for i in range(n_threads)]:
+                f.result()
+
+        check_session = Session()
+        rows = check_session.query(KoboReadingState).filter_by(user_id=1).all()
+        assert len(rows) == n_threads, (
+            "Different (user, book) pairs must each create their own "
+            "row — the on-conflict path should only block exact key "
+            "collisions, not unrelated inserts."
+        )

--- a/tests/unit/test_kobo_state_unique_constraint.py
+++ b/tests/unit/test_kobo_state_unique_constraint.py
@@ -1,0 +1,537 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for the Kobo reading-state race condition (audit
+2026-05-11, item B2).
+
+Without (user_id, book_id) uniqueness on ReadBook / KoboReadingState /
+KoboSyncedBooks / ArchivedBook, two concurrent PUTs to
+``/v1/library/<uuid>/state`` from the same device could race past the
+read-then-write check in ``get_or_create_reading_state`` and both
+INSERT, producing duplicate rows. The next ``.one_or_none()`` then
+raises MultipleResultsFound -> 500 to the device.
+
+These tests cover:
+
+1. Model declarations carry UniqueConstraint on (user_id, book_id).
+2. The migration ``migrate_kobo_unique_constraints`` dedupes existing
+   duplicates (newest LM wins for KoboReadingState, status-level + LM
+   for ReadBook, archived-wins-LM-tiebreak for ArchivedBook), reparents
+   KoboReadingState's bookmark/statistics children, and writes a
+   marker file so it's idempotent.
+3. The UNIQUE INDEX is actually created and rejects duplicate INSERTs
+   from then on.
+4. Source invariants on ``get_or_create_reading_state``: uses
+   ``sqlite_insert(...).on_conflict_do_nothing(index_elements=...)``.
+
+Concurrency is tested in
+``test_kobo_state_concurrent_insert.py`` (separate file, threaded).
+"""
+
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+
+@pytest.mark.unit
+class TestModelConstraints:
+    def test_read_book_has_user_book_unique_constraint(self):
+        from cps.ub import ReadBook
+        names = [c.name for c in ReadBook.__table_args__ if hasattr(c, "name")]
+        assert "uq_book_read_link_user_book" in names
+
+    def test_kobo_reading_state_has_user_book_unique_constraint(self):
+        from cps.ub import KoboReadingState
+        names = [c.name for c in KoboReadingState.__table_args__ if hasattr(c, "name")]
+        assert "uq_kobo_reading_state_user_book" in names
+
+    def test_kobo_synced_books_has_user_book_unique_constraint(self):
+        from cps.ub import KoboSyncedBooks
+        names = [c.name for c in KoboSyncedBooks.__table_args__ if hasattr(c, "name")]
+        assert "uq_kobo_synced_books_user_book" in names
+
+    def test_archived_book_has_user_book_unique_constraint(self):
+        from cps.ub import ArchivedBook
+        names = [c.name for c in ArchivedBook.__table_args__ if hasattr(c, "name")]
+        assert "uq_archived_book_user_book" in names
+
+
+# ---------------------------------------------------------------------------
+# Fixtures for in-memory DB-driven tests.
+# We mount an in-memory SQLite DB using the ub.Base metadata. Each test gets
+# a fresh DB + session. We skip the User FK constraint by using PRAGMA
+# foreign_keys=OFF for the test DB — we only care about the (user, book)
+# uniqueness on the four target tables.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def memory_db_session():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from cps import ub
+
+    engine = create_engine("sqlite:///:memory:", future=True)
+    # FKs off so we don't have to insert a User row for every test.
+    with engine.connect() as conn:
+        conn.exec_driver_sql("PRAGMA foreign_keys = OFF")
+
+    ub.Base.metadata.create_all(engine)
+
+    Session = sessionmaker(bind=engine, future=True)
+    session = Session()
+    yield session, engine
+    session.close()
+
+
+@pytest.fixture
+def memory_db_session_no_unique_indexes(memory_db_session):
+    """Same fixture but rebuilds the four target tables without the
+    (user_id, book_id) UniqueConstraint, simulating a pre-migration DB.
+    Required for migration / dedupe tests because SQLite enforces table-
+    level UNIQUE constraints in CREATE TABLE — DROP INDEX alone won't
+    remove them.
+    """
+    session, engine = memory_db_session
+
+    # Drop and recreate each target table with the SAME columns but no
+    # unique constraint. Use raw SQL so we don't depend on ORM metadata.
+    pre_migration_schemas = {
+        "book_read_link": """
+            CREATE TABLE book_read_link (
+                id INTEGER PRIMARY KEY,
+                book_id INTEGER,
+                user_id INTEGER,
+                read_status INTEGER NOT NULL DEFAULT 0,
+                last_modified DATETIME,
+                last_time_started_reading DATETIME,
+                times_started_reading INTEGER NOT NULL DEFAULT 0
+            )
+        """,
+        "kobo_reading_state": """
+            CREATE TABLE kobo_reading_state (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                book_id INTEGER,
+                last_modified DATETIME,
+                priority_timestamp DATETIME
+            )
+        """,
+        "kobo_synced_books": """
+            CREATE TABLE kobo_synced_books (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                book_id INTEGER
+            )
+        """,
+        "archived_book": """
+            CREATE TABLE archived_book (
+                id INTEGER PRIMARY KEY,
+                user_id INTEGER,
+                book_id INTEGER,
+                is_archived BOOLEAN,
+                last_modified DATETIME
+            )
+        """,
+    }
+    with engine.connect() as conn:
+        for table, ddl in pre_migration_schemas.items():
+            conn.exec_driver_sql(f"DROP TABLE IF EXISTS {table}")
+            conn.exec_driver_sql(ddl)
+        conn.commit()
+    session.expire_all()
+    return session, engine
+
+
+@pytest.mark.unit
+class TestUniqueIndexEnforced:
+    def test_duplicate_kobo_reading_state_rejected(self, memory_db_session):
+        from sqlalchemy.exc import IntegrityError
+        from cps.ub import KoboReadingState
+
+        session, _ = memory_db_session
+        session.add(KoboReadingState(user_id=1, book_id=42))
+        session.commit()
+
+        session.add(KoboReadingState(user_id=1, book_id=42))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+    def test_duplicate_read_book_rejected(self, memory_db_session):
+        from sqlalchemy.exc import IntegrityError
+        from cps.ub import ReadBook
+
+        session, _ = memory_db_session
+        session.add(ReadBook(user_id=1, book_id=42))
+        session.commit()
+
+        session.add(ReadBook(user_id=1, book_id=42))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+    def test_duplicate_archived_book_rejected(self, memory_db_session):
+        from sqlalchemy.exc import IntegrityError
+        from cps.ub import ArchivedBook
+
+        session, _ = memory_db_session
+        session.add(ArchivedBook(user_id=1, book_id=42, is_archived=True))
+        session.commit()
+
+        session.add(ArchivedBook(user_id=1, book_id=42, is_archived=False))
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+    def test_different_user_or_book_still_allowed(self, memory_db_session):
+        from cps.ub import KoboReadingState
+        session, _ = memory_db_session
+        session.add(KoboReadingState(user_id=1, book_id=42))
+        session.add(KoboReadingState(user_id=1, book_id=43))
+        session.add(KoboReadingState(user_id=2, book_id=42))
+        session.commit()
+        assert session.query(KoboReadingState).count() == 3
+
+
+@pytest.mark.unit
+class TestDedupeKoboReadingState:
+    def test_newer_lm_wins(self, memory_db_session_no_unique_indexes):
+        from cps.ub import KoboReadingState, _dedupe_kobo_reading_state
+
+        session, _ = memory_db_session_no_unique_indexes
+        older = KoboReadingState(
+            user_id=1, book_id=42,
+            last_modified=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        newer = KoboReadingState(
+            user_id=1, book_id=42,
+            last_modified=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        )
+        session.add_all([older, newer])
+        session.commit()
+
+        removed = _dedupe_kobo_reading_state(session)
+        session.commit()
+        assert removed == 1
+        rows = session.query(KoboReadingState).filter_by(user_id=1, book_id=42).all()
+        assert len(rows) == 1
+        assert rows[0].last_modified == newer.last_modified
+
+    def test_null_lm_loses_to_dated(self, memory_db_session_no_unique_indexes):
+        from cps.ub import KoboReadingState, _dedupe_kobo_reading_state
+
+        session, _ = memory_db_session_no_unique_indexes
+        null_lm = KoboReadingState(user_id=1, book_id=42, last_modified=None)
+        dated = KoboReadingState(
+            user_id=1, book_id=42,
+            last_modified=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        )
+        session.add_all([null_lm, dated])
+        session.commit()
+
+        _dedupe_kobo_reading_state(session)
+        session.commit()
+        rows = session.query(KoboReadingState).filter_by(user_id=1, book_id=42).all()
+        assert len(rows) == 1
+        assert rows[0].last_modified is not None
+
+    def test_bookmark_children_merged_into_winner(self, memory_db_session_no_unique_indexes):
+        from cps.ub import (KoboReadingState, KoboBookmark,
+                            _dedupe_kobo_reading_state)
+
+        session, _ = memory_db_session_no_unique_indexes
+        older = KoboReadingState(
+            user_id=1, book_id=42,
+            last_modified=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        older_bm = KoboBookmark(
+            location_source="abc", location_type="KoboSpan",
+            location_value="(1)/4/2/4",
+            progress_percent=20.0,
+            last_modified=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        older.current_bookmark = older_bm
+        newer = KoboReadingState(
+            user_id=1, book_id=42,
+            last_modified=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        )
+        newer_bm = KoboBookmark(
+            location_source="def", location_type="KoboSpan",
+            location_value="(1)/4/2/8",
+            progress_percent=80.0,
+            last_modified=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        )
+        newer.current_bookmark = newer_bm
+        session.add_all([older, newer])
+        session.commit()
+
+        _dedupe_kobo_reading_state(session)
+        session.commit()
+
+        rows = session.query(KoboReadingState).filter_by(user_id=1, book_id=42).all()
+        assert len(rows) == 1
+        assert rows[0].current_bookmark.progress_percent == 80.0
+        assert rows[0].current_bookmark.location_value == "(1)/4/2/8"
+
+    def test_winner_inherits_loser_bookmark_when_winner_had_none(
+            self, memory_db_session_no_unique_indexes):
+        from cps.ub import (KoboReadingState, KoboBookmark,
+                            _dedupe_kobo_reading_state)
+
+        session, _ = memory_db_session_no_unique_indexes
+        winner = KoboReadingState(
+            user_id=1, book_id=42,
+            last_modified=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        )
+        loser = KoboReadingState(
+            user_id=1, book_id=42,
+            last_modified=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        loser_bm = KoboBookmark(
+            progress_percent=33.0,
+            last_modified=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        loser.current_bookmark = loser_bm
+        session.add_all([winner, loser])
+        session.commit()
+
+        _dedupe_kobo_reading_state(session)
+        session.commit()
+
+        rows = session.query(KoboReadingState).filter_by(user_id=1, book_id=42).all()
+        assert len(rows) == 1
+        # Winner had no bookmark; it should now have inherited loser's.
+        assert rows[0].current_bookmark is not None
+        assert rows[0].current_bookmark.progress_percent == 33.0
+
+    def test_no_duplicates_is_noop(self, memory_db_session_no_unique_indexes):
+        from cps.ub import KoboReadingState, _dedupe_kobo_reading_state
+        session, _ = memory_db_session_no_unique_indexes
+        session.add(KoboReadingState(user_id=1, book_id=42))
+        session.commit()
+        removed = _dedupe_kobo_reading_state(session)
+        assert removed == 0
+        assert session.query(KoboReadingState).count() == 1
+
+
+@pytest.mark.unit
+class TestDedupeReadBook:
+    def test_higher_status_wins(self, memory_db_session_no_unique_indexes):
+        from cps.ub import ReadBook, _dedupe_book_read_link
+        session, _ = memory_db_session_no_unique_indexes
+        unread = ReadBook(user_id=1, book_id=42,
+                          read_status=ReadBook.STATUS_UNREAD,
+                          last_modified=datetime(2026, 5, 10, tzinfo=timezone.utc))
+        finished = ReadBook(user_id=1, book_id=42,
+                            read_status=ReadBook.STATUS_FINISHED,
+                            last_modified=datetime(2026, 5, 1, tzinfo=timezone.utc))
+        session.add_all([unread, finished])
+        session.commit()
+        _dedupe_book_read_link(session)
+        session.commit()
+        rows = session.query(ReadBook).filter_by(user_id=1, book_id=42).all()
+        assert len(rows) == 1
+        assert rows[0].read_status == ReadBook.STATUS_FINISHED
+
+    def test_times_started_summed(self, memory_db_session_no_unique_indexes):
+        from cps.ub import ReadBook, _dedupe_book_read_link
+        session, _ = memory_db_session_no_unique_indexes
+        a = ReadBook(user_id=1, book_id=42, times_started_reading=3,
+                     read_status=ReadBook.STATUS_IN_PROGRESS,
+                     last_modified=datetime(2026, 5, 10, tzinfo=timezone.utc))
+        b = ReadBook(user_id=1, book_id=42, times_started_reading=2,
+                     read_status=ReadBook.STATUS_IN_PROGRESS,
+                     last_modified=datetime(2026, 5, 1, tzinfo=timezone.utc))
+        session.add_all([a, b])
+        session.commit()
+        _dedupe_book_read_link(session)
+        session.commit()
+        rows = session.query(ReadBook).filter_by(user_id=1, book_id=42).all()
+        assert len(rows) == 1
+        assert rows[0].times_started_reading == 5
+
+    def test_latest_start_time_kept(self, memory_db_session_no_unique_indexes):
+        from cps.ub import ReadBook, _dedupe_book_read_link
+        session, _ = memory_db_session_no_unique_indexes
+        # SQLite strips timezone info on DATETIME round-trip, so compare
+        # without it. The dedupe logic only orders by comparison, which
+        # works on either aware or naive datetimes consistently.
+        older_start = datetime(2026, 4, 1)
+        newer_start = datetime(2026, 5, 1)
+        a = ReadBook(user_id=1, book_id=42,
+                     read_status=ReadBook.STATUS_IN_PROGRESS,
+                     last_modified=datetime(2026, 5, 10),
+                     last_time_started_reading=older_start)
+        b = ReadBook(user_id=1, book_id=42,
+                     read_status=ReadBook.STATUS_IN_PROGRESS,
+                     last_modified=datetime(2026, 5, 9),
+                     last_time_started_reading=newer_start)
+        session.add_all([a, b])
+        session.commit()
+        _dedupe_book_read_link(session)
+        session.commit()
+        rows = session.query(ReadBook).filter_by(user_id=1, book_id=42).all()
+        assert len(rows) == 1
+        # Test that the newer start time is picked. Compare without tzinfo
+        # since SQLite naive-DATETIME round-trip drops it.
+        got = rows[0].last_time_started_reading
+        assert got.replace(tzinfo=None) == newer_start.replace(tzinfo=None)
+
+
+@pytest.mark.unit
+class TestDedupeArchivedBook:
+    def test_archived_true_beats_false(self, memory_db_session_no_unique_indexes):
+        from cps.ub import ArchivedBook, _dedupe_archived_book
+        session, _ = memory_db_session_no_unique_indexes
+        a = ArchivedBook(user_id=1, book_id=42, is_archived=False,
+                         last_modified=datetime(2026, 5, 10, tzinfo=timezone.utc))
+        b = ArchivedBook(user_id=1, book_id=42, is_archived=True,
+                         last_modified=datetime(2026, 5, 1, tzinfo=timezone.utc))
+        session.add_all([a, b])
+        session.commit()
+        _dedupe_archived_book(session)
+        session.commit()
+        rows = session.query(ArchivedBook).filter_by(user_id=1, book_id=42).all()
+        assert len(rows) == 1
+        assert rows[0].is_archived is True
+
+
+@pytest.mark.unit
+class TestDedupeKoboSyncedBooks:
+    def test_keeps_one_row(self, memory_db_session_no_unique_indexes):
+        from cps.ub import KoboSyncedBooks, _dedupe_kobo_synced_books
+        session, _ = memory_db_session_no_unique_indexes
+        for _ in range(4):
+            session.add(KoboSyncedBooks(user_id=1, book_id=42))
+        session.commit()
+        removed = _dedupe_kobo_synced_books(session)
+        session.commit()
+        assert removed == 3
+        assert session.query(KoboSyncedBooks).filter_by(user_id=1, book_id=42).count() == 1
+
+
+@pytest.mark.unit
+class TestMigrationIdempotent:
+    def test_marker_file_written(self, tmp_path, monkeypatch,
+                                 memory_db_session_no_unique_indexes):
+        from cps import ub
+        session, engine = memory_db_session_no_unique_indexes
+
+        # Point CONFIG_DIR at tmp_path so the marker is sandboxed.
+        monkeypatch.setattr(ub.constants, "CONFIG_DIR", str(tmp_path))
+
+        ub.migrate_kobo_unique_constraints(engine, session)
+        marker = tmp_path / ".cwa_migrations" / "kobo_unique_constraints_v1"
+        assert marker.is_file()
+
+    def test_second_run_is_noop(self, tmp_path, monkeypatch,
+                                 memory_db_session_no_unique_indexes):
+        from cps import ub
+        from cps.ub import KoboReadingState
+        session, engine = memory_db_session_no_unique_indexes
+        monkeypatch.setattr(ub.constants, "CONFIG_DIR", str(tmp_path))
+
+        ub.migrate_kobo_unique_constraints(engine, session)
+
+        # Now manually insert a duplicate (we have to drop the index first
+        # since the migration created it).
+        with engine.connect() as conn:
+            conn.exec_driver_sql("DROP INDEX IF EXISTS uq_kobo_reading_state_user_book")
+            conn.commit()
+        session.add(KoboReadingState(user_id=1, book_id=42))
+        session.add(KoboReadingState(user_id=1, book_id=42))
+        session.commit()
+
+        # Second run should bail at the marker check and NOT dedupe.
+        ub.migrate_kobo_unique_constraints(engine, session)
+        assert session.query(KoboReadingState).filter_by(user_id=1, book_id=42).count() == 2
+
+    def test_runs_dedupe_when_marker_absent(self, tmp_path, monkeypatch,
+                                            memory_db_session_no_unique_indexes):
+        from cps import ub
+        from cps.ub import KoboReadingState
+        session, engine = memory_db_session_no_unique_indexes
+        monkeypatch.setattr(ub.constants, "CONFIG_DIR", str(tmp_path))
+
+        session.add(KoboReadingState(
+            user_id=1, book_id=42,
+            last_modified=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        ))
+        session.add(KoboReadingState(
+            user_id=1, book_id=42,
+            last_modified=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        ))
+        session.commit()
+        assert session.query(KoboReadingState).filter_by(user_id=1, book_id=42).count() == 2
+
+        ub.migrate_kobo_unique_constraints(engine, session)
+
+        rows = session.query(KoboReadingState).filter_by(user_id=1, book_id=42).all()
+        assert len(rows) == 1
+        # SQLite strips tz on DATETIME round-trip; compare naive.
+        assert rows[0].last_modified.replace(tzinfo=None) == datetime(2026, 5, 10)
+
+
+@pytest.mark.unit
+class TestGetOrCreateReadingStateSourceInvariants:
+    """The source-level invariants matter because Flask request context
+    + auth aren't available at unit scope. These checks pin the atomic-
+    upsert behavior so a future refactor can't regress to read-then-
+    write semantics."""
+
+    def test_uses_sqlite_on_conflict_do_nothing(self):
+        import inspect
+        from cps.kobo import get_or_create_reading_state
+        src = inspect.getsource(get_or_create_reading_state)
+        assert "on_conflict_do_nothing" in src, (
+            "get_or_create_reading_state must use INSERT ... ON CONFLICT "
+            "DO NOTHING via the sqlite dialect to be race-safe; without "
+            "it two concurrent PUTs can produce duplicate rows."
+        )
+
+    def test_index_elements_named_correctly(self):
+        import inspect
+        from cps.kobo import get_or_create_reading_state
+        src = inspect.getsource(get_or_create_reading_state)
+        # Must target the (user_id, book_id) pair, matching the UNIQUE
+        # INDEX created by migrate_kobo_unique_constraints.
+        assert 'index_elements=["user_id", "book_id"]' in src or \
+               "index_elements=['user_id', 'book_id']" in src, (
+            "on_conflict_do_nothing must specify index_elements="
+            "['user_id', 'book_id'] so SQLite routes the conflict to "
+            "the correct UNIQUE INDEX."
+        )
+
+    def test_creates_read_book_atomically(self):
+        import inspect
+        from cps.kobo import get_or_create_reading_state
+        src = inspect.getsource(get_or_create_reading_state)
+        assert "ub.ReadBook" in src and "sqlite_insert" in src, (
+            "ReadBook creation must go through the atomic sqlite_insert "
+            "path; otherwise concurrent first-PUTs race on ReadBook."
+        )
+
+    def test_creates_kobo_reading_state_atomically(self):
+        import inspect
+        from cps.kobo import get_or_create_reading_state
+        src = inspect.getsource(get_or_create_reading_state)
+        assert "ub.KoboReadingState" in src and src.count("sqlite_insert") >= 1, (
+            "KoboReadingState creation must also use sqlite_insert + "
+            "on_conflict_do_nothing — it has the same (user, book) "
+            "uniqueness constraint."
+        )
+
+    def test_no_legacy_one_or_none_pattern(self):
+        import inspect
+        from cps.kobo import get_or_create_reading_state
+        src = inspect.getsource(get_or_create_reading_state)
+        # The pre-fix pattern was `.one_or_none()` on a query that could
+        # racily return either nothing or multiple rows. The new code
+        # uses `.one()` after the atomic insert which is safe because
+        # the UNIQUE INDEX guarantees at-most-one row.
+        assert ".one_or_none()" not in src, (
+            "Legacy one_or_none pattern survives — would raise "
+            "MultipleResultsFound if duplicates ever appeared."
+        )


### PR DESCRIPTION
## Summary

Audit-2026-05-11 Tier B item B2. Two concurrent PUTs to
`/v1/library/<uuid>/state` from a Kobo device could race past the
read-then-write check in `get_or_create_reading_state` and both INSERT,
leaving the DB with duplicate `(user_id, book_id)` rows. The next
`.one_or_none()` then raises `MultipleResultsFound` → 500 to the device,
which retries forever.

Three changes:

1. **`UniqueConstraint(user_id, book_id)`** on `ReadBook`,
   `KoboReadingState`, `KoboSyncedBooks`, and `ArchivedBook`. Same shape,
   same hazard. `UserHiddenBook` already had it.

2. **`migrate_kobo_unique_constraints`** — one-time migration in
   `cps/ub.py` that dedupes any existing duplicates (newest
   `last_modified` wins, child rows merged) then creates `CREATE UNIQUE
   INDEX IF NOT EXISTS` on `(user_id, book_id)` for each table.
   Idempotent via marker file at `.cwa_migrations/kobo_unique_constraints_v1`.

3. **Atomic upsert** in `get_or_create_reading_state` — switches to
   SQLite's `INSERT … ON CONFLICT(user_id, book_id) DO NOTHING` via the
   dialect-specific insert. Two concurrent calls now both succeed (one
   inserts, the other no-ops), both then SELECT the same canonical row.

## Why this matters

Any household running two Kobos (or one Kobo that wakes/sleeps fast)
has been silently accumulating these duplicates. The 500 is the
crash; the data hazard is more subtle — once duplicates exist, any
subsequent state read raises and the device sync queue fills.

## Migration safety

Dedupe is **not** destructive in the user-visible sense: winners are
chosen by recency / activity, so the user's most-recent reading
position survives. Specifics:

- `KoboReadingState`: newest `last_modified` wins. Loser's `KoboBookmark`
  and `KoboStatistics` are merged into the winner's (newest LM wins
  per field; non-null beats null when LM is missing).
- `ReadBook`: highest `read_status` wins (FINISHED > IN_PROGRESS >
  UNREAD), then newest LM. `times_started_reading` is summed across
  losers so the user doesn't lose their read-count total.
- `ArchivedBook`: `is_archived=True` wins over `False` (the more
  recent semantic signal), then newest LM.
- `KoboSyncedBooks`: just keep one (no payload to merge).

The migration runs at most once per install — gated by a marker file.

## Test plan

29 new tests, all green locally on Python 3.12 + SQLAlchemy 2.0.49 +
SQLite 3.51:

- [x] Model `__table_args__` carry the expected constraint names (4 tests)
- [x] UNIQUE indexes reject duplicate INSERTs (4 tests)
- [x] Dedupe helpers cover the merge rules per table (10 tests)
- [x] Migration writes the marker file, second run is no-op, dedupe runs when marker absent (3 tests)
- [x] Source invariants on `get_or_create_reading_state` pin the
      `on_conflict_do_nothing` call + correct `index_elements` (5 tests)
- [x] Threaded concurrent-insert test (16 workers, real file SQLite,
      shared `Barrier`) asserts exactly one row regardless of contention (3 tests)

Existing 38 kobo unit tests still green — no regressions to popup-fix,
PUT-state robustness, sync-token, shelf, or library-sync rewrite paths.

## Risk

DB schema change. Migration is non-trivial. Recommended manual review
of `migrate_kobo_unique_constraints` + dedupe helpers in `cps/ub.py`
before merge. Once merged, the next deploy will run the migration on
`/config/app.db` exactly once.

This is **not** a `safe-tier-*` change — needs review-merge.