### PR TITLE
fix(kobo): per-callsite common_filters policy for get_book_by_uuid

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -902,6 +902,33 @@ class CalibreDB:
         self.ensure_session()
         return self.session.query(Books).filter(Books.uuid == book_uuid).first()
 
+    def get_book_by_uuid_for_kobo(self, book_uuid, *, enforce_policy):
+        """Return the Books row by uuid for the Kobo blueprint.
+
+        ``enforce_policy=True``: applies ``common_filters`` (hidden,
+        denied-tags, language, custom-column ACL) so policy-restricted
+        books are invisible — symmetric with what the web UI / OPDS /
+        sync push show. Pass on policy-boundary endpoints (metadata GET,
+        shelf-add).
+
+        ``enforce_policy=False``: bypasses filters. Use on device-
+        trailing endpoints (state GET/PUT) and on destructive user-
+        initiated ops (shelf-remove, book DELETE) so the device can
+        always clean up and keep sync state working for books already
+        on the device.
+
+        ``allow_show_archived=True`` always on the Kobo path — the
+        ``ArchivedBook`` table doubles as the Kobo's "deleted locally"
+        track. Filtering on it would 404 the device's own deletions.
+
+        Decision matrix: notes/KOBO-B4-COMMON-FILTERS-POLICY.md.
+        """
+        self.ensure_session()
+        q = self.session.query(Books).filter(Books.uuid == book_uuid)
+        if enforce_policy:
+            q = q.filter(self.common_filters(allow_show_archived=True))
+        return q.first()
+
     def get_book_format(self, book_id, file_format):
         self.ensure_session()
         return self.session.query(Data).filter(Data.book == book_id).filter(Data.format == file_format).first()

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -466,7 +466,9 @@ def HandleMetadataRequest(book_uuid):
     if not current_app.wsgi_app.is_proxied:
         log.debug('Kobo: Received unproxied request, changed request port to external server port')
     log.info("Kobo library metadata request received for book %s" % book_uuid)
-    book = calibre_db.get_book_by_uuid(book_uuid)
+    # Policy boundary: metadata GET. Symmetric with web/OPDS — books the
+    # user can't see in the web UI shouldn't expose metadata via Kobo.
+    book = calibre_db.get_book_by_uuid_for_kobo(book_uuid, enforce_policy=True)
     if not book or not book.data:
         log.info("Book %s not found in database", book_uuid)
         return redirect_or_proxy_request()
@@ -747,7 +749,13 @@ def add_items_to_shelf(items, shelf):
                 items_unknown_to_calibre.append(item)
                 continue
 
-            book = calibre_db.get_book_by_uuid(item["RevisionId"])
+            # Policy boundary: shelf-add. Adding a denied/hidden book to a
+            # Kobo-synced shelf would leak it to every other Kobo on the
+            # same account. Treat as unknown-to-calibre so the device
+            # silently drops it (existing items_unknown_to_calibre path).
+            book = calibre_db.get_book_by_uuid_for_kobo(
+                item["RevisionId"], enforce_policy=True,
+            )
             if not book:
                 items_unknown_to_calibre.append(item)
                 continue
@@ -819,7 +827,12 @@ def HandleTagRemoveItem(tag_id):
                 items_unknown_to_calibre.append(item)
                 continue
 
-            book = calibre_db.get_book_by_uuid(item["RevisionId"])
+            # Destructive, user-initiated: shelf-remove. Never block on
+            # policy filters — the user must be able to clean up shelves
+            # even when the underlying book is now hidden / denied / etc.
+            book = calibre_db.get_book_by_uuid_for_kobo(
+                item["RevisionId"], enforce_policy=False,
+            )
             if not book:
                 items_unknown_to_calibre.append(item)
                 continue
@@ -946,7 +959,11 @@ def create_kobo_tag_magic(shelf, books):
 @kobo.route("/v1/library/<book_uuid>/state", methods=["GET", "PUT"])
 @requires_kobo_auth
 def HandleStateRequest(book_uuid):
-    book = calibre_db.get_book_by_uuid(book_uuid)
+    # Device-trailing: state GET/PUT. The book is already on the Kobo;
+    # reading progress must keep syncing even if the book later becomes
+    # hidden/denied (otherwise the device retries forever and the user
+    # sees sync failures). Sync push handler is the policy boundary.
+    book = calibre_db.get_book_by_uuid_for_kobo(book_uuid, enforce_policy=False)
     if not book or not book.data:
         log.info("Book %s not found in database", book_uuid)
         return redirect_or_proxy_request()
@@ -1241,7 +1258,10 @@ def TopLevelEndpoint():
 @requires_kobo_auth
 def HandleBookDeletionRequest(book_uuid):
     log.info("Kobo book delete request received for book %s", book_uuid)
-    book = calibre_db.get_book_by_uuid(book_uuid)
+    # Destructive, user-initiated: book DELETE. Never block on policy
+    # filters — user must be able to remove a book from their Kobo
+    # regardless of current hidden / denied / language state.
+    book = calibre_db.get_book_by_uuid_for_kobo(book_uuid, enforce_policy=False)
     if not book:
         log.info("Book %s not found in database", book_uuid)
         return redirect_or_proxy_request()

--- a/notes/KOBO-B4-COMMON-FILTERS-POLICY.md
+++ b/notes/KOBO-B4-COMMON-FILTERS-POLICY.md
@@ -1,0 +1,128 @@
+# Kobo policy: `common_filters` on `get_book_by_uuid` paths
+
+Source audit: `notes/KOBO-AUDIT-2026-05-10.md` § B4. Decision date:
+2026-05-11. Decision owner: new-usemame.
+
+## The question
+
+`calibre_db.get_book_by_uuid(book_uuid)` bypasses `common_filters`, so
+the Kobo blueprint can hand back books that the user's web UI wouldn't
+show them. Five call sites in `cps/kobo.py`.
+
+`common_filters` (cps/db.py:940) enforces:
+
+1. **archived** (`ArchivedBook`) — books the user has hidden from sync.
+   *On the Kobo path, this table doubles as the device's "I deleted this
+   locally" track.* So Kobo paths must always pass
+   `allow_show_archived=True`. The Kobo sync handler at line 255/274
+   already does this.
+2. **hidden** (`UserHiddenBook`) — per-user declutter (NextGen issue #64).
+3. **language** — user's preferred language filter.
+4. **denied tags** — admin-set per-user denied tag list.
+5. **allowed tags** — admin-set per-user allowed tag list (positive ACL).
+6. **restricted custom column** — admin-set per-user custom-column ACL.
+
+## Policy framework
+
+The Kobo endpoints fall into two categories:
+
+**Policy boundary endpoints** — surfaces where the user's web policy
+(hidden / denied / language / cc-ACL) *should* propagate to the Kobo
+side. Symmetric with what they'd see in the browser. ENFORCE filters.
+
+**Device-trailing endpoints** — operations on books already on the
+device. The sync push (`HandleSyncRequest`) is the policy boundary for
+the device — it decides what reaches the Kobo. Once a book is on the
+device, the user must be able to manage their state and clean up
+without 4xx loops. DO NOT enforce filters.
+
+## Per-callsite decisions
+
+### Line 469 — `HandleMetadataRequest` (GET /v1/library/<uuid>/metadata)
+
+**ENFORCE filters.** Returns Kobo metadata (title, authors, series,
+cover URL, format URL) for a book. If the user can't see the book in
+their web UI (denied-tagged, hidden, wrong language, cc-ACL out), they
+shouldn't get its metadata via Kobo either. The device falls back to
+cached metadata gracefully on 404.
+
+This is symmetric with what `HandleSyncRequest` already filters on the
+push side. If filters change between syncs, the metadata endpoint
+hardens the boundary.
+
+### Line 750 — `add_items_to_shelf` (POST /v1/library/tags/<tag_id>/items)
+
+**ENFORCE filters.** The device is asking us to add a book to a Kobo
+shelf (a CW shelf marked `kobo_sync=True`). Adding a book the user
+isn't permitted to see is a policy violation — the resulting shelf
+would then surface that book on every other Kobo synced from the same
+account. We return the book as "unknown to calibre" via the existing
+`items_unknown_to_calibre` path, which the device handles silently.
+
+### Line 822 — `HandleTagRemoveItem` (POST /v1/library/tags/<tag_id>/items/delete)
+
+**DO NOT enforce filters.** User-initiated cleanup. The user is telling
+the Kobo to remove a book from a shelf. Blocking this on policy
+grounds would leave the book on the shelf forever — even after the
+underlying book was hidden / denied / archived. Destructive,
+user-initiated operations must never be blocked by policy filters.
+
+### Line 949 — `HandleStateRequest` (GET/PUT /v1/library/<uuid>/state)
+
+**DO NOT enforce filters.** Reading-state sync for a book already on
+the device. If a user finishes a book that later becomes
+denied-tagged, the Kobo's reading position MUST still sync (otherwise
+the device retries forever, fills its sync queue, and the user sees a
+visible failure). This is the canonical device-trailing endpoint.
+
+### Line 1244 — `HandleBookDeletionRequest` (DELETE /v1/library/<uuid>)
+
+**DO NOT enforce filters.** User-initiated deletion. Same logic as the
+shelf-remove case: cleanup ops never block. The Kobo's delete handler
+either archives the book (per-user) or just removes it from sync —
+both are net-positive even when the book is otherwise denied.
+
+## Summary table
+
+| Line | Endpoint | Enforce filters? | Reason |
+|------|----------|------------------|--------|
+| 469  | metadata GET | YES | Policy boundary. Symmetric with web/OPDS. |
+| 750  | shelf-add | YES | Policy boundary. Adding denied books to shelves leaks them. |
+| 822  | shelf-remove | NO | Destructive, user-initiated. Never block. |
+| 949  | state GET/PUT | NO | Device-trailing. Required for sync to keep working. |
+| 1244 | book DELETE | NO | Destructive, user-initiated. Never block. |
+
+## Implementation
+
+`cps/db.py` gets a new helper:
+
+```python
+def get_book_by_uuid_for_kobo(self, book_uuid, *, enforce_policy):
+    """Return Books row by uuid. When enforce_policy=True, applies
+    common_filters (with allow_show_archived=True; see KOBO-B4 doc)."""
+    self.ensure_session()
+    q = self.session.query(Books).filter(Books.uuid == book_uuid)
+    if enforce_policy:
+        q = q.filter(self.common_filters(allow_show_archived=True))
+    return q.first()
+```
+
+The five Kobo callsites switch to this helper with an explicit
+`enforce_policy=` kwarg. The kwarg-only signature forces the caller to
+state which policy applies, so future maintainers can't accidentally
+get the wrong default.
+
+`allow_show_archived=True` because `ArchivedBook` is reused on Kobo paths
+as the "device-deleted" semantic. Filtering by it here would 404 every
+book the device archived locally, breaking the device.
+
+## What this doesn't cover
+
+- The sync push (`HandleSyncRequest`). Already uses `common_filters`
+  correctly at lines 255 and 274.
+- Cover endpoints (cover, image-id, thumbnails). They take book_id,
+  not uuid, and route through the cover cache which already enforces
+  permissions.
+- Notebook-sync POST. Has its own auth/permission flow.
+- `download_required` decorator on metadata. Adds a download-permission
+  check on top of the filter — that's complementary, not redundant.

--- a/tests/unit/test_kobo_common_filters_policy.py
+++ b/tests/unit/test_kobo_common_filters_policy.py
@@ -1,0 +1,216 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Pin the Kobo per-callsite ``common_filters`` policy decisions
+(audit 2026-05-11, item B4).
+
+Background: ``calibre_db.get_book_by_uuid`` bypasses ``common_filters``.
+On the Kobo blueprint that means we can hand back books the user
+shouldn't see (hidden, denied-tag, language-filtered, custom-column-
+restricted) — which is wrong for some endpoints and right for others
+because the Kobo is a device-trailing surface for already-synced books.
+
+The audit decided per-callsite, documented in
+``notes/KOBO-B4-COMMON-FILTERS-POLICY.md``:
+
+| Line | Endpoint | Enforce filters? |
+|------|----------|-----------------|
+| 469  | metadata GET | YES |
+| 750  | shelf-add | YES |
+| 822  | shelf-remove | NO |
+| 949  | state GET/PUT | NO |
+| 1244 | book DELETE | NO |
+
+These tests pin both:
+
+1. The helper ``get_book_by_uuid_for_kobo(book_uuid, *, enforce_policy)``
+   exists, requires ``enforce_policy`` as a keyword arg, and applies
+   ``common_filters(allow_show_archived=True)`` when ``enforce_policy=True``.
+2. Each callsite in cps/kobo.py uses the helper with the policy-doc
+   decision baked in.
+"""
+
+import inspect
+
+import pytest
+
+
+@pytest.mark.unit
+class TestHelperContract:
+    def test_helper_exists_on_calibre_db(self):
+        from cps.db import CalibreDB
+        assert hasattr(CalibreDB, "get_book_by_uuid_for_kobo"), (
+            "Missing helper. cps/db.py must expose "
+            "get_book_by_uuid_for_kobo for the Kobo blueprint."
+        )
+
+    def test_enforce_policy_is_keyword_only(self):
+        from cps.db import CalibreDB
+        sig = inspect.signature(CalibreDB.get_book_by_uuid_for_kobo)
+        param = sig.parameters.get("enforce_policy")
+        assert param is not None
+        assert param.kind == inspect.Parameter.KEYWORD_ONLY, (
+            "enforce_policy must be keyword-only so callers can't "
+            "accidentally pass the wrong polarity positionally — the "
+            "kwarg name is the policy documentation."
+        )
+
+    def test_helper_applies_common_filters_when_enforced(self):
+        """Source-level: when enforce_policy=True we add a
+        ``self.common_filters(allow_show_archived=True)`` filter."""
+        from cps.db import CalibreDB
+        src = inspect.getsource(CalibreDB.get_book_by_uuid_for_kobo)
+        assert "common_filters" in src
+        assert "allow_show_archived=True" in src, (
+            "Kobo path must pass allow_show_archived=True — the "
+            "ArchivedBook table doubles as the Kobo's device-deletion "
+            "track. Filtering on it would 404 the device's own "
+            "deletions, breaking sync."
+        )
+
+    def test_helper_skips_filters_when_not_enforced(self):
+        from cps.db import CalibreDB
+        src = inspect.getsource(CalibreDB.get_book_by_uuid_for_kobo)
+        # Logic should branch on the flag — naive query with no filter
+        # when enforce_policy is False.
+        assert "if enforce_policy" in src, (
+            "Helper must branch on enforce_policy; otherwise it's not "
+            "actually implementing the policy."
+        )
+
+
+@pytest.mark.unit
+class TestPerCallsitePolicy:
+    """Each Kobo callsite must use the helper with the exact policy
+    documented in notes/KOBO-B4-COMMON-FILTERS-POLICY.md. These tests
+    inspect the source of the relevant handler so a refactor can't
+    silently flip the policy."""
+
+    def test_handle_metadata_request_enforces(self):
+        from cps.kobo import HandleMetadataRequest
+        src = inspect.getsource(HandleMetadataRequest)
+        assert "get_book_by_uuid_for_kobo" in src
+        assert "enforce_policy=True" in src, (
+            "HandleMetadataRequest must ENFORCE filters — metadata is "
+            "a policy boundary symmetric with web/OPDS. Books the user "
+            "can't see shouldn't expose metadata via Kobo."
+        )
+
+    def test_add_items_to_shelf_enforces(self):
+        from cps.kobo import add_items_to_shelf
+        src = inspect.getsource(add_items_to_shelf)
+        assert "get_book_by_uuid_for_kobo" in src
+        assert "enforce_policy=True" in src, (
+            "add_items_to_shelf must ENFORCE filters — adding a "
+            "denied/hidden book to a Kobo-synced shelf would leak it "
+            "to every Kobo synced from the account."
+        )
+
+    def test_handle_tag_remove_item_does_not_enforce(self):
+        from cps.kobo import HandleTagRemoveItem
+        src = inspect.getsource(HandleTagRemoveItem)
+        assert "get_book_by_uuid_for_kobo" in src
+        assert "enforce_policy=False" in src, (
+            "HandleTagRemoveItem must NOT enforce filters — destructive "
+            "user-initiated cleanup. Blocking on policy would leave the "
+            "book on the shelf forever."
+        )
+
+    def test_handle_state_request_does_not_enforce(self):
+        from cps.kobo import HandleStateRequest
+        src = inspect.getsource(HandleStateRequest)
+        assert "get_book_by_uuid_for_kobo" in src
+        assert "enforce_policy=False" in src, (
+            "HandleStateRequest must NOT enforce filters — device-"
+            "trailing surface for already-synced books. Filtering would "
+            "loop the device on 4xx retries."
+        )
+
+    def test_handle_book_deletion_does_not_enforce(self):
+        from cps.kobo import HandleBookDeletionRequest
+        src = inspect.getsource(HandleBookDeletionRequest)
+        assert "get_book_by_uuid_for_kobo" in src
+        assert "enforce_policy=False" in src, (
+            "HandleBookDeletionRequest must NOT enforce filters — "
+            "destructive user-initiated cleanup."
+        )
+
+
+@pytest.mark.unit
+class TestNoLegacyBypass:
+    """Audit invariant: no Kobo callsite is still using
+    get_book_by_uuid (the unfiltered helper). All five known sites
+    must go through get_book_by_uuid_for_kobo with an explicit policy."""
+
+    def test_no_unfiltered_get_book_by_uuid_in_kobo(self):
+        import cps.kobo as kobo_module
+        src = inspect.getsource(kobo_module)
+        # The unfiltered helper itself is a sibling of the new one;
+        # we want to ensure no caller in kobo.py uses it.
+        lines = [
+            ln for ln in src.splitlines()
+            if "calibre_db.get_book_by_uuid(" in ln
+            and "get_book_by_uuid_for_kobo" not in ln
+        ]
+        assert not lines, (
+            "Found Kobo callsite(s) still using the unfiltered "
+            "calibre_db.get_book_by_uuid:\n  "
+            + "\n  ".join(lines)
+            + "\nAll five known callsites must route through "
+            "get_book_by_uuid_for_kobo with an explicit "
+            "enforce_policy= kwarg."
+        )
+
+
+@pytest.mark.unit
+class TestHelperBehaviorIntegration:
+    """Light integration: bypass Flask request context by mocking the
+    pieces ``common_filters`` reaches for (current_user, ub.session)."""
+
+    def test_unenforced_path_skips_common_filters(self, mocker):
+        """When enforce_policy=False, we must NOT call common_filters
+        at all — proven by mocking it and asserting it's never invoked.
+        """
+        from cps.db import CalibreDB
+
+        mock_filter = mocker.MagicMock()
+        mocker.patch.object(CalibreDB, "common_filters", mock_filter)
+
+        mock_query_chain = mocker.MagicMock()
+        mock_query_chain.filter.return_value = mock_query_chain
+        mock_query_chain.first.return_value = None
+
+        instance = mocker.MagicMock()
+        instance.ensure_session = mocker.MagicMock()
+        instance.session.query.return_value = mock_query_chain
+        instance.common_filters = mock_filter
+
+        CalibreDB.get_book_by_uuid_for_kobo(
+            instance, "abc-uuid", enforce_policy=False,
+        )
+
+        mock_filter.assert_not_called()
+
+    def test_enforced_path_invokes_common_filters_with_archive_visible(
+            self, mocker):
+        from cps.db import CalibreDB
+
+        mock_filter = mocker.MagicMock()
+        mock_filter.return_value = "sentinel-filter-expr"
+
+        mock_query_chain = mocker.MagicMock()
+        mock_query_chain.filter.return_value = mock_query_chain
+        mock_query_chain.first.return_value = None
+
+        instance = mocker.MagicMock()
+        instance.ensure_session = mocker.MagicMock()
+        instance.session.query.return_value = mock_query_chain
+        instance.common_filters = mock_filter
+
+        CalibreDB.get_book_by_uuid_for_kobo(
+            instance, "abc-uuid", enforce_policy=True,
+        )
+
+        mock_filter.assert_called_once_with(allow_show_archived=True)


### PR DESCRIPTION
## Summary

Audit-2026-05-11 Tier B item B4. The Kobo blueprint had 5 callsites
using `calibre_db.get_book_by_uuid`, which bypasses `common_filters`.
That meant hidden / denied-tag / language-filtered / custom-column-ACL
books could leak through the Kobo path even though they're filtered
everywhere else in the app.

The audit decided **per-callsite**, not a blanket filter, because the
Kobo blueprint has two categories of endpoint:

- **Policy boundary** — surfaces where the user's web policy should
  propagate to the Kobo side. Symmetric with what they'd see in the
  browser. ENFORCE filters.
- **Device-trailing** — operations on books *already on the device*. The
  sync push (`HandleSyncRequest`) is the policy boundary for the device.
  Once a book is on the Kobo, the user must be able to manage state and
  clean up without 4xx loops. DO NOT enforce filters.

## Per-callsite decisions

| File:line | Endpoint | Enforce? | Reason |
|-----------|----------|---------|--------|
| `kobo.py:469` | metadata GET | **YES** | Policy boundary. Symmetric with web/OPDS. |
| `kobo.py:750` | shelf-add (POST tags) | **YES** | Policy boundary. Adding denied books to Kobo-synced shelves would leak. |
| `kobo.py:822` | shelf-remove (POST delete) | **NO** | Destructive, user-initiated. Never block. |
| `kobo.py:949` | state GET/PUT | **NO** | Device-trailing. Required for sync to keep working. |
| `kobo.py:1244` | book DELETE | **NO** | Destructive, user-initiated. Never block. |

Full policy doc in this PR: `notes/KOBO-B4-COMMON-FILTERS-POLICY.md`.

## Implementation

New helper `CalibreDB.get_book_by_uuid_for_kobo(book_uuid, *, enforce_policy)`:

- `enforce_policy` is **keyword-only**, so callers must state which
  policy applies. No positional default to accidentally flip.
- When `enforce_policy=True`, applies `common_filters(allow_show_archived=True)`.
- `allow_show_archived=True` is always passed because `ArchivedBook` on
  the Kobo path doubles as the device's deletion track — filtering on
  it would 404 the device's own deletions.

All 5 callsites updated to the new helper with an explicit
`enforce_policy=` kwarg and a comment documenting the decision.

## Test plan

12 new tests, all green:

- [x] Helper exists on `CalibreDB`
- [x] `enforce_policy` is keyword-only (so callers can't accidentally pass the wrong polarity positionally)
- [x] Source-level: helper applies `common_filters(allow_show_archived=True)` only when enforced
- [x] Each of the 5 callsites is pinned to its policy-doc decision via source inspection
- [x] No legacy bypass: no caller in `cps/kobo.py` still uses the unfiltered `get_book_by_uuid`
- [x] Integration (mocked): `common_filters` is invoked only on the enforced path, with `allow_show_archived=True`

Existing 38 kobo unit tests still green — no regressions to popup-fix,
PUT-state robustness, sync-token, shelf, or library-sync rewrite paths.

## Risk

Behavior change. A small subset of users who have set up hidden books
or denied-tags **AND** sync via Kobo will see different behavior at
the `metadata` and `shelf-add` endpoints (they'll get a 404 instead
of leaked content). This is the corrective behavior — those books
were never supposed to be reachable from Kobo — but it's worth
calling out so a user report after deploy makes sense.

No DB changes. No data migration. Drop-in.

This is **not** a `safe-tier-*` change — needs review-merge because
it changes user-visible behavior in policy-adjacent code.