### PR TITLE
fix(thumbnail): defer cover thumbnail regen until after metadata commit (CWA #1346, closes #134)

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -873,6 +873,7 @@ def do_edit_book(book_id, upload_formats=None):
     log.debug("[edit_book] start book_id=%s user=%s upload_formats=%s", book_id, getattr(current_user, "name", "unknown"), bool(upload_formats))
     modify_date = False
     edit_error = False
+    refresh_cover_thumbnail_after_commit = False
 
     # create the function for sorting...
     calibre_db.create_functions(config)
@@ -937,8 +938,7 @@ def do_edit_book(book_id, upload_formats=None):
                 if result:
                     book.has_cover = 1
                     modify_date = True
-                    # Force thumbnail regeneration after successful cover fetch
-                    helper.replace_cover_thumbnail_cache(book.id)
+                    refresh_cover_thumbnail_after_commit = True
                     log.debug("[edit_book] cover saved book_id=%s duration=%.3fs", book.id, time.monotonic() - cover_start)
                 else:
                     log.warning("[edit_book] cover save failed book_id=%s duration=%.3fs error=%s", book.id, time.monotonic() - cover_start, error)
@@ -1011,6 +1011,13 @@ def do_edit_book(book_id, upload_formats=None):
             calibre_db.session.merge(book)
             calibre_db.session.commit()
             log.debug("[edit_book] db commit retry ok book_id=%s duration=%.3fs", book.id, time.monotonic() - request_start)
+
+        if refresh_cover_thumbnail_after_commit:
+            helper.replace_cover_thumbnail_cache(
+                book.id,
+                book_path=book.path,
+                last_modified=book.last_modified,
+            )
 
         # CWA: Export of changed Metadata after commit, to avoid race conditions with folder renames
         # Only create log if there were actual meaningful metadata changes

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -1590,7 +1590,7 @@ def clear_cover_thumbnail_cache(book_id):
     WorkerThread.add(None, TaskClearCoverThumbnailCache(book_id), hidden=True)
 
 
-def replace_cover_thumbnail_cache(book_id):
+def replace_cover_thumbnail_cache(book_id, book_path=None, last_modified=None):
     # Always allow replacing thumbnail cache
     # Remove from pending set to allow regeneration
     _pending_thumbnail_books.discard(book_id)
@@ -1601,7 +1601,15 @@ def replace_cover_thumbnail_cache(book_id):
         log.error(f'Failed to queue thumbnail clear for book {book_id}: {e}')
     # Queue generation task and add to pending set only if successful
     try:
-        WorkerThread.add(None, TaskGenerateCoverThumbnails(book_id), hidden=True)
+        WorkerThread.add(
+            None,
+            TaskGenerateCoverThumbnails(
+                book_id,
+                book_path=book_path,
+                last_modified=last_modified,
+            ),
+            hidden=True,
+        )
         _pending_thumbnail_books.add(book_id)
     except Exception as e:
         log.error(f'Failed to queue thumbnail generation for book {book_id}: {e}')

--- a/cps/tasks/thumbnail.py
+++ b/cps/tasks/thumbnail.py
@@ -10,6 +10,7 @@ from shutil import copyfile, copyfileobj
 from urllib.request import urlopen
 from io import BytesIO
 from datetime import datetime, timezone
+from dataclasses import dataclass
 
 from .. import constants
 from cps import config, db, fs, gdriveutils, logger, ub
@@ -24,6 +25,13 @@ except (ImportError, RuntimeError) as e:
 
 
 _BASE_THUMBNAIL_HEIGHT = int(os.environ.get("CWA_THUMBNAIL_BASE_HEIGHT", "420"))
+
+
+@dataclass(frozen=True)
+class BookCoverSource:
+    id: int
+    path: str
+    last_modified: datetime
 
 
 def get_resize_height(resolution):
@@ -59,10 +67,12 @@ def get_best_fit(width, height, image_width, image_height):
 
 
 class TaskGenerateCoverThumbnails(CalibreTask):
-    def __init__(self, book_id=-1, task_message=''):
+    def __init__(self, book_id=-1, task_message='', book_path=None, last_modified=None):
         super(TaskGenerateCoverThumbnails, self).__init__(task_message)
         self.log = logger.create()
         self.book_id = book_id
+        self.book_path = book_path
+        self.last_modified = last_modified
         self.app_db_session = ub.get_new_session_instance()
         self.cache = fs.FileSystem()
         self.resolutions = [
@@ -75,7 +85,7 @@ class TaskGenerateCoverThumbnails(CalibreTask):
         try:
             if use_IM and self.stat != STAT_CANCELLED and self.stat != STAT_ENDED:
                 self.message = 'Scanning Books'
-                books_with_covers = self.get_books_with_covers(self.book_id)
+                books_with_covers = self.get_cover_sources()
                 count = len(books_with_covers)
 
                 total_generated = 0
@@ -124,6 +134,17 @@ class TaskGenerateCoverThumbnails(CalibreTask):
         books_cover = calibre_db.session.query(db.Books).filter(db.Books.has_cover == 1).filter(filter_exp).all()
         calibre_db.session.close()
         return books_cover
+
+    def get_cover_sources(self):
+        if self.book_id != -1 and self.book_path:
+            return [
+                BookCoverSource(
+                    id=int(self.book_id),
+                    path=self.book_path,
+                    last_modified=self.last_modified or datetime.now(timezone.utc),
+                )
+            ]
+        return self.get_books_with_covers(self.book_id)
 
     def get_book_cover_thumbnails(self, book_id):
         return self.app_db_session \

--- a/tests/unit/test_thumbnail_deadlock_regression.py
+++ b/tests/unit/test_thumbnail_deadlock_regression.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Regression coverage for issue #1256 / issuecomment-4188267348.
+
+The reported freeze is caused by thumbnail generation being queued while the
+metadata edit request is still using the Calibre SQLite session. The thumbnail
+worker creates its own CalibreDB session and registers SQLite Python UDFs, which
+can deadlock with in-flight metadata queries that also need those UDF callbacks.
+"""
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _call_name(node):
+    """Return dotted call name for simple ast.Call nodes."""
+    parts = []
+    current = node.func
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+def _module_tree(relative_path):
+    return ast.parse((REPO_ROOT / relative_path).read_text(encoding="utf-8"))
+
+
+def _function_def(tree, name):
+    return next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def test_cover_thumbnail_refresh_is_not_queued_before_metadata_commit():
+    """
+    Cover thumbnail replacement must be deferred until after the Calibre metadata
+    commit. Queueing it before commit lets the worker race the request thread and
+    reproduce the SQLite/GIL deadlock described in issue #1256.
+    """
+    do_edit_book = _function_def(_module_tree("cps/editbooks.py"), "do_edit_book")
+
+    thumbnail_lines = []
+    commit_lines = []
+    for node in ast.walk(do_edit_book):
+        if not isinstance(node, ast.Call):
+            continue
+        call_name = _call_name(node)
+        if call_name == "helper.replace_cover_thumbnail_cache":
+            thumbnail_lines.append(node.lineno)
+        elif call_name == "calibre_db.session.commit":
+            commit_lines.append(node.lineno)
+
+    assert thumbnail_lines, "do_edit_book should refresh thumbnails after cover changes"
+    assert commit_lines, "do_edit_book should commit Calibre metadata changes"
+
+    first_thumbnail_refresh = min(thumbnail_lines)
+    last_metadata_commit = max(commit_lines)
+
+    assert first_thumbnail_refresh > last_metadata_commit, (
+        "thumbnail refresh is queued before the metadata commit, allowing the "
+        "thumbnail worker to initialize a CalibreDB session while the request "
+        "thread is still executing SQLite metadata queries"
+    )
+
+
+def test_cover_thumbnail_refresh_passes_committed_book_snapshot():
+    """
+    The post-commit refresh should pass the book path and last_modified timestamp
+    so single-book thumbnail generation does not need to reopen metadata.db.
+    """
+    do_edit_book = _function_def(_module_tree("cps/editbooks.py"), "do_edit_book")
+
+    refresh_calls = [
+        node for node in ast.walk(do_edit_book)
+        if isinstance(node, ast.Call)
+        and _call_name(node) == "helper.replace_cover_thumbnail_cache"
+    ]
+
+    assert len(refresh_calls) == 1
+    keyword_names = {keyword.arg for keyword in refresh_calls[0].keywords}
+    assert {"book_path", "last_modified"} <= keyword_names
+
+
+def test_single_book_thumbnail_snapshot_path_avoids_calibre_db_query():
+    """
+    When a single-book refresh has a committed book_path snapshot, that branch
+    must build a BookCoverSource directly instead of falling through to
+    get_books_with_covers(), which opens a fresh CalibreDB session.
+    """
+    thumbnail_tree = _module_tree("cps/tasks/thumbnail.py")
+    get_cover_sources = _function_def(thumbnail_tree, "get_cover_sources")
+
+    snapshot_branch = get_cover_sources.body[0]
+    assert isinstance(snapshot_branch, ast.If)
+
+    snapshot_calls = {
+        _call_name(node) for node in ast.walk(snapshot_branch)
+        if isinstance(node, ast.Call)
+    }
+    assert "BookCoverSource" in snapshot_calls
+    assert "self.get_books_with_covers" not in snapshot_calls
+
+    fallback_calls = [
+        node for node in ast.walk(get_cover_sources)
+        if isinstance(node, ast.Call)
+        and _call_name(node) == "self.get_books_with_covers"
+    ]
+    assert len(fallback_calls) == 1
+    assert fallback_calls[0].lineno > snapshot_branch.lineno


### PR DESCRIPTION
## Summary

Closes #134 (requested by @Onkeyuk). Clean backport of upstream CWA PR [#1346](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1346) by [@navels](https://github.com/navels) — fixes the cover-thumbnail DB deadlock that triggers Web UI 504/502 timeouts during metadata edits on larger libraries.

Refs upstream CWA issue [#1256](https://github.com/crocodilestick/Calibre-Web-Automated/issues/1256) (4 reactions, 6 comments — long-standing).

## What the fix does

The thumbnail regeneration was previously queued *during* the Calibre metadata-edit transaction. `TaskGenerateCoverThumbnails` then re-opened `metadata.db` on the worker thread, while the editing transaction was still holding a write lock on the same SQLite file — gevent's main thread blocked, the Web UI returned 504.

Two changes:

1. `cps/editbooks.py` flips a `refresh_cover_thumbnail_after_commit` flag instead of calling `helper.replace_cover_thumbnail_cache(book.id)` mid-transaction. The actual queue happens after `calibre_db.session.commit()` returns.
2. `cps/helper.py` + `cps/tasks/thumbnail.py` pass the committed `book.path` and `last_modified` directly into `TaskGenerateCoverThumbnails`. The worker uses the new `BookCoverSource` dataclass instead of re-querying `metadata.db` for the single-book refresh case — the deadlock window is gone entirely.

## Tests

`tests/unit/test_thumbnail_deadlock_regression.py` (new, 3 tests):

- `test_cover_thumbnail_refresh_is_not_queued_before_metadata_commit` — AST pin: in `do_edit_book` the `helper.replace_cover_thumbnail_cache(...)` call must appear after `session.commit()`.
- `test_cover_thumbnail_refresh_passes_committed_book_snapshot` — pin: editbooks passes both `book_path=` and `last_modified=` keyword args.
- `test_single_book_thumbnail_snapshot_path_avoids_calibre_db_query` — pin: when `book_id != -1 and book_path` is set, `get_cover_sources()` returns a synthetic `BookCoverSource` instead of opening a CalibreDB session.

Locally on this fork: 3/3 pass.

## Conflict resolution

One trivial conflict at the top of `cps/tasks/thumbnail.py` — fork already had `_BASE_THUMBNAIL_HEIGHT` defined at module scope (from the Kobo cover-padding work in v4.0.21); upstream added the new `BookCoverSource` dataclass at the same line. Resolved by keeping both — they don't interact.

Original author preserved (`Author: Lee Nave <navels@gmail.com>`); committer is new-usemame.

## Browser verification (TODO before merge)

- [ ] Local container `localhost:8086`: edit a book's metadata + cover, confirm no 504 and the thumbnail updates within a few seconds.