### PR TITLE
fix(updater): point release check at the fork + parse vX.Y.Z tags (closes #125)

### DIFF
--- a/cps/updater.py
+++ b/cps/updater.py
@@ -24,7 +24,34 @@ from .file_helper import get_temp_dir
 
 
 log = logger.create()
-_REPOSITORY_API_URL = 'https://api.github.com/repos/janeczku/calibre-web'
+
+# Release-check target. PR #28 (v4.0.8) pointed the s6-init bootstrap probe
+# at this fork; the in-app "Check for Update" button kept hitting janeczku
+# until #125 — leaving the admin updater advertising obsolete versions. The
+# env override matches the contract from #28 so downstreams can still pin to
+# upstream or another fork by name.
+_REPOSITORY_SLUG = os.environ.get("CWA_RELEASE_REPO", "new-usemame/Calibre-Web-NextGen").strip() or "new-usemame/Calibre-Web-NextGen"
+_REPOSITORY_API_URL = 'https://api.github.com/repos/' + _REPOSITORY_SLUG
+
+
+def _normalize_tag(tag_name):
+    """Return a 3-tuple (major, minor, patch) of ints for a release tag.
+
+    Accepts both ``vX.Y.Z`` (our fork format) and ``X.Y.Z`` (upstream's
+    format). Returns ``None`` if the tag doesn't parse — callers must
+    handle that, since GitHub Releases can legitimately carry non-semver
+    tags (alpha builds, manual rebuilds, etc.).
+    """
+    if not tag_name:
+        return None
+    s = tag_name.strip().lstrip("vV")
+    parts = s.split(".")
+    if len(parts) < 3:
+        return None
+    try:
+        return (int(parts[0]), int(parts[1]), int(parts[2]))
+    except (TypeError, ValueError):
+        return None
 
 
 def is_sha1(sha1):
@@ -503,7 +530,8 @@ class Updater(threading.Thread):
         return status
 
     def _stable_updater_parse_major_version(self, commit, i, parents, current_version, status):
-        if int(commit[i + 1]['tag_name'].split('.')[1]) == current_version[1]:
+        next_parsed = _normalize_tag(commit[i + 1]['tag_name']) if i + 1 < len(commit) else None
+        if next_parsed is not None and next_parsed[1] == current_version[1]:
             parents.append([commit[i]['tag_name'],
                             commit[i]['body'].replace('\r\n', '<p>').replace('\n', '<p>')])
             status.update({
@@ -541,7 +569,12 @@ class Updater(threading.Thread):
                 status['message'] = _(u'No release information available')
                 return json.dumps(status)
             version = status['current_commit_hash']
-            current_version = status['current_commit_hash'].split('.')
+            current_parts = _normalize_tag(version)
+            if current_parts is None:
+                status['message'] = _(u'Unexpected data while reading update information')
+                log.error("Unexpected installed-version format: %s", version)
+                return json.dumps(status)
+            current_version = list(current_parts)
 
             # we are already on newest version, no update available
             if 'tag_name' not in commit[0]:
@@ -562,16 +595,14 @@ class Updater(threading.Thread):
                 if 'tag_name' not in commit[i] or 'body' not in commit[i] or 'zipball_url' not in commit[i]:
                     status['message'] = _(u'Unexpected data while reading update information')
                     return json.dumps(status)
-                major_version_update = int(commit[i]['tag_name'].split('.')[0])
-                minor_version_update = int(commit[i]['tag_name'].split('.')[1])
-                patch_version_update = int(commit[i]['tag_name'].split('.')[2])
-
-                current_version[0] = int(current_version[0])
-                current_version[1] = int(current_version[1])
-                try:
-                    current_version[2] = int(current_version[2])
-                except ValueError:
-                    current_version[2] = int(current_version[2].replace("b", "").split(' ')[0])-1
+                parsed = _normalize_tag(commit[i]['tag_name'])
+                if parsed is None:
+                    # Skip releases with non-semver tags rather than blowing up
+                    # the whole check on one weird tag.
+                    log.debug("skipping unparseable tag %s", commit[i]['tag_name'])
+                    i -= 1
+                    continue
+                major_version_update, minor_version_update, patch_version_update = parsed
 
                 # Check if major versions are identical search for newest non-equal commit and update to this one
                 if major_version_update == current_version[0]:

--- a/tests/unit/test_updater_fork_target.py
+++ b/tests/unit/test_updater_fork_target.py
@@ -1,0 +1,123 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Pin the updater's release-check target + version parser (fork issue #125).
+
+Background: PR #28 (v4.0.8) pointed the s6-init bootstrap probe at this
+fork, but left ``cps/updater.py`` hardcoded to ``janeczku/calibre-web``.
+The admin "Check for Update" button kept hitting upstream, so users on
+the fork saw "no update available" forever. @SpookyUSAF reported this
+on v4.0.34.
+
+Also pins ``_normalize_tag`` so our ``vX.Y.Z`` tag format parses without
+the ``ValueError: invalid literal for int()`` that the old `split('.')`
+path would have raised on ``v4.0.45``.
+"""
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.unit
+class TestRepositoryTarget:
+    def test_default_repo_is_new_usemame_fork(self, monkeypatch):
+        monkeypatch.delenv("CWA_RELEASE_REPO", raising=False)
+        # Reimport so the module re-reads the env at import time.
+        from cps import updater
+        importlib.reload(updater)
+        assert updater._REPOSITORY_SLUG == "new-usemame/Calibre-Web-NextGen"
+        assert updater._REPOSITORY_API_URL == (
+            "https://api.github.com/repos/new-usemame/Calibre-Web-NextGen"
+        )
+
+    def test_env_override_honored(self, monkeypatch):
+        monkeypatch.setenv("CWA_RELEASE_REPO", "someone/downstream-fork")
+        from cps import updater
+        importlib.reload(updater)
+        assert updater._REPOSITORY_SLUG == "someone/downstream-fork"
+        assert updater._REPOSITORY_API_URL.endswith(
+            "/someone/downstream-fork"
+        )
+
+    def test_empty_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("CWA_RELEASE_REPO", "   ")
+        from cps import updater
+        importlib.reload(updater)
+        assert updater._REPOSITORY_SLUG == "new-usemame/Calibre-Web-NextGen"
+
+
+@pytest.mark.unit
+class TestNormalizeTag:
+    """The pre-fix code did ``int(tag.split('.')[0])`` which raised
+    ``ValueError`` on every fork tag (``v4.0.45``) — the check button
+    would crash without comparing anything. _normalize_tag must accept
+    both ``vX.Y.Z`` (fork) and ``X.Y.Z`` (upstream) and return None on
+    unparseable input rather than raising."""
+
+    def test_fork_v_prefix_parses(self):
+        from cps.updater import _normalize_tag
+        assert _normalize_tag("v4.0.45") == (4, 0, 45)
+
+    def test_uppercase_v_prefix_parses(self):
+        from cps.updater import _normalize_tag
+        assert _normalize_tag("V1.2.3") == (1, 2, 3)
+
+    def test_no_prefix_parses(self):
+        from cps.updater import _normalize_tag
+        assert _normalize_tag("4.0.45") == (4, 0, 45)
+
+    def test_returns_none_for_non_semver(self):
+        from cps.updater import _normalize_tag
+        assert _normalize_tag("nightly-2026-05-10") is None
+        assert _normalize_tag("v4.0") is None
+        assert _normalize_tag("") is None
+        assert _normalize_tag(None) is None
+
+    def test_does_not_raise_on_garbage(self):
+        from cps.updater import _normalize_tag
+        # Used to be ``int('alpha')`` -> uncaught ValueError up the stack.
+        assert _normalize_tag("alpha.beta.gamma") is None
+        assert _normalize_tag("4.x.45") is None
+
+    def test_whitespace_tolerated(self):
+        from cps.updater import _normalize_tag
+        assert _normalize_tag("  v4.0.45 \n") == (4, 0, 45)
+
+
+@pytest.mark.unit
+class TestVersionCompareIntegration:
+    """Behavioral pin: ``_stable_available_updates`` must use the
+    fork-aware normalizer rather than raise on its own installed
+    version. We can't easily mock the full request-handler stack here
+    so we source-pin the invariants that prevent regression."""
+
+    def test_stable_check_uses_normalizer_for_current_version(self):
+        import inspect
+        from cps.updater import Updater
+        src = inspect.getsource(Updater._stable_available_updates)
+        # Pre-fix: ``status['current_commit_hash'].split('.')`` directly
+        # → int conversion would explode on 'v4.0.45'.
+        assert "_normalize_tag(version)" in src, (
+            "current-version parsing must go through _normalize_tag "
+            "so the fork's v-prefixed tags don't crash the updater"
+        )
+
+    def test_stable_check_uses_normalizer_for_remote_tags(self):
+        import inspect
+        from cps.updater import Updater
+        src = inspect.getsource(Updater._stable_available_updates)
+        assert "_normalize_tag(commit[i]['tag_name'])" in src, (
+            "each remote release tag must also go through "
+            "_normalize_tag so unparseable tags don't bring down the "
+            "whole check"
+        )
+
+    def test_major_version_parser_normalizes(self):
+        import inspect
+        from cps.updater import Updater
+        src = inspect.getsource(Updater._stable_updater_parse_major_version)
+        # Pre-fix used raw int(.split('.')[1]) on the next commit's tag.
+        assert "_normalize_tag(commit[i + 1]['tag_name'])" in src


### PR DESCRIPTION
## Summary

Closes #125 (reporter @SpookyUSAF on v4.0.34).

PR #28 (v4.0.8) pointed the s6-init bootstrap probe at this fork but left ``cps/updater.py`` still hardcoded to ``janeczku/calibre-web``. The admin "Check for Update" button kept hitting upstream, so users on the fork saw "no update available" forever even when newer fork releases existed.

There's also a latent crash: the comparison block did ``int(tag.split('.')[0])`` directly, which raises ``ValueError`` on every fork tag (``v4.0.45``) — once the URL pointed at the fork, the check would have crashed instead of reporting an update.

## Changes

1. ``_REPOSITORY_API_URL`` now resolves through the same ``CWA_RELEASE_REPO`` env contract PR #28 introduced. Default is ``new-usemame/Calibre-Web-NextGen``; downstreams can pin elsewhere by setting the env var.

2. New ``_normalize_tag()`` helper accepts ``vX.Y.Z`` and ``X.Y.Z``, returns ``None`` for unparseable tags rather than raising. The version-compare loop and the major-version branch both go through it now, so a stray non-semver tag in GitHub Releases (alpha builds, manual rebuilds) gets skipped instead of crashing the whole check.

## Tests

12 new tests in ``tests/unit/test_updater_fork_target.py``:

- ``TestRepositoryTarget`` — default fork target, env override honored, empty-env fallback.
- ``TestNormalizeTag`` — fork ``v`` prefix, uppercase ``V``, no-prefix upstream format, garbage returns None, no exception on unparseable, whitespace tolerated.
- ``TestVersionCompareIntegration`` — source-level pins that ``_normalize_tag`` is used for both the installed version and each remote tag, plus the major-version branch.

12/12 pass.

## Browser verification (TODO)

- [ ] Local container at ``localhost:8086``: navigate to ``/admin/view``, click "Check for Update" — should report an actual newer version when one exists on this fork.