### PR TITLE
fix(opds): three independent OPDS bugs (closes #121)

### DIFF
--- a/cps/opds.py
+++ b/cps/opds.py
@@ -12,6 +12,7 @@ from urllib.parse import unquote_plus
 from flask import Blueprint, request, render_template, make_response, abort, Response, g, url_for
 from flask_babel import get_locale
 from flask_babel import gettext as _
+from flask_babel import lazy_gettext as N_
 
 
 from sqlalchemy.sql.expression import func, text, or_, and_, true
@@ -47,101 +48,107 @@ OPDS_ROOT_ORDER_DEFAULT = [
     'magic_shelves',
 ]
 
+# Issue #121: title/description strings on every entry below are wrapped with
+# `N_()` (lazy_gettext) so pybabel-extract picks them up into messages.pot. The
+# pre-fix dict held bare Python literals — pybabel can't follow `_(variable)`
+# at extract time, so newer keys (`books`, `recent`, `magic_shelves`) never
+# made it into the catalog and rendered as English even on a Hungarian-locale
+# UI while the older keys (`hot`, `read`) showed translated.
 OPDS_ROOT_ENTRY_DEFS = {
     'books': {
         'endpoint': 'opds.feed_booksindex',
-        'title': 'Alphabetical Books',
-        'description': 'Books sorted alphabetically',
+        'title': N_('Alphabetical Books'),
+        'description': N_('Books sorted alphabetically'),
         'visible': lambda user, allow_anonymous: True,
     },
     'hot': {
         'endpoint': 'opds.feed_hot',
-        'title': 'Hot Books',
-        'description': 'Popular publications from this catalog based on Downloads.',
+        'title': N_('Hot Books'),
+        'description': N_('Popular publications from this catalog based on Downloads.'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_HOT),
     },
     'top_rated': {
         'endpoint': 'opds.feed_best_rated',
-        'title': 'Top Rated Books',
-        'description': 'Popular publications from this catalog based on Rating.',
+        'title': N_('Top Rated Books'),
+        'description': N_('Popular publications from this catalog based on Rating.'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_BEST_RATED),
     },
     'recent': {
         'endpoint': 'opds.feed_new',
-        'title': 'Recently added Books',
-        'description': 'The latest Books',
+        'title': N_('Recently added Books'),
+        'description': N_('The latest Books'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_RECENT),
     },
     'random': {
         'endpoint': 'opds.feed_discover',
-        'title': 'Random Books',
-        'description': 'Show Random Books',
+        'title': N_('Random Books'),
+        'description': N_('Show Random Books'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_RANDOM),
     },
     'read': {
         'endpoint': 'opds.feed_read_books',
-        'title': 'Read Books',
-        'description': 'Read Books',
+        'title': N_('Read Books'),
+        'description': N_('Read Books'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_READ_AND_UNREAD) and not user.is_anonymous,
     },
     'unread': {
         'endpoint': 'opds.feed_unread_books',
-        'title': 'Unread Books',
-        'description': 'Unread Books',
+        'title': N_('Unread Books'),
+        'description': N_('Unread Books'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_READ_AND_UNREAD) and not user.is_anonymous,
     },
     'authors': {
         'endpoint': 'opds.feed_authorindex',
-        'title': 'Authors',
-        'description': 'Books ordered by Author',
+        'title': N_('Authors'),
+        'description': N_('Books ordered by Author'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_AUTHOR),
     },
     'publishers': {
         'endpoint': 'opds.feed_publisherindex',
-        'title': 'Publishers',
-        'description': 'Books ordered by publisher',
+        'title': N_('Publishers'),
+        'description': N_('Books ordered by publisher'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_PUBLISHER),
     },
     'categories': {
         'endpoint': 'opds.feed_categoryindex',
-        'title': 'Categories',
-        'description': 'Books ordered by category',
+        'title': N_('Categories'),
+        'description': N_('Books ordered by category'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_CATEGORY),
     },
     'series': {
         'endpoint': 'opds.feed_seriesindex',
-        'title': 'Series',
-        'description': 'Books ordered by series',
+        'title': N_('Series'),
+        'description': N_('Books ordered by series'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_SERIES),
     },
     'languages': {
         'endpoint': 'opds.feed_languagesindex',
-        'title': 'Languages',
-        'description': 'Books ordered by Languages',
+        'title': N_('Languages'),
+        'description': N_('Books ordered by Languages'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_LANGUAGE),
     },
     'ratings': {
         'endpoint': 'opds.feed_ratingindex',
-        'title': 'Ratings',
-        'description': 'Books ordered by Rating',
+        'title': N_('Ratings'),
+        'description': N_('Books ordered by Rating'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_RATING),
     },
     'formats': {
         'endpoint': 'opds.feed_formatindex',
-        'title': 'File formats',
-        'description': 'Books ordered by file formats',
+        'title': N_('File formats'),
+        'description': N_('Books ordered by file formats'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_FORMAT),
     },
     'shelves': {
         'endpoint': 'opds.feed_shelfindex',
-        'title': 'Shelves',
-        'description': 'Books organized in shelves',
+        'title': N_('Shelves'),
+        'description': N_('Books organized in shelves'),
         'visible': lambda user, allow_anonymous: user.is_authenticated or allow_anonymous,
     },
     'magic_shelves': {
         'endpoint': 'opds.feed_magic_shelfindex',
-        'title': 'Magic Shelves',
-        'description': 'Books organized in magic shelves',
+        'title': N_('Magic Shelves'),
+        'description': N_('Books organized in magic shelves'),
         'visible': lambda user, allow_anonymous: user.is_authenticated or allow_anonymous,
     },
 }

--- a/cps/usermanagement.py
+++ b/cps/usermanagement.py
@@ -117,8 +117,17 @@ def create_authenticated_user(username, email=None, auth_source="unknown"):
 
 @auth.verify_password
 def verify_password(username, password):
+    # Issue #121: OPDS clients (Readest, etc.) commonly issue an
+    # unauthenticated probe before sending credentials, which lands here as
+    # ``verify_password("", "")`` and used to log a WARN per request — log
+    # spam without any signal. Short-circuit cleanly: an empty username is
+    # "no credentials submitted," not a login failure. The decorator
+    # ``requires_basic_auth_if_no_ano`` will fall back to Guest if anonymous
+    # browsing is enabled, otherwise return 401.
+    if not username:
+        return None
     user = ub.session.query(ub.User).filter(func.lower(ub.User.name) == username.lower()).first()
-    
+
     # Handle existing users
     if user:
         if user.name.lower() == "guest":
@@ -169,7 +178,11 @@ def verify_password(username, password):
         except Exception as ex:
             log.error("LDAP auto-creation error for OPDS user '%s': %s", username, ex)
     
-    # Use request.remote_addr (already corrected by ProxyFix) instead of raw header
+    # Issue #121: only warn when a non-empty username actually failed to
+    # authenticate. The empty-username probe case is filtered out at the
+    # top of this function, so reaching here means real credentials were
+    # rejected — that's worth a WARN. The previous code warned for the
+    # probe too, spamming the logs on every OPDS catalogue fetch.
     ip_address = request.remote_addr
     log.warning('OPDS Login failed for user "%s" IP-address: %s', username, ip_address)
     return None
@@ -183,11 +196,26 @@ def requires_basic_auth_if_no_ano(f):
         user = None
         if config.config_allow_reverse_proxy_header_login and not authorisation:
             user = load_user_from_reverse_proxy_header(request)
+        # Issue #121: when anonymous browsing is enabled, the previous code
+        # only substituted Guest when no auth header was present at all —
+        # so a client sending credentials with an empty or wrong username
+        # got a 401 instead of the Guest catalog it would have seen without
+        # credentials. Anon-enabled deployments should behave the same
+        # whether the client tries to authenticate or not: real creds win
+        # if they validate, otherwise fall through to Guest.
         if config.config_anonbrowse == 1 and not authorisation:
             authorisation = Authorization(
                 b"Basic", {'username': "Guest", 'password': ""})
         if not user:
             user = auth.authenticate(authorisation, "")
+        # Issue #121 part 2: graceful fallback to Guest when auth was
+        # attempted but failed and anonymous browsing is on. Without this
+        # the OPDS client never sees the anon catalog whenever it has a
+        # bad/empty credential cached.
+        if user in (False, None) and config.config_anonbrowse == 1:
+            guest_auth = Authorization(
+                b"Basic", {'username': "Guest", 'password': ""})
+            user = auth.authenticate(guest_auth, "")
         if user in (False, None):
             status = 401
         if status:

--- a/tests/unit/test_opds_bugs_121.py
+++ b/tests/unit/test_opds_bugs_121.py
@@ -1,0 +1,149 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for fork issue #121 — three independent OPDS bugs
+reported by @droM4X on v4.0.39 against the Readest client.
+
+1. **Log spam.** Every authenticated OPDS request emitted a WARN line
+   `OPDS Login failed for user "" IP-address: ...` because OPDS clients
+   commonly issue an unauthenticated probe before sending credentials.
+   The empty-username probe is not a login failure — the WARN was noise.
+
+2. **Anon+auth multiplexing.** When anonymous browsing was enabled and
+   the client also sent (possibly stale) credentials, the server
+   returned 401 instead of falling back to the Guest catalog. The user
+   expected anon-enabled deployments to behave the same whether the
+   client tried to authenticate or not.
+
+3. **Hardcoded English on three OPDS root entries.** "Alphabetical
+   Books", "Recently added Books", and "Magic Shelves" rendered in
+   English on a Hungarian-locale UI while sibling entries ("Hot Books",
+   "Read Books") localized correctly. The entries' titles were bare
+   Python literals in a dict — pybabel-extract can't follow
+   ``_(variable)`` at extract time, so those three never made it into
+   ``messages.pot``. Wrapping with ``N_()`` (lazy_gettext) marks them
+   for extraction.
+
+These tests pin the fix at the source level so a refactor can't regress
+any of the three.
+"""
+
+import inspect
+
+import pytest
+
+
+@pytest.mark.unit
+class TestEmptyUsernameProbeIsNotAnError:
+    """Bug 1: empty username must short-circuit cleanly."""
+
+    def test_verify_password_short_circuits_on_empty_username(self):
+        from cps import usermanagement
+        src = inspect.getsource(usermanagement.verify_password)
+        # The very first behavioural branch must filter `not username`
+        # and `return None` before any DB query or log line fires.
+        assert "if not username:\n        return None" in src, (
+            "verify_password must short-circuit on empty username before "
+            "hitting the DB or logging — otherwise every OPDS probe spams "
+            "a misleading WARN"
+        )
+
+    def test_no_warning_logged_for_empty_username(self, mocker):
+        """Behavioral: calling verify_password("", "") must not invoke
+        log.warning. This is the actual user-visible symptom."""
+        from cps import usermanagement
+        mock_log = mocker.patch.object(usermanagement, "log")
+        # ub.session may not be ready in the test env; the early return
+        # avoids touching it at all.
+        result = usermanagement.verify_password("", "")
+        assert result is None
+        mock_log.warning.assert_not_called()
+
+
+@pytest.mark.unit
+class TestAnonFallbackOnFailedAuth:
+    """Bug 2: when anon browsing is on and auth fails, fall back to
+    Guest instead of 401."""
+
+    def test_decorator_falls_back_to_guest_on_failed_auth_when_anon_enabled(self):
+        from cps import usermanagement
+        src = inspect.getsource(usermanagement.requires_basic_auth_if_no_ano)
+        # The fix introduces a second branch that retries auth with the
+        # synthetic Guest credentials specifically when both
+        # (a) the first auth attempt returned None/False AND
+        # (b) config.config_anonbrowse is enabled.
+        assert "config.config_anonbrowse == 1" in src
+        # Look for the second Guest-substitution branch — there are now
+        # two Guest substitutions, one for "no creds sent" (preserved
+        # from before the fix) and one for "creds sent but failed" (new).
+        guest_subs = src.count("'username': \"Guest\"")
+        assert guest_subs >= 2, (
+            "expected two Guest-credential substitutions in the decorator: "
+            "one for 'no auth header sent', one for 'auth failed AND anon "
+            "enabled' (the issue #121 fallback). Found %d." % guest_subs
+        )
+
+
+@pytest.mark.unit
+class TestOpdsRootEntryDefsAreExtractable:
+    """Bug 3: every title/description literal must be wrapped with N_()
+    so pybabel-extract picks it up into messages.pot. The OPDS root
+    dict had bare Python literals in pre-fix code, so newer keys never
+    landed in the catalog and rendered as English on translated UIs."""
+
+    def test_opds_module_imports_lazy_gettext_as_N(self):
+        import cps.opds as opds_mod
+        # N_ must be importable from the module so the entry-defs literals
+        # can use it. We assert the symbol exists rather than do a regex
+        # over the source because subtle re-exports can hide a missing
+        # marker.
+        assert hasattr(opds_mod, "N_"), (
+            "cps.opds must expose N_ (flask_babel.lazy_gettext) — without "
+            "it the dict-resident OPDS title/description literals can't "
+            "be picked up by pybabel-extract"
+        )
+
+    def test_every_root_entry_title_is_lazy_string(self):
+        from cps.opds import OPDS_ROOT_ENTRY_DEFS
+        # lazy_gettext returns a LazyString; the cheapest cross-version
+        # check is that the value is not a plain `str` instance.
+        for key, entry in OPDS_ROOT_ENTRY_DEFS.items():
+            assert not isinstance(entry["title"], str), (
+                f"OPDS root entry '{key}' has a bare-string title "
+                f"({entry['title']!r}) — wrap with N_() so the translation "
+                f"extractor picks it up"
+            )
+            assert not isinstance(entry["description"], str), (
+                f"OPDS root entry '{key}' has a bare-string description "
+                f"({entry['description']!r}) — wrap with N_() so the "
+                f"translation extractor picks it up"
+            )
+
+    def test_specific_keys_user_reported_are_marked(self):
+        """The three keys @droM4X named specifically."""
+        from cps.opds import OPDS_ROOT_ENTRY_DEFS
+        for k in ("books", "recent", "magic_shelves"):
+            title = OPDS_ROOT_ENTRY_DEFS[k]["title"]
+            # str() coercion via __str__ resolves the LazyString to the
+            # current-locale translation; in unit-test context with no
+            # locale set this is just the source English. The point
+            # of this test is that the value is no longer a bare str —
+            # see the previous test. Here we also assert the source
+            # English matches what the user reported.
+            assert str(title) in (
+                "Alphabetical Books",
+                "Recently added Books",
+                "Magic Shelves",
+            ), f"unexpected title for {k}: {title!r}"
+
+    def test_get_opds_root_entries_resolves_title_through_gettext(self):
+        """The render-side translator must still be called on the
+        LazyString. Source-pin so a refactor can't drop the gettext
+        coercion at the dict-merge step."""
+        import inspect as _inspect
+        from cps.opds import get_opds_root_entries
+        src = _inspect.getsource(get_opds_root_entries)
+        assert "_(entry_def['title'])" in src
+        assert "_(entry_def['description'])" in src


### PR DESCRIPTION
## Summary

Closes #121 (reporter @droM4X on v4.0.39, tested with the Readest OPDS client). Three independent bugs in one report; all three fixed here.

### 1. Log spam on every OPDS request

Every OPDS catalogue fetch logged `WARN  OPDS Login failed for user "" IP-address: ...` even when the user's credentials worked fine. OPDS clients commonly issue an unauthenticated probe before sending credentials — that probe landed in ``verify_password`` as ``verify_password("", "")`` which ran a DB lookup, missed, then logged the WARN. Now short-circuits at the top: no DB query, no WARN. Genuine auth failures (non-empty username with wrong password) still log at WARN as before.

### 2. Anonymous-mode regression

When anonymous browsing was enabled AND the OPDS client sent (possibly stale) credentials, the server returned 401 instead of falling back to the Guest catalog. Anon-enabled deployments should behave the same whether the client tries to authenticate or not. ``requires_basic_auth_if_no_ano`` now retries with the synthetic Guest credentials when the first auth attempt fails AND ``config.config_anonbrowse`` is on. Auth-only deployments keep their original 401 behavior — unchanged.

### 3. Hardcoded English on three OPDS root entries

"Alphabetical Books", "Recently added Books", and "Magic Shelves" rendered in English on a Hungarian-locale UI while sibling entries (`Hot Books` → `Népszerű könyvek`, `Read Books` → `Elolvasott könyvek`) localized correctly. Root cause: ``OPDS_ROOT_ENTRY_DEFS`` held bare Python literals; pybabel-extract can't follow ``_(variable)`` at extract time, so those keys never made it into ``messages.pot``. Every title and description is now wrapped with ``N_()`` (``flask_babel.lazy_gettext``); next ``pybabel extract`` run picks them up. Existing translations for the older entries are not affected because their msgid strings are unchanged.

## Tests

7 new tests in ``tests/unit/test_opds_bugs_121.py``:

- ``TestEmptyUsernameProbeIsNotAnError`` — source-pin on the short-circuit + behavioral mock asserting ``log.warning`` is never called for the empty-username probe.
- ``TestAnonFallbackOnFailedAuth`` — source-pin asserting two Guest-substitution branches in the decorator (one for "no creds sent", one for "creds sent but failed" — the new fallback).
- ``TestOpdsRootEntryDefsAreExtractable`` — pins that ``N_`` is imported in ``cps/opds.py``, every entry's title and description is a LazyString (not a bare ``str``), and the render-side ``_()`` translator is still called on each.

7/7 green.

## Browser verification (TODO before merge)

- [ ] Local container at ``localhost:8086``: hit ``/opds`` with no auth (anon enabled) — see Guest catalog.
- [ ] Hit ``/opds`` with valid Basic auth — see authed catalog.
- [ ] Hit ``/opds`` with empty / wrong creds while anon enabled — see Guest catalog, no 401, no WARN in logs.
- [ ] Switch UI locale to Hungarian, refresh ``/opds`` — confirm "Alphabetical Books" / "Recently added Books" / "Magic Shelves" can now be translated once a translator adds the strings to ``hu.po``.