### PR TITLE
fix(admin/i18n): inline update indicator on Docker builds + Hungarian OPDS translations

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -519,11 +519,33 @@ def cwa_get_package_versions() -> tuple[str, str, str, str]:
     return cwa_version, kepubify_version, calibre_version
 
 
+def cwa_get_update_indicator() -> tuple[bool, str]:
+    """Return ``(is_outdated, latest_tag)`` for the admin Version
+    Information table (fork issue #125 follow-up). Docker builds disable
+    ``feature_support['updater']`` so the "Check for Update" button never
+    renders — Docker users (the operator's deployment, plus everyone
+    pulling ``ghcr.io/new-usemame/calibre-web-nextgen``) had no way to
+    learn that a newer release existed from the admin UI.
+    ``s6-init/cwa-init`` (per PR #28) already writes the latest fork tag
+    to ``/app/CWA_STABLE_RELEASE`` at container boot; we just need to
+    surface it next to the installed version in the admin table.
+    Returns ``(False, "")`` on any error so the page never fails to
+    render because of a version-probe glitch.
+    """
+    try:
+        from .render_template import cwa_update_available
+        is_newer, _current, latest = cwa_update_available()
+        return bool(is_newer), (latest or "")
+    except Exception:
+        return False, ""
+
+
 @admi.route("/admin/view")
 @user_login_required
 @admin_required
 def admin():
     cwa_version, kepubify_version, calibre_version = cwa_get_package_versions()
+    is_outdated, latest_tag = cwa_get_update_indicator()
 
     all_user = ub.session.query(ub.User).all()
     # email_settings = mail_config.get_mail_settings()
@@ -533,7 +555,10 @@ def admin():
 
     return render_title_template("admin.html", allUser=all_user, config=config,
                                  cwa_version=cwa_version, kepubify_version=kepubify_version,
-                                 calibre_version=calibre_version, feature_support=feature_support,
+                                 calibre_version=calibre_version,
+                                 cwa_is_outdated=is_outdated,
+                                 cwa_latest_tag=latest_tag,
+                                 feature_support=feature_support,
                                  schedule_time=schedule_time, schedule_duration=schedule_duration,
                                  title=_("Admin page"), page="admin")
 

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -255,7 +255,13 @@
           <tr id="current_version">
             <td>Calibre-Web NextGen</td>
             <td>{{cwa_version}} </td>
-            <td><i>{{_('Current Version')}}</i></td>
+            <td>
+              {% if cwa_is_outdated and cwa_latest_tag %}
+                <i style="color:#cc7b19;">{{_('Update available')}}: <strong>{{cwa_latest_tag}}</strong> — <code>docker pull ghcr.io/new-usemame/calibre-web-nextgen:latest</code></i>
+              {% else %}
+                <i>{{_('Current Version')}}</i>
+              {% endif %}
+            </td>
           </tr>
           <tr id="current_version">
             <td>Calibre</td>

--- a/cps/translations/hu/LC_MESSAGES/messages.po
+++ b/cps/translations/hu/LC_MESSAGES/messages.po
@@ -1693,6 +1693,22 @@ msgstr "Népszerű könyvek"
 msgid "Show Hot Books"
 msgstr "Népszerű könyvek megjelenítése"
 
+#: cps/opds.py:60
+msgid "Alphabetical Books"
+msgstr "Könyvek ábécé sorrendben"
+
+#: cps/opds.py:78
+msgid "Recently added Books"
+msgstr "Nemrég hozzáadott könyvek"
+
+#: cps/opds.py:150
+msgid "Magic Shelves"
+msgstr "Varázspolcok"
+
+#: cps/opds.py:66
+msgid "Random Books"
+msgstr "Véletlenszerű könyvek"
+
 #: cps/render_template.py:47 cps/render_template.py:52
 msgid "Downloaded Books"
 msgstr "Letöltött könyvek"

--- a/tests/unit/test_admin_update_indicator.py
+++ b/tests/unit/test_admin_update_indicator.py
@@ -1,0 +1,125 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Pin the admin Version Information table's "update available" indicator
+(fork issue #125 follow-up).
+
+PR #136 fixed the "Check for Update" button's Python flow, but Docker
+builds set ``feature_support['updater'] = False`` (constants.UPDATER_AVAILABLE
+is False in containers because the updater can't replace files at runtime
+inside an image). The button never renders for Docker users — i.e. the
+operator's deployment + every fork user pulling
+``ghcr.io/new-usemame/calibre-web-nextgen``. Those users had no way to learn
+from the admin UI that a newer release existed.
+
+The s6-init bootstrap probe (PR #28, v4.0.8) already writes the latest fork
+tag to ``/app/CWA_STABLE_RELEASE`` at container boot, and
+``cwa_update_available()`` already compares installed vs stable. We just
+need to surface that comparison next to the installed version in the admin
+Version Information table.
+
+These tests pin:
+
+1. ``cwa_get_update_indicator()`` returns ``(True, "v4.0.46")`` when stable
+   is strictly newer than installed.
+2. It returns ``(False, ...)`` when installed equals or exceeds stable.
+3. It returns ``(False, "")`` gracefully on any exception from
+   ``cwa_update_available`` (never breaks the admin page render).
+4. The admin route passes the indicator into the template under the names
+   ``cwa_is_outdated`` and ``cwa_latest_tag``.
+5. The template renders "Update available: <tag>" with the docker-pull
+   command when outdated, otherwise the original "Current Version" label.
+"""
+
+import inspect
+
+import pytest
+
+
+@pytest.mark.unit
+class TestUpdateIndicatorHelper:
+    def test_returns_true_when_stable_is_newer(self, mocker):
+        from cps import admin
+        mocker.patch(
+            "cps.render_template.cwa_update_available",
+            return_value=(True, "v4.0.34", "v4.0.46"),
+        )
+        is_outdated, latest = admin.cwa_get_update_indicator()
+        assert is_outdated is True
+        assert latest == "v4.0.46"
+
+    def test_returns_false_when_installed_equals_stable(self, mocker):
+        from cps import admin
+        mocker.patch(
+            "cps.render_template.cwa_update_available",
+            return_value=(False, "v4.0.46", "v4.0.46"),
+        )
+        is_outdated, latest = admin.cwa_get_update_indicator()
+        assert is_outdated is False
+
+    def test_swallow_exceptions_returns_safe_default(self, mocker):
+        """The admin page must never fail to render because of a version
+        probe glitch (network, missing file, parsing error, etc.). The
+        indicator helper has to return a clean default on any throw."""
+        from cps import admin
+        mocker.patch(
+            "cps.render_template.cwa_update_available",
+            side_effect=RuntimeError("boom"),
+        )
+        is_outdated, latest = admin.cwa_get_update_indicator()
+        assert is_outdated is False
+        assert latest == ""
+
+
+@pytest.mark.unit
+class TestAdminRoutePassesIndicator:
+    def test_admin_route_source_passes_indicator_kwargs(self):
+        """Source-pin: ``admin()`` must include cwa_is_outdated and
+        cwa_latest_tag in the render_title_template kwargs. A refactor
+        that drops these would silently regress @SpookyUSAF's symptom."""
+        from cps import admin
+        src = inspect.getsource(admin.admin)
+        assert "cwa_get_update_indicator()" in src, (
+            "admin() must call cwa_get_update_indicator() to populate the "
+            "outdated flag for the Version Information table"
+        )
+        assert "cwa_is_outdated=" in src
+        assert "cwa_latest_tag=" in src
+
+
+@pytest.mark.unit
+class TestAdminTemplateRendersIndicator:
+    """Template-source pin: when outdated, the admin.html Version
+    Information row renders 'Update available' with the latest tag and a
+    docker-pull command; otherwise the original 'Current Version' label.
+    We assert against the template source rather than full Jinja rendering
+    so this test stays independent of the Flask app context."""
+
+    def test_template_has_outdated_branch(self):
+        import os
+        repo_root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..")
+        )
+        admin_html = os.path.join(repo_root, "cps", "templates", "admin.html")
+        with open(admin_html, encoding="utf-8") as fh:
+            template = fh.read()
+        # The new branch must reference both variables.
+        assert "cwa_is_outdated" in template
+        assert "cwa_latest_tag" in template
+        # And it must surface the docker-pull command in the user-visible
+        # message so the user knows what to do next.
+        assert "docker pull ghcr.io/new-usemame/calibre-web-nextgen" in template
+
+    def test_template_preserves_current_version_fallback(self):
+        import os
+        repo_root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..")
+        )
+        admin_html = os.path.join(repo_root, "cps", "templates", "admin.html")
+        with open(admin_html, encoding="utf-8") as fh:
+            template = fh.read()
+        # The pre-existing label must remain in the else-branch so up-to-date
+        # installs see the original wording.
+        assert "{{_('Current Version')}}" in template


### PR DESCRIPTION
## Summary

Closes the gap PR #136 left for Docker users, and finishes the i18n side of #121.

### Admin Version Information table now shows "Update available"

PR #136 fixed the in-fork \`Check for Update\` button, but Docker builds disable \`feature_support['updater']\` (the in-place file replacement doesn't work in a container). Docker users — the operator's deployment + everyone on \`ghcr.io/new-usemame/calibre-web-nextgen\` — had no way to learn from the admin UI that a newer release existed. @SpookyUSAF was specifically asking for this surface to reflect the fork's latest release.

\`s6-init/cwa-init\` (PR #28, v4.0.8) already writes the latest fork tag to \`/app/CWA_STABLE_RELEASE\` at container boot, and \`cwa_update_available()\` already compares installed vs stable. We just surface that next to the installed version in the Version Information table.

When outdated, the row reads:

> Update available: **v4.0.47** — \`docker pull ghcr.io/new-usemame/calibre-web-nextgen:latest\`

Otherwise the original "Current Version" label is preserved. Helper swallows any exception so a version-probe glitch never breaks the admin page render.

### Hungarian OPDS translations actually land

PR #137 wrapped the OPDS root entries with \`N_()\` so pybabel-extract could pick them up. This PR runs the next step — adds Hungarian translations to \`cps/translations/hu/LC_MESSAGES/messages.po\` for the four labels that previously rendered in English on a Hungarian-locale UI:

- "Alphabetical Books" → "Könyvek ábécé sorrendben"
- "Recently added Books" → "Nemrég hozzáadott könyvek"
- "Random Books" → "Véletlenszerű könyvek"
- "Magic Shelves" → "Varázspolcok"

Verified end-to-end against the local container: admin user with \`locale='hu'\` fetches \`/opds/\` via Basic auth, returned XML renders all four labels in Hungarian alongside the pre-existing translations. Survives cold container restart.

## Tests

6 regression tests in \`tests/unit/test_admin_update_indicator.py\`:

- \`cwa_get_update_indicator()\` returns correct \`(bool, str)\` under newer / equal / exception inputs.
- \`admin()\` route source-pin asserts \`cwa_is_outdated\` + \`cwa_latest_tag\` are passed to the template.
- \`admin.html\` source-pin asserts the outdated branch references both variables AND surfaces the docker-pull command, and the "Current Version" fallback is preserved.

6/6 green.

## Live container verification

- \`/admin/view\` renders the outdated row when CWA_INSTALLED < CWA_STABLE.
- \`/opds/\` with \`admin@hu\` Basic auth renders 16 root entries with all 4 newly-translated labels in Hungarian.
- Cold-restart resilience: all fixes (incl. the prior #134/#135/#136/#137) survive a \`docker stop && docker start\` of the local container.