### PR TITLE
fix(i18n): hu.po obsolete-msgid duplicate + msgfmt regression test (closes v4.0.47 .mo miss)

### DIFF
--- a/cps/translations/hu/LC_MESSAGES/messages.po
+++ b/cps/translations/hu/LC_MESSAGES/messages.po
@@ -7147,9 +7147,6 @@ msgstr "Olvasott/olvasatlan mutatása"
 #~ msgid "The latest Books"
 #~ msgstr "A legfrissebb könyvek"
 
-#~ msgid "Random Books"
-#~ msgstr "Könyvek találomra"
-
 #~ msgid "Books ordered by Author"
 #~ msgstr "Könyvek szerző szerint rendezve"
 

--- a/tests/unit/test_translations_compile.py
+++ b/tests/unit/test_translations_compile.py
@@ -1,0 +1,92 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression test for fork issue #121 sub-bug 3 follow-up — every shipped
+.po file must compile cleanly with ``msgfmt``.
+
+Background: ``scripts/compile_translations.sh`` deliberately doesn't fail
+the Docker build when one locale fails to compile (so a broken .po in one
+language doesn't strand all the others). The cost of that policy is that
+per-locale failures are silent unless someone reads the build logs — and
+that's exactly how v4.0.47 shipped without ``hu/messages.mo``: I'd added
+four new translations but the file also contained an obsolete ``#~ msgid``
+duplicate of one of them; msgfmt rejected the file, the build kept going,
+and on teenyverse Hungarian users got the English fallback.
+
+This test runs ``msgfmt --check`` against every ``messages.po`` in the
+translations tree so a malformed .po triggers a unit-test failure long
+before CI builds the Docker image. Acts as the test-suite-side checker
+the deferred Docker build doesn't enforce.
+"""
+
+import glob
+import os
+import shutil
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+TRANSLATIONS_DIR = os.path.join(REPO_ROOT, "cps", "translations")
+
+
+def _discover_po_files():
+    pattern = os.path.join(TRANSLATIONS_DIR, "*", "LC_MESSAGES", "messages.po")
+    return sorted(glob.glob(pattern))
+
+
+PO_FILES = _discover_po_files()
+
+
+@pytest.mark.unit
+def test_translations_dir_exists():
+    assert os.path.isdir(TRANSLATIONS_DIR), (
+        f"Expected translations dir at {TRANSLATIONS_DIR}"
+    )
+
+
+@pytest.mark.unit
+def test_at_least_one_po_file_present():
+    assert PO_FILES, "No .po files found under cps/translations"
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(
+    shutil.which("msgfmt") is None,
+    reason="msgfmt not available on this host (install gettext / brew install gettext)",
+)
+@pytest.mark.parametrize("po_path", PO_FILES, ids=lambda p: p.split(os.sep)[-3])
+def test_po_file_compiles_cleanly(po_path, tmp_path):
+    """Every shipped .po file must compile cleanly under the same
+    invocation `scripts/compile_translations.sh` uses in the Docker build:
+    plain ``msgfmt <po> -o <mo>``. Strictly hard errors (duplicate msgid,
+    malformed PO syntax, encoding problems) are what we gate on — they
+    cause the .mo to be missing in production. Per-format-string warnings
+    that ``--check`` would surface are intentionally not gated so this
+    test matches what the production build actually rejects.
+
+    Fix hint: an obsolete ``#~ msgid`` line duplicating a newly-added
+    active msgid is the most common cause of a silent .mo drop. Delete
+    the obsolete block — it's commented out anyway.
+    """
+    out_mo = tmp_path / "test.mo"
+    result = subprocess.run(
+        ["msgfmt", po_path, "-o", str(out_mo)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        locale = po_path.split(os.sep)[-3]
+        pytest.fail(
+            f"msgfmt failed for locale {locale!r} — .mo would not ship:\n"
+            f"  {po_path}\n"
+            f"--- stderr ---\n{result.stderr.rstrip()}\n"
+            f"--- fix hint ---\n"
+            f"  Run `msgfmt {po_path}` locally and address every error.\n"
+            f"  Most common cause: an obsolete `#~ msgid` line duplicates\n"
+            f"  a newly-added active msgid — delete the obsolete block.\n"
+        )
+    assert out_mo.exists(), "msgfmt should have produced a .mo file"


### PR DESCRIPTION
## Summary

PR #138's hu.po addition for "Random Books" collided with an obsolete `#~ msgid` for the same string further down the file. ``msgfmt`` treats `#~` duplicates of active entries as fatal errors, so during the v4.0.47 Docker build it silently refused to compile ``hu/messages.mo``. ``compile_translations.sh`` is intentionally tolerant (one broken locale shouldn't strand the rest) so the v4.0.47 image shipped without a Hungarian .mo. Hungarian users got the English fallback even on strings the existing hu.po already translated for years.

Caught only because the v4.0.46/v4.0.47 verification pass actually checked production behavior on teenyverse — exactly the gap the new ``CLAUDE.md`` "Enterprise verification standard" section was added to catch.

## Two changes

1. **Delete the obsolete `#~ msgid "Random Books"` block** in `hu.po` (lines 7150-7152). It was commented out; removing it isn't a behavior change.

2. **New `tests/unit/test_translations_compile.py`** parametrized over every shipped `.po`. Each test runs the same `msgfmt <po> -o <mo>` invocation `scripts/compile_translations.sh` uses in the Docker build and fails the unit suite if any locale wouldn't ship a `.mo`. Now this exact class of regression gets caught before CI builds an image, not after deploy.

## Tests

30/30 green locally — every locale's `.po` compiles. Verified by running the same test against the broken pre-fix commit (regenerated the duplicate) and confirming it fails with the expected `duplicate message definition` error.

## What the user sees after this lands

Hungarian users get the four newly-translated OPDS root labels rendered in Hungarian (Könyvek ábécé sorrendben / Nemrég hozzáadott könyvek / Véletlenszerű könyvek / Varázspolcok). Other locales unaffected.