### PR TITLE
fix(templates): point user-facing URLs at the fork (#141)

### DIFF
--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -215,7 +215,7 @@
     <a class="btn btn-default" id="epub_fixer" href="{{url_for('epub_fixer.show_epub_fixer_page')}}">{{_('CWA EPUB Fixer Service')}}</a>
   </div>
   <div class="row form-group">
-    <a class="btn btn-default github" id="cwa_github_link" href="https://github.com/crocodilestick/Calibre-Web-Automated/">{{_('CWA GitHub')}}</a>
+    <a class="btn btn-default github" id="cwa_github_link" href="https://github.com/new-usemame/Calibre-Web-NextGen/">{{_('CWA GitHub')}}</a>
     <a class="btn btn-default discord" id="cwa_discord_link" href="https://discord.gg/EjgSeek94R">{{_('CWA Discord Server')}}</a>
   </div>
   <div class="row form-group">

--- a/cps/templates/http_error.html
+++ b/cps/templates/http_error.html
@@ -41,7 +41,7 @@
   {% if issue %}
     <div class="row">
     <div class="col errorlink">Please report this issue with all related information:
-        <a href="https://github.com/crocodilestick/calibre-web-automated/issues/new/choose">{{_('Create Issue')}}</a>
+        <a href="https://github.com/new-usemame/Calibre-Web-NextGen/issues/new/choose">{{_('Create Issue')}}</a>
     </div>
       </div>
     {% endif %}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -207,7 +207,7 @@
       {%if message[0] == "cwa_update" %}
       <div class="row-fluid text-center">
         <div id="flash_info" class="alert alert-info alert-cwa">
-          {{ message[1] }} <a href="https://github.com/crocodilestick/Calibre-Web-Automated/releases">{{ _('See Changelog') }}</a>
+          {{ message[1] }} <a href="https://github.com/new-usemame/Calibre-Web-NextGen/releases">{{ _('See Changelog') }}</a>
           <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
@@ -227,7 +227,7 @@
       {%if message[0] == "translation_missing" %}
       <div class="row-fluid text-center">
         <div id="flash_info" class="alert alert-info alert-cwa">
-          {{ message[1] }} <a href="https://github.com/crocodilestick/Calibre-Web-Automated/wiki/Contributing-Translations">{{ _('Contribute here!') }}</a>
+          {{ message[1] }} <a href="https://github.com/new-usemame/Calibre-Web-NextGen/wiki/Contributing-Translations">{{ _('Contribute here!') }}</a>
           <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>

--- a/tests/unit/test_template_fork_urls.py
+++ b/tests/unit/test_template_fork_urls.py
@@ -1,0 +1,113 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression test for fork issue #141 — user-facing template URLs that
+direct users to project resources (release notes, issue tracker, project
+home) must point at ``new-usemame/Calibre-Web-NextGen``, not upstream.
+
+Cherry-picks from ``crocodilestick/Calibre-Web-Automated`` keep
+reintroducing the upstream URL into ``cps/templates/`` — the "See
+Changelog" link in the in-app update banner, the "Create Issue" link on
+error pages, and the "CWA GitHub" admin button were all still pointing
+at upstream months after the fork detached. This test pins them.
+
+Allowed upstream references (attribution + docs we don't have our own
+copy of yet) are listed explicitly so the test doesn't fight legitimate
+credit lines. Add to ``ALLOWED_UPSTREAM_REFS`` only with operator
+review — anything new should default to the fork URL.
+"""
+
+import os
+import re
+
+import pytest
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+TEMPLATES_DIR = os.path.join(REPO_ROOT, "cps", "templates")
+
+UPSTREAM_HOST_RE = re.compile(
+    r"https?://github\.com/crocodilestick/[Cc]alibre-[Ww]eb-[Aa]utomated",
+)
+
+ALLOWED_UPSTREAM_REFS = {
+    # Attribution in the public stats page: "based on Calibre-Web Automated."
+    # Credit line — must stay pointing at upstream.
+    "stats.html",
+    # Database-configuration wiki link. Our own wiki doesn't have an
+    # equivalent page yet; users follow the upstream wiki for now.
+    # Remove once we publish our own configuration docs.
+    "config_db.html",
+}
+
+
+def _list_templates():
+    found = []
+    for dirpath, _, filenames in os.walk(TEMPLATES_DIR):
+        for fn in filenames:
+            if fn.endswith((".html", ".htm", ".j2", ".jinja", ".jinja2")):
+                found.append(os.path.join(dirpath, fn))
+    return sorted(found)
+
+
+@pytest.mark.unit
+def test_no_unexpected_upstream_template_urls():
+    offenders = []
+    for path in _list_templates():
+        base = os.path.basename(path)
+        if base in ALLOWED_UPSTREAM_REFS:
+            continue
+        with open(path, encoding="utf-8") as fh:
+            for lineno, line in enumerate(fh, start=1):
+                if UPSTREAM_HOST_RE.search(line):
+                    offenders.append((path, lineno, line.rstrip()))
+    if offenders:
+        msg = ["User-facing templates still link to upstream CWA:"]
+        for path, lineno, line in offenders:
+            rel = os.path.relpath(path, REPO_ROOT)
+            msg.append(f"  {rel}:{lineno}  {line.strip()}")
+        msg.append(
+            "Point these at https://github.com/new-usemame/Calibre-Web-NextGen, "
+            "or add the filename to ALLOWED_UPSTREAM_REFS with a reason."
+        )
+        pytest.fail("\n".join(msg))
+
+
+@pytest.mark.unit
+def test_changelog_link_is_fork():
+    """Spot-pin the original #141 regression site so a refactor of
+    layout.html doesn't silently regress @droM4X's symptom."""
+    path = os.path.join(TEMPLATES_DIR, "layout.html")
+    with open(path, encoding="utf-8") as fh:
+        body = fh.read()
+    assert "new-usemame/Calibre-Web-NextGen/releases" in body, (
+        "layout.html cwa_update banner must link to the fork's releases page"
+    )
+
+
+@pytest.mark.unit
+def test_create_issue_link_is_fork():
+    """Error pages must direct bug reports at the fork's tracker, not
+    upstream's — the fork is where issues actually get triaged."""
+    path = os.path.join(TEMPLATES_DIR, "http_error.html")
+    with open(path, encoding="utf-8") as fh:
+        body = fh.read()
+    assert "new-usemame/Calibre-Web-NextGen/issues" in body, (
+        "http_error.html 'Create Issue' link must point at the fork tracker"
+    )
+
+
+@pytest.mark.unit
+def test_admin_github_button_is_fork():
+    """The Admin panel 'CWA GitHub' button is the most prominent
+    project-home link in the UI — it must land users on the fork repo
+    where they can actually file issues and follow releases."""
+    path = os.path.join(TEMPLATES_DIR, "admin.html")
+    with open(path, encoding="utf-8") as fh:
+        body = fh.read()
+    assert 'id="cwa_github_link"' in body
+    assert "new-usemame/Calibre-Web-NextGen" in body, (
+        "admin.html cwa_github_link must point at the fork repo"
+    )


### PR DESCRIPTION
## Summary

Closes #141. Three template links still pointed at upstream CWA when they should be pointing at this fork. The bug @droM4X reported was specifically the "See Changelog" link in the in-app update banner — while in there, I checked every template for the same class of regression and found three sites that should follow the fork:

- `cps/templates/layout.html` — "See Changelog" in the `cwa_update` banner (the one @droM4X reported)
- `cps/templates/http_error.html` — "Create Issue" on internal error pages (bug reports should land in *our* tracker)
- `cps/templates/admin.html` — "CWA GitHub" button on the admin panel

Two upstream references intentionally stay:
- `stats.html` — "based on Calibre-Web Automated." (attribution / credit line)
- `config_db.html` — links to upstream's wiki page for DB-config; we don't have an equivalent yet

Adds `tests/unit/test_template_fork_urls.py` so cherry-picks can't silently reintroduce the upstream URLs:
- one scan-test over the whole template tree (with an explicit allow-list for the two attribution sites above)
- three spot-pins for the three offenders above so a template refactor catches them too

## Test plan

- [x] `pytest tests/unit/test_template_fork_urls.py -v` → 4 passed
- [x] Verified `id=\"cwa_github_link\"` href reads `new-usemame/Calibre-Web-NextGen` in `admin.html`
- [x] Verified `cwa_update` banner href reads the fork releases URL in `layout.html`
- [ ] After release: pull the GHCR image, render the admin page + force an error page, eye the three links open the fork repo (not upstream)