### PR TITLE
fix(ci): make update-translations graceful when GH_PAT missing (#139 follow-up)

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -43,6 +43,27 @@ jobs:
       - name: Install gettext
         run: sudo apt-get update && sudo apt-get install -y gettext
 
+      - name: Detect commit PAT
+        # The "main protection" ruleset blocks direct pushes to main for
+        # everyone except admins, and personal repos can't bypass that
+        # for the github-actions[bot] integration. Pushing the
+        # translation-status commit therefore requires GH_PAT (new-usemame's
+        # personal token, admin-bypass eligible). When the secret is
+        # missing, the workflow still runs — it just skips the commit and
+        # logs a notice. README translation status will go stale until
+        # someone runs `scripts/update_translations.sh` locally and pushes
+        # via a normal PR, or until GH_PAT is added to repo secrets.
+        id: commit_pat
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          if [ -n "${GH_PAT}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GH_PAT secret not set; skipping translation auto-commit. Add a new-usemame PAT as GH_PAT to enable README auto-updates."
+          fi
+
       - name: Run update_translations.sh
         run: bash scripts/update_translations.sh
 
@@ -50,6 +71,7 @@ jobs:
         run: python scripts/generate_translation_status.py
 
       - name: Commit translation updates
+        if: steps.commit_pat.outputs.available == 'true'
         run: |
           # Identity must be new-usemame: validate-author + the main
           # branch ruleset bypass list both key off this committer email.
@@ -82,32 +104,20 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/actions/workflows/docker-image-build-dev.yml/dispatches \
             -d "{\"ref\":\"main\",\"inputs\":{\"ref\":\"${DEV_BUILD_SHA}\",\"branch\":\"main\"}}"
 
-      - name: Detect wiki PAT
-        id: wiki_pat
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-        run: |
-          if [ -n "${GH_PAT}" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::GH_PAT secret not set; skipping wiki status sync."
-          fi
-
       - name: Clone wiki repo
-        if: steps.wiki_pat.outputs.available == 'true'
+        if: steps.commit_pat.outputs.available == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           git clone https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git wiki-tmp
 
       - name: Generate translation status table (in wiki repo)
-        if: steps.wiki_pat.outputs.available == 'true'
+        if: steps.commit_pat.outputs.available == 'true'
         run: |
           python scripts/generate_translation_status.py wiki-tmp/Contributing-Translations.md
 
       - name: Commit and push wiki update
-        if: steps.wiki_pat.outputs.available == 'true'
+        if: steps.commit_pat.outputs.available == 'true'
         run: |
           cd wiki-tmp
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

#144 swapped the workflow's commit identity to expect \`GH_PAT\` (new-usemame's personal token), but the secret was never actually configured in the repo. So the fallback path falls back to the default \`GITHUB_TOKEN\` (github-actions[bot]) which the \"main protection\" ruleset still rejects with GH013. droM4X's visible symptom — the red workflow status — was not actually resolved by #144.

Personal-repo rulesets refuse to add the GitHub Actions integration as a bypass actor (\`Actor GitHub Actions integration must be part of the ruleset source or owner organization\`), so the only ways forward are:

a. Configure \`GH_PAT\` as a repo secret (admin-bypass eligible — fully restores README auto-update)
b. Make the push optional and skip it gracefully when \`GH_PAT\` is absent

This PR does (b) — adds a \`Detect commit PAT\` step at the top of the job (mirroring the existing wiki-PAT detection pattern), and gates the commit step + wiki-sync steps on \`commit_pat.outputs.available\`. When \`GH_PAT\` is set, full behavior is restored. When it's not, the workflow extracts/compiles/validates/triggers the dev build, then prints a notice and exits 0.

Either way, the Actions dashboard stops being red — that's the user-visible symptom @droM4X flagged.

If the operator wants the README to actually auto-update again, the one remaining manual step is: settings → secrets → add \`GH_PAT\` as a new-usemame personal token with \`repo\` + \`workflow\` scope.

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/update-translations.yml'))\"\` → valid
- [ ] After merge: confirm next \`update-translations\` run goes green even without GH_PAT
- [ ] (Operator follow-up) add GH_PAT secret → confirm next run pushes a translation-status commit