### PR TITLE
ci: tolerate missing wiki in update-translations (#139 follow-up)

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -105,19 +105,27 @@ jobs:
             -d "{\"ref\":\"main\",\"inputs\":{\"ref\":\"${DEV_BUILD_SHA}\",\"branch\":\"main\"}}"
 
       - name: Clone wiki repo
+        # The wiki is optional. Calibre-Web-NextGen is a standalone repo and the
+        # GitHub wiki has never been initialized (the .wiki.git remote 404s
+        # until someone creates the first page in the Wiki tab). We let the
+        # clone fail soft and skip the downstream wiki steps so the job stays
+        # green; if/when the wiki is initialized, the rest light up
+        # automatically.
         if: steps.commit_pat.outputs.available == 'true'
+        id: clone_wiki
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           git clone https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git wiki-tmp
 
       - name: Generate translation status table (in wiki repo)
-        if: steps.commit_pat.outputs.available == 'true'
+        if: steps.commit_pat.outputs.available == 'true' && steps.clone_wiki.outcome == 'success'
         run: |
           python scripts/generate_translation_status.py wiki-tmp/Contributing-Translations.md
 
       - name: Commit and push wiki update
-        if: steps.commit_pat.outputs.available == 'true'
+        if: steps.commit_pat.outputs.available == 'true' && steps.clone_wiki.outcome == 'success'
         run: |
           cd wiki-tmp
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

Closes the remaining loop on #139. With `GH_PAT` now configured in repo secrets (verified in run [25777791598](https://github.com/new-usemame/Calibre-Web-NextGen/actions/runs/25777791598)), the workflow successfully commits `README.md` + every `.po` file back to `main` — the user-visible piece droM4X reported.

The wiki-sync branch of the same workflow still fails because the Calibre-Web-NextGen wiki has never been initialized (the .wiki.git remote 404s on this repo). That makes the job red even when the user-visible work succeeded.

This patch makes the wiki branch fail-soft:

- `continue-on-error: true` on the clone step
- Gate the two downstream wiki steps on `steps.clone_wiki.outcome == 'success'`

If/when someone initializes the wiki by writing the first page in the GitHub UI, the wiki sync lights up automatically with no further workflow change.

## Verification

- Workflow run [25777791598](https://github.com/new-usemame/Calibre-Web-NextGen/actions/runs/25777791598) — translation commit step ✅ landed as commit [0754febb](https://github.com/new-usemame/Calibre-Web-NextGen/commit/0754febb0a775d59684df773f43dda16b13fc8a5) authored by `new-usemame` against admin-bypass on the main ruleset.
- README translation status table now refreshes automatically on each push to main.
- This PR's CI run will exercise the wiki-tolerant path; expect green even though wiki clone is a no-op.

## Labels

`safe-tier-1` — CI-only change, no app code touched.