### PR TITLE
ci: fix silent dev-build dispatch failure (#139 follow-up #2)

### DIFF
--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -9,6 +9,15 @@ name: Build & Push - Dev - Split Strategy
 
 on:
   workflow_dispatch:  # auto-trigger disabled by intent; operator dispatches manually
+    inputs:
+      ref:
+        description: "Commit SHA or branch to build (defaults to github.ref if empty)"
+        required: false
+        type: string
+      branch:
+        description: "Branch name to tag the dev image with (defaults to github.ref_name if empty)"
+        required: false
+        type: string
 jobs:
   # --------------------------------------------------------------------------------
   # JOB 1: Build Intel (amd64) on GitHub Runners

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -97,12 +97,25 @@ jobs:
           fi
 
       - name: Trigger dev build for main
+        # A workflow_dispatch HTTP API call returns 204 on success and 422 on
+        # bad inputs (e.g. undeclared `inputs.*`). curl without --fail returns 0
+        # on 422, which previously masked silent dispatch failures — the step
+        # went green while no dev build actually ran. Use --fail-with-body so
+        # any non-2xx surfaces here, and assert 204 explicitly.
         run: |
-          curl -L -X POST \
+          set -euo pipefail
+          http_code=$(curl -sS -L -X POST \
+            -o /tmp/dispatch.out -w "%{http_code}" \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             https://api.github.com/repos/${{ github.repository }}/actions/workflows/docker-image-build-dev.yml/dispatches \
-            -d "{\"ref\":\"main\",\"inputs\":{\"ref\":\"${DEV_BUILD_SHA}\",\"branch\":\"main\"}}"
+            -d "{\"ref\":\"main\",\"inputs\":{\"ref\":\"${DEV_BUILD_SHA}\",\"branch\":\"main\"}}")
+          echo "dispatch HTTP ${http_code}"
+          if [ "${http_code}" != "204" ]; then
+            echo "::error::dev-build dispatch failed (HTTP ${http_code})"
+            cat /tmp/dispatch.out
+            exit 1
+          fi
 
       - name: Clone wiki repo
         # The wiki is optional. Calibre-Web-NextGen is a standalone repo and the


### PR DESCRIPTION
## Summary

Found while auditing the post-#139 surface — another silent-fail bug in the same workflow chain.

The 'Trigger dev build for main' step in `update-translations.yml` has been failing with HTTP 422 'Unexpected inputs provided' on every push to main, but the `curl` call didn't check the status and `set -e` doesn't catch a 422 from curl, so the step went green while no dev build actually ran. **No dev image has been published from a translation-bearing main commit since this trigger pattern was introduced** — the most recent dev-build run in the Actions tab predates the trigger.

Two compounding problems:

1. **`docker-image-build-dev.yml`** declared `on: workflow_dispatch:` with no `inputs:` block but uses `inputs.ref` and `inputs.branch` in three build jobs (amd64, arm64, manifest). The GitHub API rejects dispatches that pass undeclared inputs with HTTP 422.

2. **`update-translations.yml`** dispatched with those inputs but never checked the response code. `curl -L` returns 0 on 422 unless `--fail` / `-f` is set.

## Fixes

- Declare `inputs: { ref, branch }` on `docker-image-build-dev.yml`'s `workflow_dispatch` so the inputs the build jobs already consume are accepted from the API.
- Capture the HTTP status from the dispatch curl in `update-translations.yml` and `exit 1` on anything other than 204, so a future regression surfaces in CI instead of silently bypassing the dev build.

## Verification

Confirmed the 422 was real by directly hitting the dispatch endpoint:

```
$ curl -X POST .../docker-image-build-dev.yml/dispatches -d '{...inputs.ref...}'
{ "message": "Unexpected inputs provided: [\"ref\", \"branch\"]", "status": "422" }
```

After this PR merges, the next push to main → `update-translations.yml` should successfully dispatch the dev build, and we'll see a new run in the dev-build workflow.

## Labels

`safe-tier-1` — CI-only change, no app code touched.