### PR TITLE
ci: grant dev-build packages:write so GHCR push actually lands

### DIFF
--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -18,6 +18,16 @@ on:
         description: "Branch name to tag the dev image with (defaults to github.ref_name if empty)"
         required: false
         type: string
+
+# GITHUB_TOKEN is read-only on packages by default. Builds push to
+# ghcr.io/new-usemame/calibre-web-nextgen, so packages:write is
+# required. Without it the build silently failed at the GHCR push step
+# with "denied: installation not allowed to Write organization
+# package". Mirrors the release workflow minus id-token/attestations,
+# which the dev workflow explicitly disables (provenance: false).
+permissions:
+  contents: read
+  packages: write
 jobs:
   # --------------------------------------------------------------------------------
   # JOB 1: Build Intel (amd64) on GitHub Runners


### PR DESCRIPTION
## Summary

Third layered failure in the same chain that started with #139. With dispatch finally working (#163), the dev build runs end-to-end but fails at the GHCR push step:

```
ERROR: failed to push ghcr.io/new-usemame/calibre-web-nextgen:
denied: installation not allowed to Write organization package
```

Root cause: the workflow has no top-level `permissions:` block. `GITHUB_TOKEN` defaults to read-only on packages, so logging into ghcr.io with that token cannot push. The sibling release workflow declares the perms it needs (`contents:read`, `packages:write`, `id-token:write`, `attestations:write`); the dev workflow just forgot.

## Fix

Mirror the release workflow's perms minus `id-token`/`attestations` (the dev workflow explicitly sets `provenance: false` in both build jobs, so neither is needed):

```yaml
permissions:
  contents: read
  packages: write
```

## Verification

Failed run: [25804836361](https://github.com/new-usemame/Calibre-Web-NextGen/actions/runs/25804836361) — `build-amd64` exits with the GHCR `denied` error above. The new dispatch path now correctly returns 204 → real run starts → real failure is visible. Before #163 this was masked by a 422 dispatch error.

After this PR merges, the next push to main → `update-translations` → dev build will publish a fresh dev image to `ghcr.io/new-usemame/calibre-web-nextgen` end-to-end.

## Labels

`safe-tier-1` — CI-only change, no app code touched.