### PR TITLE
ci: move dev-build ARM64 to GitHub-hosted runner (closes anonymity gap)

### DIFF
--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -141,8 +141,13 @@ jobs:
   # JOB 2: Build ARM (arm64 Only) on Oracle Runner
   # --------------------------------------------------------------------------------
   build-arm:
-    # Use your self-hosted runner labels here
-    runs-on: [self-hosted, linux, ARM64]
+    # GitHub's free native ARM64 hosted runner. The workflow originally
+    # ran on a self-hosted Oracle Cloud ARM VM (inherited from upstream
+    # CWA), but no such runner exists on Calibre-Web-NextGen — the job
+    # had been queuing indefinitely. A self-hosted runner on a *public*
+    # repo is also a meaningful attack surface (any PR can execute on
+    # operator hardware), so GitHub-hosted is the safer default.
+    runs-on: ubuntu-24.04-arm
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Set build ref


### PR DESCRIPTION
## Summary

Final piece of the #139 chain. With the dispatch fix (#163) and packages:write fix (#164), the dev build now actually runs — and surfaces the next layered bug: `build-arm` is configured for a self-hosted runner that **does not exist** on this repo.

`gh api /repos/.../actions/runners` returns `[]`. Every dev-build dispatch for the past 11+ days has been queuing forever on this job. The s6-supervise processes on the operator's home server (teenyverse) are container service supervisors, not actions-runner daemons.

The original config was inherited from upstream CWA, which had an Oracle Cloud ARM VM acting as their runner (note the comment in the file: 'Saves bandwidth and time by storing cache directly on the Oracle VM'). We forked the YAML, never the VM.

## Why GitHub-hosted instead of setting up a self-hosted runner

1. **Anonymity.** A self-hosted runner's outbound IP and hostname are visible to GitHub. For a project deliberately operating under an identity unlinked from operator accounts, pointing CI at any hardware on the operator network is the wrong move.
2. **Security.** GitHub explicitly warns against self-hosted runners on *public* repos: any contributor can submit a PR that executes arbitrary code on the runner. That's a remote-code-execution vector against operator hardware via a single drive-by PR.
3. **Reliability.** GitHub's runner is always online; a self-hosted one needs babysitting.
4. **Cost.** Free for public repos, including native ARM64 (`ubuntu-24.04-arm`).
5. **Perf.** Native ARM64, no QEMU emulation — same speed class as the previous Oracle VM.

## Fix

Single-line: `runs-on: [self-hosted, linux, ARM64]` → `runs-on: ubuntu-24.04-arm`. Plus a comment explaining the rationale so this doesn't get reverted by anyone reading the upstream-original YAML.

## Verification

After this merges, the next push to main → update-translations → dev build chain completes all three jobs (amd64 + arm + merge) end-to-end and publishes a multi-arch `:dev` tag to `ghcr.io/new-usemame/calibre-web-nextgen` — first end-to-end success since this workflow was introduced.

## Labels

`safe-tier-1` — CI-only change, no app code touched.