### PR TITLE
ci: fail-soft + GH_PAT for cosmetic dev build-number increment

### DIFF
--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -363,9 +363,17 @@ jobs:
             $(printf 'ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }}@sha256:%s ' *)
 
       # --- 4. Increment Build Number (Last Step) ---
+      # Inherited from upstream CWA. Bumps repo variable CURRENT_DEV_BUILD_NUM
+      # so each dev image gets a unique VERSION=DEV_BUILD-dev-N string. Purely
+      # cosmetic — the :dev floating tag and :sha-* tags don't depend on it,
+      # and the image works regardless. Prefer GH_PAT (already configured for
+      # the translation workflow) over the missing DEV_BUILD_NUM_INCREMENTOR_TOKEN
+      # secret, and fail-soft: a hiccup in this purely-bookkeeping step must
+      # never mark an otherwise-successful build red.
       - name: Increment dev build number
         uses: action-pack/increment@v2
         id: increment
+        continue-on-error: true
         with:
           name: 'CURRENT_DEV_BUILD_NUM'
-          token: ${{ secrets.DEV_BUILD_NUM_INCREMENTOR_TOKEN }}
+          token: ${{ secrets.GH_PAT || secrets.DEV_BUILD_NUM_INCREMENTOR_TOKEN }}


### PR DESCRIPTION
## Summary

Final loose thread in the post-#139 sweep. With ARM moved to GitHub-hosted (#165), the dev-build chain ran end-to-end and **the multi-arch `:dev` tag is live on GHCR** — verified as an OCI manifest list with amd64 (`sha256:4486ce09...`) + arm64 (`sha256:48666ca8...`).

The merge job still marked itself failed though, because the **last** step in the job (`action-pack/increment@v2`) tries to bump repo variable `CURRENT_DEV_BUILD_NUM` using a secret (`DEV_BUILD_NUM_INCREMENTOR_TOKEN`) that has never been set on this repo. That secret was a CWA-era thing we never inherited.

The increment is **purely cosmetic** — only the `VERSION=DEV_BUILD-dev-N` build-arg references it. The floating `:dev` tag and per-sha tags work regardless. A stale counter just means successive dev images share the same VERSION suffix.

## Fix

1. **Prefer `GH_PAT` over the missing secret.** The PAT we configured for the translation workflow has every scope this action needs to write a repo variable, so the increment actually works now.
2. **`continue-on-error: true`.** A hiccup in a bookkeeping step must never mark an otherwise-successful multi-arch image build red. Same pattern as the wiki fix in #158.

## Verification

After merge, the next push to main triggers `update-translations` → README commit lands → dispatch the dev build → both arch builds succeed → merge job stitches manifest list + tags `:dev` → increment step actually runs (with GH_PAT) or fails soft. End-to-end green.

## Labels

`safe-tier-1` — CI-only change, no app code touched.