### PR TITLE
fix(gevent): guard format_request against None environ (#147)

### DIFF
--- a/cps/gevent_wsgi.py
+++ b/cps/gevent_wsgi.py
@@ -23,7 +23,11 @@ class MyWSGIHandler(WSGIHandler):
             delta = '%.6f' % (self.time_finish - self.time_start)
         else:
             delta = '-'
-        forwarded = self.environ.get('HTTP_X_FORWARDED_FOR', None)
+        # gevent calls ``format_request`` for invalid requests too (e.g. a TLS
+        # ClientHello on a plain-HTTP listener). In that case ``get_environ``
+        # is never called and ``self.environ`` stays ``None`` — accessing
+        # ``.get`` would kill the access-log greenlet. See issue #147.
+        forwarded = self.environ.get('HTTP_X_FORWARDED_FOR', None) if self.environ else None
         if forwarded:
             client_address = forwarded
         else:

--- a/tests/unit/test_gevent_wsgi_format_request.py
+++ b/tests/unit/test_gevent_wsgi_format_request.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2025 Calibre-Web contributors
+# Copyright (C) 2024-2025 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for ``cps.gevent_wsgi.MyWSGIHandler.format_request``.
+
+Issue new-usemame/Calibre-Web-NextGen#147: gevent calls ``format_request``
+from its access-log path even for requests that never parsed as HTTP
+(e.g. a TLS ClientHello arriving on a plain-HTTP listener — bytes
+``\\x16\\x03\\x01...``). In that case ``get_environ`` is never invoked,
+so ``self.environ`` is ``None`` and our override raised
+``AttributeError: 'NoneType' object has no attribute 'get'`` before
+producing the access-log line. The greenlet died on every such request.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("gevent")
+
+from cps.gevent_wsgi import MyWSGIHandler  # noqa: E402
+
+
+def _stub(**overrides):
+    """Build a SimpleNamespace with every attribute ``format_request`` reads.
+
+    We bypass ``MyWSGIHandler.__init__`` (which needs a real socket) and
+    invoke the unbound method against the stub. Test caller overrides
+    only the fields it cares about.
+    """
+    base = dict(
+        time_start=0.0,
+        time_finish=0.0,
+        response_length=None,
+        environ=None,
+        client_address=("::1", 12345),
+        requestline=None,
+        _orig_status=None,
+        status=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_format_request_does_not_crash_when_environ_is_none():
+    handler = _stub(environ=None, requestline=None, status="400 Bad Request")
+    result = MyWSGIHandler.format_request(handler)
+    assert isinstance(result, str)
+    assert "400" in result
+
+
+def test_format_request_uses_forwarded_for_when_present():
+    handler = _stub(
+        environ={"HTTP_X_FORWARDED_FOR": "203.0.113.7"},
+        client_address=("::1", 12345),
+        requestline="GET / HTTP/1.1",
+        _orig_status="200 OK",
+        response_length=42,
+    )
+    result = MyWSGIHandler.format_request(handler)
+    assert "203.0.113.7" in result
+
+
+def test_format_request_falls_back_to_client_address_without_forwarded_for():
+    handler = _stub(
+        environ={},
+        client_address=("198.51.100.4", 12345),
+        requestline="GET / HTTP/1.1",
+        _orig_status="200 OK",
+        response_length=42,
+    )
+    result = MyWSGIHandler.format_request(handler)
+    assert "198.51.100.4" in result
+
+
+def test_format_request_handles_none_client_address_with_none_environ():
+    handler = _stub(environ=None, client_address=None, status="400 Bad Request")
+    result = MyWSGIHandler.format_request(handler)
+    assert isinstance(result, str)
+    assert result.startswith("- ")


### PR DESCRIPTION
## Summary

Fixes [#147](https://github.com/new-usemame/Calibre-Web-NextGen/issues/147) (reporter @iroQuai).

Container goes unhealthy when something probes the plain-HTTP listener with TLS bytes (Traefik v3 healthchecks, the bundled Dockerfile's `https://localhost:8083` curl fallback, generic TLS scanners). gevent's `pywsgi.WSGIHandler` calls `format_request` from its access-log path for **all** requests including ones that never parsed as HTTP. For those, `get_environ()` is never invoked, so `self.environ` stays `None` and our override raised:

```
File "/app/calibre-web-automated/cps/gevent_wsgi.py", line 26, in format_request
    forwarded = self.environ.get('HTTP_X_FORWARDED_FOR', None)
AttributeError: 'NoneType' object has no attribute 'get'
```

The handling greenlet dies on every such request. Reporter's workaround (`healthcheck: disable: true`) confirms the trigger.

## Root cause

The override was added by the upstream commit `1d7dcce98d` ("Log Forwarded for address in accesslog instead of client address for gevent", Ozzie Isaacs, 2024-07). It assumed `self.environ` is always set — that's only true for requests that parsed as HTTP. Bug has been latent since then; `cps/gevent_wsgi.py` is byte-identical between v4.0.44 and v4.0.53. The reporter's "worked on .44, broke on .49" recollection is partial — what likely changed is something else in their stack (Traefik probe frequency, app.db state) that started triggering the healthcheck's HTTPS fallback path, but the bug itself has always been there.

## Fix

One-line None guard:

```python
forwarded = self.environ.get('HTTP_X_FORWARDED_FOR', None) if self.environ else None
```

When environ is unavailable, fall through to `self.client_address` — same behavior as gevent's canonical `format_request`. When environ is present, behavior is identical to before.

## Test plan

- [x] **TDD failing test** — `tests/unit/test_gevent_wsgi_format_request.py` pins four shapes: `environ=None`, X-Forwarded-For present, empty environ falls back to client_address, all-None edge. Pre-fix the first/fourth cases raise `AttributeError`.
- [x] **Live reproduction** — `printf '\x16\x03\x01\x00\x05hello\n' | nc -w 2 localhost 8086` on `cwn-local` produced the exact `AttributeError` traceback from the issue.
- [x] **Post-fix verification** — same input produces only the legitimate `Invalid HTTP method` log line; no traceback, no `format_request` call in the stack.
- [x] **30 parallel TLS handshakes** (stress): zero tracebacks, container stays `healthy`, normal `GET /` still returns `200`.
- [x] **Container restart** — patched module loads cleanly, healthy in 7s.
- [x] **`gh auth status`** confirmed as `new-usemame` before push.