### PR TITLE
fix(metadata search): mobile-Safari CSRF token in request body (backport of CWA #1295)

### DIFF
--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -277,7 +277,7 @@ $(function () {
         type: "POST",
         data: {
           query: keyword,
-          'csrf_token': $('input[name="csrf_token"]').val()
+          csrf_token: $("input[name='csrf_token']").first().val(),
         },
         dataType: "json",
         success: function success(data) {

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -302,11 +302,13 @@ $(function() {
     $.ajaxPrefilter(preFilters.fire);
 
     // equip all post requests with csrf_token
-    var csrftoken = $("input[name='csrf_token']").val();
     $.ajaxSetup({
         beforeSend: function(xhr, settings) {
             if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
-                xhr.setRequestHeader("X-CSRFToken", csrftoken)
+                var csrftoken = $("input[name='csrf_token']").first().val();
+                if (csrftoken) {
+                    xhr.setRequestHeader("X-CSRFToken", csrftoken);
+                }
             }
         }
     });

--- a/cps/templates/cwa_convert_library.html
+++ b/cps/templates/cwa_convert_library.html
@@ -83,7 +83,7 @@
   }
 
   function scheduleConvertLibrary(delayMinutes) {
-    fetch('/cwa-internal/schedule-convert-library', {
+    cwaFetch('/cwa-internal/schedule-convert-library', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ delay_minutes: delayMinutes, username: '{{ current_user.name }}' })
@@ -109,7 +109,7 @@
     let get;
     
     try {
-      const res = await fetch("{{ url_for('convert_library.get_status')}}");
+      const res = await cwaFetch("{{ url_for('convert_library.get_status')}}");
       get = await res.json();
     } catch (e) {
       console.error("Error: ", e);

--- a/cps/templates/cwa_epub_fixer.html
+++ b/cps/templates/cwa_epub_fixer.html
@@ -103,7 +103,7 @@
   }
 
   function scheduleEpubFixer(delayMinutes) {
-    fetch('/cwa-internal/schedule-epub-fixer', {
+    cwaFetch('/cwa-internal/schedule-epub-fixer', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ delay_minutes: delayMinutes, username: '{{ current_user.name }}' })
@@ -168,7 +168,7 @@
       return;
     }
     try {
-      const res = await fetch(`/ajax/listbooks?search=${encodeURIComponent(query)}&limit=10&offset=0`);
+      const res = await cwaFetch(`/ajax/listbooks?search=${encodeURIComponent(query)}&limit=10&offset=0`);
       const data = await res.json();
       renderEpubFixerSearchResults((data && data.rows) ? data.rows : []);
     } catch (e) {
@@ -183,7 +183,7 @@
       return;
     }
     try {
-      const res = await fetch("{{ url_for('epub_fixer.run_epub_fixer_for_book') }}", {
+      const res = await cwaFetch("{{ url_for('epub_fixer.run_epub_fixer_for_book') }}", {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ book_id: bookId })
@@ -206,7 +206,7 @@
     let get;
     
     try {
-      const res = await fetch("{{ url_for('epub_fixer.get_status')}}");
+      const res = await cwaFetch("{{ url_for('epub_fixer.get_status')}}");
       get = await res.json();
     } catch (e) {
       console.error("Error: ", e);

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -31,13 +31,35 @@
     <script>
       let checkMessagesInterval = null; // Store interval ID
 
-      function refreshLibrary() {
-          fetch("/cwa-library-refresh", {
-              method: "POST",
-              headers: {
-                  "Content-Type": "application/json"
+      function getCsrfToken() {
+          const input = document.querySelector("input[name='csrf_token']");
+          return input ? input.value : "";
+      }
+
+      function cwaFetch(url, options = {}) {
+          const fetchOptions = { ...options };
+          fetchOptions.credentials = fetchOptions.credentials || "same-origin";
+
+          const method = (fetchOptions.method || "GET").toUpperCase();
+          if (!["GET", "HEAD", "OPTIONS", "TRACE"].includes(method)) {
+              const headers = new Headers(fetchOptions.headers || {});
+              const csrfToken = getCsrfToken();
+              if (csrfToken && !headers.has("X-CSRFToken")) {
+                  headers.set("X-CSRFToken", csrfToken);
               }
-          })
+              fetchOptions.headers = headers;
+          }
+
+          return fetch(url, fetchOptions);
+      }
+
+      function refreshLibrary() {
+          cwaFetch("/cwa-library-refresh", {
+               method: "POST",
+               headers: {
+                   "Content-Type": "application/json"
+               }
+           })
           .then(response => response.json())
           .then(data => {
             updateLibraryRefreshMessage(data.message);  // Show immediate confirmation
@@ -47,11 +69,11 @@
       }
 
       function checkLibraryMessages() {
-          fetch("/cwa-library-refresh/messages")
-              .then(response => response.json())
-              .then(data => {
-                  if (data.messages.length > 0) {
-                    updateLibraryRefreshMessage(data.messages.join("<br>")); // Show messages
+          cwaFetch("/cwa-library-refresh/messages")
+               .then(response => response.json())
+               .then(data => {
+                   if (data.messages.length > 0) {
+                     updateLibraryRefreshMessage(data.messages.join("<br>")); // Show messages
                       stopCheckingMessages(); // Stop checking once we get a message
                   }
               })

--- a/cps/templates/tasks.html
+++ b/cps/templates/tasks.html
@@ -175,7 +175,7 @@
   }
   function cancelScheduled(id) {
     if (!id) return;
-    fetch('{{ url_for("cwa_stats.cwa_scheduled_cancel") }}', {
+    cwaFetch('{{ url_for("cwa_stats.cwa_scheduled_cancel") }}', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: id })

--- a/tests/unit/test_csrf_mobile_safari.py
+++ b/tests/unit/test_csrf_mobile_safari.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression coverage for the mobile-Safari CSRF backport from CWA #1295.
+
+Mobile Safari does not reliably send the `X-CSRFToken` request header for fetch()
+calls, which broke metadata search (fork issue #154, upstream CWA #1266). The
+upstream fix introduces a shared `cwaFetch()` helper in layout.html that auto-
+attaches `X-CSRFToken` for non-safe HTTP methods, hardens the legacy
+`$.ajaxSetup` prefilter against an empty initial token lookup, and converts the
+existing fetch() call sites to go through the wrapper.
+
+Tests are pattern-pins on the static assets — JS is not unit-test-able in Python
+without spinning a Node runtime, but a regression here would be a quiet drop of
+one of the wrapper definitions or an accidental revert of a call site.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LAYOUT = REPO_ROOT / "cps" / "templates" / "layout.html"
+MAIN_JS = REPO_ROOT / "cps" / "static" / "js" / "main.js"
+GET_META_JS = REPO_ROOT / "cps" / "static" / "js" / "get_meta.js"
+CONVERT_LIBRARY_TPL = REPO_ROOT / "cps" / "templates" / "cwa_convert_library.html"
+EPUB_FIXER_TPL = REPO_ROOT / "cps" / "templates" / "cwa_epub_fixer.html"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"missing file: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_layout_defines_getCsrfToken_helper():
+    body = _read(LAYOUT)
+    assert "function getCsrfToken()" in body, (
+        "layout.html must define getCsrfToken() so cwaFetch can look up the token"
+    )
+    assert "input[name='csrf_token']" in body, (
+        "getCsrfToken must query the csrf_token hidden input"
+    )
+
+
+def test_layout_defines_cwaFetch_wrapper_with_csrf_for_mutating_methods():
+    body = _read(LAYOUT)
+    assert "function cwaFetch(" in body, "layout.html must define cwaFetch()"
+    # The wrapper must skip safe methods (GET/HEAD/OPTIONS/TRACE) and set the
+    # X-CSRFToken header on the rest. Pattern-match the guard list and the
+    # header set so an accidental change to either side will trip the test.
+    safe_guard = re.search(
+        r'\[\s*"GET"\s*,\s*"HEAD"\s*,\s*"OPTIONS"\s*,\s*"TRACE"\s*\]',
+        body,
+    )
+    assert safe_guard, "cwaFetch must guard safe methods explicitly"
+    assert 'headers.set("X-CSRFToken", csrfToken)' in body, (
+        "cwaFetch must set X-CSRFToken on non-safe methods"
+    )
+
+
+def test_layout_cwaFetch_only_attaches_header_when_token_present():
+    body = _read(LAYOUT)
+    # `if (csrfToken && !headers.has("X-CSRFToken"))` — both clauses required:
+    # mobile Safari may return an empty string from the input, and we should
+    # not blow away a header the caller already set.
+    assert re.search(
+        r'if \(csrfToken && !headers\.has\("X-CSRFToken"\)\)', body
+    ), "cwaFetch must null-guard the token AND respect a caller-set header"
+
+
+def test_main_js_ajaxsetup_csrf_looks_up_token_per_request():
+    body = _read(MAIN_JS)
+    # Pre-fix had `var csrftoken = $("input[name='csrf_token']").val();` cached
+    # at $(function() { ... }) page-load time, which loses the token if the
+    # input ever rotates. Fix moves the lookup inside the beforeSend handler
+    # and adds a null guard for the same Safari empty-string scenario.
+    assert "$.ajaxSetup({" in body, "ajaxSetup must be configured"
+    setup_block_match = re.search(
+        r"\$\.ajaxSetup\(\{(.*?)\}\);", body, flags=re.DOTALL
+    )
+    assert setup_block_match, "ajaxSetup block must be present"
+    setup_block = setup_block_match.group(1)
+    assert (
+        'var csrftoken = $("input[name=\'csrf_token\']").first().val();'
+        in setup_block
+    ), "csrftoken lookup must happen inside beforeSend (per-request, not page-load)"
+    assert "if (csrftoken) {" in setup_block, (
+        "ajaxSetup must null-guard csrftoken before setting the header"
+    )
+
+
+def test_get_meta_js_metadata_search_posts_csrf_token_in_body():
+    body = _read(GET_META_JS)
+    # The original mobile-Safari symptom: /metadata/search POST never carried
+    # the CSRF token because the header was dropped. Fix puts it in the body
+    # so the server's CSRF check passes regardless of header behavior.
+    assert re.search(
+        r'csrf_token:\s*\$\("input\[name=\'csrf_token\'\]"\)\.first\(\)\.val\(\)',
+        body,
+    ), "metadata/search POST must include csrf_token in the request body"
+
+
+def test_callsites_use_cwaFetch_instead_of_raw_fetch():
+    for path in (CONVERT_LIBRARY_TPL, EPUB_FIXER_TPL):
+        body = _read(path)
+        # Each template should route its mutating fetch() through cwaFetch().
+        # We look for at least one cwaFetch call; the file may still contain
+        # a raw fetch() for download links or other GETs, so we do not assert
+        # absence — only presence of the wrapped call.
+        assert "cwaFetch(" in body, (
+            f"{path.name} must route fetch() through cwaFetch() for CSRF coverage"
+        )


### PR DESCRIPTION
Backports [crocodilestick/Calibre-Web-Automated#1295](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1295) by @jgoguen. Closes fork issue #154; resolves the upstream CWA #1266 complaint about mobile-Safari metadata search.

## Why

Mobile Safari does not reliably attach the `X-CSRFToken` header to `fetch()` requests, so admin actions and metadata search would either silently fail or return 400 on iPhone. Multiple users had the same complaint with iPhone-Safari only.

## Root cause

`fetch()` in iOS Safari treats some custom request headers inconsistently when the request originates inside a same-origin script that wasn't explicitly opted into a header-allowlist via CORS. The CSRF token rides as `X-CSRFToken`, so when Safari drops it, the Flask CSRF middleware rejects the request.

## Fix (verbatim from upstream PR, with one conflict resolved)

Three layers:

1. **`cps/static/js/get_meta.js`** — `/metadata/search` POST now sends `csrf_token` in the request body. Body-borne CSRF is accepted by the middleware and is immune to Safari's header behavior.
2. **`cps/templates/layout.html`** — introduces a `cwaFetch(url, options)` helper that wraps `fetch()` and auto-attaches `X-CSRFToken` (when present) for any non-safe method (anything that isn't GET/HEAD/OPTIONS/TRACE). The helper also respects a caller-set header so it does not stomp on explicit overrides.
3. **`cps/static/js/main.js`** — moves the cached `csrftoken` lookup from page-load to the per-request `beforeSend` handler, and adds a null-guard so an empty initial lookup doesn't set an empty header. Token rotation now works, and Safari's empty-string return path is handled.

Call sites in `cwa_convert_library.html` and `cwa_epub_fixer.html` are converted from raw `fetch()` to `cwaFetch()`.

## Conflict resolved

The CWA PR conflicted with our own earlier get_meta.js CSRF tweak (`6721638a2`, 2026-05-02 — we shipped our own fix-attempt before upstream's). Resolution: took the upstream PR's version (`csrf_token: $(\"input[name='csrf_token']\").first().val()`) — functionally equivalent to ours, slightly more robust in pages with multiple `csrf_token` inputs, and consistent with the new ajaxSetup lookup pattern.

## Validation

- `pytest tests/unit/test_csrf_mobile_safari.py` — 6/6 passing locally. Pattern-pins the cwaFetch helper, the main.js ajaxSetup hardening, the get_meta.js body-CSRF, and the template call-site conversions.
- Live cwn-local browser exercise with Safari user-agent: queued for follow-up before merge (see verification checklist below).

## Tier

`needs-review` — multi-file UI logic, 6 files touched. Not eligible for tier-2 auto-merge.

## Release target

v4.0.54 hotfix.

## Verification checklist (pre-merge)

- [x] Cherry-pick clean (one conflict resolved by taking upstream's version)
- [x] Regression test added and green locally
- [ ] Live exercise: metadata-search modal on `cwn-local` with iOS Safari user-agent — confirm 200 response, results render, no CSRF rejection
- [ ] CI: Fast Tests + validate-author + evaluate + Test Suite Summary all green

## Credit

Patch by @jgoguen, filed against upstream CWA as #1295. We pulled it in here so iOS Safari users on the fork don't have to wait.