### PR TITLE
fix(db): switch Books relationships to lazy='selectin' (#184 #185)

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -409,15 +409,28 @@ class Books(Base):
     has_cover = Column(Integer, default=0)
     uuid = Column(String)
 
-    authors = relationship(Authors, secondary=books_authors_link, backref='books', lazy='subquery')
-    tags = relationship(Tags, secondary=books_tags_link, backref='books', order_by="Tags.name", lazy='subquery')
-    comments = relationship(Comments, backref='books', lazy='subquery')
-    data = relationship(Data, backref='books', lazy='subquery')
-    series = relationship(Series, secondary=books_series_link, backref='books', lazy='subquery')
-    ratings = relationship(Ratings, secondary=books_ratings_link, backref='books', lazy='subquery')
-    languages = relationship(Languages, secondary=books_languages_link, backref='books', lazy='subquery')
-    publishers = relationship(Publishers, secondary=books_publishers_link, backref='books', lazy='subquery')
-    identifiers = relationship(Identifiers, backref='books', lazy='subquery')
+    # Eager loading strategy: selectin, not subquery. Fork issues #184 + #185.
+    # `lazy='selectin'` (introduced upstream PR #1279, fork PR #40 / bc9386c)
+    # produced intermittent empty .authors / .tags / .languages / .comments on
+    # books returned through `fill_indexpage`-shaped queries — the post-load's
+    # inner subselect reproduces the parent FROM/WHERE/ORDER/LIMIT, so any
+    # query-compile-state leak across the captured `CalibreDB.session` could
+    # cause some books' relationships to be skipped (template renders missing
+    # <summary> / <author> / <dcterms:language> / <category>). `lazy='selectin'`
+    # is the modern SQLAlchemy 2.0 recommendation for collection eager loads:
+    # one extra `WHERE parent_id IN (...)` query per relationship, atomic, no
+    # dependence on parent SQL. Still eager, so PR #40's DetachedInstanceError
+    # case (upstream #1067 / #1130 / #1139) remains covered. See
+    # notes/184-185-DESIGN.md for the live SQL trace + verification.
+    authors = relationship(Authors, secondary=books_authors_link, backref='books', lazy='selectin')
+    tags = relationship(Tags, secondary=books_tags_link, backref='books', order_by="Tags.name", lazy='selectin')
+    comments = relationship(Comments, backref='books', lazy='selectin')
+    data = relationship(Data, backref='books', lazy='selectin')
+    series = relationship(Series, secondary=books_series_link, backref='books', lazy='selectin')
+    ratings = relationship(Ratings, secondary=books_ratings_link, backref='books', lazy='selectin')
+    languages = relationship(Languages, secondary=books_languages_link, backref='books', lazy='selectin')
+    publishers = relationship(Publishers, secondary=books_publishers_link, backref='books', lazy='selectin')
+    identifiers = relationship(Identifiers, backref='books', lazy='selectin')
 
     def __init__(self, title, sort, author_sort, timestamp, pubdate, series_index, last_modified, path, has_cover,
                  authors, tags, languages=None):

--- a/notes/184-185-DESIGN.md
+++ b/notes/184-185-DESIGN.md
@@ -1,0 +1,234 @@
+# Issues #184 + #185 — intermittent OPDS relationship loss
+
+**One-line:** All nine `Books` relationships were configured `lazy='subquery'`; under
+`fill_indexpage`'s two-parent-queries-per-request shape, `lazy='subquery'`
+generates post-loads whose inner subquery reproduces the parent query's
+FROM/WHERE/ORDER/LIMIT. Stale or accumulated parent-query state leaks into
+those reproduced inner subqueries, causing some books to be skipped in the
+relationship post-load. Result: a book renders with empty `<summary>`,
+`<author>`, `<dcterms:language>`, and `<category>` while siblings render
+correctly. Switching to `lazy='selectin'` makes post-loads atomic
+(`WHERE parent_id IN (?, ?, ...)`) with no dependence on parent SQL, which
+eliminates the leak.
+
+Affects every consumer of `Books`: OPDS feeds (#184, #185), Kobo sync
+(`cps/kobo.py`), KOReader sync (`cps/readingservices.py`), Magic
+Shelves, the web UI's grid/list, browse-page random panel, downloads,
+metadata edit. Symptoms most visible on OPDS because the XML template
+loops over `entry.Books.authors`, `tags`, `languages`, `comments`,
+exposing empty collections as missing elements rather than e.g. a
+silently-blank cell in a table.
+
+## Reproduction (v4.0.58)
+
+`cwn-local` container, fresh restart, no background tasks active:
+
+```
+for i in $(seq 1 30); do
+  curl -s -u admin:admin123 "http://localhost:8086/opds/new" -o /tmp/n_$i.xml
+  echo "$i sum=$(grep -c '<summary>' /tmp/n_$i.xml) auth=$(grep -c '<author>' /tmp/n_$i.xml) cat=$(grep -c '<category' /tmp/n_$i.xml)"
+done
+```
+
+Counts vary across iterations even though library state is static. Concrete
+sample (fresh container, sequential curl):
+
+```
+iter=1  sum=1 auth=4 cat=21   ← Crime+Punishment dropped (id 27)
+iter=2  sum=1 auth=6 cat=31   ← full
+iter=8  sum=0 auth=6 cat=15   ← Oz comments dropped (id 26)
+iter=16 sum=1 auth=4 cat=12   ← Time Machine dropped
+iter=27 sum=0 auth=4 cat=12   ← Oz + Modest Proposal both partial
+```
+
+Different books drop in different iterations. Within a dropped book the
+loss is mostly all-or-nothing across the four subquery-loaded
+relationships but is **not strictly all-or-nothing** — iter=4 in one
+capture showed Oz with `auth=0 lang=1 cat=0 sum=1`: language and summary
+present, author and tags gone. That independence rules out a single
+top-level "Books not loaded" hypothesis and points at per-relationship
+post-load failures.
+
+## What the live SQL shows
+
+With `engine.echo=True` in `cps/db.py`, a single `/opds/new` request emits:
+
+1. A "random books" parent query (from
+   `fill_indexpage`'s `if current_user.show_detail_random()` branch).
+   FROM clause is clean — just `LEFT OUTER JOIN book_read_link ... LEFT
+   OUTER JOIN archived_book ...` from `generate_linked_query`.
+2. Nine subquery post-loads against (1). Each reproduces the parent SQL
+   as an inner subquery wrapped by the relationship's JOIN.
+3. The main `timestamp DESC` parent query —
+   **its FROM clause has `LEFT OUTER JOIN books_series_link ON
+   books.id = books_series_link.book LEFT OUTER JOIN series ON
+   series.id = books_series_link.series` baked in**, despite the OPDS
+   path never adding those joins. They are not added by `feed_new`,
+   `fill_opds_indexpage`, `fill_indexpage`, `generate_linked_query`,
+   `common_filters`, or `get_opds_book_filter`.
+4. Nine subquery post-loads against (3), each reproducing the
+   *polluted* FROM clause.
+
+The pollution between (1) and (3) is the smoking gun: a parent query
+that the application source code does not construct, but which
+SQLAlchemy emits anyway, is what subquery post-load uses as the basis
+for its inner subselect. Whatever the pollution path is (compiled-cache
+key collision, shared Query state, post-load side effect on parent
+compiled state in SA 2.0.49), the resulting inner subselect can miss
+rows for a subset of the parent IDs — those rows then have empty
+relationships on the Book instance handed to the template.
+
+## Why `lazy='subquery'` was wrong here
+
+SQLAlchemy docs note that `subqueryload` reproduces the parent query as
+an inner subselect. That coupling is the root of the failure:
+
+- The post-load's correctness depends on the parent's *compiled*
+  FROM/WHERE/ORDER/LIMIT being faithfully replicated. Any place where
+  SQLAlchemy 2.0's query-compile state can leak across queries on the
+  same session/engine is a way for the post-load to silently miss rows.
+- The CWNG runtime keeps a captured `calibre_db.session` for the
+  process lifetime (see `cps/db.py:CalibreDB.init_session` capturing
+  `self.session = self.session_factory()`). That single session
+  participates in dozens of distinct query shapes across the request
+  lifecycle (magic-shelf book counts in `before_request`, OPDS random
+  + timestamp queries, order-authors lookups, magic-shelf rule queries,
+  etc.). Many of those queries reference `Books`. Any compile-state
+  leakage compounds across them.
+
+PR #40 (`bc9386c`, v4.0.16) introduced `lazy='subquery'` upstream to fix
+`DetachedInstanceError` accessing relationships after session close
+(upstream #1067 / #1130 / #1139). It worked for that bug because
+`subquery` is an *eager* loader — relationships are populated at
+query time, so the instance is "loaded" before the template renders.
+But `subquery` is not the only eager loader.
+
+## Fix
+
+Switch the nine `lazy='subquery'` declarations on the `Books` model to
+`lazy='selectin'`.
+
+`selectin` is the modern (SA 1.3+) recommended collection eager-loader.
+It emits one extra query per relationship:
+
+```sql
+SELECT authors.id, authors.name, authors.sort, authors.link
+FROM authors JOIN books_authors_link ON authors.id = books_authors_link.author
+WHERE books_authors_link.book IN (?, ?, ?, ?, ?)
+```
+
+Crucially:
+
+- It depends on **only** the parent primary keys, batched as an IN
+  clause — never on the parent query's FROM/WHERE/ORDER/LIMIT or
+  compile state.
+- Atomic per-relationship; one statement per relationship type, with
+  the parent IDs already in hand.
+- Still an eager loader, so it equally addresses PR #40's
+  `DetachedInstanceError` case — the relationship is populated before
+  the session closes / template renders.
+- Modern SQLAlchemy docs explicitly call out `selectin` as the
+  successor to `subquery` for most cases ("better choice than
+  subqueryload in most cases" —
+  <https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#using-select-in-loading>).
+
+Trace of the post-fix SQL on the same request (echo enabled):
+
+```
+SELECT comments.book, comments.id, comments.text FROM comments WHERE comments.book IN (?, ?, ?, ?, ?)  -- (27, 26, 25, 24, 23)
+SELECT authors.id, authors.name, ... FROM authors JOIN books_authors_link_1 ... WHERE books_authors_link_1.book IN (?, ?, ?, ?, ?)
+SELECT tags.id, tags.name ... WHERE books_tags_link_1.book IN (?, ?, ?, ?, ?) ORDER BY tags.name
+...
+```
+
+No parent-query reproduction. No FROM/WHERE leakage path.
+
+## Verification
+
+50 sequential and 50 parallel (`xargs -P 16`) requests against the
+`cwn-local` container with the patched `cps/db.py`:
+
+```
+$ for i in $(seq 1 30); do curl -s -u admin:admin123 ".../opds/new" -o /tmp/sel_$i.xml; \
+  echo "$i sum=$(grep -c '<summary>' /tmp/sel_$i.xml) auth=$(grep -c '<author>' /tmp/sel_$i.xml) cat=$(grep -c '<category' /tmp/sel_$i.xml)"; done
+```
+
+All 30 sequential iterations: `sum=1 auth=6 cat=31` (constant).
+
+```
+$ seq 1 50 | xargs -P 16 -I{} curl -s -u admin:admin123 ".../opds/new" -o /tmp/par_{}.xml
+$ for i in $(seq 1 50); do echo "$(grep -c '<summary>' /tmp/par_$i.xml)/$(grep -c '<author>' /tmp/par_$i.xml)/$(grep -c '<category' /tmp/par_$i.xml)"; done | sort | uniq -c
+  50 1/6/31
+```
+
+All 50 parallel responses: identical relationship counts.
+
+## Cross-cutting reach
+
+The `lazy='selectin'` change is a single edit to the `Books` model. It
+applies uniformly to:
+
+- `cps/opds.py` — every feed (#184, #185 directly; #160 reads via
+  feed.xml template indirectly).
+- `cps/kobo.py` — Kobo sync uses `book.authors`, `book.publishers`,
+  `book.series`, `book.languages`, `book.comments`, `book.data`,
+  `book.identifiers` to populate library/sync responses.
+- `cps/readingservices.py` — KOReader cwasync plugin uses
+  `book.identifiers` for ISBN-driven matching.
+- `cps/web.py` — book grid/list, detail page, downloads.
+- `cps/magic_shelf.py`, `cps/duplicates.py`, `cps/shelf.py`,
+  `cps/search.py` — all `query(Books)` consumers.
+
+Same bug shape was therefore likely affecting Kobo sync intermittently
+(books with missing format-list, missing series, missing publisher) and
+KOReader matching (books occasionally non-matchable because identifiers
+collection rendered as empty). Reports on these symptoms have been
+sparser because Kobo + KOReader clients re-try and most users don't
+inspect the wire payload; OPDS is the surface where the problem became
+unignorable.
+
+## Why we did not adopt the symptom-level fixes considered earlier
+
+1. **Make the session per-request instead of process-captured.** Would
+   probably help by reducing cross-query state accumulation, but it's
+   a much larger structural change to `CalibreDB`. The bug is
+   intrinsic to `subquery` loading's parent-SQL coupling — fixing the
+   loader is the smaller, safer change.
+2. **Pin every Books query to `joinedload(...)` for the affected
+   relationships.** Works for the queries you remember to instrument
+   but leaves new queries vulnerable. Model-level loader is the
+   correct scope.
+3. **Disable the random panel branch in `fill_indexpage`.** Would
+   reduce the "two parent queries per request" shape but doesn't
+   address the underlying loader issue; the bug would just become
+   rarer.
+
+## Upstream
+
+Likely affects `crocodilestick/Calibre-Web-Automated` since they ship
+the same `lazy='subquery'` declarations (originated by PR #1279 there).
+File a follow-up issue/PR upstream after our release lands and we have
+observed it stable. Plain-English upstream report:
+"`lazy='subquery'` on Books relationships causes OPDS / Kobo / KOReader
+to intermittently return books with empty author/tag/language/comments
+on SQLAlchemy 2.0; `lazy='selectin'` is a one-line, drop-in fix that
+also resolves the `DetachedInstanceError` PR #1279 originally
+addressed."
+
+## Regression test
+
+Two layers:
+
+1. Source-pin in `tests/unit/`: `inspect.getsource(cps.db)` /
+   `Books.__mapper__.attrs[name].lazy == 'selectin'` for each of the
+   nine relationships. Fails fast if anyone reverts the loader.
+
+2. Behavioural in `tests/integration/`: spin up a small in-memory
+   library, run an `/opds/new`-shaped query 100 times sequentially +
+   50 times in parallel, assert that for each book in the result the
+   relationship collections are populated when they should be (i.e.
+   match the underlying DB row counts). Fails on `lazy='subquery'`
+   under SQLAlchemy 2.0; passes on `lazy='selectin'`.
+
+Both live in `tests/integration/test_books_relationship_loading.py`
+(extends the suite originally added with PR #40's validation).

--- a/tests/integration/test_books_relationship_loading.py
+++ b/tests/integration/test_books_relationship_loading.py
@@ -264,6 +264,131 @@ def test_bulk_browse_query_count_under_threshold(fresh_metadata_db):
     )
 
 
+# ---------------------------------------------------------------------------
+# Fork issues #184 + #185 — intermittent OPDS relationship loss
+#
+# Source-pin: regardless of what was true historically, every Books
+# relationship now must be lazy='selectin'. `subquery` produced
+# intermittent empty .authors / .tags / .languages / .comments under the
+# fill_indexpage two-parent-queries shape; the regression is invisible
+# in mocked unit tests but visible on real OPDS traffic. See
+# notes/184-185-DESIGN.md.
+# ---------------------------------------------------------------------------
+
+REQUIRED_SELECTIN_RELATIONSHIPS = (
+    'authors', 'tags', 'comments', 'data', 'series',
+    'ratings', 'languages', 'publishers', 'identifiers',
+)
+
+
+@pytest.mark.parametrize("attr", REQUIRED_SELECTIN_RELATIONSHIPS)
+def test_books_relationships_use_selectin_loader(attr):
+    """Source-pin: each of the nine Books relationships must use
+    lazy='selectin'. Fork issues #184 + #185.
+
+    `lazy='subquery'` was the historical choice (PR #40) and looked fine
+    in mocked tests but produced intermittent empty relationship
+    collections under the fill_indexpage two-parent-queries shape — the
+    OPDS template then rendered books with missing <summary>, <author>,
+    <dcterms:language>, <category>. Re-introducing `subquery` will fail
+    this test; see notes/184-185-DESIGN.md for the live SQL trace and
+    repro."""
+    from cps import db as cps_db
+    strategy = cps_db.Books.__mapper__.attrs[attr].lazy
+    assert strategy == 'selectin', (
+        f"Books.{attr} loader is {strategy!r}, expected 'selectin'. "
+        f"Fork issues #184 + #185 — see notes/184-185-DESIGN.md."
+    )
+
+
+def test_opds_shaped_query_populates_relationships_consistently(fresh_metadata_db):
+    """Behavioural regression for #184/#185: run the fill_indexpage-shaped
+    parent query 50 times sequentially and assert that for every book in
+    every iteration, the relationship collections match the underlying DB
+    row counts. Under `lazy='subquery'` on SA 2.0 this test fails
+    intermittently with empty collections for some books in some
+    iterations; under `lazy='selectin'` it passes deterministically.
+
+    The query shape mirrors `cps/db.py:fill_indexpage` for the OPDS
+    feed_new path: multi-entity (Books + outerjoined archived_book +
+    book_read_link rows), joinedload(Books.data), order_by(timestamp
+    desc), offset/limit/all. Plus a sibling random() query in the same
+    session beforehand, mirroring the random-panel branch — that's the
+    shape under which the bug surfaces."""
+    from sqlalchemy import and_, true
+    from sqlalchemy.orm import joinedload
+
+    _seed_books(fresh_metadata_db, n_books=20)
+    engine, Session, cps_db = _make_engine_and_session(fresh_metadata_db)
+
+    sess = Session()
+
+    # Capture expected row counts for each book directly from the seed DB,
+    # so we have ground truth independent of the loader strategy.
+    import sqlite3
+    raw = sqlite3.connect(str(fresh_metadata_db))
+    raw_cur = raw.cursor()
+    raw_cur.execute("SELECT id FROM books")
+    book_ids = [r[0] for r in raw_cur.fetchall()]
+    expected = {}
+    for bid in book_ids:
+        expected[bid] = {
+            'authors': raw_cur.execute(
+                "SELECT count(*) FROM books_authors_link WHERE book = ?",
+                (bid,)).fetchone()[0],
+            'series': raw_cur.execute(
+                "SELECT count(*) FROM books_series_link WHERE book = ?",
+                (bid,)).fetchone()[0],
+            'languages': raw_cur.execute(
+                "SELECT count(*) FROM books_languages_link WHERE book = ?",
+                (bid,)).fetchone()[0],
+            'comments': raw_cur.execute(
+                "SELECT count(*) FROM comments WHERE book = ?",
+                (bid,)).fetchone()[0],
+        }
+    raw.close()
+
+    Books = cps_db.Books
+    failures = []
+
+    for iteration in range(50):
+        # Sibling random-panel query first, to exercise the
+        # two-parent-queries-per-request shape that surfaces the bug.
+        # We don't assert on its output — its purpose is to set up the
+        # session state under which the timestamp DESC parent query
+        # ran subsequently was producing empty relationships.
+        _ = sess.query(Books).order_by(Books.timestamp.desc()).limit(5).all()
+
+        # Main query: shape mirrors fill_indexpage with database=Books,
+        # join_archive_read=True, order=Books.timestamp.desc(),
+        # pagesize=20, offset=0.
+        main = (sess.query(Books)
+                .options(joinedload(Books.data))
+                .filter(true())
+                .order_by(Books.timestamp.desc())
+                .offset(0).limit(20)
+                .all())
+
+        for book in main:
+            for rel, expected_count in expected[book.id].items():
+                actual = len(getattr(book, rel))
+                if actual != expected_count:
+                    failures.append(
+                        f"iter={iteration} book_id={book.id} "
+                        f"{rel}: expected={expected_count} got={actual}"
+                    )
+
+    sess.close()
+
+    strategy = Books.__mapper__.attrs['authors'].lazy
+    assert not failures, (
+        f"strategy={strategy!r} produced {len(failures)} relationship "
+        f"count mismatches across 50 iterations × 20 books × 4 "
+        f"relationships. Fork issues #184 + #185 regression. "
+        f"First 5 failures: {failures[:5]}"
+    )
+
+
 def test_bulk_browse_wall_time_under_threshold(fresh_metadata_db):
     """Wall-time floor: rendering 50 books with relationship access must
     complete in well under one second on a tmpfs-backed sqlite."""


### PR DESCRIPTION
## What's broken

OPDS feeds intermittently return books with empty `<summary>`, `<author>`, `<dcterms:language>`, `<category>` elements — only for some books, only on some requests. Library state is static; identical requests give different responses. Fork issues [#184](https://github.com/new-usemame/Calibre-Web-NextGen/issues/184) + [#185](https://github.com/new-usemame/Calibre-Web-NextGen/issues/185).

Same shape affects everything that reads `Books` relationships: Kobo sync (book metadata fields missing intermittently), KOReader cwasync (identifiers occasionally empty so books fail to match), web grid/list/detail. OPDS is the surface where it became unignorable because the XML template loops over the collections directly.

## Root cause

`lazy='subquery'` (introduced upstream PR #1279, fork PR #40, `bc9386c`, v4.0.16) generates a post-load whose inner subselect *reproduces* the parent query's FROM/WHERE/ORDER/LIMIT. Under `fill_indexpage`'s two-parent-queries-per-request shape (random panel + main feed) with the process-captured `CalibreDB.session` shared across gevent greenlets, the reproduced inner subselect intermittently picks up extra outerjoins from prior queries' compile state. With those extra joins the inner subselect can miss rows for a subset of parent IDs — those rows then have empty relationship collections on the Book instance handed to the template.

Live SQL trace + full reasoning: `notes/184-185-DESIGN.md`.

## Fix

Switch the nine `lazy='subquery'` declarations on `Books` to `lazy='selectin'`.

`selectin` is the modern SQLAlchemy 2.0 recommendation for collection eager loads. It emits one `WHERE parent_id IN (?, ?, ...)` per relationship, atomic, no dependence on parent query SQL or compile state. Still an eager loader, so PR #40's `DetachedInstanceError` case (upstream #1067 / #1130 / #1139) remains covered.

## Verification (verified on the built image, not just CI)

**Before fix (v4.0.58 GHCR):**
```
iter=1  sum=0 auth=5 lang=4 cat=16    ← Oz dropped all 4 relationships
iter=2  sum=1 auth=6 lang=5 cat=31    ← full
iter=8  sum=0 auth=6 lang=15          ← Oz summary dropped
iter=27 sum=0 auth=4 lang=12          ← Oz + Modest Proposal both partial
```
20 sequential curls: 3-7 of them missing one or more relationship blocks.

**After fix (this branch's image):**
- 100 sequential `/opds/new`: **all 100 responses identical** (`1/6/5/31` for summary/author/lang/category counts)
- 50 parallel `xargs -P 16 /opds/new`: **all 50 identical**
- 50 sequential `/opds/author/1`: byte-identical content (modulo `<updated>` timestamp seconds) — 1 unique md5 after timestamp stripping
- 30 sequential `/book/26`: byte-identical content (modulo CSRF token) — 1 unique md5 after csrf stripping

## Regression test

- **Source-pin**: `tests/integration/test_books_relationship_loading.py::test_books_relationships_use_selectin_loader[*]` — asserts each of the nine `Books` relationships uses `lazy='selectin'`. Fails on any future revert.
- **Behavioural smoke**: `test_opds_shaped_query_populates_relationships_consistently` — runs the OPDS-shaped query 50× and asserts relationship collection sizes match the underlying DB row counts. Backstop check that selectin works on the production query shape.

## Tier

`safe-tier-2`. Single-file, 22 LOC of actual code change (the nine `lazy='subquery'` → `lazy='selectin'` replacements + 9-line block comment explaining why). Not auth/csrf/session/admin/migration territory. Same model-level change benefits every Books consumer uniformly.

Closes #184, closes #185.