### PR TITLE
feat(brand): migrate legacy instance titles to Calibre-Web NextGen

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -220,6 +220,15 @@ finally:
     pass
 PY
 
+#------------------------------------------------------------------------------------------------------------------------
+#  One-time brand-title migration (rebrand legacy defaults to "Calibre-Web NextGen")
+#------------------------------------------------------------------------------------------------------------------------
+
+echo "[cwa-init] Migrating legacy instance titles to Calibre-Web NextGen (one-time, idempotent)..."
+
+python3 /app/calibre-web-automated/scripts/migrate_brand_title.py /config/app.db \
+  || echo "[cwa-init] Brand-title migration reported a non-zero exit; continuing startup."
+
 
 echo "[cwa-init] CWA-init complete! Service exiting now..."
 

--- a/scripts/migrate_brand_title.py
+++ b/scripts/migrate_brand_title.py
@@ -1,0 +1,119 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Rebrand legacy instance titles to ``Calibre-Web NextGen``.
+
+The fresh-install default in ``cps/config_sql.py`` is already
+``Calibre-Web NextGen``. But existing installs carry whatever string
+was the default when their ``settings`` row was first inserted — that's
+``Calibre-Web`` for users migrating in from stock calibre-web, and
+``Calibre-Web Automated`` for users coming from CWA. Both of those
+read as the old brand in the browser tab and navbar after the v4.0.60
+rebrand and confuse users into thinking the upgrade didn't apply.
+
+We migrate those two legacy defaults — and only those — to the new
+brand. Any custom title (e.g. ``Maggie's Library``) is left untouched.
+The match is hyphen-and-case-agnostic so variants like
+``CALIBRE-WEB AUTOMATED`` or ``calibre web`` also get rebranded.
+
+The migration is idempotent: running it against a DB that's already
+on the new brand (or has a custom title) is a no-op.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sqlite3
+import sys
+
+
+TARGET_TITLE = "Calibre-Web NextGen"
+
+# Normalized forms of the two legacy default titles we want to migrate.
+# Anything else (custom title, already on new brand) is left alone.
+_LEGACY_NORMALIZED = frozenset({"calibreweb", "calibrewebautomated"})
+
+
+def _normalize(value: str) -> str:
+    """Strip everything but ASCII letters/digits, then lowercase."""
+    return re.sub(r"[^a-z0-9]", "", (value or "").lower())
+
+
+def should_migrate(current_title: str | None) -> bool:
+    """True iff ``current_title`` is a legacy default we should rebrand.
+
+    ``None`` and empty/whitespace strings are treated as legacy — those
+    mean "row was created before the column had any default", which is
+    effectively the same as the old default.
+    """
+    if current_title is None or not current_title.strip():
+        return True
+    return _normalize(current_title) in _LEGACY_NORMALIZED
+
+
+def migrate(db_path: str) -> tuple[bool, str | None]:
+    """Run the migration against ``db_path``.
+
+    Returns ``(updated, previous_value)``. ``updated`` is True only when
+    we actually changed the row; otherwise the DB was already on a
+    non-legacy title and we left it alone.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT config_calibre_web_title FROM settings LIMIT 1")
+        row = cur.fetchone()
+        if row is None:
+            # No settings row yet — fresh-install path. The column
+            # default handles it, nothing to migrate.
+            return False, None
+        previous = row[0]
+        if not should_migrate(previous):
+            return False, previous
+        cur.execute(
+            "UPDATE settings SET config_calibre_web_title = ?",
+            (TARGET_TITLE,),
+        )
+        conn.commit()
+        return True, previous
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Rebrand legacy instance titles to Calibre-Web NextGen",
+    )
+    parser.add_argument(
+        "db_path",
+        nargs="?",
+        default="/config/app.db",
+        help="Path to app.db (default: /config/app.db)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        updated, previous = migrate(args.db_path)
+    except sqlite3.Error as exc:
+        print(f"[brand-title-migration] sqlite error: {exc}", flush=True)
+        return 1
+
+    if updated:
+        print(
+            f"[brand-title-migration] Updated config_calibre_web_title: "
+            f"{previous!r} -> {TARGET_TITLE!r}",
+            flush=True,
+        )
+    else:
+        print(
+            f"[brand-title-migration] No change: {previous!r} is not a legacy default",
+            flush=True,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_migrate_brand_title.py
+++ b/tests/unit/test_migrate_brand_title.py
@@ -1,0 +1,218 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Pin the brand-title migration shipped with v4.0.60+.
+
+The v4.0.60 rebrand changed the *default* for fresh installs to
+``Calibre-Web NextGen`` but left existing rows alone. Maggie's install
+was still showing ``Calibre-Web`` in the browser tab after the upgrade
+because her ``settings`` row predated the default change. This migration
+fixes that for everyone migrating from stock calibre-web (default
+``Calibre-Web``) or from CWA (default ``Calibre-Web Automated``) while
+leaving anyone who picked a custom title (``Maggie's Library``,
+``Coundou Family Library``, etc.) untouched.
+
+Behavior under test:
+- ``should_migrate`` matches the two legacy defaults regardless of
+  hyphenation or case ("calibre web", "CALIBRE-WEB AUTOMATED", etc.)
+- Empty / whitespace / None are treated as legacy (same as old default).
+- Any custom or already-rebranded title is left alone.
+- ``migrate`` writes the new value and is idempotent on a second run.
+"""
+
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+
+# Import directly from the scripts/ folder. The Docker image puts
+# scripts/ on disk at /app/calibre-web-automated/scripts/; in CI the
+# repo root is the working dir, so we add it to sys.path explicitly.
+import sys
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(_REPO_ROOT, "scripts"))
+
+import migrate_brand_title as mod  # noqa: E402
+
+
+# --- helpers ----------------------------------------------------------
+
+def _make_db(tmp_path: str, title) -> str:
+    """Create a minimal sqlite app.db with one settings row.
+
+    ``title`` may be a string, None, or ``...`` to skip the row entirely
+    (simulating a never-initialized DB).
+    """
+    db_path = os.path.join(tmp_path, "app.db")
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE settings (id INTEGER PRIMARY KEY, "
+            "config_calibre_web_title TEXT)"
+        )
+        if title is not Ellipsis:
+            conn.execute(
+                "INSERT INTO settings (id, config_calibre_web_title) VALUES (1, ?)",
+                (title,),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def _read_title(db_path: str):
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT config_calibre_web_title FROM settings LIMIT 1"
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+# --- should_migrate ---------------------------------------------------
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Calibre-Web",
+        "calibre-web",
+        "CALIBRE-WEB",
+        "Calibre Web",
+        "calibreweb",
+        "  Calibre-Web  ",
+        "Calibre-Web Automated",
+        "calibre-web automated",
+        "CALIBRE WEB AUTOMATED",
+        "calibrewebautomated",
+        None,
+        "",
+        "   ",
+    ],
+)
+def test_should_migrate_recognizes_legacy(title):
+    assert mod.should_migrate(title) is True
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Calibre-Web NextGen",          # already on new brand
+        "calibre-web nextgen",
+        "Maggie's Library",
+        "Coundou Family Library",
+        "CWA",                          # acronym alone is not the legacy default
+        "Calibre-Web Automated v2",     # customized suffix
+        "My Calibre-Web",               # customized prefix
+        "Calibre-Web - Family",         # customized suffix
+        "NextGen",
+    ],
+)
+def test_should_migrate_preserves_custom(title):
+    assert mod.should_migrate(title) is False
+
+
+# --- migrate (end-to-end on real sqlite db) ---------------------------
+
+def test_migrate_rewrites_legacy_calibre_web(tmp_path):
+    db = _make_db(str(tmp_path), "Calibre-Web")
+    updated, previous = mod.migrate(db)
+    assert updated is True
+    assert previous == "Calibre-Web"
+    assert _read_title(db) == "Calibre-Web NextGen"
+
+
+def test_migrate_rewrites_legacy_calibre_web_automated(tmp_path):
+    db = _make_db(str(tmp_path), "Calibre-Web Automated")
+    updated, previous = mod.migrate(db)
+    assert updated is True
+    assert previous == "Calibre-Web Automated"
+    assert _read_title(db) == "Calibre-Web NextGen"
+
+
+def test_migrate_preserves_custom_title(tmp_path):
+    db = _make_db(str(tmp_path), "Maggie's Library")
+    updated, previous = mod.migrate(db)
+    assert updated is False
+    assert previous == "Maggie's Library"
+    assert _read_title(db) == "Maggie's Library"
+
+
+def test_migrate_noop_when_already_on_new_brand(tmp_path):
+    db = _make_db(str(tmp_path), "Calibre-Web NextGen")
+    updated, previous = mod.migrate(db)
+    assert updated is False
+    assert previous == "Calibre-Web NextGen"
+    assert _read_title(db) == "Calibre-Web NextGen"
+
+
+def test_migrate_handles_null_title(tmp_path):
+    db = _make_db(str(tmp_path), None)
+    updated, previous = mod.migrate(db)
+    assert updated is True
+    assert previous is None
+    assert _read_title(db) == "Calibre-Web NextGen"
+
+
+def test_migrate_empty_settings_table_is_safe(tmp_path):
+    db = _make_db(str(tmp_path), Ellipsis)  # no row inserted
+    updated, previous = mod.migrate(db)
+    assert updated is False
+    assert previous is None
+    # And the table is still empty after.
+    conn = sqlite3.connect(db)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM settings").fetchone()[0]
+    finally:
+        conn.close()
+    assert n == 0
+
+
+def test_migrate_is_idempotent(tmp_path):
+    db = _make_db(str(tmp_path), "Calibre-Web")
+    updated1, _ = mod.migrate(db)
+    updated2, previous2 = mod.migrate(db)
+    assert updated1 is True
+    assert updated2 is False
+    assert previous2 == "Calibre-Web NextGen"
+    assert _read_title(db) == "Calibre-Web NextGen"
+
+
+# --- CLI entrypoint ---------------------------------------------------
+
+def test_cli_returns_zero_and_prints_on_update(tmp_path, capsys):
+    db = _make_db(str(tmp_path), "Calibre-Web")
+    rc = mod.main([db])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "Updated config_calibre_web_title" in captured.out
+    assert "Calibre-Web NextGen" in captured.out
+    assert _read_title(db) == "Calibre-Web NextGen"
+
+
+def test_cli_returns_zero_and_prints_on_noop(tmp_path, capsys):
+    db = _make_db(str(tmp_path), "Maggie's Library")
+    rc = mod.main([db])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "No change" in captured.out
+    assert _read_title(db) == "Maggie's Library"
+
+
+def test_cli_returns_one_on_sqlite_error(tmp_path, capsys):
+    missing = os.path.join(str(tmp_path), "does-not-exist.db")
+    # Force sqlite to fail by pointing at a path it can't even create
+    # the table-scan against (no file, table missing). Open it once to
+    # ensure the file exists but the table does NOT, so the SELECT
+    # raises OperationalError which is sqlite3.Error.
+    sqlite3.connect(missing).close()
+    rc = mod.main([missing])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "sqlite error" in captured.out


### PR DESCRIPTION
## Symptom

After the v4.0.60 rebrand, existing users still saw `Calibre-Web` (or `Calibre-Web Automated`) in the browser tab and the top-left navbar brand link instead of `Calibre-Web NextGen`. Repro: any install that existed before v4.0.60 and never changed `Admin → Basic Configuration → Title`.

## Root cause

`cps/config_sql.py:69` changed the default to `Calibre-Web NextGen` in v4.0.60 — but SQLAlchemy column defaults only apply on row insert. Existing `settings` rows kept their old value:

- Migrating in from stock calibre-web → row was created with `Calibre-Web`.
- Migrating in from CWA → row was created with `Calibre-Web Automated`.

`cps/templates/layout.html:7` renders `<title>{{instance}} | {{title}}</title>` from `config.config_calibre_web_title`, so users see the stale value indefinitely.

## Fix

One-time, idempotent data migration in `cwa-init`:

- New `scripts/migrate_brand_title.py`: normalizes the current title to `[a-z0-9]` and rebrands it to `Calibre-Web NextGen` iff the normalized form matches one of the two legacy defaults (`calibreweb`, `calibrewebautomated`). `NULL`, empty, and whitespace-only are treated as legacy. Anything else (custom titles like `Maggie's Library`, or already on the new brand) is left alone. CLI prints what it did, exit 0 on success/no-op, exit 1 only on actual sqlite errors.
- `cwa-init/run` invokes the script after the existing dark-theme migration. A non-zero exit logs but does not abort startup.

The migration is intentionally narrow — only the two known stock defaults — so anyone who deliberately set a custom title that *happens* to look brandy (e.g. `Calibre-Web Automated v2`, `My Calibre-Web`) is preserved.

## Test plan

- [x] `pytest tests/unit/test_migrate_brand_title.py -v` — 32 cases pass locally (legacy/custom partition, NULL/empty, idempotency, CLI rc + stdout).
- [x] Live-verified against the v4.0.60 container on the operator's instance:
  - `Calibre-Web NextGen` → no-op
  - `Calibre-Web` → updated to `Calibre-Web NextGen`
  - `Coundou Family Library` → preserved
  - Second run on already-migrated DB → no-op (idempotency)
- [ ] CI green (will trigger on push)
- [ ] On next release, fresh container rebuild runs the migration once during `cwa-init`. Existing v4.0.60 deployments pick up the corrected title automatically on container restart.