### PR TITLE
chore(gitignore): ignore .cwa_migrations/ runtime markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,9 @@ cython_debug/
 
 # Dev instance files for testing in the same folder
 instance/
+
+# Runtime migration markers created by cwa-init / ub.py.run_cwa_migrations
+# inside CONFIG_DIR. These appear under repo/ when a developer points
+# CONFIG_DIR at the repo root for local container runs; they're per-
+# deployment state, not source.
+.cwa_migrations/


### PR DESCRIPTION
## Symptom

Every autopilot tick fails preflight with `repo/ has uncommitted changes — investigate before draining`. The dirty file is `.cwa_migrations/duplicates_sidebar_v1`, a small text marker (one ISO timestamp inside).

## Root cause

`cps/ub.py.run_cwa_migrations` writes idempotency markers to `os.path.join(constants.CONFIG_DIR, ".cwa_migrations")`. On a local dev container where the operator mounts `/config` at the repo root for inspection convenience, those markers materialize under `repo/.cwa_migrations/` and surface as untracked files in the working tree on every container restart.

The markers are per-deployment state — not source. Tracking them would also cause unnecessary diff noise across hosts whenever a new migration shipped (each host writes its own marker the first time `cwa-init` runs).

## Fix

One `.gitignore` rule (3 LOC + 3-line comment explaining when the directory shows up) so the marker dir stays git-invisible. No behavior change — the migration code still writes and reads the same on-disk path.

## Verification

- `git status` on the operator's working tree is clean after the rule lands.
- Autopilot preflight no longer flags `repo/ has uncommitted changes`.
- Migration paths in `cps/ub.py:1103,1307,1311` continue to resolve the same way (the `.gitignore` rule is purely about visibility).

## Tier

`safe-tier-2` — single-file `.gitignore` edit, 6 LOC added, no code, no auth/security/migration semantics changed.

## Release target

Next patch — `v4.0.61` or whenever the operator next cuts.