### PR TITLE
fix(ingest): coordinate metadata.db writes; stop concurrent-ingest crash (#192)

### DIFF
--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -36,7 +36,9 @@ sys.path.insert(1, '/app/calibre-web-automated/scripts/')
 from cwa_db import CWA_DB
 from .services.background_scheduler import BackgroundScheduler, DateTrigger
 from .services.worker import WorkerThread
-from .tasks.database import TaskReconnectDatabase
+# TaskReconnectDatabase no longer imported here — the post-ingest
+# reconnect endpoint now uses CalibreDB.refresh_for_new_data() instead.
+# See fork issue #192.
 from .tasks.auto_send import TaskAutoSend
 from .tasks.ops import TaskConvertLibraryRun, TaskEpubFixerRun
 
@@ -534,7 +536,14 @@ def cwa_internal_schedule_epub_fixer():
 @csrf.exempt
 @cwa_internal.route('/cwa-internal/reconnect-db', methods=["POST"])
 def cwa_internal_reconnect_db():
-    """Enqueue a database reconnect task in the web process.
+    """Refresh the SQLAlchemy session so new books from ingest are
+    visible to the next request.
+
+    Synchronous, light-weight: expires loaded objects and ends the
+    held read transaction on every CalibreDB instance. Does not
+    dispose the engine — that path raced with in-flight requests
+    under sustained ingest load and is the root cause of fork
+    issue #192 (web service unresponsive after concurrent ingest).
 
     Security: Only accepts localhost callers.
     """
@@ -543,9 +552,9 @@ def cwa_internal_reconnect_db():
         if remote not in (None, '127.0.0.1', '::1'):
             abort(403)
 
-        task = TaskReconnectDatabase()
-        WorkerThread.add(None, task, hidden=True)
-        return jsonify({"status": "enqueued"}), 200
+        from .db import CalibreDB
+        CalibreDB.refresh_for_new_data()
+        return jsonify({"status": "refreshed"}), 200
     except Exception as e:
         log.error(f"Internal reconnect-db failed: {e}")
         return jsonify({"error": str(e)}), 400

--- a/cps/db.py
+++ b/cps/db.py
@@ -756,6 +756,14 @@ class CalibreDB:
                         log.warning("WAL mode disabled for calibre/app_settings (%s)", reason)
                 except Exception:
                     pass
+                # Wait up to 60s for any external writer (calibredb during
+                # ingest) instead of failing fast on contention. Required
+                # for fork issue #192 — without this, transient locks on
+                # mergerfs/SMB/NFS surface as immediate OperationalError.
+                try:
+                    connection.execute(text("PRAGMA busy_timeout=60000"))
+                except Exception:
+                    pass
                 local_session = scoped_session(sessionmaker())
                 local_session.configure(bind=connection)
                 database_uuid = local_session().query(Library_Id).one_or_none()
@@ -814,6 +822,15 @@ class CalibreDB:
                         else:
                             reason = "NETWORK_SHARE_MODE=true" if nsm else "metadata.db not writable"
                             log.warning("WAL mode disabled for calibre/app_settings (%s)", reason)
+                    except Exception:
+                        pass
+                    # Wait up to 60s for any external writer (calibredb
+                    # during ingest) before failing the query. Required
+                    # for fork issue #192 — without this, transient
+                    # locks on mergerfs/SMB/NFS surface as immediate
+                    # apsw.BusyError and crash the import.
+                    try:
+                        connection.execute(text("PRAGMA busy_timeout=60000"))
                     except Exception:
                         pass
 
@@ -1428,6 +1445,38 @@ class CalibreDB:
             # Rebuild engine/session factory and update config
             self.setup_db(config.config_calibre_dir, app_db_path)
             self.update_config(config)
+
+    @classmethod
+    def refresh_for_new_data(cls):
+        """Release the read transaction on every CalibreDB instance.
+
+        Used after external writers (calibredb add during ingest) commit
+        new rows to metadata.db. Without this, the web app's SQLAlchemy
+        session sits on a stale read snapshot and the new book stays
+        invisible until the session's transaction ends. Calling
+        expire_all() + rollback() ends the transaction without
+        disposing the engine — the next query starts fresh and sees
+        the latest committed data.
+
+        Replaces the prior async TaskReconnectDatabase path which
+        disposed the shared engine on a worker thread and raced with
+        in-flight request greenlets (fork issue #192).
+        """
+        with cls._reconnect_lock:
+            for inst in list(cls.instances):
+                try:
+                    if inst.session is not None:
+                        try:
+                            inst.session.expire_all()
+                        except Exception:
+                            pass
+                        try:
+                            inst.session.rollback()
+                        except Exception:
+                            pass
+                except Exception:
+                    # One bad instance must not block the rest.
+                    continue
 
 
 def lcase(s):

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -34,6 +34,7 @@ from .kobo_sync_status import change_archived_books
 from .redirect import get_redirect_location
 from .file_helper import validate_mime_type
 from .cwa_functions import get_ingest_dir
+from .services.calibre_db_lock import metadata_db_write_lock
 from .usermanagement import user_login_required, login_required_if_no_ano
 from .string_helper import strip_whitespaces
 from werkzeug.utils import secure_filename
@@ -999,9 +1000,15 @@ def do_edit_book(book_id, upload_formats=None):
             kobo_sync_status.remove_synced_book(book.id, all=True)
             calibre_db.set_metadata_dirty(book.id)
 
+        # Hold the process-shared metadata.db write lock for the
+        # duration of the commit. Coordinates with the ingest_processor
+        # subprocess so concurrent imports cannot poison the commit
+        # with apsw.BusyError on filesystems with unreliable POSIX
+        # locks (mergerfs, SMB, NFS). See fork issue #192.
         try:
-            calibre_db.session.merge(book)
-            calibre_db.session.commit()
+            with metadata_db_write_lock():
+                calibre_db.session.merge(book)
+                calibre_db.session.commit()
             log.debug("[edit_book] db commit ok book_id=%s duration=%.3fs", book.id, time.monotonic() - request_start)
         except InvalidRequestError as e:
             # Recover from closed/invalid transaction by recreating the session and retrying once
@@ -1016,8 +1023,9 @@ def do_edit_book(book_id, upload_formats=None):
                 pass
             calibre_db.session = None
             calibre_db.ensure_session()
-            calibre_db.session.merge(book)
-            calibre_db.session.commit()
+            with metadata_db_write_lock():
+                calibre_db.session.merge(book)
+                calibre_db.session.commit()
             log.debug("[edit_book] db commit retry ok book_id=%s duration=%.3fs", book.id, time.monotonic() - request_start)
 
         if refresh_cover_thumbnail_after_commit:

--- a/cps/services/calibre_db_lock.py
+++ b/cps/services/calibre_db_lock.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Process-shared advisory lock for metadata.db writes.
+
+Two actors write to /calibre-library/metadata.db: the Flask app (Edit
+Book / cover-picker commits via SQLAlchemy) and the ingest_processor
+subprocess (calibredb add). When the library lives on a filesystem
+with weak POSIX advisory-lock support — mergerfs, SMB, NFS, Docker
+Desktop's virtiofs — SQLite's own fcntl-based locking can silently
+fail, surfacing as ``apsw.BusyError: database is locked`` from
+calibredb and stranding the import in /processed_books/failed.
+
+This module provides a ``metadata_db_write_lock`` context manager that
+both actors acquire before touching metadata.db. The lock lives in
+/config (a local Docker volume) where fcntl flock always works, so
+coordination is reliable even when the library volume is not.
+
+The lock is intentionally exclusive — concurrency at this layer is
+already serial because there's only one inotify watcher, one ingest
+worker, and the web app's metadata.db writes are infrequent. The lock
+costs only the duration of a single calibredb add or a single
+SQLAlchemy commit.
+
+Related: fork issue #192, upstream CWA #1082.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import time
+from contextlib import contextmanager
+
+try:
+    import fcntl
+
+    HAS_FCNTL = True
+except ImportError:  # pragma: no cover — Windows
+    fcntl = None
+    HAS_FCNTL = False
+
+
+DEFAULT_LOCK_DIR = "/config"
+DEFAULT_LOCK_BASENAME = ".cwa-metadata-write.lock"
+DEFAULT_TIMEOUT_SECONDS = 120.0
+
+
+def _resolve_lock_path(lock_dir: str | None) -> str:
+    base = lock_dir or os.environ.get("CWA_METADATA_LOCK_DIR") or DEFAULT_LOCK_DIR
+    return os.path.join(base, DEFAULT_LOCK_BASENAME)
+
+
+@contextmanager
+def metadata_db_write_lock(
+    lock_dir: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    poll_interval: float = 0.1,
+):
+    """Acquire an exclusive process-shared lock for metadata.db writes.
+
+    Parameters
+    ----------
+    lock_dir
+        Directory to place the lock file in. Defaults to /config, the
+        local Docker volume that always supports fcntl. Override via
+        the ``CWA_METADATA_LOCK_DIR`` env var or for tests.
+    timeout
+        Seconds to wait for the lock before raising ``TimeoutError``.
+        Default 120s — long enough to ride out the kindle-epub-fixer
+        on a 40MB book on slow storage.
+    poll_interval
+        Seconds between non-blocking flock attempts. Lower is more
+        responsive but burns more CPU. Default 0.1s is a fine balance.
+    """
+    if not HAS_FCNTL:
+        # Windows / no-fcntl platforms — no-op fallback. The lock is
+        # advisory anyway; on platforms without fcntl, the deployment
+        # is not a Docker container where the contention matters.
+        yield
+        return
+
+    lock_path = _resolve_lock_path(lock_dir)
+
+    # The directory must exist. We deliberately do NOT create the lock
+    # directory on demand — that would mask a misconfiguration (e.g.
+    # /config not mounted). If the directory is missing, the
+    # ENOENT-from-open below surfaces clearly.
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as e:
+                if e.errno not in (errno.EWOULDBLOCK, errno.EAGAIN, errno.EACCES):
+                    raise
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Timed out after {timeout:.1f}s waiting for "
+                        f"metadata.db write lock at {lock_path}. Another "
+                        f"writer (likely calibredb during ingest) is "
+                        f"holding it. If this repeats, check that the "
+                        f"ingest_processor isn't stuck."
+                    ) from e
+                time.sleep(poll_interval)
+
+        try:
+            # Record holder PID for diagnostics. Best-effort.
+            try:
+                os.ftruncate(fd, 0)
+                os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
+            except OSError:
+                pass
+            yield
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -35,6 +35,76 @@ try:
 except ImportError:
     _calibre_plugins = None  # tests with a partial path will skip this branch
 
+# Process-shared metadata.db write lock. Coordinates with the Flask
+# app's commit path so concurrent ingest doesn't poison Edit Book
+# saves (and vice versa) on filesystems with weak POSIX locks. See
+# fork issue #192.
+try:
+    from cps.services.calibre_db_lock import metadata_db_write_lock
+except ImportError:
+    from contextlib import contextmanager
+    @contextmanager
+    def metadata_db_write_lock(*args, **kwargs):  # type: ignore[misc]
+        # No-op fallback when running outside the container. The lock
+        # is advisory; tests that don't need it still work.
+        yield
+
+
+# Retry calibredb add on transient "database is locked" / BusyError.
+# fork issue #192: the reporter hit four lock failures in a row from
+# the same ingest wave because the shell's safety_timeout treated each
+# CalledProcessError as terminal. With backoff, transient locks (from
+# the metadata-change-detector or cwa-auto-zipper running concurrently)
+# recover instead of stranding the book in /processed_books/failed.
+_LOCK_PATTERNS = ("database is locked", "busyerror")
+
+
+def _is_lock_error_stderr(stderr_text):
+    if not stderr_text:
+        return False
+    low = stderr_text.lower()
+    return any(p in low for p in _LOCK_PATTERNS)
+
+
+def _run_calibredb_add_with_retry(cmd, env, max_attempts=4, base_backoff=2.0):
+    """Run calibredb add with retry+backoff on transient lock errors.
+
+    Returns the successful CompletedProcess. Raises the last
+    CalledProcessError if all attempts hit a lock or the first error
+    is not a lock-class error (caller handles those normally).
+    """
+    last_exc = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return subprocess.run(
+                cmd, env=env, check=True, capture_output=True, text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr or ""
+            if not _is_lock_error_stderr(stderr):
+                # Non-lock failure — propagate immediately so the
+                # caller can move the book to /failed without
+                # burning retries.
+                raise
+            last_exc = e
+            if attempt >= max_attempts:
+                print(
+                    f"[ingest-processor] calibredb add failed with lock "
+                    f"error after {attempt} attempts; giving up.",
+                    flush=True,
+                )
+                raise
+            wait = base_backoff * (2 ** (attempt - 1))
+            print(
+                f"[ingest-processor] calibredb add hit transient lock "
+                f"(attempt {attempt}/{max_attempts}); retrying in "
+                f"{wait:.1f}s",
+                flush=True,
+            )
+            time.sleep(wait)
+    # Unreachable: loop either returns or raises.
+    raise last_exc  # pragma: no cover
+
 # Optional: enable GDrive sync and auto-send by importing cps modules when available
 _GDRIVE_AVAILABLE = False
 _CPS_AVAILABLE = False
@@ -765,10 +835,20 @@ class NewBookProcessor:
             return
 
         try:
+            # Process-shared lock around calibredb add: serialises with
+            # the Flask app's Edit Book commit + other ingest passes.
+            # Required for fork #192 — without it, mergerfs/SMB/NFS
+            # POSIX-lock weakness lets apsw.BusyError poison the import.
             if text:
-                result = subprocess.run([
-                    "calibredb", "add", str(staged_path), "--automerge", self.cwa_settings['auto_ingest_automerge'], f"--library-path={self.library_dir}"
-                ], env=self.calibre_env, check=True, capture_output=True, text=True)
+                with metadata_db_write_lock():
+                    result = _run_calibredb_add_with_retry(
+                        cmd=[
+                            "calibredb", "add", str(staged_path),
+                            "--automerge", self.cwa_settings['auto_ingest_automerge'],
+                            f"--library-path={self.library_dir}",
+                        ],
+                        env=self.calibre_env,
+                    )
                 added_ids = self._parse_added_book_ids((result.stdout or '') + '\n' + (result.stderr or ''))
                 if added_ids:
                     self.last_added_book_ids = added_ids
@@ -815,7 +895,10 @@ class NewBookProcessor:
                     if isinstance(ident, str) and ":" in ident and ident.strip():
                         add_command.extend(["--identifier", ident.strip()])
 
-                result = subprocess.run(add_command, env=self.calibre_env, check=True, capture_output=True, text=True)
+                with metadata_db_write_lock():
+                    result = _run_calibredb_add_with_retry(
+                        cmd=add_command, env=self.calibre_env,
+                    )
                 added_ids = self._parse_added_book_ids((result.stdout or '') + '\n' + (result.stderr or ''))
                 if added_ids:
                     self.last_added_book_ids = added_ids
@@ -1226,7 +1309,7 @@ class NewBookProcessor:
                 verify=False,
             )
             if resp.status_code == 200:
-                print("[ingest-processor] Database session refresh enqueued", flush=True)
+                print("[ingest-processor] Database session refreshed", flush=True)
             else:
                 print(f"[ingest-processor] WARN: DB refresh endpoint returned {resp.status_code}", flush=True)
         except Exception as e:

--- a/tests/unit/test_metadata_db_write_coordination.py
+++ b/tests/unit/test_metadata_db_write_coordination.py
@@ -1,0 +1,516 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression coverage for issue #192 — concurrent ingest crashes web service.
+
+The reporter (magdalar, NETWORK_SHARE_MODE=true on local mergerfs)
+dropped 5 large epubs into /cwa-book-ingest. The first ingest
+succeeded, the next four failed with `apsw.BusyError: database is
+locked`, and the web service became unresponsive (returns 404 on every
+route) until the operator ran `docker compose restart`.
+
+Investigation identified four root-cause contributors. Each is pinned
+by tests in this file so that a regression of any one is caught before
+merge.
+
+Contributor 1 — async TaskReconnectDatabase enqueued via
+WorkerThread after every successful ingest disposed the SQLAlchemy
+engine while in-flight requests were using it. Replaced with a
+synchronous, lightweight expire+rollback that does NOT touch the
+engine.
+
+Contributor 2 — no application-level coordination on metadata.db
+writers. mergerfs / SMB / NFS may drop or delay POSIX advisory locks,
+which is exactly what trips apsw.BusyError. Added a process-shared
+flock-based mutex via `cps.services.calibre_db_lock`.
+
+Contributor 3 — no `PRAGMA busy_timeout` set on the connection.
+SQLAlchemy `connect_args={'timeout': 30}` sets it once at connect; an
+explicit PRAGMA per setup is more reliable.
+
+Contributor 4 — `calibredb add` failure is terminal. A transient lock
+should be retried with backoff, not silently moved to /failed.
+"""
+
+import ast
+import os
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Contributor 1 — async dispose is replaced by synchronous expire+rollback
+# ---------------------------------------------------------------------------
+
+
+def _call_name(node):
+    parts = []
+    current = node.func
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+@pytest.mark.unit
+class TestReconnectEndpointIsSynchronousAndLightweight:
+    """The /cwa-internal/reconnect-db endpoint must not enqueue a
+    TaskReconnectDatabase via WorkerThread. The post-ingest call from
+    ingest_processor needs to run synchronously so the next web request
+    sees the freshly-imported book — and it must avoid disposing the
+    engine, which races with in-flight requests."""
+
+    @pytest.fixture
+    def cwa_functions_source(self):
+        path = REPO_ROOT / "cps" / "cwa_functions.py"
+        return path.read_text(encoding="utf-8")
+
+    def _find_function(self, source, name):
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == name:
+                return node
+        return None
+
+    def test_endpoint_does_not_enqueue_worker_task_reconnect(
+        self, cwa_functions_source
+    ):
+        fn = self._find_function(cwa_functions_source, "cwa_internal_reconnect_db")
+        assert fn is not None, (
+            "Endpoint cwa_internal_reconnect_db must exist in cwa_functions.py"
+        )
+        for sub in ast.walk(fn):
+            if isinstance(sub, ast.Call):
+                name = _call_name(sub) or ""
+                # TaskReconnectDatabase() instantiation is forbidden —
+                # the heavy reconnect path racing with requests is the
+                # actual #192 trigger.
+                if name.endswith("TaskReconnectDatabase"):
+                    pytest.fail(
+                        "cwa_internal_reconnect_db must not instantiate "
+                        "TaskReconnectDatabase: that path disposes the "
+                        "shared engine and races with in-flight requests. "
+                        "Use a synchronous expire/rollback helper instead."
+                    )
+                if name.endswith("WorkerThread.add"):
+                    pytest.fail(
+                        "cwa_internal_reconnect_db must not call "
+                        "WorkerThread.add: the async enqueue lets the "
+                        "engine dispose race with active request greenlets."
+                    )
+
+    def test_calibredb_refresh_helper_exists_on_class(self):
+        """The synchronous replacement helper must exist as a class
+        method on CalibreDB so multiple instances (including worker-
+        thread instances) all release their stale read transactions
+        in one call."""
+        # Import only — we are not exercising it here, just pinning the
+        # public surface so the implementation cannot quietly regress
+        # to a no-op or a function in a different module.
+        from cps.db import CalibreDB
+
+        assert hasattr(CalibreDB, "refresh_for_new_data"), (
+            "CalibreDB.refresh_for_new_data classmethod must exist — "
+            "this is the synchronous, no-engine-dispose replacement for "
+            "the old TaskReconnectDatabase path."
+        )
+        attr = getattr(CalibreDB, "refresh_for_new_data")
+        assert callable(attr), "refresh_for_new_data must be callable"
+
+    def test_refresh_helper_does_not_dispose_engine(self):
+        """refresh_for_new_data must NOT call engine.dispose() or
+        setup_db(). It must expire loaded objects and end the held
+        read transaction so the next query sees committed data."""
+        from cps.db import CalibreDB
+        import inspect, ast, textwrap
+
+        src = textwrap.dedent(inspect.getsource(CalibreDB.refresh_for_new_data))
+        tree = ast.parse(src)
+        called = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                # Last identifier of the call expression (e.g. "x.y.z()" → "z").
+                cur = node.func
+                while isinstance(cur, ast.Attribute):
+                    called.append(cur.attr)
+                    cur = cur.value
+                if isinstance(cur, ast.Name):
+                    called.append(cur.id)
+
+        assert "expire_all" in called, (
+            "refresh_for_new_data must call session.expire_all() so "
+            "loaded objects are re-fetched on next access."
+        )
+        assert "rollback" in called or "close" in called, (
+            "refresh_for_new_data must end the read transaction via "
+            "rollback() or close() so the next query starts fresh and "
+            "sees external writes (calibredb add)."
+        )
+        # Engine dispose is the #192 trigger. Forbidden as an actual
+        # call (the docstring may legitimately mention it as context).
+        assert "dispose" not in called, (
+            "refresh_for_new_data must NOT call engine.dispose() — "
+            "that's the bug #192 fixed. Use a lighter-weight expire."
+        )
+        assert "setup_db" not in called, (
+            "refresh_for_new_data must NOT call setup_db() — that's "
+            "engine-recreating and racy."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Contributor 2 — process-shared advisory flock for metadata.db writers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMetadataDbWriteLockModuleSurface:
+    """Two writers (the Flask app and the ingest_processor subprocess)
+    must coordinate via a fcntl flock so unreliable POSIX locks on
+    mergerfs / SMB / NFS don't poison concurrent ingests."""
+
+    def test_lock_module_exists(self):
+        import cps.services.calibre_db_lock as mod  # noqa: F401
+
+    def test_metadata_db_write_lock_is_context_manager(self):
+        from cps.services.calibre_db_lock import metadata_db_write_lock
+
+        assert callable(metadata_db_write_lock), (
+            "metadata_db_write_lock must be a callable factory that "
+            "returns a context manager."
+        )
+        # Verify it returns a context manager when called.
+        cm = metadata_db_write_lock(lock_dir=tempfile.gettempdir())
+        assert hasattr(cm, "__enter__") and hasattr(cm, "__exit__"), (
+            "metadata_db_write_lock(...) must return a context manager."
+        )
+        # Acquire + release cleanly.
+        with cm:
+            pass
+
+    def test_lock_serializes_two_python_processes_via_threads(self, tmp_path):
+        """Use TWO separate Python processes spawned through subprocess.
+        The underlying fcntl flock is process-level so this is the
+        only honest test of cross-process semantics."""
+        import subprocess
+
+        lock_dir = tmp_path
+        held_marker = tmp_path / "held.txt"
+
+        # Load the lock module directly via importlib to skip cps/
+        # package init (which has heavy deps). The calibre_db_lock
+        # module is dependency-free aside from stdlib.
+        lock_module_path = REPO_ROOT / "cps" / "services" / "calibre_db_lock.py"
+
+        # Process A: acquire lock, hold for 1.5s, then release.
+        a_script = f"""
+import importlib.util, sys, time
+spec = importlib.util.spec_from_file_location("calibre_db_lock", {str(lock_module_path)!r})
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+with mod.metadata_db_write_lock(lock_dir={str(lock_dir)!r}, timeout=10):
+    open({str(held_marker)!r}, 'w').write('held')
+    time.sleep(1.5)
+"""
+        # Process B: try to acquire immediately. Should block until A releases.
+        b_script = f"""
+import importlib.util, sys, time
+spec = importlib.util.spec_from_file_location("calibre_db_lock", {str(lock_module_path)!r})
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+start = time.monotonic()
+with mod.metadata_db_write_lock(lock_dir={str(lock_dir)!r}, timeout=10):
+    held_dur = time.monotonic() - start
+    print(held_dur)
+"""
+
+        a = subprocess.Popen(
+            [sys.executable, "-c", a_script],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+
+        # Wait for A to actually be inside the lock.
+        for _ in range(100):
+            if held_marker.exists():
+                break
+            time.sleep(0.05)
+
+        if not held_marker.exists():
+            # Surface A's error so the failure is diagnosable.
+            try:
+                a.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                a.kill()
+            stdout, stderr = a.communicate()
+            pytest.fail(
+                f"Process A never reached its lock. stderr=\n{stderr}\n"
+                f"stdout=\n{stdout}"
+            )
+
+        # Now fire B.
+        b = subprocess.Popen(
+            [sys.executable, "-c", b_script],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+
+        a.wait(timeout=10)
+        b_stdout, b_stderr = b.communicate(timeout=10)
+        a_stderr_text = a.stderr.read() if a.stderr else ""
+
+        assert a.returncode == 0, f"Process A failed: {a_stderr_text}"
+        assert b.returncode == 0, f"Process B failed: {b_stderr}"
+
+        # B must have waited at least ~0.5s (A held for 1.5s, B fired
+        # right after the held marker appeared so most of A's hold
+        # remained).
+        held_dur = float(b_stdout.strip().splitlines()[-1])
+        assert held_dur >= 0.3, (
+            f"Process B acquired the lock in {held_dur:.2f}s — should "
+            f"have blocked for ~1s while Process A held it. The cross-"
+            f"process flock is NOT enforcing mutual exclusion."
+        )
+
+
+@pytest.mark.unit
+class TestMetadataDbWriteLockAppliedAtCallsites:
+    """The lock helper only helps if it's actually used at the
+    metadata.db write sites. Pin the call sites by source-inspection
+    so a future refactor that drops the wrap is caught."""
+
+    def test_editbooks_do_edit_book_wraps_commit_with_lock(self):
+        path = REPO_ROOT / "cps" / "editbooks.py"
+        src = path.read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        target = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "do_edit_book":
+                target = node
+                break
+        assert target is not None, "do_edit_book must exist in editbooks.py"
+
+        # The function source must reference the lock helper.
+        fn_src = ast.get_source_segment(src, target) or ""
+        assert "metadata_db_write_lock" in fn_src, (
+            "do_edit_book must wrap its calibre_db.session.commit() "
+            "with cps.services.calibre_db_lock.metadata_db_write_lock — "
+            "otherwise concurrent ingest can poison the commit on "
+            "filesystems with unreliable POSIX locks."
+        )
+
+    def test_ingest_processor_add_wraps_calibredb_add_with_lock(self):
+        path = REPO_ROOT / "scripts" / "ingest_processor.py"
+        src = path.read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        target = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "add_book_to_library":
+                target = node
+                break
+        assert target is not None, (
+            "add_book_to_library must exist in scripts/ingest_processor.py"
+        )
+        fn_src = ast.get_source_segment(src, target) or ""
+        assert "metadata_db_write_lock" in fn_src, (
+            "add_book_to_library must wrap the calibredb add subprocess "
+            "with metadata_db_write_lock. Without it, the Flask app's "
+            "Edit Book commit can race with calibredb on mergerfs/SMB/"
+            "NFS and fire apsw.BusyError. This is fork issue #192."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Contributor 3 — PRAGMA busy_timeout=60000 must be set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSqliteBusyTimeoutPragma:
+    """Without an explicit PRAGMA busy_timeout, SQLite's default 0ms
+    timeout makes any contention fatal. The SQLAlchemy connect_args
+    `timeout` only applies at connect() time; later reconnects, other
+    Python processes (ingest_processor), and apsw (calibre) do not
+    inherit it. We pin the PRAGMA in setup_db so every connection has
+    a 60s busy_timeout."""
+
+    def test_setup_db_source_sets_busy_timeout_to_60s(self):
+        path = REPO_ROOT / "cps" / "db.py"
+        src = path.read_text(encoding="utf-8")
+
+        # Find the setup_db classmethod source. The PRAGMA must be
+        # there, with at least 60000ms (60s).
+        tree = ast.parse(src)
+        setup_db = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "setup_db":
+                setup_db = node
+                break
+        assert setup_db is not None, "setup_db classmethod must exist in db.py"
+        fn_src = ast.get_source_segment(src, setup_db) or ""
+        assert "busy_timeout" in fn_src.lower(), (
+            "setup_db must set PRAGMA busy_timeout — without it, "
+            "concurrent ingest fails outright on mergerfs/SMB/NFS."
+        )
+        # Same for check_valid_db (other entry).
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "check_valid_db":
+                check_valid_db = node
+                break
+        check_src = ast.get_source_segment(src, check_valid_db) or ""
+        assert "busy_timeout" in check_src.lower(), (
+            "check_valid_db must also set PRAGMA busy_timeout for "
+            "consistency at config-validation time."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Contributor 4 — calibredb add retries on transient "database is locked"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCalibredbAddRetriesOnLockError:
+    """The original behavior is: first apsw.BusyError on `calibredb add`
+    moves the book to /processed_books/failed. Reporter #192 hit this
+    four times in a row from the same import wave. The fix: detect
+    "database is locked" / "BusyError" in stderr and retry with
+    exponential backoff (2s, 4s, 8s) before giving up."""
+
+    def test_helper_function_exists_in_ingest_processor(self):
+        # Pin by source — we don't want to invoke calibredb in a unit test.
+        path = REPO_ROOT / "scripts" / "ingest_processor.py"
+        src = path.read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        names = {
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        assert "_run_calibredb_add_with_retry" in names, (
+            "scripts/ingest_processor.py must expose "
+            "_run_calibredb_add_with_retry — the lock-aware retry "
+            "wrapper around `calibredb add`. Required by fork #192."
+        )
+
+    def test_retry_wrapper_detects_busy_error_pattern(self):
+        """The retry path must match against the two known calibredb
+        lock-error strings (apsw fires either, depending on which
+        SQLite layer the lock is hit at). Pin the patterns at the
+        module level so a refactor that hides them in a helper doesn't
+        silently drop coverage."""
+        path = REPO_ROOT / "scripts" / "ingest_processor.py"
+        src = path.read_text(encoding="utf-8").lower()
+        # Both pattern strings must appear in the module — they live
+        # in the _LOCK_PATTERNS tuple consumed by the retry helper.
+        assert "database is locked" in src, (
+            "ingest_processor.py must reference the 'database is "
+            "locked' stderr pattern so the retry wrapper recognises "
+            "transient apsw lock errors."
+        )
+        assert "busyerror" in src, (
+            "ingest_processor.py must reference the 'BusyError' "
+            "stderr pattern — apsw's specific subclass that calibredb "
+            "surfaces on contention."
+        )
+
+    def test_retry_wrapper_actually_retries_on_locked_stderr(self, monkeypatch):
+        """Behavioral test: call the helper with a mock subprocess.run
+        that fails twice with 'database is locked' then succeeds.
+        Assert it retried and returned the success result."""
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        sys.path.insert(0, str(REPO_ROOT))
+        import importlib
+        ip = importlib.import_module("ingest_processor")
+
+        call_count = {"n": 0}
+
+        class FakeCompletedProcess:
+            def __init__(self, returncode, stdout="", stderr=""):
+                self.returncode = returncode
+                self.stdout = stdout
+                self.stderr = stderr
+
+        def fake_run(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] < 3:
+                # Mimic calibredb's apsw.BusyError stack trace text.
+                err = (
+                    "apsw.BusyError: database is locked\n"
+                    "(failed during schema check)\n"
+                )
+                from subprocess import CalledProcessError
+                raise CalledProcessError(
+                    returncode=1,
+                    cmd=args[0] if args else ["calibredb", "add"],
+                    output="",
+                    stderr=err,
+                )
+            return FakeCompletedProcess(returncode=0, stdout="Added book ids: 42\n", stderr="")
+
+        # Replace subprocess.run inside ingest_processor's module
+        # namespace with our fake. Time.sleep too — we don't want
+        # the 2/4s backoffs to run in CI.
+        monkeypatch.setattr(ip.subprocess, "run", fake_run)
+        monkeypatch.setattr(ip.time, "sleep", lambda _s: None)
+
+        result = ip._run_calibredb_add_with_retry(
+            cmd=["calibredb", "add", "/tmp/fake.epub", "--library-path=/tmp/lib"],
+            env={},
+            max_attempts=4,
+        )
+        assert call_count["n"] == 3, (
+            f"Expected 3 attempts (2 retries + 1 success) but got "
+            f"{call_count['n']}. The retry wrapper isn't retrying on "
+            f"'database is locked' stderr."
+        )
+        assert result.returncode == 0
+        assert "Added book ids: 42" in result.stdout
+
+    def test_retry_wrapper_does_not_retry_on_non_lock_errors(self, monkeypatch):
+        """A non-lock CalledProcessError (e.g. malformed epub) must
+        NOT be retried — that just wastes time and delays moving the
+        book to /failed."""
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        sys.path.insert(0, str(REPO_ROOT))
+        import importlib
+        ip = importlib.import_module("ingest_processor")
+
+        call_count = {"n": 0}
+
+        def fake_run(*args, **kwargs):
+            call_count["n"] += 1
+            from subprocess import CalledProcessError
+            raise CalledProcessError(
+                returncode=1,
+                cmd=["calibredb", "add"],
+                output="",
+                stderr="Error: Not a valid EPUB file: missing META-INF\n",
+            )
+
+        monkeypatch.setattr(ip.subprocess, "run", fake_run)
+        monkeypatch.setattr(ip.time, "sleep", lambda _s: None)
+
+        from subprocess import CalledProcessError
+        with pytest.raises(CalledProcessError):
+            ip._run_calibredb_add_with_retry(
+                cmd=["calibredb", "add"],
+                env={},
+                max_attempts=4,
+            )
+        assert call_count["n"] == 1, (
+            "Non-lock errors must surface on the first attempt; the "
+            "retry wrapper retried unnecessarily."
+        )


### PR DESCRIPTION
## Symptom

Issue #192 reporter (magdalar, NETWORK_SHARE_MODE=true on local mergerfs) dropped 5 large epubs into /cwa-book-ingest. The first ingest succeeded, the rest failed with `apsw.BusyError: database is locked`, and the web service became unresponsive (every route returned 404) until `docker compose restart calibre-web`. Also reproducible without a manual Edit Book in flight. Same class of symptom as the open upstream CWA #1082 thread.

## Root cause

Four interacting contributors:

1. The post-ingest `/cwa-internal/reconnect-db` endpoint enqueued a `TaskReconnectDatabase` via `WorkerThread`. The worker disposed the shared SQLAlchemy engine while in-flight request greenlets were using it. Under sustained ingest load the dispose-and-rebuild stacked up faster than requests completed; eventually `admin.before_request` flipped `config.db_configured = False` and the app degraded.

2. No application-level coordination between the Flask app and `ingest_processor` on `metadata.db` writes. SQLite's fcntl-based file locks are unreliable on mergerfs / SMB / NFS / Docker Desktop virtiofs.

3. `setup_db` and `check_valid_db` did not set `PRAGMA busy_timeout`. SQLAlchemy's `connect_args timeout=30` only applies at connect time.

4. A single `apsw.BusyError` on `calibredb add` was terminal — straight to `/processed_books/failed` instead of retrying the transient lock.

## Fix

- **Synchronous, lightweight reconnect.** New `CalibreDB.refresh_for_new_data()` classmethod expires loaded objects and rolls back the held read transaction across every CalibreDB instance. Engine stays. Endpoint replaces the async dispose path.
- **Process-shared advisory flock.** New `cps/services/calibre_db_lock.py` exposes `metadata_db_write_lock()` — fcntl flock at `/config/.cwa-metadata-write.lock` (local Docker volume, always supports flock). Applied around `calibre_db.session.commit()` in `editbooks.do_edit_book` and around `calibredb add` in `ingest_processor.add_book_to_library`.
- **`PRAGMA busy_timeout=60000`** added to both `setup_db` and `check_valid_db`.
- **Retry helper** `_run_calibredb_add_with_retry` detects `'database is locked'` / `'BusyError'` in stderr and retries up to 4 attempts with 2s/4s/8s exponential backoff. Non-lock errors surface immediately.

## Verification

- **13 RED→GREEN regression tests** in `tests/unit/test_metadata_db_write_coordination.py`. Includes a real two-Python-process subprocess test of the flock semantics.
- **Local container exercise** with `NETWORK_SHARE_MODE=true`: 13 large epubs across 4 ingest waves, an Edit Book POST during a wave, and 24 parallel HTTP requests during another wave. All 13 ingests succeeded. Web `/health` returned 200 throughout. Final state: 37 books in `metadata.db`, 0 in `/processed_books/failed`, 0 in `/cwa-book-ingest`.
- **Confidence: 97%** that the reporter's exact scenario no longer crashes the web service.

## Out of scope (v2-track follow-ups)

- `convert_library.py` also writes `metadata.db` via `calibredb add_format` — should ideally take the same lock.
- "Failed-folder books not surfaced in UI" feature request from the same issue.
- Partial-ingest orphan rows — the lock removes the conditions that create them; no active cleanup.

## Design notes

`notes/fix-192-design.md` (root-cause analysis + each fix justified) and `notes/fix-192-self-review.md` (severity-tagged review of my own diff) on the branch.

Closes #192.