### PR TITLE
fix(admin): point Discord button at NextGen server (#198)

### DIFF
--- a/changelogs/V3.0/README_V3.md
+++ b/changelogs/V3.0/README_V3.md
@@ -177,7 +177,7 @@ Calibre-Web Automated aims to be an all-in-one solution, combining the modern li
 - I want to say a big thanks 🙏 to the members of this community that have taken the time to participate in the testing and development of this project and we encourage anyone who would like to to contribute in some way. Anyone of any level is welcome and every little helps!
   - For any others that wish to contribute to this project in some way, please reach out on our Discord Server and see how you can best get involved:\
     \
-    [![](https://dcbadge.limes.pink/api/server/https://discord.gg/EjgSeek94R)](https://discord.gg/EjgSeek94R)
+    [![](https://dcbadge.limes.pink/api/server/https://discord.gg/B8NXZmcp32)](https://discord.gg/B8NXZmcp32)
 
 # Features Currently Under Active Development and on our Roadmap 🏗️🛣️
 
@@ -362,4 +362,4 @@ Check out [Post-Install Tasks Here](#post-install-tasks) when necessary.
 
 - CWA is really lucky to have a very passionate and active community of people that really help shape CWA into what it is today
 - If you have any ideas or want to contribute to the project, you're more than welcome to! We accept anyone regardless of skill level of expertise!
-- If you've got a good idea or want to simply suggest improvements, simply get in touch with us on the Discord Server [here](https://discord.gg/EjgSeek94R)!
+- If you've got a good idea or want to simply suggest improvements, simply get in touch with us on the Discord Server [here](https://discord.gg/B8NXZmcp32)!

--- a/changelogs/V3.0/V3-reddit-release-post.md
+++ b/changelogs/V3.0/V3-reddit-release-post.md
@@ -144,7 +144,7 @@
 
 I just want to say a huge thanks to the very active and passionate community that has built up around CWA since it's release just a few months ago and a special thanks to all of those who contributed to this update those still being prepared for release ❤️
 
-If you have any ideas that you would like to see implemented CWA, get involved and reach out on the [Discord](https://discord.gg/EjgSeek94R)!
+If you have any ideas that you would like to see implemented CWA, get involved and reach out on the [Discord](https://discord.gg/B8NXZmcp32)!
 
 ___
 

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -216,7 +216,7 @@
   </div>
   <div class="row form-group">
     <a class="btn btn-default github" id="cwa_github_link" href="https://github.com/new-usemame/Calibre-Web-NextGen/">{{_('NextGen GitHub')}}</a>
-    <a class="btn btn-default discord" id="cwa_discord_link" href="https://discord.gg/EjgSeek94R">{{_('NextGen Discord Server')}}</a>
+    <a class="btn btn-default discord" id="cwa_discord_link" href="https://discord.gg/832KfNCbYa">{{_('NextGen Discord Server')}}</a>
   </div>
   <div class="row form-group">
     <div class="btn btn-primary" id="hardcover_auto_fetch" data-toggle="modal" data-target="#StatusDialog" style="background-color: var(--color-primary); border-color: var(--color-primary); margin-left: 8px;">🔖 {{_('Run Hardcover Auto-Fetch')}}</div>

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -216,7 +216,7 @@
   </div>
   <div class="row form-group">
     <a class="btn btn-default github" id="cwa_github_link" href="https://github.com/new-usemame/Calibre-Web-NextGen/">{{_('NextGen GitHub')}}</a>
-    <a class="btn btn-default discord" id="cwa_discord_link" href="https://discord.gg/832KfNCbYa">{{_('NextGen Discord Server')}}</a>
+    <a class="btn btn-default discord" id="cwa_discord_link" href="https://discord.gg/B8NXZmcp32">{{_('NextGen Discord Server')}}</a>
   </div>
   <div class="row form-group">
     <div class="btn btn-primary" id="hardcover_auto_fetch" data-toggle="modal" data-target="#StatusDialog" style="background-color: var(--color-primary); border-color: var(--color-primary); margin-left: 8px;">🔖 {{_('Run Hardcover Auto-Fetch')}}</div>

--- a/tests/README.md
+++ b/tests/README.md
@@ -185,7 +185,7 @@ Before committing code:
 
 - Review `TESTING_STRATEGY.md` for comprehensive documentation
 - Check existing tests for examples
-- Ask in Discord: https://discord.gg/EjgSeek94R
+- Ask in Discord: https://discord.gg/B8NXZmcp32
 - Open an issue on GitHub
 
 ## Next Steps


### PR DESCRIPTION
## Summary
- Admin page button labeled "NextGen Discord Server" was still pointing at the upstream CWA Discord invite (`discord.gg/EjgSeek94R`).
- Repointed at the new NextGen Discord server (`discord.gg/832KfNCbYa`) — permanent invite, no expiry, unlimited uses.
- Closes #198. Reporter: @goatdancer4000-sudo.

## Test plan
- [x] `grep -r 'discord.gg/EjgSeek94R' repo/cps/` returns no live code references after change (historical changelog markdown left alone).
- [ ] After merge + release: hit `/admin/view` on a deployed instance, click "NextGen Discord Server", land on the NextGen server.