### PR TITLE
fix(tests): drop stale kindle_epub_fixer.lock before re-importing ingest_processor

### DIFF
--- a/tests/unit/test_metadata_db_write_coordination.py
+++ b/tests/unit/test_metadata_db_write_coordination.py
@@ -389,6 +389,20 @@ class TestCalibredbAddRetriesOnLockError:
     "database is locked" / "BusyError" in stderr and retry with
     exponential backoff (2s, 4s, 8s) before giving up."""
 
+    @pytest.fixture(autouse=True)
+    def _drop_kindle_epub_fixer_lockfile(self):
+        # scripts/kindle_epub_fixer.py acquires /tmp/kindle_epub_fixer.lock
+        # at module-import time via O_CREAT|O_EXCL and sys.exit(2)s if
+        # it already exists. pytest-xdist runs workers as separate
+        # processes that share /tmp; a sibling worker that imported
+        # ingest_processor first can leave the lockfile behind, breaking
+        # any later worker that re-imports here. Clear it before each
+        # test in this class to guarantee the import succeeds.
+        lock_path = Path(tempfile.gettempdir()) / "kindle_epub_fixer.lock"
+        lock_path.unlink(missing_ok=True)
+        yield
+        lock_path.unlink(missing_ok=True)
+
     def test_helper_function_exists_in_ingest_processor(self):
         # Pin by source — we don't want to invoke calibredb in a unit test.
         path = REPO_ROOT / "scripts" / "ingest_processor.py"


### PR DESCRIPTION
## What this fixes

CI on PR #201 went red on two tests in `TestCalibredbAddRetriesOnLockError` with `SystemExit: 2` during `importlib.import_module(\"ingest_processor\")`. Same test file, identical contents on `main` and #201 — but `main` was green and #201 was red.

## Root cause (not in #201)

`scripts/kindle_epub_fixer.py` does this at module-import time:

```python
try:
    lock = open(tempfile.gettempdir() + '/kindle_epub_fixer.lock', 'x')
    lock.close()
except FileExistsError:
    print_and_log(\"[cwa-kindle-epub-fixer] CANCELLING... ...\")
    sys.exit(2)
```

`O_CREAT|O_EXCL`. `sys.exit(2)` on conflict. This is a process-wide lock that fires at module-import.

`scripts/ingest_processor.py:22` does `from kindle_epub_fixer import EPUBFixer`, so any worker that imports `ingest_processor` takes the kindle lockfile. pytest-xdist workers run as **separate processes** that **share `/tmp`**. Once worker A imports `ingest_processor`, the lockfile persists in `/tmp` until A's atexit hook fires. If worker B's allocation includes `test_metadata_db_write_coordination.py` and B starts before A finishes, B's `import_module(\"ingest_processor\")` re-executes the kindle top-level → `FileExistsError` → `sys.exit(2)`.

PR #201 adds a new test file (`test_xss_book_comments_clean_string_filter.py`), which **shifts pytest-xdist's worker allocation**. That's why the failure is deterministic on #201 and not on `main` — the underlying race has been latent.

## Fix

Autouse class fixture in `TestCalibredbAddRetriesOnLockError` removes `/tmp/kindle_epub_fixer.lock` before each test method and after teardown. Production code is **not** touched — the deeper \"module-import-time side effects are a code smell\" issue is a separate refactor with production behaviour implications (kindle_epub_fixer.py's lockfile is what guards against two concurrent CLI runs).

## Verification

Locally with the four-test class:

```
$ touch /tmp/kindle_epub_fixer.lock
$ .venv/bin/python -m pytest tests/unit/test_metadata_db_write_coordination.py::TestCalibredbAddRetriesOnLockError -v
... 4 passed in 9.33s
```

The CI traceback path is impossible to reach with the fixture in place: `lock_path.unlink(missing_ok=True)` runs before the `import_module` call, so the `FileExistsError` branch at `kindle_epub_fixer.py:126` can never trigger from a stale lockfile.

## Tier

`needs-review` — test-only change but touches a test class that's load-bearing for the v4.0.62 concurrent-ingest regression coverage.

## Follow-up (not this PR)

`scripts/kindle_epub_fixer.py` doing process-wide work at module-import time should be refactored to defer the lockfile acquisition into the `if __name__ == \"__main__\"` block. That's a behaviour-change that wants its own design pass — out of scope here.