### PR TITLE
refactor(scripts): move single-instance lock acquire out of module-import time

### DIFF
--- a/scripts/convert_library.py
+++ b/scripts/convert_library.py
@@ -30,49 +30,50 @@ convert_library_log_file = "/config/convert-library.log"
 # Define the logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)  # Set the logging level
-# Create a FileHandler
-file_handler = logging.FileHandler(convert_library_log_file, mode='w', encoding='utf-8')
-# Create a Formatter and set it for the handler
-LOG_FORMAT = '%(message)s'
-formatter = logging.Formatter(LOG_FORMAT)
-file_handler.setFormatter(formatter)
-# Add the handler to the logger
-logger.addHandler(file_handler)
+# Create a FileHandler if possible, otherwise use StreamHandler
+try:
+    file_handler = logging.FileHandler(convert_library_log_file, mode='w', encoding='utf-8')
+    LOG_FORMAT = '%(message)s'
+    formatter = logging.Formatter(LOG_FORMAT)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+except FileNotFoundError:
+    # Fallback for test environments where /config might not exist
+    stream_handler = logging.StreamHandler()
+    LOG_FORMAT = '%(message)s'
+    formatter = logging.Formatter(LOG_FORMAT)
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
 
 # Define user and group
 USER_NAME = "abc"
 GROUP_NAME = "abc"
 
-# Get UID and GID
-uid = pwd.getpwnam(USER_NAME).pw_uid
-gid = grp.getgrnam(GROUP_NAME).gr_gid
-
-# Set permissions for log file (skip on network shares)
+# Get UID and GID (skip if user doesn't exist, e.g., in CI environments)
+uid = None
+gid = None
 try:
-    nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
-    if not nsm:
-        subprocess.run(["chown", f"{uid}:{gid}", convert_library_log_file], check=True)
-    else:
-        print(f"[convert-library] NETWORK_SHARE_MODE=true detected; skipping chown of {convert_library_log_file}", flush=True)
-except subprocess.CalledProcessError as e:
-    print(f"[convert-library] An error occurred while attempting to set ownership of {convert_library_log_file} to abc:abc. See the following error:\n{e}", flush=True)
+    uid = pwd.getpwnam(USER_NAME).pw_uid
+    gid = grp.getgrnam(GROUP_NAME).gr_gid
+except KeyError:
+    pass
+
+# Set permissions for log file (skip on network shares or if uid/gid not available)
+if uid is not None and gid is not None:
+    try:
+        nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+        if not nsm:
+            subprocess.run(["chown", f"{uid}:{gid}", convert_library_log_file], check=True)
+        else:
+            print(f"[convert-library] NETWORK_SHARE_MODE=true detected; skipping chown of {convert_library_log_file}", flush=True)
+    except subprocess.CalledProcessError as e:
+        print(f"[convert-library] An error occurred while attempting to set ownership of {convert_library_log_file} to abc:abc. See the following error:\n{e}", flush=True)
 
 def print_and_log(string) -> None:
     """ Ensures the provided string is passed to STDOUT and stored in the runs log file """
     logger.info(string)
     print(string)
 
-
-# Creates a lock file unless one already exists meaning an instance of the script is
-# already running, then the script is closed, the user is notified and the program
-# exits with code 2
-try:
-    lock = open(tempfile.gettempdir() + '/convert_library.lock', 'x')
-    lock.close()
-except FileExistsError:
-    print_and_log("[convert-library]: CANCELLING... convert-library was initiated but is already running")
-    logger.info(f"\nNextGen Convert Library Service - Run Cancelled: {datetime.now()}")
-    sys.exit(2)
 
 # Defining function to delete the lock on script exit
 def removeLock():
@@ -81,14 +82,30 @@ def removeLock():
     except FileNotFoundError:
         ...
 
-# Will automatically run when the script exits
-atexit.register(removeLock)
 
-backup_destinations = {
-        entry.name: entry.path
-        for entry in os.scandir("/config/processed_books")
-        if entry.is_dir()
-    }
+def _acquire_lock_or_exit():
+    """Single-instance guard. Run only when this module is executed as a
+    script — never on import — so pytest-xdist workers (which share /tmp
+    across processes) don't take each other out at import time."""
+    try:
+        lock = open(tempfile.gettempdir() + '/convert_library.lock', 'x')
+        lock.close()
+    except FileExistsError:
+        print_and_log("[convert-library]: CANCELLING... convert-library was initiated but is already running")
+        logger.info(f"\nNextGen Convert Library Service - Run Cancelled: {datetime.now()}")
+        sys.exit(2)
+    atexit.register(removeLock)
+
+
+try:
+    backup_destinations = {
+            entry.name: entry.path
+            for entry in os.scandir("/config/processed_books")
+            if entry.is_dir()
+        }
+except FileNotFoundError:
+    # Fallback for test environments where /config might not exist
+    backup_destinations = {}
 
 
 class LibraryConverter:
@@ -569,6 +586,8 @@ class LibraryConverter:
 
 
 def main():
+    _acquire_lock_or_exit()
+
     parser = argparse.ArgumentParser(
         prog='convert-library',
         description='Made for the purpose of converting ebooks in a calibre library to the users specified target format (default epub)'

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -256,15 +256,13 @@ class ProcessLock:
             except:
                 pass
 
-# Global lock instance
+# Global lock instance (instantiation only — acquire happens in main()
+# so importing this module from a test runner has no side effects).
 process_lock = ProcessLock()
 
 def cleanup_lock():
     """Cleanup function for atexit"""
     process_lock.release()
-
-# Register cleanup function
-atexit.register(cleanup_lock)
 
 
 def get_app_db_path() -> str:
@@ -360,9 +358,13 @@ def gdrive_sync_if_enabled():
         except Exception as e:
             print(f"[ingest-processor] WARN: GDrive sync failed: {e}", flush=True)
 
-# Acquire process lock to prevent concurrent execution
-if not process_lock.acquire(timeout=10):
-    sys.exit(2)
+def _acquire_process_lock_or_exit():
+    """Single-instance guard. Run only when this module is executed as a
+    script — never on import — so pytest-xdist workers (which share /tmp
+    across processes) don't take each other out at import time."""
+    atexit.register(cleanup_lock)
+    if not process_lock.acquire(timeout=10):
+        sys.exit(2)
 
 # Ensure processed backups directory structure exists so backups never crash on missing folders
 try:
@@ -1397,6 +1399,8 @@ class NewBookProcessor:
 def main(filepath=None):
     """Checks if filepath is a directory. If it is, main will be ran on every file in the given directory
     Inotifywait won't detect files inside folders if the folder was moved rather than copied"""
+
+    _acquire_process_lock_or_exit()
 
     if filepath is None:
         if len(sys.argv) < 2:

--- a/scripts/kindle_epub_fixer.py
+++ b/scripts/kindle_epub_fixer.py
@@ -119,17 +119,6 @@ def exit_if_cancelled() -> None:
         sys.exit(0)
 
 ### LOCK FILES
-# Creates a lock file unless one already exists meaning an instance of the script is
-# already running, then the script is closed, the user is notified and the program
-# exits with code 2
-try:
-    lock = open(tempfile.gettempdir() + '/kindle_epub_fixer.lock', 'x')
-    lock.close()
-except FileExistsError:
-    print_and_log("[cwa-kindle-epub-fixer] CANCELLING... kindle-epub-fixer was initiated but is already running")
-    logger.info(f"\nNextGen Kindle EPUB Fixer Service - Run Ended: {datetime.now()}")
-    sys.exit(2)
-
 # Defining function to delete the lock on script exit
 def removeLock():
     try:
@@ -137,8 +126,19 @@ def removeLock():
     except FileNotFoundError:
         ...
 
-# Will automatically run when the script exits
-atexit.register(removeLock)
+
+def _acquire_lock_or_exit():
+    """Single-instance guard. Run only when this module is executed as a
+    script — never on import — so pytest-xdist workers (which share /tmp
+    across processes) don't take each other out at import time."""
+    try:
+        lock = open(tempfile.gettempdir() + '/kindle_epub_fixer.lock', 'x')
+        lock.close()
+    except FileExistsError:
+        print_and_log("[cwa-kindle-epub-fixer] CANCELLING... kindle-epub-fixer was initiated but is already running")
+        logger.info(f"\nNextGen Kindle EPUB Fixer Service - Run Ended: {datetime.now()}")
+        sys.exit(2)
+    atexit.register(removeLock)
 
 
 class EPUBFixer:
@@ -1152,6 +1152,8 @@ def get_all_epubs_in_library() -> list[str]:
 
 
 def main():
+    _acquire_lock_or_exit()
+
     parser = argparse.ArgumentParser(
         prog='kindle-epub-fixer',
         description='Checks the encoding of a given EPUB file and automatically corrects any errors that could \

--- a/tests/unit/test_script_import_side_effects.py
+++ b/tests/unit/test_script_import_side_effects.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression test pinning that importing scripts has NO side effects.
+
+Background — pytest-xdist runs workers as separate Python processes
+sharing /tmp. Three scripts (ingest_processor, kindle_epub_fixer,
+convert_library) historically acquired their single-instance lockfile
+at module-import time and called sys.exit(2) when another worker had
+already taken the lock. That made `importlib.import_module(...)` in a
+test exit the worker process with code 2, taking out unrelated tests.
+
+The fix moves all lock-acquire calls and atexit-register calls into the
+main() / __main__ path so importing the module is a pure load.
+
+This test pins that behavior: importing any of these scripts in a
+subprocess (a) succeeds with exit code 0, (b) does NOT create any
+lockfile in /tmp, (c) does NOT register an atexit handler that would
+remove a lockfile we didn't create.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _run_import(module_name: str, pre_existing_lockfile: str | None = None):
+    """Spawn a fresh Python process that imports module_name.
+
+    Returns (returncode, stdout, stderr, lockfiles_created).
+    `lockfiles_created` is the set of lock filenames present in
+    /tmp after the import that were not present before.
+    """
+    tmpdir = Path(tempfile.gettempdir())
+    lockfiles_before = {p.name for p in tmpdir.glob("*.lock")}
+
+    if pre_existing_lockfile:
+        (tmpdir / pre_existing_lockfile).touch()
+
+    try:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = f"{SCRIPTS_DIR}:{REPO_ROOT}"
+        result = subprocess.run(
+            [sys.executable, "-c", f"import {module_name}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+    finally:
+        if pre_existing_lockfile:
+            (tmpdir / pre_existing_lockfile).unlink(missing_ok=True)
+
+    lockfiles_after = {p.name for p in tmpdir.glob("*.lock")}
+    lockfiles_created = lockfiles_after - lockfiles_before
+    return result.returncode, result.stdout, result.stderr, lockfiles_created
+
+
+class TestImportIsSideEffectFree:
+    """Import-time side effects break test isolation under pytest-xdist."""
+
+    @pytest.mark.parametrize("module", ["ingest_processor", "kindle_epub_fixer", "convert_library"])
+    def test_import_succeeds_when_no_lockfile_present(self, module):
+        rc, stdout, stderr, created = _run_import(module)
+        assert rc == 0, (
+            f"Importing {module} exited with {rc}. "
+            f"stdout={stdout!r} stderr={stderr!r}. "
+            "Module-import-time side effects break test isolation."
+        )
+
+    @pytest.mark.parametrize(
+        "module,lockfile",
+        [
+            ("ingest_processor", "ingest_processor.lock"),
+            ("ingest_processor", "kindle_epub_fixer.lock"),
+            ("kindle_epub_fixer", "kindle_epub_fixer.lock"),
+            ("convert_library", "convert_library.lock"),
+            ("convert_library", "kindle_epub_fixer.lock"),
+        ],
+    )
+    def test_import_succeeds_even_with_stale_lockfile(self, module, lockfile):
+        rc, stdout, stderr, created = _run_import(module, pre_existing_lockfile=lockfile)
+        assert rc == 0, (
+            f"Importing {module} with pre-existing /tmp/{lockfile} "
+            f"exited with {rc}. stdout={stdout!r} stderr={stderr!r}. "
+            "Stale lockfile from another xdist worker must not crash import."
+        )
+
+    @pytest.mark.parametrize("module", ["ingest_processor", "kindle_epub_fixer", "convert_library"])
+    def test_import_creates_no_lockfile(self, module):
+        rc, stdout, stderr, created = _run_import(module)
+        assert rc == 0
+        assert not created, (
+            f"Importing {module} created lockfiles {created} in /tmp. "
+            "Lockfiles must be created only when the script runs as __main__."
+        )
+
+
+class TestSourcePins:
+    """Source-level pins so a future refactor that re-introduces the bug
+    is caught even if the import side-effect tests pass on a clean /tmp.
+    """
+
+    @pytest.mark.parametrize(
+        "filename,lockfile_name",
+        [
+            ("scripts/ingest_processor.py", "ingest_processor.lock"),
+            ("scripts/kindle_epub_fixer.py", "kindle_epub_fixer.lock"),
+            ("scripts/convert_library.py", "convert_library.lock"),
+        ],
+    )
+    def test_no_module_level_sys_exit_on_lock_collision(self, filename, lockfile_name):
+        import ast
+
+        source = (REPO_ROOT / filename).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        # Collect line numbers of sys.exit(...) calls that appear at MODULE level
+        # (i.e. not inside a FunctionDef / AsyncFunctionDef / ClassDef).
+        module_level_sys_exit_lines = []
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.If)):
+                # If-blocks are visited only when they are NOT guarded by __name__ == "__main__"
+                if isinstance(node, ast.If):
+                    test_src = ast.unparse(node.test) if hasattr(ast, "unparse") else ""
+                    if "__name__" in test_src:
+                        continue
+                else:
+                    continue
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute):
+                    if sub.func.attr == "exit" and isinstance(sub.func.value, ast.Name) and sub.func.value.id == "sys":
+                        module_level_sys_exit_lines.append(sub.lineno)
+
+        assert not module_level_sys_exit_lines, (
+            f"{filename} has module-level sys.exit() calls at lines "
+            f"{module_level_sys_exit_lines}. These exit the import process "
+            f"when the lockfile is held by another worker. Move them into "
+            f"main() or under `if __name__ == \"__main__\":` instead."
+        )
+
+    @pytest.mark.parametrize(
+        "filename,helper_name",
+        [
+            ("scripts/ingest_processor.py", "_acquire_process_lock_or_exit"),
+            ("scripts/kindle_epub_fixer.py", "_acquire_lock_or_exit"),
+            ("scripts/convert_library.py", "_acquire_lock_or_exit"),
+        ],
+    )
+    def test_main_calls_lock_acquire_helper(self, filename, helper_name):
+        """If the lock-acquire helper exists at module level but main() never
+        calls it, the script silently loses its single-instance guard while
+        all the import-side-effect tests still pass. This pins the wire-up.
+        """
+        import ast
+
+        source = (REPO_ROOT / filename).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        helper_defined = any(
+            isinstance(n, ast.FunctionDef) and n.name == helper_name
+            for n in tree.body
+        )
+        assert helper_defined, f"{filename} is missing module-level def {helper_name}()"
+
+        main_func = next(
+            (n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "main"),
+            None,
+        )
+        assert main_func is not None, f"{filename} has no module-level main() function"
+
+        calls_helper = any(
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Name)
+            and sub.func.id == helper_name
+            for sub in ast.walk(main_func)
+        )
+        assert calls_helper, (
+            f"{filename}::main() never calls {helper_name}(). The helper "
+            f"is defined but not wired up — running the script as __main__ "
+            f"would skip single-instance protection and let two concurrent "
+            f"invocations both proceed."
+        )
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "scripts/ingest_processor.py",
+            "scripts/kindle_epub_fixer.py",
+            "scripts/convert_library.py",
+        ],
+    )
+    def test_no_module_level_atexit_register(self, filename):
+        import ast
+
+        source = (REPO_ROOT / filename).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        # atexit.register at module level installs a handler the moment we
+        # import — even when the lock was never acquired. That would let
+        # an `import` followed by interpreter exit clean up a lockfile a
+        # different process is relying on.
+        module_level_atexit = []
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            if isinstance(node, ast.If):
+                test_src = ast.unparse(node.test) if hasattr(ast, "unparse") else ""
+                if "__name__" in test_src:
+                    continue
+            # ast.Expr wrapping a Call
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+                call = node.value
+                if (
+                    isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "register"
+                    and isinstance(call.func.value, ast.Name)
+                    and call.func.value.id == "atexit"
+                ):
+                    module_level_atexit.append(call.lineno)
+
+        assert not module_level_atexit, (
+            f"{filename} has module-level atexit.register() at lines "
+            f"{module_level_atexit}. Move into the lock-acquire helper "
+            f"so the handler is only installed when the lock was actually taken."
+        )


### PR DESCRIPTION
## Why

The three scheduled scripts (`ingest_processor.py`, `kindle_epub_fixer.py`, `convert_library.py`) historically acquired their single-instance lockfile at module-import time and called `sys.exit(2)` when another worker had already taken the lock. Under pytest-xdist (workers share `/tmp` across processes), `importlib.import_module(...)` from one worker would crash a sibling worker that had already imported the same script. That's the root cause behind the test-isolation flakes #204 patched narrowly (test-only fix, deeper refactor deferred).

## Root cause

Module-level `try: open('x') except FileExistsError: sys.exit(2)` and `atexit.register(removeLock)` at the top of each script's module body. Any process that imports the module — including a pytest-xdist worker that just wants to test `from ingest_processor import ProcessLock` — runs the lock-acquire code at import. If a sibling worker imported first, the import exits the process.

## Fix

Move lock acquire + `atexit.register` into a `_acquire_lock_or_exit()` / `_acquire_process_lock_or_exit()` helper called from `main()`. Importing the module is now a pure load; the single-instance guard runs only when the script is executed as `__main__`.

Also harden `convert_library.py` for CI environments (missing `/config` dir, missing `abc` user) with `try/except` around the `FileHandler` and `pwd.getpwnam` lookups so test runs in venv/CI no longer crash on those system-only dependencies.

## Validation

`tests/unit/test_script_import_side_effects.py` (new, 20 tests, all green):

- **Subprocess-import tests (11):** importing each script with no lockfile + with various stale lockfiles in `/tmp` returns `rc=0` and creates no lockfile.
- **AST source-pin tests (3+3):** no module-level `sys.exit()` on lock collision, no module-level `atexit.register()`.
- **AST wire-up test (3, new):** `main()` of each script actually calls its `_acquire_lock_or_exit()` helper. Without this, a future refactor could remove the call and silently lose single-instance protection while all the import-side-effect tests still pass — this is exactly what almost shipped here.

Local: `pytest tests/unit/test_script_import_side_effects.py` → 20 passed in 25s.

Smoke imports also exercised (`tests/smoke/test_smoke.py::TestLockMechanism`, which does `from ingest_processor import ProcessLock`) — passed without the import-time exit.

## Provenance

Deferred work from #204 (`fork-pr-204-opened` 2026-05-16T04:10:21Z, "narrow-test-only-fix-deeper-refactor-deferred"). The 06:00 UTC autopilot tick picked it up and started the refactor but timed out before pushing. This PR finishes that work and adds the wire-up regression test that catches what the original WIP missed (`convert_library.main()` was missing the `_acquire_lock_or_exit()` call — fix included).

## Tier

`needs-review` — fork-original behavior change (not a cherry-pick), 3 production files, ~75 net production additions plus a new test file. Within the cap for autonomous merge in principle, but fork-original branches go through operator review per `notes/CWNG-tick` rules.

## Test plan

- [x] `pytest tests/unit/test_script_import_side_effects.py` green locally (20/20)
- [x] `pytest tests/smoke/test_smoke.py::TestLockMechanism` green (proves the original use case works)
- [ ] CI green on this branch
- [ ] (after merge, operator) verify in container: `docker exec cwn-local python -c "import ingest_processor, kindle_epub_fixer, convert_library; print('OK')"` returns OK without crashing, and the scripts still single-instance-guard when invoked as `__main__`.