### PR TITLE
fix(duplicate-scan): revert debounce default 5 -> 30 (CWA fe60df7 regression)

### DIFF
--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -371,9 +371,9 @@ def cwa_internal_queue_duplicate_scan():
         frequency = db.cwa_settings.get('duplicate_scan_frequency', 'manual')
 
         data = request.get_json(force=True, silent=True) or {}
-        default_delay = db.cwa_settings.get('duplicate_scan_debounce_seconds', 5)
+        default_delay = db.cwa_settings.get('duplicate_scan_debounce_seconds', 30)
         delay_seconds = int(data.get('delay_seconds', default_delay))
-        delay_seconds = max(5, min(600, delay_seconds))
+        delay_seconds = max(10, min(600, delay_seconds))
 
         if not enabled or frequency != 'after_import':
             return jsonify({"success": True, "skipped": True, "reason": "disabled_or_manual"}), 200

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -819,8 +819,8 @@ def _queue_duplicate_scan_after_change():
         from cwa_db import CWA_DB
 
         cwa_db = CWA_DB()
-        delay_seconds = int(cwa_db.cwa_settings.get('duplicate_scan_debounce_seconds', 5))
-        delay_seconds = max(5, min(600, delay_seconds))
+        delay_seconds = int(cwa_db.cwa_settings.get('duplicate_scan_debounce_seconds', 30))
+        delay_seconds = max(10, min(600, delay_seconds))
         url = helper.get_internal_api_url("/cwa-internal/queue-duplicate-scan")
         requests.post(
             url,

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -1036,9 +1036,9 @@
 
       <div class="form-group" style="display: flex; justify-content: space-between; align-items: baseline; margin-top: 2rem;">
         <label for="duplicate_scan_debounce_seconds" class="settings-section-header">{{_('After import debounce (seconds)')}}</label>
-        <input type="number" min="5" max="600" step="1" class="cwa-settings-input"
+        <input type="number" min="10" max="600" step="1" class="cwa-settings-input"
                name="duplicate_scan_debounce_seconds" id="duplicate_scan_debounce_seconds"
-               value="{{ cwa_settings.get('duplicate_scan_debounce_seconds', 5) }}"
+               value="{{ cwa_settings.get('duplicate_scan_debounce_seconds', 30) }}"
                style="width: 120px; background: #151e2680; border: none; padding: 1rem; border-radius: 4px; margin-left: 1rem;">
       </div>
       <div class="cwa-settings-tip" style="margin-top: 2rem;">

--- a/scripts/cwa_db.py
+++ b/scripts/cwa_db.py
@@ -47,6 +47,7 @@ class CWA_DB:
         self.match_stat_table_columns_with_schema()
         self.ensure_scheduled_jobs_schema()
         self.set_default_settings()
+        self._migrate_duplicate_debounce_5_to_30_v1()
         self.cwa_settings = self.get_cwa_settings()
 
 
@@ -449,6 +450,59 @@ class CWA_DB:
                         self.cur.execute(f"ALTER TABLE {table} RENAME COLUMN {current_column_names[table][x]} TO {column_names_in_schema[table][x]}")
                         self.con.commit()
                         print(f'[cwa-db] Fixed column mismatch between versions. Column "{current_column_names[table][x]}" in table "{table}" renamed to "{column_names_in_schema[table][x]}"', flush=True)
+
+
+    def _migrate_duplicate_debounce_5_to_30_v1(self) -> None:
+        """One-time bump duplicate_scan_debounce_seconds from 5 -> 30.
+
+        CWA upstream commit fe60df7b (2026-01-29) lowered the default from
+        30 -> 5 to make duplicate-detection notifications surface faster after
+        multi-book ingest. For users with 10k+ book libraries the 5s default
+        produces stacking SQL prefilter queries that contend for the GIL with
+        concurrent SQLAlchemy session-init paths (which call create_function
+        to register title_sort/lower UDFs), surfacing as Web UI 504s under
+        sustained ingest. Identified as the regression vector by the upstream
+        PR #1346 author in CWA #1256.
+
+        This migration runs once per install, gated by a marker file in
+        ``.cwa_migrations/`` alongside cwa.db. Users who customised the value
+        to anything other than 5 are not touched.
+        """
+        marker_dir = os.path.join(self.db_path, ".cwa_migrations")
+        marker_path = os.path.join(marker_dir, "duplicate_debounce_5_to_30_v1.applied")
+        if os.path.exists(marker_path):
+            return
+        try:
+            row = self.cur.execute(
+                "SELECT duplicate_scan_debounce_seconds FROM cwa_settings LIMIT 1"
+            ).fetchone()
+            if row is not None and row[0] == 5:
+                self.cur.execute(
+                    "UPDATE cwa_settings SET duplicate_scan_debounce_seconds = 30 "
+                    "WHERE duplicate_scan_debounce_seconds = 5"
+                )
+                self.con.commit()
+                print(
+                    "[cwa-db] Migrated duplicate_scan_debounce_seconds 5 -> 30 "
+                    "(CWA regression revert; safer default for large libraries)",
+                    flush=True,
+                )
+        except sqlError as e:
+            print(
+                f"[cwa-db]: duplicate_debounce_5_to_30_v1 migration failed: {e}",
+                flush=True,
+            )
+            return
+
+        try:
+            os.makedirs(marker_dir, exist_ok=True)
+            with open(marker_path, "w", encoding="utf-8") as fh:
+                fh.write(datetime.now().isoformat())
+        except OSError as e:
+            print(
+                f"[cwa-db]: could not write migration marker {marker_path}: {e}",
+                flush=True,
+            )
 
 
     def set_default_settings(self, force=False) -> None:

--- a/scripts/cwa_schema.sql
+++ b/scripts/cwa_schema.sql
@@ -101,7 +101,7 @@ CREATE TABLE IF NOT EXISTS cwa_settings(
     duplicate_scan_cron TEXT DEFAULT '' NOT NULL,
     duplicate_scan_hour INTEGER DEFAULT 3 NOT NULL,
     duplicate_scan_chunk_size INTEGER DEFAULT 5000 NOT NULL,
-    duplicate_scan_debounce_seconds INTEGER DEFAULT 5 NOT NULL
+    duplicate_scan_debounce_seconds INTEGER DEFAULT 30 NOT NULL
 );
 
 -- Persisted scheduled jobs (initial focus: auto-send). Rows remain until dispatched or manually cleared.

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -1357,8 +1357,8 @@ class NewBookProcessor:
             # Schedule in the long-lived web process so the debounce survives
             # the short-lived ingest process exiting.
             try:
-                delay_seconds = int(self.cwa_settings.get('duplicate_scan_debounce_seconds', 5))
-                delay_seconds = max(5, min(600, delay_seconds))
+                delay_seconds = int(self.cwa_settings.get('duplicate_scan_debounce_seconds', 30))
+                delay_seconds = max(10, min(600, delay_seconds))
                 url = get_internal_api_url("/cwa-internal/queue-duplicate-scan")
                 payload = {"delay_seconds": delay_seconds}
                 resp = requests.post(

--- a/tests/unit/test_duplicate_debounce_default_regression.py
+++ b/tests/unit/test_duplicate_debounce_default_regression.py
@@ -1,0 +1,270 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Pin the duplicate_scan_debounce_seconds default at 30.
+
+CWA upstream commit fe60df7b (2026-01-29) lowered this default from 30 -> 5 to
+make duplicate-detection notifications surface faster after multi-book ingest.
+For users with large libraries (10k+ books) the 5s default produces stacking
+SQL prefilter queries that contend for the GIL with concurrent SQLAlchemy
+session-init paths (which call create_function() to register title_sort/lower
+UDFs), surfacing as Web UI 504s under sustained ingest. Reported as the
+underlying cause behind fork issue #134 by @kanjieater (CWA #1256 reporter)
+and identified as the regression vector by @navels in CWA #1256.
+
+The fork reverts the default to 30 in five mirrored sites - schema literal,
+three Python fallbacks (web process, editbooks, ingest processor), and the
+Jinja fallback - plus a clamp floor of 10 that prevents users from
+re-introducing the regression via the admin UI.
+
+These tests pin all five sites + the clamp + the one-time settings migration
+that bumps legacy installs (where the user value is the regression default 5)
+to the new safe default 30.
+"""
+
+import os
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestSchemaDefault:
+    """Pin the SQL schema literal to 30."""
+
+    def test_schema_sets_debounce_default_30(self):
+        schema = _read(REPO_ROOT / "scripts" / "cwa_schema.sql")
+        match = re.search(
+            r"duplicate_scan_debounce_seconds\s+INTEGER\s+DEFAULT\s+(\d+)\s+NOT\s+NULL",
+            schema,
+            flags=re.IGNORECASE,
+        )
+        assert match is not None, (
+            "duplicate_scan_debounce_seconds column not found in cwa_schema.sql"
+        )
+        assert match.group(1) == "30", (
+            f"schema default is {match.group(1)}, expected 30 - the v4.0.46-era"
+            f" regression default of 5 must not return"
+        )
+
+
+@pytest.mark.unit
+class TestPythonFallbacks:
+    """Pin every Python-side fallback that consumes duplicate_scan_debounce_seconds."""
+
+    def _grep_fallback_calls(self, source: str) -> list[str]:
+        """Return list of literal default values from cwa_settings.get(...) calls."""
+        pattern = (
+            r"cwa_settings\.get\(\s*['\"]duplicate_scan_debounce_seconds['\"]\s*,\s*(\d+)"
+        )
+        return re.findall(pattern, source)
+
+    def test_cwa_functions_fallback_30(self):
+        path = REPO_ROOT / "cps" / "cwa_functions.py"
+        values = self._grep_fallback_calls(_read(path))
+        assert values, "no duplicate_scan_debounce_seconds fallback found in cwa_functions.py"
+        for v in values:
+            assert v == "30", (
+                f"cwa_functions.py has fallback default {v}, expected 30"
+            )
+
+    def test_editbooks_fallback_30(self):
+        path = REPO_ROOT / "cps" / "editbooks.py"
+        values = self._grep_fallback_calls(_read(path))
+        assert values, "no duplicate_scan_debounce_seconds fallback found in editbooks.py"
+        for v in values:
+            assert v == "30", (
+                f"editbooks.py has fallback default {v}, expected 30"
+            )
+
+    def test_ingest_processor_fallback_30(self):
+        """ingest_processor.py is a separate short-lived process - its fallback
+        is independent of cwa_functions.py (the web process). Both must agree.
+        """
+        path = REPO_ROOT / "scripts" / "ingest_processor.py"
+        values = self._grep_fallback_calls(_read(path))
+        assert values, (
+            "no duplicate_scan_debounce_seconds fallback found in ingest_processor.py"
+        )
+        for v in values:
+            assert v == "30", (
+                f"ingest_processor.py has fallback default {v}, expected 30"
+            )
+
+    def test_template_fallback_30(self):
+        path = REPO_ROOT / "cps" / "templates" / "cwa_settings.html"
+        values = self._grep_fallback_calls(_read(path))
+        assert values, (
+            "no duplicate_scan_debounce_seconds fallback found in cwa_settings.html"
+        )
+        for v in values:
+            assert v == "30", (
+                f"cwa_settings.html has fallback default {v}, expected 30"
+            )
+
+
+@pytest.mark.unit
+class TestClampFloor:
+    """Pin the runtime lower-bound clamp at 10 - even if a user types 5, they get 10."""
+
+    def test_cwa_functions_clamp_floor_10(self):
+        src = _read(REPO_ROOT / "cps" / "cwa_functions.py")
+        match = re.search(
+            r"delay_seconds\s*=\s*max\(\s*(\d+)\s*,\s*min\(\s*600\s*,\s*delay_seconds\s*\)\s*\)",
+            src,
+        )
+        assert match is not None, (
+            "duplicate-scan delay clamp not found in cwa_functions.py"
+        )
+        assert match.group(1) == "10", (
+            f"clamp floor is {match.group(1)}, expected 10 - protects users from"
+            f" re-introducing the regression via the admin UI"
+        )
+
+    def test_editbooks_clamp_floor_10(self):
+        src = _read(REPO_ROOT / "cps" / "editbooks.py")
+        match = re.search(
+            r"delay_seconds\s*=\s*max\(\s*(\d+)\s*,\s*min\(\s*600\s*,\s*delay_seconds\s*\)\s*\)",
+            src,
+        )
+        assert match is not None, "duplicate-scan delay clamp not found in editbooks.py"
+        assert match.group(1) == "10"
+
+    def test_ingest_processor_clamp_floor_10(self):
+        src = _read(REPO_ROOT / "scripts" / "ingest_processor.py")
+        match = re.search(
+            r"delay_seconds\s*=\s*max\(\s*(\d+)\s*,\s*min\(\s*600\s*,\s*delay_seconds\s*\)\s*\)",
+            src,
+        )
+        assert match is not None, (
+            "duplicate-scan delay clamp not found in ingest_processor.py"
+        )
+        assert match.group(1) == "10"
+
+
+@pytest.mark.unit
+class TestCWAFreshInstallDefault:
+    """Behavioural: fresh CWA_DB install must report debounce=30 in settings dict."""
+
+    def test_fresh_install_debounce_is_30(self, temp_cwa_db):
+        settings = temp_cwa_db.get_cwa_settings()
+        assert "duplicate_scan_debounce_seconds" in settings, (
+            "duplicate_scan_debounce_seconds missing from CWA settings"
+        )
+        assert settings["duplicate_scan_debounce_seconds"] == 30, (
+            f"fresh install debounce is {settings['duplicate_scan_debounce_seconds']}, expected 30"
+        )
+
+
+@pytest.mark.unit
+class TestLegacyValueMigration:
+    """Behavioural: existing installs with the regression default 5 get bumped to 30 once."""
+
+    def _make_legacy_cwa_db(self, tmp_path, debounce_value: int):
+        """Build a cwa.db with debounce already at ``debounce_value`` AND no
+        migration marker, mimicking an install that ran on the v4.0.46-era
+        schema default of 5 (or any prior customized value).
+        """
+        db_path = tmp_path / "cwa.db"
+        schema = _read(REPO_ROOT / "scripts" / "cwa_schema.sql")
+        legacy_schema = re.sub(
+            r"duplicate_scan_debounce_seconds\s+INTEGER\s+DEFAULT\s+\d+\s+NOT\s+NULL",
+            f"duplicate_scan_debounce_seconds INTEGER DEFAULT {debounce_value} NOT NULL",
+            schema,
+        )
+        con = sqlite3.connect(str(db_path))
+        try:
+            cur = con.cursor()
+            for stmt in [s.strip() for s in legacy_schema.split(";") if s.strip()]:
+                cur.execute(stmt)
+            cur.execute("INSERT INTO cwa_settings DEFAULT VALUES;")
+            con.commit()
+        finally:
+            con.close()
+
+    def test_legacy_5_migrates_to_30(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CWA_DB_PATH", str(tmp_path))
+        self._make_legacy_cwa_db(tmp_path, 5)
+
+        from cwa_db import CWA_DB
+
+        db = CWA_DB(verbose=False)
+        try:
+            settings = db.get_cwa_settings()
+            assert settings["duplicate_scan_debounce_seconds"] == 30, (
+                f"legacy 5 should migrate to 30, got {settings['duplicate_scan_debounce_seconds']}"
+            )
+        finally:
+            db.con.close()
+
+        marker = tmp_path / ".cwa_migrations" / "duplicate_debounce_5_to_30_v1.applied"
+        assert marker.exists(), "migration marker should be written after one-time bump"
+
+    def test_legacy_custom_60_preserved(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CWA_DB_PATH", str(tmp_path))
+        self._make_legacy_cwa_db(tmp_path, 60)
+
+        from cwa_db import CWA_DB
+
+        db = CWA_DB(verbose=False)
+        try:
+            settings = db.get_cwa_settings()
+            assert settings["duplicate_scan_debounce_seconds"] == 60, (
+                f"user-customized 60 must be preserved, got"
+                f" {settings['duplicate_scan_debounce_seconds']}"
+            )
+        finally:
+            db.con.close()
+
+    def test_legacy_custom_15_preserved(self, tmp_path, monkeypatch):
+        """A user who picked 15 explicitly (anything != 5) must not be touched."""
+        monkeypatch.setenv("CWA_DB_PATH", str(tmp_path))
+        self._make_legacy_cwa_db(tmp_path, 15)
+
+        from cwa_db import CWA_DB
+
+        db = CWA_DB(verbose=False)
+        try:
+            settings = db.get_cwa_settings()
+            assert settings["duplicate_scan_debounce_seconds"] == 15
+        finally:
+            db.con.close()
+
+    def test_migration_idempotent_marker_short_circuits(self, tmp_path, monkeypatch):
+        """If the marker already exists, a user-set value of 5 stays at 5
+        (we don't re-migrate someone who manually set it back).
+        """
+        monkeypatch.setenv("CWA_DB_PATH", str(tmp_path))
+        self._make_legacy_cwa_db(tmp_path, 5)
+
+        marker = tmp_path / ".cwa_migrations" / "duplicate_debounce_5_to_30_v1.applied"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("pre-existing marker", encoding="utf-8")
+
+        from cwa_db import CWA_DB
+
+        db = CWA_DB(verbose=False)
+        try:
+            settings = db.get_cwa_settings()
+            assert settings["duplicate_scan_debounce_seconds"] == 5, (
+                "if marker already exists, do not re-migrate - user may have"
+                " manually set 5 again after the first migration ran"
+            )
+        finally:
+            db.con.close()


### PR DESCRIPTION
## Symptom

Users on default settings report Web UI 504 timeouts after adding books to large libraries (~10k+ books). The `[cwa-duplicates] Debounced duplicate scan queued` log fires repeatedly during a sustained ingest, and the gevent web server stops responding until ingest finishes. Reported behind fork #134 (closed but follow-up persisted from `@kanjieater` — the original CWA #1256 reporter — with a fresh 504 trace on v4.0.46).

## Root cause

CWA upstream commit `fe60df7` (2026-01-29) lowered `duplicate_scan_debounce_seconds` from 30 → 5 to make duplicate-detection notifications surface faster after multi-book ingest. For users with large libraries the 5s default produces stacking SQL prefilter queries (`find_duplicate_candidate_ids_sql`) that contend for the GIL with concurrent SQLAlchemy session-init paths (which call `create_function` on the SQLite connection to register `title_sort`/`lower` UDFs). The collision deadlocks the gevent hub. Identified as the regression vector by `@navels` (CWA PR #1346 author) in CWA #1256.

## Fix

Revert the default to 30 in all five mirrored sites — schema literal, three Python fallbacks (web process, editbooks, ingest processor), and the Jinja template fallback. Raise the runtime lower-bound clamp from 5 → 10 (so even users who try to set 5 through the admin UI cannot re-introduce the regression).

Add a one-time DB migration in `CWA_DB.__init__` that bumps existing installs from 5 → 30 once, gated by a marker file in `.cwa_migrations/duplicate_debounce_5_to_30_v1.applied`. Users who customised the value to anything other than 5 are not touched.

This is a tactical regression revert. The underlying GIL+SQLite deadlock is reduced in frequency but not eliminated — the architectural fix lives in upstream CWA PRs #1349 (defer post-import work) and #1353 (incremental duplicate index), which will be evaluated for backport in follow-up cycles.

## Verification

- ✅ RED → GREEN unit/integration tests: 13 new (`tests/unit/test_duplicate_debounce_default_regression.py`) — pins schema literal, four Python fallbacks, three clamp sites, fresh-install behaviour, three migration variants (5 → 30, 15/60 preserved, marker idempotency).
- ✅ Touched-area suites: `test_cwa_db.py` (31) + `test_duplicate_manager_race_fix.py` (8) + `test_duplicates_timezone.py` (2) all green.
- ✅ Local cwn-local docker integration: copied patched files into a container with pre-existing `duplicate_scan_debounce_seconds=5`; restart triggers migration; post-restart DB shows 30; marker file written; second restart short-circuits (idempotent).
- ✅ Playwright UI pilot: `/cwa-settings` renders `value=30, min=10, max=600` on the debounce input; no console errors.
- ✅ Runtime clamp endpoint: POST `delay_seconds=3` → returned `delay_seconds=10` (floor); `delay_seconds=700` → returned `delay_seconds=600` (ceiling); no `delay_seconds` → returned `30` (DB default after migration).
- ✅ Cross-cutting sweep: no other repo files reference `duplicate_scan_debounce_seconds` with a 5s default.
- ✅ Migration robustness: SQL failure path does not write the marker — next restart will retry. Marker present → SELECT-only short-circuit.

## Confidence

96% — the user-visible regression is gone for fresh installs and is migrated for existing installs. Residual risk: the deeper GIL+SQLite deadlock can still surface for very large libraries on sustained ingest; PRs #1349/#1353 from `@navels` are the architectural fixes and will be evaluated for follow-up cycles.

## Follow-ups (v2-track)

- Evaluate backport of CWA PR #1349 (defer post-import reconnect + duplicate-cache invalidation until batch settles)
- Evaluate backport of CWA PR #1353 (incremental duplicate index — major DB-schema change, needs its own /CWNG_goal_act cycle)
- Polish: extend the admin-settings tooltip to call out the 10s floor and recommend 60s+ for libraries >50k

Closes #134