### PR TITLE
fix(db): register SQLite UDFs once via connect event listener (eliminate deadlock vector)

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -909,7 +909,10 @@ def update_view_configuration():
     _config_string(to_save, "config_calibre_web_title")
     _config_string(to_save, "config_columns_to_ignore")
     if _config_string(to_save, "config_title_regex"):
-        calibre_db.create_functions(config)
+        # title_sort UDF reads ``CalibreDB.config.config_title_regex`` at
+        # call time via closure in ``_register_sqlite_udfs``; updating the
+        # config object is sufficient — no per-connection re-registration.
+        db.CalibreDB.update_config(config)
 
     if not check_valid_read_column(to_save.get("config_read_column", "0")):
         flash(_("Invalid Read Column"), category="error")

--- a/cps/db.py
+++ b/cps/db.py
@@ -16,7 +16,7 @@ from weakref import WeakSet
 from uuid import uuid4
 
 from sqlite3 import OperationalError as sqliteOperationalError
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy import Table, Column, ForeignKey, CheckConstraint
 from sqlalchemy import String, Integer, Boolean, TIMESTAMP, Float
 from sqlalchemy.orm import relationship, sessionmaker, scoped_session, joinedload, object_session
@@ -48,6 +48,61 @@ log = logger.create()
 # fires from every page render. Module-level set so we warn once per process
 # per drifted sort string. See fork issue #108.
 _AUTHOR_SORT_DRIFT_WARNED: set = set()
+
+
+def _register_sqlite_udfs(dbapi_connection, _connection_record):
+    """Register Python UDFs (lower, uuid4, title_sort) once per SQLite
+    connection — installed as a SQLAlchemy ``connect`` event listener.
+
+    Eliminates the GIL+SQLite deadlock vector behind CWA #1256: previously,
+    request handlers (``cps/web.py:get_matching_tags``, edit-book paths,
+    admin config saves, search/typeahead/check_exists) called
+    ``calibre_db.create_functions()`` mid-request. With ``StaticPool``
+    sharing one connection across all threads, that ``conn.create_function``
+    call held the GIL while a concurrent worker thread mid-query (e.g.
+    duplicate-scan SQL using ``func.lower``) was waiting for the GIL to
+    invoke the registered UDF. Classic deadlock — neither thread could
+    proceed and the gevent hub stalled.
+
+    Registering UDFs at connection time means they're available for every
+    SQL statement on the connection, no per-request re-registration needed.
+    ``StaticPool`` reuses one connection for the engine's lifetime, so this
+    listener fires exactly once unless the engine is disposed and
+    re-created (e.g. via ``setup_db`` after config changes).
+
+    ``title_sort`` reads ``CalibreDB.config.config_title_regex`` at call
+    time via a closure, so admin updates to the regex are picked up without
+    needing to re-register the UDF.
+    """
+    try:
+        dbapi_connection.create_function("lower", 1, lcase)
+    except Exception:
+        pass
+    try:
+        dbapi_connection.create_function("uuid4", 0, lambda: str(uuid4()))
+    except Exception:
+        pass
+
+    def _title_sort(title):
+        if title is None:
+            return ''
+        cfg = CalibreDB.config
+        try:
+            regex = getattr(cfg, 'config_title_regex', None) if cfg is not None else None
+            if regex:
+                title_pat = re.compile(regex, re.IGNORECASE)
+                match = title_pat.search(title)
+                if match:
+                    prep = match.group(1)
+                    title = title[len(prep):] + ', ' + prep
+        except Exception:
+            pass
+        return strip_whitespaces(title)
+
+    try:
+        dbapi_connection.create_function("title_sort", 1, _title_sort)
+    except Exception:
+        pass
 
 cc_exceptions = ['composite', 'series']
 cc_classes = {}
@@ -600,7 +655,9 @@ class CalibreDB:
             return
         self.session = self.session_factory()
         self.session.expire_on_commit = expire_on_commit
-        self.create_functions(self.config)
+        # UDFs (lower/uuid4/title_sort) are registered once per SQLite
+        # connection via the engine-level ``connect`` event listener
+        # (``_register_sqlite_udfs``); no per-Session call needed.
 
     def ensure_session(self, expire_on_commit=True):
         """Ensure a valid SQLAlchemy session exists.
@@ -741,6 +798,7 @@ class CalibreDB:
                                          isolation_level="SERIALIZABLE",
                                          connect_args={'check_same_thread': False, 'timeout': 30},
                                          poolclass=StaticPool)
+            event.listen(check_engine, "connect", _register_sqlite_udfs)
             with check_engine.begin() as connection:
                 connection.execute(text("attach database '{}' as calibre;".format(dbpath)))
                 connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
@@ -809,6 +867,7 @@ class CalibreDB:
                                            isolation_level="SERIALIZABLE",
                                            connect_args={'check_same_thread': False, 'timeout': 30},
                                            poolclass=StaticPool)
+                event.listen(cls.engine, "connect", _register_sqlite_udfs)
                 with cls.engine.begin() as connection:
                     connection.execute(text("attach database '{}' as calibre;".format(dbpath)))
                     connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
@@ -1233,8 +1292,6 @@ class CalibreDB:
     def get_typeahead(self, database, query, replace=('', ''), tag_filter=true()):
         self.ensure_session()
         query = query or ''
-        self.create_functions()
-        # self.session.connection().connection.connection.create_function("lower", 1, lcase)
         entries = self.session.query(database).filter(tag_filter). \
             filter(func.lower(database.name).ilike("%" + query + "%")).all()
         # json_dumps = json.dumps([dict(name=escape(r.name.replace(*replace))) for r in entries])
@@ -1243,8 +1300,6 @@ class CalibreDB:
 
     def check_exists_book(self, authr, title):
         self.ensure_session()
-        self.create_functions()
-        # self.session.connection().connection.connection.create_function("lower", 1, lcase)
         q = list()
         author_terms = re.split(r'\s*&\s*', authr)
         for author_term in author_terms:
@@ -1256,8 +1311,6 @@ class CalibreDB:
     def search_query(self, term, config, *join):
         self.ensure_session()
         strip_whitespaces(term).lower()
-        self.create_functions()
-        # self.session.connection().connection.connection.create_function("lower", 1, lcase)
         q = list()
         author_terms = re.split("[, ]+", term)
         for author_term in author_terms:
@@ -1361,35 +1414,25 @@ class CalibreDB:
             return sorted(languages, key=lambda x: x.name, reverse=reverse_order)
 
     def create_functions(self, config=None):
-        self.ensure_session()
-        if self.session is None:
-            log.error("create_functions: Cannot create functions because session is None")
-            return
-        
-        # user defined sort function for calibre databases (Series, etc.)
-        if config:
-            def _title_sort(title):
-                # calibre sort stuff
-                title_pat = re.compile(config.config_title_regex, re.IGNORECASE)
-                match = title_pat.search(title)
-                if match:
-                    prep = match.group(1)
-                    title = title[len(prep):] + ', ' + prep
-                return strip_whitespaces(title)
+        """Backward-compatible no-op.
 
-        try:
-            # sqlalchemy <1.4.24 and sqlalchemy 2.0
-            conn = self.session.connection().connection.driver_connection
-        except AttributeError:
-            # sqlalchemy >1.4.24
-            conn = self.session.connection().connection.connection
-        try:
-            if config:
-                conn.create_function("title_sort", 1, _title_sort)
-            conn.create_function('uuid4', 0, lambda: str(uuid4()))
-            conn.create_function("lower", 1, lcase)
-        except sqliteOperationalError:
-            pass
+        UDFs (lower/uuid4/title_sort) are now registered once per SQLite
+        connection by ``_register_sqlite_udfs`` via the engine ``connect``
+        event listener. Per-request callsites in ``cps/web.py``,
+        ``cps/editbooks.py``, ``cps/admin.py``, ``cps/helper.py``, and
+        ``cps/search.py`` previously called this method on hot paths,
+        creating the GIL+SQLite deadlock vector behind CWA #1256 when a
+        worker thread mid-``func.lower`` query collided with a request
+        thread mid-``conn.create_function``. The new model registers UDFs
+        at connect time so request handlers never re-register.
+
+        Method is preserved as a no-op so any external caller (e.g.
+        downstream plugins or tests) doesn't break. The class attribute
+        ``config`` is updated if provided so legacy callers' intent (set
+        the title-sort regex source) is preserved.
+        """
+        if config is not None:
+            type(self).config = config
 
     @classmethod
     def dispose(cls):

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -884,9 +884,6 @@ def do_edit_book(book_id, upload_formats=None):
     edit_error = False
     refresh_cover_thumbnail_after_commit = False
 
-    # create the function for sorting...
-    calibre_db.create_functions(config)
-
     book = calibre_db.get_filtered_book(book_id, allow_show_archived=True)
     # Book not found
     if not book:
@@ -1866,7 +1863,6 @@ def upload_book_formats(requested_files, book, book_id, no_cover=True):
                     db_format = db.Data(book_id, file_ext.upper(), file_size, file_name)
                     calibre_db.session.add(db_format)
                     calibre_db.session.commit()
-                    calibre_db.create_functions(config)
                 except (OperationalError, IntegrityError, StaleDataError) as e:
                     calibre_db.session.rollback()
                     log.error_or_exception("Database error: {}".format(e))

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -361,7 +361,6 @@ def edit_book_read_status(book_id, read_status=None):
         ub.session_commit("Book {} readbit toggled".format(book_id))
     else:
         try:
-            calibre_db.create_functions(config)
             book = calibre_db.get_filtered_book(book_id, True)
             book_read_status = getattr(book, 'custom_column_' + str(config.config_read_column))
             if len(book_read_status):

--- a/cps/search.py
+++ b/cps/search.py
@@ -247,8 +247,6 @@ def render_adv_search_results(term, offset=None, order=None, limit=None):
     pagination = None
 
     cc = calibre_db.get_cc_columns(config, filter_config_custom_read=True)
-    calibre_db.create_functions()
-    # calibre_db.session.connection().connection.connection.create_function("lower", 1, db.lcase)
     query = calibre_db.generate_linked_query(config.config_read_column, db.Books)
     q = query.outerjoin(db.books_series_link, db.Books.id == db.books_series_link.c.book)\
         .outerjoin(db.Series)\

--- a/cps/web.py
+++ b/cps/web.py
@@ -358,8 +358,6 @@ def get_languages_json():
 def get_matching_tags():
     tag_dict = {'tags': []}
     q = calibre_db.session.query(db.Books).filter(calibre_db.common_filters(True))
-    calibre_db.create_functions()
-    # calibre_db.session.connection().connection.connection.create_function("lower", 1, db.lcase)
     author_input = request.args.get('authors') or ''
     title_input = request.args.get('title') or ''
     include_tag_inputs = request.args.getlist('include_tag') or ''

--- a/tests/unit/test_duplicate_debounce_migration_edge_cases.py
+++ b/tests/unit/test_duplicate_debounce_migration_edge_cases.py
@@ -1,0 +1,260 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Edge cases for the v4.0.65 ``_migrate_duplicate_debounce_5_to_30_v1``.
+
+The happy path (legacy 5 -> 30; custom 15/60 preserved; marker idempotency)
+lives in ``test_duplicate_debounce_default_regression.py``. This file pins
+the failure-mode behaviour so a future refactor that quietly breaks the
+guard rails fails CI loudly:
+
+* Empty ``cwa_settings`` table (race between INSERT DEFAULT VALUES and
+  the migration) — must not crash, must not skip the marker.
+* ``.cwa_migrations`` directory not creatable (parent read-only) — migration
+  still applies the UPDATE; marker write failure is logged but not fatal.
+* Two ``CWA_DB()`` constructors in the same process (boot-time race between
+  web process and ingest_processor module-level import) — exactly one
+  migration log line, exactly one marker write, both end up at 30.
+* Concrete boundary tests for the SQL: only EXACT value 5 migrates;
+  4, 6, 0 are preserved.
+* Marker file is in ``.cwa_migrations/`` directory (parent path is
+  ``CWA_DB_PATH``), matching the kobo migration convention.
+"""
+
+import os
+import re
+import sqlite3
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+def _seed_cwa_db(tmp_path: Path, *, debounce_value: int | None,
+                 insert_row: bool = True):
+    """Write a cwa.db at ``tmp_path/cwa.db`` with the production schema patched
+    to the requested debounce default. If ``insert_row`` is False the table is
+    created empty (no default-values row) — tests the boot-race window where
+    settings INSERT hasn't happened yet.
+    """
+    schema = _read(REPO_ROOT / "scripts" / "cwa_schema.sql")
+    if debounce_value is not None:
+        schema = re.sub(
+            r"duplicate_scan_debounce_seconds\s+INTEGER\s+DEFAULT\s+\d+\s+NOT\s+NULL",
+            f"duplicate_scan_debounce_seconds INTEGER DEFAULT {debounce_value} NOT NULL",
+            schema,
+        )
+    db_path = tmp_path / "cwa.db"
+    con = sqlite3.connect(str(db_path))
+    try:
+        cur = con.cursor()
+        for stmt in [s.strip() for s in schema.split(";") if s.strip()]:
+            cur.execute(stmt)
+        if insert_row:
+            cur.execute("INSERT INTO cwa_settings DEFAULT VALUES;")
+        con.commit()
+    finally:
+        con.close()
+
+
+@pytest.mark.unit
+class TestMigrationEdgeCasesAroundBoundary:
+    """Pin: only the EXACT value 5 migrates. 4, 6, 0, negative all preserved."""
+
+    @pytest.mark.parametrize("preserved", [0, 1, 2, 3, 4, 6, 7, 10, 25, 31, 100])
+    def test_only_5_migrates_not_neighbours(self, tmp_path, monkeypatch, preserved):
+        monkeypatch.setenv("CWA_DB_PATH", str(tmp_path))
+        _seed_cwa_db(tmp_path, debounce_value=preserved)
+
+        from cwa_db import CWA_DB
+
+        db = CWA_DB(verbose=False)
+        try:
+            settings = db.get_cwa_settings()
+            assert settings["duplicate_scan_debounce_seconds"] == preserved, (
+                f"value {preserved} (!=5) must be preserved verbatim, "
+                f"got {settings['duplicate_scan_debounce_seconds']}"
+            )
+        finally:
+            db.con.close()
+
+
+@pytest.mark.unit
+class TestEmptyTableHandling:
+    """Pin: an empty cwa_settings table (race window) doesn't crash the
+    migration and doesn't leave the marker un-written.
+    """
+
+    def test_empty_table_no_crash(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CWA_DB_PATH", str(tmp_path))
+        # Build cwa.db with the table created but no row inserted yet.
+        _seed_cwa_db(tmp_path, debounce_value=None, insert_row=False)
+
+        from cwa_db import CWA_DB
+
+        db = CWA_DB(verbose=False)
+        try:
+            # Either the row was inserted during CWA_DB.__init__ at the
+            # set_default_settings path, or it remains absent; either way
+            # the migration must not crash.
+            settings = db.get_cwa_settings()
+            assert "duplicate_scan_debounce_seconds" in settings
+        finally:
+            db.con.close()
+
+
+@pytest.mark.unit
+class TestMarkerWriteFailureNonFatal:
+    """If marker dir cannot be created (parent read-only), the migration
+    must still apply the SQL bump — the marker write failure is logged
+    but not fatal. Without this guarantee, the migration would skip and
+    affected users would stay at 5 forever.
+    """
+
+    def test_marker_write_failure_does_not_block_sql_bump(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("CWA_DB_PATH", str(tmp_path))
+        _seed_cwa_db(tmp_path, debounce_value=5)
+
+        # Pre-create the marker dir as a FILE (so makedirs fails) — simulates
+        # a permission/filesystem failure on the marker write path.
+        marker_dir_path = tmp_path / ".cwa_migrations"
+        marker_dir_path.write_text("not a directory", encoding="utf-8")
+
+        from cwa_db import CWA_DB
+
+        db = CWA_DB(verbose=False)
+        try:
+            settings = db.get_cwa_settings()
+            assert settings["duplicate_scan_debounce_seconds"] == 30, (
+                "SQL bump must apply even when marker write fails — "
+                "otherwise affected users stay at 5 forever"
+            )
+        finally:
+            db.con.close()
+
+
+@pytest.mark.unit
+class TestConcurrentCWADBConstructors:
+    """Boot-race: web process and ingest_processor both module-import
+    cwa_db simultaneously. Both CWA_DB() __init__ runs. The migration must
+    end with the value at 30, not crash, not double-apply, not loop.
+
+    With marker-file gating this should be safe because the second
+    constructor sees the marker (written by the first) and short-circuits.
+    The window where both run the SELECT before either writes the marker is
+    tolerable because the UPDATE is idempotent (already-30 rows are
+    untouched by ``WHERE ... = 5``).
+    """
+
+    def test_two_concurrent_constructors_converge_to_30(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CWA_DB_PATH", str(tmp_path))
+        _seed_cwa_db(tmp_path, debounce_value=5)
+
+        from cwa_db import CWA_DB
+
+        results = []
+        errors = []
+        barrier = threading.Barrier(2)
+
+        def worker():
+            try:
+                barrier.wait(timeout=5)
+                db = CWA_DB(verbose=False)
+                settings = db.get_cwa_settings()
+                results.append(settings["duplicate_scan_debounce_seconds"])
+                db.con.close()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"errors during concurrent CWA_DB init: {errors}"
+        assert results == [30, 30], (
+            f"both concurrent constructors should converge to 30, got {results}"
+        )
+
+        # Marker must exist.
+        marker = tmp_path / ".cwa_migrations" / "duplicate_debounce_5_to_30_v1.applied"
+        assert marker.exists(), "marker should be written by one of the constructors"
+
+
+@pytest.mark.unit
+class TestMarkerNameMatchesConvention:
+    """The kobo migration uses ``CONFIG_DIR/.cwa_migrations/<marker_name>``.
+    Our migration must use the same convention so future operators can find
+    it in the same directory and clean / inspect uniformly.
+    """
+
+    def test_marker_path_matches_kobo_convention(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CWA_DB_PATH", str(tmp_path))
+        _seed_cwa_db(tmp_path, debounce_value=5)
+
+        from cwa_db import CWA_DB
+
+        db = CWA_DB(verbose=False)
+        try:
+            db.get_cwa_settings()
+        finally:
+            db.con.close()
+
+        # Marker must be at tmp_path/.cwa_migrations/<name>
+        marker_dir = tmp_path / ".cwa_migrations"
+        assert marker_dir.is_dir(), (
+            "marker directory ``.cwa_migrations/`` must exist alongside cwa.db"
+        )
+        markers = list(marker_dir.iterdir())
+        names = [m.name for m in markers]
+        assert "duplicate_debounce_5_to_30_v1.applied" in names, (
+            f"versioned marker file expected; got {names}"
+        )
+
+
+@pytest.mark.unit
+class TestSourcePinSchemaMigrationOrder:
+    """Pin: the migration runs AFTER set_default_settings but BEFORE
+    get_cwa_settings — otherwise we'd either skip the migration entirely
+    (if it runs before the table exists / before set_default_settings
+    populates the row) or return stale data (if it runs after the public
+    settings dict is captured).
+    """
+
+    def test_init_order_set_defaults_then_migrate_then_get_settings(self):
+        src = _read(REPO_ROOT / "scripts" / "cwa_db.py")
+        # Find the __init__ body and assert ordering.
+        m = re.search(
+            r"def __init__\(self, verbose=False\):(.*?)def\s+\w+\(",
+            src,
+            flags=re.DOTALL,
+        )
+        assert m, "could not locate CWA_DB.__init__ in cwa_db.py"
+        body = m.group(1)
+
+        set_defaults_pos = body.find("self.set_default_settings()")
+        migrate_pos = body.find("self._migrate_duplicate_debounce_5_to_30_v1()")
+        get_settings_pos = body.find("self.cwa_settings = self.get_cwa_settings()")
+
+        assert -1 < set_defaults_pos < migrate_pos < get_settings_pos, (
+            f"init must call set_default_settings -> migrate -> get_cwa_settings in "
+            f"that order; got positions "
+            f"set={set_defaults_pos} mig={migrate_pos} get={get_settings_pos}"
+        )

--- a/tests/unit/test_sqlite_udf_registration_listener.py
+++ b/tests/unit/test_sqlite_udf_registration_listener.py
@@ -1,0 +1,443 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Pin the SQLite UDF registration contract behind the CWA #1256 root-cause fix.
+
+The deadlock pattern: ``StaticPool`` shares a single SQLite connection across
+all threads. A worker thread mid-``func.lower`` query holds the SQLite mutex
+while waiting for the Python GIL (to invoke the registered ``lower`` UDF that
+SQLite calls back into Python for). A concurrent request handler calling
+``conn.create_function(...)`` holds the GIL while waiting for the SQLite mutex.
+Classic deadlock.
+
+The fix moves UDF registration out of every request-handler hot path and into
+a single ``connect`` event listener that fires once when SQLAlchemy opens the
+connection. After this PR, ``conn.create_function`` is never called from a
+request handler — the deadlock vector is structurally gone.
+
+These tests pin the contract:
+  1. Source-pin every request-handler module is free of ``calibre_db.create_functions``.
+  2. Source-pin the engine ``connect`` event listener is registered in both
+     ``check_valid_db`` and ``setup_db``.
+  3. Source-pin ``init_session`` no longer calls ``create_functions``.
+  4. Behavioural: a fresh engine + listener serves ``SELECT lower('FOO')``
+     without any explicit per-Session/per-request UDF registration.
+  5. Behavioural: ``title_sort`` reads the live ``CalibreDB.config`` so admin
+     updates to ``config_title_regex`` take effect without re-registration.
+  6. Behavioural: concurrent ``func.lower`` queries on the same StaticPool
+     connection make forward progress (smoke test, not a deadlock proof).
+"""
+
+import ast
+import re
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.pool import StaticPool
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestSourcePinNoRequestHandlerCallsites:
+    """Pin that the six request-handler modules are free of UDF re-registration."""
+
+    REQUEST_HANDLER_PATHS = [
+        "cps/web.py",
+        "cps/editbooks.py",
+        "cps/admin.py",
+        "cps/helper.py",
+        "cps/search.py",
+    ]
+
+    def test_no_calibre_db_create_functions_in_request_handlers(self):
+        offenders = []
+        for relpath in self.REQUEST_HANDLER_PATHS:
+            src = _read(REPO_ROOT / relpath)
+            for ln, line in enumerate(src.splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("#") or stripped.startswith('"""'):
+                    continue
+                if "calibre_db.create_functions" in line:
+                    offenders.append(f"{relpath}:{ln}: {stripped}")
+        assert not offenders, (
+            "calibre_db.create_functions must not be called from request handlers — "
+            "it's the GIL+SQLite deadlock vector. Use the engine connect event "
+            "listener instead. Offenders:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_no_self_create_functions_in_internal_db_hot_paths(self):
+        """Three internal db.py methods (get_typeahead, check_exists_book,
+        search_query) used to call self.create_functions() before the
+        func.lower SQL — same deadlock vector. They must not anymore.
+        """
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        tree = ast.parse(src)
+        offenders = []
+        target_methods = {"get_typeahead", "check_exists_book", "search_query"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name in target_methods:
+                for sub in ast.walk(node):
+                    if (
+                        isinstance(sub, ast.Call)
+                        and isinstance(sub.func, ast.Attribute)
+                        and sub.func.attr == "create_functions"
+                        and isinstance(sub.func.value, ast.Name)
+                        and sub.func.value.id == "self"
+                    ):
+                        offenders.append(f"{node.name} (line {sub.lineno})")
+        assert not offenders, (
+            "self.create_functions() must not be called inside hot-path db.py "
+            "methods — UDFs are registered once per connection by the engine "
+            "connect listener. Offenders: " + ", ".join(offenders)
+        )
+
+
+@pytest.mark.unit
+class TestSourcePinConnectListener:
+    """Pin that _register_sqlite_udfs is wired into both engines."""
+
+    def test_module_level_register_function_exists(self):
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        assert re.search(
+            r"^def _register_sqlite_udfs\(dbapi_connection, _connection_record\):",
+            src,
+            flags=re.MULTILINE,
+        ), "module-level _register_sqlite_udfs(...) function must exist in cps/db.py"
+
+    def test_main_engine_registers_listener(self):
+        """``setup_db`` must register the listener on ``cls.engine``."""
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        assert re.search(
+            r'event\.listen\(\s*cls\.engine\s*,\s*["\']connect["\']\s*,\s*_register_sqlite_udfs\s*\)',
+            src,
+        ), "event.listen(cls.engine, 'connect', _register_sqlite_udfs) must be wired in setup_db"
+
+    def test_check_engine_registers_listener(self):
+        """``check_valid_db`` builds a temp engine for DB validation — must
+        also register the listener, otherwise the validation query crashes
+        with `no such function: lower`."""
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        assert re.search(
+            r'event\.listen\(\s*check_engine\s*,\s*["\']connect["\']\s*,\s*_register_sqlite_udfs\s*\)',
+            src,
+        ), "event.listen(check_engine, 'connect', _register_sqlite_udfs) must be wired in check_valid_db"
+
+
+@pytest.mark.unit
+class TestSourcePinInitSession:
+    """init_session must NOT call create_functions anymore — the listener does."""
+
+    def test_init_session_does_not_call_create_functions(self):
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "init_session":
+                for sub in ast.walk(node):
+                    if (
+                        isinstance(sub, ast.Call)
+                        and isinstance(sub.func, ast.Attribute)
+                        and sub.func.attr == "create_functions"
+                    ):
+                        pytest.fail(
+                            "init_session() must not call create_functions — "
+                            "the engine connect event listener handles UDF registration"
+                        )
+                return
+        pytest.fail("init_session method not found in cps/db.py")
+
+
+@pytest.mark.unit
+class TestEngineConnectListenerBehavior:
+    """Behavioural: a fresh engine + listener serves func.lower/title_sort
+    queries without any explicit per-Session UDF registration.
+    """
+
+    def _make_engine_with_listener(self):
+        """Build an in-memory SQLite engine wired to the production listener."""
+        # Reuse the production listener so any divergence is caught.
+        import importlib
+        import sys
+
+        # Add scripts/ to sys.path because cps imports something that needs it.
+        scripts_dir = REPO_ROOT / "scripts"
+        if str(scripts_dir) not in sys.path:
+            sys.path.insert(0, str(scripts_dir))
+
+        from cps import db as cps_db
+
+        engine = sa.create_engine(
+            "sqlite://",
+            poolclass=StaticPool,
+            connect_args={"check_same_thread": False, "timeout": 30},
+        )
+        sa.event.listen(engine, "connect", cps_db._register_sqlite_udfs)
+        return engine, cps_db
+
+    def test_lower_udf_available_without_explicit_registration(self):
+        engine, cps_db = self._make_engine_with_listener()
+        with engine.connect() as conn:
+            result = conn.execute(sa.text("SELECT lower('FOOBAR') AS r")).scalar()
+        assert result == "foobar", (
+            f"lower('FOOBAR') UDF should be registered automatically; got {result!r}"
+        )
+
+    def test_uuid4_udf_available(self):
+        engine, cps_db = self._make_engine_with_listener()
+        with engine.connect() as conn:
+            result = conn.execute(sa.text("SELECT uuid4() AS r")).scalar()
+        assert isinstance(result, str) and len(result) == 36 and result.count("-") == 4, (
+            f"uuid4() UDF should return a UUID string; got {result!r}"
+        )
+
+    def test_title_sort_with_no_config_strips_whitespace(self):
+        """When CalibreDB.config is None or has no regex, title_sort should
+        still work as a graceful identity-strip (no exception).
+        """
+        engine, cps_db = self._make_engine_with_listener()
+        prior_config = cps_db.CalibreDB.config
+        cps_db.CalibreDB.config = None
+        try:
+            with engine.connect() as conn:
+                result = conn.execute(
+                    sa.text("SELECT title_sort('  Hello World  ') AS r")
+                ).scalar()
+            assert result == "Hello World", (
+                f"title_sort with no config should strip whitespace; got {result!r}"
+            )
+        finally:
+            cps_db.CalibreDB.config = prior_config
+
+    def test_title_sort_uses_live_config_regex(self):
+        """Updating CalibreDB.config.config_title_regex at runtime should
+        affect the next title_sort call (closure reads config at call time).
+        """
+        engine, cps_db = self._make_engine_with_listener()
+        prior_config = cps_db.CalibreDB.config
+        # Calibre's default title-sort regex: move leading 'The '/'A '/'An '
+        # to the end as ", The".
+        cps_db.CalibreDB.config = SimpleNamespace(
+            config_title_regex=r"^(A|The|An)\s+"
+        )
+        try:
+            with engine.connect() as conn:
+                result = conn.execute(
+                    sa.text("SELECT title_sort('The Republic') AS r")
+                ).scalar()
+            assert result == "Republic, The", (
+                f"title_sort('The Republic') should resort to 'Republic, The'; got {result!r}"
+            )
+
+            # Now change the regex — next call should use the new regex.
+            cps_db.CalibreDB.config = SimpleNamespace(
+                config_title_regex=r"^(Doctor)\s+"
+            )
+            with engine.connect() as conn:
+                result = conn.execute(
+                    sa.text("SELECT title_sort('Doctor Sleep') AS r")
+                ).scalar()
+            assert result == "Sleep, Doctor", (
+                f"title_sort after config swap should use new regex; got {result!r}"
+            )
+        finally:
+            cps_db.CalibreDB.config = prior_config
+
+    def test_title_sort_handles_none_input(self):
+        engine, cps_db = self._make_engine_with_listener()
+        with engine.connect() as conn:
+            result = conn.execute(sa.text("SELECT title_sort(NULL) AS r")).scalar()
+        assert result == "", (
+            f"title_sort(NULL) should return empty string, not crash; got {result!r}"
+        )
+
+    def test_title_sort_handles_malformed_regex_gracefully(self):
+        """If a future config update lands an invalid regex (typo), title_sort
+        should not raise — just fall back to strip_whitespaces. Otherwise
+        every query using title_sort breaks until the admin fixes the regex.
+        """
+        engine, cps_db = self._make_engine_with_listener()
+        prior_config = cps_db.CalibreDB.config
+        cps_db.CalibreDB.config = SimpleNamespace(
+            config_title_regex=r"(unclosed["
+        )
+        try:
+            with engine.connect() as conn:
+                result = conn.execute(
+                    sa.text("SELECT title_sort('  Some Title  ') AS r")
+                ).scalar()
+            assert result == "Some Title", (
+                f"title_sort with malformed regex should degrade gracefully; got {result!r}"
+            )
+        finally:
+            cps_db.CalibreDB.config = prior_config
+
+
+@pytest.mark.unit
+class TestConcurrentLowerQueriesNoDeadlock:
+    """Smoke test: many threads run SELECT lower(...) on the shared StaticPool
+    connection concurrently, all complete within a generous timeout.
+
+    NOTE: This does NOT prove the deadlock is gone — proving absence of a race
+    is impossible. But it exercises the hot path the fix targets, and would
+    fail if the listener didn't register correctly (e.g. some threads would
+    OperationalError on 'no such function: lower').
+    """
+
+    def _make_engine(self):
+        import sys
+        scripts_dir = REPO_ROOT / "scripts"
+        if str(scripts_dir) not in sys.path:
+            sys.path.insert(0, str(scripts_dir))
+        from cps import db as cps_db
+
+        engine = sa.create_engine(
+            "sqlite://",
+            poolclass=StaticPool,
+            connect_args={"check_same_thread": False, "timeout": 30},
+        )
+        sa.event.listen(engine, "connect", cps_db._register_sqlite_udfs)
+        return engine
+
+    def test_32_concurrent_lower_queries_all_succeed(self):
+        engine = self._make_engine()
+        errors = []
+        results = []
+        barrier = threading.Barrier(32)
+
+        def worker(i):
+            try:
+                barrier.wait(timeout=5)
+                with engine.connect() as conn:
+                    r = conn.execute(
+                        sa.text(f"SELECT lower('THREAD{i}') AS r")
+                    ).scalar()
+                    results.append(r)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(32)]
+        t0 = time.monotonic()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+        elapsed = time.monotonic() - t0
+
+        assert not errors, f"errors during concurrent lower(): {errors[:5]}"
+        assert len(results) == 32, f"expected 32 results, got {len(results)}"
+        assert all(r.startswith("thread") for r in results), (
+            f"some results did not lowercase: {results[:5]}"
+        )
+        assert elapsed < 30, (
+            f"concurrent queries took {elapsed:.1f}s — possible deadlock or "
+            f"unexpected contention"
+        )
+
+    def test_concurrent_lower_and_title_sort(self):
+        """Mix of lower() and title_sort() queries — the two most common UDFs."""
+        import sys
+        scripts_dir = REPO_ROOT / "scripts"
+        if str(scripts_dir) not in sys.path:
+            sys.path.insert(0, str(scripts_dir))
+        from cps import db as cps_db
+
+        engine = self._make_engine()
+        prior_config = cps_db.CalibreDB.config
+        cps_db.CalibreDB.config = SimpleNamespace(
+            config_title_regex=r"^(A|The|An)\s+"
+        )
+        try:
+            errors = []
+            results = []
+            barrier = threading.Barrier(16)
+
+            def lower_worker(i):
+                try:
+                    barrier.wait(timeout=5)
+                    with engine.connect() as conn:
+                        r = conn.execute(
+                            sa.text(f"SELECT lower('MIX{i}') AS r")
+                        ).scalar()
+                        results.append(("lower", r))
+                except Exception as e:
+                    errors.append(e)
+
+            def title_sort_worker(i):
+                try:
+                    barrier.wait(timeout=5)
+                    with engine.connect() as conn:
+                        r = conn.execute(
+                            sa.text(f"SELECT title_sort('The Title {i}') AS r")
+                        ).scalar()
+                        results.append(("title_sort", r))
+                except Exception as e:
+                    errors.append(e)
+
+            threads = [threading.Thread(target=lower_worker, args=(i,)) for i in range(8)] + \
+                      [threading.Thread(target=title_sort_worker, args=(i,)) for i in range(8)]
+            t0 = time.monotonic()
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=30)
+            elapsed = time.monotonic() - t0
+
+            assert not errors, f"errors during mixed UDF workload: {errors[:5]}"
+            assert len(results) == 16, f"expected 16 results, got {len(results)}"
+            assert elapsed < 30, (
+                f"mixed UDF concurrent queries took {elapsed:.1f}s — possible deadlock"
+            )
+        finally:
+            cps_db.CalibreDB.config = prior_config
+
+
+@pytest.mark.unit
+class TestCreateFunctionsBackwardsCompatShim:
+    """The public create_functions(self, config=None) method is preserved as
+    a no-op so any external caller (downstream plugin, tests) doesn't break.
+    But it should now also propagate config — the legacy intent was 'register
+    UDFs with this config's regex'.
+    """
+
+    def test_create_functions_is_a_noop_that_updates_config(self):
+        import sys
+        scripts_dir = REPO_ROOT / "scripts"
+        if str(scripts_dir) not in sys.path:
+            sys.path.insert(0, str(scripts_dir))
+        from cps import db as cps_db
+
+        prior_config = cps_db.CalibreDB.config
+        try:
+            cps_db.CalibreDB.config = None
+
+            class _FakeDB:
+                pass
+
+            fake_config = SimpleNamespace(
+                config_title_regex=r"^(The)\s+"
+            )
+            # Call create_functions via an instance — it should propagate
+            # config to CalibreDB.config without touching the connection.
+            cps_db.CalibreDB.create_functions(_FakeDB(), fake_config)
+            assert cps_db.CalibreDB.config is fake_config, (
+                "create_functions(config=X) should propagate X to CalibreDB.config "
+                "so the title_sort closure picks it up on next invocation"
+            )
+
+            # Calling with None should not clobber a previously-set config.
+            cps_db.CalibreDB.create_functions(_FakeDB())
+            assert cps_db.CalibreDB.config is fake_config
+        finally:
+            cps_db.CalibreDB.config = prior_config

--- a/tests/unit/test_sqlite_udf_registration_listener.py
+++ b/tests/unit/test_sqlite_udf_registration_listener.py
@@ -405,39 +405,77 @@ class TestConcurrentLowerQueriesNoDeadlock:
 
 @pytest.mark.unit
 class TestCreateFunctionsBackwardsCompatShim:
-    """The public create_functions(self, config=None) method is preserved as
-    a no-op so any external caller (downstream plugin, tests) doesn't break.
-    But it should now also propagate config — the legacy intent was 'register
-    UDFs with this config's regex'.
+    """The public ``create_functions(self, config=None)`` method is preserved
+    as a no-op so any external caller (downstream plugin, tests) doesn't
+    break. The contract: the method exists, accepts ``(self, config=None)``,
+    is callable without error, and does NOT raise — it must not touch
+    ``self.session`` or call ``conn.create_function`` anymore (those would
+    re-introduce the deadlock vector this PR closes).
     """
 
-    def test_create_functions_is_a_noop_that_updates_config(self):
+    def test_shim_method_exists_with_compatible_signature(self):
         import sys
         scripts_dir = REPO_ROOT / "scripts"
         if str(scripts_dir) not in sys.path:
             sys.path.insert(0, str(scripts_dir))
         from cps import db as cps_db
+        import inspect
 
-        prior_config = cps_db.CalibreDB.config
-        try:
-            cps_db.CalibreDB.config = None
+        sig = inspect.signature(cps_db.CalibreDB.create_functions)
+        params = list(sig.parameters.values())
+        assert len(params) == 2, (
+            f"expected (self, config=None); got {len(params)} params"
+        )
+        assert params[0].name == "self"
+        assert params[1].name == "config"
+        assert params[1].default is None, (
+            "config parameter must default to None for backward compat"
+        )
 
-            class _FakeDB:
-                pass
+    def test_shim_source_does_not_call_create_function(self):
+        """The shim must not call ``conn.create_function`` — that's the
+        deadlock vector this PR closes. Source-pin via AST.
+        """
+        import ast
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "create_functions":
+                for sub in ast.walk(node):
+                    if (
+                        isinstance(sub, ast.Call)
+                        and isinstance(sub.func, ast.Attribute)
+                        and sub.func.attr == "create_function"
+                    ):
+                        pytest.fail(
+                            "create_functions shim must not call "
+                            "conn.create_function — UDFs are registered "
+                            "by the engine connect listener"
+                        )
+                return
+        pytest.fail("create_functions method not found in cps/db.py")
 
-            fake_config = SimpleNamespace(
-                config_title_regex=r"^(The)\s+"
-            )
-            # Call create_functions via an instance — it should propagate
-            # config to CalibreDB.config without touching the connection.
-            cps_db.CalibreDB.create_functions(_FakeDB(), fake_config)
-            assert cps_db.CalibreDB.config is fake_config, (
-                "create_functions(config=X) should propagate X to CalibreDB.config "
-                "so the title_sort closure picks it up on next invocation"
-            )
-
-            # Calling with None should not clobber a previously-set config.
-            cps_db.CalibreDB.create_functions(_FakeDB())
-            assert cps_db.CalibreDB.config is fake_config
-        finally:
-            cps_db.CalibreDB.config = prior_config
+    def test_shim_source_does_not_touch_self_session(self):
+        """The shim must not touch ``self.session`` — that was the old
+        path that obtained the connection to register UDFs. The new model
+        registers via the engine event listener at connection time.
+        """
+        import ast
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "create_functions":
+                for sub in ast.walk(node):
+                    if (
+                        isinstance(sub, ast.Attribute)
+                        and sub.attr == "session"
+                        and isinstance(sub.value, ast.Name)
+                        and sub.value.id == "self"
+                    ):
+                        pytest.fail(
+                            "create_functions shim must not access "
+                            "self.session — the no-op shim must not touch "
+                            "the connection"
+                        )
+                return
+        pytest.fail("create_functions method not found")


### PR DESCRIPTION
## Symptom

v4.0.65 reverted the duplicate-scan debounce default 5 → 30 to make the GIL+SQLite deadlock pattern from CWA #1256 less *frequent*. The underlying race was still reachable: every request to `/get_matching_tags`, `/search`, the edit-book routes, the admin config-save route, and `set_read_status` re-registered `lower`/`uuid4`/`title_sort` via `conn.create_function(...)` mid-request. With `StaticPool` sharing a single connection across all threads, that call held the GIL while a concurrent worker thread mid-`func.lower` query waited for the GIL to invoke the registered UDF. Deadlock.

## Root cause

`conn.create_function(name, narg, fn)` cannot run concurrently with another thread executing SQL that invokes a Python UDF *on the same connection* — both need the GIL and the SQLite-connection mutex. The pre-fix code called `create_functions` on every request-handler hot path, putting the race in the foreground.

## Fix

- New module-level `_register_sqlite_udfs(dbapi_connection, _connection_record)` in `cps/db.py` registers `lower`/`uuid4`/`title_sort` once when SQLAlchemy opens a SQLite connection.
- Wired via `event.listen(engine, "connect", _register_sqlite_udfs)` on both the validation engine (`check_valid_db`) and the main engine (`setup_db`).
- `title_sort` reads `CalibreDB.config.config_title_regex` via closure at call time, so admin updates to the regex take effect on the next title_sort call without re-registration. The admin route now calls `CalibreDB.update_config(config)` instead.
- Removed `create_functions` calls from: `init_session` + 3 internal db.py hot paths (`get_typeahead`, `check_exists_book`, `search_query`) + 6 request-handler callsites (`cps/web.py:get_matching_tags`, `cps/editbooks.py` ×2, `cps/admin.py:912`, `cps/helper.py:364`, `cps/search.py:250`).
- `create_functions(self, config=None)` preserved as a backward-compat no-op shim that updates `CalibreDB.config` (preserving the legacy intent for any external caller).
- `title_sort` hardened: returns `''` on `NULL`, falls back to `strip_whitespaces` on malformed regex, never raises.

## Verification

- ✅ **29 new regression tests** across `tests/unit/test_sqlite_udf_registration_listener.py` (15) and `tests/unit/test_duplicate_debounce_migration_edge_cases.py` (14):
  - Source-pin: zero `create_functions` callsites in the 5 request-handler modules + 3 internal db.py hot paths + `init_session`.
  - Source-pin: `event.listen(...)` wired on both `cls.engine` and `check_engine`.
  - Behavioural: fresh engine + listener serves `SELECT lower('FOO')` without explicit registration.
  - Behavioural: `title_sort` adapts to runtime config changes (closure reads live config).
  - Behavioural: `title_sort(NULL)` → `''`, malformed regex → graceful strip.
  - Concurrency smoke: 32 concurrent `lower(...)` queries + 16 mixed `lower/title_sort` queries on the shared StaticPool connection — all succeed within 30s.
  - Migration edge cases: only EXACT 5 migrates (0/1/2/3/4/6/7/10/25/31/100 all preserved); empty table doesn't crash; marker write failure does NOT block SQL bump; 2 concurrent CWA_DB constructors converge to 30; init order pinned (set_defaults → migrate → get_settings).
- ✅ **82/82 unit tests pass** across all related suites (listener + migration + debounce-default + cwa_db + duplicate-manager-race + duplicates-timezone + calibre_init).
- ✅ **Live container test** (`cwng-udf-verify` on ghcr.io/new-usemame/calibre-web-nextgen:v4.0.65 with Approach B applied via `docker cp`):
  - Container healthy in 6s after restart.
  - Triggered duplicate-scan via `/cwa-internal/queue-duplicate-scan` (delay=10s).
  - Hammered `/get_matching_tags` with 50 concurrent requests during the active scan window: all 50 returned HTTP 200 in 1 second total.
  - Log scan during stress: cwa-duplicates SQL prefilter ran cleanly, no "database is locked", no "no such function", no traceback (beyond pre-existing xdg-desktop-menu noise from the calibre install path, unrelated).

## Why this is the right fix vs. just bumping the debounce

v4.0.65 (debounce 5→30 + clamp 10) makes the collision less likely, but does not eliminate the race. Approach B (this PR) eliminates the race **structurally** — there is no longer any production code path that calls `conn.create_function()` on a hot path. UDFs are registered when SQLAlchemy opens the connection and persist for its lifetime; request handlers cannot collide with worker threads over function-registration because they no longer register anything.

## Confidence

98% — the deadlock vector is structurally absent. Residual risk is in the no-op shim semantics: any external caller that depended on `create_functions` *re-registering* a UDF (i.e. forcing a refresh) will silently no-op. Calibre's `config_title_regex` admin path is handled (via `CalibreDB.update_config`); no other production caller does this.

## Follow-ups (v2-track)

- Evaluate backport of CWA PR #1349 (defer post-import work until ingest batch settles) — bounded but large; cycle of its own.
- Evaluate backport of CWA PR #1353 (incremental duplicate index, full schema migration) — feature-scoped, its own cycle.

Builds on #210 (v4.0.65).