### PR TITLE
Backport janeczku #3624: serve_book defense-in-depth response headers

### DIFF
--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -161,6 +161,7 @@ CWA detached from the original Calibre-Web upstream (`janeczku/calibre-web`) at 
 | `01649f8e` | [`4c1d7a9f`](https://github.com/janeczku/calibre-web/commit/4c1d7a9f) | @jvoisin | Shelf reorder POST now requires edit permission, not just view permission |
 | `b716b0bd` | [`94899056`](https://github.com/janeczku/calibre-web/commit/94899056) | upstream | `chmod 0600` on freshly generated `.key` Fernet key file |
 | `119e591c` | [`fd744af7`](https://github.com/janeczku/calibre-web/commit/fd744af7) | @jvoisin | 500 page: log the full traceback server-side, but only render it to authenticated admins |
+| `TBD` | [`c784149d`](https://github.com/janeczku/calibre-web/commit/c784149d) (upstream PR [#3624](https://github.com/janeczku/calibre-web/pull/3624)) | @jvoisin | `serve_book` defense-in-depth: set `Content-Disposition: inline`, `X-Content-Type-Options: nosniff`, and `Content-Security-Policy: script-src 'none'; object-src 'none'` on the PDF/generic response built from `send_from_directory`, so the browser cannot MIME-sniff book content into an executable type or run inline scripts when rendering inline. |
 
 `fixes/fix_kobo` (Kobo IDOR on `generate_auth_token` / `deleteauthtoken`) was independently fixed in our PR #18 (`9f50bb2`); upstream and fork landed on identical guards.
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -2034,6 +2034,9 @@ def serve_book(book_id, book_format, anyname):
         # enable byte range read of pdf
         response = make_response(
             send_from_directory(os.path.join(config.get_book_path(), book.path), data.name + "." + book_format))
+        response.headers['Content-Disposition'] = 'inline'
+        response.headers['X-Content-Type-Options'] = 'nosniff'
+        response.headers['Content-Security-Policy'] = "script-src 'none'; object-src 'none'"
         if not range_header:
             log.info('Serving book: %s', data.name)
             response.headers['Accept-Ranges'] = 'bytes'

--- a/tests/unit/test_serve_book_security_headers.py
+++ b/tests/unit/test_serve_book_security_headers.py
@@ -1,0 +1,92 @@
+# Calibre-Web Automated - fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression test for janeczku/calibre-web PR #3624 (jvoisin):
+serve_book() must set three defense-in-depth response headers on the
+send_from_directory path so book content cannot be MIME-sniffed into an
+executable type or run inline scripts when rendered by the browser.
+
+Source-pin test: parses cps/web.py and walks the serve_book AST to
+confirm the three header assignments are present. A regression that
+silently drops any of these headers fails this test.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+WEB_PY = REPO_ROOT / "cps" / "web.py"
+
+REQUIRED_HEADERS = {
+    "Content-Disposition": "inline",
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": "script-src 'none'; object-src 'none'",
+}
+
+
+def _serve_book_func():
+    tree = ast.parse(WEB_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "serve_book":
+            return node
+    raise AssertionError("serve_book() not found in cps/web.py")
+
+
+def _collect_header_assignments(func_node):
+    """Yield (header_name, header_value_or_None) for every
+    `response.headers['Header'] = value` in serve_book's body."""
+    for node in ast.walk(func_node):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if not isinstance(target, ast.Subscript):
+                continue
+            sub_value = target.value
+            if not (isinstance(sub_value, ast.Attribute) and sub_value.attr == "headers"):
+                continue
+            key_node = target.slice
+            if isinstance(key_node, ast.Constant) and isinstance(key_node.value, str):
+                val = node.value.value if isinstance(node.value, ast.Constant) else None
+                yield key_node.value, val
+
+
+@pytest.mark.unit
+class TestServeBookSecurityHeaders:
+    def test_all_three_security_headers_present(self):
+        func = _serve_book_func()
+        seen = {h for h, _ in _collect_header_assignments(func)}
+        missing = set(REQUIRED_HEADERS) - seen
+        assert not missing, (
+            f"serve_book() is missing security headers: {sorted(missing)}. "
+            "Backport from janeczku/calibre-web PR #3624 (jvoisin) requires "
+            "Content-Disposition, X-Content-Type-Options, Content-Security-Policy."
+        )
+
+    @pytest.mark.parametrize("header,expected", sorted(REQUIRED_HEADERS.items()))
+    def test_header_value_matches_upstream(self, header, expected):
+        func = _serve_book_func()
+        assignments = dict(_collect_header_assignments(func))
+        assert assignments.get(header) == expected, (
+            f"serve_book() sets {header!r} to {assignments.get(header)!r}, "
+            f"expected {expected!r} per janeczku/calibre-web PR #3624."
+        )
+
+    def test_headers_attached_to_send_from_directory_response(self):
+        """The headers must live on the PDF/generic path that uses
+        send_from_directory, not on the EPUB-repair or TXT paths."""
+        func_source = ast.get_source_segment(
+            WEB_PY.read_text(encoding="utf-8"), _serve_book_func()
+        )
+        idx_send_from_dir = func_source.find("send_from_directory(")
+        idx_csp = func_source.find("Content-Security-Policy")
+        assert idx_send_from_dir > 0, "send_from_directory call missing in serve_book()"
+        assert idx_csp > idx_send_from_dir, (
+            "Content-Security-Policy header must be set on the response built "
+            "from send_from_directory() inside serve_book(); it appears earlier instead."
+        )


### PR DESCRIPTION
Backport of [`janeczku/calibre-web#3624`](https://github.com/janeczku/calibre-web/pull/3624) by **@jvoisin** (commit [`c784149d`](https://github.com/janeczku/calibre-web/commit/c784149d)).

## Why

`serve_book` returns the raw book file at `/show/<book_id>/<book_format>`. The response had no MIME-sniffing protection, no CSP, and no Content-Disposition hint, which means a hostile book payload could be (a) sniffed into an executable MIME type by older browsers, or (b) execute embedded `<script>` tags if the browser renders the response inline (e.g. a malformed PDF/HTML hybrid). This is defense-in-depth — there is no known exploit shipped against Calibre-Web users, but the headers cost nothing and close a class of attacks.

Upstream has been sitting open ~31 days waiting for janeczku's next release.

## Change

Adds three headers to the `send_from_directory` PDF/generic response path in `cps/web.py:serve_book`:

```
Content-Disposition: inline
X-Content-Type-Options: nosniff
Content-Security-Policy: script-src 'none'; object-src 'none'
```

This is the exact set @jvoisin patched upstream. We only patch the `send_from_directory` path so the change is byte-for-byte the same as the upstream commit. The EPUB-repair and TXT response paths inside `serve_book` are CWA additions and could receive the same hardening as a follow-up.

## Tests

`tests/unit/test_serve_book_security_headers.py` (5 tests) pins:
- All three header keys are present on a `response.headers[...] = ...` assignment inside `serve_book`.
- Each header value matches the upstream string exactly (parametrized).
- The CSP header appears AFTER the `send_from_directory(` call inside the function body, so a future edit that moves the headers onto a different (e.g. EPUB-repair) path would fail the position check.

All five pass under `repo/.venv` / `pytest -v`.

## Tier

`safe-tier-2` — single file, 3 LOC pure addition, no auth/csrf/session/admin/migration surface. No new behavior; only response headers.

## Verification gate

- [x] Research-first: read upstream PR, diff, comment thread (none), commit author (jvoisin)
- [x] Map symptom to code: `cps/web.py:serve_book` near `send_from_directory`
- [x] Reproduce: trivial — the upstream patch is identical to what we ship
- [x] Regression test written + green (5 tests)
- [x] Source-pin matches upstream string exactly
- [x] Existing test suite: not run against full file (heavy Flask init not needed for this scope)

## Credit

Original patch: @jvoisin in [janeczku/calibre-web#3624](https://github.com/janeczku/calibre-web/pull/3624).