### PR TITLE
fix(kobo): emit tombstones for unknown tags + advance cursor past shelf-add

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -319,6 +319,23 @@ def HandleSyncRequest():
             book.Books.last_modified.replace(tzinfo=None), new_books_last_modified
         )
 
+        # Also advance the cursor by BookShelf.date_added when the row
+        # carries one (only_kobo_shelves branch selects it on line ~242).
+        # The filter at line ~258-261 matches a book when EITHER
+        # Books.last_modified OR BookShelf.date_added is past the
+        # cursor. Without this max() the cursor only tracks
+        # last_modified, so a book added to a kobo_sync shelf after its
+        # own last_modified re-matches every sync and traps the device
+        # in an infinite cont_sync loop (fork #220 — wire-confirmed
+        # 112 syncs in 60s during the 2026-05-17 MITM capture). Guard
+        # with getattr because the else branch's SELECT does not
+        # include date_added.
+        date_added = getattr(book, "date_added", None)
+        if date_added is not None:
+            if hasattr(date_added, "replace") and getattr(date_added, "tzinfo", None) is not None:
+                date_added = date_added.replace(tzinfo=None)
+            new_books_last_modified = max(date_added, new_books_last_modified)
+
         new_books_last_created = max(ts_created, new_books_last_created)
         kobo_sync_status.add_synced_books(book.Books.id)
 
@@ -371,28 +388,43 @@ def HandleSyncRequest():
 
     sync_shelves(sync_token, sync_results, only_kobo_shelves)
 
-    # Add magic shelves as collections
+    # Always emit DeletedTags for magic shelves that should NOT be on
+    # the device — covers two distinct cases:
+    #   (a) per-shelf kobo_sync flag was just flipped to False (user
+    #       toggled a specific magic shelf off in the UI), or
+    #   (b) global config_kobo_sync_magic_shelves flag was flipped off
+    #       (admin disabled the whole feature). In case (b) every
+    #       magic shelf the user owns needs a tombstone, even ones
+    #       still marked kobo_sync=True, because the device may have
+    #       synced them while the global flag was on.
+    # Without this, toggling either flag off leaves orphan magic-shelf
+    # entries on previously-synced devices that retry DELETE forever
+    # (B1 retry loop). Wire-confirmed against the live
+    # "Test_E2E_Discovered" magic-shelf during the 2026-05-17 capture.
+    deletable_magic_shelves = ub.session.query(ub.MagicShelf).filter_by(
+        user_id=current_user.id,
+    )
     if config.config_kobo_sync_magic_shelves:
-
-        for shelf in ub.session.query(ub.MagicShelf)\
-            .filter_by(user_id=current_user.id, kobo_sync=False)\
-            .all():
-
-            sync_results.append({
-                "DeletedTag": {
-                    "Tag": {
-                        "Id": shelf.uuid,
-                        "LastModified": convert_to_kobo_timestamp_string(shelf.last_modified)
-                    }
+        deletable_magic_shelves = deletable_magic_shelves.filter_by(kobo_sync=False)
+    # else: global flag off, emit DeletedTag for all magic shelves
+    for shelf in deletable_magic_shelves.all():
+        sync_results.append({
+            "DeletedTag": {
+                "Tag": {
+                    "Id": shelf.uuid,
+                    "LastModified": convert_to_kobo_timestamp_string(shelf.last_modified)
                 }
-            })
+            }
+        })
 
+    # Add magic shelves as collections (only when feature is enabled)
+    if config.config_kobo_sync_magic_shelves:
         magic_shelves = ub.session.query(ub.MagicShelf)\
             .filter_by(user_id=current_user.id, kobo_sync=True)\
             .all()
 
         new_tags_last_modified = sync_token.tags_last_modified
-            
+
         for shelf in magic_shelves:
             books, _ = magic_shelf.get_books_for_magic_shelf(
                 shelf.id, page=1, page_size=None
@@ -727,11 +759,19 @@ def HandleTagUpdate(tag_id):
     shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.uuid == tag_id,
                                               ub.Shelf.user_id == current_user.id).one_or_none()
     if not shelf:
-        log.debug("Received Kobo tag update request on a collection unknown to CalibreWeb")
-        if config.config_kobo_proxy:
-            return redirect_or_proxy_request()
-        else:
-            abort(404, description="Collection isn't known to CalibreWeb")
+        # Device-trailing: the shelf is unknown to CalibreWeb because it
+        # was deleted server-side (or was a magic-shelf that no longer
+        # syncs). The device only sees the absence; without a tombstone
+        # in the sync response it pushes DELETE here every sync. Answering
+        # 404 makes the device interpret the failure as transient and
+        # retry forever, burning bandwidth indefinitely. Match the
+        # HandleStateRequest pattern (line ~989) and
+        # redirect_or_proxy_request() unconditionally so the loop ends,
+        # regardless of config_kobo_proxy.
+        log.debug("Received Kobo tag update for unknown collection %s — "
+                  "answering via redirect_or_proxy_request to terminate "
+                  "the device's retry loop", tag_id)
+        return redirect_or_proxy_request()
 
     if request.method == "DELETE":
         if not shelf_lib.delete_shelf_helper(shelf):
@@ -825,9 +865,16 @@ def HandleTagRemoveItem(tag_id):
     shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.uuid == tag_id,
                                               ub.Shelf.user_id == current_user.id).one_or_none()
     if not shelf:
+        # Same device-trailing pattern as HandleTagUpdate: the shelf
+        # vanished server-side between syncs but the device still
+        # thinks it exists and is now trying to remove an item from it.
+        # Answering 404 traps the device in a retry loop. Mirror the
+        # HandleStateRequest pattern and redirect_or_proxy_request().
         log.debug(
-            "Received a request to remove an item from a Collection unknown to CalibreWeb.")
-        abort(404, description="Collection isn't known to CalibreWeb")
+            "Received Kobo tag-remove-item for unknown collection %s — "
+            "answering via redirect_or_proxy_request to terminate "
+            "the device's retry loop", tag_id)
+        return redirect_or_proxy_request()
 
     if not shelf_lib.check_shelf_edit_permissions(shelf):
         abort(401, description="User is unauthaurized to edit shelf.")

--- a/tests/unit/test_kobo_bug_cluster_2026_05_17.py
+++ b/tests/unit/test_kobo_bug_cluster_2026_05_17.py
@@ -1,0 +1,398 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for the Kobo bug cluster surfaced by the 2026-05-17
+MITM capture against a real Libra Colour FW 4.45.23684.
+
+Three bugs share a common anti-pattern: the sync contract emits
+ABSENCES from a sync response instead of TOMBSTONES, and a sibling
+handler answers unknown items with abort(404) instead of the
+"shut up the retry loop" redirect_or_proxy_request() pattern.
+
+B1 — Ghost-shelf 404 retry loop. cps/kobo.py:HandleTagUpdate
+abort(404)s when the shelf is unknown unless config_kobo_proxy is on,
+which causes the device to retry DELETE forever (≥6 retries per
+sync, observed in the capture).
+
+B2 — Two-axis cursor latent fork #220 loop. cps/kobo.py:HandleSyncRequest
+filters books by (BookShelf.date_added > books_last_modified) OR
+(Books.last_modified > books_last_modified), but only advances the
+cursor by Books.last_modified. A book added to a kobo_sync shelf
+after its own last_modified will re-match every sync forever, with
+the server emitting "x-kobo-sync: continue" as the trap signal.
+Wire-verified 112 syncs in 60s against the live instance during the
+capture session.
+
+B4 — Magic-shelf orphan after server-side toggle off. The DeletedTag
+emission for magic shelves is wholly nested under "if
+config.config_kobo_sync_magic_shelves:". When admin flips the global
+flag off, previously-synced magic shelves stay on the device forever.
+"""
+
+import inspect
+from datetime import datetime, timedelta
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# B1 — HandleTagUpdate must terminate the retry loop on unknown shelf
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestB1HandleTagUpdateTerminatesRetryLoop:
+    """Source-pinned: HandleTagUpdate must not abort(404) when the shelf
+    is unknown — the device interprets 404 as transient and retries
+    forever. The pattern from HandleStateRequest (line 988-989) is the
+    canonical fix: redirect_or_proxy_request() unconditionally."""
+
+    def test_does_not_abort_404_on_unknown_shelf(self):
+        from cps.kobo import HandleTagUpdate
+        src = inspect.getsource(HandleTagUpdate)
+        assert "abort(404" not in src, (
+            "HandleTagUpdate must not abort(404) when the shelf is "
+            "unknown. The Kobo device interprets 404 as transient and "
+            "retries DELETE every sync forever. Use "
+            "redirect_or_proxy_request() to terminate the loop, "
+            "matching HandleStateRequest's pattern."
+        )
+
+    def test_calls_redirect_or_proxy_request_unconditionally(self):
+        from cps.kobo import HandleTagUpdate
+        src = inspect.getsource(HandleTagUpdate)
+        assert "redirect_or_proxy_request()" in src, (
+            "HandleTagUpdate must call redirect_or_proxy_request() in "
+            "the unknown-shelf branch so the device's DELETE retry "
+            "loop terminates."
+        )
+
+    def test_no_config_kobo_proxy_gate_on_unknown_shelf(self):
+        """The fix removes the `if config.config_kobo_proxy: ... else:
+        abort(404)` asymmetry so the loop terminates regardless of
+        the proxy setting."""
+        from cps.kobo import HandleTagUpdate
+        src = inspect.getsource(HandleTagUpdate)
+        # The shape we don't want is the unknown-shelf branch wrapped
+        # in `if config.config_kobo_proxy:` — that's the bug shape.
+        assert "if config.config_kobo_proxy" not in src.split("def HandleTagUpdate")[1].split("if request.method")[0], (
+            "The unknown-shelf branch must not gate "
+            "redirect_or_proxy_request() behind config_kobo_proxy. "
+            "Either way (proxy on or off) the device's retry loop "
+            "needs to terminate."
+        )
+
+
+@pytest.mark.unit
+class TestB1HandleTagRemoveItemTerminatesRetryLoop:
+    """Cross-cutting sweep: HandleTagRemoveItem shares the same
+    abort(404) anti-pattern. If a shelf disappeared between syncs, the
+    device's POST to /items/delete on the stale shelf id would 404 and
+    likely retry. Apply the same fix."""
+
+    def test_does_not_abort_404_on_unknown_shelf(self):
+        from cps.kobo import HandleTagRemoveItem
+        src = inspect.getsource(HandleTagRemoveItem)
+        assert "abort(404" not in src, (
+            "HandleTagRemoveItem must not abort(404) when the shelf is "
+            "unknown — the device-trailing pattern is to "
+            "redirect_or_proxy_request() so the retry loop terminates."
+        )
+
+
+# ---------------------------------------------------------------------------
+# B2 — HandleSyncRequest cursor must advance past BookShelf.date_added
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestB2CursorAdvancePastShelfAdd:
+    """Source-pinned: when iterating matched books in HandleSyncRequest,
+    the new_books_last_modified watermark must advance past
+    book.date_added, not only book.Books.last_modified.
+
+    Wire-verified live: 112 syncs in 60s, 436KB wasted per minute,
+    x-kobo-sync: continue every time."""
+
+    def test_cursor_advance_reads_date_added(self):
+        from cps.kobo import HandleSyncRequest
+        src = inspect.getsource(HandleSyncRequest)
+        # We want SOME reference to date_added in the cursor advance
+        # block. Tolerate either explicit `book.date_added` access or
+        # getattr-with-default pattern.
+        assert (
+            "book.date_added" in src
+            or "getattr(book, 'date_added'" in src
+            or 'getattr(book, "date_added"' in src
+        ), (
+            "HandleSyncRequest's cursor advance must read book.date_added "
+            "(the BookShelf.date_added selected at the top of the "
+            "only_kobo_shelves branch) and roll new_books_last_modified "
+            "forward by it. Without this, a book added to a kobo_sync "
+            "shelf after its own last_modified will re-match every sync "
+            "and trigger fork #220's infinite cont_sync loop."
+        )
+
+    def test_cursor_advance_includes_date_added_in_max(self):
+        """Defense-in-depth: the date_added value must actually be max'd
+        into new_books_last_modified, not just read for logging."""
+        from cps.kobo import HandleSyncRequest
+        src = inspect.getsource(HandleSyncRequest)
+        # The fix shape: "new_books_last_modified = max(<something with date_added>, new_books_last_modified)"
+        # or any line that assigns to new_books_last_modified AND mentions date_added.
+        # Search for max() with date_added reference in the same statement.
+        lines = src.splitlines()
+        found = False
+        # Walk multi-line statements looking for any block that assigns
+        # new_books_last_modified and references date_added within ~5
+        # lines (handles multiline max() calls).
+        for i, line in enumerate(lines):
+            if "new_books_last_modified" in line and "=" in line:
+                window = "\n".join(lines[i:min(i + 6, len(lines))])
+                if "date_added" in window:
+                    found = True
+                    break
+        assert found, (
+            "Expected an assignment of the form "
+            "`new_books_last_modified = max(date_added, ...)` (or "
+            "equivalent multiline max() expression) so the cursor "
+            "actually rolls past the shelf-add timestamp."
+        )
+
+
+@pytest.mark.unit
+class TestB2CursorAdvanceBehavioral:
+    """Behavioral: simulate the iteration logic the fix changes, prove
+    cursor advances correctly past date_added even when last_modified
+    is older."""
+
+    def test_advance_past_shelf_add_when_book_lm_is_older(self):
+        """Reproduces the fork #220 condition exactly: book.last_modified
+        is OLDER than the cursor, but BookShelf.date_added is NEWER.
+        After processing, the cursor must include date_added so the
+        next sync doesn't re-match the same book."""
+        from types import SimpleNamespace
+
+        # Cursor at T0
+        cursor = datetime(2026, 5, 5, 21, 55, 47)
+        # Book modified before cursor — so on its own it wouldn't match
+        book_lm = datetime(2026, 5, 3, 12, 0, 0)
+        # But it was added to a kobo_sync shelf AFTER the cursor
+        shelf_add = datetime(2026, 5, 17, 15, 22, 31)
+
+        book_row = SimpleNamespace(
+            Books=SimpleNamespace(last_modified=book_lm),
+            date_added=shelf_add,
+            is_archived=False,
+        )
+
+        # The fix's cursor-advance shape — assert it lands on shelf_add,
+        # not book_lm or cursor.
+        new_books_last_modified = cursor
+        new_books_last_modified = max(
+            book_row.Books.last_modified, new_books_last_modified
+        )
+        # The fix line: also fold in date_added when present.
+        da = getattr(book_row, "date_added", None)
+        if da is not None:
+            if hasattr(da, "replace") and da.tzinfo is not None:
+                da = da.replace(tzinfo=None)
+            new_books_last_modified = max(da, new_books_last_modified)
+
+        assert new_books_last_modified == shelf_add, (
+            "Cursor must advance past BookShelf.date_added when "
+            "date_added is newer than both the cursor and the book's "
+            "last_modified. Without this, the same book re-matches "
+            "every sync forever (fork #220)."
+        )
+
+    def test_advance_unaffected_when_date_added_is_none(self):
+        """Cross-cutting: when only_kobo_shelves=False, the SELECT
+        does NOT include BookShelf.date_added, so the iteration row
+        has no `.date_added` attribute. getattr(..., None) must guard
+        the cursor-advance from raising AttributeError."""
+        from types import SimpleNamespace
+
+        cursor = datetime(2026, 1, 1, 0, 0, 0)
+        book_lm = datetime(2026, 5, 1, 0, 0, 0)
+
+        # Row WITHOUT date_added (simulates the else-branch SELECT shape)
+        book_row = SimpleNamespace(
+            Books=SimpleNamespace(last_modified=book_lm),
+            is_archived=False,
+        )
+
+        new_books_last_modified = cursor
+        new_books_last_modified = max(
+            book_row.Books.last_modified, new_books_last_modified
+        )
+        da = getattr(book_row, "date_added", None)
+        if da is not None:
+            new_books_last_modified = max(da, new_books_last_modified)
+
+        assert new_books_last_modified == book_lm, (
+            "When date_added is absent on the row, cursor advance "
+            "must not raise AttributeError and must fall back to "
+            "advancing by book.last_modified only."
+        )
+
+
+# ---------------------------------------------------------------------------
+# B4 — Magic-shelf DeletedTag emission must not be gated by global flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestB4MagicShelfDeletedTagAlwaysEmitted:
+    """Source-pinned: when admin flips config_kobo_sync_magic_shelves
+    from True to False, previously-synced magic shelves must still
+    receive DeletedTag tombstones so the device cleans up orphan tags.
+
+    The original code's "if config.config_kobo_sync_magic_shelves:"
+    block wholly skipped the DeletedTag emission when the flag was
+    off — leaving the device with orphan shelves it tried to delete
+    forever (via the B1 retry loop)."""
+
+    def test_deleted_tag_emission_for_magic_shelves_runs_when_flag_off(self):
+        """The fix shape: a deletable-magic-shelves query that runs
+        regardless of config_kobo_sync_magic_shelves, only restricting
+        which shelves get a DeletedTag based on the flag state."""
+        from cps.kobo import HandleSyncRequest
+        src = inspect.getsource(HandleSyncRequest)
+        # The bug shape was:
+        #     if config.config_kobo_sync_magic_shelves:
+        #         for shelf in query(MagicShelf).filter_by(kobo_sync=False):
+        #             sync_results.append({"DeletedTag": ...})
+        #         <new/changed tag emission>
+        # The fix should pull the DeletedTag block OUT of that guard.
+        # Look for a phrase indicating the fix.
+        assert (
+            "deletable_magic_shelves" in src
+            or "Always emit DeletedTags for magic" in src
+            or "even when" in src and "config_kobo_sync_magic_shelves" in src
+        ), (
+            "HandleSyncRequest must emit DeletedTag for orphan magic "
+            "shelves even when config_kobo_sync_magic_shelves is False. "
+            "Otherwise toggling the flag off leaves orphan tags on "
+            "previously-synced devices that the device tries to delete "
+            "forever (B1 retry loop)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# B2 + B4 — combined behavioral via direct call on a real SQLite stack
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kobo_sync_stack(tmp_path, monkeypatch):
+    """Minimal Flask app + ub-side DB + a stub current_user for testing
+    HandleSyncRequest indirectly via sync_shelves and the magic-shelf
+    emission block. We avoid the full app stack to keep the test fast
+    and hermetic."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker, scoped_session
+    from cps import ub
+
+    db_path = tmp_path / "ub.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    ub.Base.metadata.create_all(engine)
+    Session = scoped_session(sessionmaker(bind=engine, future=True))
+    session = Session()
+
+    # Patch ub.session so the module under test uses our test session.
+    monkeypatch.setattr(ub, "session", session, raising=False)
+
+    # Build a user
+    user = ub.User()
+    user.name = "kobouser"
+    user.email = "kobo@example.invalid"
+    user.kobo_only_shelves_sync = False
+    user.role = 0
+    user.locale = "en"
+    user.default_language = "all"
+    user.allowed_tags = ""
+    user.denied_tags = ""
+    user.allowed_column_value = ""
+    user.denied_column_value = ""
+    user.sidebar_view = 0
+    user.password = "x"
+    session.add(user)
+    session.commit()
+
+    yield {"session": session, "user": user, "Session": Session, "ub": ub}
+
+    Session.remove()
+
+
+@pytest.mark.unit
+class TestB4MagicShelfDeletedTagBehavioral:
+    """Behavioral: with a MagicShelf row and config flag OFF, the
+    sync response must emit a DeletedTag for that shelf."""
+
+    def test_deletedtag_emitted_when_flag_off(self, kobo_sync_stack, monkeypatch):
+        from datetime import datetime, timezone
+        import uuid
+
+        ub = kobo_sync_stack["ub"]
+        session = kobo_sync_stack["session"]
+        user = kobo_sync_stack["user"]
+
+        # Create a MagicShelf for this user
+        ms = ub.MagicShelf()
+        ms.user_id = user.id
+        ms.name = "Test_E2E_Discovered"
+        ms.uuid = str(uuid.uuid4())
+        ms.kobo_sync = True
+        ms.last_modified = datetime.now(timezone.utc)
+        ms.created = datetime.now(timezone.utc)
+        ms.rules = "[]"
+        ms.is_active = True
+        session.add(ms)
+        session.commit()
+
+        # Patch the config flag OFF — this is the orphan-trigger condition
+        from cps import config as cps_config
+        monkeypatch.setattr(cps_config, "config_kobo_sync_magic_shelves", False, raising=False)
+
+        # Patch current_user resolution
+        from cps import kobo as kobo_module
+
+        # Build a stub for current_user with .id
+        from types import SimpleNamespace
+        stub_user = SimpleNamespace(id=user.id, kobo_only_shelves_sync=False)
+        monkeypatch.setattr(kobo_module, "current_user", stub_user, raising=False)
+
+        # Now invoke the post-fix emission path. The fix lives inside
+        # HandleSyncRequest at the magic-shelf section. We approximate
+        # by directly invoking the deletable-magic-shelves query the
+        # fix should expose.
+        sync_results = []
+        deletable_query = ub.session.query(ub.MagicShelf).filter_by(user_id=user.id)
+        if cps_config.config_kobo_sync_magic_shelves:
+            deletable_query = deletable_query.filter_by(kobo_sync=False)
+
+        for shelf in deletable_query.all():
+            sync_results.append({
+                "DeletedTag": {
+                    "Tag": {
+                        "Id": shelf.uuid,
+                        "LastModified": shelf.last_modified.isoformat() if shelf.last_modified else None,
+                    }
+                }
+            })
+
+        assert len(sync_results) == 1, (
+            f"Expected exactly one DeletedTag for the orphan magic "
+            f"shelf when config flag is off; got {len(sync_results)} "
+            f"results: {sync_results}"
+        )
+        assert sync_results[0]["DeletedTag"]["Tag"]["Id"] == ms.uuid, (
+            "DeletedTag emitted for the wrong shelf UUID"
+        )


### PR DESCRIPTION
## Symptom

Three live-captured bugs from a 2026-05-17 MITM session against a real
Libra Colour FW 4.45.23684 paired to a CWNG instance. All share the
same anti-pattern: the sync contract emits ABSENCES instead of
TOMBSTONES, and sibling handlers reply 404 to unknown items — which
the device interprets as transient and retries forever.

| # | Symptom (plain-English) | Live evidence |
|---|---|---|
| **B1** | Device retries DELETE on shelves that no longer exist server-side, every sync forever (visible 404s in CWA logs, identical on every cycle) | Wire capture: 2 ghost shelf IDs hit on every sync, including the `Test_E2E_Discovered` shelf and a user-created shelf |
| **B2** | Adding a book to a Kobo-sync shelf causes the device to sync the same book in a loop, burning bandwidth indefinitely until the book's `last_modified` independently advances | Wire-confirmed live: 112 sync requests in 60 seconds, identical 4118-byte responses, ~436 KB/min wasted, `x-kobo-sync: continue` every cycle |
| **B4** | Toggling `config_kobo_sync_magic_shelves` off (or removing a magic shelf) leaves orphan shelf entries on previously-synced devices that the device tries to DELETE every sync (combines with B1 to amplify) | `Test_E2E_Discovered` magic-shelf orphan visible on device after server-side toggle off |

## Root cause

**B1**: `cps/kobo.py:HandleTagUpdate` (`/v1/library/tags/<id>` DELETE/PUT) and
`HandleTagRemoveItem` (`/v1/library/tags/<id>/items/delete` POST) both
`abort(404)` when the shelf is unknown. The sibling `HandleStateRequest`
(line ~989) documents the correct pattern with an explicit "device
retries forever and the user sees sync failures" comment — it uses
`redirect_or_proxy_request()` unconditionally. The tag handlers were
gated by `config_kobo_proxy` instead, so an all-local instance fell
into the 404 path.

**B2**: `HandleSyncRequest`'s filter at line ~258 matches a book when
EITHER `Books.last_modified` OR `BookShelf.date_added` is past the
sync cursor. But the cursor advance at line ~318 only ever reads
`book.Books.last_modified`. A book added to a `kobo_sync` shelf after
its own `last_modified` re-matches every sync forever — `cont_sync`
stays True, and the server emits `x-kobo-sync: continue` as the trap
signal that tells the device to come back immediately.

**B4**: The magic-shelf DeletedTag emission block was wholly nested
under `if config.config_kobo_sync_magic_shelves:`. When the global
flag flipped off, no tombstones were ever emitted, so the device
retained orphan shelves indefinitely.

## Fix

**B1**: Drop the `config_kobo_proxy` gate in `HandleTagUpdate` and
`HandleTagRemoveItem`, return `redirect_or_proxy_request()`
unconditionally. Mirrors the documented `HandleStateRequest` pattern.

**B2**: In the per-book iteration loop, also fold `book.date_added`
into `new_books_last_modified` via `max()`. Guarded with `getattr`
because the `else` branch's SELECT doesn't include `BookShelf.date_added`.

**B4**: Restructure the magic-shelf emission so a `deletable_magic_shelves`
query runs regardless of the global flag — when the flag is on, restrict
to per-shelf `kobo_sync=False`; when off, emit for ALL the user's magic
shelves so the device can clean up orphans.

## What does NOT ship in this PR

B3 (orphan book on device after CW delete) shares the same
absence-not-tombstone root cause, but the fix needs a schema migration
to capture the book UUID before `editbooks.delete_whole_book` deletes
the row. Per the goal-file allowance ("B3 may be a larger change
requiring a schema migration. Better to defer to its own review-tier
PR than to bundle"), deferred to a follow-up.

## Verification

**Tests** (10 new, all green; 0 regressions in the kobo unit suite of 95):

- Source-pinned regressions assert `abort(404)` can't return to
  `HandleTagUpdate`/`HandleTagRemoveItem`, that the cursor-advance
  reads `date_added`, and that the magic-shelf DeletedTag emission
  isn't wholly nested under the global flag.
- Behavioral tests simulate the fixed cursor-advance logic and run
  the magic-shelf deletable query against a real SQLite stack.

**Live container** (`cwn-local` rebuilt from this branch):

- **B1**: `DELETE /kobo/<token>/v1/library/tags/00000000-...` → HTTP 200
  (was 404). Loop terminates.
- **B2**: With `BookShelf.date_added` set to 2026-05-20 and cursor at
  2026-05-15, sync #1 returns the book with `x-kobo-sync: continue`,
  sync #2 with returned token returns empty (`x-kobo-sync: `, no
  `continue`). Loop terminates after one cycle. Pre-fix, the wire
  capture showed 112 cycles in 60s.
- **B4**: With `config_kobo_sync_magic_shelves=0` + 5 magic shelves
  owned by user, sync response contains 5 `DeletedTag` entries
  including the live-captured `Test_E2E_Discovered` UUID. Pre-fix, 0
  `DeletedTag` entries.

**Normal flow** verified with magic-shelves re-enabled: subsequent
syncs converge (`x-kobo-sync` empty) — no infinite loops in any path.

**Cross-cutting sweep**:

- `HandleTagAddItem` (POST `/items` on unknown shelf) deliberately
  left at `abort(404)` — different semantics (book add to a
  non-existent shelf should fail visibly; device doesn't auto-retry
  user-initiated adds the way it does device-pushed deletes).
- Regular shelf delete via web UI: `shelf_lib.delete_shelf_helper`
  adds ShelfArchive → `sync_shelves` emits DeletedTag (existing
  behavior, unchanged). Combined with B1 fix, the device's
  confirmation-DELETE no longer loops.

**i18n**: no user-facing strings changed (only log messages).
**Stress / concurrency**: not applicable — no new DB writes, no
threading changes.

## Confidence

≥95% the live-captured symptoms are gone. The cursor-advance fix is
the most user-visible (eliminates the bandwidth waste in fork #220);
the tombstone fixes eliminate the visible 404 spam in CW logs that
operator observed.

## Credits

Reproduction + diagnosis based on the wire capture session against
the live Libra Colour. Fork issue #220 (Hoite) reported the B2
symptom independently before the capture confirmed the root cause.

Resolves the B1/B2/B4 portion of `notes/KOBO-BUG-CLUSTER-PROMPT-2026-05-17.md`.
Closes #220 (B2 portion — separate B3 PR to follow for the
delete-orphan case).