### PR TITLE
fix(kobo): emit DeletedEntitlement for hard-deleted books (B3)

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -1348,6 +1348,21 @@ def move_coverfile(meta, db_book):
 
 
 def delete_whole_book(book_id, book):
+    # Capture a tombstone for every Kobo-synced user BEFORE we touch
+    # any of the metadata.db / app.db rows. The Kobo protocol needs the
+    # book's UUID to address a DeletedEntitlement on the device; once
+    # the book row is gone there is no way to recover it. Sync handler
+    # consumes these on the next sync and tells each affected device to
+    # archive its local copy. Without this, hard-deleted books linger on
+    # synced devices forever.
+    try:
+        kobo_sync_status.record_book_deletion(book_id, getattr(book, "uuid", None))
+    except Exception as e:
+        # Tombstone capture is best-effort; a failure here must not
+        # block the user's delete action. Worst case: the device keeps
+        # the orphan (same as pre-fix behavior), no data loss.
+        log.warning("Could not record kobo deletion tombstone for book %s: %s", book_id, e)
+
     # delete book from shelves, Downloads, Read list
     ub.session.query(ub.BookShelf).filter(ub.BookShelf.book_id == book_id).delete()
     ub.session.query(ub.ReadBook).filter(ub.ReadBook.book_id == book_id).delete()

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -449,6 +449,57 @@ def HandleSyncRequest():
 
         sync_token.tags_last_modified = new_tags_last_modified
 
+    # Emit DeletedEntitlement tombstones for books hard-deleted from CW
+    # (B3 fix — closes the orphan-book-on-device gap from the 2026-05-17
+    # MITM capture). editbooks.delete_whole_book captures (user_id,
+    # book_uuid, deleted_at) into kobo_deleted_book before tearing down
+    # the metadata.db row; here we play those tombstones back to each
+    # affected device as DeletedEntitlement and advance
+    # archive_last_modified past the tombstone so the device sees each
+    # one exactly once. Page-cap with SYNC_ITEM_LIMIT so a mass-delete
+    # doesn't blow past the device's sync-response size limit.
+    # Compare against the device's cursor (sync_token.archive_last_modified),
+    # NOT against the local new_archived_last_modified — the latter has
+    # already been rolled forward by any ArchivedBook.last_modified row,
+    # which would mask legitimate tombstones whose deleted_at lies
+    # between sync_token.archive_last_modified and new_archived_last_modified.
+    cursor_archive_lm = sync_token.archive_last_modified
+    pending_deletions = (
+        ub.session.query(ub.KoboDeletedBook)
+        .filter(ub.KoboDeletedBook.user_id == current_user.id)
+        .filter(ub.KoboDeletedBook.deleted_at > cursor_archive_lm)
+        .order_by(ub.KoboDeletedBook.deleted_at)
+        .limit(SYNC_ITEM_LIMIT)
+        .all()
+    )
+    for tombstone in pending_deletions:
+        sync_results.append({
+            "DeletedEntitlement": {
+                "BookEntitlement": {
+                    "Id": tombstone.book_uuid,
+                    "RevisionId": tombstone.book_uuid,
+                    "CrossRevisionId": tombstone.book_uuid,
+                }
+            }
+        })
+        ta = tombstone.deleted_at
+        if hasattr(ta, "replace") and getattr(ta, "tzinfo", None) is not None:
+            ta = ta.replace(tzinfo=None)
+        new_archived_last_modified = max(ta, new_archived_last_modified)
+
+    # If there are MORE pending deletions than SYNC_ITEM_LIMIT, mark
+    # cont_sync so the device comes back for the next page rather than
+    # losing tombstones to the page cap.
+    if len(pending_deletions) >= SYNC_ITEM_LIMIT:
+        remaining = (
+            ub.session.query(ub.KoboDeletedBook)
+            .filter(ub.KoboDeletedBook.user_id == current_user.id)
+            .filter(ub.KoboDeletedBook.deleted_at > new_archived_last_modified)
+            .count()
+        )
+        if remaining > 0:
+            cont_sync = True
+
     # update last created timestamp to distinguish between new and changed entitlements
     if not cont_sync:
         sync_token.books_last_created = new_books_last_created

--- a/cps/kobo_sync_status.py
+++ b/cps/kobo_sync_status.py
@@ -25,6 +25,67 @@ def add_synced_books(book_id):
         ub.session_commit()
 
 
+def record_book_deletion(book_id, book_uuid, session=None):
+    """Record a book hard-deletion as a tombstone for each user who had
+    it synced to a Kobo device.
+
+    Called by editbooks.delete_whole_book / delete_book_from_table BEFORE
+    the metadata.db row is removed (so book.uuid is still accessible).
+
+    For every (user_id, book_id) pair in kobo_synced_books with this
+    book_id, inserts a kobo_deleted_book row capturing the UUID. The
+    Kobo sync handler emits DeletedEntitlement for these rows on each
+    affected user's next sync, then advances archive_last_modified past
+    them so the device sees each tombstone exactly once. Without this,
+    the device retains the book locally forever — calibre absence is
+    not interpreted as deletion, only tombstones are.
+
+    No-op when book_uuid is falsy (defensive — shouldn't happen, but
+    saves us from corrupt rows if upstream changes).
+
+    Idempotent per (user_id, book_uuid): the UNIQUE constraint coalesces
+    re-runs to the existing row (deleted_at unchanged) via
+    INSERT OR IGNORE semantics.
+    """
+    if not book_uuid:
+        return
+    s = session if session else ub.session
+    affected_user_ids = [
+        row.user_id for row in
+        s.query(ub.KoboSyncedBooks.user_id)
+         .filter(ub.KoboSyncedBooks.book_id == book_id)
+         .all()
+    ]
+    if not affected_user_ids:
+        return
+
+    now = datetime.now(timezone.utc)
+    for user_id in affected_user_ids:
+        existing = (
+            s.query(ub.KoboDeletedBook)
+             .filter(ub.KoboDeletedBook.user_id == user_id,
+                     ub.KoboDeletedBook.book_uuid == book_uuid)
+             .one_or_none()
+        )
+        if existing is None:
+            s.add(ub.KoboDeletedBook(
+                user_id=user_id,
+                book_uuid=book_uuid,
+                deleted_at=now,
+            ))
+
+    # Clear the now-stale kobo_synced_books rows so the per-user
+    # two-way-deletion logic doesn't trip over them on a later sync.
+    s.query(ub.KoboSyncedBooks).filter(
+        ub.KoboSyncedBooks.book_id == book_id
+    ).delete(synchronize_session=False)
+
+    if session is None:
+        ub.session_commit()
+    else:
+        ub.session_commit(_session=s)
+
+
 # Select all entries of current book in kobo_synced_books table, which are from current user and delete them
 def remove_synced_book(book_id, all=False, session=None):
     if not all:

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -724,6 +724,36 @@ class KoboSyncedBooks(Base):
     )
 
 
+class KoboDeletedBook(Base):
+    """Tombstone table for books deleted from CW that need to be reported
+    to Kobo devices as DeletedEntitlement on next sync.
+
+    Why we need it: calibre's metadata.db row goes away the moment the
+    book is deleted (cps/editbooks.py:delete_whole_book), and the
+    KoboSyncedBooks table carries only (user_id, book_id) — no UUID. The
+    Kobo protocol needs the book's UUID to address the DeletedEntitlement
+    on the device. So we snapshot (user_id, book_uuid, deleted_at) at
+    delete time, before the book row is gone.
+
+    Lifecycle: rows live as long as the deletion is "newer than" any
+    device's sync cursor. With cursor-based emission (advance
+    archive_last_modified past deleted_at on emit), each device sees
+    each DeletedEntitlement exactly once. Rows can be GC'd by a
+    periodic cleanup once they're older than the oldest active sync
+    token's archive_last_modified — left as a follow-up; current
+    storage cost is one short row per deleted book per affected user.
+    """
+    __tablename__ = 'kobo_deleted_book'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey('user.id'), nullable=False, index=True)
+    book_uuid = Column(String, nullable=False)
+    deleted_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), index=True)
+
+    __table_args__ = (
+        UniqueConstraint('user_id', 'book_uuid', name='uq_kobo_deleted_book_user_uuid'),
+    )
+
+
 # CWA #1258 (backport for fork #153): per-user OPDS shelf-exposure helpers.
 # Mirrors the kobo_only_shelves_sync pattern — the User-side flag is added
 # in the User class above; the helpers below maintain the two exposure
@@ -1564,6 +1594,57 @@ def _loser_wins_lm(loser, winner):
     return lo > wn
 
 
+def migrate_kobo_deleted_book(engine, _session):
+    """Create the kobo_deleted_book tombstone table if it doesn't exist.
+
+    Idempotent: gated by a marker file in CONFIG_DIR/.cwa_migrations/ so
+    it runs at most once per install. The marker is a perf optimization,
+    not correctness — the underlying DDL uses CREATE TABLE IF NOT EXISTS
+    so re-running is safe.
+
+    Why this table exists: see the KoboDeletedBook model docstring.
+    Captures (user_id, book_uuid, deleted_at) at the moment a book is
+    deleted, so HandleSyncRequest can emit DeletedEntitlement on the
+    next sync per affected user — the existing two-way deletion logic
+    can only handle books removed from kobo_sync shelves, not hard
+    deletes from the calibre library.
+    """
+    from sqlalchemy import inspect as sa_inspect
+    marker_path = os.path.join(constants.CONFIG_DIR, ".cwa_migrations",
+                               "kobo_deleted_book_v1")
+    if os.path.isfile(marker_path):
+        return
+
+    inspector = sa_inspect(engine)
+    if "kobo_deleted_book" not in inspector.get_table_names():
+        try:
+            KoboDeletedBook.__table__.create(engine, checkfirst=True)
+        except Exception as e:
+            log.error("[kobo-deleted-book-migration] create_all failed: %s", e)
+            return
+
+    # Indexes for the sync query path: (user_id, deleted_at) covers the
+    # "rows for current_user where deleted_at > cursor" pattern.
+    try:
+        _run_ddl_with_retry(
+            engine,
+            "CREATE INDEX IF NOT EXISTS idx_kobo_deleted_book_user_deleted "
+            "ON kobo_deleted_book(user_id, deleted_at)",
+        )
+    except Exception as e:
+        log.warning("[kobo-deleted-book-migration] index creation failed: %s", e)
+
+    try:
+        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+        with open(marker_path, "w", encoding="utf-8") as fh:
+            fh.write(datetime.now(timezone.utc).isoformat())
+    except OSError as e:
+        log.warning(
+            "[kobo-deleted-book-migration] could not write marker %s: %s",
+            marker_path, e,
+        )
+
+
 def migrate_shelf_table(engine, _session):
     """Ensure Shelf.kobo_sync column exists; backfill DDL if not (legacy
     fork branch — predates the dedicated kobo_sync migrations elsewhere).
@@ -1613,6 +1694,7 @@ def migrate_Database(_session):
     migrate_config_table(engine, _session)
     migrate_magic_shelf_table(engine, _session)
     migrate_kobo_unique_constraints(engine, _session)
+    migrate_kobo_deleted_book(engine, _session)
     migrate_book_cover_preview_table(engine, _session)
 
     # Ensure progress syncing tables in app.db (user-related tables)

--- a/tests/unit/test_kobo_deleted_book_tombstone.py
+++ b/tests/unit/test_kobo_deleted_book_tombstone.py
@@ -1,0 +1,469 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""B3 regression tests: orphan book on device after CW delete.
+
+Companion fix to the B1/B2/B4 cluster shipped in v4.0.70. Closes the
+last bug in the 2026-05-17 MITM-captured cluster — books deleted from
+CW persisted on the device because no DeletedEntitlement was ever
+emitted to the Kobo sync response (no UUID retained after the row went
+away).
+
+Design:
+- New ub.KoboDeletedBook tombstone table — (user_id, book_uuid,
+  deleted_at) snapshot at delete time.
+- editbooks.delete_whole_book calls kobo_sync_status.record_book_deletion
+  BEFORE deleting metadata, capturing UUID for every user with a
+  matching kobo_synced_books row.
+- HandleSyncRequest emits DeletedEntitlement for tombstones with
+  deleted_at > sync_token.archive_last_modified, advances cursor past
+  them so each device sees each tombstone exactly once.
+"""
+
+import inspect
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Source-pinned: the wiring exists where we expect it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestB3SourceWiring:
+    """The fix has three distinct surfaces; any one missing breaks the
+    full pipeline. Source-pin all three so a refactor can't silently
+    strip part of it."""
+
+    def test_kobo_deleted_book_model_defined(self):
+        """Model must exist with the (user_id, book_uuid, deleted_at)
+        contract the sync emit + tombstone-capture logic both depend on."""
+        from cps.ub import KoboDeletedBook
+        assert KoboDeletedBook.__tablename__ == "kobo_deleted_book"
+        cols = {c.name for c in KoboDeletedBook.__table__.columns}
+        assert {"id", "user_id", "book_uuid", "deleted_at"} <= cols, (
+            f"KoboDeletedBook missing required columns. Got: {cols}"
+        )
+        # UNIQUE on (user_id, book_uuid) is the dedupe contract that
+        # record_book_deletion relies on for idempotency.
+        from sqlalchemy import UniqueConstraint
+        uc_names = {
+            c.name for c in KoboDeletedBook.__table__.constraints
+            if isinstance(c, UniqueConstraint)
+        }
+        assert "uq_kobo_deleted_book_user_uuid" in uc_names, (
+            "UniqueConstraint on (user_id, book_uuid) missing — "
+            "record_book_deletion relies on it for idempotency."
+        )
+
+    def test_migration_runs_from_migrate_database(self):
+        from cps.ub import migrate_Database
+        src = inspect.getsource(migrate_Database)
+        assert "migrate_kobo_deleted_book" in src, (
+            "migrate_kobo_deleted_book must be called from migrate_Database "
+            "so existing installs get the table on upgrade."
+        )
+
+    def test_record_book_deletion_helper_exists(self):
+        from cps.kobo_sync_status import record_book_deletion
+        sig = inspect.signature(record_book_deletion)
+        assert "book_id" in sig.parameters
+        assert "book_uuid" in sig.parameters, (
+            "record_book_deletion must take book_uuid — the UUID can't "
+            "be recovered after the metadata row is gone."
+        )
+
+    def test_delete_whole_book_calls_record_book_deletion(self):
+        from cps.editbooks import delete_whole_book
+        src = inspect.getsource(delete_whole_book)
+        assert "record_book_deletion" in src, (
+            "delete_whole_book must call kobo_sync_status."
+            "record_book_deletion BEFORE removing the metadata row — "
+            "otherwise the UUID is lost and no DeletedEntitlement can "
+            "be emitted, leaving the book on every synced device "
+            "forever (B3)."
+        )
+
+    def test_handle_sync_emits_deleted_entitlement(self):
+        from cps.kobo import HandleSyncRequest
+        src = inspect.getsource(HandleSyncRequest)
+        assert "DeletedEntitlement" in src, (
+            "HandleSyncRequest must emit DeletedEntitlement for "
+            "kobo_deleted_book rows — that's the device-side signal "
+            "to archive the local copy."
+        )
+        assert "KoboDeletedBook" in src, (
+            "HandleSyncRequest must query KoboDeletedBook (the "
+            "tombstone table) to find books to emit DeletedEntitlement "
+            "for."
+        )
+
+    def test_handle_sync_uses_device_cursor_not_local_watermark(self):
+        """The filter must compare against sync_token.archive_last_modified
+        (the device's cursor), not new_archived_last_modified — the
+        latter has already been advanced by any ArchivedBook row, which
+        would mask legitimate tombstones whose deleted_at lies between
+        the cursor and the new local watermark."""
+        from cps.kobo import HandleSyncRequest
+        src = inspect.getsource(HandleSyncRequest)
+        assert (
+            "sync_token.archive_last_modified" in src
+            and "KoboDeletedBook.deleted_at" in src
+        ), (
+            "HandleSyncRequest must filter KoboDeletedBook by "
+            "sync_token.archive_last_modified (the device cursor), "
+            "not the local new_archived_last_modified variable."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: real SQLite stack, record + emit roundtrip
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kobo_b3_stack(tmp_path, monkeypatch):
+    """Minimal ub-side DB + a stub current_user. Tests the
+    record_book_deletion ↔ KoboDeletedBook persistence path end to end."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker, scoped_session
+    from cps import ub
+
+    db_path = tmp_path / "b3.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    ub.Base.metadata.create_all(engine)
+    Session = scoped_session(sessionmaker(bind=engine, future=True))
+    session = Session()
+    monkeypatch.setattr(ub, "session", session, raising=False)
+
+    # Two users — proves the helper covers all affected users, not just
+    # the current request's user (a deleted book affects everyone who
+    # had it synced).
+    users = []
+    for name in ("u_a", "u_b", "u_c"):
+        u = ub.User()
+        u.name = name
+        u.email = f"{name}@example.invalid"
+        u.role = 0
+        u.locale = "en"
+        u.default_language = "all"
+        u.allowed_tags = ""
+        u.denied_tags = ""
+        u.allowed_column_value = ""
+        u.denied_column_value = ""
+        u.sidebar_view = 0
+        u.password = "x"
+        u.kobo_only_shelves_sync = False
+        session.add(u)
+        users.append(u)
+    session.commit()
+
+    yield {"session": session, "users": users, "ub": ub}
+    Session.remove()
+
+
+@pytest.mark.unit
+class TestB3RecordBookDeletion:
+    def test_creates_tombstone_for_each_synced_user(self, kobo_b3_stack):
+        from cps import kobo_sync_status
+        ub = kobo_b3_stack["ub"]
+        session = kobo_b3_stack["session"]
+        u_a, u_b, u_c = kobo_b3_stack["users"]
+
+        # u_a and u_b had book 42 synced; u_c did not.
+        session.add(ub.KoboSyncedBooks(user_id=u_a.id, book_id=42))
+        session.add(ub.KoboSyncedBooks(user_id=u_b.id, book_id=42))
+        session.commit()
+
+        kobo_sync_status.record_book_deletion(42, "abc-uuid-42", session=session)
+
+        tombs = session.query(ub.KoboDeletedBook).filter_by(book_uuid="abc-uuid-42").all()
+        affected_users = sorted([t.user_id for t in tombs])
+        assert affected_users == sorted([u_a.id, u_b.id]), (
+            "Tombstone must be created for u_a and u_b (had the book "
+            "synced) but not u_c (did not). "
+            f"Got affected_users={affected_users}"
+        )
+
+        # KoboSyncedBooks rows for this book are cleared.
+        remaining_synced = session.query(ub.KoboSyncedBooks).filter_by(book_id=42).count()
+        assert remaining_synced == 0, (
+            "KoboSyncedBooks rows for the deleted book must be cleared "
+            "after recording the deletion — the two-way deletion logic "
+            "in HandleSyncRequest would otherwise trip over a stale row."
+        )
+
+    def test_idempotent_on_double_invocation(self, kobo_b3_stack):
+        """If delete_whole_book runs twice for the same UUID (e.g. retry
+        path), the UNIQUE(user_id, book_uuid) constraint must coalesce
+        — no duplicate tombstone, no exception."""
+        from cps import kobo_sync_status
+        ub = kobo_b3_stack["ub"]
+        session = kobo_b3_stack["session"]
+        u_a = kobo_b3_stack["users"][0]
+
+        session.add(ub.KoboSyncedBooks(user_id=u_a.id, book_id=100))
+        session.commit()
+
+        kobo_sync_status.record_book_deletion(100, "uuid-100", session=session)
+        # Re-add the synced row to simulate a hypothetical re-run scenario
+        session.add(ub.KoboSyncedBooks(user_id=u_a.id, book_id=100))
+        session.commit()
+        kobo_sync_status.record_book_deletion(100, "uuid-100", session=session)
+
+        tombs = session.query(ub.KoboDeletedBook).filter_by(book_uuid="uuid-100").count()
+        assert tombs == 1, (
+            f"Double-invocation must coalesce via UNIQUE; got {tombs} "
+            f"rows for the same (user, uuid) pair."
+        )
+
+    def test_noop_when_book_uuid_missing(self, kobo_b3_stack):
+        """Defensive: if upstream changes mean book.uuid is None at
+        delete time, we silently no-op rather than write garbage rows
+        the sync handler would emit as DeletedEntitlement for a null
+        UUID (device-side error)."""
+        from cps import kobo_sync_status
+        ub = kobo_b3_stack["ub"]
+        session = kobo_b3_stack["session"]
+        u_a = kobo_b3_stack["users"][0]
+
+        session.add(ub.KoboSyncedBooks(user_id=u_a.id, book_id=99))
+        session.commit()
+
+        kobo_sync_status.record_book_deletion(99, None, session=session)
+        kobo_sync_status.record_book_deletion(99, "", session=session)
+
+        tombs = session.query(ub.KoboDeletedBook).count()
+        assert tombs == 0, (
+            f"Tombstone with null/empty UUID must not be written. "
+            f"Got {tombs} rows."
+        )
+
+    def test_noop_when_no_users_had_book_synced(self, kobo_b3_stack):
+        """If a book is deleted but no user ever synced it to a Kobo,
+        no tombstone is needed — kobo_deleted_book stays empty."""
+        from cps import kobo_sync_status
+        ub = kobo_b3_stack["ub"]
+        session = kobo_b3_stack["session"]
+
+        # No KoboSyncedBooks rows for book 200
+        kobo_sync_status.record_book_deletion(200, "uuid-200", session=session)
+
+        tombs = session.query(ub.KoboDeletedBook).count()
+        assert tombs == 0
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: sync emission picks up tombstones, advances cursor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestB3SyncEmission:
+    def test_tombstone_emit_logic_picks_up_pending_rows(self, kobo_b3_stack):
+        """Direct test of the query+emit shape used in HandleSyncRequest's
+        DeletedEntitlement block. Builds a few tombstones, simulates the
+        device's cursor, asserts only newer-than-cursor rows surface and
+        the response payload matches the Kobo DeletedEntitlement schema."""
+        ub = kobo_b3_stack["ub"]
+        session = kobo_b3_stack["session"]
+        u_a = kobo_b3_stack["users"][0]
+
+        t0 = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+        t1 = t0 + timedelta(hours=1)
+        t2 = t0 + timedelta(hours=2)
+        t3 = t0 + timedelta(hours=3)
+
+        # Tombstones at t1, t2, t3. Device's cursor was at t1 (saw t1).
+        session.add(ub.KoboDeletedBook(user_id=u_a.id, book_uuid="uuid-1", deleted_at=t1))
+        session.add(ub.KoboDeletedBook(user_id=u_a.id, book_uuid="uuid-2", deleted_at=t2))
+        session.add(ub.KoboDeletedBook(user_id=u_a.id, book_uuid="uuid-3", deleted_at=t3))
+        session.commit()
+
+        cursor_archive_lm = t1  # device saw t1 last
+        SYNC_ITEM_LIMIT = 100
+
+        pending = (
+            session.query(ub.KoboDeletedBook)
+            .filter(ub.KoboDeletedBook.user_id == u_a.id)
+            .filter(ub.KoboDeletedBook.deleted_at > cursor_archive_lm)
+            .order_by(ub.KoboDeletedBook.deleted_at)
+            .limit(SYNC_ITEM_LIMIT)
+            .all()
+        )
+
+        sync_results = []
+        new_archived_last_modified = cursor_archive_lm
+        for tombstone in pending:
+            sync_results.append({
+                "DeletedEntitlement": {
+                    "BookEntitlement": {
+                        "Id": tombstone.book_uuid,
+                        "RevisionId": tombstone.book_uuid,
+                        "CrossRevisionId": tombstone.book_uuid,
+                    }
+                }
+            })
+            ta = tombstone.deleted_at
+            if hasattr(ta, "replace") and getattr(ta, "tzinfo", None) is not None:
+                ta = ta.replace(tzinfo=None)
+            if isinstance(new_archived_last_modified, datetime):
+                if new_archived_last_modified.tzinfo is not None:
+                    new_archived_last_modified = new_archived_last_modified.replace(tzinfo=None)
+            new_archived_last_modified = max(ta, new_archived_last_modified)
+
+        assert len(sync_results) == 2, (
+            f"Expected 2 tombstones past cursor (uuid-2, uuid-3); "
+            f"got {len(sync_results)}: {sync_results}"
+        )
+        uuids = [r["DeletedEntitlement"]["BookEntitlement"]["RevisionId"]
+                 for r in sync_results]
+        assert uuids == ["uuid-2", "uuid-3"], (
+            f"Tombstones must emit in deleted_at order; got {uuids}"
+        )
+
+        # Cursor advances past the newest emitted tombstone.
+        expected = t3.replace(tzinfo=None) if t3.tzinfo else t3
+        assert new_archived_last_modified == expected, (
+            f"Cursor must advance to t3 ({expected}); "
+            f"got {new_archived_last_modified}"
+        )
+
+    def test_second_sync_does_not_re_emit_tombstones(self, kobo_b3_stack):
+        """Once a device's cursor has advanced past a tombstone, the
+        next sync from that device must not re-emit it (idempotent
+        per device-cycle, like every other sync element)."""
+        ub = kobo_b3_stack["ub"]
+        session = kobo_b3_stack["session"]
+        u_a = kobo_b3_stack["users"][0]
+
+        t0 = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        session.add(ub.KoboDeletedBook(user_id=u_a.id, book_uuid="uuid-X", deleted_at=t0))
+        session.commit()
+
+        # First sync: cursor at min, tombstone at t0 — should emit.
+        cursor_1 = datetime.min
+        rows_1 = (
+            session.query(ub.KoboDeletedBook)
+            .filter(ub.KoboDeletedBook.user_id == u_a.id)
+            .filter(ub.KoboDeletedBook.deleted_at > cursor_1)
+            .all()
+        )
+        assert len(rows_1) == 1
+
+        # Cursor advances to t0.
+        cursor_2 = t0
+        rows_2 = (
+            session.query(ub.KoboDeletedBook)
+            .filter(ub.KoboDeletedBook.user_id == u_a.id)
+            .filter(ub.KoboDeletedBook.deleted_at > cursor_2)
+            .all()
+        )
+        assert len(rows_2) == 0, (
+            f"Second sync must not re-emit already-seen tombstones; "
+            f"got {len(rows_2)}: {[(r.book_uuid, r.deleted_at) for r in rows_2]}"
+        )
+
+    def test_user_isolation_no_cross_user_leak(self, kobo_b3_stack):
+        """Tombstone for u_a must NEVER appear in u_b's sync response.
+        kobo_deleted_book is user-keyed; the query must filter by
+        current_user.id."""
+        ub = kobo_b3_stack["ub"]
+        session = kobo_b3_stack["session"]
+        u_a, u_b, _ = kobo_b3_stack["users"]
+
+        t0 = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        session.add(ub.KoboDeletedBook(user_id=u_a.id, book_uuid="uuid-a", deleted_at=t0))
+        session.add(ub.KoboDeletedBook(user_id=u_b.id, book_uuid="uuid-b", deleted_at=t0))
+        session.commit()
+
+        for u in (u_a, u_b):
+            rows = (
+                session.query(ub.KoboDeletedBook)
+                .filter(ub.KoboDeletedBook.user_id == u.id)
+                .all()
+            )
+            uuids = sorted([r.book_uuid for r in rows])
+            expected = ["uuid-a"] if u is u_a else ["uuid-b"]
+            assert uuids == expected, (
+                f"User {u.name} saw {uuids}, expected {expected} — "
+                f"cross-user tombstone leak."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Migration: table creation, idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestB3Migration:
+    def test_migration_creates_table(self, tmp_path, monkeypatch):
+        from sqlalchemy import create_engine, inspect as sa_inspect
+        from sqlalchemy.orm import sessionmaker
+        from cps import ub, constants
+
+        # Point CONFIG_DIR at tmp_path so the marker file lands in
+        # a hermetic location.
+        monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path), raising=False)
+
+        db_path = tmp_path / "mig.db"
+        engine = create_engine(
+            f"sqlite:///{db_path}",
+            connect_args={"check_same_thread": False},
+            future=True,
+        )
+        # Create only ONE table to simulate a partial migration state
+        # — the migration must add kobo_deleted_book even though the
+        # rest of the schema isn't there yet.
+        ub.User.__table__.create(engine, checkfirst=True)
+
+        Session = sessionmaker(bind=engine, future=True)
+        session = Session()
+
+        ub.migrate_kobo_deleted_book(engine, session)
+
+        inspector = sa_inspect(engine)
+        assert "kobo_deleted_book" in inspector.get_table_names(), (
+            "migrate_kobo_deleted_book must create the table when it "
+            "doesn't exist."
+        )
+
+        # Marker file is written so repeated runs are no-ops.
+        import os
+        marker_path = os.path.join(str(tmp_path), ".cwa_migrations", "kobo_deleted_book_v1")
+        assert os.path.isfile(marker_path), (
+            f"Migration marker file missing at {marker_path} — "
+            f"second run would re-execute DDL unnecessarily."
+        )
+
+    def test_migration_is_idempotent(self, tmp_path, monkeypatch):
+        """Second run with marker present must be a no-op (no exception,
+        no DDL re-issued)."""
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+        from cps import ub, constants
+
+        monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path), raising=False)
+
+        db_path = tmp_path / "mig2.db"
+        engine = create_engine(
+            f"sqlite:///{db_path}",
+            connect_args={"check_same_thread": False},
+            future=True,
+        )
+        ub.Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine, future=True)
+        session = Session()
+
+        ub.migrate_kobo_deleted_book(engine, session)
+        # Second run — must not raise
+        ub.migrate_kobo_deleted_book(engine, session)


### PR DESCRIPTION
## Symptom

Books deleted from CW persist on Kobo devices forever. The operator manually long-presses → archives them on the device every time the library changes. Wire-confirmed in the 2026-05-17 MITM capture: book UUID `0b800030-997b-4d71-9a1d-0d162c26c867` stayed on the Libra Colour despite CW having removed it, with `cps.kobo:980 Book ... not found in database` firing every sync.

This is the deferred portion of the Kobo bug cluster from `notes/KOBO-BUG-CLUSTER-PROMPT-2026-05-17.md`. B1/B2/B4 shipped in v4.0.70 (#226); B3 needed a schema migration so it landed as its own review-tier PR per the goal-file allowance.

## Root cause

`cps/editbooks.py:delete_whole_book` (line ~1350):

```python
ub.session.query(ub.BookShelf).filter(ub.BookShelf.book_id == book_id).delete()
ub.session.query(ub.ReadBook).filter(ub.ReadBook.book_id == book_id).delete()
ub.session.query(ub.ArchivedBook).filter(ub.ArchivedBook.book_id == book_id).delete()
...
calibre_db.session.query(db.Books).filter(db.Books.id == book_id).delete()
```

The `ArchivedBook` row is destroyed outright (line 1354), and `KoboSyncedBooks` only stores `(user_id, book_id)` — no UUID. By the time `HandleSyncRequest` runs the next sync, the calibre `metadata.db` row is gone too. The Kobo protocol needs the book's UUID to address a `DeletedEntitlement` to the device, and we have no way to retrieve it after deletion. The device sees absence-from-sync-response (not change), interprets it as "still on shelf, nothing changed," and retains the book locally.

## Fix

**Schema** (`cps/ub.py`):
- New `KoboDeletedBook` model — `(user_id, book_uuid, deleted_at)` snapshot at delete time.
- `UNIQUE(user_id, book_uuid)` for idempotent capture under retry.
- `(user_id, deleted_at)` index for the sync query path.
- `migrate_kobo_deleted_book` migration — creates the table if missing, gated by `CONFIG_DIR/.cwa_migrations/kobo_deleted_book_v1` marker. Idempotent on re-run via `CREATE TABLE IF NOT EXISTS` regardless of marker state.

**Capture** (`cps/kobo_sync_status.py`):
- `record_book_deletion(book_id, book_uuid)` enumerates affected users via `KoboSyncedBooks`, inserts tombstones, clears the stale `KoboSyncedBooks` rows so two-way-deletion logic doesn't trip over them.
- No-op when UUID is falsy. Idempotent per `(user_id, book_uuid)`.

**Hook** (`cps/editbooks.py:delete_whole_book`):
- Calls `record_book_deletion(book_id, book.uuid)` BEFORE touching any metadata. Wrapped in try/except so a tombstone-capture failure can't block the user's delete action.

**Emission** (`cps/kobo.py:HandleSyncRequest`):
- Queries `KoboDeletedBook` for `current_user` where `deleted_at > sync_token.archive_last_modified`.
- Filters against the device cursor (NOT the local `new_archived_last_modified` which would mask legitimate tombstones whose `deleted_at` lies between the cursor and the local watermark).
- Emits `{"DeletedEntitlement": {"BookEntitlement": {"Id": uuid, "RevisionId": uuid, "CrossRevisionId": uuid}}}`.
- Advances `new_archived_last_modified` past each emitted tombstone — each device sees each tombstone exactly once.
- Paginates via `SYNC_ITEM_LIMIT` + `cont_sync` so mass-deletes don't blow past the device's response cap.

## Verification

**15 new regression tests** (`tests/unit/test_kobo_deleted_book_tombstone.py`), all green; 95 pre-existing kobo unit tests still pass; 0 regressions:

- **Source-pinned**: model defined with right columns + UNIQUE; migration wired into `migrate_Database`; helper exists with `(book_id, book_uuid)` signature; `delete_whole_book` calls it; `HandleSyncRequest` emits `DeletedEntitlement` AND filters by `sync_token.archive_last_modified` (the device cursor).
- **Behavioral SQLite** (`record_book_deletion`): creates per-affected-user tombstones (not cross-user), idempotent on double-invocation, no-ops on missing UUID, no-ops when no user had the book synced, clears stale `KoboSyncedBooks` rows.
- **Sync emission**: pending rows surface in `deleted_at` order, cursor advance prevents re-emit on second sync, user_id filter prevents cross-user tombstone leak.
- **Migration**: creates table from blank schema, marker written, second run is a no-op.

**Live container** (`cwn-local` rebuilt from this branch):

1. Container starts cleanly; migration ran on cold boot (table + indexes + marker present).
2. Manually inserted a tombstone row for `cwng84test` user → sync response contained 1 `DeletedEntitlement` with `{Id, RevisionId, CrossRevisionId}` all set to the tombstone UUID, alongside the normal sync entitlements + magic-shelf tags.
3. Returned synctoken had `archive_last_modified` advanced to the tombstone's `deleted_at` (`2026-05-18T12:00:00`).
4. Second sync with the returned token returned 0 `DeletedEntitlement` entries — cursor advance correct, no re-emit.
5. No new `ERROR / WARN / Traceback` in container logs (only pre-existing calibre-install warnings).

## Cross-cutting

- `editbooks.delete_book_from_table` calls `delete_whole_book` indirectly (via the JSON/bulk-delete path at line 1443), so the tombstone capture covers that route automatically.
- `helper.delete_book` is file-teardown only — no metadata row delete — so no hook needed.
- The B1/B2/B4 cluster from v4.0.70 is unchanged.

## Confidence

≥95% — the live container repro shows the full pipeline (capture → emission → cursor advance) working end-to-end. The migration is idempotent and the capture is best-effort so the worst-case failure mode is the pre-fix behavior (orphan on device, no data loss).

## Credits

Operator pain report 2026-05-17 + wire capture confirming the symptom against book UUID `0b800030-997b-4d71-9a1d-0d162c26c867`.

Closes the B3 portion of `notes/KOBO-BUG-CLUSTER-PROMPT-2026-05-17.md`. Design doc that informed this PR: `notes/B3-kobo-deleted-book-tombstone-DESIGN.md`.