### PR TITLE
feat(kobo): admin per-book "Resend to Kobo" action

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -13,7 +13,7 @@ import time
 import sys
 import string
 import requests
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from datetime import time as datetime_time
 from functools import wraps
 from urllib.parse import urlparse
@@ -1286,6 +1286,42 @@ def do_full_kobo_sync(userid):
     message = _("{} sync entries deleted").format(count)
     ub.session_commit(message)
     return Response(json.dumps([{"type": "success", "message": message}]), mimetype='application/json')
+
+
+@admi.route("/ajax/kobo_resend/<int:userid>/<int:bookid>", methods=["POST"])
+@user_login_required
+@admin_required
+def ajax_kobo_resend(userid, bookid):
+    return do_kobo_resend(userid, bookid)
+
+
+def do_kobo_resend(userid, bookid):
+    # Force re-delivery of one book to one user's Kobo on the next sync.
+    # Clears the (user_id, book_id) row from kobo_synced_books so the
+    # sync emits NewEntitlement, and bumps Books.last_modified so the
+    # sync filter (Books.last_modified > sync_token.books_last_modified)
+    # picks the book up regardless of where the device's cursor is.
+    book = calibre_db.session.query(db.Books).filter(db.Books.id == bookid).first()
+    if book is None:
+        message = _("Book {} not found").format(bookid)
+        return Response(json.dumps([{"type": "danger", "message": message}]),
+                        mimetype='application/json')
+    deleted = ub.session.query(ub.KoboSyncedBooks).filter(
+        ub.KoboSyncedBooks.user_id == userid,
+        ub.KoboSyncedBooks.book_id == bookid,
+    ).delete()
+    book.last_modified = datetime.now(timezone.utc)
+    calibre_db.session.commit()
+    if deleted:
+        message = _("Cleared sync state for book {0} (user {1}); the device "
+                    "will re-receive the book on next sync").format(bookid, userid)
+    else:
+        message = _("Book {0} was not in the sync record for user {1}; "
+                    "last_modified bumped so the device will receive on next "
+                    "sync").format(bookid, userid)
+    ub.session_commit(message)
+    return Response(json.dumps([{"type": "success", "message": message}]),
+                    mimetype='application/json')
 
 
 def check_valid_read_column(column):

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -803,6 +803,7 @@ $(function() {
             $(this).find(".modal-body").html("...");
             $("#config_delete_kobo_token").show();
             $("#kobo_full_sync").show();
+            $("#kobo_resend_book_block").show();
         });
 
     $("#config_delete_kobo_token").click(function() {
@@ -817,6 +818,7 @@ $(function() {
                 });
                 $("#config_delete_kobo_token").hide();
                 $("#kobo_full_sync").hide();
+                $("#kobo_resend_book_block").hide();
             }
         );
     });
@@ -890,6 +892,38 @@ $(function() {
                 });
             }
         );
+    });
+
+    $("#kobo_resend_button").click(function() {
+        var $btn = $(this);
+        var userid = $btn.data('userid');
+        var bookid = parseInt($("#kobo_resend_book_id").val(), 10);
+        var $feedback = $("#kobo_resend_feedback");
+        $feedback.text("");
+        if (!bookid || bookid < 1) {
+            $feedback.css("color", "var(--color-danger, #a94442)").text($btn.data('invalid-id-text') || "Enter a book ID");
+            return;
+        }
+        $btn.addClass("disabled");
+        $.ajax({
+            method: "post",
+            url: getPath() + "/ajax/kobo_resend/" + userid + "/" + bookid,
+            timeout: 5000,
+            success: function(data) {
+                data.forEach(function(item) {
+                    if (!jQuery.isEmptyObject(item)) {
+                        var color = item.type === "success" ? "var(--color-success, #3c763d)" : "var(--color-danger, #a94442)";
+                        $feedback.css("color", color).text(item.message);
+                    }
+                });
+            },
+            error: function() {
+                $feedback.css("color", "var(--color-danger, #a94442)").text("Request failed");
+            },
+            complete: function() {
+                $btn.removeClass("disabled");
+            }
+        });
     });
 
     $("#user_submit").click(function() {

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -328,6 +328,17 @@
         <div>
           <div class="btn btn-default" id="kobo_full_sync" data-value="{% if current_user.role_admin() %}{{ content.id }}{% else %}0{% endif %}" {% if not content.remote_auth_token.first() %} style="display: none;" {% endif %}>{{_('Force full kobo sync')}}</div>
         </div>
+        {% if current_user.role_admin() %}
+        <div id="kobo_resend_book_block" style="margin-top: 10px;{% if not content.remote_auth_token.first() %} display: none;{% endif %}">
+          <label for="kobo_resend_book_id" style="display: block; margin-bottom: 4px;">{{_('Resend one book to this Kobo')}}</label>
+          <div style="display: flex; gap: 6px; align-items: center;">
+            <input type="number" min="1" id="kobo_resend_book_id" placeholder="{{_('Book ID')}}" style="width: 120px;" class="form-control input-sm">
+            <div class="btn btn-default" id="kobo_resend_button" data-userid="{{ content.id }}">{{_('Resend')}}</div>
+            <span id="kobo_resend_feedback" style="margin-left: 8px;"></span>
+          </div>
+          <small class="help-block">{{_('Clears the sync record for one book so the device re-downloads it on next sync. Find the book ID in the book detail page URL.')}}</small>
+        </div>
+        {% endif %}
         {% if kobo_support and not content.role_anonymous() and not simple %}
         <div style="margin-top: 20px;
                     background: #202c34a3;

--- a/tests/unit/test_kobo_admin_resend_book.py
+++ b/tests/unit/test_kobo_admin_resend_book.py
@@ -1,0 +1,173 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for A2 — per-book "Resend to Kobo" admin action.
+
+Goal:
+    Admin clicks "Resend" on user_edit.html, the (user_id, book_id)
+    row in kobo_synced_books is cleared, and Books.last_modified is
+    bumped to NOW. On the user's next Kobo sync, the device receives
+    the book again (as NewEntitlement since the synced-row is gone)
+    and re-downloads the file.
+
+Why both:
+    The row deletion alone isn't enough — if the cursor has advanced
+    past Books.last_modified, the sync filter
+    ``Books.last_modified > sync_token.books_last_modified`` excludes
+    the book and the device never sees it again. The fix must do
+    both: clear the per-user sync record AND bump last_modified.
+
+These tests pin the implementation at the source-text level (route
+shape, function shape) so a future refactor that drops one of the
+two writes silently re-introduces a partial-fix bug.
+"""
+
+import inspect
+
+import pytest
+
+
+@pytest.mark.unit
+class TestRouteRegistered:
+    def test_kobo_resend_endpoint_is_admin_only(self):
+        from cps import admin as admin_mod
+        src = inspect.getsource(admin_mod)
+        # The route must require admin (admin_required decorator).
+        # Pinning the exact route + decorator stack catches refactors
+        # that accidentally drop the admin gate, which would let any
+        # logged-in user resend books to any other user's Kobo.
+        assert "/ajax/kobo_resend/" in src, (
+            "admin module must register /ajax/kobo_resend/<userid>/<bookid> "
+            "route for the per-book resend action."
+        )
+        # Find the route registration and verify decorator stack
+        idx = src.index("/ajax/kobo_resend/")
+        # Look at the ~400 chars around the route for the decorator stack.
+        window = src[idx:idx + 400]
+        assert "@admin_required" in window, (
+            "/ajax/kobo_resend/<userid>/<bookid> must be @admin_required. "
+            "Without this gate any logged-in user could clear another "
+            "user's Kobo sync state."
+        )
+        assert "methods=[\"POST\"]" in window, (
+            "/ajax/kobo_resend/<userid>/<bookid> must be POST-only."
+        )
+
+    def test_endpoint_passes_userid_and_bookid(self):
+        from cps.admin import ajax_kobo_resend
+        # The handler signature must take both user and book parameters
+        # so the SQL filter narrows to the (user, book) pair.
+        sig = inspect.signature(ajax_kobo_resend)
+        params = list(sig.parameters)
+        assert params == ["userid", "bookid"], (
+            "ajax_kobo_resend must accept (userid, bookid) so it can "
+            "delete the exact (user_id, book_id) row from "
+            "kobo_synced_books."
+        )
+
+
+@pytest.mark.unit
+class TestDoKoboResendShape:
+    """Source-pinned: the helper must perform two writes — clear the
+    sync row AND bump last_modified. Either one alone is a partial fix
+    that doesn't restore device-side delivery."""
+
+    def test_clears_kobo_synced_books_row_for_pair(self):
+        from cps.admin import do_kobo_resend
+        src = inspect.getsource(do_kobo_resend)
+        assert "ub.KoboSyncedBooks" in src, (
+            "do_kobo_resend must touch the KoboSyncedBooks table — "
+            "without the deletion the next sync emits "
+            "ChangedEntitlement rather than re-delivering the file."
+        )
+        assert ".delete()" in src, (
+            "do_kobo_resend must call .delete() on the filtered query "
+            "so the (user_id, book_id) row goes away."
+        )
+        # Both filters must be present so we delete only the targeted
+        # pair (not all rows for the user or all rows for the book).
+        assert "user_id" in src and "book_id" in src, (
+            "do_kobo_resend must filter the delete by both user_id "
+            "AND book_id; deleting all rows for a user is "
+            "do_full_kobo_sync's job, and deleting all rows for a "
+            "book is remove_synced_book(all=True)."
+        )
+
+    def test_bumps_last_modified_with_aware_datetime(self):
+        from cps.admin import do_kobo_resend
+        src = inspect.getsource(do_kobo_resend)
+        assert "last_modified" in src, (
+            "do_kobo_resend must bump Books.last_modified so the sync "
+            "filter `Books.last_modified > books_last_modified` picks "
+            "up the book even when the cursor has advanced past the "
+            "book's original mtime."
+        )
+        # Use timezone-aware UTC datetime to match the cps/editbooks
+        # canonical writer pattern (datetime.now(timezone.utc)).
+        assert "datetime.now(timezone.utc)" in src, (
+            "do_kobo_resend must bump last_modified using "
+            "datetime.now(timezone.utc) for parity with editbooks.py "
+            "writers — naive timestamps drift across DST boundaries "
+            "and can land in the past relative to the sync cursor."
+        )
+
+    def test_validates_book_exists_before_writing(self):
+        from cps.admin import do_kobo_resend
+        src = inspect.getsource(do_kobo_resend)
+        # The book existence check must happen so an admin entering an
+        # invalid book ID gets feedback rather than a silent no-op.
+        assert "calibre_db.session.query(db.Books)" in src, (
+            "do_kobo_resend must verify the book exists in the calibre "
+            "library before bumping last_modified — otherwise an "
+            "invalid book ID silently no-ops."
+        )
+
+    def test_commits_both_sessions(self):
+        from cps.admin import do_kobo_resend
+        src = inspect.getsource(do_kobo_resend)
+        # Both writes go to different SQLAlchemy sessions — calibre_db
+        # for Books.last_modified, ub for KoboSyncedBooks — so both
+        # need explicit commits.
+        assert "calibre_db.session.commit()" in src, (
+            "do_kobo_resend must commit calibre_db.session — without "
+            "the commit the Books.last_modified bump is lost on the "
+            "next session expire/rollback."
+        )
+        assert "ub.session_commit" in src, (
+            "do_kobo_resend must commit ub.session — without the "
+            "commit the KoboSyncedBooks deletion is rolled back."
+        )
+
+
+@pytest.mark.unit
+class TestSecurityShape:
+    """Defensive: the route accepts integer IDs, requires admin auth,
+    and doesn't expose either user or book IDs to non-admins."""
+
+    def test_route_uses_int_converters(self):
+        from cps import admin as admin_mod
+        src = inspect.getsource(admin_mod)
+        # The route signature must use <int:...> not <...> so Flask
+        # rejects non-integer paths before reaching our handler. This
+        # makes SQL injection on the path effectively impossible.
+        idx = src.index("/ajax/kobo_resend/")
+        window = src[idx:idx + 100]
+        assert "/<int:userid>/<int:bookid>" in window, (
+            "/ajax/kobo_resend route must use <int:userid>/<int:bookid> "
+            "Flask converters to reject non-numeric paths at the "
+            "routing layer."
+        )
+
+    def test_route_is_user_login_required_and_admin_required(self):
+        from cps import admin as admin_mod
+        src = inspect.getsource(admin_mod)
+        idx = src.index("/ajax/kobo_resend/")
+        window = src[idx:idx + 400]
+        assert "@user_login_required" in window, (
+            "/ajax/kobo_resend route must require login."
+        )
+        assert "@admin_required" in window, (
+            "/ajax/kobo_resend route must require admin."
+        )


### PR DESCRIPTION
## Symptom

When a single book gets corrupted on the device, the cover goes stale, or a format conversion lands after the original sync, the only path to re-deliver one book is the nuclear *Force Full Kobo Sync*. That re-sends the user's entire library — expensive bandwidth + slow rescans on the device.

## Fix

Per-book resend action on **admin → Edit User**, alongside the existing *Force Full Kobo Sync* button. Admin enters a book ID, clicks **Resend**, and on the user's next sync the device receives that one book as `NewEntitlement` (forcing a fresh download).

The mechanism is twofold:

1. Delete the `(user_id, book_id)` row from `kobo_synced_books` so the sync emits `NewEntitlement`, not `ChangedEntitlement`.
2. Bump `Books.last_modified = datetime.now(timezone.utc)` so the sync filter `Books.last_modified > sync_token.books_last_modified` picks the book up no matter where the device's cursor sits.

Either step alone is a partial fix — the deletion alone leaves a book stuck behind an advanced cursor; the timestamp bump alone changes a `ChangedEntitlement` (not a re-delivery).

## Endpoint

`POST /ajax/kobo_resend/<int:userid>/<int:bookid>`

- `@user_login_required` + `@admin_required`
- Integer-coerced at the routing layer (`<int:...>` rejects non-numeric paths at routing)
- CSRF-protected via the global `ajaxSetup` `beforeSend` hook
- Returns success / danger JSON in the same shape as `/ajax/fullsync`

## UI

New block on `user_edit.html` under the existing *Kobo Sync Token* section:

- Book-ID number input + Resend button + inline feedback span
- Hidden behind `{% if current_user.role_admin() %}` so non-admin viewers never see it
- Show/hide in lockstep with the *Force Full Kobo Sync* button (token-deletion / token-creation modal hooks updated)
- Inline feedback shows success in green, errors in red (invalid book ID, empty/zero input, network failure)

## Verification

- RED → GREEN: `tests/unit/test_kobo_admin_resend_book.py` (8 tests covering route shape, decorator stack, both writes, both commits, security shape)
- Local docker cwn-local: live HTTP POST verified — `(user_id=3, book_id=2)` row cleared; `Books.last_modified` bumped from `2026-05-15 22:59:49+00:00` to current time
- Kobo protocol: next `GET /v1/library/sync` returns `NewEntitlement` for the resent book (not `ChangedEntitlement`)
- Playwright UI pilot: button renders, fills, posts; success/error/empty/zero all produce correct color-coded feedback
- All 123 Kobo unit tests + 36 admin/translations tests pass
- Adjacent: token-deletion hides the resend block + the existing fullsync button together

## Tier

borderline safe-tier-2 / review-tier — touches admin.py (high-touch file per CLAUDE.md tier policy), adds one new admin POST endpoint, ~40 LOC of new server code + ~30 LOC JS + ~10 LOC HTML. Tagging `safe-tier-2` since the new code only calls existing helpers (no new abstractions) and the security shape is conservative (admin-only, int-only path, CSRF-protected, defense-in-depth on the template).