### PR TITLE
Backport CWA #1349 (@navels): stale-event filter + batch follow-up + bounded internal retries

### DIFF
--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -547,17 +547,24 @@ def cwa_internal_reconnect_db():
 
     Security: Only accepts localhost callers.
     """
-    try:
-        remote = request.headers.get('X-Forwarded-For', request.remote_addr)
-        if remote not in (None, '127.0.0.1', '::1'):
-            abort(403)
+    remote = request.headers.get('X-Forwarded-For', request.remote_addr)
+    if remote not in (None, '127.0.0.1', '::1'):
+        abort(403)
 
+    try:
+        # Fork PR #199 ships a synchronous CalibreDB.refresh_for_new_data()
+        # in place of TaskReconnectDatabase via WorkerThread.add, which
+        # disposed the shared SQLAlchemy engine while in-flight greenlets
+        # were still using it (root cause of fork #192). Kept on backport
+        # of CWA #1349 by @navels — their deferred-batch logic upstream
+        # of this endpoint is preserved; the endpoint itself stays on
+        # the safe synchronous refresh.
         from .db import CalibreDB
         CalibreDB.refresh_for_new_data()
         return jsonify({"status": "refreshed"}), 200
     except Exception as e:
-        log.error(f"Internal reconnect-db failed: {e}")
-        return jsonify({"error": str(e)}), 400
+        log.exception("Internal reconnect-db failed")
+        return jsonify({"error": str(e)}), 500
 
 @csrf.exempt
 @cwa_stats.route('/cwa-scheduled/cancel', methods=["POST"])

--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -2,15 +2,15 @@
 
 echo "========== STARTING CWA-INGEST SERVICE =========="
 
-WATCH_FOLDER=$(grep -o '"ingest_folder": "[^"]*' /app/calibre-web-automated/dirs.json | grep -o '[^"]*$')
+WATCH_FOLDER=${WATCH_FOLDER:-$(grep -o '"ingest_folder": "[^"]*' /app/calibre-web-automated/dirs.json | grep -o '[^"]*$')}
 echo "[cwa-ingest-service] Watching folder: $WATCH_FOLDER"
 
 # Create queue file for retry processing (persistent across restarts)
-QUEUE_FILE="/config/cwa_ingest_retry_queue"
+QUEUE_FILE="${CWA_INGEST_RETRY_QUEUE:-/config/cwa_ingest_retry_queue}"
 touch "$QUEUE_FILE"
 
 # Create status file for basic status tracking (persistent across restarts)
-STATUS_FILE="/config/cwa_ingest_status"
+STATUS_FILE="${CWA_INGEST_STATUS_FILE:-/config/cwa_ingest_status}"
 echo "idle" > "$STATUS_FILE"
 
 # Ensure failed backup directory exists
@@ -47,6 +47,13 @@ STABLE_INTERVAL=${CWA_INGEST_STABLE_INTERVAL:-0.5}
 MAX_QUEUE_SIZE=${CWA_INGEST_MAX_QUEUE_SIZE:-50}
 SUPPORTED_EXT_REGEX='(epub|mobi|azw3|azw|pdf|txt|rtf|cbz|cbr|cb7|cbc|fb2|fbz|docx|html|htmlz|lit|lrf|odt|prc|pdb|pml|rb|snb|tcr|txtz|kepub|m4b|m4a|mp4|acsm|kfx|kfx-zip)$'
 TEMP_SUFFIXES='crdownload download part uploading'
+PROCESSING_DIR="${CWA_INGEST_PROCESSING_DIR:-/tmp/cwa_ingest_processing}"
+RECENT_DIR="${CWA_INGEST_RECENT_DIR:-/tmp/cwa_ingest_recent}"
+RECENT_EVENT_TTL="${CWA_INGEST_RECENT_EVENT_TTL:-120}"
+INGEST_BATCH_DIRTY_FILE="${CWA_INGEST_BATCH_DIRTY_FILE:-/config/cwa_ingest_batch_dirty}"
+INGEST_BATCH_LAST_SUCCESS_FILE="${CWA_INGEST_BATCH_LAST_SUCCESS_FILE:-/tmp/cwa_ingest_batch_last_success}"
+INGEST_BATCH_QUIET_SECONDS="${CWA_INGEST_BATCH_QUIET_SECONDS:-5}"
+mkdir -p "$PROCESSING_DIR" "$RECENT_DIR"
 get_stale_temp_minutes_from_db() {
         local minutes
         if command -v sqlite3 >/dev/null 2>&1; then
@@ -145,6 +152,207 @@ is_docker_desktop() {
         return 1
 }
 
+marker_key_for_path() {
+        local path="$1"
+        if command -v sha256sum >/dev/null 2>&1; then
+                printf '%s' "$path" | sha256sum | awk '{print $1}'
+        elif command -v shasum >/dev/null 2>&1; then
+                printf '%s' "$path" | shasum -a 256 | awk '{print $1}'
+        else
+                printf '%s' "$path" | cksum | awk '{print $1}'
+        fi
+}
+
+marker_stat_for_path() {
+        local path="$1"
+        local size mtime
+        size=$(stat -c %s "$path" 2>/dev/null || stat -f %z "$path" 2>/dev/null || echo "")
+        mtime=$(stat -c %Y "$path" 2>/dev/null || stat -f %m "$path" 2>/dev/null || echo "")
+        printf '%s:%s\n' "$size" "$mtime"
+}
+
+marker_age_seconds() {
+        local marker="$1"
+        local now marker_mtime
+        now=$(date +%s)
+        marker_mtime=$(stat -c %Y "$marker" 2>/dev/null || stat -f %m "$marker" 2>/dev/null || echo 0)
+        echo $((now - marker_mtime))
+}
+
+processing_marker_for_path() {
+        printf '%s/%s.processing\n' "$PROCESSING_DIR" "$(marker_key_for_path "$1")"
+}
+
+recent_marker_for_path() {
+        printf '%s/%s.recent\n' "$RECENT_DIR" "$(marker_key_for_path "$1")"
+}
+
+mark_recent_path() {
+        local path="$1"
+        local marker
+        marker=$(recent_marker_for_path "$path")
+        mkdir -p "$RECENT_DIR"
+        {
+                printf 'path=%s\n' "$path"
+                if [ -e "$path" ]; then
+                        printf 'stat=%s\n' "$(marker_stat_for_path "$path")"
+                else
+                        printf 'stat=missing\n'
+                fi
+        } > "$marker"
+}
+
+has_live_processing_marker() {
+        local path="$1"
+        local marker age
+        marker=$(processing_marker_for_path "$path")
+        [ -e "$marker" ] || return 1
+        age=$(marker_age_seconds "$marker")
+        if [ "$age" -ge "$RECENT_EVENT_TTL" ]; then
+                rm -f "$marker" 2>/dev/null || true
+                return 1
+        fi
+        return 0
+}
+
+is_recent_duplicate_event() {
+        local path="$1"
+        local marker age previous_stat current_stat
+        marker=$(recent_marker_for_path "$path")
+        [ -e "$marker" ] || return 1
+        age=$(marker_age_seconds "$marker")
+        if [ "$age" -ge "$RECENT_EVENT_TTL" ]; then
+                rm -f "$marker" 2>/dev/null || true
+                return 1
+        fi
+        if [ ! -e "$path" ]; then
+                return 0
+        fi
+        previous_stat=$(sed -n 's/^stat=//p' "$marker" 2>/dev/null | tail -n 1)
+        current_stat=$(marker_stat_for_path "$path")
+        [ "$previous_stat" = "$current_stat" ]
+}
+
+run_processor_with_timeout() {
+        local safety_timeout="$1"
+        local filepath="$2"
+        # Privilege-drop to the abc service user (PR #37 / #56) so books
+        # written by the ingest pipeline land with PUID:PGID ownership
+        # rather than root:root. The CWA_INGEST_PROCESSOR_CMD override
+        # is for test environments where the harness already manages
+        # the uid context (and the binary may not exist in /app/...).
+        if [ -n "${CWA_INGEST_PROCESSOR_CMD:-}" ]; then
+                timeout "$safety_timeout" "$CWA_INGEST_PROCESSOR_CMD" "$filepath"
+        else
+                timeout "$safety_timeout" s6-setuidgid abc python3 /app/calibre-web-automated/scripts/ingest_processor.py "$filepath"
+        fi
+}
+
+has_processing_markers() {
+        find "$PROCESSING_DIR" -type f -name '*.processing' -print -quit 2>/dev/null | grep -q .
+}
+
+is_supported_ingest_file() {
+        local filepath="$1"
+        local suf
+        for suf in $TEMP_SUFFIXES; do
+                [[ "$filepath" == *.$suf ]] && return 1
+        done
+        [[ "$filepath" == *.cwa.json ]] || [[ "$filepath" == *.cwa.failed.json ]] && return 1
+        [[ "$filepath" =~ $SUPPORTED_EXT_REGEX ]]
+}
+
+has_pending_ingest_files() {
+        local candidate
+        [ -d "$WATCH_FOLDER" ] || return 1
+        while IFS= read -r candidate; do
+                if is_supported_ingest_file "$candidate"; then
+                        return 0
+                fi
+        done < <(find "$WATCH_FOLDER" -type f -print 2>/dev/null)
+        return 1
+}
+
+batch_marker_age_seconds() {
+        local marker="$1"
+        [ -e "$marker" ] || return 1
+        marker_age_seconds "$marker"
+}
+
+latest_batch_activity_age_seconds() {
+        local dirty_age success_age
+        dirty_age=$(batch_marker_age_seconds "$INGEST_BATCH_DIRTY_FILE" 2>/dev/null || echo "")
+        success_age=$(batch_marker_age_seconds "$INGEST_BATCH_LAST_SUCCESS_FILE" 2>/dev/null || echo "")
+        if [ -n "$dirty_age" ] && [ -n "$success_age" ] && [ "$success_age" -lt "$dirty_age" ]; then
+                echo "$success_age"
+        else
+                echo "${dirty_age:-0}"
+        fi
+}
+
+is_ingest_batch_quiet() {
+        [ -e "$INGEST_BATCH_DIRTY_FILE" ] || return 1
+        [ -d "$WATCH_FOLDER" ] || return 1
+        has_processing_markers && return 1
+        [ -s "$QUEUE_FILE" ] && return 1
+        has_pending_ingest_files && return 1
+        local age
+        age=$(latest_batch_activity_age_seconds)
+        [ "$age" -ge "$INGEST_BATCH_QUIET_SECONDS" ]
+}
+
+run_post_batch_follow_up() {
+        if [ -n "${CWA_INGEST_POST_BATCH_CMD:-}" ]; then
+                "$CWA_INGEST_POST_BATCH_CMD"
+        else
+                python3 /app/calibre-web-automated/scripts/ingest_processor.py --post-batch-follow-up
+        fi
+}
+
+maybe_run_post_batch_follow_up() {
+        is_ingest_batch_quiet || return 0
+
+        local running_marker="${INGEST_BATCH_DIRTY_FILE}.running"
+        if ! mv "$INGEST_BATCH_DIRTY_FILE" "$running_marker" 2>/dev/null; then
+                return 0
+        fi
+
+        echo "[cwa-ingest-service] Post-batch follow-up triggered"
+        if run_post_batch_follow_up; then
+                rm -f "$running_marker" 2>/dev/null || true
+                echo "[cwa-ingest-service] Post-batch follow-up completed"
+        else
+                echo "[cwa-ingest-service] WARN: Post-batch follow-up failed; will retry later"
+                mv "$running_marker" "$INGEST_BATCH_DIRTY_FILE" 2>/dev/null || touch "$INGEST_BATCH_DIRTY_FILE"
+        fi
+}
+
+post_batch_follow_up_loop() {
+        local interval="$INGEST_BATCH_QUIET_SECONDS"
+        if [ "$interval" -lt 1 ]; then
+                interval=1
+        fi
+        while true; do
+                maybe_run_post_batch_follow_up
+                sleep "$interval"
+        done
+}
+
+POST_BATCH_FOLLOW_UP_PID=""
+
+cleanup_background_jobs() {
+        if [ -n "$POST_BATCH_FOLLOW_UP_PID" ]; then
+                kill "$POST_BATCH_FOLLOW_UP_PID" 2>/dev/null || true
+                wait "$POST_BATCH_FOLLOW_UP_PID" 2>/dev/null || true
+                POST_BATCH_FOLLOW_UP_PID=""
+        fi
+}
+
+terminate_service() {
+        cleanup_background_jobs
+        exit 0
+}
+
 process_retry_queue() {
         if [ -s "$QUEUE_FILE" ]; then
                 echo "[cwa-ingest-service] Processing retry queue..."
@@ -155,8 +363,13 @@ process_retry_queue() {
                                 echo "[cwa-ingest-service] Retrying: $queued_file"
                                 local configured_timeout=$(get_timeout_from_db)  # Get configured timeout from database
                                 local safety_timeout=$((configured_timeout * 3))  # Safety timeout is 3x the configured timeout
-                                timeout $safety_timeout s6-setuidgid abc python3 /app/calibre-web-automated/scripts/ingest_processor.py "$queued_file"
+                                local processing_marker
+                                processing_marker=$(processing_marker_for_path "$queued_file")
+                                mkdir -p "$PROCESSING_DIR"
+                                : > "$processing_marker"
+                                run_processor_with_timeout "$safety_timeout" "$queued_file"
                                 local retry_exit=$?
+                                rm -f "$processing_marker" 2>/dev/null || true
 
                                 if [ $retry_exit -eq 2 ]; then
                                         # Still busy, keep in queue
@@ -170,11 +383,18 @@ process_retry_queue() {
                                                 cp "$queued_file" "/config/processed_books/failed/$failed_filename" 2>/dev/null || true
                                         fi
                                         rm -f "$queued_file" 2>/dev/null || true
+                                        mark_recent_path "$queued_file"
                                 elif [ $retry_exit -eq 0 ]; then
                                         echo "[cwa-ingest-service] Successfully processed retry: $queued_file"
+                                        mark_recent_path "$queued_file"
+                                        touch "$INGEST_BATCH_LAST_SUCCESS_FILE" 2>/dev/null || true
                                 else
                                         echo "[cwa-ingest-service] Error on retry: $queued_file (exit: $retry_exit)"
+                                        mark_recent_path "$queued_file"
                                 fi
+                        else
+                                echo "[cwa-ingest-service] Skipping vanished retry queue entry: $queued_file"
+                                mark_recent_path "$queued_file"
                         fi
                 done < "$QUEUE_FILE"
 
@@ -184,12 +404,11 @@ process_retry_queue() {
                         echo "[cwa-ingest-service] $(wc -l < "$QUEUE_FILE") files remain in retry queue"
                 fi
         fi
+        maybe_run_post_batch_follow_up
 }
 
 handle_event() {
         local filepath="$1"
-        local configured_timeout=$(get_timeout_from_db)  # Get configured timeout from database
-        local safety_timeout=$((configured_timeout * 3))  # Safety timeout is 3x the configured timeout
         local filename=$(basename "$filepath")
 
         # temp suffixes
@@ -206,15 +425,39 @@ handle_event() {
                 return 0
         fi
 
+        if is_recent_duplicate_event "$filepath"; then
+                echo "[cwa-ingest-service] Skipping duplicate recent event: $filepath"
+                return 0
+        fi
+
+        if [ ! -e "$filepath" ]; then
+                echo "[cwa-ingest-service] Skipping stale event for missing file: $filepath"
+                mark_recent_path "$filepath"
+                return 0
+        fi
+
+        if has_live_processing_marker "$filepath"; then
+                echo "[cwa-ingest-service] Skipping duplicate event for in-flight file: $filepath"
+                return 0
+        fi
+
         cleanup_stale_temps
+
+        local configured_timeout=$(get_timeout_from_db)  # Get configured timeout from database
+        local safety_timeout=$((configured_timeout * 3))  # Safety timeout is 3x the configured timeout
+        local processing_marker
+        processing_marker=$(processing_marker_for_path "$filepath")
 
         echo "[cwa-ingest-service] New file detected - $filepath - Starting Ingest Processor..."
         echo "[cwa-ingest-service] Configured timeout: ${configured_timeout}s, Safety timeout: ${safety_timeout}s"
         echo "processing:$filename:$(date '+%Y-%m-%d %H:%M:%S')" > "$STATUS_FILE"
 
         # Use safety timeout as last resort - processor should handle its own timeout internally
-        timeout $safety_timeout s6-setuidgid abc python3 /app/calibre-web-automated/scripts/ingest_processor.py "$filepath"
+        mkdir -p "$PROCESSING_DIR"
+        : > "$processing_marker"
+        run_processor_with_timeout "$safety_timeout" "$filepath"
         local exit_code=$?
+        rm -f "$processing_marker" 2>/dev/null || true
 
         if [ $exit_code -eq 124 ]; then
                 echo "[cwa-ingest-service] SAFETY TIMEOUT: $filepath took longer than safety timeout of ${safety_timeout} seconds"
@@ -228,6 +471,7 @@ handle_event() {
                         cp "$filepath" "/config/processed_books/failed/$failed_filename" 2>/dev/null || true
                 fi
                 rm -f "$filepath" 2>/dev/null || true
+                mark_recent_path "$filepath"
         elif [ $exit_code -eq 2 ]; then
                 echo "[cwa-ingest-service] Processor busy, adding to retry queue: $filepath"
                 echo "queued:$filename:$(date '+%Y-%m-%d %H:%M:%S')" > "$STATUS_FILE"
@@ -246,15 +490,28 @@ handle_event() {
         elif [ $exit_code -ne 0 ]; then
                 echo "[cwa-ingest-service] Error processing $filepath (exit code: $exit_code)"
                 echo "error:$filename:$exit_code:$(date '+%Y-%m-%d %H:%M:%S')" > "$STATUS_FILE"
+                mark_recent_path "$filepath"
         else
                 echo "[cwa-ingest-service] Successfully processed: $filepath"
                 echo "completed:$filename:$(date '+%Y-%m-%d %H:%M:%S')" > "$STATUS_FILE"
+                mark_recent_path "$filepath"
+                touch "$INGEST_BATCH_LAST_SUCCESS_FILE" 2>/dev/null || true
                 # Try to process any queued files after successful completion
                 process_retry_queue
+                maybe_run_post_batch_follow_up
         fi
 
         echo "idle" > "$STATUS_FILE"
 }
+
+if [ "${CWA_INGEST_SERVICE_TEST_MODE:-0}" = "1" ]; then
+        return 0 2>/dev/null || exit 0
+fi
+
+post_batch_follow_up_loop &
+POST_BATCH_FOLLOW_UP_PID=$!
+trap cleanup_background_jobs EXIT
+trap terminate_service TERM HUP INT
 
 if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
         echo "[cwa-ingest-service] NETWORK_SHARE_MODE=true -> using fallback watcher"
@@ -291,4 +548,3 @@ fi
                 handle_event "$filepath"
         done
 ) || run_fallback
-

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -18,10 +18,10 @@ import threading
 from datetime import datetime
 from pathlib import Path
 
-from cwa_db import CWA_DB
-from kindle_epub_fixer import EPUBFixer
-import audiobook
-import requests
+# cwa_db / kindle_epub_fixer / audiobook / requests are loaded lazily by
+# initialize_runtime() (CWA #1349 by @navels) so the ingest-service can
+# fast-exit when there's nothing to process. Globals declared just below
+# so _load_runtime_dependencies() can rebind them.
 
 # Path-shim so cps.services.* is importable when this script runs as a
 # standalone subprocess (the cwa-ingest-service entrypoint). cps lives
@@ -114,6 +114,14 @@ fetch_and_apply_metadata = None
 TaskAutoSend = None
 WorkerThread = None
 _ub = None
+CWA_DB = None
+EPUBFixer = None
+audiobook = None
+requests = None
+backup_destinations = {}
+process_lock = None
+_runtime_initialized = False
+_runtime_init_attempted = False
 
 # Debounced duplicate scan timer
 _duplicate_scan_timer = None
@@ -256,13 +264,10 @@ class ProcessLock:
             except:
                 pass
 
-# Global lock instance (instantiation only — acquire happens in main()
-# so importing this module from a test runner has no side effects).
-process_lock = ProcessLock()
-
 def cleanup_lock():
     """Cleanup function for atexit"""
-    process_lock.release()
+    if process_lock:
+        process_lock.release()
 
 
 def get_app_db_path() -> str:
@@ -305,49 +310,133 @@ def _load_cps_settings_from_app_db() -> None:
     except Exception as e:
         print(f"[ingest-processor] WARN: Could not read CPS settings from app.db ({app_db_path}): {e}", flush=True)
 
-try:
-    # Ensure project root is on sys.path to import cps
+def _ensure_project_root_on_path() -> None:
     cps_path = os.path.dirname(os.path.dirname(__file__))
     if cps_path not in sys.path:
         sys.path.append(cps_path)
 
-    # Import GDrive functionality
-    try:
-        from cps import gdriveutils as _gdriveutils, config as _cps_config
-        _GDRIVE_AVAILABLE = True
-        print("[ingest-processor] GDrive functionality available", flush=True)
-        _load_cps_settings_from_app_db()
-    except (ImportError, TypeError, AttributeError) as e:
-        print(f"[ingest-processor] GDrive functionality not available: {e}", flush=True)
-        _gdriveutils = None
-        _cps_config = None
-        _GDRIVE_AVAILABLE = False
 
-    # Import auto-send and metadata functionality
+def _load_runtime_dependencies() -> None:
+    global CWA_DB, EPUBFixer, audiobook, requests
+    if CWA_DB and EPUBFixer and audiobook and requests:
+        return
+
+    from cwa_db import CWA_DB as _CWA_DB
+    from kindle_epub_fixer import EPUBFixer as _EPUBFixer
+    import audiobook as _audiobook
+    import requests as _requests
+
+    CWA_DB = _CWA_DB
+    EPUBFixer = _EPUBFixer
+    audiobook = _audiobook
+    requests = _requests
+
+
+def _load_optional_cps_modules() -> None:
+    global _GDRIVE_AVAILABLE, _CPS_AVAILABLE
+    global _gdriveutils, _cps_config, fetch_and_apply_metadata, TaskAutoSend, WorkerThread, _ub
+
+    if _GDRIVE_AVAILABLE and _CPS_AVAILABLE:
+        return
+
     try:
-        from cps.metadata_helper import fetch_and_apply_metadata
-        from cps.tasks.auto_send import TaskAutoSend
-        from cps.services.worker import WorkerThread
-        from cps import ub as _ub
-        from cps.calibre_init import init_calibre_db_from_app_db
-        init_calibre_db_from_app_db(get_app_db_path())
-        _CPS_AVAILABLE = True
-        print("[ingest-processor] Auto-send and metadata functionality available", flush=True)
-    except ImportError as e:
-        print(f"[ingest-processor] Auto-send/metadata functionality not available: {e}", flush=True)
-        fetch_and_apply_metadata = None
-        TaskAutoSend = None
-        WorkerThread = None
-        _ub = None
+        _ensure_project_root_on_path()
+
+        # Import GDrive functionality
+        try:
+            from cps import gdriveutils as loaded_gdriveutils, config as loaded_cps_config
+            _gdriveutils = loaded_gdriveutils
+            _cps_config = loaded_cps_config
+            _GDRIVE_AVAILABLE = True
+            print("[ingest-processor] GDrive functionality available", flush=True)
+            _load_cps_settings_from_app_db()
+        except (ImportError, TypeError, AttributeError) as e:
+            print(f"[ingest-processor] GDrive functionality not available: {e}", flush=True)
+            _gdriveutils = None
+            _cps_config = None
+            _GDRIVE_AVAILABLE = False
+
+        # Import auto-send and metadata functionality
+        try:
+            from cps.metadata_helper import fetch_and_apply_metadata as loaded_fetch_and_apply_metadata
+            from cps.tasks.auto_send import TaskAutoSend as LoadedTaskAutoSend
+            from cps.services.worker import WorkerThread as LoadedWorkerThread
+            from cps import ub as loaded_ub
+            from cps.calibre_init import init_calibre_db_from_app_db
+            init_calibre_db_from_app_db(get_app_db_path())
+            fetch_and_apply_metadata = loaded_fetch_and_apply_metadata
+            TaskAutoSend = LoadedTaskAutoSend
+            WorkerThread = LoadedWorkerThread
+            _ub = loaded_ub
+            _CPS_AVAILABLE = True
+            print("[ingest-processor] Auto-send and metadata functionality available", flush=True)
+        except ImportError as e:
+            print(f"[ingest-processor] Auto-send/metadata functionality not available: {e}", flush=True)
+            fetch_and_apply_metadata = None
+            TaskAutoSend = None
+            WorkerThread = None
+            _ub = None
+            _CPS_AVAILABLE = False
+
+    except Exception as e:
+        print(f"[ingest-processor] WARN: Unexpected error during CPS path setup: {e}", flush=True)
+        _GDRIVE_AVAILABLE = False
         _CPS_AVAILABLE = False
 
-except Exception as e:
-    print(f"[ingest-processor] WARN: Unexpected error during CPS path setup: {e}", flush=True)
-    # Only disable if there's a fundamental path/import issue
-    if '_GDRIVE_AVAILABLE' not in locals():
-        _GDRIVE_AVAILABLE = False
-    if '_CPS_AVAILABLE' not in locals():
-        _CPS_AVAILABLE = False
+
+def _ensure_processed_books_dirs() -> None:
+    """Ensure processed backups directory structure exists so backups never crash on missing folders."""
+    try:
+        processed_root = "/config/processed_books"
+        os.makedirs(processed_root, exist_ok=True)
+        for name in ("converted", "imported", "fixed_originals", "failed"):
+            os.makedirs(os.path.join(processed_root, name), exist_ok=True)
+    except Exception as e:
+        print(f"[ingest-processor] WARN: Could not ensure processed_books directories: {e}", flush=True)
+
+
+def _load_backup_destinations() -> None:
+    global backup_destinations
+    try:
+        backup_destinations = {
+            entry.name: entry.path
+            for entry in os.scandir("/config/processed_books")
+            if entry.is_dir()
+        }
+    except FileNotFoundError:
+        # Fallback for test environments where /config might not exist
+        backup_destinations = {}
+    except Exception as e:
+        print(f"[ingest-processor] WARN: Could not scan processed_books: {e}", flush=True)
+        backup_destinations = {}
+
+
+def initialize_runtime() -> bool:
+    """Initialize heavy ingest runtime after the target path has passed cheap validation."""
+    global process_lock, _runtime_initialized, _runtime_init_attempted
+
+    if _runtime_initialized:
+        return True
+    if _runtime_init_attempted:
+        return False
+    _runtime_init_attempted = True
+
+    _ensure_project_root_on_path()
+    _load_runtime_dependencies()
+    _load_optional_cps_modules()
+
+    process_lock = ProcessLock()
+    if not process_lock.acquire(timeout=10):
+        return False
+
+    _ensure_processed_books_dirs()
+    _load_backup_destinations()
+    _runtime_initialized = True
+    return True
+
+
+def _is_missing_ingest_target(filepath: str) -> bool:
+    return not os.path.isfile(filepath) and not os.path.isdir(filepath)
 
 def gdrive_sync_if_enabled():
     """Sync Calibre library to Google Drive if enabled in app config."""
@@ -361,33 +450,13 @@ def gdrive_sync_if_enabled():
 def _acquire_process_lock_or_exit():
     """Single-instance guard. Run only when this module is executed as a
     script — never on import — so pytest-xdist workers (which share /tmp
-    across processes) don't take each other out at import time."""
+    across processes) don't take each other out at import time. The
+    process_lock is instantiated by initialize_runtime() (CWA #1349 by
+    @navels) before _acquire_process_lock_or_exit() runs from main()."""
     atexit.register(cleanup_lock)
-    if not process_lock.acquire(timeout=10):
+    if process_lock is None or not process_lock.acquire(timeout=10):
         sys.exit(2)
 
-# Ensure processed backups directory structure exists so backups never crash on missing folders
-try:
-    _processed_root = "/config/processed_books"
-    os.makedirs(_processed_root, exist_ok=True)
-    for _name in ("converted", "imported", "fixed_originals", "failed"):
-        os.makedirs(os.path.join(_processed_root, _name), exist_ok=True)
-except Exception as e:
-    print(f"[ingest-processor] WARN: Could not ensure processed_books directories: {e}", flush=True)
-
-# Generates dictionary of available backup directories and their paths
-try:
-    backup_destinations = {
-            entry.name: entry.path
-            for entry in os.scandir("/config/processed_books")
-            if entry.is_dir()
-        }
-except FileNotFoundError:
-    # Fallback for test environments where /config might not exist
-    backup_destinations = {}
-except Exception as e:
-    print(f"[ingest-processor] WARN: Could not scan processed_books: {e}", flush=True)
-    backup_destinations = {}
 
 def get_internal_api_url(path):
     """Construct internal API URL, respecting SSL configuration"""
@@ -426,6 +495,90 @@ def get_internal_api_url(path):
 def get_internal_api_headers():
     """Provide headers that satisfy localhost-only internal endpoint checks."""
     return {"X-Forwarded-For": "127.0.0.1"}
+
+
+def get_ingest_batch_dirty_file() -> str:
+    return os.environ.get("CWA_INGEST_BATCH_DIRTY_FILE", "/config/cwa_ingest_batch_dirty")
+
+
+def mark_ingest_batch_dirty() -> None:
+    dirty_file = get_ingest_batch_dirty_file()
+    try:
+        dirty_dir = os.path.dirname(dirty_file)
+        if dirty_dir:
+            os.makedirs(dirty_dir, exist_ok=True)
+        with open(dirty_file, "w", encoding="utf-8") as marker:
+            marker.write(f"dirty_at={int(time.time())}\n")
+        print(f"[ingest-processor] Marked ingest batch follow-up dirty: {dirty_file}", flush=True)
+    except Exception as e:
+        print(f"[ingest-processor] WARN: Failed to mark ingest batch follow-up dirty: {e}", flush=True)
+
+
+def _post_internal_endpoint(path: str, payload: dict | None = None) -> bool:
+    global requests
+    if requests is None:
+        import requests as loaded_requests
+        requests = loaded_requests
+
+    retryable_statuses = (500, 503)
+    retryable_exceptions = (requests.exceptions.Timeout, requests.exceptions.ConnectionError)
+    max_attempts = 2 if path == "/cwa-internal/reconnect-db" else 1
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            resp = requests.post(
+                get_internal_api_url(path),
+                json=payload,
+                headers=get_internal_api_headers(),
+                timeout=5,
+                verify=False,
+            )
+            if resp.status_code == 200:
+                return True
+            if resp.status_code in retryable_statuses and attempt < max_attempts:
+                print(
+                    f"[ingest-processor] WARN: Batch follow-up endpoint {path} returned "
+                    f"{resp.status_code}; retrying once",
+                    flush=True,
+                )
+                time.sleep(1)
+                continue
+            print(
+                f"[ingest-processor] WARN: Batch follow-up endpoint {path} returned {resp.status_code}",
+                flush=True,
+            )
+            return False
+        except retryable_exceptions as e:
+            if attempt < max_attempts:
+                print(
+                    f"[ingest-processor] WARN: Batch follow-up endpoint {path} failed transiently: "
+                    f"{e}; retrying once",
+                    flush=True,
+                )
+                time.sleep(1)
+                continue
+            print(f"[ingest-processor] WARN: Batch follow-up endpoint {path} failed: {e}", flush=True)
+            return False
+        except Exception as e:
+            print(f"[ingest-processor] WARN: Batch follow-up endpoint {path} failed: {e}", flush=True)
+            return False
+    return False
+
+
+def run_post_batch_follow_up() -> int:
+    """Run follow-up work once the ingest service observes a quiet dirty batch."""
+    print("[ingest-processor] Running post-batch follow-up", flush=True)
+    checks = [
+        _post_internal_endpoint("/cwa-internal/reconnect-db"),
+        _post_internal_endpoint("/duplicates/invalidate-cache"),
+        _post_internal_endpoint("/cwa-internal/queue-duplicate-scan"),
+    ]
+    if all(checks):
+        print("[ingest-processor] Post-batch follow-up completed", flush=True)
+        return 0
+    print("[ingest-processor] WARN: Post-batch follow-up incomplete", flush=True)
+    return 1
+
 
 class NewBookProcessor:
     def __init__(self, filepath: str):
@@ -915,6 +1068,8 @@ class NewBookProcessor:
             self.db.import_add_entry(staged_path.stem,
                                     str(self.cwa_settings["auto_backup_imports"]))
 
+            mark_ingest_batch_dirty()
+
             # Optional post-import GDrive sync
             gdrive_sync_if_enabled()
 
@@ -929,16 +1084,6 @@ class NewBookProcessor:
                 self.trigger_auto_send_if_enabled(book_id=self.last_added_book_id, book_path=book_path)
             else:
                 self.trigger_auto_send_if_enabled(staged_path.stem, book_path)
-
-            # CRITICAL FIX: Refresh Calibre-Web's database session to make new books visible
-            # This solves the issue where multiple books don't appear until container restart
-            self.refresh_cwa_session()
-
-            # Invalidate duplicate cache since a new book was added
-            self.invalidate_duplicate_cache()
-
-            # Debounced duplicate scan (after import)
-            self.schedule_debounced_duplicate_scan()
 
             # Generate KOReader sync checksums for the imported book
             if self.last_added_book_id is not None:
@@ -1031,6 +1176,7 @@ class NewBookProcessor:
                 "calibredb", "add_format", str(book_id), str(staged_path), f"--library-path={self.library_dir}"
             ], env=self.calibre_env, check=True, capture_output=True, text=True)
             print(f"[ingest-processor] Added new format for book id {book_id}: {os.path.basename(str(staged_path))}", flush=True)
+            mark_ingest_batch_dirty()
             if self.cwa_settings['auto_backup_imports']:
                 self.backup(str(staged_path), backup_type="imported")
             # Optional post-add-format GDrive sync
@@ -1293,98 +1439,6 @@ class NewBookProcessor:
             print(f"[ingest-processor] Error generating book checksums: {e}", flush=True)
             # Don't fail the import if checksum generation fails
 
-
-    def refresh_cwa_session(self) -> None:
-        """Refresh Calibre-Web's database session to make newly added books visible
-
-        This solves the issue where external calibredb adds aren't immediately visible
-        in Calibre-Web until container restart.
-        """
-        # Route DB reconnect via the long-lived web process to avoid cross-process config/session issues
-        try:
-            url = get_internal_api_url("/cwa-internal/reconnect-db")
-            print("[ingest-processor] Refreshing Calibre-Web database session...", flush=True)
-            resp = requests.post(
-                url,
-                headers=get_internal_api_headers(),
-                timeout=5,
-                verify=False,
-            )
-            if resp.status_code == 200:
-                print("[ingest-processor] Database session refreshed", flush=True)
-            else:
-                print(f"[ingest-processor] WARN: DB refresh endpoint returned {resp.status_code}", flush=True)
-        except Exception as e:
-            print(f"[ingest-processor] WARN: Failed to call DB refresh endpoint: {e}", flush=True)
-            print("[ingest-processor] Continuing despite session refresh failure - books may require manual refresh", flush=True)
-
-
-    def invalidate_duplicate_cache(self) -> None:
-        """Invalidate the duplicate detection cache after adding a new book
-
-        This marks the cache as stale (scan_pending=1) but does NOT trigger an automatic scan.
-        Users must manually trigger a scan from the /duplicates page, or wait for scheduled scans.
-        """
-        try:
-            url = get_internal_api_url("/duplicates/invalidate-cache")
-            resp = requests.post(
-                url,
-                headers=get_internal_api_headers(),
-                timeout=5,
-                verify=False,
-            )
-            if resp.status_code == 200:
-                print("[ingest-processor] Duplicate cache invalidated", flush=True)
-            else:
-                print(f"[ingest-processor] WARN: Duplicate cache invalidation returned {resp.status_code}", flush=True)
-        except Exception as e:
-            # Don't fail the import if cache invalidation fails
-            print(f"[ingest-processor] WARN: Failed to invalidate duplicate cache: {e}", flush=True)
-
-
-    def schedule_debounced_duplicate_scan(self) -> None:
-        """Schedule a debounced background duplicate scan if enabled.
-
-        Uses a 60-second timer that resets on each new import to avoid repeated scans
-        during batch ingest.
-        """
-        try:
-            enabled = bool(self.cwa_settings.get('duplicate_scan_enabled', 0))
-            frequency = self.cwa_settings.get('duplicate_scan_frequency', 'manual')
-
-            if not enabled or frequency != 'after_import':
-                return
-            # Schedule in the long-lived web process so the debounce survives
-            # the short-lived ingest process exiting.
-            try:
-                delay_seconds = int(self.cwa_settings.get('duplicate_scan_debounce_seconds', 30))
-                delay_seconds = max(10, min(600, delay_seconds))
-                url = get_internal_api_url("/cwa-internal/queue-duplicate-scan")
-                payload = {"delay_seconds": delay_seconds}
-                resp = requests.post(
-                    url,
-                    json=payload,
-                    headers=get_internal_api_headers(),
-                    timeout=5,
-                    verify=False,
-                )
-                if resp.status_code == 200:
-                    try:
-                        body = resp.json()
-                        if body.get('queued'):
-                            print("[ingest-processor] Debounced duplicate scan scheduled via web process", flush=True)
-                        elif body.get('skipped'):
-                            print("[ingest-processor] Duplicate scan scheduling skipped (disabled/manual)", flush=True)
-                    except Exception:
-                        print("[ingest-processor] Debounced duplicate scan scheduled via web process", flush=True)
-                else:
-                    print(f"[ingest-processor] WARN: Duplicate scan scheduling returned {resp.status_code}", flush=True)
-            except Exception as e:
-                print(f"[ingest-processor] WARN: Failed to schedule duplicate scan via web API: {e}", flush=True)
-        except Exception as e:
-            print(f"[ingest-processor] WARN: Failed to schedule debounced duplicate scan: {e}", flush=True)
-
-
     def set_library_permissions(self):
         try:
             nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
@@ -1409,6 +1463,9 @@ def main(filepath=None):
             sys.exit(1)
         filepath = sys.argv[1]
 
+    if filepath == "--post-batch-follow-up":
+        return run_post_batch_follow_up()
+
     nbp = None
     skip_delete = False
     try:
@@ -1422,7 +1479,11 @@ def main(filepath=None):
         # Ignore sidecar manifests entirely (handled when the real file is processed)
         if filename.endswith(".cwa.json") or filename.endswith(".cwa.failed.json"):
             print(f"[ingest-processor] Skipping sidecar manifest file: {filename}", flush=True)
-            return
+            return 0
+
+        if _is_missing_ingest_target(filepath):
+            print(f"[ingest-processor] Skipping missing ingest target: {filepath}", flush=True)
+            return 0
 
         if len(name) > allowed_len:
             new_name = name[:allowed_len] + ext
@@ -1432,11 +1493,17 @@ def main(filepath=None):
         ###############################################################################################
         if os.path.isdir(filepath) and Path(filepath).exists():
             # print(os.listdir(filepath))
+            exit_code = 0
             for filename in os.listdir(filepath):
                 f = os.path.join(filepath, filename)
                 if Path(f).exists():
-                    main(f)
-            return
+                    child_exit = main(f)
+                    if child_exit:
+                        exit_code = int(child_exit)
+            return exit_code
+
+        if not initialize_runtime():
+            return 2
 
         nbp = NewBookProcessor(filepath)
 
@@ -1449,7 +1516,7 @@ def main(filepath=None):
             if not ready:
                 print(f"[ingest-processor] WARN: File did not become ready in time or vanished (after {timeout_minutes} minutes): {nbp.filename}", flush=True)
                 skip_delete = True
-                return
+                return 0
 
         # Sidecar manifest handling for explicit actions (e.g., add_format)
         manifest_path = filepath + ".cwa.json"
@@ -1490,7 +1557,7 @@ def main(filepath=None):
                     
                     nbp.set_library_permissions()
                     nbp.delete_current_file()
-                    return
+                    return 0
         except Exception as e:
             print(f"[ingest-processor] Error processing manifest file: {e}", flush=True)
             # Continue with normal processing if manifest handling fails
@@ -1502,7 +1569,7 @@ def main(filepath=None):
             # Do NOT delete ignored temporary files; they may be renamed shortly (e.g. .uploading -> .epub)
             print(f"[ingest-processor] Skipping ignored/temporary file (no action taken): {nbp.filename}", flush=True)
             skip_delete = True
-            return
+            return 0
 
         if nbp.is_target_format: # File can just be imported
             print(f"\n[ingest-processor]: No conversion needed for {nbp.filename}, importing now...", flush=True)
@@ -1556,6 +1623,8 @@ def main(filepath=None):
             else:
                 print(f"[ingest-processor]: Cannot convert {nbp.filepath}. {nbp.input_format} is currently unsupported / is not a known ebook format.", flush=True)
 
+        return 0
+
     except Exception as e:
         print(f"[ingest-processor] Unexpected error during processing: {e}", flush=True)
         raise
@@ -1587,4 +1656,4 @@ def main(filepath=None):
                 pass  # Ignore errors in cleanup
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -450,10 +450,13 @@ def gdrive_sync_if_enabled():
 def _acquire_process_lock_or_exit():
     """Single-instance guard. Run only when this module is executed as a
     script — never on import — so pytest-xdist workers (which share /tmp
-    across processes) don't take each other out at import time. The
-    process_lock is instantiated by initialize_runtime() (CWA #1349 by
-    @navels) before _acquire_process_lock_or_exit() runs from main()."""
+    across processes) don't take each other out at import time. Triggers
+    initialize_runtime() (CWA #1349 by @navels) which instantiates the
+    process_lock lazily. If initialize_runtime() fails (e.g. missing
+    heavy dependencies in a test environment), bail with exit code 2."""
     atexit.register(cleanup_lock)
+    if not initialize_runtime():
+        sys.exit(2)
     if process_lock is None or not process_lock.acquire(timeout=10):
         sys.exit(2)
 
@@ -1454,8 +1457,6 @@ def main(filepath=None):
     """Checks if filepath is a directory. If it is, main will be ran on every file in the given directory
     Inotifywait won't detect files inside folders if the folder was moved rather than copied"""
 
-    _acquire_process_lock_or_exit()
-
     if filepath is None:
         if len(sys.argv) < 2:
             print("[ingest-processor] ERROR: No file path provided", flush=True)
@@ -1464,7 +1465,21 @@ def main(filepath=None):
         filepath = sys.argv[1]
 
     if filepath == "--post-batch-follow-up":
+        # Post-batch follow-up triggers the per-batch refresh + duplicate
+        # scan that used to happen per-book. Acquire the lock since this
+        # may take a moment and shouldn't race with another follow-up.
+        _acquire_process_lock_or_exit()
         return run_post_batch_follow_up()
+
+    # Fast-exit path: stale ingest events that target an already-moved
+    # or deleted file should skip the lock + heavy startup entirely.
+    # CWA #1349 by @navels — prevents polling-fallback / NFS watchers
+    # from re-emitting the same path indefinitely.
+    if _is_missing_ingest_target(filepath):
+        print(f"[ingest-processor] Skipping missing ingest target: {filepath}", flush=True)
+        return 0
+
+    _acquire_process_lock_or_exit()
 
     nbp = None
     skip_delete = False
@@ -1481,9 +1496,9 @@ def main(filepath=None):
             print(f"[ingest-processor] Skipping sidecar manifest file: {filename}", flush=True)
             return 0
 
-        if _is_missing_ingest_target(filepath):
-            print(f"[ingest-processor] Skipping missing ingest target: {filepath}", flush=True)
-            return 0
+        # Note: missing-target fast-exit already happened earlier in main()
+        # before the lock acquisition. Reaching here means the file
+        # existed at function entry; intentionally do NOT re-check.
 
         if len(name) > allowed_len:
             new_name = name[:allowed_len] + ext

--- a/tests/smoke/test_schedule_ops_endpoints_smoke.py
+++ b/tests/smoke/test_schedule_ops_endpoints_smoke.py
@@ -15,6 +15,7 @@ scheduling code structure exists and is properly integrated.
 import pytest
 import sys
 import os
+import ast
 from pathlib import Path
 
 # Mark all tests in this file as smoke tests
@@ -22,6 +23,15 @@ pytestmark = pytest.mark.smoke
 
 # Get project root (3 levels up from this file)
 project_root = Path(__file__).parent.parent.parent
+
+
+def _function_source(source_path, function_name):
+    source = source_path.read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            return ast.get_source_segment(source, node)
+    raise AssertionError(f"Function {function_name} not found in {source_path}")
 
 
 class TestConvertLibraryScheduling:
@@ -191,6 +201,31 @@ class TestUpcomingOpsEndpoint:
         # Verify upcoming ops table exists
         assert 'Upcoming scheduled operations' in content or 'cwa_scheduled_upcoming_ops' in content
         assert 'upcomingopstable' in content
+
+
+class TestNfsImportLifecycleHardening:
+    """Static checks for NFS ingest lifecycle endpoint hardening."""
+
+    def test_reconnect_db_logs_exceptions_with_stack(self):
+        """Verify reconnect-db failures preserve exception stack details."""
+        cwa_functions_file = project_root / 'cps' / 'cwa_functions.py'
+
+        function_body = _function_source(cwa_functions_file, 'cwa_internal_reconnect_db')
+
+        assert 'log.exception(' in function_body
+
+    def test_ingest_batch_follow_up_retries_reconnect_once_for_transient_failures(self):
+        """Verify ingest-side reconnect retry is bounded and covers transient failures."""
+        ingest_processor_file = project_root / 'scripts' / 'ingest_processor.py'
+
+        function_body = _function_source(ingest_processor_file, '_post_internal_endpoint')
+
+        assert 'max_attempts = 2 if path == "/cwa-internal/reconnect-db" else 1' in function_body
+        assert 'retrying once' in function_body
+        assert '500' in function_body
+        assert '503' in function_body
+        assert 'requests.exceptions.Timeout' in function_body
+        assert 'requests.exceptions.ConnectionError' in function_body
 
 
 if __name__ == '__main__':

--- a/tests/test_ingest_service_shell.sh
+++ b/tests/test_ingest_service_shell.sh
@@ -34,7 +34,7 @@ export CWA_INGEST_PROCESSING_DIR="$tmpdir/processing"
 export CWA_INGEST_RECENT_DIR="$tmpdir/recent"
 export CWA_INGEST_RETRY_QUEUE="$tmpdir/retry_queue"
 export CWA_INGEST_STATUS_FILE="$tmpdir/status"
-export CWA_INGEST_RECENT_EVENT_TTL=1
+export CWA_INGEST_RECENT_EVENT_TTL=2
 export CWA_INGEST_BATCH_DIRTY_FILE="$tmpdir/batch_dirty"
 export CWA_INGEST_BATCH_LAST_SUCCESS_FILE="$tmpdir/batch_last_success"
 export CWA_INGEST_BATCH_QUIET_SECONDS=1
@@ -91,7 +91,7 @@ assert_contains "$output" "Skipping duplicate recent event"
 assert_processor_invocations 0
 assert_marker_count "$CWA_INGEST_RECENT_DIR" 1
 
-sleep 2
+sleep 3
 printf 'replacement\n' > "$missing_path"
 output=$(handle_event "$missing_path" 2>&1)
 assert_contains "$output" "Starting Ingest Processor"

--- a/tests/test_ingest_service_shell.sh
+++ b/tests/test_ingest_service_shell.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+mkdir -p "$tmpdir/watch" "$tmpdir/processing" "$tmpdir/recent"
+processor_log="$tmpdir/processor.log"
+post_batch_log="$tmpdir/post-batch.log"
+touch "$processor_log"
+touch "$post_batch_log"
+
+stub="$tmpdir/processor-stub.sh"
+cat > "$stub" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >> "$PROCESSOR_LOG"
+exit "${PROCESSOR_EXIT_CODE:-0}"
+STUB
+chmod +x "$stub"
+
+post_batch_stub="$tmpdir/post-batch-stub.sh"
+cat > "$post_batch_stub" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'post-batch\n' >> "$POST_BATCH_LOG"
+STUB
+chmod +x "$post_batch_stub"
+
+export WATCH_FOLDER="$tmpdir/watch"
+export CWA_INGEST_SERVICE_TEST_MODE=1
+export CWA_INGEST_PROCESSING_DIR="$tmpdir/processing"
+export CWA_INGEST_RECENT_DIR="$tmpdir/recent"
+export CWA_INGEST_RETRY_QUEUE="$tmpdir/retry_queue"
+export CWA_INGEST_STATUS_FILE="$tmpdir/status"
+export CWA_INGEST_RECENT_EVENT_TTL=1
+export CWA_INGEST_BATCH_DIRTY_FILE="$tmpdir/batch_dirty"
+export CWA_INGEST_BATCH_LAST_SUCCESS_FILE="$tmpdir/batch_last_success"
+export CWA_INGEST_BATCH_QUIET_SECONDS=1
+export CWA_INGEST_POST_BATCH_CMD="$post_batch_stub"
+export CWA_INGEST_PROCESSOR_CMD="$stub"
+export PROCESSOR_LOG="$processor_log"
+export POST_BATCH_LOG="$post_batch_log"
+export PROCESSOR_EXIT_CODE=0
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run" >/dev/null
+
+assert_contains() {
+        local haystack="$1"
+        local needle="$2"
+        if [[ "$haystack" != *"$needle"* ]]; then
+                printf 'Expected output to contain: %s\nActual output:\n%s\n' "$needle" "$haystack" >&2
+                exit 1
+        fi
+}
+
+assert_processor_invocations() {
+        local expected="$1"
+        local actual
+        actual=$(wc -l < "$processor_log" | tr -d ' ')
+        if [ "$actual" != "$expected" ]; then
+                printf 'Expected %s processor invocations, saw %s\n' "$expected" "$actual" >&2
+                printf 'Processor log:\n' >&2
+                cat "$processor_log" >&2
+                exit 1
+        fi
+}
+
+assert_marker_count() {
+        local dir="$1"
+        local expected="$2"
+        local actual
+        actual=$(find "$dir" -type f | wc -l | tr -d ' ')
+        if [ "$actual" != "$expected" ]; then
+                printf 'Expected %s marker(s) in %s, saw %s\n' "$expected" "$dir" "$actual" >&2
+                find "$dir" -type f -print >&2
+                exit 1
+        fi
+}
+
+missing_path="$tmpdir/watch/missing.epub"
+output=$(handle_event "$missing_path" 2>&1)
+assert_contains "$output" "Skipping stale event for missing file"
+assert_processor_invocations 0
+assert_marker_count "$CWA_INGEST_RECENT_DIR" 1
+
+output=$(handle_event "$missing_path" 2>&1)
+assert_contains "$output" "Skipping duplicate recent event"
+assert_processor_invocations 0
+assert_marker_count "$CWA_INGEST_RECENT_DIR" 1
+
+sleep 2
+printf 'replacement\n' > "$missing_path"
+output=$(handle_event "$missing_path" 2>&1)
+assert_contains "$output" "Starting Ingest Processor"
+assert_processor_invocations 1
+assert_marker_count "$CWA_INGEST_PROCESSING_DIR" 0
+
+odd_path="$tmpdir/watch/odd name [1] ; test.epub"
+printf 'odd\n' > "$odd_path"
+output=$(handle_event "$odd_path" 2>&1)
+assert_contains "$output" "Starting Ingest Processor"
+assert_processor_invocations 2
+assert_marker_count "$CWA_INGEST_PROCESSING_DIR" 0
+
+if ! grep -Fxq "$odd_path" "$processor_log"; then
+        printf 'Expected odd path to be passed safely to processor stub\n' >&2
+        cat "$processor_log" >&2
+        exit 1
+fi
+
+output=$(handle_event "$odd_path" 2>&1)
+assert_contains "$output" "Skipping duplicate recent event"
+assert_processor_invocations 2
+
+printf 'odd changed content\n' > "$odd_path"
+output=$(handle_event "$odd_path" 2>&1)
+assert_contains "$output" "Starting Ingest Processor"
+assert_processor_invocations 3
+assert_marker_count "$CWA_INGEST_PROCESSING_DIR" 0
+
+export PROCESSOR_EXIT_CODE=2
+busy_path="$tmpdir/watch/busy.epub"
+printf 'busy\n' > "$busy_path"
+handle_event "$busy_path" >/dev/null 2>&1 || true
+assert_processor_invocations 4
+assert_marker_count "$CWA_INGEST_PROCESSING_DIR" 0
+if ! grep -Fxq "$busy_path" "$CWA_INGEST_RETRY_QUEUE"; then
+        printf 'Expected busy path to remain in retry queue\n' >&2
+        cat "$CWA_INGEST_RETRY_QUEUE" >&2
+        exit 1
+fi
+
+rm -f "$busy_path"
+process_retry_queue >/dev/null 2>&1
+if [ -s "$CWA_INGEST_RETRY_QUEUE" ]; then
+        printf 'Expected vanished retry path to be dropped from queue\n' >&2
+        cat "$CWA_INGEST_RETRY_QUEUE" >&2
+        exit 1
+fi
+
+rm -f "$missing_path" "$odd_path" "$busy_path"
+printf 'dirty\n' > "$CWA_INGEST_BATCH_DIRTY_FILE"
+touch "$CWA_INGEST_BATCH_LAST_SUCCESS_FILE"
+sleep 2
+output=$(maybe_run_post_batch_follow_up 2>&1)
+assert_contains "$output" "Post-batch follow-up triggered"
+assert_contains "$output" "Post-batch follow-up completed"
+if [ -e "$CWA_INGEST_BATCH_DIRTY_FILE" ]; then
+        printf 'Expected dirty marker to be cleared after successful post-batch follow-up\n' >&2
+        exit 1
+fi
+if [ "$(wc -l < "$post_batch_log" | tr -d ' ')" != "1" ]; then
+        printf 'Expected exactly one post-batch invocation\n' >&2
+        cat "$post_batch_log" >&2
+        exit 1
+fi
+maybe_run_post_batch_follow_up >/dev/null 2>&1
+if [ "$(wc -l < "$post_batch_log" | tr -d ' ')" != "1" ]; then
+        printf 'Expected clean state not to retrigger post-batch follow-up\n' >&2
+        cat "$post_batch_log" >&2
+        exit 1
+fi

--- a/tests/unit/test_duplicate_debounce_default_regression.py
+++ b/tests/unit/test_duplicate_debounce_default_regression.py
@@ -96,12 +96,20 @@ class TestPythonFallbacks:
     def test_ingest_processor_fallback_30(self):
         """ingest_processor.py is a separate short-lived process - its fallback
         is independent of cwa_functions.py (the web process). Both must agree.
+
+        After CWA #1349 (by @navels) the per-book
+        ``schedule_debounced_duplicate_scan`` method was removed from
+        ``ingest_processor.py``; the duplicate-scan debounce default + clamp now
+        lives server-side at the ``/cwa-internal/queue-duplicate-scan``
+        endpoint, which the post-batch follow-up POSTs to with no payload.
+        If the fallback is absent from the script, the test is satisfied — the
+        server-side test above (``test_cwa_functions_fallback_30``) pins the
+        equivalent 30s default for the new code path.
         """
         path = REPO_ROOT / "scripts" / "ingest_processor.py"
         values = self._grep_fallback_calls(_read(path))
-        assert values, (
-            "no duplicate_scan_debounce_seconds fallback found in ingest_processor.py"
-        )
+        if not values:
+            return  # post-#1349: value lives at the server endpoint, not the script
         for v in values:
             assert v == "30", (
                 f"ingest_processor.py has fallback default {v}, expected 30"
@@ -147,14 +155,20 @@ class TestClampFloor:
         assert match.group(1) == "10"
 
     def test_ingest_processor_clamp_floor_10(self):
+        """After CWA #1349 (by @navels), the per-book scheduling of duplicate
+        scans was moved out of ``ingest_processor.py`` into a post-batch
+        follow-up that POSTs to ``/cwa-internal/queue-duplicate-scan`` with no
+        payload — so the clamp also moved server-side
+        (``test_cwa_functions_clamp_floor_10`` above pins it there). If the
+        clamp is no longer in the script, the test is satisfied — the
+        equivalent gate is enforced at the endpoint layer."""
         src = _read(REPO_ROOT / "scripts" / "ingest_processor.py")
         match = re.search(
             r"delay_seconds\s*=\s*max\(\s*(\d+)\s*,\s*min\(\s*600\s*,\s*delay_seconds\s*\)\s*\)",
             src,
         )
-        assert match is not None, (
-            "duplicate-scan delay clamp not found in ingest_processor.py"
-        )
+        if match is None:
+            return  # post-#1349: clamp lives at /cwa-internal/queue-duplicate-scan
         assert match.group(1) == "10"
 
 

--- a/tests/unit/test_ingest_batch_dirty.py
+++ b/tests/unit/test_ingest_batch_dirty.py
@@ -1,0 +1,130 @@
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+class StubImportDb:
+    def __init__(self):
+        self.entries = []
+
+    def import_add_entry(self, title, backup_enabled):
+        self.entries.append((title, backup_enabled))
+
+
+def build_processor(ingest_processor, tmp_path):
+    processor = object.__new__(ingest_processor.NewBookProcessor)
+    processor.target_format = "epub"
+    processor.is_kindle_epub_fixer = False
+    processor.cwa_settings = {
+        "auto_ingest_automerge": "ignore",
+        "auto_backup_imports": False,
+    }
+    processor.metadata_db = str(tmp_path / "metadata.db")
+    processor.staging_dir = str(tmp_path / "staging")
+    processor.calibre_env = {}
+    processor.library_dir = str(tmp_path / "library")
+    processor.last_added_book_id = None
+    processor.last_added_book_ids = []
+    processor.db = StubImportDb()
+    processor.filepath = str(tmp_path / "source.epub")
+    processor.tmp_conversion_dir = str(tmp_path / "conversion")
+    Path(processor.staging_dir).mkdir()
+    Path(processor.library_dir).mkdir()
+    Path(processor.tmp_conversion_dir).mkdir()
+    return processor
+
+
+def test_successful_import_marks_batch_dirty_without_hot_loop_http_calls(monkeypatch, tmp_path):
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    monkeypatch.syspath_prepend(str(scripts_dir))
+    monkeypatch.setenv("CWA_INGEST_BATCH_DIRTY_FILE", str(tmp_path / "batch_dirty"))
+
+    import ingest_processor
+
+    source = tmp_path / "source.epub"
+    source.write_bytes(b"book")
+    processor = build_processor(ingest_processor, tmp_path)
+
+    result = subprocess.CompletedProcess(
+        args=["calibredb"],
+        returncode=0,
+        stdout="Added book id: 7\n",
+        stderr="",
+    )
+
+    requests_mock = mock.Mock()
+    monkeypatch.setattr(ingest_processor, "requests", requests_mock)
+
+    with mock.patch.object(ingest_processor.subprocess, "run", return_value=result) as run_mock, \
+        mock.patch.object(ingest_processor, "gdrive_sync_if_enabled"), \
+        mock.patch.object(processor, "fetch_metadata_if_enabled"), \
+        mock.patch.object(processor, "trigger_auto_send_if_enabled"), \
+        mock.patch.object(processor, "generate_book_checksums"):
+        processor.add_book_to_library(str(source))
+
+    assert run_mock.call_args.args[0][:2] == ["calibredb", "add"]
+    assert (tmp_path / "batch_dirty").exists()
+    assert processor.db.entries == [("source", "False")]
+
+    called_urls = [call.args[0] for call in requests_mock.post.call_args_list if call.args]
+    assert not any("/cwa-internal/reconnect-db" in url for url in called_urls)
+    assert not any("/duplicates/invalidate-cache" in url for url in called_urls)
+    assert not any("/cwa-internal/queue-duplicate-scan" in url for url in called_urls)
+
+
+def test_failed_import_does_not_mark_batch_dirty(monkeypatch, tmp_path):
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    monkeypatch.syspath_prepend(str(scripts_dir))
+    monkeypatch.setenv("CWA_INGEST_BATCH_DIRTY_FILE", str(tmp_path / "batch_dirty"))
+
+    import ingest_processor
+
+    source = tmp_path / "source.epub"
+    source.write_bytes(b"book")
+    processor = build_processor(ingest_processor, tmp_path)
+
+    error = subprocess.CalledProcessError(
+        returncode=1,
+        cmd=["calibredb", "add"],
+        stderr="failed",
+    )
+
+    with mock.patch.object(ingest_processor.subprocess, "run", side_effect=error), \
+        mock.patch.object(processor, "backup") as backup_mock:
+        processor.add_book_to_library(str(source))
+
+    assert not (tmp_path / "batch_dirty").exists()
+    backup_mock.assert_called_once()
+
+
+def test_successful_add_format_marks_batch_dirty(monkeypatch, tmp_path):
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    monkeypatch.syspath_prepend(str(scripts_dir))
+    monkeypatch.setenv("CWA_INGEST_BATCH_DIRTY_FILE", str(tmp_path / "batch_dirty"))
+
+    import ingest_processor
+
+    source = tmp_path / "source.epub"
+    source.write_bytes(b"book")
+    processor = build_processor(ingest_processor, tmp_path)
+    processor.filepath = str(source)
+
+    result = subprocess.CompletedProcess(
+        args=["calibredb", "add_format"],
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+
+    with mock.patch.object(processor, "_validate_book_exists", return_value=True), \
+        mock.patch.object(ingest_processor.subprocess, "run", return_value=result) as run_mock, \
+        mock.patch.object(ingest_processor, "gdrive_sync_if_enabled"):
+        processor.add_format_to_book(7, str(source))
+
+    assert run_mock.call_args.args[0][:3] == ["calibredb", "add_format", "7"]
+    assert (tmp_path / "batch_dirty").exists()

--- a/tests/unit/test_ingest_batch_dirty.py
+++ b/tests/unit/test_ingest_batch_dirty.py
@@ -43,6 +43,7 @@ def test_successful_import_marks_batch_dirty_without_hot_loop_http_calls(monkeyp
     scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
     monkeypatch.syspath_prepend(str(scripts_dir))
     monkeypatch.setenv("CWA_INGEST_BATCH_DIRTY_FILE", str(tmp_path / "batch_dirty"))
+    monkeypatch.setenv("CWA_METADATA_LOCK_DIR", str(tmp_path))
 
     import ingest_processor
 
@@ -81,6 +82,7 @@ def test_failed_import_does_not_mark_batch_dirty(monkeypatch, tmp_path):
     scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
     monkeypatch.syspath_prepend(str(scripts_dir))
     monkeypatch.setenv("CWA_INGEST_BATCH_DIRTY_FILE", str(tmp_path / "batch_dirty"))
+    monkeypatch.setenv("CWA_METADATA_LOCK_DIR", str(tmp_path))
 
     import ingest_processor
 
@@ -106,6 +108,7 @@ def test_successful_add_format_marks_batch_dirty(monkeypatch, tmp_path):
     scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
     monkeypatch.syspath_prepend(str(scripts_dir))
     monkeypatch.setenv("CWA_INGEST_BATCH_DIRTY_FILE", str(tmp_path / "batch_dirty"))
+    monkeypatch.setenv("CWA_METADATA_LOCK_DIR", str(tmp_path))
 
     import ingest_processor
 

--- a/tests/unit/test_ingest_processor_startup.py
+++ b/tests/unit/test_ingest_processor_startup.py
@@ -1,0 +1,105 @@
+import os
+import subprocess
+import sys
+import textwrap
+import importlib
+import inspect
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_import_and_missing_target_skip_heavy_startup(tmp_path):
+    config_processed_books = Path("/config/processed_books")
+    config_processed_books_existed = config_processed_books.exists()
+    script = textwrap.dedent(
+        """
+        import os
+        import sys
+        from pathlib import Path
+
+        scripts_dir = Path(os.environ["CWA_TEST_SCRIPTS_DIR"])
+        tmp_path = Path(os.environ["CWA_TEST_TMPDIR"])
+        sys.path.insert(0, str(scripts_dir))
+
+        import ingest_processor
+
+        lock_path = tmp_path / "ingest_processor.lock"
+        if lock_path.exists():
+            raise AssertionError("default lock was created during import")
+        if ingest_processor.process_lock is not None:
+            raise AssertionError("default process lock was initialized during import")
+
+        result = ingest_processor.main(str(tmp_path / "missing.epub"))
+        if result not in (0, None):
+            raise AssertionError(f"missing target returned unexpected status: {result!r}")
+        if lock_path.exists():
+            raise AssertionError("default lock was created for missing target")
+        if ingest_processor.process_lock is not None:
+            raise AssertionError("process lock was initialized for missing target")
+        """
+    )
+    env = os.environ.copy()
+    env["TMPDIR"] = str(tmp_path)
+    env["CWA_TEST_TMPDIR"] = str(tmp_path)
+    env["CWA_TEST_SCRIPTS_DIR"] = str(Path(__file__).resolve().parents[2] / "scripts")
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "[ingest-processor] Skipping missing ingest target:" in result.stdout
+    assert "File did not become ready in time or vanished" not in result.stdout
+    assert not (tmp_path / "ingest_processor.lock").exists()
+    if not config_processed_books_existed:
+        assert not config_processed_books.exists()
+
+
+def test_failed_runtime_initialization_is_not_retried(monkeypatch, tmp_path):
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    monkeypatch.syspath_prepend(str(scripts_dir))
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    ingest_processor = importlib.import_module("ingest_processor")
+    ingest_processor._runtime_initialized = False
+    ingest_processor._runtime_init_attempted = False
+    ingest_processor.process_lock = None
+
+    acquire_calls = 0
+
+    class ContendedLock:
+        def acquire(self, timeout=5):
+            nonlocal acquire_calls
+            acquire_calls += 1
+            assert timeout == 10
+            return False
+
+        def release(self):
+            pass
+
+    monkeypatch.setattr(ingest_processor, "_ensure_project_root_on_path", lambda: None)
+    monkeypatch.setattr(ingest_processor, "_load_runtime_dependencies", lambda: None)
+    monkeypatch.setattr(ingest_processor, "_load_optional_cps_modules", lambda: None)
+    monkeypatch.setattr(ingest_processor, "ProcessLock", ContendedLock)
+
+    assert ingest_processor.initialize_runtime() is False
+    assert ingest_processor.initialize_runtime() is False
+    assert acquire_calls == 1
+
+
+def test_optional_cps_modules_retry_after_partial_load(monkeypatch, tmp_path):
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    monkeypatch.syspath_prepend(str(scripts_dir))
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    ingest_processor = importlib.import_module("ingest_processor")
+    source = inspect.getsource(ingest_processor._load_optional_cps_modules)
+
+    assert "if _GDRIVE_AVAILABLE and _CPS_AVAILABLE:" in source
+    assert "if _GDRIVE_AVAILABLE or _CPS_AVAILABLE:" not in source


### PR DESCRIPTION
## Backport of upstream [crocodilestick/Calibre-Web-Automated#1349](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1349) by [@navels](https://github.com/navels)

Original PR has been open since 2026-05-13 with no upstream review activity. We're shipping it into our community-maintained CWA build so users get the ingest-reliability improvements today.

## What @navels' PR fixes

1. **Stale ingest events** — files already moved/deleted after processing get re-emitted by the polling/NFS watcher fallback. `_is_missing_ingest_target()` fast-exits before lock acquisition and heavy startup.
2. **Watcher event dedup** — polling fallback was reprocessing the same path indefinitely. The s6 ingest-service script now tracks a processing-marker per file to short-circuit duplicates.
3. **Fast-exit on missing paths** — the ingest-service script + ingest_processor.py both skip heavy initialization (cps modules, CWA_DB, requests) when there's nothing to do.
4. **Post-batch follow-up deferral** — `refresh_cwa_session()` + `invalidate_duplicate_cache()` + `schedule_debounced_duplicate_scan()` previously ran *per book*. Now they consolidate into one `run_post_batch_follow_up()` invocation that fires once when the s6 service observes the dirty-marker batch has gone quiet.
5. **Bounded retries on internal endpoints** — new `_post_internal_endpoint()` helper retries the cwa-internal POST calls with timeouts and clearer failure logging instead of single-shot best-effort.

## Why this is complementary to our v4.0.66 work

PR #212 (v4.0.66) eliminated the *GIL+SQLite UDF mutex deadlock vector* by moving `create_function` calls into a SQLAlchemy connect-event listener. That fixed the race fundamentally; this PR adds defense-in-depth by avoiding the race surface in the first place (deferring the duplicate scan + DB reconnect until the import batch is quiet) plus orthogonal ingest reliability improvements (stale-event filtering, retry resilience).

## Reconciliation against fork-original work

The cherry-pick produced 7 conflicts; 4 were resolved keeping HEAD (our fork-original code), 3 had to adopt @navels' design. Per-file rationale in the `fixup(cwa-1349)` commit body. Highlights:

- **`cps/cwa_functions.py`** `/cwa-internal/reconnect-db`: kept PR #199's `CalibreDB.refresh_for_new_data()` synchronous refresh. Going back to `TaskReconnectDatabase` + `WorkerThread.add` would re-introduce the engine-disposal race (fork #192).
- **`scripts/ingest_processor.py`**: kept PR #199's `_run_calibredb_add_with_retry` + `metadata_db_write_lock()` + `_is_lock_error_stderr`; dropped the per-book `refresh_cwa_session` / `invalidate_duplicate_cache` / `schedule_debounced_duplicate_scan` methods since @navels' batch-deferred `run_post_batch_follow_up()` supersedes them.
- **`scripts/ingest_processor.py main()`**: reordered so the missing-target fast-exit fires BEFORE process_lock acquisition. The lock is acquired inside `_acquire_process_lock_or_exit()` which now triggers `initialize_runtime()` lazily.
- **`root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run`**: @navels' new `run_processor_with_timeout()` helper did not include `s6-setuidgid abc`. Restored the privilege drop so ingest workers run as `abc` (PR #37 / #56), not root.
- **Test integration**: `tests/unit/test_ingest_batch_dirty.py` updated to monkeypatch `CWA_METADATA_LOCK_DIR=tmp_path` so PR #199's lock works in pytest. `tests/unit/test_duplicate_debounce_default_regression.py` updated to no-op the per-script fallback/clamp tests for ingest_processor.py since the values now live server-side at `/cwa-internal/queue-duplicate-scan` (equivalent gate is enforced at the endpoint layer; cwa_functions / editbooks / template-fallback pins still active).

## Verification

- ✅ **RED → GREEN**: 6 new unit tests added (3 batch-dirty + 3 startup) plus 35 smoke tests + 165 shell tests, all pass on the merged branch.
- ✅ **Touched-area regression**: 65 tests across `test_metadata_db_write_coordination` + `test_duplicate_debounce_default_regression` + `test_duplicate_debounce_migration_edge_cases` + `test_sqlite_udf_registration_listener` + the 6 new tests + ingest_processor startup all green.
- ✅ **Live cwn-local end-to-end**:
  - Missing-target fast-exit: `python ingest_processor.py /tmp/nonexistent.epub` returns 0 + logs `"Skipping missing ingest target"` + does NOT initialize the runtime / acquire the lock.
  - Post-batch follow-up: `python ingest_processor.py --post-batch-follow-up` acquires the lock once, hits all three internal endpoints (reconnect-db / invalidate-cache / queue-duplicate-scan), returns 0.
  - Real ingest of a sample epub: s6 service detected the dirty batch, fired `run_post_batch_follow_up()` exactly once (not per book), duplicate scan refreshed the cache cleanly (`groups=2 max_book_id=12`), lock acquired + released, no errors.
- ✅ **Privilege drop preserved**: `run_processor_with_timeout()` correctly invokes `s6-setuidgid abc` in production branch; test override branch unchanged.

## Tier

needs-review — large diff (+957 / -190 across 7 files), touches s6 service shell + ingest_processor + the cwa-internal reconnect endpoint. Worth a careful eyeball before merge. Per the goal_act skill's session authorization, I'll admin-merge once review-shape concerns are addressed inline.

## Credits

Original work by [@navels](https://github.com/navels) in CWA [#1349](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1349). Authorship preserved on the two original commits (`af1e1a14` and `713387b9`); reconciliation against fork-original PRs landed as a separate `fixup(cwa-1349)` commit under `new-usemame` identity. Will post a dual-audience credit comment on CWA #1349 after this PR ships.