### PR TITLE
feat(duplicates): incremental index — backport CWA #1353 (@navels)

### DIFF
--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -35,10 +35,10 @@ import sys
 sys.path.insert(1, '/app/calibre-web-automated/scripts/')
 from cwa_db import CWA_DB
 from .services.background_scheduler import BackgroundScheduler, DateTrigger
-from .services.worker import WorkerThread
-# TaskReconnectDatabase no longer imported here — the post-ingest
-# reconnect endpoint now uses CalibreDB.refresh_for_new_data() instead.
-# See fork issue #192.
+from .services.worker import WorkerThread, STAT_FINISH_SUCCESS, STAT_FAIL, STAT_ENDED, STAT_CANCELLED
+# TaskReconnectDatabase deliberately not imported here — the post-ingest
+# reconnect endpoint uses CalibreDB.refresh_for_new_data() instead, to avoid
+# the engine-disposal race in fork issue #192 (PR #199, v4.0.30).
 from .tasks.auto_send import TaskAutoSend
 from .tasks.ops import TaskConvertLibraryRun, TaskEpubFixerRun
 
@@ -64,10 +64,24 @@ DIRS_JSON = "/app/calibre-web-automated/dirs.json"
 # Debounced duplicate scan timer (web process)
 _duplicate_scan_timer = None
 _duplicate_scan_lock = Lock()
+_duplicate_scan_book_ids = set()
 
 ##———————————————————————————END OF GLOBAL VARIABLES——————————————————————————##
 
 ##————————————————————————————————————————————————————————————————————————————##
+
+
+def _duplicate_full_scan_running():
+    terminal_stats = {STAT_FINISH_SUCCESS, STAT_FAIL, STAT_ENDED, STAT_CANCELLED}
+    try:
+        for __, __, __, task, __ in WorkerThread.get_instance().tasks:
+            if getattr(task, "stat", None) in terminal_stats:
+                continue
+            if task.__class__.__name__ == "TaskDuplicateScan" and getattr(task, "full_scan", False):
+                return True
+    except Exception as ex:
+        log.debug("[cwa-duplicates] Could not check duplicate full-scan worker state: %s", str(ex))
+    return False
 ##                                                                            ##
 ##                               CWA SWITCH THEME                             ##
 ##                                                                            ##
@@ -207,6 +221,22 @@ def get_ingest_status():
                 return {'state': status_line, 'filename': '', 'timestamp': '', 'detail': ''}
     except (FileNotFoundError, IOError):
         return {'state': 'unknown', 'filename': '', 'timestamp': '', 'detail': ''}
+
+
+def _coerce_book_ids(raw_book_ids):
+    if raw_book_ids is None:
+        return []
+    if isinstance(raw_book_ids, (str, int)):
+        raw_book_ids = [raw_book_ids]
+    book_ids = []
+    for raw_book_id in raw_book_ids:
+        try:
+            book_id = int(raw_book_id)
+        except (TypeError, ValueError):
+            continue
+        if book_id > 0:
+            book_ids.append(book_id)
+    return list(dict.fromkeys(book_ids))
 
 def get_ingest_queue_size():
     """Get the number of files in the retry queue"""
@@ -359,59 +389,141 @@ def cwa_internal_queue_duplicate_scan():
     """Debounce and queue an incremental duplicate scan in the web process.
 
     Security: Limited to localhost callers (within container/host).
-    Payload JSON: {delay_seconds:int}
+    Payload JSON: {delay_seconds:int, book_ids:[int]}
     """
     try:
         remote = request.headers.get('X-Forwarded-For', request.remote_addr)
         if remote not in (None, '127.0.0.1', '::1'):
             abort(403)
 
-        db = CWA_DB()
-        enabled = bool(db.cwa_settings.get('duplicate_scan_enabled', 0))
-        frequency = db.cwa_settings.get('duplicate_scan_frequency', 'manual')
-
         data = request.get_json(force=True, silent=True) or {}
-        default_delay = db.cwa_settings.get('duplicate_scan_debounce_seconds', 30)
-        delay_seconds = int(data.get('delay_seconds', default_delay))
-        delay_seconds = max(10, min(600, delay_seconds))
-
-        if not enabled or frequency != 'after_import':
-            return jsonify({"success": True, "skipped": True, "reason": "disabled_or_manual"}), 200
-
-        global _duplicate_scan_timer
-        with _duplicate_scan_lock:
-            if _duplicate_scan_timer is not None:
-                try:
-                    _duplicate_scan_timer.cancel()
-                except Exception:
-                    pass
-
-            def _enqueue_scan():
-                try:
-                    log.debug("[cwa-duplicates] Timer fired, attempting to import TaskDuplicateScan...")
-                    from .tasks.duplicate_scan import TaskDuplicateScan
-                    log.debug("[cwa-duplicates] TaskDuplicateScan imported successfully, creating task...")
-                    task = TaskDuplicateScan(full_scan=False, trigger_type='after_import')
-                    log.debug("[cwa-duplicates] Task created, adding to WorkerThread...")
-                    WorkerThread.add('System', task, hidden=False)
-                    log.info("[cwa-duplicates] Debounced duplicate scan queued (after_import)")
-                    print("[cwa-duplicates] Debounced duplicate scan queued (after_import)", flush=True)
-                except Exception as e:
-                    log.error("[cwa-duplicates] Failed to queue debounced duplicate scan: %s", str(e))
-                    print(f"[cwa-duplicates] ERROR: Failed to queue debounced duplicate scan: {e}", flush=True)
-                    import traceback
-                    traceback.print_exc()
-
-            _duplicate_scan_timer = Timer(delay_seconds, _enqueue_scan)
-            _duplicate_scan_timer.daemon = True
-            _duplicate_scan_timer.start()
-            log.info("[cwa-duplicates] Timer started with %d second delay", delay_seconds)
-            print(f"[cwa-duplicates] Timer started with {delay_seconds} second delay", flush=True)
-
-        return jsonify({"success": True, "queued": True, "delay_seconds": delay_seconds}), 200
+        result = queue_debounced_duplicate_scan(
+            delay_seconds=data.get('delay_seconds'),
+            book_ids=data.get('book_ids'),
+        )
+        return jsonify(result), 200
     except Exception as e:
         log.error("[cwa-duplicates] Failed to schedule debounced duplicate scan: %s", str(e))
         return jsonify({"success": False, "error": str(e)}), 500
+
+
+@csrf.exempt
+@cwa_internal.route('/cwa-internal/run-duplicate-scan', methods=["POST"])
+def cwa_internal_run_duplicate_scan():
+    """Run a bounded incremental duplicate scan synchronously in the web process.
+
+    Security: Limited to localhost callers (within container/host).
+    Payload JSON: {book_ids:[int]}
+    """
+    try:
+        remote = request.headers.get('X-Forwarded-For', request.remote_addr)
+        if remote not in (None, '127.0.0.1', '::1'):
+            abort(403)
+
+        data = request.get_json(force=True, silent=True) or {}
+        book_ids = _coerce_book_ids(data.get('book_ids'))
+        if not book_ids:
+            return jsonify({"success": True, "skipped": True, "reason": "no_book_ids"}), 200
+
+        db = CWA_DB()
+        enabled = bool(db.cwa_settings.get('duplicate_scan_enabled', 0))
+        frequency = db.cwa_settings.get('duplicate_scan_frequency', 'manual')
+        if not enabled or frequency != 'after_import':
+            return jsonify({"success": True, "skipped": True, "reason": "disabled_or_manual"}), 200
+
+        from .tasks.duplicate_scan import TaskDuplicateScan
+        task = TaskDuplicateScan(
+            full_scan=False,
+            trigger_type='after_import',
+            book_ids=book_ids,
+        )
+        task.run(None)
+        return jsonify({
+            "success": True,
+            "result_count": task.result_count,
+            "message": str(getattr(task, "message", "")),
+        }), 200
+    except Exception as e:
+        log.error("[cwa-duplicates] Failed to run synchronous duplicate scan: %s", str(e))
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@csrf.exempt
+@cwa_internal.route('/cwa-internal/duplicate-scan-status', methods=["GET", "POST"])
+def cwa_internal_duplicate_scan_status():
+    """Expose duplicate scan worker state to localhost-only ingest helpers."""
+    try:
+        remote = request.headers.get('X-Forwarded-For', request.remote_addr)
+        if remote not in (None, '127.0.0.1', '::1'):
+            abort(403)
+
+        return jsonify({
+            "success": True,
+            "full_scan_running": _duplicate_full_scan_running(),
+        }), 200
+    except Exception as e:
+        log.error("[cwa-duplicates] Failed to read duplicate scan status: %s", str(e))
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+def queue_debounced_duplicate_scan(delay_seconds=None, book_ids=None):
+    """Debounce and queue an incremental duplicate scan in the web process."""
+    db = CWA_DB()
+    enabled = bool(db.cwa_settings.get('duplicate_scan_enabled', 0))
+    frequency = db.cwa_settings.get('duplicate_scan_frequency', 'manual')
+    default_delay = db.cwa_settings.get('duplicate_scan_debounce_seconds', 30)
+    delay_seconds = int(delay_seconds if delay_seconds is not None else default_delay)
+    delay_seconds = max(10, min(600, delay_seconds))
+    book_ids = _coerce_book_ids(book_ids)
+
+    if not enabled or frequency != 'after_import':
+        return {"success": True, "skipped": True, "reason": "disabled_or_manual"}
+
+    global _duplicate_scan_timer, _duplicate_scan_book_ids
+    with _duplicate_scan_lock:
+        if _duplicate_scan_timer is not None:
+            try:
+                _duplicate_scan_timer.cancel()
+            except Exception:
+                pass
+
+        _duplicate_scan_book_ids.update(book_ids)
+
+        def _enqueue_scan():
+            try:
+                log.debug("[cwa-duplicates] Timer fired, attempting to import TaskDuplicateScan...")
+                from .tasks.duplicate_scan import TaskDuplicateScan
+                log.debug("[cwa-duplicates] TaskDuplicateScan imported successfully, creating task...")
+                with _duplicate_scan_lock:
+                    queued_book_ids = sorted(_duplicate_scan_book_ids) if _duplicate_scan_book_ids else None
+                    _duplicate_scan_book_ids.clear()
+                task = TaskDuplicateScan(
+                    full_scan=False,
+                    trigger_type='after_import',
+                    book_ids=queued_book_ids,
+                )
+                log.debug("[cwa-duplicates] Task created, adding to WorkerThread...")
+                WorkerThread.add('System', task, hidden=False)
+                log.info("[cwa-duplicates] Debounced duplicate scan queued (after_import)")
+                print("[cwa-duplicates] Debounced duplicate scan queued (after_import)", flush=True)
+            except Exception as e:
+                log.error("[cwa-duplicates] Failed to queue debounced duplicate scan: %s", str(e))
+                print(f"[cwa-duplicates] ERROR: Failed to queue debounced duplicate scan: {e}", flush=True)
+                import traceback
+                traceback.print_exc()
+
+        _duplicate_scan_timer = Timer(delay_seconds, _enqueue_scan)
+        _duplicate_scan_timer.daemon = True
+        _duplicate_scan_timer.start()
+        log.info("[cwa-duplicates] Timer started with %d second delay", delay_seconds)
+        print(f"[cwa-duplicates] Timer started with {delay_seconds} second delay", flush=True)
+
+    return {"success": True, "queued": True, "delay_seconds": delay_seconds}
+
+
+def duplicate_scan_debounce_pending():
+    with _duplicate_scan_lock:
+        return _duplicate_scan_timer is not None and _duplicate_scan_timer.is_alive()
 
 @csrf.exempt
 @cwa_internal.route('/cwa-internal/schedule-convert-library', methods=["POST"])
@@ -739,7 +851,7 @@ def set_cwa_settings():
                         elif setting == 'duplicate_scan_chunk_size':
                             int_value = max(500, min(50000, int_value))
                         elif setting == 'duplicate_scan_debounce_seconds':
-                            int_value = max(5, min(600, int_value))
+                            int_value = max(10, min(600, int_value))
                         elif setting == 'cover_download_max_mb':
                             int_value = max(1, min(200, int_value))
                         result[setting] = int_value
@@ -876,8 +988,26 @@ def set_cwa_settings():
             config.config_kobo_sync_magic_shelves = 'config_kobo_sync_magic_shelves' in request.form
             config.save()
 
+            duplicate_criteria_changed = False
+            try:
+                from .duplicate_index import get_criteria_fingerprint
+                submitted_settings = dict(cwa_settings)
+                submitted_settings.update(result)
+                duplicate_criteria_changed = (
+                    get_criteria_fingerprint(cwa_settings) != get_criteria_fingerprint(submitted_settings)
+                )
+            except Exception as e:
+                log.warning("[cwa-duplicates] Could not compare duplicate criteria settings: %s", str(e))
+
             cwa_db.update_cwa_settings(result)
             cwa_settings = cwa_db.get_cwa_settings()
+
+            if duplicate_criteria_changed:
+                try:
+                    from .duplicate_index import mark_duplicate_index_pending
+                    mark_duplicate_index_pending("duplicate criteria settings changed")
+                except Exception as e:
+                    log.warning("[cwa-duplicates] Could not mark duplicate index pending: %s", str(e))
 
             # If KOReader sync was just enabled, ensure required tables exist
             if not previous_koreader_enabled and bool(cwa_settings.get('koreader_sync_enabled', 0)):
@@ -909,8 +1039,22 @@ def set_cwa_settings():
 
         elif request.form['submit_button'] == "Apply Default Settings":
             cwa_db = CWA_DB()
+            duplicate_criteria_changed = False
+            try:
+                from .duplicate_index import get_criteria_fingerprint
+                previous_fingerprint = get_criteria_fingerprint(cwa_settings)
+                default_settings = dict(cwa_db.cwa_default_settings)
+                duplicate_criteria_changed = previous_fingerprint != get_criteria_fingerprint(default_settings)
+            except Exception as e:
+                log.warning("[cwa-duplicates] Could not compare duplicate criteria defaults: %s", str(e))
             cwa_db.set_default_settings(force=True)
             cwa_settings = cwa_db.get_cwa_settings()
+            if duplicate_criteria_changed:
+                try:
+                    from .duplicate_index import mark_duplicate_index_pending
+                    mark_duplicate_index_pending("duplicate criteria settings changed")
+                except Exception as e:
+                    log.warning("[cwa-duplicates] Could not mark duplicate index pending: %s", str(e))
 
     elif request.method == 'GET':
         cwa_db = CWA_DB()

--- a/cps/db.py
+++ b/cps/db.py
@@ -1181,9 +1181,15 @@ class CalibreDB:
         pagesize = pagesize or self.config.config_books_per_page
         if current_user.show_detail_random():
             random_query = self.generate_linked_query(config_read_column, database)
-            # Eagerly load the data relationship for random books to prevent session errors
+            # Eagerly load template relationships to prevent detached lazy-load
+            # failures if another request tears down the shared scoped session.
             if database == Books:
-                random_query = random_query.options(joinedload(Books.data))
+                random_query = random_query.options(
+                    joinedload(Books.authors),
+                    joinedload(Books.data),
+                    joinedload(Books.series),
+                    joinedload(Books.ratings),
+                )
             randm = (random_query.filter(self.common_filters(allow_show_archived,
                                                              viewing_tag_id=viewing_tag_id,
                                                              allow_show_hidden=allow_show_hidden,
@@ -1197,9 +1203,15 @@ class CalibreDB:
         else:
             query = self.session.query(database)
         
-        # Eagerly load the data relationship to prevent DetachedInstanceError in templates
+        # Eagerly load template relationships to prevent DetachedInstanceError
+        # during rendering under concurrent status/notification requests.
         if database == Books:
-            query = query.options(joinedload(Books.data))
+            query = query.options(
+                joinedload(Books.authors),
+                joinedload(Books.data),
+                joinedload(Books.series),
+                joinedload(Books.ratings),
+            )
         
         off = int(int(pagesize) * (page - 1))
 

--- a/cps/duplicate_index.py
+++ b/cps/duplicate_index.py
@@ -1,0 +1,578 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable
+
+from sqlalchemy import func
+from sqlalchemy.orm import joinedload
+
+from . import calibre_db, db, logger
+from .duplicates import (
+    _AWARE_MIN,
+    _timestamp_or_default,
+    filter_dismissed_groups,
+    generate_group_hash,
+    get_common_filters,
+    normalize_title_for_duplicates,
+)
+
+sys.path.insert(1, "/app/calibre-web-automated/scripts/")
+from cwa_db import CWA_DB
+
+
+log = logger.create()
+
+NORMALIZATION_VERSION = "duplicate-index-v1"
+MAX_INCREMENTAL_BOOK_IDS = 1000
+DUPLICATE_INDEX_REBUILD_BATCH_SIZE = 250
+INGEST_BATCH_DIRTY_FILE = "/config/cwa_ingest_batch_dirty"
+INGEST_BATCH_ACTIVE_FILE = "/config/cwa_ingest_batch_active"
+
+CRITERIA_KEYS = (
+    "duplicate_detection_title",
+    "duplicate_detection_author",
+    "duplicate_detection_language",
+    "duplicate_detection_series",
+    "duplicate_detection_publisher",
+    "duplicate_detection_format",
+)
+
+
+@dataclass(frozen=True)
+class BookKeyParts:
+    normalized_title: str
+    normalized_author: str
+    normalized_language: str
+    normalized_series: str
+    normalized_publisher: str
+    format_signature: str
+
+    def as_db_tuple(self):
+        return (
+            self.normalized_title,
+            self.normalized_author,
+            self.normalized_language,
+            self.normalized_series,
+            self.normalized_publisher,
+            self.format_signature,
+        )
+
+
+def _hash_json(payload) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _setting_enabled(settings, key, default):
+    return bool(int(settings.get(key, default) or 0))
+
+
+def get_effective_duplicate_criteria(settings):
+    criteria = {
+        "title": _setting_enabled(settings, "duplicate_detection_title", 1),
+        "author": _setting_enabled(settings, "duplicate_detection_author", 1),
+        "language": _setting_enabled(settings, "duplicate_detection_language", 1),
+        "series": _setting_enabled(settings, "duplicate_detection_series", 0),
+        "publisher": _setting_enabled(settings, "duplicate_detection_publisher", 0),
+        "format": _setting_enabled(settings, "duplicate_detection_format", 0),
+    }
+    if not any(criteria.values()):
+        criteria["title"] = True
+        criteria["author"] = True
+    return criteria
+
+
+def get_criteria_fingerprint(settings):
+    return _hash_json(
+        {
+            "normalization_version": NORMALIZATION_VERSION,
+            "criteria": get_effective_duplicate_criteria(settings),
+        }
+    )
+
+
+def _primary_author(book):
+    if not getattr(book, "authors", None):
+        return "unknown"
+    book.ordered_authors = calibre_db.order_authors([book])
+    if book.ordered_authors and len(book.ordered_authors) > 0 and book.ordered_authors[0].name:
+        return book.ordered_authors[0].name
+    return "unknown"
+
+
+def build_book_key_parts(book, settings):
+    primary_author = _primary_author(book)
+    title = book.title if getattr(book, "title", None) else "untitled"
+
+    if getattr(book, "languages", None):
+        language = book.languages[0].lang_code if book.languages[0].lang_code else "unknown"
+    else:
+        language = "unknown"
+
+    if getattr(book, "series", None):
+        series = book.series[0].name if book.series[0].name else "no_series"
+    else:
+        series = "no_series"
+
+    if getattr(book, "publishers", None):
+        publisher = book.publishers[0].name if book.publishers[0].name else "unknown_publisher"
+    else:
+        publisher = "unknown_publisher"
+
+    if getattr(book, "data", None):
+        formats = sorted([data.format.lower() for data in book.data if data.format])
+        format_signature = ",".join(formats) if formats else "no_format"
+    else:
+        format_signature = "no_format"
+
+    # Keep title normalization stable across criteria: even title-only keys strip a
+    # leading primary-author prefix, unlike the old Python fallback's no-author mode.
+    return BookKeyParts(
+        normalized_title=normalize_title_for_duplicates(title, primary_author),
+        normalized_author=primary_author.lower().strip() if primary_author else "unknown",
+        normalized_language=language.lower().strip(),
+        normalized_series=series.lower().strip(),
+        normalized_publisher=publisher.lower().strip(),
+        format_signature=format_signature,
+    )
+
+
+def _enabled_key_values(parts: BookKeyParts, settings):
+    criteria = get_effective_duplicate_criteria(settings)
+    values = []
+    if criteria["title"]:
+        values.append(("title", parts.normalized_title))
+    if criteria["author"]:
+        values.append(("author", parts.normalized_author))
+    if criteria["language"]:
+        values.append(("language", parts.normalized_language))
+    if criteria["series"]:
+        values.append(("series", parts.normalized_series))
+    if criteria["publisher"]:
+        values.append(("publisher", parts.normalized_publisher))
+    if criteria["format"]:
+        values.append(("format", parts.format_signature))
+    return values
+
+
+def build_duplicate_key(book, settings):
+    return _hash_json(_enabled_key_values(build_book_key_parts(book, settings), settings))
+
+
+def _book_query(book_ids=None):
+    query = (
+        calibre_db.session.query(db.Books)
+        .options(joinedload(db.Books.data))
+        .options(joinedload(db.Books.authors))
+        .options(joinedload(db.Books.languages))
+        .options(joinedload(db.Books.series))
+        .options(joinedload(db.Books.publishers))
+    )
+    if book_ids is not None:
+        query = query.filter(db.Books.id.in_(list(book_ids)))
+    return query
+
+
+def _load_books_by_ids(book_ids=None, user_id=None):
+    query = _book_query(book_ids)
+    if user_id is not None:
+        query = query.filter(get_common_filters(user_id=user_id))
+    return query.order_by(db.Books.title, db.Books.timestamp.desc()).all()
+
+
+def _current_max_book_id():
+    max_book_id = calibre_db.session.query(func.max(db.Books.id)).scalar()
+    return int(max_book_id or 0)
+
+
+def library_has_books():
+    return _current_max_book_id() > 0
+
+
+def _current_library_book_ids():
+    book_ids = set()
+    for row in calibre_db.session.query(db.Books.id).all():
+        if hasattr(row, "id"):
+            value = row.id
+        else:
+            try:
+                value = row[0]
+            except (TypeError, IndexError):
+                value = row
+        if value is not None:
+            book_ids.add(int(value))
+    return book_ids
+
+
+def _chunks(values, size):
+    values = list(values)
+    for start in range(0, len(values), size):
+        yield values[start:start + size]
+
+
+def upsert_book_keys(book_ids: Iterable[int], settings):
+    book_ids = {int(book_id) for book_id in book_ids if book_id is not None}
+    if len(book_ids) > MAX_INCREMENTAL_BOOK_IDS:
+        raise ValueError(f"Incremental duplicate index update exceeds {MAX_INCREMENTAL_BOOK_IDS} books")
+    if not book_ids:
+        return {"updated": 0, "missing": 0, "missing_ids": [], "fingerprint": get_criteria_fingerprint(settings)}
+
+    fingerprint = get_criteria_fingerprint(settings)
+    books = _load_books_by_ids(book_ids)
+    loaded_book_ids = {int(book.id) for book in books}
+    cwa_db = CWA_DB()
+    updated = 0
+    for book in books:
+        parts = build_book_key_parts(book, settings)
+        duplicate_key = _hash_json(_enabled_key_values(parts, settings))
+        cwa_db.cur.execute(
+            """
+            INSERT INTO cwa_duplicate_book_keys (
+                book_id, normalized_title, normalized_author, normalized_language,
+                normalized_series, normalized_publisher, format_signature,
+                duplicate_key, criteria_fingerprint, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(book_id) DO UPDATE SET
+                normalized_title = excluded.normalized_title,
+                normalized_author = excluded.normalized_author,
+                normalized_language = excluded.normalized_language,
+                normalized_series = excluded.normalized_series,
+                normalized_publisher = excluded.normalized_publisher,
+                format_signature = excluded.format_signature,
+                duplicate_key = excluded.duplicate_key,
+                criteria_fingerprint = excluded.criteria_fingerprint,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (book.id, *parts.as_db_tuple(), duplicate_key, fingerprint),
+        )
+        updated += 1
+    cwa_db.con.commit()
+    missing_ids = sorted(book_ids - loaded_book_ids)
+    return {"updated": updated, "missing": len(missing_ids), "missing_ids": missing_ids, "fingerprint": fingerprint}
+
+
+def delete_book_keys(book_ids: Iterable[int]):
+    book_ids = {int(book_id) for book_id in book_ids if book_id is not None}
+    if not book_ids:
+        return 0
+    cwa_db = CWA_DB()
+    placeholders = ",".join("?" for _ in book_ids)
+    cwa_db.cur.execute(f"DELETE FROM cwa_duplicate_book_keys WHERE book_id IN ({placeholders})", tuple(book_ids))
+    deleted = cwa_db.cur.rowcount
+    cwa_db.con.commit()
+    return deleted
+
+
+def rebuild_duplicate_index(settings, progress_callback=None):
+    fingerprint = get_criteria_fingerprint(settings)
+    book_ids = sorted(_current_library_book_ids())
+    total_books = len(book_ids)
+    key_rows = []
+
+    indexed_count = 0
+    if progress_callback:
+        progress_callback(indexed_count, total_books)
+    for batch_ids in _chunks(book_ids, DUPLICATE_INDEX_REBUILD_BATCH_SIZE):
+        books_by_id = {int(book.id): book for book in _load_books_by_ids(batch_ids)}
+        for book_id in batch_ids:
+            book = books_by_id.get(int(book_id))
+            if book is None:
+                continue
+            parts = build_book_key_parts(book, settings)
+            duplicate_key = _hash_json(_enabled_key_values(parts, settings))
+            key_rows.append(
+                (book.id, *parts.as_db_tuple(), duplicate_key, fingerprint)
+            )
+            indexed_count += 1
+            if progress_callback and (indexed_count % 25 == 0 or indexed_count == total_books):
+                progress_callback(indexed_count, total_books)
+
+    cwa_db = CWA_DB()
+    cwa_db.cur.execute("DELETE FROM cwa_duplicate_book_keys")
+    cwa_db.cur.executemany(
+        """
+        INSERT OR REPLACE INTO cwa_duplicate_book_keys (
+            book_id, normalized_title, normalized_author, normalized_language,
+            normalized_series, normalized_publisher, format_signature,
+            duplicate_key, criteria_fingerprint, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+        """,
+        key_rows,
+    )
+    cwa_db.con.commit()
+    return {
+        "max_book_id": max(book_ids, default=0),
+        "indexed_count": indexed_count,
+        "fingerprint": fingerprint,
+    }
+
+
+def _duplicate_key_rows(settings, candidate_book_ids=None):
+    fingerprint = get_criteria_fingerprint(settings)
+    cwa_db = CWA_DB()
+    params = [fingerprint]
+    where = "criteria_fingerprint = ?"
+    if candidate_book_ids is not None:
+        candidate_book_ids = {int(book_id) for book_id in candidate_book_ids if book_id is not None}
+        if not candidate_book_ids:
+            return []
+        placeholders = ",".join("?" for _ in candidate_book_ids)
+        where = (
+            "criteria_fingerprint = ? AND duplicate_key IN ("
+            "SELECT duplicate_key FROM cwa_duplicate_book_keys "
+            f"WHERE criteria_fingerprint = ? AND book_id IN ({placeholders})"
+            ")"
+        )
+        params = [fingerprint, fingerprint, *candidate_book_ids]
+    cwa_db.cur.execute(
+        f"""
+        SELECT duplicate_key, GROUP_CONCAT(book_id), COUNT(*)
+        FROM cwa_duplicate_book_keys
+        WHERE {where}
+        GROUP BY duplicate_key
+        HAVING COUNT(*) > 1
+        """,
+        tuple(params),
+    )
+    return cwa_db.cur.fetchall()
+
+
+def _indexed_group_book_ids_for_books(settings, book_ids):
+    book_ids = {int(book_id) for book_id in book_ids if book_id is not None}
+    if not book_ids:
+        return set()
+
+    fingerprint = get_criteria_fingerprint(settings)
+    placeholders = ",".join("?" for _ in book_ids)
+    cwa_db = CWA_DB()
+    cwa_db.cur.execute(
+        f"""
+        SELECT GROUP_CONCAT(book_id)
+        FROM cwa_duplicate_book_keys
+        WHERE criteria_fingerprint = ?
+          AND duplicate_key IN (
+              SELECT duplicate_key
+              FROM cwa_duplicate_book_keys
+              WHERE criteria_fingerprint = ? AND book_id IN ({placeholders})
+          )
+        GROUP BY duplicate_key
+        """,
+        (fingerprint, fingerprint, *book_ids),
+    )
+    affected_ids = set()
+    for (book_ids_str,) in cwa_db.cur.fetchall():
+        if book_ids_str:
+            affected_ids.update(int(book_id) for book_id in book_ids_str.split(",") if book_id)
+    return affected_ids
+
+
+def _decorate_books_for_group(books):
+    for book in books:
+        if not hasattr(book, "ordered_authors") or not book.ordered_authors:
+            book.ordered_authors = calibre_db.order_authors([book])
+        if book.ordered_authors and len(book.ordered_authors) > 0:
+            book.author_names = ", ".join(
+                [author.name.replace("|", ",") for author in book.ordered_authors if author.name]
+            )
+        else:
+            book.author_names = "Unknown"
+        book.cover_url = f"/cover/{book.id}" if getattr(book, "has_cover", None) else "/static/generic_cover.svg"
+
+
+def _group_from_books(books):
+    books.sort(key=lambda book: _timestamp_or_default(book.timestamp, _AWARE_MIN), reverse=True)
+    _decorate_books_for_group(books)
+    display_title = books[0].title if books[0].title else "Untitled"
+    display_author = "Unknown"
+    if hasattr(books[0], "author_names") and books[0].author_names:
+        display_author = books[0].author_names.split(",")[0].strip()
+    return {
+        "title": display_title,
+        "author": display_author,
+        "count": len(books),
+        "books": books,
+        "group_hash": generate_group_hash(display_title, display_author),
+    }
+
+
+def get_duplicate_groups_from_index(settings, include_dismissed=False, user_id=None, candidate_book_ids=None):
+    duplicate_groups = []
+    for _duplicate_key, book_ids_str, _count in _duplicate_key_rows(settings, candidate_book_ids=candidate_book_ids):
+        book_ids = [int(book_id) for book_id in book_ids_str.split(",") if book_id]
+        books = _load_books_by_ids(book_ids, user_id=user_id)
+        if len(books) < 2:
+            continue
+        duplicate_groups.append(_group_from_books(books))
+
+    duplicate_groups.sort(key=lambda group: (group["title"].lower(), group["author"].lower()))
+    if not include_dismissed:
+        duplicate_groups = filter_dismissed_groups(duplicate_groups, user_id=user_id)
+    return duplicate_groups
+
+
+def _cached_group_book_ids(group):
+    if "book_ids" in group:
+        return {int(book_id) for book_id in group.get("book_ids", [])}
+    return {int(book.id) for book in group.get("books", [])}
+
+
+def _serialize_group_for_cache(group):
+    if "book_ids" in group:
+        book_ids = [int(book_id) for book_id in group.get("book_ids", [])]
+    else:
+        book_ids = [book.id for book in group.get("books", [])]
+    return {
+        "title": group.get("title", ""),
+        "author": group.get("author", ""),
+        "count": group.get("count", 0),
+        "group_hash": group.get("group_hash", ""),
+        "book_ids": book_ids,
+    }
+
+
+def _write_duplicate_cache_groups(cwa_db, duplicate_groups, max_book_id):
+    serialized_groups = [_serialize_group_for_cache(group) for group in duplicate_groups]
+    cwa_db.cur.execute(
+        """
+        UPDATE cwa_duplicate_cache
+        SET scan_timestamp = ?,
+            duplicate_groups_json = ?,
+            total_count = ?,
+            scan_pending = 0,
+            last_scanned_book_id = ?
+        WHERE id = 1
+        """,
+        (datetime.now().isoformat(), json.dumps(serialized_groups), len(serialized_groups), max_book_id),
+    )
+    cwa_db.con.commit()
+
+
+def merge_affected_groups_into_cache(candidate_book_ids, settings):
+    candidate_book_ids = {int(book_id) for book_id in candidate_book_ids if book_id is not None}
+    if len(candidate_book_ids) > MAX_INCREMENTAL_BOOK_IDS:
+        mark_duplicate_index_pending("incremental candidate set too large")
+        return {"updated": False, "pending": True, "reason": "candidate set too large"}
+    if not candidate_book_ids:
+        return {"updated": False, "pending": False, "merged_count": 0}
+
+    affected_ids = set(candidate_book_ids)
+    affected_ids.update(_indexed_group_book_ids_for_books(settings, candidate_book_ids))
+
+    upsert_result = upsert_book_keys(candidate_book_ids, settings)
+    missing_ids = upsert_result.get("missing_ids", [])
+    if missing_ids:
+        delete_book_keys(missing_ids)
+    affected_rows = _duplicate_key_rows(settings, candidate_book_ids=candidate_book_ids)
+    for _duplicate_key, book_ids_str, _count in affected_rows:
+        affected_ids.update(int(book_id) for book_id in book_ids_str.split(",") if book_id)
+
+    cwa_db = CWA_DB()
+    cache_data = cwa_db.get_duplicate_cache() or {}
+    cached_groups = cache_data.get("duplicate_groups", []) or []
+    retained_groups = [group for group in cached_groups if not (_cached_group_book_ids(group) & affected_ids)]
+    fresh_groups = get_duplicate_groups_from_index(settings, include_dismissed=True, candidate_book_ids=affected_ids)
+    merged_groups = retained_groups + fresh_groups
+    merged_groups.sort(key=lambda group: (group["title"].lower(), group["author"].lower()))
+    _write_duplicate_cache_groups(cwa_db, merged_groups, _current_max_book_id())
+    return {"updated": True, "pending": False, "merged_count": len(merged_groups)}
+
+
+def mark_duplicate_index_pending(reason=None):
+    cwa_db = CWA_DB()
+    cwa_db.cur.execute("UPDATE cwa_duplicate_cache SET scan_pending = 1 WHERE id = 1")
+    cwa_db.con.commit()
+    if reason:
+        log.info("[cwa-duplicates] Duplicate index marked pending: %s", reason)
+    return True
+
+
+def has_valid_duplicate_index_baseline(settings, candidate_book_ids=None):
+    cwa_db = CWA_DB()
+    cache_data = cwa_db.get_duplicate_cache()
+
+    candidate_ids = {int(book_id) for book_id in candidate_book_ids or [] if book_id is not None}
+    library_book_ids = _current_library_book_ids()
+    if not library_book_ids:
+        return True
+
+    # A fresh library can build its initial duplicate index incrementally when
+    # the candidate set covers every current book.
+    if not cache_data:
+        return bool(candidate_ids) and library_book_ids.issubset(candidate_ids)
+
+    if cache_data.get("scan_pending") and not candidate_ids:
+        return False
+
+    if library_book_ids and int(cache_data.get("last_scanned_book_id") or 0) <= 0:
+        if candidate_ids and library_book_ids.issubset(candidate_ids):
+            return True
+        return False
+
+    fingerprint = get_criteria_fingerprint(settings)
+    cwa_db.cur.execute(
+        "SELECT book_id FROM cwa_duplicate_book_keys WHERE criteria_fingerprint = ?",
+        (fingerprint,),
+    )
+    indexed_book_ids = {int(row[0]) for row in cwa_db.cur.fetchall()}
+    missing_book_ids = library_book_ids - indexed_book_ids
+    if not missing_book_ids:
+        return True
+
+    return missing_book_ids.issubset(candidate_ids)
+
+
+def ingest_batch_follow_up_pending():
+    return (
+        os.path.exists(INGEST_BATCH_ACTIVE_FILE)
+        or os.path.exists(INGEST_BATCH_DIRTY_FILE)
+        or os.path.exists(f"{INGEST_BATCH_DIRTY_FILE}.running")
+    )
+
+
+def duplicate_index_needs_manual_full_scan(settings):
+    """Return True only when UI should ask for a manual full scan.
+
+    During active imports, the debounced after-import scan is responsible for
+    indexing books newer than the last full baseline. Do not turn that temporary
+    lag into a manual full-scan requirement.
+    """
+    cwa_db = CWA_DB()
+    cache_data = cwa_db.get_duplicate_cache()
+    if not cache_data:
+        return library_has_books()
+
+    library_book_ids = _current_library_book_ids()
+    if not library_book_ids:
+        return False
+
+    last_scanned_book_id = int(cache_data.get("last_scanned_book_id") or 0)
+    if last_scanned_book_id <= 0:
+        return not ingest_batch_follow_up_pending()
+
+    fingerprint = get_criteria_fingerprint(settings)
+    cwa_db.cur.execute(
+        "SELECT book_id FROM cwa_duplicate_book_keys WHERE criteria_fingerprint = ?",
+        (fingerprint,),
+    )
+    indexed_book_ids = {int(row[0]) for row in cwa_db.cur.fetchall()}
+    missing_book_ids = library_book_ids - indexed_book_ids
+    if not missing_book_ids:
+        return False
+
+    missing_existing_books = {book_id for book_id in missing_book_ids if book_id <= last_scanned_book_id}
+    if missing_existing_books:
+        return True
+
+    if ingest_batch_follow_up_pending():
+        return False
+
+    return True

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import joinedload
 from datetime import datetime, timezone
 from functools import wraps
 import hashlib
+import json
 import os
 import time
 from shutil import copyfile
@@ -29,6 +30,34 @@ from cwa_db import CWA_DB
 
 duplicates = Blueprint('duplicates', __name__)
 log = logger.create()
+
+
+def _duplicate_scan_transiently_pending():
+    try:
+        from cps.duplicate_index import ingest_batch_follow_up_pending
+        if ingest_batch_follow_up_pending():
+            return True
+    except Exception as ex:
+        log.debug("[cwa-duplicates] Could not check ingest follow-up marker state: %s", str(ex))
+
+    try:
+        from cps.cwa_functions import duplicate_scan_debounce_pending
+        if duplicate_scan_debounce_pending():
+            return True
+    except Exception as ex:
+        log.debug("[cwa-duplicates] Could not check duplicate scan debounce state: %s", str(ex))
+
+    try:
+        terminal_stats = {STAT_FINISH_SUCCESS, STAT_FAIL, STAT_ENDED, STAT_CANCELLED}
+        for __, __, __, task, __ in WorkerThread.get_instance().tasks:
+            if task.stat in terminal_stats:
+                continue
+            if task.__class__.__name__ == "TaskDuplicateScan" or str(getattr(task, "name", "")).lower() == "duplicate scan":
+                return True
+    except Exception as ex:
+        log.debug("[cwa-duplicates] Could not check duplicate scan worker state: %s", str(ex))
+
+    return False
 
 
 def _normalize_timestamp(ts):
@@ -277,39 +306,48 @@ def filter_dismissed_groups(duplicate_groups, user_id=None):
 @login_required_if_no_ano
 @admin_or_edit_required
 def show_duplicates():
-    """Display books with duplicate titles and authors"""
+    """Display cached duplicate groups and prompt for the initial index scan."""
     print("[cwa-duplicates] Loading duplicates page...", flush=True)
     log.info("[cwa-duplicates] Loading duplicates page for user: %s", current_user.name)
     
     try:
-        # Use SQL/Python detection to find all duplicates once, then filter for current user
-        all_groups = find_duplicate_books(include_dismissed=True)
-        duplicate_groups = filter_dismissed_groups(all_groups, current_user.id if current_user else None)
+        cwa_db = CWA_DB()
+        settings = cwa_db.cwa_settings
+        duplicate_groups = []
+        duplicate_index_needs_full_scan = True
 
-        # Update cache so notifications reflect the latest scan
         try:
-            max_book_id = 0
-            try:
-                max_id_result = calibre_db.session.query(func.max(db.Books.id)).scalar()
-                max_book_id = max_id_result if max_id_result is not None else 0
-            except Exception as max_ex:
-                log.warning("[cwa-duplicates] Could not get max book ID for cache update: %s", str(max_ex))
+            from cps.duplicate_index import (
+                duplicate_index_needs_manual_full_scan,
+                get_duplicate_groups_from_index,
+                library_has_books,
+            )
 
-            cwa_db_cache = CWA_DB()
-            cwa_db_cache.update_duplicate_cache(all_groups, len(all_groups), max_book_id)
-            log.debug("[cwa-duplicates] Cache updated from /duplicates page load")
-        except Exception as cache_ex:
-            log.warning("[cwa-duplicates] Failed to update cache from /duplicates page: %s", str(cache_ex))
+            duplicate_index_needs_full_scan = (
+                library_has_books()
+                and duplicate_index_needs_manual_full_scan(settings)
+                and not _duplicate_scan_transiently_pending()
+            )
+            if duplicate_index_needs_full_scan:
+                log.info("[cwa-duplicates] Duplicate index baseline missing; prompting for manual full scan")
+            else:
+                duplicate_groups = get_duplicate_groups_from_index(
+                    settings,
+                    include_dismissed=False,
+                    user_id=current_user.id if current_user else None,
+                )
+        except Exception as index_ex:
+            log.warning("[cwa-duplicates] Could not load duplicate index state: %s", str(index_ex))
 
         # Compute next scheduled scan run
-        cwa_db = CWA_DB()
-        next_scan_run = get_next_duplicate_scan_run(cwa_db.cwa_settings)
+        next_scan_run = get_next_duplicate_scan_run(settings)
         
         print(f"[cwa-duplicates] Found {len(duplicate_groups)} duplicate groups total", flush=True)
         log.info("[cwa-duplicates] Found %s duplicate groups total", len(duplicate_groups))
         
         return render_title_template('duplicates.html', 
                                      duplicate_groups=duplicate_groups,
+                                     duplicate_index_needs_full_scan=duplicate_index_needs_full_scan,
                                      next_scan_run=next_scan_run,
                                      title=_("Duplicate Books"), 
                                      page="duplicates")
@@ -320,6 +358,7 @@ def show_duplicates():
         # Return empty page on error
         return render_title_template('duplicates.html', 
                                      duplicate_groups=[],
+                                     duplicate_index_needs_full_scan=False,
                                      next_scan_run=None,
                                      title=_("Duplicate Books"), 
                                      page="duplicates")
@@ -506,7 +545,7 @@ def find_duplicate_candidate_ids_sql(use_title, use_author, user_id=None, min_bo
     if not use_title and not use_author:
         return None
 
-    print("[cwa-duplicates] Using SQL hybrid prefilter (candidate IDs)", flush=True)
+    log.debug("[cwa-duplicates] Using SQL hybrid prefilter (candidate IDs)")
 
     # Note: these GROUP BY fields are evaluated by SQLite at query time; they are not cached
     # groupings in memory. We only use this query to prefilter candidate IDs.
@@ -550,21 +589,12 @@ def find_duplicate_candidate_ids_sql(use_title, use_author, user_id=None, min_bo
     if min_book_id is not None:
         query = query.having(max_id_field >= int(min_book_id))
 
-    # Debug: print the actual SQL being executed
     try:
-        from sqlalchemy.dialects import sqlite
-        compiled = query.statement.compile(dialect=sqlite.dialect(), compile_kwargs={"literal_binds": True})
-        print(f"[cwa-duplicates] SQL prefilter query:\n{compiled}", flush=True)
-    except Exception as debug_ex:
-        print(f"[cwa-duplicates] Could not compile SQL for debug: {debug_ex}", flush=True)
-
-    try:
-        print(f"[cwa-duplicates] Executing SQL prefilter query (min_book_id={min_book_id})...", flush=True)
+        log.debug("[cwa-duplicates] Executing SQL prefilter query (min_book_id=%s)...", min_book_id)
         results = query.all()
-        print(f"[cwa-duplicates] SQL prefilter query completed, got {len(results)} result rows", flush=True)
+        log.debug("[cwa-duplicates] SQL prefilter query completed, got %s result rows", len(results))
     except Exception as e:
         log.error("[cwa-duplicates] Hybrid prefilter SQL failed: %s", str(e))
-        print(f"[cwa-duplicates] Hybrid prefilter SQL failed: {str(e)}", flush=True)
         return None
 
     candidate_ids = set()
@@ -573,7 +603,7 @@ def find_duplicate_candidate_ids_sql(use_title, use_author, user_id=None, min_bo
             continue
         candidate_ids.update(int(bid) for bid in row.book_ids_str.split(',') if bid)
 
-    print(f"[cwa-duplicates] Hybrid prefilter returned {len(candidate_ids)} candidate books", flush=True)
+    log.debug("[cwa-duplicates] Hybrid prefilter returned %s candidate books", len(candidate_ids))
     return candidate_ids
 
 
@@ -1031,10 +1061,47 @@ def get_duplicate_status():
         # Check if notifications are enabled
         notifications_enabled = cwa_db.cwa_settings.get('duplicate_notifications_enabled', 1)
         
+        try:
+            from cps.duplicate_index import library_has_books
+            duplicate_library_has_books = library_has_books()
+        except Exception as index_ex:
+            log.warning("[cwa-duplicates] Could not check duplicate library size in status endpoint: %s", str(index_ex))
+            duplicate_library_has_books = True
+
         # Try to get cached results first
         cache_data = cwa_db.get_duplicate_cache()
+        duplicate_index_needs_full_scan = (
+            duplicate_library_has_books
+            and (bool(cache_data.get('scan_pending')) if cache_data else True)
+        )
+        if cache_data and duplicate_library_has_books:
+            try:
+                from cps.duplicate_index import (
+                    duplicate_index_needs_manual_full_scan,
+                )
+
+                duplicate_index_needs_full_scan = (
+                    duplicate_library_has_books
+                    and duplicate_index_needs_manual_full_scan(cwa_db.cwa_settings)
+                    and not _duplicate_scan_transiently_pending()
+                )
+            except Exception as index_ex:
+                log.warning("[cwa-duplicates] Could not check duplicate index baseline in status endpoint: %s", str(index_ex))
+                duplicate_index_needs_full_scan = True
         
         if cache_data and cache_data.get('duplicate_groups') is not None:
+            if duplicate_index_needs_full_scan:
+                return jsonify({
+                    'success': True,
+                    'enabled': bool(notifications_enabled),
+                    'count': 0,
+                    'preview': [],
+                    'cached': False,
+                    'stale': True,
+                    'needs_scan': True,
+                    'needs_full_scan': True
+                })
+
             # Cache is available; use it even if scan is pending
             duplicate_groups = cache_data['duplicate_groups']
             
@@ -1063,7 +1130,8 @@ def get_duplicate_status():
                 'preview': preview,
                 'cached': True,
                 'stale': bool(cache_data.get('scan_pending')),
-                'needs_scan': bool(cache_data.get('scan_pending'))
+                'needs_scan': duplicate_index_needs_full_scan,
+                'needs_full_scan': duplicate_index_needs_full_scan
             })
         
         # Cache is missing - DO NOT trigger scan here!
@@ -1080,7 +1148,8 @@ def get_duplicate_status():
             'count': 0,
             'preview': [],
             'cached': False,
-            'needs_scan': True  # Frontend can optionally show "scan needed" message
+            'needs_scan': duplicate_index_needs_full_scan,  # Frontend can optionally show "scan needed" message
+            'needs_full_scan': duplicate_index_needs_full_scan
         })
     except Exception as e:
         log.error("[cwa-duplicates] Error getting duplicate status: %s", str(e))
@@ -1090,6 +1159,21 @@ def get_duplicate_status():
             'count': 0,
             'preview': []
         }), 500
+
+
+@duplicates.route("/duplicates/dismiss-setup-notice", methods=['POST'])
+@login_required_if_no_ano
+@admin_or_edit_required
+def dismiss_duplicate_scan_setup_notice():
+    """Remember that the current duplicate-index setup notice was dismissed."""
+    try:
+        notice_file = f"/app/cwa_duplicate_index_setup_notice_{getattr(current_user, 'id', 'unknown')}"
+        with open(notice_file, 'w') as f:
+            f.write("dismissed\n")
+        return jsonify({"success": True})
+    except Exception as e:
+        log.error("[cwa-duplicates] Failed to dismiss duplicate setup notice: %s", str(e))
+        return jsonify({"success": False, "error": str(e)}), 500
 
 
 @duplicates.route("/duplicates/dismiss/<group_hash>", methods=['POST'])
@@ -1219,6 +1303,19 @@ def invalidate_cache():
 def trigger_scan():
     """Manually trigger a duplicate scan"""
     try:
+        try:
+            from cps.duplicate_index import ingest_batch_follow_up_pending
+            if ingest_batch_follow_up_pending():
+                log.info("[cwa-duplicates] Manual full scan blocked while ingest is active")
+                return jsonify({
+                    'success': False,
+                    'blocked': True,
+                    'reason': 'ingest_in_progress',
+                    'message': _('Import is in progress. Run a full duplicate scan after ingest finishes.'),
+                }), 409
+        except Exception as ex:
+            log.warning("[cwa-duplicates] Could not check ingest state before manual scan: %s", str(ex))
+
         # Invalidate cache and run fresh scan
         cwa_db = CWA_DB()
         cwa_db.invalidate_duplicate_cache()
@@ -1244,15 +1341,17 @@ def trigger_scan():
             print(f"[cwa-duplicates] Failed to queue task, using fallback: {str(e)}", flush=True)
 
             # Fallback to synchronous scan to avoid hard failures
-            duplicate_groups = find_duplicate_books(include_dismissed=False)
-            max_book_id = 0
-            try:
-                max_id_result = calibre_db.session.query(func.max(db.Books.id)).scalar()
-                max_book_id = max_id_result if max_id_result is not None else 0
-            except Exception as ex:
-                log.warning("[cwa-duplicates] Could not get max book ID in trigger_scan fallback: %s", str(ex))
+            from cps.duplicate_index import get_duplicate_groups_from_index, rebuild_duplicate_index
 
-            all_groups = find_duplicate_books(include_dismissed=True)
+            settings = cwa_db.cwa_settings
+            rebuild_metadata = rebuild_duplicate_index(settings)
+            duplicate_groups = get_duplicate_groups_from_index(
+                settings,
+                include_dismissed=False,
+                user_id=current_user.id if current_user else None,
+            )
+            all_groups = get_duplicate_groups_from_index(settings, include_dismissed=True)
+            max_book_id = rebuild_metadata.get('max_book_id', 0)
             cwa_db.update_duplicate_cache(all_groups, len(all_groups), max_book_id)
 
             # Check if auto-resolution is enabled for fallback sync scan
@@ -1283,9 +1382,18 @@ def trigger_scan():
                                   flush=True)
                             
                             # Re-scan to get updated counts after resolution
-                            duplicate_groups = find_duplicate_books(include_dismissed=False)
-                            all_groups = find_duplicate_books(include_dismissed=True)
-                            cwa_db.update_duplicate_cache(all_groups, len(all_groups), max_book_id)
+                            rebuild_metadata = rebuild_duplicate_index(settings)
+                            duplicate_groups = get_duplicate_groups_from_index(
+                                settings,
+                                include_dismissed=False,
+                                user_id=current_user.id if current_user else None,
+                            )
+                            all_groups = get_duplicate_groups_from_index(settings, include_dismissed=True)
+                            cwa_db.update_duplicate_cache(
+                                all_groups,
+                                len(all_groups),
+                                rebuild_metadata.get('max_book_id', max_book_id),
+                            )
                             log.debug("[cwa-duplicates] Cache refreshed after fallback auto-resolution")
                 except Exception as ex:
                     log.error("[cwa-duplicates] Error during fallback auto-resolution: %s", str(ex))
@@ -1306,62 +1414,6 @@ def trigger_scan():
             'success': False,
             'error': str(e)
         }), 500
-
-
-@duplicates.route("/duplicates/scan-progress/<task_id>", methods=['GET'])
-@login_required_if_no_ano
-@admin_or_edit_required
-def scan_progress(task_id):
-    """Get progress for a queued duplicate scan task"""
-    try:
-        worker = WorkerThread.get_instance()
-        task = None
-        for __, __, __, queued_task, __ in worker.tasks:
-            if str(queued_task.id) == str(task_id):
-                task = queued_task
-                break
-
-        if task is None:
-            return jsonify({'success': False, 'error': 'Task not found'}), 404
-
-        status = 'running'
-        if task.stat in (STAT_FINISH_SUCCESS,):
-            status = 'completed'
-        elif task.stat in (STAT_FAIL,):
-            status = 'failed'
-        elif task.stat in (STAT_CANCELLED, STAT_ENDED):
-            status = 'cancelled'
-
-        message = getattr(task, 'message', '')
-        if status == 'failed' and getattr(task, 'error', None):
-            message = task.error
-
-        return jsonify({
-            'success': True,
-            'task_id': str(task.id),
-            'progress': task.progress,
-            'status': status,
-            'message': message,
-            'result_count': getattr(task, 'result_count', None)
-        })
-    except Exception as e:
-        log.error("[cwa-duplicates] Error fetching scan progress: %s", str(e))
-        return jsonify({'success': False, 'error': str(e)}), 500
-
-
-@duplicates.route("/duplicates/cancel-scan/<task_id>", methods=['POST'])
-@csrf.exempt
-@login_required_if_no_ano
-@admin_or_edit_required
-def cancel_scan(task_id):
-    """Cancel a running or queued duplicate scan task."""
-    try:
-        worker = WorkerThread.get_instance()
-        worker.end_task(task_id)
-        return jsonify({'success': True, 'message': 'Scan cancelled'})
-    except Exception as e:
-        log.error("[cwa-duplicates] Error cancelling scan: %s", str(e))
-        return jsonify({'success': False, 'error': str(e)}), 500
 
 
 @duplicates.route("/duplicates/preview-resolution", methods=["POST"])
@@ -1387,13 +1439,16 @@ def preview_resolution():
             }), 400
         
         print("[cwa-duplicates] Calling auto_resolve_duplicates in dry_run mode...", flush=True)
-        # Note: No duplicate_groups passed - will scan to get fresh data for preview
+        duplicate_groups = _get_duplicate_groups_for_resolution(current_user.id)
         result = auto_resolve_duplicates(
             strategy=strategy,
             dry_run=True,
             user_id=current_user.id,
-            trigger_type='manual'
+            trigger_type='manual',
+            duplicate_groups=duplicate_groups
         )
+        if 'preview' not in result:
+            result['preview'] = []
         
         print(f"[cwa-duplicates] Preview result: {result.get('success', False)}, resolved_count={result.get('resolved_count', 0)}", flush=True)
         return jsonify(result)
@@ -1423,19 +1478,28 @@ def execute_resolution():
                 'success': False,
                 'error': _('Invalid resolution strategy')
             }), 400
+
+        try:
+            from cps.duplicate_index import ingest_batch_follow_up_pending
+            if ingest_batch_follow_up_pending():
+                log.info("[cwa-duplicates] Auto-resolution blocked while ingest is active")
+                return jsonify({
+                    'success': False,
+                    'blocked': True,
+                    'reason': 'ingest_in_progress',
+                    'message': _('Import is in progress. Execute duplicate resolution after ingest finishes.'),
+                }), 409
+        except Exception as ex:
+            log.warning("[cwa-duplicates] Could not check ingest state before auto-resolution: %s", str(ex))
         
-        # Note: No duplicate_groups passed - will scan to get fresh data for execution
+        duplicate_groups = _get_duplicate_groups_for_resolution(current_user.id)
         result = auto_resolve_duplicates(
             strategy=strategy,
             dry_run=False,
             user_id=current_user.id,
-            trigger_type='manual'
+            trigger_type='manual',
+            duplicate_groups=duplicate_groups
         )
-        
-        # Invalidate cache after resolution
-        if result['success'] and result['deleted_count'] > 0:
-            cwa_db = CWA_DB()
-            cwa_db.invalidate_duplicate_cache()
         
         return jsonify(result)
         
@@ -1445,6 +1509,39 @@ def execute_resolution():
             'success': False,
             'error': str(e)
         }), 500
+
+
+def _get_duplicate_groups_for_resolution(user_id=None):
+    """Use the same indexed duplicate source as the Duplicates page."""
+    try:
+        from cps.duplicate_index import get_duplicate_groups_from_index
+
+        cwa_db = CWA_DB()
+        return get_duplicate_groups_from_index(
+            cwa_db.cwa_settings,
+            include_dismissed=False,
+            user_id=user_id,
+        )
+    except Exception as ex:
+        log.warning("[cwa-duplicates] Failed to load indexed groups for resolution, falling back to legacy scan: %s", str(ex))
+        return find_duplicate_books(include_dismissed=False, user_id=user_id)
+
+
+def _refresh_duplicate_cache_after_resolution(cwa_db):
+    """Refresh cached duplicate groups after resolution removes books/index rows."""
+    try:
+        from cps.duplicate_index import get_duplicate_groups_from_index, _current_max_book_id
+
+        duplicate_groups = get_duplicate_groups_from_index(cwa_db.cwa_settings, include_dismissed=True)
+        if not cwa_db.update_duplicate_cache(duplicate_groups, len(duplicate_groups), _current_max_book_id()):
+            raise RuntimeError("update_duplicate_cache returned False")
+        log.debug("[cwa-duplicates] Duplicate cache refreshed after auto-resolution")
+    except Exception as ex:
+        log.warning("[cwa-duplicates] Failed to refresh cache after resolution: %s", str(ex))
+        try:
+            cwa_db.invalidate_duplicate_cache()
+        except Exception as invalidate_ex:
+            log.warning("[cwa-duplicates] Failed to invalidate cache after resolution: %s", str(invalidate_ex))
 
 
 def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trigger_type='manual', duplicate_groups=None):
@@ -1685,6 +1782,13 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
                         result['errors'].append(f"Failed to delete book {book.id}: {str(e)}")
                 
                 if deleted_ids:
+                    try:
+                        from cps.duplicate_index import delete_book_keys
+                        delete_book_keys(deleted_ids)
+                    except Exception as e:
+                        log.warning("[cwa-duplicates] Failed to delete duplicate index keys for books %s: %s",
+                                    deleted_ids, str(e))
+
                     # Log to audit table
                     cwa_db.log_duplicate_resolution(
                         group_hash=group['group_hash'],
@@ -1719,13 +1823,10 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
         if result['errors']:
             result['success'] = False
         
-        # Invalidate cache if any books were deleted
-        if result['deleted_count'] > 0:
-            try:
-                cwa_db.invalidate_duplicate_cache()
-                log.debug("[cwa-duplicates] Duplicate cache invalidated after auto-resolution")
-            except Exception as ex:
-                log.warning("[cwa-duplicates] Failed to invalidate cache after resolution: %s", str(ex))
+        # Refresh cache only after real deletions. Dry-run previews report the
+        # would-be deleted count but must not mutate scan/index state.
+        if not dry_run and result['deleted_count'] > 0:
+            _refresh_duplicate_cache_after_resolution(cwa_db)
         
         # Log timing information
         elapsed_time = time.time() - start_time

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -714,18 +714,7 @@ def delete_selected_books():
     if vals:
         for book_id in vals:
             delete_book_from_table(book_id, "", True, skip_cache_invalidation=True)
-        
-        # Invalidate duplicate cache once after all deletions
-        try:
-            import sys
-            sys.path.insert(1, '/app/calibre-web-automated/scripts/')
-            from cwa_db import CWA_DB
-            cwa_db = CWA_DB()
-            cwa_db.invalidate_duplicate_cache()
-        except Exception as e:
-            log.error("Failed to invalidate duplicate cache after batch deletion: %s", str(e))
-        
-        # Note: Not queuing duplicate scan here since page reload will trigger fresh scan
+        _queue_duplicate_scan_after_change(vals)
         return json.dumps({'success': True})
     return ""
 
@@ -795,40 +784,24 @@ def merge_list_book():
                                     break
                     delete_book_from_table(from_book.id, "", True, skip_cache_invalidation=True)
             calibre_db.session.commit()
-            
-            # Invalidate duplicate cache once after all merges
-            try:
-                import sys
-                sys.path.insert(1, '/app/calibre-web-automated/scripts/')
-                from cwa_db import CWA_DB
-                cwa_db = CWA_DB()
-                cwa_db.invalidate_duplicate_cache()
-            except Exception as e:
-                log.error("Failed to invalidate duplicate cache after merge: %s", str(e))
-            
-            # Note: Not queuing duplicate scan here since page reload will trigger fresh scan
+            _queue_duplicate_scan_after_change([to_book.id] + vals)
             return json.dumps({'success': True})
     return ""
 
 
-def _queue_duplicate_scan_after_change():
+def _queue_duplicate_scan_after_change(book_ids=None):
     """Queue a debounced duplicate scan after manual changes."""
     try:
-        import requests
         sys.path.insert(1, '/app/calibre-web-automated/scripts/')
         from cwa_db import CWA_DB
+        from .cwa_functions import queue_debounced_duplicate_scan
 
         cwa_db = CWA_DB()
         delay_seconds = int(cwa_db.cwa_settings.get('duplicate_scan_debounce_seconds', 30))
         delay_seconds = max(10, min(600, delay_seconds))
-        url = helper.get_internal_api_url("/cwa-internal/queue-duplicate-scan")
-        requests.post(
-            url,
-            json={"delay_seconds": delay_seconds},
-            headers={"X-Forwarded-For": "127.0.0.1"},
-            timeout=5,
-            verify=False,
-        )
+        result = queue_debounced_duplicate_scan(delay_seconds=delay_seconds, book_ids=book_ids or [])
+        if result.get("skipped"):
+            log.debug("Duplicate scan scheduling skipped after change: %s", result.get("reason"))
     except Exception as e:
         log.error("Failed to queue duplicate scan after change: %s", str(e))
 
@@ -1089,6 +1062,8 @@ def do_edit_book(book_id, upload_formats=None):
 
         if not edit_error and not title_author_error and cover_upload_success is not False:
             flash(_("Metadata successfully updated"), category="success")
+            if modify_date:
+                _queue_duplicate_scan_after_change([book.id])
 
         if upload_formats:
             return Response(json.dumps({"location": url_for('edit-book.show_edit_book', book_id=book_id)}), mimetype='application/json')
@@ -1462,11 +1437,30 @@ def delete_book_from_table(book_id, book_format, json_response, location="", ski
                     if book_format.upper() in ['KEPUB', 'EPUB', 'EPUB3']:
                         kobo_sync_status.remove_synced_book(book.id, True)
                 calibre_db.session.commit()
-                
-                # Invalidate duplicate cache after book deletion (unless batching)
-                if not skip_cache_invalidation:
+
+                refreshed_duplicate_cache = False
+                if not book_format:
                     try:
-                        import sys
+                        from cps.duplicate_index import (
+                            _current_max_book_id,
+                            delete_book_keys,
+                            get_duplicate_groups_from_index,
+                        )
+                        sys.path.insert(1, '/app/calibre-web-automated/scripts/')
+                        from cwa_db import CWA_DB
+
+                        delete_book_keys([book_id])
+                        cwa_db = CWA_DB()
+                        duplicate_groups = get_duplicate_groups_from_index(cwa_db.cwa_settings, include_dismissed=True)
+                        cwa_db.update_duplicate_cache(duplicate_groups, len(duplicate_groups), _current_max_book_id())
+                        refreshed_duplicate_cache = True
+                    except Exception as e:
+                        log.warning("Failed to refresh duplicate index/cache after deleting book %s: %s", book_id, str(e))
+                
+                # Skip cache invalidation when batching, or when the indexed refresh
+                # above already handled it; otherwise mark the cache as stale.
+                if not skip_cache_invalidation and not refreshed_duplicate_cache:
+                    try:
                         sys.path.insert(1, '/app/calibre-web-automated/scripts/')
                         from cwa_db import CWA_DB
                         cwa_db = CWA_DB()

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -66,6 +66,14 @@ from .embed_helper import do_calibre_export
 
 log = logger.create()
 
+
+def _directory_contains_only_nfs_placeholders(path):
+    try:
+        entries = os.listdir(path)
+    except OSError:
+        return False
+    return bool(entries) and all(entry.startswith(".nfs") for entry in entries)
+
 try:
     from wand.image import Image
     from wand.exceptions import MissingDelegateError, BlobError
@@ -409,6 +417,12 @@ def delete_book_file(book, calibrepath, book_format=None):
                                            path=book.path)
                     shutil.rmtree(path)
                 except (IOError, OSError) as ex:
+                    if _directory_contains_only_nfs_placeholders(path):
+                        log.warning(
+                            "Deleting book %s left NFS placeholder files in %s; continuing database cleanup",
+                            book.id, path,
+                        )
+                        return True, None
                     log.error("Deleting book %s failed: %s", book.id, ex)
                     return False, _("Deleting book %(id)s failed: %(message)s", id=book.id, message=ex)
                 authorpath = os.path.join(calibrepath, os.path.split(book.path)[0])

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -27,6 +27,40 @@ from cwa_db import CWA_DB
 
 log = logger.create()
 
+
+def _duplicate_setup_notice_dismissed():
+    notice_file = f"/app/cwa_duplicate_index_setup_notice_{getattr(current_user, 'id', 'unknown')}"
+    return os.path.isfile(notice_file)
+
+
+def duplicate_index_setup_notification(settings, cwa_db=None):
+    notice_file = f"/app/cwa_duplicate_index_setup_notice_{getattr(current_user, 'id', 'unknown')}"
+    if os.path.isfile(notice_file):
+        return False
+
+    try:
+        from cps.duplicate_index import duplicate_index_needs_manual_full_scan, library_has_books
+
+        if not library_has_books():
+            return False
+        if not duplicate_index_needs_manual_full_scan(settings):
+            return False
+    except Exception as e:
+        log.debug("[cwa-duplicates] Failed to check duplicate setup notification state: %s", str(e))
+        return False
+
+    try:
+        message = _(
+            "Duplicate scanning needs a one-time full scan before fast duplicate checks can run after imports "
+            "and metadata changes. "
+        )
+        flash(message, category="duplicate_scan_setup")
+        return True
+    except Exception as e:
+        log.debug("[cwa-duplicates] Failed to show duplicate index setup notification: %s", str(e))
+        return False
+
+
 def get_sidebar_config(kwargs=None):
     kwargs = kwargs or []
     simple = bool([e for e in ['kindle', 'tolino', "kobo", "bookeen"]
@@ -297,7 +331,20 @@ def render_title_template(*args, **kwargs):
             notifications_enabled = bool(cwa_db.cwa_settings.get('duplicate_notifications_enabled', 1))
             if detection_enabled:
                 cache_data = cwa_db.get_duplicate_cache()
-                if cache_data and cache_data.get('duplicate_groups') is not None:
+                duplicate_setup_notice_dismissed = _duplicate_setup_notice_dismissed()
+                duplicate_setup_notice_shown = False
+                if not duplicate_setup_notice_dismissed:
+                    duplicate_setup_notice_shown = duplicate_index_setup_notification(cwa_db.cwa_settings, cwa_db=cwa_db)
+
+                if duplicate_setup_notice_shown:
+                    duplicate_notification = {
+                        "enabled": notifications_enabled,
+                        "count": 0,
+                        "preview": [],
+                        "cached": False,
+                        "stale": True,
+                    }
+                elif cache_data and cache_data.get('duplicate_groups') is not None:
                     duplicate_groups = cache_data.get('duplicate_groups') or []
                     try:
                         dismissed_groups = ub.session.query(ub.DismissedDuplicateGroup.group_hash)\

--- a/cps/static/js/duplicate-notifier.js
+++ b/cps/static/js/duplicate-notifier.js
@@ -105,6 +105,10 @@
         const modal = document.getElementById('duplicate-notification-modal');
         return modal && modal.classList.contains('active');
     }
+
+    function isDuplicatesPage() {
+        return window.location.pathname.replace(/\/+$/, '').endsWith('/duplicates');
+    }
     
     /**
      * Show the notification modal
@@ -158,7 +162,6 @@
                 // Mark as shown and store count
                 markNotificationShown();
                 setLastNotifiedCount(count);
-                stopStatusPolling();
             }, 500);
         }
     }
@@ -168,15 +171,16 @@
             return;
         }
 
+        if (!window.CWADuplicateScanActive) {
+            updateBadge(data.count);
+        }
+        document.dispatchEvent(new CustomEvent('cwa:duplicates-status', { detail: data }));
+
         if (isModalActive()) {
-            stopStatusPolling();
             return;
         }
 
-        updateBadge(data.count);
-
-        if (data.count > 0 && data.enabled) {
-            stopStatusPolling();
+        if (data.count > 0 && data.enabled && !isDuplicatesPage()) {
             showNotificationModal(data);
             if (isModalActive()) {
                 return;
@@ -185,11 +189,6 @@
 
         if ((data.needs_scan || data.stale) && !isModalActive()) {
             startStatusPolling();
-            return;
-        }
-
-        if (data.count > 0) {
-            stopStatusPolling();
             return;
         }
 

--- a/cps/static/js/duplicates.js
+++ b/cps/static/js/duplicates.js
@@ -50,6 +50,43 @@ $(document).ready(function() {
             }
         });
     }
+
+    function escapeHtml(value) {
+        return $('<div>').text(value || '').html();
+    }
+
+    function showResolutionSuccess(data) {
+        $('#success_modal_title').text('Resolution Complete');
+        $('#success_modal_message').html(
+            '<div class="resolution-success-summary">' +
+                '<div class="resolution-success-stat">' +
+                    '<span class="resolution-success-value">' + data.resolved_count + '</span>' +
+                    '<span class="resolution-success-label">Groups Resolved</span>' +
+                '</div>' +
+                '<div class="resolution-success-stat">' +
+                    '<span class="resolution-success-value">' + data.kept_count + '</span>' +
+                    '<span class="resolution-success-label">Books Kept</span>' +
+                '</div>' +
+                '<div class="resolution-success-stat">' +
+                    '<span class="resolution-success-value">' + data.deleted_count + '</span>' +
+                    '<span class="resolution-success-label">Books Deleted</span>' +
+                '</div>' +
+            '</div>'
+        );
+        $('#success_modal').modal('show');
+    }
+
+    function showResolutionError(message) {
+        $('#error_modal_title').text('Resolution Failed');
+        $('#error_modal_message').html(message);
+        $('#error_modal').modal('show');
+    }
+
+    function showDuplicateScanError(title, message) {
+        $('#error_modal_title').text(title);
+        $('#error_modal_message').html(escapeHtml(message));
+        $('#error_modal').modal('show');
+    }
     
     // Handle individual checkbox changes  
     $(document).on('change', '.book-checkbox', function() {
@@ -383,85 +420,160 @@ $(document).ready(function() {
         });
     });
     
-    let activeScanTaskId = null;
+    function showScanNotification(message, alertClass) {
+        $('#duplicate_scan_notification').parent().remove();
 
-    function updateProgressUI(progress, message) {
-        const pct = Math.round((progress || 0) * 100);
-        $('#scan_progress_container').show();
-        $('#scan_progress_bar').css('width', pct + '%');
-        $('#scan_progress_label').text(pct + '%');
-        $('#scan_progress_message').text(message || '');
-        $('#cancel_scan').show();
+        var notificationHtml =
+            '<div class="row-fluid text-center">' +
+                '<div id="duplicate_scan_notification" class="alert ' + alertClass + ' refresh-cwa">' +
+                    message +
+                    '<button type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+                        '<span aria-hidden="true">&times;</span>' +
+                    '</button>' +
+                '</div>' +
+            '</div>';
+
+        $('.navbar').after(notificationHtml);
     }
 
-    function resetProgressUI() {
-        $('#scan_progress_container').hide();
-        $('#scan_progress_bar').css('width', '0%');
-        $('#scan_progress_label').text('0%');
-        $('#scan_progress_message').text('');
-        $('#cancel_scan').hide();
-        activeScanTaskId = null;
+    var duplicateScanPollTimer = null;
+    var duplicateScanTaskId = null;
+    var duplicateScanWasActive = false;
+    window.CWADuplicateScanActive = false;
+
+    function duplicateScanEndpoint(path) {
+        if (typeof getPath === 'function') {
+            return getPath() + path;
+        }
+        return path;
     }
 
-    function pollScanProgress(taskId, btn) {
-        activeScanTaskId = taskId;
-        const pollInterval = 2000;
-        function pollOnce() {
-            $.ajax({
-                url: '/duplicates/scan-progress/' + taskId,
-                type: 'GET',
-                dataType: 'json',
-                success: function(response) {
-                    if (!response.success) {
-                        clearInterval(poller);
-                        btn.prop('disabled', false);
-                        btn.html('<span class="glyphicon glyphicon-refresh"></span> Scan for Duplicates Now');
-                        resetProgressUI();
-                        alert('Scan failed: ' + (response.error || 'Unknown error'));
-                        return;
-                    }
+    function parseTaskProgress(task) {
+        var progress = parseInt(task.progress, 10);
+        if (isNaN(progress)) {
+            return 0;
+        }
+        return Math.max(0, Math.min(100, progress));
+    }
 
-                    updateProgressUI(response.progress, response.message);
+    function isDuplicateScanTask(task) {
+        if (duplicateScanTaskId && String(task.task_id) === String(duplicateScanTaskId)) {
+            return true;
+        }
+        return String(task.taskMessage || '').toLowerCase().indexOf('duplicate scan') !== -1;
+    }
 
-                    if (response.status === 'completed') {
-                        clearInterval(poller);
-                        btn.prop('disabled', false);
-                        btn.html('<span class="glyphicon glyphicon-refresh"></span> Scan for Duplicates Now');
-                        const resultCount = (response.result_count !== null && response.result_count !== undefined)
-                            ? response.result_count
-                            : null;
-                        const doneMessage = resultCount !== null
-                            ? 'Scan completed. Found ' + resultCount + ' duplicate groups.'
-                            : 'Scan completed.';
-                        updateProgressUI(1, doneMessage + ' Refreshing...');
-                        alert(doneMessage);
-                        setTimeout(function() {
-                            resetProgressUI();
-                            location.reload();
-                        }, 800);
-                    } else if (response.status === 'failed') {
-                        clearInterval(poller);
-                        btn.prop('disabled', false);
-                        btn.html('<span class="glyphicon glyphicon-refresh"></span> Scan for Duplicates Now');
-                        resetProgressUI();
-                        alert('Scan failed: ' + (response.message || 'Unknown error'));
-                    } else if (response.status === 'cancelled') {
-                        clearInterval(poller);
-                        btn.prop('disabled', false);
-                        btn.html('<span class="glyphicon glyphicon-refresh"></span> Scan for Duplicates Now');
-                        resetProgressUI();
-                        alert('Scan cancelled');
-                    }
-                },
-                error: function(xhr, status, error) {
-                    console.error('[CWA Duplicates] Error polling scan progress:', error);
+    function isRunningDuplicateScanTask(task) {
+        return isDuplicateScanTask(task) && task.stat !== 1 && task.stat !== 3 && task.stat !== 4 && task.stat !== 5;
+    }
+
+    function setDuplicateScanNotice(task) {
+        var progress = parseTaskProgress(task);
+        var message = task.taskMessage || 'Duplicate scan is running in the background.';
+        window.CWADuplicateScanActive = true;
+        if (window.CWADuplicates && window.CWADuplicates.updateBadge) {
+            window.CWADuplicates.updateBadge(0);
+        }
+        $('#duplicate_index_setup_notice').hide();
+        $('#duplicate_results_content').hide();
+        $('#no_duplicate_books_message').hide();
+        $('#duplicate_scan_results_status').show();
+        $('#duplicate_scan_task_title').text('Duplicate scan is running.');
+        $('#duplicate_scan_task_message').text(message);
+        $('#duplicate_scan_task_progress_container').show();
+        $('#duplicate_scan_task_link')
+            .attr('href', duplicateScanEndpoint('/tasks'))
+            .text('View Background Tasks');
+        $('#duplicate_scan_task_progress')
+            .addClass('active')
+            .css('width', progress + '%')
+            .attr('aria-valuenow', progress);
+        $('#duplicate_scan_task_progress_label').text(progress + '%');
+    }
+
+    function showDuplicateScanFinishedNotice() {
+        window.CWADuplicateScanActive = false;
+        $('#duplicate_index_setup_notice').hide();
+        $('#duplicate_results_content').hide();
+        $('#no_duplicate_books_message').hide();
+        $('#duplicate_scan_results_status').show();
+        $('#duplicate_scan_task_title').text('Duplicate scan is running.');
+        $('#duplicate_scan_task_message').text('Duplicate scan finished. Updating results...');
+        $('#duplicate_scan_task_progress_container').show();
+        $('#duplicate_scan_task_link')
+            .attr('href', duplicateScanEndpoint('/tasks'))
+            .text('View Background Tasks');
+        $('#duplicate_scan_task_progress')
+            .removeClass('active')
+            .css('width', '100%')
+            .attr('aria-valuenow', 100);
+        $('#duplicate_scan_task_progress_label').text('100%');
+        setTimeout(function() {
+            window.location.reload();
+        }, 500);
+    }
+
+    function showDuplicateResultsAvailableNotice(count) {
+        if (duplicateScanWasActive) {
+            return;
+        }
+        if (!$('#no_duplicate_books_message').length) {
+            return;
+        }
+        if ($('#duplicate_scan_results_status').is(':visible')) {
+            if ($('#duplicate_scan_task_title').text() === 'Duplicate Books Found') {
+                $('#duplicate_scan_task_message').text(
+                    'Found ' + count + ' duplicate ' + (count === 1 ? 'group' : 'groups') + '. Refresh the page to review them.'
+                );
+            }
+            return;
+        }
+        $('#duplicate_results_content').hide();
+        $('#no_duplicate_books_message').hide();
+        $('#duplicate_scan_results_status').show();
+        $('#duplicate_scan_task_title').text('Duplicate Books Found');
+        $('#duplicate_scan_task_message').text(
+            'Found ' + count + ' duplicate ' + (count === 1 ? 'group' : 'groups') + '. Refresh the page to review them.'
+        );
+        $('#duplicate_scan_task_progress_container').hide();
+        $('#duplicate_scan_task_link')
+            .attr('href', window.location.href)
+            .text('Refresh Page');
+    }
+
+    function pollDuplicateScanTask() {
+        $.getJSON(duplicateScanEndpoint('/ajax/emailstat'), function(tasks) {
+            var runningTask = null;
+            $.each(tasks || [], function(index, task) {
+                if (isRunningDuplicateScanTask(task)) {
+                    runningTask = task;
+                    return false;
                 }
             });
-        }
 
-        const poller = setInterval(pollOnce, pollInterval);
-        pollOnce();
+            if (runningTask) {
+                duplicateScanWasActive = true;
+                duplicateScanTaskId = runningTask.task_id;
+                setDuplicateScanNotice(runningTask);
+                if (!duplicateScanPollTimer) {
+                    duplicateScanPollTimer = setInterval(pollDuplicateScanTask, 2000);
+                }
+            } else if (duplicateScanWasActive) {
+                showDuplicateScanFinishedNotice();
+                clearInterval(duplicateScanPollTimer);
+                duplicateScanPollTimer = null;
+            }
+        });
     }
+
+    pollDuplicateScanTask();
+
+    document.addEventListener('cwa:duplicates-status', function(event) {
+        var data = event.detail || {};
+        if (data.count > 0 && !data.needs_scan && !data.needs_full_scan) {
+            showDuplicateResultsAvailableNotice(Number(data.count || 0));
+        }
+    });
 
     // Manual scan trigger
     $('#trigger_scan').on('click', function() {
@@ -470,62 +582,61 @@ $(document).ready(function() {
         btn.html('<span class="glyphicon glyphicon-refresh glyphicon-spin"></span> Scanning...');
         
         $.ajax({
-            url: '/duplicates/trigger-scan',
+            url: duplicateScanEndpoint('/duplicates/trigger-scan'),
             type: 'POST',
             headers: {
                 'X-CSRFToken': csrfToken
             },
             dataType: 'json',
             success: function(response) {
-                if (response.success && response.task_id) {
-                    updateProgressUI(0, 'Queued...');
-                    pollScanProgress(response.task_id, btn);
-                } else if (response.success) {
+                if (response.success) {
+                    if (response.queued === true) {
+                        duplicateScanTaskId = response.task_id || null;
+                        duplicateScanWasActive = true;
+                        setDuplicateScanNotice({
+                            taskMessage: 'Duplicate scan is queued.',
+                            progress: '0 %',
+                            task_id: duplicateScanTaskId,
+                            stat: 0
+                        });
+                        if (!duplicateScanPollTimer) {
+                            duplicateScanPollTimer = setInterval(pollDuplicateScanTask, 2000);
+                        }
+                        pollDuplicateScanTask();
+                        return;
+                    }
                     if (response.queued === false && response.fallback_reason) {
                         console.warn('[CWA Duplicates] Background queue failed, fallback used:', response.fallback_reason);
                     }
-                    const count = (response.count !== undefined && response.count !== null)
+                    var count = (response.count !== undefined && response.count !== null)
                         ? response.count
                         : null;
-                    const message = count !== null
+                    var message = count !== null
                         ? 'Scan completed. Found ' + count + ' duplicate groups.'
                         : 'Scan completed.';
-                    alert(message);
-                    location.reload();
+                    showScanNotification(message, 'alert-success');
+                    setTimeout(function() {
+                        location.reload();
+                    }, 800);
                 } else {
-                    alert('Scan failed: ' + response.error);
+                    showScanNotification('Scan failed: ' + response.error, 'alert-danger');
                 }
             },
             error: function(xhr, status, error) {
                 console.error('[CWA Duplicates] Error triggering scan:', error);
-                alert('Error: Failed to trigger duplicate scan');
-            },
-            complete: function() {
-                // Button state will be restored by poller
-            }
-        });
-    });
-
-    // Cancel scan
-    $('#cancel_scan').on('click', function() {
-        if (!activeScanTaskId) {
-            return;
-        }
-        $.ajax({
-            url: '/duplicates/cancel-scan/' + activeScanTaskId,
-            type: 'POST',
-            headers: {
-                'X-CSRFToken': csrfToken
-            },
-            dataType: 'json',
-            success: function(response) {
-                if (!response.success) {
-                    alert('Cancel failed: ' + response.error);
+                var response = xhr.responseJSON || {};
+                if (xhr.status === 409 && response.blocked) {
+                    showDuplicateScanError(
+                        'Duplicate Scan Blocked',
+                        response.message || 'Import is in progress. Run a full duplicate scan after ingest finishes.'
+                    );
+                } else {
+                    showScanNotification('Error: Failed to trigger duplicate scan', 'alert-danger');
                 }
             },
-            error: function(xhr, status, error) {
-                console.error('[CWA Duplicates] Error cancelling scan:', error);
-                alert('Error: Failed to cancel duplicate scan');
+            complete: function() {
+                btn.prop('disabled', false);
+                btn.html('<span class="glyphicon glyphicon-refresh"></span> Scan for Duplicates Now');
             }
         });
     });
@@ -566,13 +677,14 @@ $(document).ready(function() {
     // Execute resolution
     $('#execute_resolution').on('click', function() {
         if ($(this).hasClass('disabled')) return;
-        
-        if (!confirm('Are you sure you want to execute auto-resolution? This will permanently delete duplicate books.')) {
-            return;
-        }
-        
+
+        $('#execute_resolution_strategy_name').text($('#resolution_strategy option:selected').text());
+        $('#execute_resolution_modal').modal('show');
+    });
+
+    $('#execute_resolution_confirm').on('click', function() {
         var strategy = $('#resolution_strategy').val();
-        var btn = $(this);
+        var btn = $('#execute_resolution');
         btn.addClass('disabled').html('<span class="glyphicon glyphicon-refresh glyphicon-spin"></span> Executing...');
         
         $.ajax({
@@ -585,15 +697,17 @@ $(document).ready(function() {
             data: JSON.stringify({ strategy: strategy }),
             success: function(data) {
                 if (data.success) {
-                    alert('Resolution complete!\n\nResolved: ' + data.resolved_count + ' groups\nKept: ' + data.kept_count + ' books\nDeleted: ' + data.deleted_count + ' books');
-                    location.reload();
+                    showResolutionSuccess(data);
                 } else {
-                    alert('Errors occurred:\n' + (data.errors || []).join('\n'));
+                    var errors = data.errors || ['Unknown error occurred during resolution'];
+                    showResolutionError('Errors occurred:<br>' + errors.map(escapeHtml).join('<br>'));
                     btn.removeClass('disabled').html('<span class="glyphicon glyphicon-flash"></span> Execute Resolution');
                 }
             },
-            error: function() {
-                alert('Failed to execute resolution');
+            error: function(xhr, status, error) {
+                console.error('[CWA Duplicates] Failed to execute resolution:', error);
+                var response = xhr.responseJSON || {};
+                showResolutionError(response.message || response.error || 'Failed to execute resolution. Check browser console for details.');
                 btn.removeClass('disabled').html('<span class="glyphicon glyphicon-flash"></span> Execute Resolution');
             }
         });
@@ -652,4 +766,4 @@ $(document).ready(function() {
     // Initialize
     updateSelectionCount();
     updateBookItemVisuals();
-}); 
+});

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -313,6 +313,17 @@ $(function() {
         }
     });
 
+    $(document).on("click", ".duplicate-scan-setup-dismiss", function() {
+        var dismissUrl = $(this).data("dismiss-url");
+        if (!dismissUrl) {
+            return;
+        }
+        $.ajax({
+            method: "post",
+            url: dismissUrl
+        });
+    });
+
     function restartTimer() {
         $("#spinner").addClass("hidden");
         $("#RestartDialog").modal("hide");

--- a/cps/tasks/duplicate_scan.py
+++ b/cps/tasks/duplicate_scan.py
@@ -11,7 +11,15 @@ from sqlalchemy import func
 from flask_babel import lazy_gettext as N_
 
 from cps import calibre_db, db, logger
-from cps.duplicates import find_duplicate_books_python, find_duplicate_candidate_ids_sql
+from cps.duplicate_index import (
+    MAX_INCREMENTAL_BOOK_IDS,
+    get_duplicate_groups_from_index,
+    has_valid_duplicate_index_baseline,
+    ingest_batch_follow_up_pending,
+    mark_duplicate_index_pending,
+    merge_affected_groups_into_cache,
+    rebuild_duplicate_index,
+)
 from cps.services.worker import CalibreTask, STAT_CANCELLED, STAT_ENDED
 from cps.ub import init_db_thread
 
@@ -24,12 +32,20 @@ log = logger.create()
 
 
 class TaskDuplicateScan(CalibreTask):
-    def __init__(self, full_scan=True, task_message=None, trigger_type='manual', user_id=None):
+    def __init__(self, full_scan=True, task_message=None, trigger_type='manual', user_id=None, book_ids=None):
         super(TaskDuplicateScan, self).__init__(task_message or N_('Duplicate scan'))
         self.full_scan = full_scan
         self.trigger_type = trigger_type
         self.result_count = 0
         self.user_id = user_id
+        self.book_ids = []
+        for book_id in book_ids or []:
+            try:
+                parsed_book_id = int(book_id)
+            except (TypeError, ValueError):
+                continue
+            if parsed_book_id > 0:
+                self.book_ids.append(parsed_book_id)
 
     @property
     def name(self):
@@ -56,25 +72,47 @@ class TaskDuplicateScan(CalibreTask):
             cwa_db = CWA_DB()
             cache_data = cwa_db.get_duplicate_cache() or {}
 
-            if not self.full_scan:
-                last_scanned_book_id = int(cache_data.get('last_scanned_book_id') or 0)
-                if last_scanned_book_id == 0:
-                    # No baseline yet; fall back to full scan
-                    self.full_scan = True
-
-            self.progress = 0.1
-            self.message = N_('Scanning for duplicates')
-
-            # Import here to avoid circular dependency during module import
-            from cps.duplicates import find_duplicate_books
-
             if self.stat in (STAT_CANCELLED, STAT_ENDED):
                 return
 
+            if self.full_scan and self.trigger_type != 'manual' and ingest_batch_follow_up_pending():
+                self.result_count = 0
+                self.found_duplicate_groups = []
+                self.progress = 1
+                self.message = N_('Duplicate scan skipped: import in progress')
+                self._handleSuccess()
+                log.info("[cwa-duplicates] Full duplicate scan skipped because ingest is active")
+                return
+
             if self.full_scan:
-                duplicate_groups = find_duplicate_books(include_dismissed=False, user_id=self.user_id)
+                settings = cwa_db.cwa_settings
+                self.progress = 0.05
+                self.message = N_('Building duplicate index')
+
+                def update_rebuild_progress(processed, total):
+                    if self.stat in (STAT_CANCELLED, STAT_ENDED):
+                        return
+                    if total:
+                        self.progress = 0.05 + (0.75 * (processed / total))
+                        self.message = N_(
+                            'Building duplicate index: %(processed)s/%(total)s books',
+                            processed=processed,
+                            total=total,
+                        )
+                    else:
+                        self.progress = 0.8
+                        self.message = N_('Building duplicate index: no books')
+
+                rebuild_metadata = rebuild_duplicate_index(settings, progress_callback=update_rebuild_progress)
+                self.progress = 0.85
+                self.message = N_('Finding duplicate groups')
+                duplicate_groups = get_duplicate_groups_from_index(
+                    settings,
+                    include_dismissed=False,
+                    user_id=self.user_id,
+                )
                 self.result_count = len(duplicate_groups)
-                
+
                 # Store the duplicate groups for passing to auto-resolution
                 self.found_duplicate_groups = duplicate_groups
 
@@ -82,145 +120,53 @@ class TaskDuplicateScan(CalibreTask):
                     return
 
                 # Update cache with full results (including dismissed groups)
-                all_groups = find_duplicate_books(include_dismissed=True, user_id=self.user_id)
-
-                max_book_id = 0
-                try:
-                    max_id_result = calibre_db.session.query(func.max(db.Books.id)).scalar()
-                    max_book_id = max_id_result if max_id_result is not None else 0
-                except Exception as ex:
-                    log.warning("[cwa-duplicates] Could not get max book ID in TaskDuplicateScan: %s", str(ex))
-
+                self.progress = 0.95
+                self.message = N_('Updating duplicate cache')
+                all_groups = get_duplicate_groups_from_index(settings, include_dismissed=True)
+                max_book_id = rebuild_metadata.get('max_book_id', 0)
                 cwa_db.update_duplicate_cache(all_groups, len(all_groups), max_book_id)
                 log.info("[cwa-duplicates] Duplicate cache updated (full scan): groups=%s max_book_id=%s",
                          len(all_groups), max_book_id)
             else:
-                # Incremental scan: only groups impacted by newly added books
+                # Incremental after-import work must stay bounded to changed candidate groups.
                 settings = cwa_db.cwa_settings
-                use_title = settings.get('duplicate_detection_title', 1)
-                use_author = settings.get('duplicate_detection_author', 1)
-                use_language = settings.get('duplicate_detection_language', 1)
-                use_series = settings.get('duplicate_detection_series', 0)
-                use_publisher = settings.get('duplicate_detection_publisher', 0)
-                use_format = settings.get('duplicate_detection_format', 0)
-
                 last_scanned_book_id = int(cache_data.get('last_scanned_book_id') or 0)
-                candidate_ids = find_duplicate_candidate_ids_sql(use_title, use_author, user_id=self.user_id,
-                                                                min_book_id=last_scanned_book_id)
+                if self.book_ids:
+                    candidate_ids = list(dict.fromkeys(self.book_ids))
+                else:
+                    candidate_ids = [
+                        int(row[0])
+                        for row in (
+                            calibre_db.session.query(db.Books.id)
+                            .filter(db.Books.id > last_scanned_book_id)
+                            .order_by(db.Books.id)
+                            .limit(MAX_INCREMENTAL_BOOK_IDS + 1)
+                            .all()
+                        )
+                        if row[0] is not None
+                    ]
+                    if len(candidate_ids) > MAX_INCREMENTAL_BOOK_IDS:
+                        mark_duplicate_index_pending("after_import incremental book set too large")
+                        self.result_count = 0
+                        self.found_duplicate_groups = []
+                        self.progress = 1
+                        self.message = N_('Duplicate scan pending: manual scan required')
+                        self._handleSuccess()
+                        log.info("[cwa-duplicates] After-import duplicate scan marked pending: too many new books")
+                        return
 
-                if candidate_ids is None:
-                    log.warning("[cwa-duplicates] Incremental scan prefilter unavailable; falling back to full scan")
-                    print("[cwa-duplicates] Incremental scan prefilter unavailable; falling back to full scan", flush=True)
-
-                    duplicate_groups = find_duplicate_books(include_dismissed=False, user_id=self.user_id)
-                    self.result_count = len(duplicate_groups)
-                    self.found_duplicate_groups = duplicate_groups
-
-                    all_groups = find_duplicate_books(include_dismissed=True, user_id=self.user_id)
-
-                    max_book_id = 0
-                    try:
-                        max_id_result = calibre_db.session.query(func.max(db.Books.id)).scalar()
-                        max_book_id = max_id_result if max_id_result is not None else 0
-                    except Exception as ex:
-                        log.warning("[cwa-duplicates] Could not get max book ID in TaskDuplicateScan fallback: %s", str(ex))
-
-                    cwa_db.update_duplicate_cache(all_groups, len(all_groups), max_book_id)
-                    log.info("[cwa-duplicates] Duplicate cache updated (fallback full scan): groups=%s max_book_id=%s",
-                             len(all_groups), max_book_id)
-
+                if not has_valid_duplicate_index_baseline(settings, candidate_book_ids=candidate_ids):
+                    mark_duplicate_index_pending("after_import without valid duplicate index baseline")
+                    self.result_count = 0
+                    self.found_duplicate_groups = []
                     self.progress = 1
-                    self.message = N_('Duplicate scan completed: %(count)s groups', count=self.result_count)
+                    self.message = N_('Duplicate scan pending: manual scan required')
                     self._handleSuccess()
-
-                    log.debug("[cwa-duplicates] Scan complete (fallback). result_count=%s, trigger_type=%s",
-                              self.result_count, self.trigger_type)
-                    print(f"[cwa-duplicates] Scan complete (fallback): {self.result_count} groups found, trigger_type={self.trigger_type}",
-                          flush=True)
-
-                    if self.result_count > 0:
-                        try:
-                            auto_resolve_enabled = cwa_db.cwa_settings.get('duplicate_auto_resolve_enabled', 0)
-                            auto_resolve_strategy = cwa_db.cwa_settings.get('duplicate_auto_resolve_strategy', 'newest')
-                            cooldown_minutes = int(cwa_db.cwa_settings.get('duplicate_auto_resolve_cooldown_minutes', 0))
-
-                            log.debug("[cwa-duplicates] Auto-resolution settings: enabled=%s, strategy=%s, cooldown=%s min",
-                                      auto_resolve_enabled, auto_resolve_strategy, cooldown_minutes)
-                            print(f"[cwa-duplicates] Auto-resolution settings: enabled={auto_resolve_enabled}, "
-                                  f"strategy={auto_resolve_strategy}, cooldown={cooldown_minutes} min", flush=True)
-
-                            if auto_resolve_enabled:
-                                if cooldown_minutes > 0:
-                                    try:
-                                        last_resolution = cwa_db.cur.execute("""
-                                            SELECT MAX(timestamp) FROM cwa_duplicate_resolutions 
-                                            WHERE trigger_type='automatic'
-                                        """).fetchone()[0]
-
-                                        if last_resolution:
-                                            from datetime import datetime, timedelta
-                                            last_time = datetime.fromisoformat(last_resolution)
-                                            now = datetime.now()
-                                            elapsed = (now - last_time).total_seconds() / 60
-
-                                            if elapsed < cooldown_minutes:
-                                                remaining = cooldown_minutes - elapsed
-                                                log.info("[cwa-duplicates] Auto-resolution skipped due to cooldown: %.1f minutes remaining",
-                                                         remaining)
-                                                print(f"[cwa-duplicates] Auto-resolution on cooldown ({remaining:.1f} min remaining)",
-                                                      flush=True)
-                                                return
-                                    except Exception as e:
-                                        log.warning("[cwa-duplicates] Cooldown check failed: %s", str(e))
-
-                                log.info("[cwa-duplicates] Auto-resolution enabled, triggering resolution with strategy: %s",
-                                         auto_resolve_strategy)
-                                print(f"[cwa-duplicates] Auto-resolution enabled, triggering with strategy: {auto_resolve_strategy}",
-                                      flush=True)
-
-                                from cps.duplicates import auto_resolve_duplicates
-
-                                groups_to_pass = getattr(self, 'found_duplicate_groups', None)
-                                log.debug("[cwa-duplicates] Passing %s groups to auto_resolve (type: %s)",
-                                          len(groups_to_pass) if groups_to_pass else 'None', type(groups_to_pass).__name__)
-                                print(f"[cwa-duplicates] Passing {len(groups_to_pass) if groups_to_pass else 'None'} pre-scanned groups to auto_resolve",
-                                      flush=True)
-
-                                result = auto_resolve_duplicates(
-                                    strategy=auto_resolve_strategy,
-                                    dry_run=False,
-                                    user_id=None,
-                                    trigger_type='automatic',
-                                    duplicate_groups=groups_to_pass
-                                )
-
-                                if result['success']:
-                                    log.info("[cwa-duplicates] Auto-resolution completed: resolved=%s, kept=%s, deleted=%s",
-                                             result['resolved_count'], result['kept_count'], result['deleted_count'])
-                                    print(f"[cwa-duplicates] Auto-resolution completed: {result['resolved_count']} groups resolved, "
-                                          f"{result['deleted_count']} books deleted, {result['kept_count']} books kept", flush=True)
-
-                                    self.message = N_('Duplicate scan completed: %(count)s groups auto-resolved',
-                                                      count=result['resolved_count'])
-                                else:
-                                    log.warning("[cwa-duplicates] Auto-resolution completed with errors: %s",
-                                                result.get('errors', []))
-                                    print(f"[cwa-duplicates] Auto-resolution errors: {result.get('errors', [])}", flush=True)
-                            else:
-                                log.debug("[cwa-duplicates] Auto-resolution disabled in settings")
-                                print("[cwa-duplicates] Auto-resolution disabled in settings", flush=True)
-                        except Exception as ex:
-                            log.error("[cwa-duplicates] Exception during auto-resolution check: %s", str(ex))
-                            print(f"[cwa-duplicates] Exception during auto-resolution check: {str(ex)}", flush=True)
-                    else:
-                        log.debug("[cwa-duplicates] No duplicates found, skipping auto-resolution")
-                        print("[cwa-duplicates] No duplicates found, skipping auto-resolution", flush=True)
+                    log.info("[cwa-duplicates] After-import duplicate scan marked pending: no valid baseline")
                     return
-                
+
                 log.debug("[cwa-duplicates] Incremental scan: last_scanned_book_id=%s, candidate_ids=%s",
                          last_scanned_book_id, len(candidate_ids) if candidate_ids else 0)
-                print(f"[cwa-duplicates] Incremental scan: last_scanned_book_id={last_scanned_book_id}, "
-                      f"candidates={len(candidate_ids) if candidate_ids else 0}", flush=True)
 
                 max_book_id = 0
                 try:
@@ -238,73 +184,47 @@ class TaskDuplicateScan(CalibreTask):
                             WHERE id = 1
                         """, (max_book_id, datetime.now().isoformat()))
                         cwa_db.con.commit()
-                        log.info("[cwa-duplicates] Incremental scan: no candidates; cache timestamp updated (last_scanned_book_id=%s)",
-                                 max_book_id)
+                        log.info(
+                            "[cwa-duplicates] Incremental scan: no candidates; cache timestamp updated "
+                            "(last_scanned_book_id=%s)",
+                            max_book_id,
+                        )
                     except Exception:
                         pass
                     self.result_count = 0
                 else:
-                    # Identify affected groups in cache
-                    cached_groups = cache_data.get('duplicate_groups', [])
-                    candidate_set = set(candidate_ids)
-                    affected_hashes = {
-                        group.get('group_hash')
-                        for group in cached_groups
-                        if group.get('book_ids') and candidate_set.intersection(set(group.get('book_ids')))
-                    }
-
-                    # Recompute groups for candidate IDs (include dismissed for cache)
-                    recomputed_groups = find_duplicate_books_python(
-                        use_title, use_author, use_language, use_series, use_publisher, use_format,
-                        include_dismissed=True, user_id=self.user_id, candidate_ids=candidate_ids
-                    )
-
-                    # Serialize recomputed groups
-                    serialized_groups = []
-                    for group in recomputed_groups:
-                        serialized_groups.append({
-                            'title': group.get('title', ''),
-                            'author': group.get('author', ''),
-                            'count': group.get('count', 0),
-                            'group_hash': group.get('group_hash', ''),
-                            'book_ids': [book.id for book in group.get('books', [])]
-                        })
-
-                    # Merge cache: remove affected, then append recomputed
-                    kept_groups = [g for g in cached_groups if g.get('group_hash') not in affected_hashes]
-                    merged_groups = kept_groups + serialized_groups
-
                     try:
-                        import json
-                        cwa_db.cur.execute("""
-                            UPDATE cwa_duplicate_cache
-                            SET scan_timestamp = ?,
-                                duplicate_groups_json = ?,
-                                total_count = ?,
-                                scan_pending = 0,
-                                last_scanned_book_id = ?
-                            WHERE id = 1
-                        """, (datetime.now().isoformat(), json.dumps(merged_groups), len(merged_groups), max_book_id))
-                        cwa_db.con.commit()
-                        log.info("[cwa-duplicates] Duplicate cache updated (incremental): merged_groups=%s max_book_id=%s",
-                                 len(merged_groups), max_book_id)
+                        merge_result = merge_affected_groups_into_cache(candidate_ids, settings)
                     except Exception as ex:
-                        log.warning("[cwa-duplicates] Failed to update incremental cache: %s", str(ex))
+                        mark_duplicate_index_pending("after_import incremental duplicate merge failed")
+                        self.result_count = 0
+                        self.found_duplicate_groups = []
+                        self.progress = 1
+                        self.message = N_('Duplicate scan pending: manual scan required')
+                        self._handleSuccess()
+                        log.warning("[cwa-duplicates] Failed to update incremental duplicate index cache: %s", str(ex))
+                        return
 
-                    # Result count is unresolved duplicates for this run (exclude dismissed)
-                    unresolved_in_candidates = find_duplicate_books_python(
-                        use_title, use_author, use_language, use_series, use_publisher, use_format,
-                        include_dismissed=False, user_id=self.user_id, candidate_ids=candidate_ids
+                    if merge_result.get("pending"):
+                        self.result_count = 0
+                        self.found_duplicate_groups = []
+                        self.progress = 1
+                        self.message = N_('Duplicate scan pending: manual scan required')
+                        self._handleSuccess()
+                        log.info("[cwa-duplicates] Incremental duplicate merge marked pending: %s",
+                                 merge_result.get("reason", "unknown"))
+                        return
+
+                    unresolved_in_candidates = get_duplicate_groups_from_index(
+                        settings,
+                        include_dismissed=False,
+                        user_id=self.user_id,
+                        candidate_book_ids=candidate_ids,
                     )
                     self.result_count = len(unresolved_in_candidates)
-                    
-                    # Store the duplicate groups for passing to auto-resolution
                     self.found_duplicate_groups = unresolved_in_candidates
-                    
                     log.debug("[cwa-duplicates] Incremental scan result: %s unresolved groups among candidates",
                              self.result_count)
-                    print(f"[cwa-duplicates] Incremental scan result: {self.result_count} unresolved duplicate groups", 
-                          flush=True)
 
             self.progress = 1
             if self.full_scan:
@@ -313,78 +233,51 @@ class TaskDuplicateScan(CalibreTask):
                 self.message = N_('Duplicate scan completed: %(count)s new groups', count=self.result_count)
             self._handleSuccess()
 
-            # Ensure cache is refreshed for after_import scans so notifications update reliably
-            try:
-                if self.trigger_type == 'after_import':
-                    all_groups = find_duplicate_books(include_dismissed=True, user_id=self.user_id)
-                    max_book_id = 0
-                    try:
-                        max_id_result = calibre_db.session.query(func.max(db.Books.id)).scalar()
-                        max_book_id = max_id_result if max_id_result is not None else 0
-                    except Exception as ex:
-                        log.warning("[cwa-duplicates] Could not get max book ID for after_import cache refresh: %s", str(ex))
-                    cwa_db.update_duplicate_cache(all_groups, len(all_groups), max_book_id)
-                    log.info("[cwa-duplicates] Cache refreshed after after_import scan: groups=%s max_book_id=%s",
-                             len(all_groups), max_book_id)
-            except Exception as ex:
-                log.warning("[cwa-duplicates] Failed to refresh cache after after_import scan: %s", str(ex))
-            
             # Check if auto-resolution is enabled
-            log.debug("[cwa-duplicates] Scan complete. result_count=%s, trigger_type=%s", 
+            log.debug("[cwa-duplicates] Scan complete. result_count=%s, trigger_type=%s",
                      self.result_count, self.trigger_type)
-            print(f"[cwa-duplicates] Scan complete: {self.result_count} groups found, trigger_type={self.trigger_type}", 
-                  flush=True)
-            
+
             if self.result_count > 0:  # Only if duplicates were found
                 try:
                     auto_resolve_enabled = cwa_db.cwa_settings.get('duplicate_auto_resolve_enabled', 0)
                     auto_resolve_strategy = cwa_db.cwa_settings.get('duplicate_auto_resolve_strategy', 'newest')
                     cooldown_minutes = int(cwa_db.cwa_settings.get('duplicate_auto_resolve_cooldown_minutes', 0))
-                    
+
                     log.debug("[cwa-duplicates] Auto-resolution settings: enabled=%s, strategy=%s, cooldown=%s min",
                              auto_resolve_enabled, auto_resolve_strategy, cooldown_minutes)
-                    print(f"[cwa-duplicates] Auto-resolution settings: enabled={auto_resolve_enabled}, "
-                          f"strategy={auto_resolve_strategy}, cooldown={cooldown_minutes} min", flush=True)
-                    
+
                     if auto_resolve_enabled:
                         # Check cooldown period
                         if cooldown_minutes > 0:
                             try:
                                 last_resolution = cwa_db.cur.execute("""
-                                    SELECT MAX(timestamp) FROM cwa_duplicate_resolutions 
+                                    SELECT MAX(timestamp) FROM cwa_duplicate_resolutions
                                     WHERE trigger_type='automatic'
                                 """).fetchone()[0]
-                                
+
                                 if last_resolution:
-                                    from datetime import datetime, timedelta
                                     last_time = datetime.fromisoformat(last_resolution)
                                     now = datetime.now()
                                     elapsed = (now - last_time).total_seconds() / 60
-                                    
+
                                     if elapsed < cooldown_minutes:
                                         remaining = cooldown_minutes - elapsed
-                                        log.info("[cwa-duplicates] Auto-resolution skipped due to cooldown: %.1f minutes remaining", 
+                                        log.info("[cwa-duplicates] Auto-resolution skipped due to cooldown: %.1f minutes remaining",
                                                 remaining)
-                                        print(f"[cwa-duplicates] Auto-resolution on cooldown ({remaining:.1f} min remaining)", 
-                                              flush=True)
                                         return
                             except Exception as e:
                                 log.warning("[cwa-duplicates] Cooldown check failed: %s", str(e))
-                        
-                        log.info("[cwa-duplicates] Auto-resolution enabled, triggering resolution with strategy: %s", 
+
+                        log.info("[cwa-duplicates] Auto-resolution enabled, triggering resolution with strategy: %s",
                                 auto_resolve_strategy)
-                        print(f"[cwa-duplicates] Auto-resolution enabled, triggering with strategy: {auto_resolve_strategy}", 
-                              flush=True)
-                        
+
                         from cps.duplicates import auto_resolve_duplicates
-                        
+
                         # Pass the pre-scanned duplicate groups to avoid re-scanning
                         groups_to_pass = getattr(self, 'found_duplicate_groups', None)
-                        log.debug("[cwa-duplicates] Passing %s groups to auto_resolve (type: %s)", 
+                        log.debug("[cwa-duplicates] Passing %s groups to auto_resolve (type: %s)",
                                  len(groups_to_pass) if groups_to_pass else 'None', type(groups_to_pass).__name__)
-                        print(f"[cwa-duplicates] Passing {len(groups_to_pass) if groups_to_pass else 'None'} pre-scanned groups to auto_resolve", 
-                              flush=True)
-                        
+
                         result = auto_resolve_duplicates(
                             strategy=auto_resolve_strategy,
                             dry_run=False,
@@ -392,29 +285,23 @@ class TaskDuplicateScan(CalibreTask):
                             trigger_type='automatic',
                             duplicate_groups=groups_to_pass
                         )
-                        
+
                         if result['success']:
                             log.info("[cwa-duplicates] Auto-resolution completed: resolved=%s, kept=%s, deleted=%s",
                                     result['resolved_count'], result['kept_count'], result['deleted_count'])
-                            print(f"[cwa-duplicates] Auto-resolution completed: {result['resolved_count']} groups resolved, "
-                                  f"{result['deleted_count']} books deleted, {result['kept_count']} books kept", flush=True)
-                            
-                            self.message = N_('Duplicate scan completed: %(count)s groups auto-resolved', 
+
+                            self.message = N_('Duplicate scan completed: %(count)s groups auto-resolved',
                                             count=result['resolved_count'])
                         else:
-                            log.warning("[cwa-duplicates] Auto-resolution completed with errors: %s", 
+                            log.warning("[cwa-duplicates] Auto-resolution completed with errors: %s",
                                        result.get('errors', []))
-                            print(f"[cwa-duplicates] Auto-resolution errors: {result.get('errors', [])}", flush=True)
                     else:
                         log.debug("[cwa-duplicates] Auto-resolution disabled in settings")
-                        print("[cwa-duplicates] Auto-resolution disabled in settings", flush=True)
                 except Exception as ex:
                     log.error("[cwa-duplicates] Exception during auto-resolution check: %s", str(ex))
-                    print(f"[cwa-duplicates] Exception during auto-resolution check: {str(ex)}", flush=True)
             else:
                 log.debug("[cwa-duplicates] No duplicates found, skipping auto-resolution")
-                print("[cwa-duplicates] No duplicates found, skipping auto-resolution", flush=True)
-                    
+
         except Exception as ex:
             log.error("[cwa-duplicates] Duplicate scan task failed: %s", str(ex))
             self._handleError(str(ex))

--- a/cps/templates/duplicates.html
+++ b/cps/templates/duplicates.html
@@ -212,22 +212,77 @@
   .text-muted {
       color: whitesmoke !important;
   }
-  /* Success Modal Styling */
-  #success_modal .modal-header {
-      background-color: #28a745;
-      color: white;
-      border-radius: 6px 6px 0 0;
-  }
   #success_modal .modal-content {
+      background: #252525;
+      border: 1px solid rgba(46, 204, 113, 0.45);
       border-radius: 6px;
-      border: none;
-      box-shadow: 0 6px 16px rgba(0,0,0,0.2), 0 3px 6px rgba(0,0,0,0.1);
+      box-shadow: 0 18px 42px rgba(0, 0, 0, 0.45);
+      color: #f4f4f4;
+      overflow: hidden;
+  }
+  #success_modal .modal-header {
+      background: linear-gradient(135deg, #1f8f46 0%, #28a745 100%);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+      color: #fff;
+      padding: 18px 24px;
+  }
+  #success_modal .modal-header span {
+      font-size: 18px;
+      font-weight: 700;
+      letter-spacing: 0.02em;
   }
   #success_modal .modal-body {
-      padding: 30px;
+      color: #f4f4f4;
+      padding: 26px 30px 22px;
   }
   #success_modal .success-icon {
       animation: success-bounce 0.6s ease-out;
+      color: #2ecc71;
+      font-size: 52px;
+      margin-bottom: 20px;
+      text-shadow: 0 0 22px rgba(46, 204, 113, 0.28);
+  }
+  #success_modal .modal-footer {
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      padding: 18px 30px;
+  }
+  #success_modal .modal-footer .btn {
+      margin: 0;
+      min-height: 46px;
+      min-width: 76px;
+      line-height: 1.2;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+  }
+  #success_modal .resolution-success-summary {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 8px;
+  }
+  #success_modal .resolution-success-stat {
+      background: rgba(46, 204, 113, 0.09);
+      border: 1px solid rgba(46, 204, 113, 0.22);
+      border-radius: 5px;
+      padding: 14px 10px;
+      text-align: center;
+  }
+  #success_modal .resolution-success-value {
+      color: #8af0ad;
+      display: block;
+      font-size: 24px;
+      font-weight: 800;
+      line-height: 1.1;
+  }
+  #success_modal .resolution-success-label {
+      color: #d7d7d7;
+      display: block;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      margin-top: 7px;
+      text-transform: uppercase;
   }
   @keyframes success-bounce {
       0% { transform: scale(0.3); opacity: 0; }
@@ -255,6 +310,60 @@
       0%, 100% { transform: translateX(0); }
       10%, 30%, 50%, 70%, 90% { transform: translateX(-5px); }
       20%, 40%, 60%, 80% { transform: translateX(5px); }
+  }
+  #execute_resolution_modal .modal-content {
+      background: #252525;
+      border: 1px solid rgba(229, 144, 41, 0.55);
+      border-radius: 6px;
+      box-shadow: 0 18px 42px rgba(0, 0, 0, 0.45);
+      color: #f4f4f4;
+      overflow: hidden;
+  }
+  #execute_resolution_modal .modal-header {
+      background: linear-gradient(135deg, #8f2f24 0%, #c9512c 100%);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+      color: #fff;
+      padding: 18px 24px;
+  }
+  #execute_resolution_modal .modal-header span {
+      font-size: 18px;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+  }
+  #execute_resolution_modal .modal-body {
+      color: #f4f4f4;
+      font-size: 15px;
+      line-height: 1.55;
+      padding: 24px;
+  }
+  #execute_resolution_modal .strategy-summary {
+      background: rgba(229, 144, 41, 0.12);
+      border-left: 4px solid #e59029;
+      border-radius: 4px;
+      margin: 18px 0;
+      padding: 12px 14px;
+  }
+  #execute_resolution_modal .danger-note {
+      color: #ffcfbf;
+      font-weight: 700;
+      margin-bottom: 0;
+  }
+  #execute_resolution_modal .modal-footer {
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: 12px;
+      padding: 18px 30px;
+  }
+  #execute_resolution_modal .modal-footer .btn,
+  #execute_resolution_modal .modal-footer input.btn {
+      margin: 0;
+      min-height: 46px;
+      line-height: 1.2;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
   }
   .bulk-actions {
       margin-bottom: 30px;
@@ -355,6 +464,29 @@
       max-width: 100%;
     }
   }
+  #duplicate_scan_results_status {
+      display: none;
+  }
+  #duplicate_scan_task_notice {
+      max-width: 720px;
+      margin: 0 auto;
+      color: #ddd;
+  }
+  #duplicate_scan_task_notice .duplicate-scan-progress-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      margin-top: 10px;
+      color: #8bd8ef;
+      font-weight: 600;
+  }
+  #duplicate_scan_task_notice .duplicate-scan-progress {
+      display: block;
+      width: 100%;
+      height: 20px;
+      margin: 6px 0 6px 0;
+      overflow: hidden;
+  }
 </style>
 {% endblock %}
 
@@ -370,10 +502,12 @@
       <div class="bulk-actions" style="margin-bottom: 20px;">
         <div class="form-inline">
           <button type="button" class="btn btn-sm btn-default" id="trigger_scan">
-            <span class="glyphicon glyphicon-refresh"></span> {{_('Scan for Duplicates Now')}}
-          </button>
-          <button type="button" class="btn btn-sm btn-danger" id="cancel_scan" style="display: none;">
-            <span class="glyphicon glyphicon-ban-circle"></span> {{_('Cancel Scan')}}
+            <span class="glyphicon glyphicon-refresh"></span>
+            {% if duplicate_index_needs_full_scan %}
+              {{_('Run Full Duplicate Scan')}}
+            {% else %}
+              {{_('Scan for Duplicates Now')}}
+            {% endif %}
           </button>
           {% if duplicate_groups %}
             <button type="button" class="btn btn-sm btn-default" id="select_all">{{_('Select Duplicates')}}</button>
@@ -383,25 +517,47 @@
           {% endif %}
         </div>
 
-        <div id="scan_progress_container" style="margin-top: 12px; display: none;">
-          <div style="display: flex; align-items: center; gap: 12px;">
-            <div style="flex: 1; background: #22303a; border-radius: 6px; overflow: hidden; height: 10px;">
-              <div id="scan_progress_bar" style="height: 10px; width: 0%; background: linear-gradient(90deg, #2ecc71, #3498db);"></div>
-            </div>
-            <span id="scan_progress_label" style="color: #ddd; font-size: 12px;">0%</span>
-          </div>
-          <div id="scan_progress_message" style="margin-top: 6px; color: #bbb; font-size: 12px;"></div>
-        </div>
-
         {% if next_scan_run %}
           <div style="margin-top: 10px; color: #bbb; font-size: 12px;">
             {{_('Next scheduled scan:')}} <span id="next_scan_run">{{ next_scan_run }}</span>
           </div>
         {% endif %}
       </div>
+
+      {% if duplicate_index_needs_full_scan %}
+        <div id="duplicate_index_setup_notice" class="cwa-settings-tip" style="margin: 0 0 24px 0; background: rgba(243, 156, 18, 0.16); border-left: 4px solid #f39c12; padding: 16px; border-radius: 6px;">
+          <strong style="color: #f39c12;">{{_('Duplicate scanning needs a one-time full scan.')}}</strong>
+          <p style="color: #ddd; margin: 8px 0 0 0;">
+            {{_('CWA now uses a duplicate index to keep duplicate checks fast during imports and metadata changes. Before incremental scans can run, the index needs an initial baseline.')}}
+          </p>
+          <p style="color: #bbb; margin: 8px 0 0 0;">
+            {{_('Click "Run Full Duplicate Scan" to build it. This may take several minutes on large libraries, and you can keep using CWA while it runs.')}}
+          </p>
+        </div>
+      {% endif %}
+
+      <div id="duplicate_scan_results_status" class="no-duplicates">
+        <div id="duplicate_scan_task_notice">
+          <h3 id="duplicate_scan_task_title" style="color: #8bd8ef;">{{_('Duplicate scan is running.')}}</h3>
+          <p id="duplicate_scan_task_message">{{_('You can keep using CWA while it runs.')}}</p>
+          <div id="duplicate_scan_task_progress_container">
+            <div class="duplicate-scan-progress-header">
+              <span>{{_('Progress')}}</span>
+              <span id="duplicate_scan_task_progress_label">0%</span>
+            </div>
+            <div class="progress duplicate-scan-progress">
+              <div id="duplicate_scan_task_progress" class="progress-bar progress-bar-info progress-bar-striped active"
+                   role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"
+                   style="width: 0%;"></div>
+            </div>
+          </div>
+          <a id="duplicate_scan_task_link" href="{{ url_for('tasks.get_tasks_status') }}">{{_('View Background Tasks')}}</a>
+        </div>
+      </div>
       
       {% if duplicate_groups %}
 
+        <div id="duplicate_results_content">
         <!-- Auto-Resolution Section -->
         <div class="settings-container" style="margin-bottom: 30px; padding: 25px; background: #1c28328a; border-radius: 10px; margin-inline: 0rem; max-width: none;">
           <h4 style="color: white; margin-bottom: 15px; display: flex; align-items: center;">
@@ -511,13 +667,36 @@
           </div>
           {% endfor %}
         </div>
-      {% else %}
-        <div class="no-duplicates">
-          <h3>{{_('No Duplicate Books Found')}}</h3>
-          <p>{{_('Your library has no books with duplicate title and author combinations.')}}</p>
-          <p class="text-muted">{{_('This search looks for books with identical titles AND authors to avoid false positives.')}}</p>
+        </div>
+      {% elif not duplicate_index_needs_full_scan %}
+        <div id="no_duplicate_books_message" class="no-duplicates">
+            <h3>{{_('No Duplicate Books Found')}}</h3>
+            <p>{{_('Your library has no books with duplicate title and author combinations.')}}</p>
+            <p class="text-muted">{{_('This search looks for books with identical titles AND authors to avoid false positives.')}}</p>
         </div>
       {% endif %}
+</div>
+
+<!-- Execute Resolution Confirmation Modal -->
+<div class="modal fade" id="execute_resolution_modal" role="dialog" aria-labelledby="executeResolutionLabel">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header text-center">
+        <span>{{_('Execute Auto-Resolution')}}</span>
+      </div>
+      <div class="modal-body">
+        <div class="text-left">{{_('CWA will resolve duplicate groups using the selected strategy and permanently delete duplicate books.')}}</div>
+        <div class="text-left strategy-summary">
+          {{_('Selected strategy:')}} <strong id="execute_resolution_strategy_name"></strong>
+        </div>
+        <div class="text-left danger-note">{{_('This action cannot be undone!')}}</div>
+      </div>
+      <div class="modal-footer">
+        <input id="execute_resolution_confirm" type="button" class="btn btn-danger" value="{{_('Execute Resolution')}}" name="execute_resolution_confirm" data-dismiss="modal">
+        <button id="execute_resolution_abort" type="button" class="btn btn-default" data-dismiss="modal">{{_('Cancel')}}</button>
+      </div>
+    </div>
+  </div>
 </div>
 
 <!-- Delete Confirmation Modal -->
@@ -594,15 +773,15 @@
 <div class="modal fade" id="success_modal" role="dialog" aria-labelledby="successModalLabel">
   <div class="modal-dialog">
     <div class="modal-content">
-      <div class="modal-header bg-success text-center">
+      <div class="modal-header text-center">
         <span id="success_modal_title">{{_('Success')}}</span>
       </div>
       <div class="modal-body">
         <div class="text-center">
-          <div class="success-icon" style="font-size: 48px; color: #28a745; margin-bottom: 20px;">
+          <div class="success-icon">
             <i class="glyphicon glyphicon-ok-circle"></i>
           </div>
-          <p id="success_modal_message">{{_('Selected duplicate books have been deleted successfully!')}}</p>
+          <div id="success_modal_message">{{_('Selected duplicate books have been deleted successfully!')}}</div>
         </div>
       </div>
       <div class="modal-footer">

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -239,6 +239,18 @@
         </div>
       </div>
       {%endif%}
+      {%if message[0] == "duplicate_scan_setup" %}
+      <div class="row-fluid text-center">
+        <div id="flash_info" class="alert alert-info alert-cwa">
+          {{ message[1] }} <a href="{{ url_for('duplicates.show_duplicates') }}">{{ _('Open Duplicates') }}</a>
+          <button type="button" class="close duplicate-scan-setup-dismiss"
+                  data-dismiss-url="{{ url_for('duplicates.dismiss_duplicate_scan_setup_notice') }}"
+                  data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      </div>
+      {%endif%}
       {%if message[0] == "cwa_arch_warning" %}
       <div class="row-fluid text-center">
         <div id="flash_danger" class="alert alert-danger alert-cwa">

--- a/scripts/cwa_db.py
+++ b/scripts/cwa_db.py
@@ -39,7 +39,16 @@ class CWA_DB:
         # Support both Docker and CI environments for schema path
         script_dir = os.path.dirname(os.path.abspath(__file__))
         self.schema_path = os.path.join(script_dir, "cwa_schema.sql")
-        self.stats_tables = ["cwa_enforcement", "cwa_import", "cwa_conversions", "epub_fixes", "cwa_user_activity", "cwa_duplicate_cache", "cwa_duplicate_resolutions"]
+        self.stats_tables = [
+            "cwa_enforcement",
+            "cwa_import",
+            "cwa_conversions",
+            "epub_fixes",
+            "cwa_user_activity",
+            "cwa_duplicate_cache",
+            "cwa_duplicate_book_keys",
+            "cwa_duplicate_resolutions",
+        ]
         self.tables, self.schema = self.make_tables()
 
         self.cwa_default_settings = self.get_cwa_default_settings()

--- a/scripts/cwa_schema.sql
+++ b/scripts/cwa_schema.sql
@@ -179,6 +179,23 @@ CREATE TABLE IF NOT EXISTS cwa_duplicate_cache (
 -- Insert default row for cache table
 INSERT OR IGNORE INTO cwa_duplicate_cache (id, scan_pending) VALUES (1, 1);
 
+-- Persisted duplicate key index for bounded duplicate-cache maintenance.
+CREATE TABLE IF NOT EXISTS cwa_duplicate_book_keys (
+    book_id INTEGER PRIMARY KEY,
+    normalized_title TEXT NOT NULL DEFAULT '',
+    normalized_author TEXT NOT NULL DEFAULT '',
+    normalized_language TEXT NOT NULL DEFAULT '',
+    normalized_series TEXT NOT NULL DEFAULT '',
+    normalized_publisher TEXT NOT NULL DEFAULT '',
+    format_signature TEXT NOT NULL DEFAULT '',
+    duplicate_key TEXT NOT NULL,
+    criteria_fingerprint TEXT NOT NULL,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_cwa_duplicate_book_keys_key
+    ON cwa_duplicate_book_keys(criteria_fingerprint, duplicate_key);
+
 -- Auto-resolution audit log
 CREATE TABLE IF NOT EXISTS cwa_duplicate_resolutions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -145,9 +145,8 @@ process_lock = None
 _runtime_initialized = False
 _runtime_init_attempted = False
 
-# Debounced duplicate scan timer
-_duplicate_scan_timer = None
-_duplicate_scan_lock = threading.Lock()
+DUPLICATE_FULL_SCAN_WAIT_INTERVAL_SECONDS = 2
+DUPLICATE_FULL_SCAN_WAIT_TIMEOUT_SECONDS = int(os.environ.get("CWA_DUPLICATE_FULL_SCAN_WAIT_TIMEOUT_SECONDS", "7200"))
 
 class ProcessLock:
     """Robust process lock using both file locking and PID tracking"""
@@ -525,9 +524,12 @@ def get_internal_api_headers():
     """Provide headers that satisfy localhost-only internal endpoint checks."""
     return {"X-Forwarded-For": "127.0.0.1"}
 
-
 def get_ingest_batch_dirty_file() -> str:
     return os.environ.get("CWA_INGEST_BATCH_DIRTY_FILE", "/config/cwa_ingest_batch_dirty")
+
+
+def get_ingest_batch_active_file() -> str:
+    return os.environ.get("CWA_INGEST_BATCH_ACTIVE_FILE", "/config/cwa_ingest_batch_active")
 
 
 def mark_ingest_batch_dirty() -> None:
@@ -543,7 +545,28 @@ def mark_ingest_batch_dirty() -> None:
         print(f"[ingest-processor] WARN: Failed to mark ingest batch follow-up dirty: {e}", flush=True)
 
 
-def _post_internal_endpoint(path: str, payload: dict | None = None) -> bool:
+def mark_ingest_batch_active() -> None:
+    active_file = get_ingest_batch_active_file()
+    try:
+        active_dir = os.path.dirname(active_file)
+        if active_dir:
+            os.makedirs(active_dir, exist_ok=True)
+        with open(active_file, "w", encoding="utf-8") as marker:
+            marker.write(f"active_at={int(time.time())}\n")
+    except Exception as e:
+        print(f"[ingest-processor] WARN: Failed to mark ingest active: {e}", flush=True)
+
+
+def clear_ingest_batch_active() -> None:
+    try:
+        os.remove(get_ingest_batch_active_file())
+    except FileNotFoundError:
+        pass
+    except Exception as e:
+        print(f"[ingest-processor] WARN: Failed to clear ingest active marker: {e}", flush=True)
+
+
+def _post_internal_endpoint(path: str, payload: dict | None = None, timeout: int = 5) -> bool:
     global requests
     if requests is None:
         import requests as loaded_requests
@@ -559,7 +582,7 @@ def _post_internal_endpoint(path: str, payload: dict | None = None) -> bool:
                 get_internal_api_url(path),
                 json=payload,
                 headers=get_internal_api_headers(),
-                timeout=5,
+                timeout=timeout,
                 verify=False,
             )
             if resp.status_code == 200:
@@ -594,19 +617,96 @@ def _post_internal_endpoint(path: str, payload: dict | None = None) -> bool:
     return False
 
 
+def duplicate_full_scan_running() -> bool:
+    global requests
+    if requests is None:
+        import requests as loaded_requests
+        requests = loaded_requests
+
+    try:
+        resp = requests.post(
+            get_internal_api_url("/cwa-internal/duplicate-scan-status"),
+            headers=get_internal_api_headers(),
+            timeout=5,
+            verify=False,
+        )
+        if resp.status_code != 200:
+            print(
+                f"[ingest-processor] WARN: Duplicate scan status endpoint returned {resp.status_code}; continuing ingest",
+                flush=True,
+            )
+            return False
+        data = resp.json()
+        return bool(data.get("full_scan_running"))
+    except Exception as e:
+        print(f"[ingest-processor] WARN: Could not check duplicate scan status: {e}; continuing ingest", flush=True)
+        return False
+
+
+def wait_for_duplicate_full_scan_to_finish() -> None:
+    start_time = time.time()
+    logged_wait = False
+    while duplicate_full_scan_running():
+        elapsed = time.time() - start_time
+        if elapsed > DUPLICATE_FULL_SCAN_WAIT_TIMEOUT_SECONDS:
+            print(
+                "[ingest-processor] WARN: Timed out waiting for duplicate full scan; continuing ingest",
+                flush=True,
+            )
+            return
+        if not logged_wait or int(elapsed) % 30 < DUPLICATE_FULL_SCAN_WAIT_INTERVAL_SECONDS:
+            print("[ingest-processor] Duplicate full scan is running; waiting before modifying library", flush=True)
+            logged_wait = True
+        time.sleep(DUPLICATE_FULL_SCAN_WAIT_INTERVAL_SECONDS)
+
+
 def run_post_batch_follow_up() -> int:
-    """Run follow-up work once the ingest service observes a quiet dirty batch."""
+    """Run follow-up work once the ingest service observes a quiet dirty batch.
+
+    After #1353 the per-book incremental duplicate scan happens inline during
+    add_book_to_library / add_format_to_book, so the only deferred work left is
+    the DB reconnect that flushes the long-lived web process's SQLAlchemy
+    session and makes newly-added books visible. /duplicates/invalidate-cache
+    and /cwa-internal/queue-duplicate-scan are no longer needed here.
+    """
     print("[ingest-processor] Running post-batch follow-up", flush=True)
     checks = [
         _post_internal_endpoint("/cwa-internal/reconnect-db"),
-        _post_internal_endpoint("/duplicates/invalidate-cache"),
-        _post_internal_endpoint("/cwa-internal/queue-duplicate-scan"),
     ]
     if all(checks):
         print("[ingest-processor] Post-batch follow-up completed", flush=True)
         return 0
     print("[ingest-processor] WARN: Post-batch follow-up incomplete", flush=True)
     return 1
+
+
+def run_duplicate_scan_for_books(book_ids) -> None:
+    parsed_book_ids = []
+    for book_id in book_ids or []:
+        try:
+            parsed_book_id = int(book_id)
+        except (TypeError, ValueError):
+            continue
+        if parsed_book_id > 0:
+            parsed_book_ids.append(parsed_book_id)
+
+    if not parsed_book_ids:
+        return
+
+    if _post_internal_endpoint(
+        "/cwa-internal/run-duplicate-scan",
+        payload={"book_ids": parsed_book_ids},
+        timeout=30,
+    ):
+        print(
+            f"[ingest-processor] Synchronous duplicate scan completed for book IDs: {parsed_book_ids}",
+            flush=True,
+        )
+    else:
+        print(
+            f"[ingest-processor] WARN: Synchronous duplicate scan failed for book IDs: {parsed_book_ids}",
+            flush=True,
+        )
 
 
 class NewBookProcessor:
@@ -1019,6 +1119,8 @@ class NewBookProcessor:
             return
 
         try:
+            mark_ingest_batch_active()
+            wait_for_duplicate_full_scan_to_finish()
             # Process-shared lock around calibredb add: serialises with
             # the Flask app's Edit Book commit + other ingest passes.
             # Required for fork #192 — without it, mergerfs/SMB/NFS
@@ -1137,6 +1239,8 @@ class NewBookProcessor:
                 except Exception as e:
                     print(f"[ingest-processor] WARN: Failed to set timestamp for new book: {e}", flush=True)
 
+            run_duplicate_scan_for_books(self.last_added_book_ids or [self.last_added_book_id])
+
             # If we overwrote an existing book, Calibre does not bump books.timestamp, only last_modified.
             # Update timestamp to last_modified for any rows changed by this import so sorting by 'new' reflects overwrites.
             if self.cwa_settings.get('auto_ingest_automerge') == 'overwrite':
@@ -1163,6 +1267,7 @@ class NewBookProcessor:
         except Exception as e:
             print(f"[ingest-processor] ingest-processor ran into the following error:\n{e}", flush=True)
         finally:
+            clear_ingest_batch_active()
             if staged_path.exists():
                 os.remove(staged_path)
 
@@ -1201,11 +1306,14 @@ class NewBookProcessor:
             return
 
         try:
+            mark_ingest_batch_active()
+            wait_for_duplicate_full_scan_to_finish()
             result = subprocess.run([
                 "calibredb", "add_format", str(book_id), str(staged_path), f"--library-path={self.library_dir}"
             ], env=self.calibre_env, check=True, capture_output=True, text=True)
             print(f"[ingest-processor] Added new format for book id {book_id}: {os.path.basename(str(staged_path))}", flush=True)
             mark_ingest_batch_dirty()
+            run_duplicate_scan_for_books([book_id])
             if self.cwa_settings['auto_backup_imports']:
                 self.backup(str(staged_path), backup_type="imported")
             # Optional post-add-format GDrive sync
@@ -1217,6 +1325,7 @@ class NewBookProcessor:
         except Exception as e:
             print(f"[ingest-processor] Unexpected error while adding format for book id {book_id}: {e}", flush=True)
         finally:
+            clear_ingest_batch_active()
             if staged_path.exists():
                 os.remove(staged_path)
 

--- a/tests/unit/test_duplicate_delete_index_maintenance.py
+++ b/tests/unit/test_duplicate_delete_index_maintenance.py
@@ -1,0 +1,455 @@
+from datetime import datetime, timezone
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+import importlib.util
+import pathlib
+import sys
+
+
+def _install_stub(name, attrs=None):
+    module = ModuleType(name)
+    if attrs:
+        for key, value in attrs.items():
+            setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+class _Logger:
+    def debug(self, *args, **kwargs):
+        return None
+
+    def info(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        return None
+
+    def error(self, *args, **kwargs):
+        return None
+
+    def error_or_exception(self, *args, **kwargs):
+        return None
+
+
+class _Field:
+    def __eq__(self, other):
+        return ("eq", other)
+
+
+class _Query:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def delete(self):
+        self.calls.append("format-delete")
+        return 1
+
+
+class _Session:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def query(self, *args, **kwargs):
+        return _Query(self.calls)
+
+    def commit(self):
+        self.calls.append("commit")
+
+    def rollback(self):
+        self.calls.append("rollback")
+
+    def close(self):
+        self.calls.append("close")
+
+
+class _CwaDB:
+    instances = []
+
+    def __init__(self):
+        self.invalidated = False
+        self.cache_updates = []
+        self.cwa_settings = {"duplicate_detection_enabled": 1}
+        self.resolutions = []
+        self.scheduled_cancelled = []
+        self.__class__.instances.append(self)
+
+    def invalidate_duplicate_cache(self):
+        self.invalidated = True
+        return True
+
+    def update_duplicate_cache(self, duplicate_groups, total_count, max_book_id=None):
+        self.cache_updates.append((duplicate_groups, total_count, max_book_id))
+        return True
+
+    def close(self):
+        return None
+
+    def log_duplicate_resolution(self, **kwargs):
+        self.resolutions.append(kwargs)
+
+    def scheduled_cancel_for_book(self, book_id):
+        self.scheduled_cancelled.append(book_id)
+        return 0
+
+
+def _clear_modules():
+    for name in list(sys.modules):
+        if (
+            name == "cps"
+            or name.startswith("cps.")
+            or name == "cwa_db"
+            or name == "flask"
+            or name == "flask_babel"
+            or name == "sqlalchemy"
+            or name.startswith("sqlalchemy.")
+            or name == "werkzeug"
+            or name.startswith("werkzeug.")
+        ):
+            sys.modules.pop(name, None)
+
+
+def _decorator(func=None, *args, **kwargs):
+    if func is None:
+        return lambda wrapped: wrapped
+    return func
+
+
+def _install_common_web_stubs():
+    class _Blueprint:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        def route(self, *args, **kwargs):
+            return lambda wrapped: wrapped
+
+    _install_stub(
+        "flask",
+        {
+            "Blueprint": _Blueprint,
+            "request": SimpleNamespace(form=SimpleNamespace(to_dict=lambda: {}), headers={}, files={}),
+            "flash": lambda *args, **kwargs: None,
+            "redirect": lambda location: location,
+            "url_for": lambda endpoint, **kwargs: f"/{endpoint}",
+            "abort": lambda code: (_ for _ in ()).throw(RuntimeError(code)),
+            "Response": lambda body=None, **kwargs: body,
+            "jsonify": lambda *args, **kwargs: {"args": args, "kwargs": kwargs},
+        },
+    )
+    _install_stub(
+        "flask_babel",
+        {
+            "gettext": lambda text, **kwargs: text % kwargs if kwargs else text,
+            "lazy_gettext": lambda text, **kwargs: text % kwargs if kwargs else text,
+            "get_locale": lambda: "en",
+        },
+    )
+    _install_stub("werkzeug")
+    _install_stub("werkzeug.utils", {"secure_filename": lambda value: value})
+
+
+def _load_editbooks_module(delete_key_calls):
+    _clear_modules()
+    _install_common_web_stubs()
+
+    cps = _install_stub("cps")
+    logger = _install_stub("cps.logger", {"create": lambda: _Logger()})
+    helper = _install_stub("cps.helper", {"delete_book": lambda *args, **kwargs: (True, None)})
+    config = _install_stub("cps.config", {"get_book_path": lambda: "/library"})
+    calls = []
+    calibre_db = _install_stub(
+        "cps.calibre_db",
+        {"get_book": lambda book_id: SimpleNamespace(id=book_id), "session": _Session(calls)},
+    )
+    data_cls = SimpleNamespace(book=_Field(), format=_Field())
+    db = _install_stub("cps.db", {"Data": data_cls})
+    current_user = SimpleNamespace(role_delete_books=lambda: True)
+
+    cps.logger = logger
+    cps.helper = helper
+    cps.config = config
+    cps.calibre_db = calibre_db
+    cps.db = db
+
+    for name in ("constants", "isoLanguages", "gdriveutils", "uploader"):
+        module = _install_stub(f"cps.{name}")
+        setattr(cps, name, module)
+
+    _install_stub("cps.ub")
+    _install_stub(
+        "cps.kobo_sync_status",
+        {
+            "remove_synced_book": lambda *args, **kwargs: calls.append("kobo"),
+            "change_archived_books": lambda *args, **kwargs: None,
+        },
+    )
+    _install_stub("cps.clean_html", {"clean_string": lambda value: value})
+    _install_stub("cps.services")
+    _install_stub("cps.services.worker", {"WorkerThread": SimpleNamespace(get_instance=lambda: None)})
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _noop_lock(*args, **kwargs):
+        yield
+
+    _install_stub("cps.services.calibre_db_lock", {"metadata_db_write_lock": _noop_lock})
+    _install_stub("cps.tasks")
+    _install_stub("cps.tasks.upload", {"TaskUpload": object})
+    _install_stub("cps.render_template", {"render_title_template": lambda *args, **kwargs: ""})
+    _install_stub("cps.redirect", {"get_redirect_location": lambda location, endpoint: location or f"/{endpoint}"})
+    _install_stub("cps.file_helper", {"validate_mime_type": lambda *args, **kwargs: True})
+    _install_stub("cps.cwa_functions", {"get_ingest_dir": lambda: "/ingest"})
+    _install_stub(
+        "cps.usermanagement",
+        {"user_login_required": _decorator, "login_required_if_no_ano": _decorator},
+    )
+    _install_stub("cps.string_helper", {"strip_whitespaces": lambda value: value.strip()})
+    _install_stub("cps.cw_login", {"current_user": current_user, "login_required": _decorator})
+    _install_stub(
+        "cps.duplicate_index",
+        {
+            "delete_book_keys": lambda ids: delete_key_calls.append(list(ids)),
+            "get_duplicate_groups_from_index": lambda settings, include_dismissed=False: [],
+            "_current_max_book_id": lambda: 1,
+        },
+    )
+    _install_stub("cwa_db", {"CWA_DB": _CwaDB})
+    _install_stub(
+        "sqlalchemy.exc",
+        {
+            "OperationalError": Exception,
+            "IntegrityError": Exception,
+            "InterfaceError": Exception,
+            "InvalidRequestError": Exception,
+        },
+    )
+    _install_stub("sqlalchemy.orm")
+    _install_stub("sqlalchemy.orm.exc", {"StaleDataError": Exception})
+    _install_stub("sqlalchemy.sql")
+    _install_stub("sqlalchemy.sql.expression", {"func": SimpleNamespace()})
+
+    editbooks_path = pathlib.Path(__file__).resolve().parents[2] / "cps" / "editbooks.py"
+    spec = importlib.util.spec_from_file_location("cps.editbooks", editbooks_path)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "cps"
+    sys.modules["cps.editbooks"] = module
+    spec.loader.exec_module(module)
+    module.render_delete_book_result = lambda *args, **kwargs: "deleted"
+    module.delete_whole_book = lambda book_id, book: calls.append(("whole", book_id))
+    return module, calls
+
+
+def _load_duplicates_module(delete_key_calls):
+    _clear_modules()
+    _install_common_web_stubs()
+
+    cps = _install_stub("cps")
+    logger = _install_stub("cps.logger", {"create": lambda: _Logger()})
+    calls = []
+    session = _Session(calls)
+    calibre_books = {}
+    calibre_db = _install_stub(
+        "cps.calibre_db",
+        {
+            "ensure_session": lambda: calls.append("ensure-session"),
+            "get_book": lambda book_id: calibre_books.get(book_id),
+            "session": session,
+        },
+    )
+    helper = _install_stub("cps.helper", {"delete_book": lambda *args, **kwargs: (True, None)})
+    config = _install_stub(
+        "cps.config",
+        {"config_calibre_dir": "/library", "get_book_path": lambda: "/library"},
+    )
+    db = _install_stub("cps.db", {"Books": SimpleNamespace(id=_Field())})
+    current_user = SimpleNamespace(is_authenticated=True, id=9, role_admin=lambda: True, role_edit=lambda: True)
+
+    cps.logger = logger
+    cps.calibre_db = calibre_db
+    cps.helper = helper
+    cps.config = config
+    cps.db = db
+
+    _install_stub("cps.ub", {"init_db_thread": lambda: calls.append("init-db-thread")})
+    _install_stub("cps.csrf", {"exempt": _decorator})
+    _install_stub("cps.admin", {"admin_required": _decorator})
+    _install_stub("cps.usermanagement", {"login_required_if_no_ano": _decorator})
+    _install_stub("cps.render_template", {"render_title_template": lambda *args, **kwargs: ""})
+    _install_stub("cps.cw_login", {"current_user": current_user})
+    _install_stub(
+        "cps.services.worker",
+        {
+            "WorkerThread": SimpleNamespace(get_instance=lambda: None),
+            "STAT_FINISH_SUCCESS": "success",
+            "STAT_FAIL": "fail",
+            "STAT_ENDED": "ended",
+            "STAT_CANCELLED": "cancelled",
+        },
+    )
+    _install_stub("cps.services")
+    _install_stub("cps.editbooks", {"delete_whole_book": lambda book_id, book: calls.append(("whole", book_id))})
+    _install_stub(
+        "cps.duplicate_index",
+        {
+            "delete_book_keys": lambda ids: delete_key_calls.append(list(ids)),
+            "get_duplicate_groups_from_index": lambda settings, include_dismissed=False: [],
+            "_current_max_book_id": lambda: 1,
+        },
+    )
+    _install_stub("cwa_db", {"CWA_DB": _CwaDB})
+    _install_stub(
+        "sqlalchemy",
+        {
+            "func": SimpleNamespace(),
+            "and_": lambda *args: args,
+            "case": lambda *args, **kwargs: ("case", args, kwargs),
+        },
+    )
+    _install_stub("sqlalchemy.sql")
+    _install_stub("sqlalchemy.sql.expression", {"true": lambda: True, "false": lambda: False})
+    _install_stub("sqlalchemy.orm", {"joinedload": lambda *args, **kwargs: None})
+
+    duplicates_path = pathlib.Path(__file__).resolve().parents[2] / "cps" / "duplicates.py"
+    spec = importlib.util.spec_from_file_location("cps.duplicates", duplicates_path)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "cps"
+    sys.modules["cps.duplicates"] = module
+    spec.loader.exec_module(module)
+    return module, calibre_books, calls
+
+
+def test_delete_book_from_table_whole_book_deletes_duplicate_keys_and_refreshes_cache():
+    _CwaDB.instances = []
+    delete_key_calls = []
+    module, calls = _load_editbooks_module(delete_key_calls)
+
+    result = module.delete_book_from_table(12, "", True)
+
+    assert result == "deleted"
+    assert ("whole", 12) in calls
+    assert "commit" in calls
+    assert delete_key_calls == [[12]]
+    assert _CwaDB.instances[-1].cache_updates == [([], 0, 1)]
+    assert _CwaDB.instances[-1].invalidated is False
+
+
+def test_delete_book_from_table_format_only_keeps_duplicate_keys_and_invalidates_cache():
+    _CwaDB.instances = []
+    delete_key_calls = []
+    module, calls = _load_editbooks_module(delete_key_calls)
+
+    result = module.delete_book_from_table(12, "EPUB", True)
+
+    assert result == "deleted"
+    assert "format-delete" in calls
+    assert "commit" in calls
+    assert delete_key_calls == []
+    assert _CwaDB.instances[-1].invalidated is True
+
+
+def test_auto_resolve_duplicates_deletes_duplicate_keys_and_refreshes_cache():
+    _CwaDB.instances = []
+    delete_key_calls = []
+    module, calibre_books, calls = _load_duplicates_module(delete_key_calls)
+    kept = SimpleNamespace(
+        id=1,
+        title="Dune",
+        timestamp=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        data=[],
+        path="Dune",
+    )
+    deleted = SimpleNamespace(
+        id=2,
+        title="Dune",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        data=[],
+        path="Dune Copy",
+    )
+    calibre_books[1] = kept
+    calibre_books[2] = deleted
+
+    with patch("os.path.exists", return_value=False), patch("os.makedirs"):
+        result = module.auto_resolve_duplicates(
+            strategy="newest",
+            duplicate_groups=[
+                {
+                    "group_hash": "abc123",
+                    "title": "Dune",
+                    "author": "Frank Herbert",
+                    "books": [kept, deleted],
+                }
+            ],
+        )
+
+    assert result["success"] is True
+    assert result["deleted_count"] == 1
+    assert ("whole", 2) in calls
+    assert delete_key_calls == [[2]]
+    assert _CwaDB.instances[-1].cache_updates == [([], 0, 1)]
+    assert _CwaDB.instances[-1].invalidated is False
+
+
+def test_auto_resolve_dry_run_does_not_invalidate_duplicate_cache():
+    _CwaDB.instances = []
+    delete_key_calls = []
+    module, _calibre_books, calls = _load_duplicates_module(delete_key_calls)
+    kept = SimpleNamespace(
+        id=1,
+        title="Dune",
+        timestamp=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        data=[],
+        path="Dune",
+    )
+    deleted = SimpleNamespace(
+        id=2,
+        title="Dune",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        data=[],
+        path="Dune Copy",
+    )
+
+    result = module.auto_resolve_duplicates(
+        strategy="newest",
+        dry_run=True,
+        duplicate_groups=[
+            {
+                "group_hash": "abc123",
+                "title": "Dune",
+                "author": "Frank Herbert",
+                "books": [kept, deleted],
+            }
+        ],
+    )
+
+    assert result["success"] is True
+    assert result["deleted_count"] == 1
+    assert result["preview"]
+    assert ("whole", 2) not in calls
+    assert delete_key_calls == []
+    assert _CwaDB.instances[-1].invalidated is False
+
+
+_modules_snapshot: dict[str, "ModuleType"] = {}
+
+
+def setup_module(module):
+    """Snapshot sys.modules so teardown can restore real modules that the
+    test file's stubs would otherwise overwrite. Without this, downstream
+    test files (e.g. test_helper.py) would either find stubbed packages
+    in sys.modules or re-trigger SQLAlchemy mapper registration with
+    conflicting table state."""
+    _modules_snapshot.clear()
+    _modules_snapshot.update(sys.modules)
+
+
+def teardown_module(module):
+    """Restore the pre-test sys.modules. Anything added is removed; anything
+    replaced (a stub overwriting a real package) is put back to the real one."""
+    for name in list(sys.modules):
+        if name not in _modules_snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(_modules_snapshot)

--- a/tests/unit/test_duplicate_index.py
+++ b/tests/unit/test_duplicate_index.py
@@ -1,0 +1,689 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+from datetime import datetime, timezone
+from types import ModuleType, SimpleNamespace
+import importlib.util
+import json
+import pathlib
+import sqlite3
+import sys
+
+import pytest
+
+
+def _install_stub(name, attrs=None):
+    module = ModuleType(name)
+    if attrs:
+        for key, value in attrs.items():
+            setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _load_duplicate_index_module():
+    for name in list(sys.modules):
+        if name in ("cps.duplicate_index", "cps.duplicates", "cps", "sqlalchemy") or name.startswith(
+            "sqlalchemy."
+        ):
+            sys.modules.pop(name, None)
+
+    cps = _install_stub("cps")
+
+    class _Logger:
+        def info(self, *args, **kwargs):
+            return None
+
+    logger = _install_stub("cps.logger", {"create": lambda: _Logger()})
+
+    class _BookId:
+        def in_(self, values):
+            return ("book_id_in", tuple(values))
+
+    class _OrderColumn:
+        def desc(self):
+            return self
+
+    class _Books:
+        id = _BookId()
+        title = _OrderColumn()
+        timestamp = _OrderColumn()
+        data = object()
+        authors = object()
+        languages = object()
+        series = object()
+        publishers = object()
+
+    db = _install_stub("cps.db", {"Books": _Books})
+    calibre_db = _install_stub("cps.calibre_db", {"session": None, "order_authors": lambda books: books[0].authors})
+    cps.db = db
+    cps.calibre_db = calibre_db
+    cps.logger = logger
+
+    def _normalize_title(title, primary_author=None):
+        normalized = (title or "untitled").lower().strip()
+        if primary_author:
+            prefix = f"{primary_author.lower().strip()}, "
+            if normalized.startswith(prefix):
+                normalized = normalized[len(prefix):].strip()
+        return normalized
+
+    def _group_hash(title, author):
+        import hashlib
+
+        payload = f"{(title or 'untitled').lower().strip()}|{(author or 'unknown').lower().strip()}"
+        return hashlib.md5(payload.encode()).hexdigest()
+
+    duplicates = _install_stub(
+        "cps.duplicates",
+        {
+            "_AWARE_MIN": datetime.min.replace(tzinfo=timezone.utc),
+            "_timestamp_or_default": lambda ts, default: (
+                ts.replace(tzinfo=timezone.utc) if ts and ts.tzinfo is None else (ts or default)
+            ),
+            "filter_dismissed_groups": lambda groups, user_id=None: [
+                group for group in groups if group.get("group_hash") != "dismissed"
+            ],
+            "generate_group_hash": _group_hash,
+            "get_common_filters": lambda user_id=None: True,
+            "normalize_title_for_duplicates": _normalize_title,
+        },
+    )
+    cps.duplicates = duplicates
+
+    _install_stub("cwa_db", {"CWA_DB": object})
+
+    duplicate_index_path = pathlib.Path(__file__).resolve().parents[2] / "cps" / "duplicate_index.py"
+    spec = importlib.util.spec_from_file_location("cps.duplicate_index", duplicate_index_path)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "cps"
+    sys.modules["cps.duplicate_index"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeCwaDB:
+    _connection = None
+
+    def __init__(self):
+        self.con = self.__class__._connection
+        self.cur = self.con.cursor()
+
+    @classmethod
+    def reset(cls):
+        cls._connection = sqlite3.connect(":memory:")
+        cls._connection.executescript(
+            """
+            CREATE TABLE cwa_duplicate_book_keys (
+                book_id INTEGER PRIMARY KEY,
+                normalized_title TEXT NOT NULL DEFAULT '',
+                normalized_author TEXT NOT NULL DEFAULT '',
+                normalized_language TEXT NOT NULL DEFAULT '',
+                normalized_series TEXT NOT NULL DEFAULT '',
+                normalized_publisher TEXT NOT NULL DEFAULT '',
+                format_signature TEXT NOT NULL DEFAULT '',
+                duplicate_key TEXT NOT NULL,
+                criteria_fingerprint TEXT NOT NULL,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE INDEX idx_cwa_duplicate_book_keys_key
+                ON cwa_duplicate_book_keys(criteria_fingerprint, duplicate_key);
+            CREATE TABLE cwa_duplicate_cache (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                scan_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                duplicate_groups_json TEXT,
+                total_count INTEGER DEFAULT 0,
+                scan_pending INTEGER DEFAULT 1,
+                last_scanned_book_id INTEGER DEFAULT 0
+            );
+            INSERT INTO cwa_duplicate_cache (id, scan_pending) VALUES (1, 1);
+            """
+        )
+
+    def get_duplicate_cache(self):
+        row = self.cur.execute(
+            """
+            SELECT duplicate_groups_json, total_count, scan_pending, last_scanned_book_id
+            FROM cwa_duplicate_cache
+            WHERE id = 1
+            """
+        ).fetchone()
+        if row and row[0]:
+            return {
+                "duplicate_groups": json.loads(row[0]),
+                "total_count": row[1],
+                "scan_pending": bool(row[2]),
+                "last_scanned_book_id": row[3],
+            }
+        return None
+
+    def update_duplicate_cache(self, duplicate_groups, total_count, max_book_id=None):
+        serializable = [
+            {
+                "title": group.get("title", ""),
+                "author": group.get("author", ""),
+                "count": group.get("count", 0),
+                "group_hash": group.get("group_hash", ""),
+                "book_ids": [book.id for book in group.get("books", [])],
+            }
+            for group in duplicate_groups
+        ]
+        self.cur.execute(
+            """
+            UPDATE cwa_duplicate_cache
+            SET duplicate_groups_json = ?, total_count = ?, scan_pending = 0, last_scanned_book_id = ?
+            WHERE id = 1
+            """,
+            (json.dumps(serializable), total_count, max_book_id or 0),
+        )
+        self.con.commit()
+        return True
+
+
+class _Query:
+    def __init__(self, books, scalar_value=None):
+        self.books = list(books)
+        self.scalar_value = scalar_value
+
+    def options(self, *args):
+        return self
+
+    def filter(self, expression):
+        if isinstance(expression, tuple) and expression[0] == "book_id_in":
+            wanted = set(expression[1])
+            self.books = [book for book in self.books if book.id in wanted]
+        return self
+
+    def order_by(self, *args):
+        return self
+
+    def all(self):
+        return list(self.books)
+
+    def scalar(self):
+        return self.scalar_value
+
+
+class _Session:
+    def __init__(self, books):
+        self.books = list(books)
+
+    def query(self, subject):
+        subject_text = str(subject)
+        if "max" in subject_text:
+            return _Query([], max([book.id for book in self.books], default=0))
+        if "count" in subject_text:
+            return _Query([], len(self.books))
+        return _Query(self.books)
+
+
+def _book(
+    book_id,
+    title,
+    author,
+    language="eng",
+    series=None,
+    publisher=None,
+    formats=None,
+    timestamp=None,
+):
+    return SimpleNamespace(
+        id=book_id,
+        title=title,
+        authors=[SimpleNamespace(name=author)],
+        languages=[SimpleNamespace(lang_code=language)] if language is not None else [],
+        series=[SimpleNamespace(name=series)] if series is not None else [],
+        publishers=[SimpleNamespace(name=publisher)] if publisher is not None else [],
+        data=[SimpleNamespace(format=fmt) for fmt in (formats or [])],
+        timestamp=timestamp or datetime(2024, 1, book_id, tzinfo=timezone.utc),
+        has_cover=False,
+    )
+
+
+@pytest.fixture
+def duplicate_index(monkeypatch):
+    module = _load_duplicate_index_module()
+    _FakeCwaDB.reset()
+    monkeypatch.setattr(module, "CWA_DB", _FakeCwaDB)
+    monkeypatch.setattr(module, "joinedload", lambda value: value)
+    yield module
+    for name in (
+        "cps.duplicate_index",
+        "cps.duplicates",
+        "cps.calibre_db",
+        "cps.db",
+        "cps.logger",
+        "cps",
+        "cwa_db",
+    ):
+        sys.modules.pop(name, None)
+
+
+def test_effective_criteria_falls_back_to_title_author(duplicate_index):
+    criteria = duplicate_index.get_effective_duplicate_criteria(
+        {
+            "duplicate_detection_title": 0,
+            "duplicate_detection_author": 0,
+            "duplicate_detection_language": 0,
+            "duplicate_detection_series": 0,
+            "duplicate_detection_publisher": 0,
+            "duplicate_detection_format": 0,
+        }
+    )
+
+    assert criteria == {
+        "title": True,
+        "author": True,
+        "language": False,
+        "series": False,
+        "publisher": False,
+        "format": False,
+    }
+
+
+def test_fingerprint_changes_when_effective_criteria_change(duplicate_index):
+    title_author = duplicate_index.get_criteria_fingerprint(
+        {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+    )
+    title_author_language = duplicate_index.get_criteria_fingerprint(
+        {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 1}
+    )
+
+    assert title_author != title_author_language
+
+
+def test_build_book_key_parts_matches_python_duplicate_fallbacks(duplicate_index):
+    book = _book(
+        1,
+        "Homer, The Iliad",
+        "Homer",
+        language=None,
+        series=None,
+        publisher=None,
+        formats=["EPUB", "PDF"],
+    )
+
+    parts = duplicate_index.build_book_key_parts(book, {})
+
+    assert parts.normalized_title == "the iliad"
+    assert parts.normalized_author == "homer"
+    assert parts.normalized_language == "unknown"
+    assert parts.normalized_series == "no_series"
+    assert parts.normalized_publisher == "unknown_publisher"
+    assert parts.format_signature == "epub,pdf"
+
+
+def test_title_only_key_parts_still_strip_primary_author_prefix(duplicate_index):
+    book = _book(1, "Homer, The Iliad", "Homer")
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 0, "duplicate_detection_language": 0}
+
+    parts = duplicate_index.build_book_key_parts(book, settings)
+    key_values = duplicate_index._enabled_key_values(parts, settings)
+
+    assert parts.normalized_title == "the iliad"
+    assert parts.normalized_author == "homer"
+    assert key_values == [("title", "the iliad")]
+
+
+def test_upsert_and_delete_book_keys(duplicate_index):
+    books = [_book(1, "Dune", "Frank Herbert"), _book(2, "Dune", "Frank Herbert")]
+    duplicate_index.calibre_db.session = _Session(books)
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+
+    result = duplicate_index.upsert_book_keys({1, 2}, settings)
+    cwa_db = _FakeCwaDB()
+    rows = cwa_db.cur.execute(
+        """
+        SELECT book_id, normalized_title, normalized_author, criteria_fingerprint
+        FROM cwa_duplicate_book_keys
+        ORDER BY book_id
+        """
+    ).fetchall()
+
+    assert result["updated"] == 2
+    assert [(row[0], row[1], row[2]) for row in rows] == [
+        (1, "dune", "frank herbert"),
+        (2, "dune", "frank herbert"),
+    ]
+    assert all(row[3] == result["fingerprint"] for row in rows)
+
+    assert duplicate_index.delete_book_keys({1}) == 1
+    remaining = cwa_db.cur.execute("SELECT book_id FROM cwa_duplicate_book_keys").fetchall()
+    assert remaining == [(2,)]
+
+
+def test_grouped_index_queries_and_dismissed_filtering(duplicate_index):
+    books = [_book(1, "Dune", "Frank Herbert"), _book(2, "Dune", "Frank Herbert"), _book(3, "Other", "Writer")]
+    duplicate_index.calibre_db.session = _Session(books)
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+    duplicate_index.upsert_book_keys({1, 2, 3}, settings)
+
+    groups = duplicate_index.get_duplicate_groups_from_index(settings, include_dismissed=True)
+
+    assert len(groups) == 1
+    assert groups[0]["title"] == "Dune"
+    assert groups[0]["author"] == "Frank Herbert"
+    assert groups[0]["count"] == 2
+    assert [book.id for book in groups[0]["books"]] == [2, 1]
+
+    duplicate_index.filter_dismissed_groups = lambda groups, user_id=None: []
+    assert duplicate_index.get_duplicate_groups_from_index(settings, include_dismissed=False, user_id=7) == []
+
+
+def test_cache_merge_keeps_serialization_shape(duplicate_index):
+    books = [_book(1, "Dune", "Frank Herbert"), _book(2, "Dune", "Frank Herbert"), _book(3, "Other", "Writer")]
+    duplicate_index.calibre_db.session = _Session(books)
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+    duplicate_index.upsert_book_keys({1, 2, 3}, settings)
+
+    result = duplicate_index.merge_affected_groups_into_cache({1}, settings)
+    cache = _FakeCwaDB().get_duplicate_cache()
+
+    assert result["updated"] is True
+    assert cache["total_count"] == 1
+    assert set(cache["duplicate_groups"][0]) == {"title", "author", "count", "group_hash", "book_ids"}
+    assert cache["duplicate_groups"][0]["book_ids"] == [2, 1]
+
+
+def test_cache_merge_preserves_retained_group_book_ids(duplicate_index):
+    books = [
+        _book(1, "Dune", "Frank Herbert"),
+        _book(2, "Dune", "Frank Herbert"),
+        _book(3, "Foundation", "Isaac Asimov"),
+        _book(4, "Foundation", "Isaac Asimov"),
+    ]
+    duplicate_index.calibre_db.session = _Session(books)
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+    duplicate_index.upsert_book_keys({1, 2, 3, 4}, settings)
+
+    cwa_db = _FakeCwaDB()
+    retained_group = {
+        "title": "Foundation",
+        "author": "Isaac Asimov",
+        "count": 2,
+        "group_hash": "foundation-hash",
+        "book_ids": [4, 3],
+    }
+    cwa_db.cur.execute(
+        """
+        UPDATE cwa_duplicate_cache
+        SET duplicate_groups_json = ?, total_count = ?, scan_pending = 0, last_scanned_book_id = ?
+        WHERE id = 1
+        """,
+        (json.dumps([retained_group]), 1, 4),
+    )
+    cwa_db.con.commit()
+
+    result = duplicate_index.merge_affected_groups_into_cache({1}, settings)
+    cache = _FakeCwaDB().get_duplicate_cache()
+    groups_by_title = {group["title"]: group for group in cache["duplicate_groups"]}
+
+    assert result["updated"] is True
+    assert groups_by_title["Foundation"]["book_ids"] == [4, 3]
+    assert groups_by_title["Dune"]["book_ids"] == [2, 1]
+
+
+def test_cache_merge_deletes_key_rows_for_missing_candidate_ids(duplicate_index):
+    books = [_book(1, "Dune", "Frank Herbert"), _book(2, "Dune", "Frank Herbert")]
+    duplicate_index.calibre_db.session = _Session(books)
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+    duplicate_index.upsert_book_keys({1, 2}, settings)
+    metadata = duplicate_index.rebuild_duplicate_index(settings)
+    groups = duplicate_index.get_duplicate_groups_from_index(settings, include_dismissed=True)
+    _FakeCwaDB().update_duplicate_cache(groups, len(groups), metadata["max_book_id"])
+
+    duplicate_index.calibre_db.session = _Session([books[1]])
+    result = duplicate_index.merge_affected_groups_into_cache({1}, settings)
+    key_rows = _FakeCwaDB().cur.execute("SELECT book_id FROM cwa_duplicate_book_keys ORDER BY book_id").fetchall()
+    cache = _FakeCwaDB().get_duplicate_cache()
+
+    assert result["updated"] is True
+    assert key_rows == [(2,)]
+    assert cache["duplicate_groups"] == []
+
+
+def test_rebuild_duplicate_index_replaces_active_fingerprint_and_removes_orphans(duplicate_index):
+    books = [_book(1, "Dune", "Frank Herbert"), _book(2, "Dune", "Frank Herbert")]
+    duplicate_index.calibre_db.session = _Session(books)
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+    fingerprint = duplicate_index.get_criteria_fingerprint(settings)
+
+    cwa_db = _FakeCwaDB()
+    cwa_db.cur.execute(
+        """
+        INSERT INTO cwa_duplicate_book_keys (
+            book_id, normalized_title, normalized_author, duplicate_key, criteria_fingerprint
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        (1, "stale", "stale", "stale-key", fingerprint),
+    )
+    cwa_db.cur.execute(
+        """
+        INSERT INTO cwa_duplicate_book_keys (
+            book_id, normalized_title, normalized_author, duplicate_key, criteria_fingerprint
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        (99, "orphan", "orphan", "orphan-key", "abandoned-fingerprint"),
+    )
+    cwa_db.con.commit()
+
+    result = duplicate_index.rebuild_duplicate_index(settings)
+    rows = cwa_db.cur.execute(
+        """
+        SELECT book_id, normalized_title, criteria_fingerprint
+        FROM cwa_duplicate_book_keys
+        ORDER BY book_id
+        """
+    ).fetchall()
+
+    assert result == {"max_book_id": 2, "indexed_count": 2, "fingerprint": fingerprint}
+    assert rows == [(1, "dune", fingerprint), (2, "dune", fingerprint)]
+
+
+def _seed_cache(scan_pending=False, last_scanned_book_id=1):
+    cwa_db = _FakeCwaDB()
+    cwa_db.cur.execute(
+        """
+        UPDATE cwa_duplicate_cache
+        SET duplicate_groups_json = ?, scan_pending = ?, last_scanned_book_id = ?
+        WHERE id = 1
+        """,
+        (json.dumps([]), int(scan_pending), last_scanned_book_id),
+    )
+    cwa_db.con.commit()
+
+
+def test_has_valid_duplicate_index_baseline_states(duplicate_index):
+    books = [_book(1, "Dune", "Frank Herbert"), _book(2, "Dune", "Frank Herbert")]
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+
+    duplicate_index.calibre_db.session = _Session(books)
+    duplicate_index.upsert_book_keys({1, 2}, settings)
+    _seed_cache(scan_pending=False, last_scanned_book_id=2)
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings) is True
+
+    _seed_cache(scan_pending=True, last_scanned_book_id=2)
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings) is False
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings, candidate_book_ids={2}) is True
+
+    _seed_cache(scan_pending=False, last_scanned_book_id=0)
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings) is False
+
+    duplicate_index.delete_book_keys({2})
+    _seed_cache(scan_pending=True, last_scanned_book_id=2)
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings) is False
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings, candidate_book_ids={2}) is True
+
+    _FakeCwaDB.reset()
+    duplicate_index.calibre_db.session = _Session([])
+    _seed_cache(scan_pending=False, last_scanned_book_id=0)
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings) is True
+
+
+def test_has_valid_duplicate_index_baseline_requires_candidate_to_cover_missing_current_book(duplicate_index):
+    books = [
+        _book(1, "Dune", "Frank Herbert"),
+        _book(2, "Dune Messiah", "Frank Herbert"),
+        _book(3, "Children of Dune", "Frank Herbert"),
+        _book(4, "God Emperor of Dune", "Frank Herbert"),
+    ]
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+
+    duplicate_index.calibre_db.session = _Session(books)
+    duplicate_index.upsert_book_keys({1, 2, 3}, settings)
+    _seed_cache(scan_pending=False, last_scanned_book_id=4)
+
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings, candidate_book_ids={3}) is False
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings, candidate_book_ids={4}) is True
+
+
+def test_has_valid_duplicate_index_baseline_allows_initial_incremental_when_candidates_cover_library(duplicate_index):
+    books = [_book(1, "Dune", "Frank Herbert")]
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+
+    duplicate_index.calibre_db.session = _Session(books)
+
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings) is False
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings, candidate_book_ids={1}) is True
+    assert duplicate_index.has_valid_duplicate_index_baseline(settings, candidate_book_ids={2}) is False
+
+
+def test_manual_full_scan_not_needed_for_new_books_during_dirty_ingest(duplicate_index, monkeypatch, tmp_path):
+    books = [
+        _book(1, "Dune", "Frank Herbert"),
+        _book(2, "Dune Messiah", "Frank Herbert"),
+        _book(3, "Children of Dune", "Frank Herbert"),
+        _book(4, "God Emperor of Dune", "Frank Herbert"),
+    ]
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+    dirty_file = tmp_path / "cwa_ingest_batch_dirty"
+
+    duplicate_index.calibre_db.session = _Session(books)
+    duplicate_index.upsert_book_keys({1, 2}, settings)
+    _seed_cache(scan_pending=True, last_scanned_book_id=2)
+    monkeypatch.setattr(duplicate_index, "INGEST_BATCH_DIRTY_FILE", str(dirty_file))
+    dirty_file.write_text("dirty_at=1\n")
+
+    assert duplicate_index.duplicate_index_needs_manual_full_scan(settings) is False
+
+
+def test_manual_full_scan_not_needed_for_new_books_during_running_ingest_follow_up(
+    duplicate_index, monkeypatch, tmp_path
+):
+    books = [
+        _book(1, "Dune", "Frank Herbert"),
+        _book(2, "Dune Messiah", "Frank Herbert"),
+    ]
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+    dirty_file = tmp_path / "cwa_ingest_batch_dirty"
+
+    duplicate_index.calibre_db.session = _Session(books)
+    duplicate_index.upsert_book_keys({1}, settings)
+    _seed_cache(scan_pending=True, last_scanned_book_id=1)
+    monkeypatch.setattr(duplicate_index, "INGEST_BATCH_DIRTY_FILE", str(dirty_file))
+    dirty_file.with_suffix(dirty_file.suffix + ".running").write_text("dirty_at=1\n")
+
+    assert duplicate_index.duplicate_index_needs_manual_full_scan(settings) is False
+
+
+def test_manual_full_scan_not_needed_while_ingest_active(duplicate_index, monkeypatch, tmp_path):
+    books = [_book(1, "Dune", "Frank Herbert")]
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+    active_file = tmp_path / "cwa_ingest_batch_active"
+
+    duplicate_index.calibre_db.session = _Session(books)
+    _seed_cache(scan_pending=True, last_scanned_book_id=0)
+    monkeypatch.setattr(duplicate_index, "INGEST_BATCH_ACTIVE_FILE", str(active_file))
+    active_file.write_text("active_at=1\n")
+
+    assert duplicate_index.duplicate_index_needs_manual_full_scan(settings) is False
+
+
+def test_initial_manual_full_scan_not_needed_during_dirty_ingest(duplicate_index, monkeypatch, tmp_path):
+    books = [_book(1, "Dune", "Frank Herbert")]
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+    dirty_file = tmp_path / "cwa_ingest_batch_dirty"
+
+    duplicate_index.calibre_db.session = _Session(books)
+    _seed_cache(scan_pending=True, last_scanned_book_id=0)
+    monkeypatch.setattr(duplicate_index, "INGEST_BATCH_DIRTY_FILE", str(dirty_file))
+    dirty_file.write_text("dirty_at=1\n")
+
+    assert duplicate_index.duplicate_index_needs_manual_full_scan(settings) is False
+
+
+def test_manual_full_scan_not_needed_when_pending_cache_has_complete_index(duplicate_index):
+    books = [
+        _book(1, "Dune", "Frank Herbert"),
+        _book(2, "Dune Messiah", "Frank Herbert"),
+    ]
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+
+    duplicate_index.calibre_db.session = _Session(books)
+    duplicate_index.upsert_book_keys({1, 2}, settings)
+    _seed_cache(scan_pending=True, last_scanned_book_id=2)
+
+    assert duplicate_index.duplicate_index_needs_manual_full_scan(settings) is False
+
+
+def test_manual_full_scan_needed_for_old_missing_book_even_during_dirty_ingest(duplicate_index, monkeypatch, tmp_path):
+    books = [
+        _book(1, "Dune", "Frank Herbert"),
+        _book(2, "Dune Messiah", "Frank Herbert"),
+        _book(3, "Children of Dune", "Frank Herbert"),
+    ]
+    settings = {"duplicate_detection_title": 1, "duplicate_detection_author": 1, "duplicate_detection_language": 0}
+    dirty_file = tmp_path / "cwa_ingest_batch_dirty"
+
+    duplicate_index.calibre_db.session = _Session(books)
+    duplicate_index.upsert_book_keys({1, 3}, settings)
+    _seed_cache(scan_pending=True, last_scanned_book_id=3)
+    monkeypatch.setattr(duplicate_index, "INGEST_BATCH_DIRTY_FILE", str(dirty_file))
+    dirty_file.write_text("dirty_at=1\n")
+
+    assert duplicate_index.duplicate_index_needs_manual_full_scan(settings) is True
+
+
+def test_mark_duplicate_index_pending_sets_cache_pending(duplicate_index):
+    _seed_cache(scan_pending=False, last_scanned_book_id=4)
+
+    assert duplicate_index.mark_duplicate_index_pending("criteria changed") is True
+
+    cache = _FakeCwaDB().get_duplicate_cache()
+    assert cache["scan_pending"] is True
+    assert cache["last_scanned_book_id"] == 4
+
+
+def test_schema_contains_duplicate_book_key_table():
+    schema = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "cwa_schema.sql"
+    sql = schema.read_text()
+    connection = sqlite3.connect(":memory:")
+    connection.executescript(sql)
+
+    table = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'cwa_duplicate_book_keys'"
+    ).fetchone()
+    index = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_cwa_duplicate_book_keys_key'"
+    ).fetchone()
+
+    assert table == ("cwa_duplicate_book_keys",)
+    assert index == ("idx_cwa_duplicate_book_keys_key",)
+
+
+_modules_snapshot: dict = {}
+
+
+def setup_module(module):
+    _modules_snapshot.clear()
+    _modules_snapshot.update(sys.modules)
+
+
+def teardown_module(module):
+    for name in list(sys.modules):
+        if name not in _modules_snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(_modules_snapshot)

--- a/tests/unit/test_duplicate_manager_race_fix.py
+++ b/tests/unit/test_duplicate_manager_race_fix.py
@@ -72,17 +72,20 @@ class TestEditbooksBatchedInvalidation:
         )
 
     def test_delete_selected_books_invalidates_once_after_loop(self):
+        """Pin: exactly ONE post-batch scan scheduling per delete_selected_books
+        call. After CWA #1353 (PR #232) the mechanism switched from a direct
+        `invalidate_duplicate_cache()` call to `_queue_duplicate_scan_after_change()`
+        which queues a debounced incremental scan over the affected book IDs.
+        The invariant is the same: one call after the loop, not per-book."""
         src = self._read_editbooks()
         match = re.search(
             r"def delete_selected_books\(\).*?return\s+\"\"",
             src, re.DOTALL,
         )
         body = match.group(0)
-        # exactly ONE invalidate_duplicate_cache call in the function body
-        # (the one after the loop, not per-book inside delete_book_from_table)
-        n_calls = body.count("invalidate_duplicate_cache()")
+        n_calls = body.count("_queue_duplicate_scan_after_change(")
         assert n_calls == 1, (
-            f"expected exactly 1 invalidate_duplicate_cache() call in "
+            f"expected exactly 1 _queue_duplicate_scan_after_change() call in "
             f"delete_selected_books (one batched call after the loop); "
             f"found {n_calls}"
         )
@@ -101,33 +104,39 @@ class TestEditbooksBatchedInvalidation:
         )
 
     def test_merge_list_book_invalidates_once_after_loop(self):
+        """Same invariant as delete_selected_books: exactly one post-batch
+        scan scheduling per merge_list_book call (after CWA #1353 / PR #232
+        the mechanism is `_queue_duplicate_scan_after_change`)."""
         src = self._read_editbooks()
         match = re.search(
             r"def merge_list_book\(\).*?return\s+\"\"",
             src, re.DOTALL,
         )
         body = match.group(0)
-        n_calls = body.count("invalidate_duplicate_cache()")
+        n_calls = body.count("_queue_duplicate_scan_after_change(")
         assert n_calls == 1, (
-            f"expected exactly 1 invalidate_duplicate_cache() call in "
+            f"expected exactly 1 _queue_duplicate_scan_after_change() call in "
             f"merge_list_book (one batched call after the loop); "
             f"found {n_calls}"
         )
 
     def test_delete_book_from_table_guards_invalidation_on_param(self):
-        """The internal cache-invalidation block must be gated by
-        `if not skip_cache_invalidation:` so bulk callers don't trigger it."""
+        """The internal cache-invalidation block must check `skip_cache_invalidation`
+        so bulk callers don't trigger it. After CWA #1353 (PR #232) the guard
+        was tightened to `if not skip_cache_invalidation and not refreshed_duplicate_cache`,
+        avoiding a double-invalidate when the new indexed refresh already ran;
+        the original PR #100 invariant (skip-flag honored) is preserved."""
         src = self._read_editbooks()
-        # find the delete_book_from_table body up to the next top-level def
         match = re.search(
             r"def delete_book_from_table\(.*?\):.*?(?=\n(?:def |@)\w)",
             src, re.DOTALL,
         )
         assert match is not None, "delete_book_from_table not found"
         body = match.group(0)
-        assert "if not skip_cache_invalidation:" in body, (
-            "delete_book_from_table must wrap its invalidate_duplicate_cache "
-            "block in `if not skip_cache_invalidation:` to honor the flag"
+        assert "skip_cache_invalidation" in body and "not skip_cache_invalidation" in body, (
+            "delete_book_from_table must read `skip_cache_invalidation` to gate "
+            "its invalidate-cache path; the bulk-delete optimization from "
+            "fork PR #100 depends on this guard"
         )
 
 

--- a/tests/unit/test_duplicate_scan_index_rewire.py
+++ b/tests/unit/test_duplicate_scan_index_rewire.py
@@ -1,0 +1,843 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+from types import ModuleType, SimpleNamespace
+import importlib.util
+import pathlib
+import sys
+
+
+def _install_stub(name, attrs=None):
+    module = ModuleType(name)
+    if attrs:
+        for key, value in attrs.items():
+            setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+class _Logger:
+    def debug(self, *args, **kwargs):
+        return None
+
+    def info(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        return None
+
+    def error(self, *args, **kwargs):
+        return None
+
+
+class _CalibreTask:
+    def __init__(self, message):
+        self.id = "task-id"
+        self.message = message
+        self.progress = 0
+        self.stat = None
+        self.success = False
+        self.error = None
+
+    def _handleSuccess(self):
+        self.success = True
+
+    def _handleError(self, message):
+        self.error = message
+
+
+class _TaskCwaDB:
+    instances = []
+
+    def __init__(self):
+        self.cwa_settings = {
+            "duplicate_auto_resolve_enabled": 0,
+            "duplicate_auto_resolve_strategy": "newest",
+            "duplicate_auto_resolve_cooldown_minutes": 0,
+        }
+        self.cache_updates = []
+        self.cur = SimpleNamespace(
+            execute=lambda *args, **kwargs: SimpleNamespace(fetchone=lambda: [None])
+        )
+        self.con = SimpleNamespace(commit=lambda: None)
+        self.__class__.instances.append(self)
+
+    def get_duplicate_cache(self):
+        return {"last_scanned_book_id": 42, "scan_pending": False}
+
+    def update_duplicate_cache(self, duplicate_groups, total_count, max_book_id=None):
+        self.cache_updates.append((duplicate_groups, total_count, max_book_id))
+        return True
+
+
+def _clear_modules():
+    for name in list(sys.modules):
+        if (
+            name == "cps"
+            or name.startswith("cps.")
+            or name == "cwa_db"
+            or name == "sqlalchemy"
+            or name.startswith("sqlalchemy.")
+        ):
+            sys.modules.pop(name, None)
+
+
+def _load_duplicate_scan_module(monkeypatch, calls):
+    _clear_modules()
+    cps = _install_stub("cps")
+    calibre_db = _install_stub(
+        "cps.calibre_db",
+        {
+            "ensure_session": lambda: None,
+            "session": SimpleNamespace(close=lambda: None),
+        },
+    )
+    db = _install_stub("cps.db", {"Books": SimpleNamespace(id=object())})
+    logger = _install_stub("cps.logger", {"create": lambda: _Logger()})
+    cps.calibre_db = calibre_db
+    cps.db = db
+    cps.logger = logger
+
+    def _rebuild(settings, progress_callback=None):
+        calls.append(("rebuild", settings))
+        if progress_callback:
+            progress_callback(1, 3)
+            progress_callback(3, 3)
+        return {"max_book_id": 99, "indexed_count": 3, "fingerprint": "fp"}
+
+    def _groups(settings, include_dismissed=False, user_id=None, candidate_book_ids=None):
+        calls.append(("groups", include_dismissed, user_id, candidate_book_ids))
+        return [{"title": "Dune", "author": "Frank Herbert", "count": 2, "books": []}]
+
+    _install_stub(
+        "cps.duplicate_index",
+        {
+            "rebuild_duplicate_index": _rebuild,
+            "MAX_INCREMENTAL_BOOK_IDS": 1000,
+            "get_effective_duplicate_criteria": lambda settings: {"title": True, "author": True},
+            "get_duplicate_groups_from_index": _groups,
+            "has_valid_duplicate_index_baseline": lambda settings, candidate_book_ids=None: True,
+            "ingest_batch_follow_up_pending": lambda: False,
+            "mark_duplicate_index_pending": lambda reason=None: True,
+            "merge_affected_groups_into_cache": lambda candidate_book_ids, settings: {
+                "updated": True,
+                "pending": False,
+                "merged_count": 1,
+            },
+        },
+    )
+
+    def _legacy_scan(*args, **kwargs):
+        raise AssertionError("find_duplicate_books should not be used for full scans")
+
+    auto_resolve_calls = []
+
+    def _auto_resolve_duplicates(**kwargs):
+        auto_resolve_calls.append(kwargs)
+        return {"success": True, "resolved_count": 1, "kept_count": 1, "deleted_count": 1}
+
+    duplicates = _install_stub(
+        "cps.duplicates",
+        {
+            "find_duplicate_books": _legacy_scan,
+            "find_duplicate_books_python": lambda *args, **kwargs: [],
+            "find_duplicate_candidate_ids_sql": lambda *args, **kwargs: [],
+            "find_duplicate_books_sql": lambda *args, **kwargs: [],
+            "auto_resolve_duplicates": _auto_resolve_duplicates,
+        },
+    )
+    cps.duplicates = duplicates
+    _install_stub("cps.services")
+    _install_stub(
+        "cps.services.worker",
+        {
+            "CalibreTask": _CalibreTask,
+            "STAT_CANCELLED": "cancelled",
+            "STAT_ENDED": "ended",
+        },
+    )
+    _install_stub("cps.ub", {"init_db_thread": lambda: None})
+    _install_stub("flask_babel", {"lazy_gettext": lambda text, **kwargs: text % kwargs if kwargs else text})
+    _install_stub("sqlalchemy", {"func": SimpleNamespace(max=lambda value: value)})
+    _install_stub("cwa_db", {"CWA_DB": _TaskCwaDB})
+
+    task_path = pathlib.Path(__file__).resolve().parents[2] / "cps" / "tasks" / "duplicate_scan.py"
+    spec = importlib.util.spec_from_file_location("cps.tasks.duplicate_scan", task_path)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "cps.tasks"
+    sys.modules["cps.tasks.duplicate_scan"] = module
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "CWA_DB", _TaskCwaDB)
+    return module, auto_resolve_calls
+
+
+def test_full_duplicate_scan_rebuilds_index_and_updates_cache(monkeypatch):
+    calls = []
+    module, _auto_resolve_calls = _load_duplicate_scan_module(monkeypatch, calls)
+    _TaskCwaDB.instances = []
+
+    task = module.TaskDuplicateScan(full_scan=True, trigger_type="scheduled", user_id=7)
+    task.run(worker_thread=None)
+
+    assert task.success is True
+    assert task.result_count == 1
+    assert calls == [
+        ("rebuild", _TaskCwaDB.instances[0].cwa_settings),
+        ("groups", False, 7, None),
+        ("groups", True, None, None),
+    ]
+    assert _TaskCwaDB.instances[0].cache_updates == [
+        ([{"title": "Dune", "author": "Frank Herbert", "count": 2, "books": []}], 1, 99)
+    ]
+
+
+def test_full_duplicate_scan_skips_when_ingest_active(monkeypatch):
+    calls = []
+    module, _auto_resolve_calls = _load_duplicate_scan_module(monkeypatch, calls)
+    monkeypatch.setattr(module, "ingest_batch_follow_up_pending", lambda: True)
+
+    task = module.TaskDuplicateScan(full_scan=True, trigger_type="scheduled", user_id=7)
+    task.run(worker_thread=None)
+
+    assert task.success is True
+    assert task.result_count == 0
+    assert task.message == "Duplicate scan skipped: import in progress"
+    assert calls == []
+
+
+def test_scheduled_duplicate_scan_uses_global_unresolved_groups(monkeypatch):
+    calls = []
+    module, _auto_resolve_calls = _load_duplicate_scan_module(monkeypatch, calls)
+    _TaskCwaDB.instances = []
+
+    task = module.TaskDuplicateScan(full_scan=True, trigger_type="scheduled")
+    task.run(worker_thread=None)
+
+    assert task.success is True
+    assert ("groups", False, None, None) in calls
+    assert ("groups", True, None, None) in calls
+
+
+def test_full_duplicate_scan_passes_unresolved_groups_to_auto_resolution(monkeypatch):
+    calls = []
+    module, auto_resolve_calls = _load_duplicate_scan_module(monkeypatch, calls)
+    _TaskCwaDB.instances = []
+
+    task = module.TaskDuplicateScan(full_scan=True, trigger_type="manual", user_id=7)
+    first_db = _TaskCwaDB()
+    first_db.cwa_settings["duplicate_auto_resolve_enabled"] = 1
+    monkeypatch.setattr(module, "CWA_DB", lambda: first_db)
+
+    task.run(worker_thread=None)
+
+    assert auto_resolve_calls
+    assert auto_resolve_calls[0]["duplicate_groups"] == task.found_duplicate_groups
+    assert auto_resolve_calls[0]["user_id"] is None
+    assert auto_resolve_calls[0]["trigger_type"] == "automatic"
+
+
+def _make_legacy_raise(module, monkeypatch):
+    duplicates = sys.modules["cps.duplicates"]
+
+    def _raise_legacy(*args, **kwargs):
+        raise AssertionError("after_import must not call legacy duplicate scans")
+
+    monkeypatch.setattr(duplicates, "find_duplicate_books", _raise_legacy)
+    monkeypatch.setattr(duplicates, "find_duplicate_books_python", _raise_legacy)
+    monkeypatch.setattr(duplicates, "find_duplicate_books_sql", _raise_legacy)
+    if hasattr(module, "find_duplicate_candidate_ids_sql"):
+        monkeypatch.setattr(module, "find_duplicate_candidate_ids_sql", lambda *args, **kwargs: [50, 51])
+
+
+class _BookIdColumn:
+    def __gt__(self, other):
+        return ("book_id_gt", other)
+
+
+class _BookIdQuery:
+    def __init__(self, book_ids, max_book_id=None):
+        self.book_ids = book_ids
+        self.max_book_id = max_book_id if max_book_id is not None else max(book_ids or [0])
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def limit(self, limit):
+        self.book_ids = self.book_ids[:limit]
+        return self
+
+    def all(self):
+        return [(book_id,) for book_id in self.book_ids]
+
+    def scalar(self):
+        return self.max_book_id
+
+
+class _BookIdSession:
+    def __init__(self, book_ids, max_book_id=None):
+        self.book_ids = book_ids
+        self.max_book_id = max_book_id
+
+    def query(self, *args, **kwargs):
+        return _BookIdQuery(self.book_ids, self.max_book_id)
+
+
+def _stub_incremental_book_ids(module, book_ids, max_book_id=None):
+    module.db.Books.id = _BookIdColumn()
+    module.calibre_db.session = _BookIdSession(book_ids, max_book_id=max_book_id)
+
+
+def test_after_import_valid_baseline_merges_index_without_legacy_scans(monkeypatch):
+    calls = []
+    module, _auto_resolve_calls = _load_duplicate_scan_module(monkeypatch, calls)
+    _TaskCwaDB.instances = []
+    _make_legacy_raise(module, monkeypatch)
+    pending_reasons = []
+    merge_calls = []
+
+    baseline_calls = []
+
+    def _baseline(settings, candidate_book_ids=None):
+        baseline_calls.append((settings, list(candidate_book_ids or [])))
+        indexed_count = 2
+        library_count = 3
+        return indexed_count + len(set(candidate_book_ids or [])) >= library_count
+
+    _stub_incremental_book_ids(module, [50], max_book_id=50)
+    monkeypatch.setattr(module, "has_valid_duplicate_index_baseline", _baseline)
+    monkeypatch.setattr(
+        module, "mark_duplicate_index_pending", lambda reason=None: pending_reasons.append(reason) or True
+    )
+    monkeypatch.setattr(
+        module,
+        "merge_affected_groups_into_cache",
+        lambda candidate_book_ids, settings: merge_calls.append((list(candidate_book_ids), settings))
+        or {"updated": True, "pending": False, "merged_count": 1},
+    )
+
+    task = module.TaskDuplicateScan(full_scan=False, trigger_type="after_import", user_id=7)
+    task.run(worker_thread=None)
+
+    assert task.success is True
+    assert task.result_count == 1
+    assert pending_reasons == []
+    assert baseline_calls == [(_TaskCwaDB.instances[0].cwa_settings, [50])]
+    assert merge_calls == [([50], _TaskCwaDB.instances[0].cwa_settings)]
+    assert ("groups", False, 7, [50]) in calls
+
+
+def test_after_import_uses_provided_book_ids_without_candidate_lookup(monkeypatch):
+    calls = []
+    module, _auto_resolve_calls = _load_duplicate_scan_module(monkeypatch, calls)
+    _TaskCwaDB.instances = []
+    _make_legacy_raise(module, monkeypatch)
+    merge_calls = []
+
+    monkeypatch.setattr(module, "has_valid_duplicate_index_baseline", lambda settings, candidate_book_ids=None: True)
+    monkeypatch.setattr(
+        module,
+        "merge_affected_groups_into_cache",
+        lambda candidate_book_ids, settings: merge_calls.append((list(candidate_book_ids), settings))
+        or {"updated": True, "pending": False, "merged_count": 1},
+    )
+
+    task = module.TaskDuplicateScan(full_scan=False, trigger_type="after_import", user_id=7, book_ids=[12, "13", 12])
+    task.run(worker_thread=None)
+
+    assert task.success is True
+    assert merge_calls == [([12, 13], _TaskCwaDB.instances[0].cwa_settings)]
+    assert ("groups", False, 7, [12, 13]) in calls
+
+
+def test_after_import_missing_baseline_marks_pending_after_candidate_lookup(monkeypatch):
+    calls = []
+    module, _auto_resolve_calls = _load_duplicate_scan_module(monkeypatch, calls)
+    _TaskCwaDB.instances = []
+    _make_legacy_raise(module, monkeypatch)
+    pending_reasons = []
+
+    monkeypatch.setattr(
+        module, "has_valid_duplicate_index_baseline", lambda settings, candidate_book_ids=None: False
+    )
+    _stub_incremental_book_ids(module, [50], max_book_id=50)
+    monkeypatch.setattr(
+        module, "mark_duplicate_index_pending", lambda reason=None: pending_reasons.append(reason) or True
+    )
+    _stub_incremental_book_ids(module, [50], max_book_id=50)
+
+    task = module.TaskDuplicateScan(full_scan=False, trigger_type="after_import", user_id=7)
+    task.run(worker_thread=None)
+
+    assert task.success is True
+    assert task.result_count == 0
+    assert pending_reasons == ["after_import without valid duplicate index baseline"]
+    assert calls == []
+
+
+def test_after_import_stale_fingerprint_marks_pending(monkeypatch):
+    calls = []
+    module, _auto_resolve_calls = _load_duplicate_scan_module(monkeypatch, calls)
+    _TaskCwaDB.instances = []
+    _make_legacy_raise(module, monkeypatch)
+    pending_reasons = []
+
+    monkeypatch.setattr(
+        module, "has_valid_duplicate_index_baseline", lambda settings, candidate_book_ids=None: False
+    )
+    _stub_incremental_book_ids(module, [50], max_book_id=50)
+    monkeypatch.setattr(
+        module, "mark_duplicate_index_pending", lambda reason=None: pending_reasons.append(reason) or True
+    )
+
+    task = module.TaskDuplicateScan(full_scan=False, trigger_type="after_import", user_id=7)
+    task.run(worker_thread=None)
+
+    assert task.success is True
+    assert task.message == "Duplicate scan pending: manual scan required"
+    assert pending_reasons == ["after_import without valid duplicate index baseline"]
+    assert calls == []
+
+
+def test_after_import_too_many_new_books_marks_pending(monkeypatch):
+    calls = []
+    module, _auto_resolve_calls = _load_duplicate_scan_module(monkeypatch, calls)
+    _TaskCwaDB.instances = []
+    _make_legacy_raise(module, monkeypatch)
+    pending_reasons = []
+
+    monkeypatch.setattr(module, "has_valid_duplicate_index_baseline", lambda settings, candidate_book_ids=None: True)
+    _stub_incremental_book_ids(module, list(range(1, module.MAX_INCREMENTAL_BOOK_IDS + 2)))
+    monkeypatch.setattr(
+        module, "mark_duplicate_index_pending", lambda reason=None: pending_reasons.append(reason) or True
+    )
+
+    task = module.TaskDuplicateScan(full_scan=False, trigger_type="after_import", user_id=7)
+    task.run(worker_thread=None)
+
+    assert task.success is True
+    assert task.result_count == 0
+    assert pending_reasons == ["after_import incremental book set too large"]
+    assert calls == []
+
+
+def test_after_import_empty_candidate_set_does_not_merge_or_mark_pending(monkeypatch):
+    calls = []
+    module, _auto_resolve_calls = _load_duplicate_scan_module(monkeypatch, calls)
+    _TaskCwaDB.instances = []
+    _make_legacy_raise(module, monkeypatch)
+    pending_reasons = []
+
+    monkeypatch.setattr(module, "has_valid_duplicate_index_baseline", lambda settings, candidate_book_ids=None: True)
+    _stub_incremental_book_ids(module, [])
+    monkeypatch.setattr(
+        module, "mark_duplicate_index_pending", lambda reason=None: pending_reasons.append(reason) or True
+    )
+    monkeypatch.setattr(
+        module,
+        "merge_affected_groups_into_cache",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("merge should not run")),
+    )
+
+    task = module.TaskDuplicateScan(full_scan=False, trigger_type="after_import", user_id=7)
+    task.run(worker_thread=None)
+
+    assert task.success is True
+    assert task.result_count == 0
+    assert pending_reasons == []
+    assert calls == []
+
+
+def test_after_import_merge_failure_marks_pending(monkeypatch):
+    calls = []
+    module, _auto_resolve_calls = _load_duplicate_scan_module(monkeypatch, calls)
+    _TaskCwaDB.instances = []
+    _make_legacy_raise(module, monkeypatch)
+    pending_reasons = []
+
+    monkeypatch.setattr(module, "has_valid_duplicate_index_baseline", lambda settings, candidate_book_ids=None: True)
+    _stub_incremental_book_ids(module, [50], max_book_id=50)
+    monkeypatch.setattr(
+        module, "mark_duplicate_index_pending", lambda reason=None: pending_reasons.append(reason) or True
+    )
+    monkeypatch.setattr(
+        module,
+        "merge_affected_groups_into_cache",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("merge failed")),
+    )
+
+    task = module.TaskDuplicateScan(full_scan=False, trigger_type="after_import", user_id=7)
+    task.run(worker_thread=None)
+
+    assert task.success is True
+    assert task.result_count == 0
+    assert pending_reasons == ["after_import incremental duplicate merge failed"]
+    assert calls == []
+
+
+class _RouteCwaDB:
+    instances = []
+    cache_data = {"scan_pending": True, "duplicate_groups": [], "last_scanned_book_id": 0}
+
+    def __init__(self):
+        self.cwa_settings = {
+            "duplicate_auto_resolve_enabled": 0,
+            "duplicate_auto_resolve_strategy": "newest",
+        }
+        self.invalidated = False
+        self.cache_updates = []
+        self.__class__.instances.append(self)
+
+    def invalidate_duplicate_cache(self):
+        self.invalidated = True
+
+    def get_duplicate_cache(self):
+        return self.__class__.cache_data
+
+    def update_duplicate_cache(self, duplicate_groups, total_count, max_book_id=None):
+        self.cache_updates.append((duplicate_groups, total_count, max_book_id))
+        return True
+
+
+def _load_duplicates_route_module(
+    monkeypatch,
+    calls,
+    baseline_valid=True,
+    render_calls=None,
+    library_has_books=True,
+    ingest_pending=False,
+):
+    _clear_modules()
+    _RouteCwaDB.cache_data = {"scan_pending": not baseline_valid, "duplicate_groups": [], "last_scanned_book_id": 55 if baseline_valid else 0}
+    cps = _install_stub("cps")
+    for name in ("db", "calibre_db", "ub", "config", "helper"):
+        module = _install_stub(f"cps.{name}")
+        setattr(cps, name, module)
+    logger = _install_stub("cps.logger", {"create": lambda: _Logger()})
+    csrf = _install_stub("cps.csrf", {"exempt": lambda fn: fn})
+    cps.logger = logger
+    cps.csrf = csrf
+
+    class _WorkerThread:
+        @staticmethod
+        def add(*args, **kwargs):
+            raise RuntimeError("queue unavailable")
+
+    _install_stub("cps.services")
+    _install_stub(
+        "cps.services.worker",
+        {
+            "WorkerThread": _WorkerThread,
+            "STAT_FINISH_SUCCESS": 0,
+            "STAT_FAIL": 1,
+            "STAT_ENDED": 2,
+            "STAT_CANCELLED": 3,
+        },
+    )
+    _install_stub("cps.admin", {"admin_required": lambda fn: fn})
+    _install_stub("cps.usermanagement", {"login_required_if_no_ano": lambda fn: fn})
+    def _render_title_template(*args, **kwargs):
+        if render_calls is not None:
+            render_calls.append((args, kwargs))
+        return kwargs
+
+    _install_stub("cps.render_template", {"render_title_template": _render_title_template})
+    user = SimpleNamespace(
+        id=7,
+        name="tester",
+        is_authenticated=True,
+        role_admin=lambda: True,
+        role_edit=lambda: True,
+    )
+    _install_stub("cps.cw_login", {"current_user": user})
+
+    class _Blueprint:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        def route(self, *args, **kwargs):
+            return lambda fn: fn
+
+    _install_stub(
+        "flask",
+        {
+            "Blueprint": _Blueprint,
+            "jsonify": lambda payload=None, **kwargs: payload if payload is not None else kwargs,
+            "request": object(),
+            "abort": lambda *args, **kwargs: None,
+        },
+    )
+    _install_stub("flask_babel", {"gettext": lambda text, **kwargs: text % kwargs if kwargs else text})
+    _install_stub("sqlalchemy", {"func": object(), "and_": lambda *args, **kwargs: None, "case": lambda *args, **kwargs: None})
+    _install_stub("sqlalchemy.sql")
+    _install_stub("sqlalchemy.sql.expression", {"true": True, "false": False})
+    _install_stub("sqlalchemy.orm", {"joinedload": lambda *args, **kwargs: None})
+    _install_stub("cwa_db", {"CWA_DB": _RouteCwaDB})
+
+    def _rebuild(settings):
+        calls.append(("rebuild", settings))
+        return {"max_book_id": 55, "indexed_count": 2, "fingerprint": "fp"}
+
+    def _groups(settings, include_dismissed=False, user_id=None, candidate_book_ids=None):
+        calls.append(("groups", include_dismissed, user_id, candidate_book_ids))
+        if not library_has_books:
+            return []
+        return [{"title": "Dune", "author": "Frank Herbert", "count": 2, "books": []}]
+
+    _install_stub(
+        "cps.duplicate_index",
+        {
+            "rebuild_duplicate_index": _rebuild,
+            "get_duplicate_groups_from_index": _groups,
+            "duplicate_index_needs_manual_full_scan": lambda settings: not baseline_valid,
+            "has_valid_duplicate_index_baseline": lambda settings, candidate_book_ids=None: baseline_valid,
+            "library_has_books": lambda: library_has_books,
+            "ingest_batch_follow_up_pending": lambda: ingest_pending,
+        },
+    )
+
+    duplicates_path = pathlib.Path(__file__).resolve().parents[2] / "cps" / "duplicates.py"
+    spec = importlib.util.spec_from_file_location("cps.duplicates", duplicates_path)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "cps"
+    sys.modules["cps.duplicates"] = module
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "CWA_DB", _RouteCwaDB)
+    monkeypatch.setattr(module, "find_duplicate_books", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError))
+    return module
+
+
+def test_duplicates_page_prompts_for_full_scan_when_index_baseline_missing(monkeypatch):
+    calls = []
+    render_calls = []
+    module = _load_duplicates_route_module(monkeypatch, calls, baseline_valid=False, render_calls=render_calls)
+
+    response = module.show_duplicates()
+
+    assert response["duplicate_index_needs_full_scan"] is True
+    assert response["duplicate_groups"] == []
+    assert calls == []
+    assert render_calls
+
+
+def test_duplicates_page_does_not_prompt_for_full_scan_when_library_empty(monkeypatch):
+    calls = []
+    module = _load_duplicates_route_module(monkeypatch, calls, baseline_valid=False, library_has_books=False)
+
+    response = module.show_duplicates()
+
+    assert response["duplicate_index_needs_full_scan"] is False
+    assert response["duplicate_groups"] == []
+    assert calls == [("groups", False, 7, None)]
+
+
+def test_duplicates_page_uses_index_when_baseline_exists(monkeypatch):
+    calls = []
+    module = _load_duplicates_route_module(monkeypatch, calls, baseline_valid=True)
+
+    response = module.show_duplicates()
+
+    assert response["duplicate_index_needs_full_scan"] is False
+    assert response["duplicate_groups"] == [
+        {"title": "Dune", "author": "Frank Herbert", "count": 2, "books": []}
+    ]
+    assert calls == [("groups", False, 7, None)]
+
+
+def test_duplicate_status_ignores_old_cache_when_index_baseline_missing(monkeypatch):
+    calls = []
+    module = _load_duplicates_route_module(monkeypatch, calls, baseline_valid=False)
+    _RouteCwaDB.cache_data = {
+        "scan_pending": False,
+        "duplicate_groups": [
+            {"title": "Dune", "author": "Frank Herbert", "count": 2, "group_hash": "abc"},
+        ],
+        "last_scanned_book_id": 55,
+    }
+
+    response = module.get_duplicate_status()
+
+    assert response["success"] is True
+    assert response["count"] == 0
+    assert response["preview"] == []
+    assert response["cached"] is False
+    assert response["stale"] is True
+    assert response["needs_scan"] is True
+    assert response["needs_full_scan"] is True
+
+
+def test_duplicate_status_does_not_require_scan_when_library_empty(monkeypatch):
+    calls = []
+    module = _load_duplicates_route_module(monkeypatch, calls, baseline_valid=False, library_has_books=False)
+    _RouteCwaDB.cache_data = {
+        "scan_pending": True,
+        "duplicate_groups": [],
+        "last_scanned_book_id": 0,
+    }
+
+    response = module.get_duplicate_status()
+
+    assert response["success"] is True
+    assert response["count"] == 0
+    assert response["cached"] is True
+    assert response["stale"] is True
+    assert response["needs_scan"] is False
+    assert response["needs_full_scan"] is False
+
+
+def test_manual_trigger_sync_fallback_rebuilds_index_and_cache(monkeypatch):
+    calls = []
+    module = _load_duplicates_route_module(monkeypatch, calls)
+    _RouteCwaDB.instances = []
+
+    response = module.trigger_scan()
+
+    assert response["success"] is True
+    assert response["fallback"] is True
+    assert response["count"] == 1
+    assert calls == [
+        ("rebuild", _RouteCwaDB.instances[0].cwa_settings),
+        ("groups", False, 7, None),
+        ("groups", True, None, None),
+    ]
+    assert _RouteCwaDB.instances[0].invalidated is True
+    assert _RouteCwaDB.instances[0].cache_updates == [
+        ([{"title": "Dune", "author": "Frank Herbert", "count": 2, "books": []}], 1, 55)
+    ]
+
+
+def test_manual_trigger_blocks_full_scan_while_ingest_pending(monkeypatch):
+    calls = []
+    module = _load_duplicates_route_module(monkeypatch, calls, ingest_pending=True)
+    _RouteCwaDB.instances = []
+
+    response, status = module.trigger_scan()
+
+    assert status == 409
+    assert response["blocked"] is True
+    assert response["reason"] == "ingest_in_progress"
+    assert calls == []
+    assert _RouteCwaDB.instances == []
+
+
+def test_execute_resolution_blocks_while_ingest_pending(monkeypatch):
+    calls = []
+    module = _load_duplicates_route_module(monkeypatch, calls, ingest_pending=True)
+    flask_module = sys.modules["flask"]
+    flask_module.request = SimpleNamespace(json={"strategy": "newest"})
+    auto_resolve_calls = []
+    monkeypatch.setattr(
+        module,
+        "auto_resolve_duplicates",
+        lambda **kwargs: auto_resolve_calls.append(kwargs) or {"success": True},
+    )
+
+    response, status = module.execute_resolution()
+
+    assert status == 409
+    assert response["blocked"] is True
+    assert response["reason"] == "ingest_in_progress"
+    assert "Import is in progress" in response["message"]
+    assert auto_resolve_calls == []
+
+
+def test_preview_resolution_uses_indexed_duplicate_groups(monkeypatch):
+    calls = []
+    module = _load_duplicates_route_module(monkeypatch, calls)
+    flask_module = sys.modules["flask"]
+    flask_module.request = SimpleNamespace(json={"strategy": "newest"})
+    auto_resolve_calls = []
+    expected_result = {
+        "success": True,
+        "resolved_count": 1,
+        "kept_count": 1,
+        "deleted_count": 1,
+        "errors": [],
+        "preview": [{"title": "Dune"}],
+    }
+    monkeypatch.setattr(
+        module,
+        "auto_resolve_duplicates",
+        lambda **kwargs: auto_resolve_calls.append(kwargs) or expected_result,
+    )
+
+    response = module.preview_resolution()
+
+    assert response == expected_result
+    assert auto_resolve_calls
+    assert auto_resolve_calls[0]["duplicate_groups"] == [
+        {"title": "Dune", "author": "Frank Herbert", "count": 2, "books": []}
+    ]
+    assert auto_resolve_calls[0]["dry_run"] is True
+    assert calls == [("groups", False, 7, None)]
+
+
+def test_execute_resolution_uses_indexed_duplicate_groups(monkeypatch):
+    calls = []
+    module = _load_duplicates_route_module(monkeypatch, calls)
+    flask_module = sys.modules["flask"]
+    flask_module.request = SimpleNamespace(json={"strategy": "newest"})
+    auto_resolve_calls = []
+    monkeypatch.setattr(
+        module,
+        "auto_resolve_duplicates",
+        lambda **kwargs: auto_resolve_calls.append(kwargs) or {"success": True},
+    )
+
+    response = module.execute_resolution()
+
+    assert response["success"] is True
+    assert auto_resolve_calls
+    assert auto_resolve_calls[0]["duplicate_groups"] == [
+        {"title": "Dune", "author": "Frank Herbert", "count": 2, "books": []}
+    ]
+    assert auto_resolve_calls[0]["dry_run"] is False
+    assert calls == [("groups", False, 7, None)]
+
+
+def test_manual_trigger_sync_fallback_passes_unresolved_groups_to_auto_resolution(monkeypatch):
+    calls = []
+    module = _load_duplicates_route_module(monkeypatch, calls)
+    fallback_db = _RouteCwaDB()
+    fallback_db.cwa_settings["duplicate_auto_resolve_enabled"] = 1
+    auto_resolve_calls = []
+
+    monkeypatch.setattr(module, "CWA_DB", lambda: fallback_db)
+    monkeypatch.setattr(
+        module,
+        "auto_resolve_duplicates",
+        lambda **kwargs: auto_resolve_calls.append(kwargs)
+        or {"success": True, "resolved_count": 1, "kept_count": 1, "deleted_count": 1},
+    )
+
+    response = module.trigger_scan()
+
+    assert response["success"] is True
+    assert response["fallback"] is True
+    assert [call[0] for call in calls] == ["rebuild", "groups", "groups", "rebuild", "groups", "groups"]
+    assert auto_resolve_calls
+    assert auto_resolve_calls[0]["duplicate_groups"] == [
+        {"title": "Dune", "author": "Frank Herbert", "count": 2, "books": []}
+    ]
+    assert auto_resolve_calls[0]["user_id"] == 7
+    assert auto_resolve_calls[0]["trigger_type"] == "manual"
+
+
+_modules_snapshot: dict = {}
+
+
+def setup_module(module):
+    _modules_snapshot.clear()
+    _modules_snapshot.update(sys.modules)
+
+
+def teardown_module(module):
+    for name in list(sys.modules):
+        if name not in _modules_snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(_modules_snapshot)

--- a/tests/unit/test_duplicate_scan_queue_settings.py
+++ b/tests/unit/test_duplicate_scan_queue_settings.py
@@ -1,0 +1,311 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from types import ModuleType, SimpleNamespace
+import importlib.util
+import pathlib
+import sys
+
+
+def _install_stub(name, attrs=None):
+    module = ModuleType(name)
+    if attrs:
+        for key, value in attrs.items():
+            setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+class _Blueprint:
+    def __init__(self, *args, **kwargs):
+        return None
+
+    def route(self, *args, **kwargs):
+        return lambda fn: fn
+
+
+class _Logger:
+    def debug(self, *args, **kwargs):
+        return None
+
+    def info(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        return None
+
+    def error(self, *args, **kwargs):
+        return None
+
+
+class _SettingsCwaDB:
+    instances = []
+    default_settings = {
+        "auto_convert_target_format": "epub",
+        "duplicate_detection_title": 1,
+        "duplicate_detection_author": 1,
+        "duplicate_detection_language": 0,
+        "duplicate_detection_series": 0,
+        "duplicate_detection_publisher": 0,
+        "duplicate_detection_format": 0,
+        "duplicate_scan_enabled": 1,
+        "duplicate_scan_frequency": "after_import",
+        "duplicate_scan_debounce_seconds": 60,
+        "koreader_sync_enabled": 0,
+    }
+
+    def __init__(self):
+        self.cwa_default_settings = dict(self.default_settings)
+        self.cwa_settings = dict(self.default_settings)
+        self.updated_settings = None
+        self.__class__.instances.append(self)
+
+    def update_cwa_settings(self, result):
+        self.updated_settings = dict(result)
+        self.cwa_settings.update(result)
+
+    def get_cwa_settings(self):
+        return dict(self.cwa_settings)
+
+    def set_default_settings(self, force=False):
+        self.cwa_settings = dict(self.cwa_default_settings)
+
+
+def _clear_modules():
+    for name in list(sys.modules):
+        if name == "cps" or name.startswith("cps.") or name == "cwa_db":
+            sys.modules.pop(name, None)
+
+
+def _load_cwa_functions(monkeypatch, request):
+    _clear_modules()
+    cps = _install_stub("cps")
+    for name in ("config", "constants", "csrf", "helper", "ub", "calibre_db"):
+        module = _install_stub(f"cps.{name}")
+        setattr(cps, name, module)
+    cps.config.config_kobo_sync_magic_shelves = False
+    cps.config.save = lambda: None
+    cps.helper.get_internal_api_url = lambda path: f"http://localhost{path}"
+    cps.logger = _install_stub("cps.logger", {"create": lambda: _Logger()})
+    cps.csrf.exempt = lambda fn: fn
+
+    _install_stub(
+        "cps.usermanagement",
+        {"login_required_if_no_ano": lambda fn: fn, "user_login_required": lambda fn: fn},
+    )
+    _install_stub("cps.admin", {"admin_required": lambda fn: fn})
+    _install_stub("cps.render_template", {"render_title_template": lambda *args, **kwargs: {"template": args[0]}})
+    _install_stub("cps.cw_login", {"current_user": SimpleNamespace(id=7), "login_user": None, "logout_user": None})
+    _install_stub("cps.web", {"cwa_get_num_books_in_library": lambda: 0})
+    _install_stub("cps.services")
+    _install_stub("cps.services.background_scheduler", {"BackgroundScheduler": lambda: None, "DateTrigger": object})
+    worker_module = _install_stub(
+        "cps.services.worker",
+        {
+            "WorkerThread": SimpleNamespace(add=lambda *args, **kwargs: None),
+            "STAT_FINISH_SUCCESS": 3,
+            "STAT_FAIL": 1,
+            "STAT_ENDED": 4,
+            "STAT_CANCELLED": 5,
+        },
+    )
+    _install_stub("cps.tasks")
+    _install_stub("cps.tasks.database", {"TaskReconnectDatabase": object})
+    _install_stub("cps.tasks.auto_send", {"TaskAutoSend": object})
+    _install_stub("cps.tasks.ops", {"TaskConvertLibraryRun": object, "TaskEpubFixerRun": object})
+    _install_stub("cwa_db", {"CWA_DB": _SettingsCwaDB})
+    _install_stub(
+        "flask",
+        {
+            "Blueprint": _Blueprint,
+            "redirect": lambda *args, **kwargs: None,
+            "flash": lambda *args, **kwargs: None,
+            "url_for": lambda endpoint, **kwargs: endpoint,
+            "request": request,
+            "send_from_directory": lambda *args, **kwargs: None,
+            "abort": lambda *args, **kwargs: None,
+            "jsonify": lambda payload=None, **kwargs: payload if payload is not None else kwargs,
+            "current_app": SimpleNamespace(config={}),
+        },
+    )
+    _install_stub(
+        "flask_babel",
+        {
+            "gettext": lambda text, **kwargs: text % kwargs if kwargs else text,
+            "lazy_gettext": lambda text, **kwargs: text,
+        },
+    )
+    _install_stub(
+        "cps.duplicate_index",
+        {
+            "get_criteria_fingerprint": lambda settings: tuple(
+                int(settings.get(key, 0))
+                for key in (
+                    "duplicate_detection_title",
+                    "duplicate_detection_author",
+                    "duplicate_detection_language",
+                    "duplicate_detection_series",
+                    "duplicate_detection_publisher",
+                    "duplicate_detection_format",
+                )
+            ),
+            "mark_duplicate_index_pending": lambda reason=None: pending_reasons.append(reason) or True,
+        },
+    )
+
+    path = pathlib.Path(__file__).resolve().parents[2] / "cps" / "cwa_functions.py"
+    spec = importlib.util.spec_from_file_location("cps.cwa_functions", path)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "cps"
+    sys.modules["cps.cwa_functions"] = module
+    spec.loader.exec_module(module)
+    module.WorkerThread = worker_module.WorkerThread
+    monkeypatch.setattr(module, "get_next_duplicate_scan_run", lambda settings: None)
+    return module
+
+
+pending_reasons = []
+
+
+def test_internal_duplicate_queue_passes_coalesced_book_ids(monkeypatch):
+    added_tasks = []
+    timers = []
+
+    class _TaskDuplicateScan:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class _ImmediateTimer:
+        def __init__(self, delay, func):
+            self.delay = delay
+            self.func = func
+            self.daemon = False
+            timers.append(self)
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            return None
+
+    request = SimpleNamespace(
+        headers={},
+        remote_addr="127.0.0.1",
+        get_json=lambda force=True, silent=True: {"delay_seconds": 5, "book_ids": [4, "5", 4]},
+    )
+    module = _load_cwa_functions(monkeypatch, request)
+    monkeypatch.setattr(module, "Timer", _ImmediateTimer)
+    module.WorkerThread.add = lambda username, task, hidden=False: added_tasks.append((username, task, hidden))
+    _install_stub("cps.tasks.duplicate_scan", {"TaskDuplicateScan": _TaskDuplicateScan})
+
+    response, status = module.cwa_internal_queue_duplicate_scan()
+    timers[0].func()
+
+    assert status == 200
+    assert response["queued"] is True
+    assert added_tasks[0][1].kwargs["book_ids"] == [4, 5]
+
+
+def test_internal_duplicate_queue_defaults_to_sixty_second_debounce(monkeypatch):
+    timers = []
+
+    class _ImmediateTimer:
+        def __init__(self, delay, func):
+            self.delay = delay
+            self.func = func
+            self.daemon = False
+            timers.append(self)
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            return None
+
+    request = SimpleNamespace(
+        headers={},
+        remote_addr="127.0.0.1",
+        get_json=lambda force=True, silent=True: {},
+    )
+    module = _load_cwa_functions(monkeypatch, request)
+    monkeypatch.setattr(module, "Timer", _ImmediateTimer)
+
+    response, status = module.cwa_internal_queue_duplicate_scan()
+
+    assert status == 200
+    assert response["delay_seconds"] == 60
+    assert timers[0].delay == 60
+
+
+def test_direct_duplicate_queue_helper_defaults_to_settings(monkeypatch):
+    timers = []
+
+    class _ImmediateTimer:
+        def __init__(self, delay, func):
+            self.delay = delay
+            self.func = func
+            self.daemon = False
+            timers.append(self)
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            return None
+
+    request = SimpleNamespace(headers={}, remote_addr="127.0.0.1", get_json=lambda force=True, silent=True: {})
+    module = _load_cwa_functions(monkeypatch, request)
+    monkeypatch.setattr(module, "Timer", _ImmediateTimer)
+
+    response = module.queue_debounced_duplicate_scan(book_ids=[9])
+
+    assert response == {"success": True, "queued": True, "delay_seconds": 60}
+    assert timers[0].delay == 60
+
+
+def test_cwa_settings_criteria_change_marks_duplicate_index_pending(monkeypatch):
+    pending_reasons.clear()
+    request = SimpleNamespace(
+        method="POST",
+        form={"submit_button": "Submit", "auto_convert_target_format": "epub", "duplicate_detection_title": "on"},
+    )
+    module = _load_cwa_functions(monkeypatch, request)
+    _SettingsCwaDB.instances = []
+
+    module.set_cwa_settings()
+
+    assert pending_reasons == ["duplicate criteria settings changed"]
+
+
+def test_cwa_settings_unchanged_criteria_does_not_mark_pending(monkeypatch):
+    pending_reasons.clear()
+    request = SimpleNamespace(
+        method="POST",
+        form={
+            "submit_button": "Submit",
+            "auto_convert_target_format": "epub",
+            "duplicate_detection_title": "on",
+            "duplicate_detection_author": "on",
+        },
+    )
+    module = _load_cwa_functions(monkeypatch, request)
+    _SettingsCwaDB.instances = []
+
+    module.set_cwa_settings()
+
+    assert pending_reasons == []
+
+
+_modules_snapshot: dict = {}
+
+
+def setup_module(module):
+    _modules_snapshot.clear()
+    _modules_snapshot.update(sys.modules)
+
+
+def teardown_module(module):
+    for name in list(sys.modules):
+        if name not in _modules_snapshot:
+            sys.modules.pop(name, None)
+    sys.modules.update(_modules_snapshot)

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -20,6 +20,7 @@ are tested in integration tests instead.
 import pytest
 from unittest.mock import Mock, patch, MagicMock, PropertyMock
 import re
+from types import SimpleNamespace
 
 # Import config for accessing in tests
 from cps import config
@@ -34,7 +35,9 @@ from cps.helper import (
     check_username,
     valid_email,
     valid_password,
-    uniq
+    uniq,
+    delete_book_file,
+    _directory_contains_only_nfs_placeholders,
 )
 
 
@@ -168,6 +171,42 @@ class TestGetValidFilename:
         result = get_valid_filename("Author1|Author2|Author3")
         assert "|" not in result
         assert "," in result  # Pipes become commas
+
+
+class TestDeleteBookFile:
+    """Test file deletion edge cases."""
+
+    def test_directory_contains_only_nfs_placeholders(self, tmp_path):
+        book_dir = tmp_path / "book"
+        book_dir.mkdir()
+        (book_dir / ".nfs.123").write_text("placeholder")
+        (book_dir / ".nfs.456").write_text("placeholder")
+
+        assert _directory_contains_only_nfs_placeholders(str(book_dir)) is True
+
+    def test_directory_contains_only_nfs_placeholders_rejects_regular_files(self, tmp_path):
+        book_dir = tmp_path / "book"
+        book_dir.mkdir()
+        (book_dir / ".nfs.123").write_text("placeholder")
+        (book_dir / "cover.jpg").write_text("cover")
+
+        assert _directory_contains_only_nfs_placeholders(str(book_dir)) is False
+
+    def test_delete_book_file_tolerates_nfs_placeholders_after_unlink(self, tmp_path, monkeypatch):
+        calibre_dir = tmp_path / "library"
+        book_dir = calibre_dir / "Author" / "Book (1)"
+        book_dir.mkdir(parents=True)
+        (book_dir / ".nfs.123").write_text("placeholder")
+        book = SimpleNamespace(id=1, path="Author/Book (1)")
+
+        monkeypatch.setattr("cps.helper.os.walk", lambda path: [(path, [], [])])
+
+        def _raise_directory_not_empty(path):
+            raise OSError(39, "Directory not empty", path)
+
+        monkeypatch.setattr("cps.helper.shutil.rmtree", _raise_directory_not_empty)
+
+        assert delete_book_file(book, str(calibre_dir)) == (True, None)
 
 
 # ============================================================================

--- a/tests/unit/test_ingest_batch_dirty.py
+++ b/tests/unit/test_ingest_batch_dirty.py
@@ -43,6 +43,7 @@ def test_successful_import_marks_batch_dirty_without_hot_loop_http_calls(monkeyp
     scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
     monkeypatch.syspath_prepend(str(scripts_dir))
     monkeypatch.setenv("CWA_INGEST_BATCH_DIRTY_FILE", str(tmp_path / "batch_dirty"))
+    monkeypatch.setenv("CWA_INGEST_BATCH_ACTIVE_FILE", str(tmp_path / "batch_active"))
     monkeypatch.setenv("CWA_METADATA_LOCK_DIR", str(tmp_path))
 
     import ingest_processor
@@ -65,11 +66,14 @@ def test_successful_import_marks_batch_dirty_without_hot_loop_http_calls(monkeyp
         mock.patch.object(ingest_processor, "gdrive_sync_if_enabled"), \
         mock.patch.object(processor, "fetch_metadata_if_enabled"), \
         mock.patch.object(processor, "trigger_auto_send_if_enabled"), \
-        mock.patch.object(processor, "generate_book_checksums"):
+        mock.patch.object(processor, "generate_book_checksums"), \
+        mock.patch.object(ingest_processor, "wait_for_duplicate_full_scan_to_finish") as wait_mock:
         processor.add_book_to_library(str(source))
 
+    wait_mock.assert_called_once()
     assert run_mock.call_args.args[0][:2] == ["calibredb", "add"]
     assert (tmp_path / "batch_dirty").exists()
+    assert not (tmp_path / "batch_active").exists()
     assert processor.db.entries == [("source", "False")]
 
     called_urls = [call.args[0] for call in requests_mock.post.call_args_list if call.args]
@@ -82,6 +86,7 @@ def test_failed_import_does_not_mark_batch_dirty(monkeypatch, tmp_path):
     scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
     monkeypatch.syspath_prepend(str(scripts_dir))
     monkeypatch.setenv("CWA_INGEST_BATCH_DIRTY_FILE", str(tmp_path / "batch_dirty"))
+    monkeypatch.setenv("CWA_INGEST_BATCH_ACTIVE_FILE", str(tmp_path / "batch_active"))
     monkeypatch.setenv("CWA_METADATA_LOCK_DIR", str(tmp_path))
 
     import ingest_processor
@@ -101,6 +106,7 @@ def test_failed_import_does_not_mark_batch_dirty(monkeypatch, tmp_path):
         processor.add_book_to_library(str(source))
 
     assert not (tmp_path / "batch_dirty").exists()
+    assert not (tmp_path / "batch_active").exists()
     backup_mock.assert_called_once()
 
 
@@ -108,6 +114,7 @@ def test_successful_add_format_marks_batch_dirty(monkeypatch, tmp_path):
     scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
     monkeypatch.syspath_prepend(str(scripts_dir))
     monkeypatch.setenv("CWA_INGEST_BATCH_DIRTY_FILE", str(tmp_path / "batch_dirty"))
+    monkeypatch.setenv("CWA_INGEST_BATCH_ACTIVE_FILE", str(tmp_path / "batch_active"))
     monkeypatch.setenv("CWA_METADATA_LOCK_DIR", str(tmp_path))
 
     import ingest_processor
@@ -126,8 +133,11 @@ def test_successful_add_format_marks_batch_dirty(monkeypatch, tmp_path):
 
     with mock.patch.object(processor, "_validate_book_exists", return_value=True), \
         mock.patch.object(ingest_processor.subprocess, "run", return_value=result) as run_mock, \
-        mock.patch.object(ingest_processor, "gdrive_sync_if_enabled"):
+        mock.patch.object(ingest_processor, "gdrive_sync_if_enabled"), \
+        mock.patch.object(ingest_processor, "wait_for_duplicate_full_scan_to_finish") as wait_mock:
         processor.add_format_to_book(7, str(source))
 
+    wait_mock.assert_called_once()
     assert run_mock.call_args.args[0][:3] == ["calibredb", "add_format", "7"]
     assert (tmp_path / "batch_dirty").exists()
+    assert not (tmp_path / "batch_active").exists()


### PR DESCRIPTION
## Symptom

On libraries with 10k+ books, opening the Duplicates page or letting an after-import duplicate scan run held the SQLite connection through a full-library scan. With our deadlock vector eliminated in v4.0.66 (PR #212), the scan was no longer crashing — but it was still slow, blocking other requests while it ran, and rebuilding the entire duplicate group set on every change.

## Root cause

Stock CWA's duplicate detection is O(N) over the book table: every scan rebuilds groups from scratch by re-normalising title/author/series/publisher/format for every book and bucketing into duplicate groups. The cache is invalidated on every import/edit/delete and the next view triggers another full scan.

## Fix

@navels' upstream CWA #1353 replaces the O(N) scan with an O(1) maintained index:

1. New `cwa_duplicate_book_keys` SQL table — one row per book with normalized keys + a criteria-aware fingerprint.
2. New `cps/duplicate_index.py` (+578 LOC) — upsert/delete book keys, rebuild on settings change, query duplicate groups directly from indexed rows.
3. Each book import (`add_book_to_library` / `add_format_to_book`) now calls `run_duplicate_scan_for_books([book_id])` inline — single-book index upsert in milliseconds instead of full-library scan.
4. Manual scans and ingest interlock via a new `cwa_ingest_batch_active` marker file + `wait_for_duplicate_full_scan_to_finish()` — ingest waits for any running full scan; manual full scans block during active ingest.
5. Duplicates page renders a one-time-baseline-scan notice on fresh installs; replaces alert dialogs with Bootstrap-modal feedback (`Resolution Preview`, success/error modals).

## Fork reconciliation

Backported on top of significant fork divergence in the ingest pipeline:

- **Preserves PR #199** metadata.db flock (`metadata_db_write_lock()` + `_run_calibredb_add_with_retry`) — required for fork issue #192 on mergerfs/SMB/NFS where SQLite's fcntl locks silently fail.
- **Preserves PR #210** debounce default 30 + clamp floor 10 across all 5 mirrored sites (schema, 3 Python fallbacks, template). Upstream's 60/5 is strictly safer in stock CWA but our PR #212 already eliminated the deadlock vector that motivated the conservative default; existing fork users on 30 stay at 30, no new migration.
- **Preserves PR #212** SQLite UDF connect-event listener (no `TaskReconnectDatabase` re-import). Adopts `STAT_FINISH_SUCCESS, STAT_FAIL, STAT_ENDED, STAT_CANCELLED` to power @navels' new `_duplicate_full_scan_running()` worker-state check.
- **Preserves PR #37/#56** `s6-setuidgid abc` privilege drop on the ingest worker.
- **Preserves v4.0.74 / v4.0.75** fast-exit pattern (`_is_missing_ingest_target` before lock acquisition + `_load_fork_cps_imports` deferred cps imports). Reordered active-marker calls in `add_book_to_library` so flock acquisition still wraps the calibredb call, with the active marker + wait-for-full-scan check happening first.
- **Preserves PR #100** batched cache invalidation semantics. Switches the mechanism in `delete_selected_books` / `merge_list_book` from per-batch `invalidate_duplicate_cache()` to per-batch `_queue_duplicate_scan_after_change(book_ids)` — still exactly one call per batch (not per-book), just scoped to the affected book IDs now. `delete_book_from_table`'s skip-flag guard tightened to `if not skip_cache_invalidation and not refreshed_duplicate_cache` to avoid double-invalidate when the new indexed refresh handled it.
- **Simplifies `run_post_batch_follow_up()`** to `/cwa-internal/reconnect-db` only — the deferred `invalidate-cache` + `queue-duplicate-scan` calls from #1349 are redundant in the new architecture (per-book incremental scans happen inline during ingest).

## Verification

**173 unit tests** pass (21 new + 4 + 17 + 11 in dedicated index test files, 3 updated in `test_ingest_batch_dirty.py` for the active marker + wait-for-full-scan path, 8 updated in `test_helper.py`, 3 updated PR #100 regression pins in `test_duplicate_manager_race_fix.py`).

**Live container exercise on cwn-local:**
- Schema migration applied idempotently: `cwa_duplicate_book_keys` table + index created on first container start; subsequent restarts are no-ops.
- Baseline full scan: 15 books indexed with normalized title + composite duplicate_key + criteria fingerprint.
- Duplicates page: identifies "Alice's Adventures in Wonderland" (5 duplicates) + "The Republic" (2 duplicates) from the index.
- "Run Full Duplicate Scan" baseline notice shows correctly on fresh installs; disappears after first scan.
- Resolution Preview modal (replaces `alert()`) renders KEEP/DELETE per-book breakdown with timestamps + formats in 0.02s for 2 groups.
- Sidebar "Duplicates: 2" badge updates from the indexed cache.
- Per-book incremental scan via `POST /cwa-internal/run-duplicate-scan` `{"book_ids":[5,12,14,15,16]}` returns `{"message":"Duplicate scan completed: 1 new groups","result_count":1,"success":true}`.
- `POST /cwa-internal/duplicate-scan-status` returns `{"full_scan_running":false,"success":true}`.
- No console errors, no traceback in container logs.

**Cross-cutting sweep:**
- OPDS (200), /health (200), /tasks (302), /admin/view (302), /duplicates (200 authed), /duplicates/status (200 authed) all responding.
- Fork-critical patterns preserved (verified via grep): `metadata_db_write_lock`, `_run_calibredb_add_with_retry`, `s6-setuidgid abc`, debounce 30 + clamp 10 across all 5 sites.

## Confidence

~95% — verified end-to-end on cwn-local with the user-visible flow (baseline scan, Duplicates page, Preview modal) working as designed. The architectural change is internal to duplicate detection; adjacent subsystems (Kobo sync, OPDS, edit-book flow) verified unaffected via route smoke + log scan.

Inspired-by @navels in https://github.com/crocodilestick/Calibre-Web-Automated/pull/1353