### PR TITLE
H1 Phase 1 (P1): extend kobo_annotation_sync schema for highlight import + web-reader sync

### DIFF
--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -458,7 +458,8 @@ def process_annotation_for_sync(
                                 hardcover_journal_id=result.get('id'),
                                 highlighted_text=highlighted_text,
                                 note_text=note_text,
-                                highlight_color=highlight_color
+                                highlight_color=highlight_color,
+                                source='hardcover',
                             )
                             ub.session.add(sync_record)
                         ub.session_commit()

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -32,7 +32,7 @@ except ImportError as e:
         oauth_support = False
 from sqlalchemy import create_engine, exc, exists, event, text
 from sqlalchemy import Column, ForeignKey, Index, UniqueConstraint
-from sqlalchemy import String, Integer, SmallInteger, Boolean, DateTime, Float, JSON
+from sqlalchemy import String, Integer, SmallInteger, Boolean, DateTime, Float, JSON, Text
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.sql.expression import func
 try:
@@ -831,7 +831,18 @@ class KoboStatistics(Base):
 
 
 class KoboAnnotationSync(Base):
-    """Track which Kobo annotations have been synced to external services (e.g., Hardcover)."""
+    """Per-user-per-annotation record for Kobo highlights/notes.
+
+    Originally added for the Hardcover annotation backports (CWA #1166 +
+    #1324) — those fields are ``synced_to_hardcover`` + ``hardcover_journal_id``
+    plus the inline ``highlighted_text`` / ``highlight_color`` / ``note_text``.
+
+    H1 Phase 1 extends this table to be the source-of-truth for ALL highlight
+    ingestion paths (Kobo device upload, web reader, KOReader plugin) — see
+    ``notes/KOBO-WEB-READER-ANNOTATIONS-DESIGN.md``. The position fields below
+    are nullable so pre-H1 Hardcover-sync rows continue to work; the import
+    path populates them when available.
+    """
     __tablename__ = 'kobo_annotation_sync'
 
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -845,7 +856,20 @@ class KoboAnnotationSync(Base):
     highlighted_text = Column(String, nullable=True)
     highlight_color = Column(String, nullable=True)
     note_text = Column(String, nullable=True)
-    
+    # H1 Phase 1 — Kobo-native position fields (also used for re-anchoring).
+    content_id = Column(String, nullable=True)  # chapter pointer "<book_uuid>!!<chapter_file>"
+    start_container_path = Column(Text, nullable=True)
+    start_container_child_index = Column(Integer, nullable=True)
+    start_offset = Column(Integer, nullable=True)
+    end_container_path = Column(Text, nullable=True)
+    end_container_child_index = Column(Integer, nullable=True)
+    end_offset = Column(Integer, nullable=True)
+    context_string = Column(Text, nullable=True)  # ±50 chars around highlight, for re-anchoring
+    chapter_progress = Column(Float, nullable=True)  # 0.0-1.0 within chapter
+    cfi_range = Column(String, nullable=True)  # epub.js native; computed from Kobo coords at insert time
+    source = Column(String, nullable=True)  # 'kobo' | 'webreader' | 'koreader' | 'hardcover'
+    hidden = Column(Boolean, default=False, nullable=True)  # soft-delete flag
+
     __table_args__ = (
         Index('ix_kobo_annotation_sync_user_annotation', 'user_id', 'annotation_id'),
         Index('ix_kobo_annotation_sync_user_book', 'user_id', 'book_id'),
@@ -1683,6 +1707,79 @@ def migrate_book_cover_preview_table(engine, _session):
             print(f"[cover-preview-migration] Could not create idx_bcp_user_locked: {e}", flush=True)
 
 
+def migrate_kobo_annotation_sync_h1_columns(engine, _session):
+    """H1 Phase 1: extend ``kobo_annotation_sync`` with position + source
+    tracking columns for the Kobo highlight import / view / web-reader
+    sync pipeline (see notes/KOBO-WEB-READER-ANNOTATIONS-DESIGN.md §1.1).
+
+    Pre-H1 the table only carried Hardcover-sync fields (CWA #1166, #1324):
+    ``synced_to_hardcover`` + ``hardcover_journal_id`` + inline
+    ``highlighted_text`` / ``highlight_color`` / ``note_text``. H1 reuses
+    the same table as the source-of-truth for ALL highlight ingestion
+    paths; the columns added here are nullable so existing Hardcover-sync
+    rows keep working untouched.
+
+    All ADDs are individually conditional on column-existence, so this
+    migration is idempotent — re-running it is a no-op.
+    """
+    from sqlalchemy import inspect as sa_inspect
+
+    inspector = sa_inspect(engine)
+    if "kobo_annotation_sync" not in inspector.get_table_names():
+        # Fresh install — Base.metadata.create_all already produced the
+        # full schema; nothing to migrate.
+        return
+
+    existing_cols = {c["name"] for c in inspector.get_columns("kobo_annotation_sync")}
+
+    # column name → DDL fragment (must omit leading "ALTER TABLE foo ADD COLUMN")
+    pending = [
+        ("content_id",                  "content_id VARCHAR"),
+        ("start_container_path",        "start_container_path TEXT"),
+        ("start_container_child_index", "start_container_child_index INTEGER"),
+        ("start_offset",                "start_offset INTEGER"),
+        ("end_container_path",          "end_container_path TEXT"),
+        ("end_container_child_index",   "end_container_child_index INTEGER"),
+        ("end_offset",                  "end_offset INTEGER"),
+        ("context_string",              "context_string TEXT"),
+        ("chapter_progress",            "chapter_progress REAL"),
+        ("cfi_range",                   "cfi_range VARCHAR"),
+        ("source",                      "source VARCHAR"),
+        ("hidden",                      "hidden BOOLEAN DEFAULT 0"),
+    ]
+
+    statements = [
+        f"ALTER TABLE kobo_annotation_sync ADD COLUMN {ddl}"
+        for col, ddl in pending
+        if col not in existing_cols
+    ]
+    if not statements:
+        return
+
+    try:
+        _run_ddl_with_retry(engine, statements)
+    except Exception as e:
+        log.error("[kobo-annotation-sync-h1-migration] ADD COLUMN failed: %s", e)
+        return
+
+    # Backfill source='hardcover' for pre-H1 rows so the import path can
+    # distinguish them from new ingestion sources without scanning all
+    # five Hardcover-specific columns. Only touches rows that didn't get
+    # a source set later (idempotent under re-runs).
+    try:
+        with engine.connect() as conn:
+            trans = conn.begin()
+            conn.execute(text(
+                "UPDATE kobo_annotation_sync SET source = 'hardcover' "
+                "WHERE source IS NULL AND synced_to_hardcover = 1"
+            ))
+            trans.commit()
+    except Exception as e:
+        log.warning(
+            "[kobo-annotation-sync-h1-migration] source backfill failed: %s", e
+        )
+
+
 def migrate_Database(_session):
     engine = _session.bind
     add_missing_tables(engine, _session)
@@ -1695,6 +1792,7 @@ def migrate_Database(_session):
     migrate_magic_shelf_table(engine, _session)
     migrate_kobo_unique_constraints(engine, _session)
     migrate_kobo_deleted_book(engine, _session)
+    migrate_kobo_annotation_sync_h1_columns(engine, _session)
     migrate_book_cover_preview_table(engine, _session)
 
     # Ensure progress syncing tables in app.db (user-related tables)

--- a/tests/unit/test_kobo_annotation_sync_h1_schema.py
+++ b/tests/unit/test_kobo_annotation_sync_h1_schema.py
@@ -1,0 +1,357 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for the H1 Phase 1 schema migration on
+``kobo_annotation_sync`` (extends the Hardcover-sync table with Kobo-native
+position columns + source tracking — see
+``notes/KOBO-WEB-READER-ANNOTATIONS-DESIGN.md`` §1.1).
+
+Coverage:
+
+1. The ``KoboAnnotationSync`` model declares the 12 new H1 columns.
+2. ``migrate_kobo_annotation_sync_h1_columns`` adds missing columns to a
+   pre-H1 (Hardcover-only) schema and backfills ``source='hardcover'`` for
+   rows that came from the Hardcover sync path.
+3. The migration is idempotent — running it twice on the same DB is a
+   no-op and doesn't damage existing data.
+4. Pre-existing Hardcover-sync rows are readable through the new model
+   (the position fields default to ``None``, no constraint violations).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import sessionmaker
+
+
+# --- Helpers ---------------------------------------------------------------
+
+# The exact schema kobo_annotation_sync had BEFORE the H1 migration ran.
+# Matches the production app.db on teenyverse pre-v4.0.78 (verified via
+# `sqlite3 .schema kobo_annotation_sync` on 2026-05-18).
+PRE_H1_SCHEMA = """
+CREATE TABLE kobo_annotation_sync (
+    id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    annotation_id VARCHAR NOT NULL,
+    book_id INTEGER NOT NULL,
+    synced_to_hardcover BOOLEAN,
+    hardcover_journal_id INTEGER,
+    created_at DATETIME,
+    last_synced DATETIME,
+    highlighted_text VARCHAR,
+    highlight_color VARCHAR,
+    note_text VARCHAR,
+    PRIMARY KEY (id),
+    FOREIGN KEY(user_id) REFERENCES user (id)
+)
+"""
+
+PRE_H1_INDEX_USER_ANN = (
+    "CREATE INDEX ix_kobo_annotation_sync_user_annotation "
+    "ON kobo_annotation_sync (user_id, annotation_id)"
+)
+PRE_H1_INDEX_USER_BOOK = (
+    "CREATE INDEX ix_kobo_annotation_sync_user_book "
+    "ON kobo_annotation_sync (user_id, book_id)"
+)
+
+H1_NEW_COLUMNS = {
+    "content_id",
+    "start_container_path",
+    "start_container_child_index",
+    "start_offset",
+    "end_container_path",
+    "end_container_child_index",
+    "end_offset",
+    "context_string",
+    "chapter_progress",
+    "cfi_range",
+    "source",
+    "hidden",
+}
+
+
+def _build_pre_h1_db():
+    """Spin up an in-memory SQLite that matches the pre-H1 production
+    schema, with a couple of rows so we can verify they survive the
+    migration."""
+    engine = create_engine("sqlite:///:memory:", future=True)
+    with engine.connect() as conn:
+        conn.exec_driver_sql("PRAGMA foreign_keys = OFF")
+        conn.exec_driver_sql(PRE_H1_SCHEMA)
+        conn.exec_driver_sql(PRE_H1_INDEX_USER_ANN)
+        conn.exec_driver_sql(PRE_H1_INDEX_USER_BOOK)
+        # Two rows the Hardcover sync path would have inserted.
+        conn.exec_driver_sql(
+            "INSERT INTO kobo_annotation_sync (user_id, annotation_id, book_id, "
+            "synced_to_hardcover, hardcover_journal_id, highlighted_text, "
+            "highlight_color, note_text) "
+            "VALUES (1, 'aaa-111', 42, 1, 9001, 'animal farm passage', "
+            "'yellow', 'my note')"
+        )
+        conn.exec_driver_sql(
+            "INSERT INTO kobo_annotation_sync (user_id, annotation_id, book_id, "
+            "synced_to_hardcover, hardcover_journal_id, highlighted_text) "
+            "VALUES (1, 'bbb-222', 42, 0, NULL, 'another passage')"
+        )
+        conn.commit()
+    return engine
+
+
+# --- 1. Model declaration --------------------------------------------------
+
+
+@pytest.mark.unit
+class TestKoboAnnotationSyncModelDeclaration:
+    """Pin the SQLAlchemy model — H1 columns must be declared on the
+    ``KoboAnnotationSync`` class so ORM-level reads/writes see them."""
+
+    def test_model_declares_all_h1_columns(self):
+        from cps.ub import KoboAnnotationSync
+
+        declared = {c.name for c in KoboAnnotationSync.__table__.columns}
+        missing = H1_NEW_COLUMNS - declared
+        assert not missing, f"H1 columns missing from model: {sorted(missing)}"
+
+    def test_h1_columns_are_nullable(self):
+        from cps.ub import KoboAnnotationSync
+
+        cols_by_name = {c.name: c for c in KoboAnnotationSync.__table__.columns}
+        # Every H1 addition must be nullable so pre-H1 rows continue to
+        # satisfy NOT NULL constraints.
+        for name in H1_NEW_COLUMNS:
+            assert cols_by_name[name].nullable, (
+                f"Column {name!r} must be nullable to preserve pre-H1 rows"
+            )
+
+    def test_position_columns_are_correct_types(self):
+        """Pin column SQL types so a future refactor can't quietly change
+        them (a Kobo position swapping Integer↔String would silently break
+        the CFI converter)."""
+        from cps.ub import KoboAnnotationSync
+
+        cols = {c.name: c for c in KoboAnnotationSync.__table__.columns}
+        # Integer-typed positions
+        for name in (
+            "start_container_child_index",
+            "start_offset",
+            "end_container_child_index",
+            "end_offset",
+        ):
+            assert cols[name].type.__class__.__name__ in {"Integer", "INTEGER"}, (
+                f"{name} must be Integer-typed, got {type(cols[name].type).__name__}"
+            )
+        # Float-typed progress
+        assert cols["chapter_progress"].type.__class__.__name__ in {"Float", "FLOAT"}, (
+            "chapter_progress must be Float-typed"
+        )
+
+
+# --- 2. Migration adds missing columns + backfills source ------------------
+
+
+@pytest.mark.unit
+class TestH1MigrationOnPreH1Database:
+    """End-to-end: run the migration against a pre-H1 schema and verify
+    columns appear with the correct types AND existing rows survive AND
+    Hardcover rows get their ``source`` backfilled."""
+
+    def test_migration_adds_all_h1_columns(self):
+        from cps import ub
+
+        engine = _build_pre_h1_db()
+        Session = sessionmaker(bind=engine, future=True)
+        session = Session()
+
+        # Sanity: pre-migration the new columns must NOT exist (otherwise
+        # this test would be coverage theatre — passing with no fix).
+        insp = inspect(engine)
+        pre_cols = {c["name"] for c in insp.get_columns("kobo_annotation_sync")}
+        assert H1_NEW_COLUMNS.isdisjoint(pre_cols), (
+            "Test bug: pre-H1 schema already has H1 columns"
+        )
+
+        ub.migrate_kobo_annotation_sync_h1_columns(engine, session)
+
+        post_cols = {c["name"] for c in inspect(engine).get_columns("kobo_annotation_sync")}
+        missing = H1_NEW_COLUMNS - post_cols
+        assert not missing, f"Migration failed to add: {sorted(missing)}"
+
+    def test_pre_h1_rows_survive_migration(self):
+        from cps import ub
+
+        engine = _build_pre_h1_db()
+        Session = sessionmaker(bind=engine, future=True)
+        session = Session()
+
+        ub.migrate_kobo_annotation_sync_h1_columns(engine, session)
+
+        with engine.connect() as conn:
+            count = conn.exec_driver_sql(
+                "SELECT COUNT(*) FROM kobo_annotation_sync"
+            ).scalar()
+            assert count == 2
+
+            # The Hardcover-specific fields are untouched.
+            row = conn.exec_driver_sql(
+                "SELECT highlighted_text, highlight_color, note_text, "
+                "synced_to_hardcover, hardcover_journal_id "
+                "FROM kobo_annotation_sync WHERE annotation_id = 'aaa-111'"
+            ).fetchone()
+            assert row == ("animal farm passage", "yellow", "my note", 1, 9001)
+
+            # The new columns are NULL on pre-H1 rows.
+            row2 = conn.exec_driver_sql(
+                "SELECT content_id, start_offset, cfi_range, hidden "
+                "FROM kobo_annotation_sync WHERE annotation_id = 'aaa-111'"
+            ).fetchone()
+            # hidden has a SQL-level DEFAULT 0 so it's not strictly NULL —
+            # but for ALTER TABLE ADD COLUMN ... DEFAULT, SQLite back-fills
+            # the literal default into all existing rows.
+            assert row2[0] is None
+            assert row2[1] is None
+            assert row2[2] is None
+            assert row2[3] in (0, False)
+
+    def test_source_backfilled_for_hardcover_rows(self):
+        """The Hardcover sync path is the only writer to this table
+        pre-H1, so its rows are the unambiguous backfill candidates. After
+        the migration, rows with ``synced_to_hardcover = 1`` get
+        ``source = 'hardcover'``; the un-synced row is left NULL so a
+        subsequent ingestion path can claim it."""
+        from cps import ub
+
+        engine = _build_pre_h1_db()
+        Session = sessionmaker(bind=engine, future=True)
+        session = Session()
+
+        ub.migrate_kobo_annotation_sync_h1_columns(engine, session)
+
+        with engine.connect() as conn:
+            synced_source = conn.exec_driver_sql(
+                "SELECT source FROM kobo_annotation_sync WHERE annotation_id = 'aaa-111'"
+            ).scalar()
+            unsynced_source = conn.exec_driver_sql(
+                "SELECT source FROM kobo_annotation_sync WHERE annotation_id = 'bbb-222'"
+            ).scalar()
+
+        assert synced_source == "hardcover"
+        assert unsynced_source is None
+
+    def test_migration_idempotent(self):
+        from cps import ub
+
+        engine = _build_pre_h1_db()
+        Session = sessionmaker(bind=engine, future=True)
+        session = Session()
+
+        ub.migrate_kobo_annotation_sync_h1_columns(engine, session)
+        # Inject a row that simulates a non-Hardcover origin AFTER the
+        # first migration ran, so we can prove the second run doesn't
+        # clobber it.
+        with engine.connect() as conn:
+            conn.exec_driver_sql(
+                "INSERT INTO kobo_annotation_sync (user_id, annotation_id, book_id, "
+                "synced_to_hardcover, highlighted_text, source) "
+                "VALUES (1, 'ccc-333', 42, 0, 'web-reader hl', 'webreader')"
+            )
+            conn.commit()
+
+        # Re-run: must not raise, must not damage rows.
+        ub.migrate_kobo_annotation_sync_h1_columns(engine, session)
+
+        with engine.connect() as conn:
+            webreader_source = conn.exec_driver_sql(
+                "SELECT source FROM kobo_annotation_sync WHERE annotation_id = 'ccc-333'"
+            ).scalar()
+        assert webreader_source == "webreader", (
+            "Second migration run must not overwrite an already-set source"
+        )
+
+
+# --- 3. ORM-level read+write through the new columns -----------------------
+
+
+@pytest.mark.unit
+class TestModelORMRoundTrip:
+    """The migration is only useful if the model can actually read/write
+    the new columns via SQLAlchemy. This catches schema/model drift —
+    e.g. a column-name typo where DDL says ``cfi_range`` but the model
+    says ``cfi_rang`` would silently fail at SELECT time."""
+
+    def test_full_h1_record_round_trips_through_orm(self):
+        from cps import ub
+
+        engine = create_engine("sqlite:///:memory:", future=True)
+        with engine.connect() as conn:
+            conn.exec_driver_sql("PRAGMA foreign_keys = OFF")
+        ub.Base.metadata.create_all(engine)
+
+        Session = sessionmaker(bind=engine, future=True)
+        session = Session()
+
+        record = ub.KoboAnnotationSync(
+            user_id=7,
+            annotation_id="dead-beef-1234",
+            book_id=348,  # Animal Farm in Maggie's library
+            highlighted_text="All animals are equal",
+            highlight_color="yellow",
+            note_text="key thesis",
+            content_id="b3d1b38b-74fd-43b7-a796-996e5a6a8b04!!chapter6.html",
+            start_container_path="span#kobo\\.4\\.1",
+            start_container_child_index=-99,
+            start_offset=0,
+            end_container_path="span#kobo\\.4\\.2",
+            end_container_child_index=-99,
+            end_offset=116,
+            context_string="...All animals are equal but some animals are more equal...",
+            chapter_progress=0.024,
+            cfi_range="epubcfi(/6/18!/4[kobo.4.1]:0,/4[kobo.4.2]:116)",
+            source="kobo",
+            hidden=False,
+        )
+        session.add(record)
+        session.commit()
+
+        # Read back through a fresh session to defeat identity-map caching.
+        session2 = Session()
+        row = session2.query(ub.KoboAnnotationSync).filter_by(annotation_id="dead-beef-1234").one()
+        assert row.cfi_range == "epubcfi(/6/18!/4[kobo.4.1]:0,/4[kobo.4.2]:116)"
+        assert row.start_offset == 0
+        assert row.end_offset == 116
+        assert row.chapter_progress == 0.024
+        assert row.source == "kobo"
+        assert row.hidden in (0, False)
+
+
+# --- 4. Hardcover sync path tags new rows with source='hardcover' ---------
+
+
+@pytest.mark.unit
+class TestHardcoverSyncTagsSource:
+    """Source-pin: the Hardcover annotation sync path in
+    ``cps/readingservices.py::process_annotation_for_sync`` must pass
+    ``source='hardcover'`` when constructing a new ``KoboAnnotationSync``.
+
+    Without this, every Hardcover-sync row gets ``source=NULL`` at insert
+    time — the migration backfill only labels CURRENT rows at restart,
+    not rows created between restarts. Source-pinning the constructor
+    keeps the source column meaningful for the H1 import path's
+    deduplication and source-of-truth logic.
+    """
+
+    def test_readingservices_constructor_passes_source(self):
+        import inspect as py_inspect
+        from cps import readingservices
+
+        src = py_inspect.getsource(readingservices)
+        # The constructor block must include source='hardcover'.
+        assert "source='hardcover'" in src or 'source="hardcover"' in src, (
+            "readingservices.py must tag new Hardcover-sync rows with "
+            "source='hardcover'; otherwise they appear as un-sourced "
+            "until the next migrate_Database run backfills them"
+        )


### PR DESCRIPTION
## Symptom

Phase 1 of H1 — the headline Kobo highlight import/view/export feature. Closes CW #2155 (26 reactions, the single largest Kobo feature request anywhere) once the full P1–P5 bundle ships; this PR is the foundation.

## What this PR does

Adds the schema columns that the import + view + web-reader pipeline needs to the existing ``kobo_annotation_sync`` table (originally added by CWA #1166 + #1324 for Hardcover annotation sync — we reuse rather than fork a new table).

**New columns (all nullable):**

| Column | Type | Purpose |
|---|---|---|
| ``content_id`` | VARCHAR | chapter pointer `<book_uuid>!!<chapter_file>` |
| ``start_container_path`` | TEXT | Kobo-native position |
| ``start_container_child_index`` | INTEGER | DOM index sentinel (``-99`` = use selector) |
| ``start_offset`` | INTEGER | character offset within span |
| ``end_container_path`` | TEXT | terminal span (multi-span highlights) |
| ``end_container_child_index`` | INTEGER | terminal-span DOM index |
| ``end_offset`` | INTEGER | terminal-span character offset |
| ``context_string`` | TEXT | ±50 chars around highlight for re-anchoring |
| ``chapter_progress`` | REAL | 0.0–1.0 within chapter |
| ``cfi_range`` | VARCHAR | epub.js native CFI (computed by P2's converter) |
| ``source`` | VARCHAR | ``kobo`` / ``webreader`` / ``koreader`` / ``hardcover`` |
| ``hidden`` | BOOLEAN DEFAULT 0 | soft-delete flag |

Existing Hardcover-sync rows stay untouched (every new column is nullable). The migration also backfills ``source='hardcover'`` on existing rows where ``synced_to_hardcover = 1`` so the new column is meaningful from day one, and updates the Hardcover sync constructor in ``cps/readingservices.py`` to tag new rows at insert time too.

## Verification

- **RED → GREEN** regression tests (8 new + 1 source-pin) in ``tests/unit/test_kobo_annotation_sync_h1_schema.py``:
  - Model declares all 12 H1 columns, all nullable, position fields integer-typed, ``chapter_progress`` float-typed.
  - Migration on a pre-H1 schema adds all columns + backfills source on Hardcover-sync rows + leaves un-synced rows un-sourced.
  - Migration is idempotent (re-running it doesn't damage rows or overwrite already-set source values).
  - ORM round-trip writes & reads back every H1 field.
  - Source-pin: ``cps/readingservices.py`` constructor passes ``source='hardcover'``.
- **Full Kobo + Hardcover + readingservices unit suite:** 158/158 pass.
- **Live container:** ``docker cp`` to cwn-local + restart → schema goes from 11 to 23 columns, no migration errors in logs, second restart is a no-op, ``/health`` returns 200.

## Cross-cutting sweep

- ``cps/readingservices.py`` (Hardcover write path) — sourced now at insert time.
- ``cps/admin.py`` (only references ``"kobo_annotation_sync"`` as a string in a CSV-export allowlist) — no change needed.
- No new dependencies; ``lxml``, ``beautifulsoup4``, ``python-magic`` are already in ``requirements.txt`` for P2–P3.
- Future PRs (P2 converter, P3 import endpoint) populate the new fields. P1 ships behaviorally-inert from the user's perspective.

## Tier

``safe-tier-2`` — additive nullable columns, idempotent migration, no existing column types or constraints changed, single subsystem.

## Design reference

``notes/KOBO-WEB-READER-ANNOTATIONS-DESIGN.md`` §1.1 (schema reuse decision) and §4 (Phase 1 component breakdown).