### PR TITLE
fix(#219): create book_format_checksums unconditionally + gate sibling writers

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -928,13 +928,16 @@ class CalibreDB:
             for inst in cls.instances:
                 inst.init_session()
 
-            # Ensure progress syncing tables exist in metadata.db (book checksums)
+            # Ensure progress syncing tables exist in metadata.db (book checksums).
+            # The table is a schema invariant — its existence must not depend on
+            # KOReader sync being enabled, because three writers in scripts/
+            # (ingest_processor, cover_enforcer, kindle_epub_fixer) historically
+            # fire on every ingest. The table is small and empty when sync is
+            # off; the writers themselves are gated separately. See fork #219.
             from .progress_syncing.models import ensure_calibre_db_tables
-            from .progress_syncing.settings import is_koreader_sync_enabled
             if (
                 db_writable
                 and os.getenv('NETWORK_SHARE_MODE', 'False').lower() not in ('1', 'true', 'yes', 'on')
-                and is_koreader_sync_enabled()
             ):
                 ensure_calibre_db_tables(conn)
 

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1795,11 +1795,11 @@ def migrate_Database(_session):
     migrate_kobo_annotation_sync_h1_columns(engine, _session)
     migrate_book_cover_preview_table(engine, _session)
 
-    # Ensure progress syncing tables in app.db (user-related tables)
+    # Ensure progress syncing tables in app.db (user-related tables).
+    # Schema invariant — must not be gated on KOReader sync being enabled.
+    # See fork #219.
     from .progress_syncing.models import ensure_app_db_tables
-    from .progress_syncing.settings import is_koreader_sync_enabled
-    if is_koreader_sync_enabled():
-        ensure_app_db_tables(engine.raw_connection())
+    ensure_app_db_tables(engine.raw_connection())
     
     # Migrate system magic shelves for existing users
     try:

--- a/scripts/cover_enforcer.py
+++ b/scripts/cover_enforcer.py
@@ -312,6 +312,16 @@ class Enforcer:
             if project_root not in sys.path:
                 sys.path.insert(0, project_root)
 
+            # Skip entirely when KOReader sync is disabled — matches PR #94's
+            # gating in cps/helper.py. See fork #219 for the root cause.
+            try:
+                from cps.progress_syncing.settings import is_koreader_sync_enabled
+                if not is_koreader_sync_enabled():
+                    return
+            except Exception:
+                # Fail closed: if the flag can't be read, don't risk writes.
+                return
+
             from cps.progress_syncing.checksums import calculate_koreader_partial_md5, store_checksum, CHECKSUM_VERSION
 
             # Calculate new checksum

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -463,6 +463,22 @@ def initialize_runtime() -> bool:
 def _is_missing_ingest_target(filepath: str) -> bool:
     return not os.path.isfile(filepath) and not os.path.isdir(filepath)
 
+
+def _is_koreader_sync_enabled() -> bool:
+    """Lazy proxy for cps.progress_syncing.settings.is_koreader_sync_enabled.
+
+    Used to skip KOReader partial-MD5 generation when sync is disabled —
+    matches the gating PR #94 added in ``cps/helper.py``. Fails closed so
+    a missing setting can't accidentally trigger writes against a
+    not-yet-created table. See fork #219.
+    """
+    try:
+        from cps.progress_syncing.settings import is_koreader_sync_enabled
+        return bool(is_koreader_sync_enabled())
+    except Exception:
+        return False
+
+
 def gdrive_sync_if_enabled():
     """Sync Calibre library to Google Drive if enabled in app config."""
     if _GDRIVE_AVAILABLE and getattr(_cps_config, "config_use_google_drive", False):
@@ -1216,11 +1232,15 @@ class NewBookProcessor:
             else:
                 self.trigger_auto_send_if_enabled(staged_path.stem, book_path)
 
-            # Generate KOReader sync checksums for the imported book
-            if self.last_added_book_id is not None:
-                self.generate_book_checksums(staged_path.stem, book_id=self.last_added_book_id)
-            else:
-                self.generate_book_checksums(staged_path.stem)
+            # Generate KOReader sync checksums for the imported book.
+            # Gated on is_koreader_sync_enabled() so disabled-sync instances
+            # skip the (slow) partial-MD5 work entirely — see PR #94 for the
+            # same pattern in cps/helper.py, and fork #219 for the root cause.
+            if _is_koreader_sync_enabled():
+                if self.last_added_book_id is not None:
+                    self.generate_book_checksums(staged_path.stem, book_id=self.last_added_book_id)
+                else:
+                    self.generate_book_checksums(staged_path.stem)
 
             # Ensure newly imported books have their timestamp set to the current time
             # so they appear at the top of "Recently Added" views.

--- a/scripts/kindle_epub_fixer.py
+++ b/scripts/kindle_epub_fixer.py
@@ -376,6 +376,16 @@ class EPUBFixer:
             if project_root not in sys.path:
                 sys.path.insert(0, project_root)
 
+            # Skip entirely when KOReader sync is disabled — matches PR #94's
+            # gating in cps/helper.py. See fork #219 for the root cause.
+            try:
+                from cps.progress_syncing.settings import is_koreader_sync_enabled
+                if not is_koreader_sync_enabled():
+                    return
+            except Exception:
+                # Fail closed: if the flag can't be read, don't risk writes.
+                return
+
             from cps.progress_syncing.checksums import calculate_koreader_partial_md5, store_checksum, CHECKSUM_VERSION
 
             # Calculate new checksum

--- a/tests/unit/test_book_format_checksums_table_creation.py
+++ b/tests/unit/test_book_format_checksums_table_creation.py
@@ -1,0 +1,228 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for fork issue #219 — "Missing database table on fresh installation".
+
+Symptom: on a fresh install (and on upgrades), the ``book_format_checksums``
+table is never created in ``metadata.db``. Every ingested book then logs
+``ERROR ... Failed to store checksum for book N: no such table:
+book_format_checksums`` because three callers in ``scripts/`` (ingest_processor,
+cover_enforcer, kindle_epub_fixer) write checksums on every ingest without
+checking whether KOReader sync is enabled.
+
+Root cause has two parts:
+
+1. **Schema is treated as a feature toggle.** ``cps/db.py`` and ``cps/ub.py``
+   gate ``ensure_calibre_db_tables`` / ``ensure_app_db_tables`` on
+   ``is_koreader_sync_enabled()``. The table is a schema invariant, not a
+   feature toggle — it must always exist so writers (and the user's later
+   feature-flip to enable sync) work without ordering hazards.
+
+2. **Three sibling writers are unguarded.** ``helper.py`` was fixed by PR #94
+   (v4.0.28) to gate its checksum write on ``is_koreader_sync_enabled()``, but
+   the same pattern was never applied to ``ingest_processor.py``,
+   ``cover_enforcer.py``, or ``kindle_epub_fixer.py``. Those three still fire
+   unconditionally on every ingest, wasting MD5 CPU when sync is off.
+
+The fix applies both parts:
+
+- Drop the ``is_koreader_sync_enabled()`` gate from the ``ensure_*`` callers
+  so the table always exists.
+- Add the ``is_koreader_sync_enabled()`` gate to the three sibling writers so
+  they match the v4.0.28 pattern from PR #94.
+
+These tests pin both halves of the fix so a future refactor can't accidentally
+re-introduce the original gate-mismatch.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — schema-invariant fix (gate removed from ensure_* callers)
+# ---------------------------------------------------------------------------
+
+
+class TestCpsDbAlwaysEnsuresCalibreTables:
+    """``cps/db.py`` must call ``ensure_calibre_db_tables`` unconditionally on
+    startup (modulo the safety checks for db_writable + NETWORK_SHARE_MODE)."""
+
+    DB_FILE = REPO_ROOT / "cps" / "db.py"
+
+    def _read(self) -> str:
+        return self.DB_FILE.read_text(encoding="utf-8")
+
+    def test_ensure_calibre_db_tables_call_is_present(self):
+        src = self._read()
+        assert "ensure_calibre_db_tables(" in src
+
+    def test_ensure_calibre_db_tables_is_not_gated_on_koreader_setting(self):
+        # The gate is the bug. Removing it is the fix.
+        src = self._read()
+        call_idx = src.find("ensure_calibre_db_tables(conn)")
+        assert call_idx != -1, (
+            "Expected 'ensure_calibre_db_tables(conn)' call in cps/db.py"
+        )
+
+        # Look at the ~400-char window before the call. The original gate had
+        # 'is_koreader_sync_enabled()' immediately preceding the call inside
+        # the if-condition. The fix removes that.
+        window_start = max(0, call_idx - 400)
+        window = src[window_start:call_idx]
+        assert "is_koreader_sync_enabled" not in window, (
+            "cps/db.py must not gate ensure_calibre_db_tables on "
+            "is_koreader_sync_enabled() — the table is a schema invariant. "
+            "See fork issue #219."
+        )
+
+
+class TestCpsUbAlwaysEnsuresAppTables:
+    """``cps/ub.py`` must call ``ensure_app_db_tables`` unconditionally at the
+    end of ``migrate_Database``. Same reasoning: schema invariant."""
+
+    UB_FILE = REPO_ROOT / "cps" / "ub.py"
+
+    def _read(self) -> str:
+        return self.UB_FILE.read_text(encoding="utf-8")
+
+    def test_ensure_app_db_tables_call_is_present(self):
+        src = self._read()
+        assert "ensure_app_db_tables(" in src
+
+    def test_ensure_app_db_tables_is_not_gated_on_koreader_setting(self):
+        src = self._read()
+        call_idx = src.find("ensure_app_db_tables(engine.raw_connection())")
+        assert call_idx != -1, (
+            "Expected 'ensure_app_db_tables(engine.raw_connection())' call "
+            "in cps/ub.py"
+        )
+        window_start = max(0, call_idx - 400)
+        window = src[window_start:call_idx]
+        assert "is_koreader_sync_enabled" not in window, (
+            "cps/ub.py must not gate ensure_app_db_tables on "
+            "is_koreader_sync_enabled() — the table is a schema invariant. "
+            "See fork issue #219."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — match PR #94 (v4.0.28) gating pattern at sibling write paths
+# ---------------------------------------------------------------------------
+
+
+class _ScriptWriteGuardCase:
+    """Source-pin shared assertions for the three unguarded write paths."""
+
+    SCRIPT_PATH: Path = None  # type: ignore[assignment]
+    CALL_NEEDLE: str = ""
+
+    def _read(self) -> str:
+        return self.SCRIPT_PATH.read_text(encoding="utf-8")
+
+    def test_call_site_is_present(self):
+        src = self._read()
+        assert self.CALL_NEEDLE in src, (
+            f"Expected {self.CALL_NEEDLE!r} in {self.SCRIPT_PATH.name}; "
+            "the test target moved or got renamed."
+        )
+
+    def test_call_site_is_gated_on_is_koreader_sync_enabled(self):
+        # Match the v4.0.28 / PR #94 pattern: the call must be wrapped in
+        # `if is_koreader_sync_enabled():` so disabled-sync instances skip
+        # the MD5 work entirely (and avoid noisy "no such table" errors on
+        # any future code path that hasn't yet been migrated). Window is
+        # generous (2500 chars) because the gate may live near the top of
+        # the enclosing function while the call is several blocks later.
+        src = self._read()
+        call_idx = src.find(self.CALL_NEEDLE)
+        assert call_idx != -1
+        window_start = max(0, call_idx - 2500)
+        window = src[window_start:call_idx]
+        assert "is_koreader_sync_enabled" in window, (
+            f"{self.SCRIPT_PATH.name}: {self.CALL_NEEDLE!r} must be gated on "
+            "is_koreader_sync_enabled() — see fork issue #219 + PR #94."
+        )
+
+
+class TestIngestProcessorGatesGenerateBookChecksums(_ScriptWriteGuardCase):
+    SCRIPT_PATH = REPO_ROOT / "scripts" / "ingest_processor.py"
+    CALL_NEEDLE = "self.generate_book_checksums("
+
+
+class TestCoverEnforcerGatesChecksumRecalc(_ScriptWriteGuardCase):
+    SCRIPT_PATH = REPO_ROOT / "scripts" / "cover_enforcer.py"
+    # The call site we care about is the body of
+    # `_recalculate_checksum_after_modification`, which imports + calls
+    # `store_checksum`. Gating must happen either at the body's top
+    # (preferred) or at every caller. Source-pin by checking that
+    # `store_checksum(` is preceded by an `is_koreader_sync_enabled()`
+    # reference in the same file.
+    CALL_NEEDLE = "store_checksum("
+
+
+class TestKindleEpubFixerGatesChecksumRecalc(_ScriptWriteGuardCase):
+    SCRIPT_PATH = REPO_ROOT / "scripts" / "kindle_epub_fixer.py"
+    CALL_NEEDLE = "store_checksum("
+
+
+# ---------------------------------------------------------------------------
+# Part 3 — behavioral test: real SQLite, real ensure_* call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStoreChecksumWorksAfterUnconditionalEnsure:
+    """End-to-end micro-test: a fresh DB + unconditional ensure_* call +
+    store_checksum should write a row, not crash with 'no such table'.
+    This is the user-visible symptom from #219, rendered as a test."""
+
+    def test_store_checksum_after_ensure_calibre_db_tables(self, tmp_path):
+        # Stand up a metadata.db-shaped sqlite (just the `books` table is
+        # needed for the foreign key).
+        db_path = tmp_path / "metadata.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE books (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "title TEXT)"
+        )
+        conn.execute("INSERT INTO books (id, title) VALUES (42, 'Test Book')")
+        conn.commit()
+
+        # Run the schema setup (this is what cps/db.py calls on startup).
+        from cps.progress_syncing.models import ensure_calibre_db_tables
+        ensure_calibre_db_tables(conn)
+
+        # Now exercise store_checksum directly against the same DB. This
+        # mimics the ingest-processor / cover-enforcer / kindle-epub-fixer
+        # path that fails in #219.
+        from cps.progress_syncing.checksums.manager import store_checksum
+        ok = store_checksum(
+            book_id=42,
+            book_format="EPUB",
+            checksum="deadbeef" * 4,
+            version="koreader",
+            db_connection=conn,
+        )
+        assert ok is True, (
+            "store_checksum must succeed after ensure_calibre_db_tables — "
+            "this is the user-visible symptom from #219."
+        )
+
+        row = conn.execute(
+            "SELECT book, format, checksum FROM book_format_checksums "
+            "WHERE book = 42"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == 42
+        assert row[1].upper() == "EPUB"
+        assert row[2] == "deadbeef" * 4


### PR DESCRIPTION
## Symptom

Reported by @thealmostmighty in #219 (confirmed by @droM4X, manual-workaround attempted by @Hoite). On a fresh install (and on upgrades), every ingested book logs:

```
ERROR ... Failed to store checksum for book N: no such table: book_format_checksums
```

The `book_format_checksums` table is never created in `metadata.db`, but the ingest pipeline writes to it on every import.

## Root cause

Two interacting bugs:

1. **Schema treated as a feature toggle.** `cps/db.py` and `cps/ub.py` gated `ensure_calibre_db_tables` / `ensure_app_db_tables` on `is_koreader_sync_enabled()`. KOReader sync is off by default — so on a fresh install the tables are never created, and the ``cwa-checksum-backfill`` service prints `WARNING: Database schema not ready after 30s, proceeding anyway...`.

2. **Three sibling writers in `scripts/` are unguarded.** PR #94 (v4.0.28) fixed the same pattern in `cps/helper.py` by gating its `calculate_and_store_checksum` call on `is_koreader_sync_enabled()`. But the same gate was never added to:
   - `scripts/ingest_processor.py:generate_book_checksums` (the one in the user's logs)
   - `scripts/cover_enforcer.py:_recalculate_checksum_after_modification`
   - `scripts/kindle_epub_fixer.py:_recalculate_checksum_after_modification`

   They all fire `store_checksum` on every ingest regardless of feature flag.

@Hoite's workaround creates the table in `app.db` — wrong location. The writers connect to `metadata.db` (the Calibre library DB), which is why @thealmostmighty saw the error persist after running the workaround.

## Fix

Both halves:

- **Schema invariant.** Drop the `is_koreader_sync_enabled()` gate from `cps/db.py` and `cps/ub.py`. The `ensure_*` functions are idempotent and produce empty tables when sync is off — zero cost.
- **Match PR #94 pattern at sibling writers.** Add `if not is_koreader_sync_enabled(): return` at the top of each of the three writers. Disabled-sync instances skip the partial-MD5 work entirely.

The pure utilities in `cps/progress_syncing/checksums/manager.py` stay unguarded so explicit-backfill paths (used right after a user enables sync mid-instance) still work — same rationale PR #94 used.

## Verification

**Tests (11 new in `tests/unit/test_book_format_checksums_table_creation.py`):**
- Source-pin: `cps/db.py` no longer gates `ensure_calibre_db_tables` on `is_koreader_sync_enabled()`.
- Source-pin: `cps/ub.py` no longer gates `ensure_app_db_tables` on `is_koreader_sync_enabled()`.
- Source-pin: three sibling writers all reference `is_koreader_sync_enabled()` ahead of their `store_checksum` call.
- Behavioral: `store_checksum` against a fresh in-memory SQLite + `ensure_calibre_db_tables` writes a row.
- Full progress_syncing + helper test suite: 75/75 pass.

**Live container (`cwng-bug219-repro`, fresh image build off this branch):**

| Path | Result |
|---|---|
| Empty volumes → start → check schema | `book_format_checksums` present in `metadata.db` from t=0 |
| Empty volumes → start → check schema | `kosync_progress` present in `app.db` from t=0 |
| Sync OFF + ingest EPUB | `Failed to store checksum` count: **0** |
| Sync OFF + ingest EPUB | `Generating KOReader sync checksums` message: **absent** (gate fired) |
| Sync ON + restart + ingest EPUB | `cwa-checksum-backfill` reports `schema ready (attempt 1)` (was: `WARNING: Database schema not ready after 30s`) |
| Sync ON + ingest EPUB | `book_format_checksums` row written; `SELECT COUNT(*)` = 2 (one backfilled, one fresh) |

## Tier

`safe-tier-2` — schema-existence change + three callsite gates; idempotent; covered by 11 regression tests.

## Adjacency considered

- `cps/cwa_functions.py` on-toggle-enable path — now functionally redundant (schema is always created at startup), but left as harmless defense-in-depth.
- `cps/helper.py` — already correctly gated by PR #94.
- `scripts/generate_book_checksums.py` (cwa-checksum-backfill) — already correctly gated.
- `cps/progress_syncing/protocols/kosync.py` — blueprint-level `is_koreader_sync_enabled()` gate protects all writes to `kosync_progress`.

Closes #219.