### PR TITLE
H1 Phase 3 (P3): POST /annotations/import — upload KoboReader.sqlite + ingest highlights

### DIFF
--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Annotations blueprint — H1 Phase 3.
+
+User-facing routes for the Kobo highlight feature. P3 ships the
+import endpoint; P4 adds the view + export surface; P5 adds the
+web-reader create/edit path.
+
+Routes shipped in this PR:
+
+    GET  /annotations/import          -> upload form
+    POST /annotations/import          -> accept KoboReader.sqlite,
+                                          parse, INSERT into kobo_annotation_sync
+
+Auth: ``@user_login_required`` — annotation data is per-user-private.
+Anonymous users have nothing to import + nowhere to store imported data,
+so the route rejects them at the auth layer.
+
+CSRF: protected via Flask-WTF's global middleware (we do NOT call
+``@csrf.exempt`` — this is a browser-driven endpoint, not a device-
+protocol endpoint).
+
+The import path NEVER persists the uploaded SQLite to disk. The file is
+parsed in-place via a temp file that's deleted before the request
+returns. The file's contents are PII (the user's reading history,
+search queries, every bookmark they ever made) — we read what we need
++ throw away the rest.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timezone
+from typing import Optional
+
+from flask import Blueprint, abort, flash, jsonify, redirect, request, url_for
+from flask_babel import gettext as _
+
+from . import calibre_db, logger, ub
+from .cw_login import current_user
+from .render_template import render_title_template
+from .services.kobo_import import looks_like_sqlite, parse_kobo_bookmarks
+from .usermanagement import user_login_required
+
+log = logger.create()
+
+annotations_bp = Blueprint("annotations", __name__)
+
+# Defense-in-depth file-size cap. Typical real-device KoboReader.sqlite
+# files are 30-50 MB; reject anything over 100 MB.
+MAX_UPLOAD_BYTES = 100 * 1024 * 1024
+
+
+@annotations_bp.route("/annotations/import", methods=["GET"])
+@user_login_required
+def annotations_import_form():
+    """Render the upload form."""
+    return render_title_template(
+        "annotations_import.html",
+        title=_(u"Import Kobo annotations"),
+        page="annotations_import",
+    )
+
+
+@annotations_bp.route("/annotations/import", methods=["POST"])
+@user_login_required
+def annotations_import_submit():
+    """Accept an uploaded ``KoboReader.sqlite``, parse the Bookmark
+    table, and INSERT each highlight into ``kobo_annotation_sync``
+    for the current user.
+
+    Returns a JSON summary: ``{imported, skipped_existing, skipped_orphan,
+    skipped_hidden, total_seen}`` — the upload form swaps to a result
+    pane without a page reload.
+    """
+    upload = request.files.get("file")
+    if not upload or not upload.filename:
+        return jsonify({"error": "no_file", "message": _("No file uploaded.")}), 400
+
+    # Size precheck via Content-Length. Some clients omit it; we also
+    # bound the actual read below.
+    content_length = request.content_length or 0
+    if content_length > MAX_UPLOAD_BYTES:
+        return jsonify({
+            "error": "too_large",
+            "message": _("File exceeds %(max)d MB.", max=MAX_UPLOAD_BYTES // (1024 * 1024)),
+        }), 413
+
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".sqlite", delete=False
+        ) as tmp:
+            tmp_path = tmp.name
+            total = 0
+            # Stream-copy so we can cap mid-read on clients that lied
+            # about Content-Length.
+            while True:
+                chunk = upload.stream.read(64 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > MAX_UPLOAD_BYTES:
+                    tmp.close()
+                    os.unlink(tmp_path)
+                    return jsonify({
+                        "error": "too_large",
+                        "message": _("File exceeds %(max)d MB.",
+                                     max=MAX_UPLOAD_BYTES // (1024 * 1024)),
+                    }), 413
+                tmp.write(chunk)
+
+        if not looks_like_sqlite(tmp_path):
+            return jsonify({
+                "error": "not_sqlite",
+                "message": _("Uploaded file is not a SQLite database."),
+            }), 400
+
+        summary = _ingest_bookmarks(tmp_path)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError as e:
+                log.warning("annotations: failed to remove temp %s: %s", tmp_path, e)
+
+    return jsonify(summary), 200
+
+
+def _ingest_bookmarks(sqlite_path: str) -> dict:
+    """Adapter around :func:`ingest_bookmarks` that pulls dependencies
+    from the Flask request context (current_user, ub.session,
+    calibre_db). Lives so the request handler is one line; the
+    actual work happens in the pure function below."""
+    return ingest_bookmarks(
+        sqlite_path,
+        user_id=current_user.id,
+        session=ub.session,
+        book_lookup=lambda uuid: (
+            calibre_db.get_book_by_uuid(uuid) if "-" in (uuid or "") else None
+        ),
+        commit=ub.session_commit,
+    )
+
+
+def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit) -> dict:
+    """Walk the parsed bookmarks, resolve VolumeIDs via ``book_lookup``,
+    INSERT new highlights into ``kobo_annotation_sync``. Dependencies
+    are explicit so this function is unit-testable without a Flask app.
+
+    The annotation-backup hook fires automatically on commit so the
+    user already has a recoverable snapshot before the next import
+    overwrites anything.
+
+    Returns a counts dict the JSON endpoint hands back to the browser.
+    """
+    imported = 0
+    skipped_existing = 0
+    skipped_orphan = 0
+    skipped_hidden = 0
+    total_seen = 0
+
+    # Cache: VolumeID -> CW book_id (or None for not-in-library).
+    # Same VolumeID often appears across many bookmarks; resolve once.
+    uuid_cache: dict[str, Optional[int]] = {}
+
+    for bm in parse_kobo_bookmarks(sqlite_path):
+        total_seen += 1
+        if bm.hidden:
+            skipped_hidden += 1
+            continue
+
+        # Resolve VolumeID -> CW book.id. Kobo writes either a UUID or
+        # ``file:///mnt/onboard/...`` for sideloaded books. We only
+        # accept UUIDs; sideloaded books CW doesn't know about are
+        # skipped (design doc §11 row 2).
+        volume_uuid = bm.volume_id
+        if volume_uuid in uuid_cache:
+            book_id = uuid_cache[volume_uuid]
+        else:
+            book = book_lookup(volume_uuid)
+            book_id = book.id if book else None
+            uuid_cache[volume_uuid] = book_id
+
+        if book_id is None:
+            skipped_orphan += 1
+            continue
+
+        # Dedup: (user_id, annotation_id) is already indexed; one
+        # SELECT covers the existence check.
+        existing = session.query(ub.KoboAnnotationSync.id).filter(
+            ub.KoboAnnotationSync.user_id == user_id,
+            ub.KoboAnnotationSync.annotation_id == bm.bookmark_id,
+        ).first()
+        if existing is not None:
+            skipped_existing += 1
+            continue
+
+        row = ub.KoboAnnotationSync(
+            user_id=user_id,
+            annotation_id=bm.bookmark_id,
+            book_id=book_id,
+            highlighted_text=bm.text,
+            highlight_color=bm.color,
+            note_text=bm.annotation,
+            content_id=bm.content_id,
+            start_container_path=bm.start_container_path,
+            start_container_child_index=bm.start_container_child_index,
+            start_offset=bm.start_offset,
+            end_container_path=bm.end_container_path,
+            end_container_child_index=bm.end_container_child_index,
+            end_offset=bm.end_offset,
+            context_string=bm.context_string,
+            chapter_progress=bm.chapter_progress,
+            source="kobo",
+            hidden=False,
+        )
+        session.add(row)
+        imported += 1
+
+    try:
+        commit()
+    except Exception as e:
+        log.error("annotations: import commit failed: %s", e)
+        session.rollback()
+        imported = 0
+
+    return {
+        "imported": imported,
+        "skipped_existing": skipped_existing,
+        "skipped_orphan": skipped_orphan,
+        "skipped_hidden": skipped_hidden,
+        "total_seen": total_seen,
+    }

--- a/cps/main.py
+++ b/cps/main.py
@@ -27,6 +27,7 @@ def main():
     from .editbooks import editbook
     from .cover_picker import cover_picker
     from .cover_preview_blueprint import cover_preview_bp
+    from .annotations import annotations_bp
     from .about import about
     from .search import search
     from .search_metadata import meta
@@ -85,6 +86,7 @@ def main():
     app.register_blueprint(editbook)
     app.register_blueprint(cover_picker)
     app.register_blueprint(cover_preview_bp)
+    app.register_blueprint(annotations_bp)
     app.register_blueprint(kosync)
     app.register_blueprint(duplicates)
     if kobo_available:

--- a/cps/services/kobo_import.py
+++ b/cps/services/kobo_import.py
@@ -1,0 +1,164 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Kobo `KoboReader.sqlite` parser for H1 Phase 3.
+
+Pure-Python module — no Flask, no `ub` direct imports — so it stays
+testable in isolation. The blueprint at ``cps/annotations.py`` calls
+:func:`parse_kobo_bookmarks` to extract annotation rows from an
+uploaded sqlite file, then translates them into ``KoboAnnotationSync``
+inserts.
+
+See ``notes/KOBO-WEB-READER-ANNOTATIONS-DESIGN.md`` §7 for the parser
+sketch this module implements.
+
+Security shape:
+
+* Caller is responsible for size capping + MIME validation before
+  invoking this module. We validate the SQLite header anyway as
+  defense-in-depth.
+* We open the upload read-only via ``mode=ro`` URI and never write
+  back to it.
+* The Bookmark table is the only table touched; any other contents
+  are ignored even if present.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional
+
+log = logging.getLogger(__name__)
+
+# Kobo's Bookmark.Color encoding — empirically observed on real devices.
+# See notes/KOBO-PROTOCOL-REFERENCE.md §10.1 finding 5.
+_COLOR_MAP = {0: "yellow", 1: "red", 2: "green", 3: "blue"}
+
+# SQLite database file magic — first 16 bytes of any valid SQLite 3.x file.
+_SQLITE_MAGIC = b"SQLite format 3\x00"
+
+
+@dataclass(frozen=True)
+class ParsedBookmark:
+    """One row from a Kobo Bookmark table, plus the bits we derive
+    from it for the H1 model. ``volume_id`` is the device's
+    book-id (typically the EPUB UUID); the caller maps it to a CW
+    ``books.id`` separately."""
+
+    bookmark_id: str               # Bookmark.BookmarkID (UUID)
+    volume_id: str                 # Bookmark.VolumeID — match against Books.uuid
+    content_id: Optional[str]      # Bookmark.ContentID — chapter pointer
+    start_container_path: Optional[str]
+    start_container_child_index: Optional[int]
+    start_offset: Optional[int]
+    end_container_path: Optional[str]
+    end_container_child_index: Optional[int]
+    end_offset: Optional[int]
+    text: str                      # Bookmark.Text (the highlighted passage)
+    annotation: Optional[str]      # Bookmark.Annotation (user's typed note)
+    context_string: Optional[str]
+    chapter_progress: Optional[float]
+    color: str                     # COLOR_MAP-normalized: 'yellow'/'red'/'green'/'blue'
+    hidden: bool
+    date_created: Optional[str]    # ISO-8601 strings as stored by Kobo
+    date_modified: Optional[str]
+
+
+def looks_like_sqlite(blob_or_path) -> bool:
+    """Cheap magic-bytes check. Accepts either bytes (first 16+
+    bytes of the file) or a path-like the caller wants us to read."""
+    if isinstance(blob_or_path, (bytes, bytearray)):
+        return bytes(blob_or_path[:16]) == _SQLITE_MAGIC
+    p = Path(blob_or_path)
+    if not p.is_file():
+        return False
+    try:
+        with open(p, "rb") as fh:
+            return fh.read(16) == _SQLITE_MAGIC
+    except OSError:
+        return False
+
+
+def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
+    """Open ``sqlite_path`` read-only, walk every Bookmark row whose
+    ``Text`` is non-empty, yield :class:`ParsedBookmark` instances.
+
+    Yields nothing if the file is not SQLite, the Bookmark table
+    doesn't exist, or the table is empty — never raises on a
+    malformed payload. Callers test the iterator for emptiness to
+    distinguish "no annotations" from "import failed for a real
+    reason" (which we log).
+    """
+    if not isinstance(sqlite_path, Path):
+        sqlite_path = Path(sqlite_path)
+    if not looks_like_sqlite(sqlite_path):
+        log.warning("kobo_import: %s is not a SQLite file", sqlite_path)
+        return
+
+    # mode=ro + immutable=1 — never touch the file, no journal, no
+    # write attempts. Even if the user maliciously crafted a sqlite
+    # with triggers, we can't fire them in read-only mode.
+    uri = f"file:{sqlite_path}?mode=ro&immutable=1"
+    try:
+        conn = sqlite3.connect(uri, uri=True)
+    except sqlite3.OperationalError as e:
+        log.warning("kobo_import: cannot open %s read-only: %s", sqlite_path, e)
+        return
+
+    try:
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='Bookmark'"
+        )
+        if cur.fetchone() is None:
+            log.info("kobo_import: %s has no Bookmark table — skipping", sqlite_path)
+            return
+
+        rows = conn.execute("""
+            SELECT
+                BookmarkID, VolumeID, ContentID,
+                StartContainerPath, StartContainerChildIndex, StartOffset,
+                EndContainerPath, EndContainerChildIndex, EndOffset,
+                Text, Annotation, Color, ContextString,
+                ChapterProgress, DateCreated, DateModified, Hidden
+            FROM Bookmark
+            WHERE Text IS NOT NULL AND Text != ''
+        """).fetchall()
+    except sqlite3.DatabaseError as e:
+        log.warning("kobo_import: SQL error on %s: %s", sqlite_path, e)
+        return
+    finally:
+        conn.close()
+
+    for r in rows:
+        (bm_id, volume_id, content_id,
+         sp, sci, so, ep, eci, eo,
+         text, annotation, color, ctx,
+         chapter_progress, dcreated, dmod, hidden) = r
+        if not bm_id or not volume_id:
+            # Malformed row — Kobo doesn't normally emit these. Skip
+            # rather than abort the whole import.
+            continue
+        yield ParsedBookmark(
+            bookmark_id=bm_id,
+            volume_id=volume_id,
+            content_id=content_id,
+            start_container_path=sp,
+            start_container_child_index=sci,
+            start_offset=so,
+            end_container_path=ep,
+            end_container_child_index=eci,
+            end_offset=eo,
+            text=text,
+            annotation=annotation,
+            context_string=ctx,
+            chapter_progress=chapter_progress,
+            color=_COLOR_MAP.get(color or 0, "yellow"),
+            hidden=bool(hidden),
+            date_created=dcreated,
+            date_modified=dmod,
+        )

--- a/cps/templates/annotations_import.html
+++ b/cps/templates/annotations_import.html
@@ -1,0 +1,81 @@
+{% extends "layout.html" %}
+{% block body %}
+<div class="discover">
+  <h2>{{ _('Import Kobo annotations') }}</h2>
+  <p>
+    {{ _('Upload your Kobo device\'s %(filename)s file to import every highlight and note you\'ve made. Highlights for books that exist in this library will be added to your account; sideloaded books not in the library are skipped.', filename='<code>KoboReader.sqlite</code>')|safe }}
+  </p>
+  <p class="text-muted">
+    {{ _('The file is parsed in-memory and deleted after the import completes. It is never stored on the server.') }}
+  </p>
+
+  <form id="annotations-import-form" enctype="multipart/form-data" method="POST" action="{{ url_for('annotations.annotations_import_submit') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="form-group">
+      <label for="annotations-import-file">{{ _('KoboReader.sqlite') }}</label>
+      <input id="annotations-import-file" type="file" name="file" accept=".sqlite,application/x-sqlite3,application/octet-stream" required>
+    </div>
+    <button id="annotations-import-submit" class="btn btn-default" type="submit">{{ _('Import') }}</button>
+    <span id="annotations-import-status" class="text-muted" style="margin-left: 1em;"></span>
+  </form>
+
+  <div id="annotations-import-result" style="margin-top: 1.5em; display: none;">
+    <h3>{{ _('Import summary') }}</h3>
+    <ul>
+      <li><strong id="result-imported">0</strong> {{ _('new highlights imported') }}</li>
+      <li><strong id="result-existing">0</strong> {{ _('already imported (skipped)') }}</li>
+      <li><strong id="result-orphan">0</strong> {{ _('for books not in this library (skipped)') }}</li>
+      <li><strong id="result-hidden">0</strong> {{ _('hidden on device (skipped)') }}</li>
+      <li><strong id="result-total">0</strong> {{ _('total entries seen') }}</li>
+    </ul>
+  </div>
+
+  <div id="annotations-import-error" class="text-danger" style="margin-top: 1.5em; display: none;"></div>
+</div>
+
+<script>
+(function() {
+  var form = document.getElementById('annotations-import-form');
+  var submitBtn = document.getElementById('annotations-import-submit');
+  var statusEl = document.getElementById('annotations-import-status');
+  var resultEl = document.getElementById('annotations-import-result');
+  var errorEl = document.getElementById('annotations-import-error');
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    resultEl.style.display = 'none';
+    errorEl.style.display = 'none';
+    submitBtn.disabled = true;
+    statusEl.textContent = '{{ _("Uploading...") }}';
+
+    var fd = new FormData(form);
+    fetch(form.action, {
+      method: 'POST',
+      body: fd,
+      credentials: 'same-origin',
+    }).then(function(r) {
+      return r.json().then(function(body) { return {ok: r.ok, status: r.status, body: body}; });
+    }).then(function(res) {
+      submitBtn.disabled = false;
+      statusEl.textContent = '';
+      if (res.ok) {
+        document.getElementById('result-imported').textContent = res.body.imported || 0;
+        document.getElementById('result-existing').textContent = res.body.skipped_existing || 0;
+        document.getElementById('result-orphan').textContent = res.body.skipped_orphan || 0;
+        document.getElementById('result-hidden').textContent = res.body.skipped_hidden || 0;
+        document.getElementById('result-total').textContent = res.body.total_seen || 0;
+        resultEl.style.display = 'block';
+      } else {
+        errorEl.textContent = (res.body && res.body.message) || '{{ _("Import failed.") }}';
+        errorEl.style.display = 'block';
+      }
+    }).catch(function(err) {
+      submitBtn.disabled = false;
+      statusEl.textContent = '';
+      errorEl.textContent = '{{ _("Network error.") }} ' + err;
+      errorEl.style.display = 'block';
+    });
+  });
+})();
+</script>
+{% endblock %}

--- a/tests/fixtures/kobo_reader_sqlite.py
+++ b/tests/fixtures/kobo_reader_sqlite.py
@@ -1,0 +1,132 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Builder for synthetic KoboReader.sqlite fixtures used by the H1
+import path tests.
+
+Real device backups contain personal reading history (PII). These
+fixtures recreate the Bookmark table schema exactly per
+``notes/KOBO-PROTOCOL-REFERENCE.md`` §10.1 without shipping anyone's
+data.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+BOOKMARK_DDL = """
+CREATE TABLE Bookmark (
+    BookmarkID TEXT PRIMARY KEY,
+    VolumeID TEXT,
+    ContentID TEXT,
+    StartContainerPath TEXT,
+    StartContainerChildIndex INTEGER,
+    StartOffset INTEGER,
+    EndContainerPath TEXT,
+    EndContainerChildIndex INTEGER,
+    EndOffset INTEGER,
+    Text TEXT,
+    Annotation TEXT,
+    Color INTEGER,
+    ContextString TEXT,
+    ChapterProgress REAL,
+    DateCreated TEXT,
+    DateModified TEXT,
+    Hidden INTEGER DEFAULT 0
+)
+"""
+
+
+def build_synthetic_kobo_db(
+    path: Path,
+    book_uuid: str = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04",
+    extra_book_uuid: str = "11111111-2222-3333-4444-555555555555",
+    sideloaded_uri: str = "file:///mnt/onboard/sideloaded.epub",
+) -> Path:
+    """Write a KoboReader.sqlite with a mix of bookmarks the H1 import
+    path needs to handle:
+
+    * 3 highlights on a UUID-tagged book (matches CW library)
+    * 1 highlight with a typed note (Annotation populated)
+    * 1 highlight in red color (color != 0)
+    * 1 highlight on a sideloaded book (``file://`` URI) — must be skipped
+    * 1 hidden highlight (Hidden=1) — must be skipped
+    * 1 highlight on an unrelated UUID (no CW book) — must be skipped
+    """
+    if not isinstance(path, Path):
+        path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    conn = sqlite3.connect(path)
+    conn.executescript(BOOKMARK_DDL)
+
+    rows = [
+        # bm_id, volume_id, content_id, sp, sci, so, ep, eci, eo, text, ann, color, ctx, prog, dcreated, dmod, hidden
+        ("bm-001", book_uuid, f"{book_uuid}!!chapter1.html",
+         "span#kobo\\.1\\.1", -99, 0, "span#kobo\\.1\\.1", -99, 15,
+         "All animals are equal.", None, 0, "... All animals are equal. But ...",
+         0.01, "2026-01-01T10:00:00Z", "2026-01-01T10:00:00Z", 0),
+        ("bm-002", book_uuid, f"{book_uuid}!!chapter1.html",
+         "span#kobo\\.1\\.2", -99, 0, "span#kobo\\.1\\.3", -99, 21,
+         "Four legs good, two legs bad.", "my favorite line", 1,
+         "Four legs good, two legs bad.", 0.024, "2026-01-01T10:05:00Z",
+         "2026-01-01T10:05:00Z", 0),
+        ("bm-003", book_uuid, f"{book_uuid}!!chapter2.html",
+         "span#kobo\\.2\\.1", -99, 8, "span#kobo\\.2\\.1", -99, 17,
+         "Comrade Napoleon", None, 2, "...Comrade Napoleon is always right...",
+         0.5, "2026-01-02T10:00:00Z", "2026-01-02T10:00:00Z", 0),
+        # sideloaded — must be skipped
+        ("bm-004", sideloaded_uri, "sideloaded!!ch1.html",
+         "span#kobo\\.4\\.1", -99, 0, "span#kobo\\.4\\.1", -99, 10,
+         "sideloaded text", None, 0, None, 0.1,
+         "2026-01-03T10:00:00Z", "2026-01-03T10:00:00Z", 0),
+        # hidden — must be skipped
+        ("bm-005", book_uuid, f"{book_uuid}!!chapter1.html",
+         "span#kobo\\.1\\.4", -99, 0, "span#kobo\\.1\\.4", -99, 30,
+         "deleted on device", None, 0, None, 0.05,
+         "2026-01-04T10:00:00Z", "2026-01-04T10:00:00Z", 1),
+        # unrelated UUID — must be skipped (no CW book matches)
+        ("bm-006", extra_book_uuid, f"{extra_book_uuid}!!intro.html",
+         "span#kobo\\.5\\.1", -99, 0, "span#kobo\\.5\\.1", -99, 12,
+         "orphan highlight", None, 3, None, 0.0,
+         "2026-01-05T10:00:00Z", "2026-01-05T10:00:00Z", 0),
+        # malformed: empty BookmarkID — must be skipped silently
+        ("", book_uuid, None, None, None, None, None, None, None,
+         "malformed", None, 0, None, None, None, None, 0),
+        # empty text — must be skipped (parser WHERE clause filters)
+        ("bm-008", book_uuid, f"{book_uuid}!!chapter1.html",
+         "span#kobo\\.1\\.7", -99, 0, "span#kobo\\.1\\.7", -99, 5,
+         "", None, 0, None, 0.0,
+         "2026-01-06T10:00:00Z", "2026-01-06T10:00:00Z", 0),
+    ]
+
+    conn.executemany(
+        "INSERT INTO Bookmark VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def build_empty_sqlite_no_bookmark_table(path: Path) -> Path:
+    """A valid SQLite file with no Bookmark table — exercises the
+    schema-validation skip path."""
+    if path.exists():
+        path.unlink()
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE OtherTable (id INTEGER)")
+    conn.commit()
+    conn.close()
+    return path
+
+
+def build_not_sqlite(path: Path) -> Path:
+    """Not a SQLite file at all — exercises the magic-bytes rejection."""
+    path.write_bytes(b"This is not a sqlite file. " * 100)
+    return path

--- a/tests/unit/test_annotations_import_endpoint.py
+++ b/tests/unit/test_annotations_import_endpoint.py
@@ -1,0 +1,283 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Integration tests for the H1 Phase 3 import path.
+
+Exercises ``cps.annotations.ingest_bookmarks`` end-to-end against an
+in-memory SQLAlchemy session — covers the full INSERT loop including
+UUID resolution, orphan-skipping, hidden-row filtering, dedup against
+``(user_id, annotation_id)``, and the JSON summary shape the endpoint
+returns.
+
+Coverage:
+
+1. End-to-end ingest of the canonical synthetic fixture produces the
+   expected counts: imported=3, skipped_orphan=2, skipped_hidden=1.
+2. All H1 columns on each inserted row are populated.
+3. Re-running the same import is idempotent — second pass counts as
+   ``skipped_existing``.
+4. Mixed UUID + sideloaded ``file://`` URIs split correctly into
+   imported vs skipped_orphan.
+5. Multi-user isolation — user A's import never resolves user B's
+   existing rows.
+6. Commit failure rolls back cleanly + reports imported=0.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from tests.fixtures.kobo_reader_sqlite import build_synthetic_kobo_db
+
+
+@pytest.fixture
+def memory_db(tmp_path, monkeypatch):
+    """Same shape as the backup-feature fixture — full ub.Base schema
+    in-memory + worker autostart disabled so the after_flush hook
+    doesn't try to dispatch to a production-DB-bound thread."""
+    from cps import ub, constants
+    from cps.services import annotation_backup
+
+    annotation_backup.reset_for_tests()
+    monkeypatch.setattr(annotation_backup, "WORKER_AUTOSTART", False)
+
+    engine = create_engine("sqlite:///:memory:", future=True)
+    with engine.connect() as conn:
+        conn.exec_driver_sql("PRAGMA foreign_keys = OFF")
+    ub.Base.metadata.create_all(engine)
+
+    Session = sessionmaker(bind=engine, future=True)
+    session = Session()
+
+    monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path))
+    yield session, engine, tmp_path
+    session.close()
+    annotation_backup.reset_for_tests()
+
+
+def _make_book_lookup(uuid_to_book_id: dict[str, int]):
+    """Build a callable that maps Bookmark.VolumeID → fake Book
+    object whose ``.id`` is what the production lookup would return.
+    Unknown UUIDs return ``None`` to simulate "book not in library"."""
+    def lookup(uuid):
+        if not uuid or uuid not in uuid_to_book_id:
+            return None
+        return SimpleNamespace(id=uuid_to_book_id[uuid])
+    return lookup
+
+
+@pytest.fixture
+def synthetic_db(tmp_path):
+    return build_synthetic_kobo_db(tmp_path / "kr.sqlite")
+
+
+# ---------------------------------------------------------------------------
+# 1 + 4. End-to-end ingest produces the expected counts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIngestCounts:
+    def test_canonical_fixture_counts(self, memory_db, synthetic_db):
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        # Only the primary UUID maps to a CW book; the extra UUID +
+        # the file:// URI are both orphans.
+        book_lookup = _make_book_lookup({
+            "b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348,
+        })
+
+        result = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=book_lookup, commit=session.commit,
+        )
+        assert result["imported"] == 3, result
+        assert result["skipped_hidden"] == 1, result
+        assert result["skipped_orphan"] == 2, result    # bm-004 sideloaded + bm-006 unknown UUID
+        assert result["skipped_existing"] == 0, result
+        # total_seen excludes empty BookmarkID + empty Text rows
+        # (filtered at the parser SQL level).
+        assert result["total_seen"] == 6, result
+
+    def test_inserted_rows_carry_full_h1_payload(self, memory_db, synthetic_db):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        book_lookup = _make_book_lookup({
+            "b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348,
+        })
+        ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=book_lookup, commit=session.commit,
+        )
+
+        # bm-002 has all the bells: multi-span, typed note, red color.
+        row = session.query(ub.KoboAnnotationSync).filter_by(
+            annotation_id="bm-002"
+        ).one()
+        assert row.user_id == 7
+        assert row.book_id == 348
+        assert row.highlighted_text == "Four legs good, two legs bad."
+        assert row.highlight_color == "red"
+        assert row.note_text == "my favorite line"
+        assert row.start_container_path == "span#kobo\\.1\\.2"
+        assert row.end_container_path == "span#kobo\\.1\\.3"
+        assert row.start_offset == 0
+        assert row.end_offset == 21
+        assert row.source == "kobo"
+        assert row.chapter_progress == 0.024
+
+    def test_color_round_trips(self, memory_db, synthetic_db):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        book_lookup = _make_book_lookup({
+            "b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348,
+        })
+        ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=book_lookup, commit=session.commit,
+        )
+        rows = {r.annotation_id: r for r in
+                session.query(ub.KoboAnnotationSync).filter_by(user_id=7).all()}
+        assert rows["bm-001"].highlight_color == "yellow"
+        assert rows["bm-002"].highlight_color == "red"
+        assert rows["bm-003"].highlight_color == "green"
+
+
+# ---------------------------------------------------------------------------
+# 2. Re-import is idempotent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIdempotency:
+    def test_second_import_skips_existing(self, memory_db, synthetic_db):
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        book_lookup = _make_book_lookup({
+            "b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348,
+        })
+
+        first = ingest_bookmarks(synthetic_db, user_id=7, session=session,
+                                  book_lookup=book_lookup, commit=session.commit)
+        assert first["imported"] == 3
+
+        second = ingest_bookmarks(synthetic_db, user_id=7, session=session,
+                                   book_lookup=book_lookup, commit=session.commit)
+        assert second["imported"] == 0
+        assert second["skipped_existing"] == 3, second
+        # Orphans are still orphans on re-import; that count stays.
+        assert second["skipped_orphan"] == 2
+
+    def test_no_duplicate_rows_after_double_import(self, memory_db, synthetic_db):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        book_lookup = _make_book_lookup({
+            "b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348,
+        })
+
+        for _i in range(3):
+            ingest_bookmarks(synthetic_db, user_id=7, session=session,
+                              book_lookup=book_lookup, commit=session.commit)
+
+        total = session.query(ub.KoboAnnotationSync).filter_by(user_id=7).count()
+        assert total == 3, "Re-import must never duplicate rows"
+
+
+# ---------------------------------------------------------------------------
+# 3. Multi-user isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMultiUserIsolation:
+    def test_user_a_import_does_not_collide_with_user_b(self, memory_db, synthetic_db):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        # User B has already imported the same annotations earlier.
+        ingest_bookmarks(
+            synthetic_db, user_id=99, session=session,
+            book_lookup=_make_book_lookup({"b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348}),
+            commit=session.commit,
+        )
+        # User A imports for the first time — must NOT see user B's
+        # rows as "existing" — annotation_id is scoped per-user.
+        result = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=_make_book_lookup({"b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348}),
+            commit=session.commit,
+        )
+        assert result["imported"] == 3
+        assert result["skipped_existing"] == 0
+
+        a_rows = session.query(ub.KoboAnnotationSync).filter_by(user_id=7).count()
+        b_rows = session.query(ub.KoboAnnotationSync).filter_by(user_id=99).count()
+        assert a_rows == 3
+        assert b_rows == 3
+
+
+# ---------------------------------------------------------------------------
+# 4. Sideloaded URI handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSideloadedBookHandling:
+    def test_file_uri_volume_id_counted_as_orphan(self, memory_db, synthetic_db):
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        # Only the UUID-format VolumeID maps; file://... doesn't.
+        result = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=_make_book_lookup({"b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348}),
+            commit=session.commit,
+        )
+        # bm-004 (file:// URI) counts as orphan + bm-006 (unknown UUID)
+        # also orphan = 2.
+        assert result["skipped_orphan"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 5. Commit failure rolls back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCommitFailure:
+    def test_commit_failure_reports_imported_zero(self, memory_db, synthetic_db):
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        book_lookup = _make_book_lookup({
+            "b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348,
+        })
+
+        def boom():
+            raise RuntimeError("synthetic commit failure")
+
+        result = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=book_lookup, commit=boom,
+        )
+        assert result["imported"] == 0
+        # Other counts are still reported honestly so the user sees
+        # what would have been imported if the commit had succeeded.
+        assert result["skipped_orphan"] == 2
+        assert result["skipped_hidden"] == 1

--- a/tests/unit/test_kobo_import_parser.py
+++ b/tests/unit/test_kobo_import_parser.py
@@ -1,0 +1,154 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for the H1 Phase 3 ``cps.services.kobo_import`` module.
+
+Coverage:
+
+1. ``looks_like_sqlite`` accepts a real sqlite, rejects garbage.
+2. Parser yields one ``ParsedBookmark`` per valid Bookmark row.
+3. Hidden rows + empty-text rows + empty-BookmarkID rows are filtered.
+4. Color integers map to the expected color names.
+5. Multi-span highlight preserves both start + end fields.
+6. Note (Annotation) field round-trips.
+7. ``ContextString`` field round-trips for re-anchoring downstream.
+8. Missing Bookmark table → empty iterator, no raise.
+9. Non-SQLite file → empty iterator, no raise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.fixtures.kobo_reader_sqlite import (
+    build_synthetic_kobo_db,
+    build_empty_sqlite_no_bookmark_table,
+    build_not_sqlite,
+)
+
+
+@pytest.mark.unit
+class TestLooksLikeSqlite:
+    def test_accepts_real_sqlite(self, tmp_path):
+        from cps.services.kobo_import import looks_like_sqlite
+
+        p = build_synthetic_kobo_db(tmp_path / "test.sqlite")
+        assert looks_like_sqlite(p) is True
+
+    def test_rejects_garbage_file(self, tmp_path):
+        from cps.services.kobo_import import looks_like_sqlite
+
+        p = build_not_sqlite(tmp_path / "garbage.sqlite")
+        assert looks_like_sqlite(p) is False
+
+    def test_rejects_missing_file(self, tmp_path):
+        from cps.services.kobo_import import looks_like_sqlite
+
+        assert looks_like_sqlite(tmp_path / "nonexistent.sqlite") is False
+
+    def test_accepts_blob_form(self):
+        from cps.services.kobo_import import looks_like_sqlite
+
+        magic = b"SQLite format 3\x00" + b"trailing payload"
+        assert looks_like_sqlite(magic) is True
+        assert looks_like_sqlite(b"not even close") is False
+
+
+@pytest.mark.unit
+class TestParseKoboBookmarks:
+    def test_yields_one_per_valid_row(self, tmp_path):
+        from cps.services.kobo_import import parse_kobo_bookmarks
+
+        p = build_synthetic_kobo_db(tmp_path / "k.sqlite")
+        rows = list(parse_kobo_bookmarks(p))
+        # Fixture has 6 valid-text rows (bm-001..006); bm-007 has empty
+        # BookmarkID + bm-008 has empty Text — both filtered.
+        bm_ids = {r.bookmark_id for r in rows}
+        assert "bm-001" in bm_ids
+        assert "bm-002" in bm_ids
+        assert "bm-003" in bm_ids
+        assert "bm-004" in bm_ids  # sideloaded — yielded; caller decides
+        assert "bm-005" in bm_ids  # hidden — yielded with hidden=True; caller filters
+        assert "bm-006" in bm_ids
+        # malformed (empty BookmarkID) — filtered
+        assert "" not in bm_ids
+        # empty-Text — filtered at SQL level
+        assert "bm-008" not in bm_ids
+
+    def test_color_map_normalized(self, tmp_path):
+        from cps.services.kobo_import import parse_kobo_bookmarks
+
+        p = build_synthetic_kobo_db(tmp_path / "k.sqlite")
+        rows = {r.bookmark_id: r for r in parse_kobo_bookmarks(p)}
+        assert rows["bm-001"].color == "yellow"  # Color=0
+        assert rows["bm-002"].color == "red"     # Color=1
+        assert rows["bm-003"].color == "green"   # Color=2
+        assert rows["bm-006"].color == "blue"    # Color=3
+
+    def test_typed_note_round_trips(self, tmp_path):
+        from cps.services.kobo_import import parse_kobo_bookmarks
+
+        p = build_synthetic_kobo_db(tmp_path / "k.sqlite")
+        rows = {r.bookmark_id: r for r in parse_kobo_bookmarks(p)}
+        assert rows["bm-002"].annotation == "my favorite line"
+        assert rows["bm-001"].annotation is None
+
+    def test_context_string_round_trips(self, tmp_path):
+        from cps.services.kobo_import import parse_kobo_bookmarks
+
+        p = build_synthetic_kobo_db(tmp_path / "k.sqlite")
+        rows = {r.bookmark_id: r for r in parse_kobo_bookmarks(p)}
+        assert "All animals are equal" in rows["bm-001"].context_string
+
+    def test_multi_span_preserves_end_fields(self, tmp_path):
+        from cps.services.kobo_import import parse_kobo_bookmarks
+
+        p = build_synthetic_kobo_db(tmp_path / "k.sqlite")
+        rows = {r.bookmark_id: r for r in parse_kobo_bookmarks(p)}
+        bm = rows["bm-002"]
+        # Multi-span: start = kobo.1.2, end = kobo.1.3
+        assert bm.start_container_path == "span#kobo\\.1\\.2"
+        assert bm.end_container_path == "span#kobo\\.1\\.3"
+        assert bm.start_offset == 0
+        assert bm.end_offset == 21
+
+    def test_hidden_flag_preserved(self, tmp_path):
+        """Parser yields hidden rows; downstream code decides whether
+        to skip. Pin that the flag is correctly surfaced."""
+        from cps.services.kobo_import import parse_kobo_bookmarks
+
+        p = build_synthetic_kobo_db(tmp_path / "k.sqlite")
+        rows = {r.bookmark_id: r for r in parse_kobo_bookmarks(p)}
+        assert rows["bm-005"].hidden is True
+        assert rows["bm-001"].hidden is False
+
+    def test_sideloaded_volume_id_preserved_as_uri(self, tmp_path):
+        from cps.services.kobo_import import parse_kobo_bookmarks
+
+        p = build_synthetic_kobo_db(tmp_path / "k.sqlite")
+        rows = {r.bookmark_id: r for r in parse_kobo_bookmarks(p)}
+        assert rows["bm-004"].volume_id.startswith("file:///")
+
+
+@pytest.mark.unit
+class TestParserEdgeCases:
+    def test_no_bookmark_table_yields_empty(self, tmp_path):
+        from cps.services.kobo_import import parse_kobo_bookmarks
+
+        p = build_empty_sqlite_no_bookmark_table(tmp_path / "empty.sqlite")
+        assert list(parse_kobo_bookmarks(p)) == []
+
+    def test_not_sqlite_yields_empty(self, tmp_path):
+        from cps.services.kobo_import import parse_kobo_bookmarks
+
+        p = build_not_sqlite(tmp_path / "garbage.sqlite")
+        assert list(parse_kobo_bookmarks(p)) == []
+
+    def test_missing_file_yields_empty(self, tmp_path):
+        from cps.services.kobo_import import parse_kobo_bookmarks
+
+        assert list(parse_kobo_bookmarks(tmp_path / "nope.sqlite")) == []


### PR DESCRIPTION
The first user-visible piece of H1. A user uploads their Kobo's ``KoboReader.sqlite`` and CWNG ingests every highlight, note, and color into their account, ready for the view/render surfaces in P4 + P5.

## Pipeline

1. ``GET /annotations/import`` — upload form (renders via ``cps/templates/annotations_import.html``)
2. ``POST /annotations/import`` — multipart file upload (CSRF + ``user_login_required``)
3. Stream upload into a ``NamedTemporaryFile`` with a 100 MB cap (pre-read + mid-read checks so a lying ``Content-Length`` can't sneak past)
4. ``cps.services.kobo_import.parse_kobo_bookmarks()`` walks ``Bookmark`` rows with ``Text != ''`` — read-only SQLite open (``mode=ro&immutable=1``) so we can't fire triggers
5. ``cps.annotations.ingest_bookmarks()`` resolves each ``VolumeID`` against the CW library via ``calibre_db.get_book_by_uuid``
6. ``(user_id, annotation_id)`` dedup short-circuits re-imports
7. Hidden=1 rows skipped (device-side soft-delete)
8. Sideloaded ``file://`` URIs + unknown UUIDs counted as orphans + skipped
9. Temp file unlinked in ``finally`` before the JSON response returns — file contents are PII (reading history), never persisted on the server
10. The #241 ``after_commit`` backup hook captures the imported state automatically — a future re-import that would overwrite anything has a recoverable snapshot already on disk

## Why orphans skip rather than INSERT-with-NULL-book_id

The design doc (§11 row 2) says ignore sideloaded books CW doesn't know about. Two reasons: the user typically doesn't want highlights for books they no longer have in CW, and ``kobo_annotation_sync.book_id`` is ``NOT NULL`` on the existing schema (preserves the Hardcover sync invariant from CWA #1166 / #1324). Allowing orphans would mean a schema migration to drop NOT NULL — bigger blast radius than this PR is taking on.

## Security shape

- **CSRF:** Flask-WTF default; NOT ``@csrf.exempt`` — this is browser-driven, not device-protocol
- **Auth:** ``@user_login_required`` — annotation data is per-user-private; anonymous users can't reach the form
- **Size cap:** 100 MB hard limit, streamed read so a hostile client can't fill RAM
- **SQLite sandbox:** opened ``mode=ro&immutable=1`` URI; magic bytes validated; temp file unlinked in ``finally``
- **VolumeID lookup:** parameterized SQLAlchemy query via ``calibre_db.get_book_by_uuid`` — no injection surface
- **Scope isolation:** ``(user_id, annotation_id)`` dedup is per-user; user A's import can never resolve user B's rows as ``existing``

## Verification

**22 P3-specific tests** (14 parser + 8 ingest), all green RED→GREEN:

- Parser: SQLite magic-byte check accepts real DB / rejects garbage / handles missing file
- Parser: Yields one ``ParsedBookmark`` per valid row; filters empty BookmarkID + empty Text
- Parser: Color map normalizes 0/1/2/3 → yellow/red/green/blue
- Parser: Multi-span path preserves end fields
- Parser: Typed note + ContextString round-trip
- Parser: Hidden flag preserved; sideloaded ``file://`` URI preserved
- Parser: No Bookmark table / non-SQLite / missing file → empty iterator (no raise)
- Ingest: Canonical fixture → exact counts (imported=3, skipped_hidden=1, skipped_orphan=2, skipped_existing=0, total_seen=6)
- Ingest: All H1 columns populated on each inserted row (multi-span ``start_container_path`` / ``end_container_path``, color, note, ``chapter_progress``, ``source='kobo'``)
- Ingest: Re-import idempotent — second pass = 0 imported, 3 skipped_existing
- Ingest: Multi-user isolation — user A's import doesn't see user B's rows as existing
- Ingest: Sideloaded URI orphan handling
- Ingest: Commit failure rolls back cleanly + reports imported=0

**Broader suite:** 265/266 in the related test families pass. The one failure is ``test_ingest_batch_dirty.py::test_successful_import_marks_batch_dirty_without_hot_loop_http_calls`` — pre-existing flake on ``main`` (writes to ``/config/`` which doesn't exist on macOS dev machines), unrelated to P3. Verified by stashing my changes and re-running the test on clean ``main``.

**Live ``cwn-local`` end-to-end:**

```
$ curl -s -b cookies.txt -X POST -F "csrf_token=..." -F "file=@synth.sqlite" \
    http://localhost:8086/annotations/import
{"imported":3,"skipped_existing":0,"skipped_hidden":1,"skipped_orphan":2,"total_seen":6}
HTTP=200
```

After import: ``sqlite3 /config/app.db "SELECT … FROM kobo_annotation_sync"`` shows 3 rows scoped to user 3 / book 2 with full H1 payload populated. The annotation-backup ``after_commit`` hook fired automatically and produced a 600-byte gzipped snapshot at ``/config/annotation-backups/3/2/<UTC-iso>.json.gz``. Re-import: ``{imported=0, skipped_existing=3}``; backup count stays at 1 — content-hash dedup intact.

**Adjacency sweep:**

- Hardcover sync's write path (``cps/readingservices.py``) still works (Hardcover-source-pin test passes, full Hardcover unit suite passes)
- The annotation-backup hook captures P3's INSERTs the same way it captures Hardcover's — same Session-level event, no per-writer wiring
- ``calibre_db.get_book_by_uuid`` is the same lookup used by the Kobo sync path's existing UUID-resolution branch
- No conflict with P2's CFI converter — P3 leaves ``cfi_range`` NULL; P5 (or a backfill job) computes from the populated Kobo-native columns later

**Skipped gates (with reason):**

- Playwright UI pilot — the form is a simple HTML upload + tiny ``fetch()`` handler with no JS state machine; the live ``curl`` end-to-end above exercised the actual user-visible flow (login → CSRF → multipart POST → JSON response → DB + disk state). The page renders cleanly (HTTP 200, title in ``<title>``, CSRF token present in form) — a deeper UI pilot would just confirm the same evidence the curl flow already produced.
- i18n end-to-end — all user-visible strings are wrapped with ``_()`` / ``gettext`` in the template; ``compile_translations.sh`` runs in CI; no new strings need locale-specific compile for this PR (the new strings will be picked up by the next translation update bot run)

## Tier

``needs-review`` — new endpoint, file upload, new blueprint registered into the app. Even with the safety net behind it, this is the surface that takes user-supplied bytes and turns them into DB rows — worth your eye.