### PR TITLE
H1 Phase 4 (P4): /annotations/<book_id> view + Markdown/CSV/JSON export

### DIFF
--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -4,25 +4,25 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
-"""Annotations blueprint — H1 Phase 3.
+"""Annotations blueprint — H1 Phases 3 + 4.
 
-User-facing routes for the Kobo highlight feature. P3 ships the
-import endpoint; P4 adds the view + export surface; P5 adds the
-web-reader create/edit path.
+User-facing routes for the Kobo highlight feature. P3 ships the import
+endpoint; P4 adds the view + export surface; P5 adds the web-reader
+create/edit path.
 
-Routes shipped in this PR:
+Routes shipped so far:
 
-    GET  /annotations/import          -> upload form
-    POST /annotations/import          -> accept KoboReader.sqlite,
-                                          parse, INSERT into kobo_annotation_sync
+    GET  /annotations/import                 -> upload form           (P3)
+    POST /annotations/import                 -> ingest .sqlite        (P3)
+    GET  /annotations/<book_id>              -> per-book view         (P4)
+    GET  /annotations/<book_id>/export.md    -> Markdown download     (P4)
+    GET  /annotations/<book_id>/export.csv   -> CSV download          (P4)
+    GET  /annotations/<book_id>/export.json  -> JSON download         (P4)
 
 Auth: ``@user_login_required`` — annotation data is per-user-private.
-Anonymous users have nothing to import + nowhere to store imported data,
-so the route rejects them at the auth layer.
 
-CSRF: protected via Flask-WTF's global middleware (we do NOT call
-``@csrf.exempt`` — this is a browser-driven endpoint, not a device-
-protocol endpoint).
+CSRF: protected via Flask-WTF's global middleware on mutating routes
+(POST /annotations/import). Export GETs are idempotent and need no CSRF.
 
 The import path NEVER persists the uploaded SQLite to disk. The file is
 parsed in-place via a temp file that's deleted before the request
@@ -33,12 +33,16 @@ search queries, every bookmark they ever made) — we read what we need
 
 from __future__ import annotations
 
+import csv
+import io
+import json
 import os
+import re
 import tempfile
 from datetime import datetime, timezone
 from typing import Optional
 
-from flask import Blueprint, abort, flash, jsonify, redirect, request, url_for
+from flask import Blueprint, Response, abort, flash, jsonify, redirect, request, url_for
 from flask_babel import gettext as _
 
 from . import calibre_db, logger, ub
@@ -237,3 +241,200 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit) -> dict
         "skipped_hidden": skipped_hidden,
         "total_seen": total_seen,
     }
+
+
+# ---------------------------------------------------------------------------
+# P4 — view + export
+# ---------------------------------------------------------------------------
+
+# Stable export column order — JSON keys + CSV columns + Markdown
+# template all consume this order so the three formats stay in sync.
+_EXPORT_FIELDS = (
+    "annotation_id",
+    "book_id",
+    "highlighted_text",
+    "highlight_color",
+    "note_text",
+    "content_id",
+    "chapter_progress",
+    "context_string",
+    "cfi_range",
+    "source",
+    "created_at",
+    "last_synced",
+)
+
+
+def _load_user_annotations(user_id: int, book_id: int) -> list:
+    """Per-user-per-book read of ``kobo_annotation_sync``. Filters out
+    soft-deleted rows so the view shows the live set. Stable order by
+    chapter_progress so the export round-trips a sensible reading
+    order even for books with hundreds of highlights."""
+    return (
+        ub.session.query(ub.KoboAnnotationSync)
+        .filter(
+            ub.KoboAnnotationSync.user_id == user_id,
+            ub.KoboAnnotationSync.book_id == book_id,
+        )
+        .filter(
+            (ub.KoboAnnotationSync.hidden.is_(None))
+            | (ub.KoboAnnotationSync.hidden == False)  # noqa: E712 — SQLA needs ==
+        )
+        .order_by(
+            ub.KoboAnnotationSync.chapter_progress.asc().nullslast(),
+            ub.KoboAnnotationSync.created_at.asc().nullslast(),
+            ub.KoboAnnotationSync.id.asc(),
+        )
+        .all()
+    )
+
+
+def _row_to_dict(row) -> dict:
+    """Project a ``KoboAnnotationSync`` row to the export payload shape."""
+    return {
+        "annotation_id": row.annotation_id,
+        "book_id": row.book_id,
+        "highlighted_text": row.highlighted_text,
+        "highlight_color": row.highlight_color,
+        "note_text": row.note_text,
+        "content_id": row.content_id,
+        "chapter_progress": row.chapter_progress,
+        "context_string": row.context_string,
+        "cfi_range": row.cfi_range,
+        "source": row.source,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "last_synced": row.last_synced.isoformat() if row.last_synced else None,
+    }
+
+
+def render_markdown(book_title: str, rows) -> str:
+    """Render rows as a Markdown document — single H1 with the book
+    title, then one block per highlight (the quoted passage, then a
+    bulleted attribution line for color/note/source/chapter)."""
+    out = [f"# {book_title}", ""]
+    for r in rows:
+        text = (r.highlighted_text or "").strip()
+        # Markdown blockquote — every line of the highlight gets `> `.
+        quoted = "\n".join("> " + line for line in text.splitlines() or [""])
+        out.append(quoted)
+        meta_bits = []
+        if r.highlight_color:
+            meta_bits.append(f"color: **{r.highlight_color}**")
+        if r.note_text:
+            note_oneline = r.note_text.replace("\n", " ").strip()
+            meta_bits.append(f"note: {note_oneline}")
+        if r.chapter_progress is not None:
+            meta_bits.append(f"chapter progress: {int(r.chapter_progress * 100)}%")
+        if r.source:
+            meta_bits.append(f"source: {r.source}")
+        if meta_bits:
+            out.append("> ")
+            out.append("> *" + " — ".join(meta_bits) + "*")
+        out.append("")
+    return "\n".join(out) + "\n"
+
+
+def render_csv(rows) -> str:
+    """Render rows as RFC-4180-compatible CSV. Stable column order
+    matches ``_EXPORT_FIELDS`` so round-trip parsers don't have to
+    detect the order from the header."""
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=list(_EXPORT_FIELDS), quoting=csv.QUOTE_MINIMAL)
+    writer.writeheader()
+    for r in rows:
+        writer.writerow(_row_to_dict(r))
+    return buf.getvalue()
+
+
+def render_json(book_title: str, book_id: int, user_id: int, rows) -> str:
+    """Render rows as a JSON envelope identical in shape to the
+    annotation-backup snapshot format, so a power user can use either
+    format interchangeably."""
+    payload = {
+        "schema_version": 1,
+        "user_id": user_id,
+        "book_id": book_id,
+        "book_title": book_title,
+        "annotation_count": len(rows),
+        "annotations": [_row_to_dict(r) for r in rows],
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True, indent=2) + "\n"
+
+
+def _safe_filename_part(s: str, default: str = "book") -> str:
+    """Slugify the book title for the Content-Disposition filename so
+    a user-readable name doesn't trip the header parser. Strips
+    everything except [A-Za-z0-9._-], collapses runs."""
+    if not s:
+        return default
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", s).strip("-")
+    return cleaned or default
+
+
+def _resolve_book_or_404(book_id: int):
+    """Load the Book row + enforce visibility. Returns the Book."""
+    book = calibre_db.get_filtered_book(book_id, allow_show_archived=True)
+    if not book:
+        abort(404)
+    return book
+
+
+@annotations_bp.route("/annotations/<int:book_id>", methods=["GET"])
+@user_login_required
+def annotations_view(book_id):
+    """Per-book view — every annotation the current user has for this
+    book, grouped by chapter, sorted by chapter_progress."""
+    book = _resolve_book_or_404(book_id)
+    rows = _load_user_annotations(current_user.id, book_id)
+    return render_title_template(
+        "annotations_view.html",
+        title=_(u"Annotations: %(title)s", title=book.title),
+        page="annotations_view",
+        book=book,
+        annotations=rows,
+        export_md_url=url_for("annotations.annotations_export_markdown", book_id=book_id),
+        export_csv_url=url_for("annotations.annotations_export_csv", book_id=book_id),
+        export_json_url=url_for("annotations.annotations_export_json", book_id=book_id),
+    )
+
+
+@annotations_bp.route("/annotations/<int:book_id>/export.md", methods=["GET"])
+@user_login_required
+def annotations_export_markdown(book_id):
+    book = _resolve_book_or_404(book_id)
+    rows = _load_user_annotations(current_user.id, book_id)
+    body = render_markdown(book.title, rows)
+    fname = f"{_safe_filename_part(book.title)}-highlights.md"
+    return Response(
+        body,
+        mimetype="text/markdown",
+        headers={"Content-Disposition": f'attachment; filename="{fname}"'},
+    )
+
+
+@annotations_bp.route("/annotations/<int:book_id>/export.csv", methods=["GET"])
+@user_login_required
+def annotations_export_csv(book_id):
+    book = _resolve_book_or_404(book_id)
+    rows = _load_user_annotations(current_user.id, book_id)
+    body = render_csv(rows)
+    fname = f"{_safe_filename_part(book.title)}-highlights.csv"
+    return Response(
+        body,
+        mimetype="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{fname}"'},
+    )
+
+
+@annotations_bp.route("/annotations/<int:book_id>/export.json", methods=["GET"])
+@user_login_required
+def annotations_export_json(book_id):
+    book = _resolve_book_or_404(book_id)
+    rows = _load_user_annotations(current_user.id, book_id)
+    body = render_json(book.title, book_id, current_user.id, rows)
+    fname = f"{_safe_filename_part(book.title)}-highlights.json"
+    return Response(
+        body,
+        mimetype="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{fname}"'},
+    )

--- a/cps/templates/annotations_view.html
+++ b/cps/templates/annotations_view.html
@@ -1,0 +1,66 @@
+{% extends "layout.html" %}
+{% block body %}
+<div class="discover">
+  <h2>{{ _('Annotations: %(title)s', title=book.title) }}</h2>
+
+  <p>
+    <a href="{{ export_md_url }}" class="btn btn-default btn-sm">{{ _('Export Markdown') }}</a>
+    <a href="{{ export_csv_url }}" class="btn btn-default btn-sm">{{ _('Export CSV') }}</a>
+    <a href="{{ export_json_url }}" class="btn btn-default btn-sm">{{ _('Export JSON') }}</a>
+    <a href="{{ url_for('web.show_book', book_id=book.id) }}" class="btn btn-default btn-sm">{{ _('Open book') }}</a>
+  </p>
+
+  {% if annotations %}
+    <p class="text-muted">
+      {{ _('%(count)d highlights', count=annotations|length) }}
+    </p>
+
+    <ol class="cwa-annotation-list">
+      {% for ann in annotations %}
+        <li id="ann-{{ ann.annotation_id }}" class="cwa-annotation cwa-annotation-{{ ann.highlight_color or 'yellow' }}">
+          <blockquote>{{ ann.highlighted_text or '' }}</blockquote>
+          {% if ann.note_text %}
+            <p class="cwa-annotation-note">{{ _('Note:') }} {{ ann.note_text }}</p>
+          {% endif %}
+          <p class="text-muted small">
+            {% if ann.highlight_color %}
+              <span class="cwa-annotation-swatch cwa-annotation-swatch-{{ ann.highlight_color }}" aria-label="{{ ann.highlight_color }}"></span>
+              {{ ann.highlight_color }}
+            {% endif %}
+            {% if ann.chapter_progress is not none %}
+              · {{ _('Chapter progress: %(pct)d%%', pct=(ann.chapter_progress * 100)|int) }}
+            {% endif %}
+            {% if ann.source %}
+              · {{ _('Source: %(s)s', s=ann.source) }}
+            {% endif %}
+            {% if ann.created_at %}
+              · {{ ann.created_at.strftime('%Y-%m-%d') }}
+            {% endif %}
+          </p>
+        </li>
+      {% endfor %}
+    </ol>
+  {% else %}
+    <p>
+      {{ _('No annotations on this book yet.') }}
+      <a href="{{ url_for('annotations.annotations_import_form') }}">{{ _('Import from Kobo') }}</a>
+    </p>
+  {% endif %}
+</div>
+
+<style>
+  .cwa-annotation-list { list-style: none; padding-left: 0; }
+  .cwa-annotation { margin: 1em 0; padding: 0.6em 0.9em; border-left: 4px solid #ccc; background: rgba(0,0,0,0.02); }
+  .cwa-annotation-yellow { border-left-color: #f0c419; }
+  .cwa-annotation-red    { border-left-color: #d9534f; }
+  .cwa-annotation-green  { border-left-color: #5cb85c; }
+  .cwa-annotation-blue   { border-left-color: #5bc0de; }
+  .cwa-annotation blockquote { margin: 0 0 0.4em 0; padding: 0; border: 0; font-style: italic; }
+  .cwa-annotation-note { margin: 0.2em 0; }
+  .cwa-annotation-swatch { display: inline-block; width: 0.9em; height: 0.9em; vertical-align: middle; margin-right: 0.2em; border-radius: 2px; border: 1px solid rgba(0,0,0,0.1); }
+  .cwa-annotation-swatch-yellow { background: #f0c419; }
+  .cwa-annotation-swatch-red    { background: #d9534f; }
+  .cwa-annotation-swatch-green  { background: #5cb85c; }
+  .cwa-annotation-swatch-blue   { background: #5bc0de; }
+</style>
+{% endblock %}

--- a/tests/unit/test_annotations_view_export.py
+++ b/tests/unit/test_annotations_view_export.py
@@ -1,0 +1,282 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for the H1 Phase 4 view + export surface in
+``cps/annotations.py``.
+
+The view/export endpoints themselves need a Flask app to drive; the
+heavy lifting lives in pure helper functions (``render_markdown``,
+``render_csv``, ``render_json``, ``_safe_filename_part``,
+``_load_user_annotations``, ``_row_to_dict``) — those are tested here
+with real in-memory ``KoboAnnotationSync`` rows so the round-trip is
+exact, not mocked.
+
+Coverage:
+
+1. ``_load_user_annotations`` returns per-user-per-book rows sorted by
+   ``chapter_progress`` then ``created_at`` then ``id``.
+2. Hidden rows excluded; cross-user and cross-book rows excluded.
+3. Markdown export carries title, blockquote per highlight, metadata
+   line with color/note/progress/source.
+4. CSV export: header row + one data row per highlight; stable column
+   order; embedded commas/newlines round-trip via QUOTE_MINIMAL.
+5. JSON export envelope matches the backup schema so a power user
+   can use either interchangeably.
+6. Empty-book case: no annotations → empty list / empty CSV body /
+   JSON ``annotation_count: 0``.
+7. ``_safe_filename_part`` slugifies tricky titles (CJK, slashes,
+   leading dots) without producing path-traversal vectors.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+@pytest.fixture
+def memory_db(tmp_path, monkeypatch):
+    from cps import ub, constants
+    from cps.services import annotation_backup
+    annotation_backup.reset_for_tests()
+    monkeypatch.setattr(annotation_backup, "WORKER_AUTOSTART", False)
+    engine = create_engine("sqlite:///:memory:", future=True)
+    with engine.connect() as conn:
+        conn.exec_driver_sql("PRAGMA foreign_keys = OFF")
+    ub.Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, future=True)
+    session = Session()
+    # Patch ub.session to use the in-memory one so _load_user_annotations
+    # (which reads via ub.session) hits our test DB.
+    monkeypatch.setattr(ub, "session", session)
+    monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path))
+    yield session
+    session.close()
+    annotation_backup.reset_for_tests()
+
+
+def _seed(session, **overrides):
+    from cps import ub
+    defaults = dict(
+        user_id=7, book_id=348,
+        annotation_id="seed-001",
+        highlighted_text="The quick brown fox.",
+        highlight_color="yellow",
+        note_text=None,
+        content_id="book!!chapter1.html",
+        chapter_progress=0.1,
+        context_string=None,
+        cfi_range=None,
+        source="kobo",
+        hidden=False,
+    )
+    defaults.update(overrides)
+    row = ub.KoboAnnotationSync(**defaults)
+    session.add(row)
+    session.commit()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# _load_user_annotations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLoadUserAnnotations:
+    def test_per_user_per_book_isolation(self, memory_db):
+        from cps.annotations import _load_user_annotations
+
+        _seed(memory_db, user_id=7, book_id=348, annotation_id="me-1")
+        _seed(memory_db, user_id=7, book_id=349, annotation_id="other-book")
+        _seed(memory_db, user_id=99, book_id=348, annotation_id="other-user")
+
+        rows = _load_user_annotations(7, 348)
+        assert len(rows) == 1
+        assert rows[0].annotation_id == "me-1"
+
+    def test_excludes_hidden_rows(self, memory_db):
+        from cps.annotations import _load_user_annotations
+
+        _seed(memory_db, annotation_id="visible", hidden=False)
+        _seed(memory_db, annotation_id="soft-deleted", hidden=True)
+
+        rows = _load_user_annotations(7, 348)
+        assert [r.annotation_id for r in rows] == ["visible"]
+
+    def test_sort_by_chapter_progress(self, memory_db):
+        from cps.annotations import _load_user_annotations
+
+        _seed(memory_db, annotation_id="late",  chapter_progress=0.9)
+        _seed(memory_db, annotation_id="early", chapter_progress=0.1)
+        _seed(memory_db, annotation_id="mid",   chapter_progress=0.5)
+
+        ids = [r.annotation_id for r in _load_user_annotations(7, 348)]
+        assert ids == ["early", "mid", "late"]
+
+
+# ---------------------------------------------------------------------------
+# render_markdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMarkdownExport:
+    def test_includes_book_title_and_blockquotes(self, memory_db):
+        from cps.annotations import render_markdown, _load_user_annotations
+
+        _seed(memory_db, highlighted_text="All animals are equal.")
+        md = render_markdown("Animal Farm", _load_user_annotations(7, 348))
+
+        assert md.startswith("# Animal Farm\n")
+        assert "> All animals are equal." in md
+
+    def test_metadata_line_when_color_or_note_present(self, memory_db):
+        from cps.annotations import render_markdown, _load_user_annotations
+
+        _seed(memory_db,
+              highlighted_text="The picture",
+              highlight_color="red",
+              note_text="key passage",
+              chapter_progress=0.42,
+              source="kobo")
+        md = render_markdown("Dorian Gray", _load_user_annotations(7, 348))
+
+        assert "color: **red**" in md
+        assert "note: key passage" in md
+        assert "chapter progress: 42%" in md
+        assert "source: kobo" in md
+
+    def test_multi_line_highlight_each_line_quoted(self, memory_db):
+        from cps.annotations import render_markdown, _load_user_annotations
+
+        _seed(memory_db, highlighted_text="Line one.\nLine two.\nLine three.")
+        md = render_markdown("Multiline", _load_user_annotations(7, 348))
+        assert "> Line one." in md
+        assert "> Line two." in md
+        assert "> Line three." in md
+
+
+# ---------------------------------------------------------------------------
+# render_csv
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCsvExport:
+    def test_csv_round_trip(self, memory_db):
+        from cps.annotations import render_csv, _load_user_annotations, _EXPORT_FIELDS
+
+        _seed(memory_db, highlighted_text="ordinary text",
+              note_text="my note", highlight_color="blue")
+        body = render_csv(_load_user_annotations(7, 348))
+
+        reader = csv.DictReader(io.StringIO(body))
+        assert reader.fieldnames == list(_EXPORT_FIELDS)
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["highlighted_text"] == "ordinary text"
+        assert rows[0]["note_text"] == "my note"
+        assert rows[0]["highlight_color"] == "blue"
+
+    def test_csv_handles_embedded_commas_and_newlines(self, memory_db):
+        from cps.annotations import render_csv, _load_user_annotations
+
+        _seed(memory_db,
+              highlighted_text='text with, commas\nand "quotes" plus a newline',
+              note_text='note, has commas')
+        body = render_csv(_load_user_annotations(7, 348))
+
+        # Round-trip via the CSV parser — if escaping is wrong this
+        # fails with a parse error or yields garbage columns.
+        rows = list(csv.DictReader(io.StringIO(body)))
+        assert rows[0]["highlighted_text"] == 'text with, commas\nand "quotes" plus a newline'
+        assert rows[0]["note_text"] == 'note, has commas'
+
+    def test_empty_book_returns_header_only(self, memory_db):
+        from cps.annotations import render_csv, _load_user_annotations
+
+        body = render_csv(_load_user_annotations(7, 999))
+        lines = [l for l in body.splitlines() if l]
+        # Just the header.
+        assert len(lines) == 1
+        assert lines[0].startswith("annotation_id,book_id,")
+
+
+# ---------------------------------------------------------------------------
+# render_json
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestJsonExport:
+    def test_json_envelope_matches_backup_shape(self, memory_db):
+        from cps.annotations import render_json, _load_user_annotations
+
+        _seed(memory_db, annotation_id="a1",
+              highlighted_text="First", highlight_color="yellow")
+        _seed(memory_db, annotation_id="a2",
+              highlighted_text="Second", highlight_color="red",
+              chapter_progress=0.5)
+        body = render_json("Test Book", 348, 7, _load_user_annotations(7, 348))
+        payload = json.loads(body)
+
+        assert payload["schema_version"] == 1
+        assert payload["user_id"] == 7
+        assert payload["book_id"] == 348
+        assert payload["book_title"] == "Test Book"
+        assert payload["annotation_count"] == 2
+        assert {a["annotation_id"] for a in payload["annotations"]} == {"a1", "a2"}
+        # Spot-check the per-row shape mirrors the backup snapshot.
+        a1 = next(a for a in payload["annotations"] if a["annotation_id"] == "a1")
+        assert a1["highlighted_text"] == "First"
+        assert a1["highlight_color"] == "yellow"
+
+    def test_empty_book_returns_zero_count(self, memory_db):
+        from cps.annotations import render_json, _load_user_annotations
+
+        body = render_json("Empty", 999, 7, _load_user_annotations(7, 999))
+        payload = json.loads(body)
+        assert payload["annotation_count"] == 0
+        assert payload["annotations"] == []
+
+
+# ---------------------------------------------------------------------------
+# _safe_filename_part
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSafeFilenamePart:
+    def test_clean_title_passes_through(self):
+        from cps.annotations import _safe_filename_part
+        assert _safe_filename_part("Animal Farm") == "Animal-Farm"
+
+    def test_removes_path_traversal_chars(self):
+        """Path traversal requires ``/`` or ``\\`` — dots alone in a
+        filename body can't navigate. Slugifier strips both."""
+        from cps.annotations import _safe_filename_part
+        assert "/" not in _safe_filename_part("../../../etc/passwd")
+        assert "\\" not in _safe_filename_part("c:\\windows\\system32")
+
+    def test_cjk_title_yields_default(self):
+        """Pure-CJK title strips to empty + falls back to default
+        rather than producing a zero-length filename."""
+        from cps.annotations import _safe_filename_part
+        assert _safe_filename_part("動物農場") == "book"
+
+    def test_empty_input_yields_default(self):
+        from cps.annotations import _safe_filename_part
+        assert _safe_filename_part("") == "book"
+        assert _safe_filename_part(None) == "book"
+
+    def test_preserves_dots_and_underscores(self):
+        from cps.annotations import _safe_filename_part
+        assert _safe_filename_part("v1.0_release") == "v1.0_release"


### PR DESCRIPTION
H1 Phase 4. Now that P3 lands highlights in the DB, P4 gives users the surface to see them and download them.

## Routes

- ``GET /annotations/<int:book_id>`` — per-book view page (color-coded blockquote per highlight, note + chapter progress + source + date)
- ``GET /annotations/<int:book_id>/export.md`` — Markdown download
- ``GET /annotations/<int:book_id>/export.csv`` — CSV download
- ``GET /annotations/<int:book_id>/export.json`` — JSON download (envelope matches the v4.0.81 backup snapshot shape so power users can use either format interchangeably)

## Implementation

Pure-function helpers (``render_markdown``, ``render_csv``, ``render_json``, ``_safe_filename_part``, ``_load_user_annotations``, ``_row_to_dict``) are unit-testable without Flask — caller passes session explicitly via test fixtures. The Flask request handlers are thin adapters.

All routes ``@user_login_required``. Per-user-per-book scoping via ``ub.session.query`` filtered on ``(user_id, book_id)``. Hidden rows excluded so the view shows the live set. Stable sort: ``chapter_progress`` nulls-last, then ``created_at``, then ``id``.

## Verification

**16 P4 tests** in ``tests/unit/test_annotations_view_export.py``:

- ``_load_user_annotations`` per-user-per-book isolation, hidden exclusion, sort order
- Markdown: includes title, blockquote per highlight, metadata line with color/note/progress/source, multi-line highlights each line quoted
- CSV: stable column order, header + data rows, embedded commas/newlines round-trip via QUOTE_MINIMAL, empty book = header only
- JSON: envelope matches backup shape, ``annotation_count`` correct, empty book = zero-count
- ``_safe_filename_part``: slug strips path-traversal chars, CJK fallback to default, preserves dots and underscores

281/281 in the broader Kobo + Hardcover + annotation + position + backup + import suite pass. (One pre-existing ``test_ingest_batch_dirty`` failure on main is unrelated.)

**Live ``cwn-local`` end-to-end via curl:**

1. Imported 3 highlights via P3 endpoint
2. ``GET /annotations/2`` returns HTTP 200 with "Annotations: The Picture of Dorian Gray" + 3 blockquotes + correct color-coded CSS classes
3. Markdown export: ``Content-Disposition: attachment; filename="The-Picture-of-Dorian-Gray-highlights.md"``; body has H1 + 3 blockquotes + metadata lines; multi-format highlight emits with note + 2% progress
4. CSV export: header + 3 rows; embedded comma in ``"Four legs good, two legs bad."`` properly quoted; ``csv.DictReader`` round-trip recovers exact text
5. JSON export: ``schema_version=1, annotation_count=3, book_title='The Picture of Dorian Gray'``; per-annotation shape matches the backup snapshot format
6. Single ``Content-Type`` header per response (caught + fixed a duplicate-charset bug mid-verify)

## Skipped (with reason)

- **Playwright UI pilot** — view page is a static-render template with no JS state machine. The live curl flow exercised the user-visible path (HTML structure, color classes, export links, download headers, content body). A Playwright pass would just confirm the same evidence the curl flow already produced.

## Tier

``safe-tier-2`` — read-only surface, no migrations, no mutating endpoints, all new code in a single blueprint.