### PR TITLE
H1 Phase 5 (P5): web reader overlay — render imported Kobo highlights via epub.js

### DIFF
--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -379,6 +379,83 @@ def _resolve_book_or_404(book_id: int):
     return book
 
 
+def _resolve_epub_path(book) -> Optional[str]:
+    """Find the on-disk EPUB file for a book — mirrors the lookup
+    pattern in ``cps/web.py``'s serve_book. Returns ``None`` if no
+    EPUB/KEPUB format exists or the file is missing on disk."""
+    from . import config
+    for fmt in book.data or []:
+        ext = (fmt.format or "").upper()
+        if ext not in ("EPUB", "KEPUB"):
+            continue
+        path = os.path.join(config.get_book_path(), book.path, fmt.name + "." + ext.lower())
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def _ensure_cfi_range(row, book) -> Optional[str]:
+    """If ``row.cfi_range`` is missing, try to compute it on the fly
+    via P2's converter, persist back to the DB, and return the new
+    value. Returns None when computation isn't possible (no EPUB on
+    disk, malformed position data, etc.) — caller renders the
+    annotation in the sidebar without an overlay."""
+    if row.cfi_range:
+        return row.cfi_range
+    if not row.content_id or "!!" not in (row.content_id or ""):
+        return None
+    epub_path = _resolve_epub_path(book)
+    if not epub_path:
+        return None
+    from pathlib import Path as _Path
+    from .services.kobo_position import compute_cfi_range, KoboPosition
+    try:
+        cfi = compute_cfi_range(_Path(epub_path), KoboPosition(
+            content_id=row.content_id,
+            start_container_path=row.start_container_path or "",
+            start_container_child_index=row.start_container_child_index,
+            start_offset=row.start_offset or 0,
+            end_container_path=row.end_container_path or "",
+            end_container_child_index=row.end_container_child_index,
+            end_offset=row.end_offset or 0,
+            context_string=row.context_string,
+        ))
+    except Exception as e:
+        log.warning("annotations: cfi compute failed for %s: %s", row.annotation_id, e)
+        return None
+    if cfi:
+        row.cfi_range = cfi
+        try:
+            ub.session_commit()
+        except Exception as e:
+            log.error("annotations: cfi persist failed: %s", e)
+            ub.session.rollback()
+    return cfi
+
+
+@annotations_bp.route("/annotations/<int:book_id>/data.json", methods=["GET"])
+@user_login_required
+def annotations_data(book_id):
+    """Lightweight JSON list for the web reader — every visible
+    annotation for the current user + book, with cfi_range computed on
+    the fly + cached if missing. Excludes hidden rows."""
+    book = _resolve_book_or_404(book_id)
+    rows = _load_user_annotations(current_user.id, book_id)
+    out = []
+    for r in rows:
+        cfi = _ensure_cfi_range(r, book)
+        out.append({
+            "annotation_id": r.annotation_id,
+            "cfi_range": cfi,
+            "highlighted_text": r.highlighted_text,
+            "highlight_color": r.highlight_color or "yellow",
+            "note_text": r.note_text,
+            "chapter_progress": r.chapter_progress,
+            "source": r.source,
+        })
+    return jsonify({"annotations": out, "annotation_count": len(out)})
+
+
 @annotations_bp.route("/annotations/<int:book_id>", methods=["GET"])
 @user_login_required
 def annotations_view(book_id):

--- a/cps/static/js/reading/annotations.js
+++ b/cps/static/js/reading/annotations.js
@@ -1,0 +1,126 @@
+/* H1 Phase 5 — render imported Kobo highlights as colored overlays in
+ * the in-browser EPUB reader.
+ *
+ * Reads `/annotations/<book_id>/data.json` once on rendition ready,
+ * iterates the result, and calls `rendition.annotations.highlight(cfi,
+ * data, callback, className, styles)` for each annotation that has a
+ * resolvable CFI. Annotations without a CFI (P2's converter couldn't
+ * place them) still appear in the sidebar list — they just don't
+ * overlay on the page.
+ *
+ * The annotations panel in the reader sidebar gets populated from
+ * the same payload.
+ *
+ * Depends on the `calibre.annotationsApiBase` global set by read.html
+ * (the per-book root, e.g. `/annotations/2`). The data endpoint is
+ * `${base}/data.json`.
+ */
+/* global $, calibre, reader */
+(function () {
+    "use strict";
+
+    var COLOR_RGBA = {
+        yellow: "rgba(240, 196, 25, 0.40)",
+        red:    "rgba(217, 83, 79, 0.40)",
+        green:  "rgba(92, 184, 92, 0.40)",
+        blue:   "rgba(91, 192, 222, 0.40)"
+    };
+
+    function colorStyle(color) {
+        var c = (color in COLOR_RGBA) ? color : "yellow";
+        return { fill: COLOR_RGBA[c], "fill-opacity": "0.40", "mix-blend-mode": "multiply" };
+    }
+
+    function init() {
+        if (!calibre || !calibre.annotationsApiBase) {
+            return;
+        }
+        if (!window.reader || !reader.rendition) {
+            // epub.js init runs async; retry on next tick.
+            setTimeout(init, 100);
+            return;
+        }
+
+        var dataUrl = calibre.annotationsApiBase + "/data.json";
+        fetch(dataUrl, { credentials: "same-origin" })
+            .then(function (r) { return r.ok ? r.json() : { annotations: [] }; })
+            .then(function (payload) {
+                var rows = (payload && payload.annotations) || [];
+                renderOverlays(rows);
+                renderSidebarList(rows);
+            })
+            .catch(function (err) {
+                if (window.console) { console.warn("annotations fetch failed:", err); }
+            });
+    }
+
+    function renderOverlays(rows) {
+        if (!reader || !reader.rendition || !reader.rendition.annotations) {
+            return;
+        }
+        rows.forEach(function (row) {
+            if (!row.cfi_range) {
+                return; // No CFI — sidebar only, no page overlay.
+            }
+            try {
+                reader.rendition.annotations.highlight(
+                    row.cfi_range,
+                    { id: row.annotation_id },
+                    null,
+                    "cwa-annotation-overlay cwa-annotation-overlay-" + (row.highlight_color || "yellow"),
+                    colorStyle(row.highlight_color)
+                );
+            } catch (e) {
+                if (window.console) { console.warn("annotation overlay failed for " + row.annotation_id + ":", e); }
+            }
+        });
+    }
+
+    function renderSidebarList(rows) {
+        var ol = document.getElementById("annotations-list");
+        if (!ol) { return; }
+        ol.innerHTML = "";
+        if (!rows.length) {
+            var empty = document.createElement("li");
+            empty.className = "text-muted small";
+            empty.textContent = "No annotations on this book.";
+            ol.appendChild(empty);
+            return;
+        }
+        rows.forEach(function (row) {
+            var li = document.createElement("li");
+            li.className = "cwa-annotation cwa-annotation-" + (row.highlight_color || "yellow");
+            li.dataset.cfi = row.cfi_range || "";
+            li.dataset.annotationId = row.annotation_id;
+
+            var quote = document.createElement("blockquote");
+            quote.textContent = row.highlighted_text || "";
+            li.appendChild(quote);
+
+            if (row.note_text) {
+                var noteP = document.createElement("p");
+                noteP.className = "cwa-annotation-note";
+                noteP.textContent = row.note_text;
+                li.appendChild(noteP);
+            }
+            // Click the entry to jump to its CFI in the reader.
+            if (row.cfi_range) {
+                li.style.cursor = "pointer";
+                li.addEventListener("click", function () {
+                    try {
+                        reader.rendition.display(row.cfi_range);
+                    } catch (e) {
+                        // CFI may not resolve if the book has been reuploaded — silent fall-through.
+                    }
+                });
+            }
+            ol.appendChild(li);
+        });
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -30,7 +30,7 @@
             <a id="show-Toc" class="show_view icon-list-1 active" data-view="Toc">TOC</a>
             <a id="show-Bookmarks" class="show_view icon-bookmark" data-view="Bookmarks">Bookmarks</a>
             <a id="back-button" data-view="Back to Books" href="{{ url_for('web.index') }}">Books</a>
-            <!--a id="show-Notes" class="show_view icon-edit" data-view="Notes">Notes</a-->
+            <a id="show-Annotations" class="show_view icon-edit" data-view="Annotations">{{ _('Annotations') }}</a>
 
         </div>
         <div id="tocView" class="view">
@@ -41,13 +41,12 @@
         <div id="bookmarksView" class="view">
             <ul id="bookmarks"></ul>
         </div>
-        <!--div id="notesView" class="view">
-          <div id="new-note">
-            <textarea id="note-text"></textarea>
-            <button id="note-anchor">Anchor</button>
-          </div>
-          <ol id="notes"></ol>
-        </div-->
+        <div id="annotationsView" class="view">
+            <ol id="annotations-list"></ol>
+            <p style="padding: 0.5em 1em; font-size: 0.85em;">
+                <a href="{{ url_for('annotations.annotations_view', book_id=bookid) }}" target="_blank">{{ _('Open annotations page') }}</a>
+            </p>
+        </div>
     </div>
     <div id="main">
 
@@ -131,7 +130,8 @@
             bookUrl: "{{ url_for('web.serve_book', book_id=bookid, book_format=book_format, anyname='file.epub') }}",
             bookmark: "{{ bookmark.bookmark_key if bookmark != None }}",
             useBookmarks: "{{ current_user.is_authenticated | tojson }}",
-            kosyncPercent: {{ kosync_progress | tojson if kosync_progress is not none else 'null' }}
+            kosyncPercent: {{ kosync_progress | tojson if kosync_progress is not none else 'null' }},
+            annotationsApiBase: "{{ url_for('annotations.annotations_view', book_id=bookid).rstrip('/') }}"
         };
 
         window.themes = {
@@ -237,6 +237,7 @@
       <script src="{{ url_for('static', filename='js/libs/screenfull.min.js') }}"></script>
       <script src="{{ url_for('static', filename='js/libs/reader.min.js') }}"></script>
       <script src="{{ url_for('static', filename='js/reading/epub.js') }}"></script>
-      <script src="{{ url_for('static', filename='js/reading/epub-progress.js') }}"></script>      
+      <script src="{{ url_for('static', filename='js/reading/epub-progress.js') }}"></script>
+      <script src="{{ url_for('static', filename='js/reading/annotations.js') }}"></script>
     </body>
 </html>

--- a/tests/unit/test_annotations_data_endpoint.py
+++ b/tests/unit/test_annotations_data_endpoint.py
@@ -1,0 +1,207 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for the H1 Phase 5 data endpoint helpers in
+``cps/annotations.py``.
+
+The Flask-level routing + auth is covered by the live container smoke;
+this file pins the pure helpers:
+
+1. ``_resolve_epub_path`` returns the on-disk EPUB path for a book
+   whose ``data`` carries an ``EPUB``/``KEPUB`` format; None when
+   neither format exists or the file is missing on disk.
+2. ``_ensure_cfi_range`` short-circuits when the row already has a
+   ``cfi_range``; otherwise calls P2's converter; persists the
+   result back when the conversion succeeds; tolerates malformed
+   ``content_id``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from tests.fixtures.kepub_fixture import build_synthetic_kepub
+
+
+@pytest.fixture
+def memory_db(tmp_path, monkeypatch):
+    from cps import ub, constants
+    from cps.services import annotation_backup, kobo_position
+    annotation_backup.reset_for_tests()
+    monkeypatch.setattr(annotation_backup, "WORKER_AUTOSTART", False)
+    kobo_position._get_spine.cache_clear()
+    kobo_position._get_chapter_dom.cache_clear()
+
+    engine = create_engine("sqlite:///:memory:", future=True)
+    with engine.connect() as conn:
+        conn.exec_driver_sql("PRAGMA foreign_keys = OFF")
+    ub.Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, future=True)
+    session = Session()
+    monkeypatch.setattr(ub, "session", session)
+    monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path))
+    yield session
+    session.close()
+    annotation_backup.reset_for_tests()
+
+
+def _make_book(tmp_path, with_epub=True):
+    """Build a fake Book row stand-in + write a synthetic kepub to
+    ``<tmp_path>/<book.path>/<data.name>.kepub`` so
+    ``_resolve_epub_path`` can find it."""
+    book_path = "Author/Title"
+    book_dir = tmp_path / "library" / book_path
+    book_dir.mkdir(parents=True)
+    data_name = "title"
+    if with_epub:
+        build_synthetic_kepub(book_dir / (data_name + ".kepub"))
+    fmt = SimpleNamespace(format="KEPUB", name=data_name)
+    book = SimpleNamespace(
+        id=1, path=book_path, title="Title",
+        data=[fmt] if with_epub else [],
+    )
+    return book
+
+
+# ---------------------------------------------------------------------------
+# _resolve_epub_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolveEpubPath:
+    def test_finds_kepub_on_disk(self, tmp_path, monkeypatch):
+        from cps import annotations as ann_mod
+        from cps import config
+
+        book = _make_book(tmp_path, with_epub=True)
+        monkeypatch.setattr(
+            config, "get_book_path",
+            lambda: str(tmp_path / "library"),
+        )
+
+        path = ann_mod._resolve_epub_path(book)
+        assert path is not None
+        assert Path(path).is_file()
+        assert path.endswith(".kepub")
+
+    def test_returns_none_when_no_epub_format(self, tmp_path, monkeypatch):
+        from cps import annotations as ann_mod
+        from cps import config
+
+        book = _make_book(tmp_path, with_epub=False)
+        monkeypatch.setattr(
+            config, "get_book_path",
+            lambda: str(tmp_path / "library"),
+        )
+
+        assert ann_mod._resolve_epub_path(book) is None
+
+    def test_returns_none_when_file_missing_on_disk(self, tmp_path, monkeypatch):
+        from cps import annotations as ann_mod
+        from cps import config
+
+        # Book has an EPUB format declared but the file isn't there.
+        book = SimpleNamespace(
+            id=1, path="Author/Missing", title="Missing",
+            data=[SimpleNamespace(format="EPUB", name="missing")],
+        )
+        monkeypatch.setattr(
+            config, "get_book_path",
+            lambda: str(tmp_path / "library"),
+        )
+        assert ann_mod._resolve_epub_path(book) is None
+
+
+# ---------------------------------------------------------------------------
+# _ensure_cfi_range
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEnsureCfiRange:
+    def test_short_circuits_when_cfi_already_present(self, memory_db, tmp_path):
+        from cps import ub, annotations as ann_mod
+
+        row = ub.KoboAnnotationSync(
+            user_id=7, book_id=1, annotation_id="cached-cfi",
+            highlighted_text="x", cfi_range="epubcfi(/already/present)",
+            source="kobo",
+        )
+        memory_db.add(row); memory_db.commit()
+
+        book = _make_book(tmp_path, with_epub=False)
+        # No epub on disk + no content_id — but cfi already set, so we
+        # never reach the compute path.
+        result = ann_mod._ensure_cfi_range(row, book)
+        assert result == "epubcfi(/already/present)"
+
+    def test_computes_cfi_when_missing(self, memory_db, tmp_path, monkeypatch):
+        from cps import ub, annotations as ann_mod, config
+
+        row = ub.KoboAnnotationSync(
+            user_id=7, book_id=1, annotation_id="needs-cfi",
+            highlighted_text="hello",
+            cfi_range=None,
+            content_id="00000000-0000-0000-0000-deadbeefcafe!!chapter1.html",
+            start_container_path="span#kobo\\.1\\.1",
+            start_container_child_index=-99, start_offset=0,
+            end_container_path="span#kobo\\.1\\.1",
+            end_container_child_index=-99, end_offset=15,
+            source="kobo",
+        )
+        memory_db.add(row); memory_db.commit()
+
+        book = _make_book(tmp_path, with_epub=True)
+        monkeypatch.setattr(
+            config, "get_book_path",
+            lambda: str(tmp_path / "library"),
+        )
+
+        result = ann_mod._ensure_cfi_range(row, book)
+        assert result is not None
+        assert result.startswith("epubcfi(")
+        # The compute path persists back to the row.
+        assert row.cfi_range == result
+
+    def test_returns_none_on_malformed_content_id(self, memory_db, tmp_path):
+        from cps import ub, annotations as ann_mod
+
+        row = ub.KoboAnnotationSync(
+            user_id=7, book_id=1, annotation_id="bad-content",
+            highlighted_text="x", content_id="no-double-bang",
+            source="kobo",
+        )
+        memory_db.add(row); memory_db.commit()
+
+        book = _make_book(tmp_path, with_epub=True)
+        assert ann_mod._ensure_cfi_range(row, book) is None
+
+    def test_returns_none_when_no_epub_on_disk(self, memory_db, tmp_path, monkeypatch):
+        from cps import ub, annotations as ann_mod, config
+
+        row = ub.KoboAnnotationSync(
+            user_id=7, book_id=1, annotation_id="no-epub",
+            highlighted_text="x",
+            content_id="00000000-0000-0000-0000-deadbeefcafe!!chapter1.html",
+            start_container_path="span#kobo\\.1\\.1",
+            start_container_child_index=-99, start_offset=0,
+            end_container_path="span#kobo\\.1\\.1",
+            end_container_child_index=-99, end_offset=10,
+            source="kobo",
+        )
+        memory_db.add(row); memory_db.commit()
+
+        book = _make_book(tmp_path, with_epub=False)
+        monkeypatch.setattr(
+            config, "get_book_path",
+            lambda: str(tmp_path / "library"),
+        )
+        assert ann_mod._ensure_cfi_range(row, book) is None


### PR DESCRIPTION
The headline visual piece of H1. Imported highlights from P3 now show in the in-browser EPUB reader as color-coded overlays, plus a sidebar list panel.

Closes the core promise of the H1 design (notes/KOBO-WEB-READER-ANNOTATIONS-DESIGN.md §2 edges 1 + 2): server → web reader render, web reader's "Annotations" sidebar wired to the imported set.

## What lands here

- ``GET /annotations/<int:book_id>/data.json`` — JSON list for the reader. For rows where ``cfi_range`` is NULL (P3-imported rows arrive position-only), the endpoint computes CFI on the fly via P2's ``compute_cfi_range`` using the EPUB on disk, then persists back so subsequent reads cache-hit.
- Uncomment + rename the previously-disabled Notes panel in ``cps/templates/read.html`` → "Annotations". New ``annotations-list`` ``<ol>`` in the sidebar.
- ``cps/static/js/reading/annotations.js`` — on ``reader.rendition`` ready, fetches ``data.json``, iterates, calls ``reader.rendition.annotations.highlight(cfi, ...)`` for each row with a resolvable CFI, populates the sidebar list, makes each list item clickable to jump to its CFI.
- Color mapping: yellow / red / green / blue (Kobo's palette) → rgba fill with 40% opacity + ``mix-blend-mode: multiply`` so highlights read cleanly on light + dark + sepia + black themes.

## Deliberate scope cap

**Out of scope for this PR:**

- Text-select-to-create popup (new highlights from the web reader)
- DELETE endpoint + sidebar delete button

Those land in a small follow-up so this PR ships clean. Users can see + jump to highlights they imported via P3, but can't edit them in the reader yet. The ``/annotations/<book_id>`` view + the three export formats remain the surfaces for inspection + export.

## Verification

**7 P5 helper tests** in ``tests/unit/test_annotations_data_endpoint.py`` (RED→GREEN):

- ``_resolve_epub_path``: finds kepub on disk; returns None when no EPUB/KEPUB format; returns None when file missing.
- ``_ensure_cfi_range``: short-circuits when ``cfi_range`` already set; computes via P2 when missing + persists back; returns None on malformed ``content_id``; returns None when no EPUB on disk.

**288/288 in broader Kobo + Hardcover + annotation + position + backup + import suite pass.** Pre-existing ``test_ingest_batch_dirty`` flake on main is unrelated.

**Live cwn-local end-to-end:**

- ``GET /annotations/2/data.json`` returns 3 imported highlights (seeded via P3 endpoint). ``cfi_range`` is null because cwn-local's Dorian Gray copy is Project Gutenberg HTML, not the synthetic kepub structure the fixture matches — annotations still surface in the sidebar list, just without page overlays. The CFI compute path is exercised in the unit test against a synthetic kepub.
- ``GET /read/2/epub`` renders HTTP 200 with ``id="show-Annotations"`` tab, ``id="annotationsView"`` view, ``id="annotations-list"`` ``<ol>``, ``annotationsApiBase`` global, ``annotations.js`` script tag.
- **Playwright pilot**: reader page loads, "Annotations" sidebar tab visible alongside TOC + Bookmarks, no console errors from ``annotations.js``, no failed XHRs. (Lone 500 console error is the pre-existing ``view_settings`` bug on root ``/`` — unrelated to P5.)

## Tier

``needs-review`` — UI + new JS file + new endpoint + cross-cutting between cps/annotations.py and the reader template. Worth your eye.