### PR TITLE
test(integration): enable koreader_sync flag for checksum suite (fix #244)

### DIFF
--- a/tests/integration/test_ingest_checksums.py
+++ b/tests/integration/test_ingest_checksums.py
@@ -14,6 +14,7 @@ Note: These are integration tests that require a running CWA container.
 """
 
 import pytest
+import subprocess
 import sys
 import time
 import sqlite3
@@ -22,6 +23,41 @@ from pathlib import Path
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _enable_koreader_sync(cwa_container, container_name):
+    """Flip `cwa_settings.koreader_sync_enabled` to 1 for this module's lifetime.
+
+    PR #238 / fork #219 gated `book_format_checksums` writes on this flag so
+    disabled-sync instances skip the (slow) partial-MD5 work. The default in
+    `cwa_schema.sql` is 0, so a fresh test container reports `len(checksums)
+    == 0` after ingest and every test in this module would assertion-fail —
+    the regression fork #244 documents.
+
+    The feature these tests verify (checksum generation during ingest) only
+    runs when sync is enabled. Skipping the tests when the flag is 0 would
+    be coverage theater. Enabling the flag exercises the real path.
+
+    `is_koreader_sync_enabled()` re-reads cwa_settings via a fresh
+    `CWA_DB()` instance on every call, so the in-container ingest_processor
+    picks up the flip immediately without a service restart.
+    """
+    subprocess.run(
+        ["docker", "exec", container_name, "sqlite3", "/config/cwa.db",
+         "UPDATE cwa_settings SET koreader_sync_enabled=1"],
+        check=True, timeout=10,
+    )
+    try:
+        yield
+    finally:
+        # Restore the schema default so any later test module that shares the
+        # session-scoped container sees the unmodified state.
+        subprocess.run(
+            ["docker", "exec", container_name, "sqlite3", "/config/cwa.db",
+             "UPDATE cwa_settings SET koreader_sync_enabled=0"],
+            check=False, timeout=10,
+        )
 
 
 def get_book_checksums(db_path, book_id=None):
@@ -39,10 +75,6 @@ def get_book_checksums(db_path, book_id=None):
                 SELECT book, format, checksum FROM book_format_checksums
             """).fetchall()
         return results
-    except sqlite3.OperationalError as e:
-        if "no such table: book_format_checksums" in str(e).lower():
-            pytest.skip("KOReader sync disabled; checksum table not initialized")
-        raise
     finally:
         conn.close()
 


### PR DESCRIPTION
## Symptom

Six tests in `tests/integration/test_ingest_checksums.py` failed on every PR opened against `main` since v4.0.79 / PR #238 shipped:

```
FAILED test_epub_ingest_generates_checksum
FAILED test_converted_book_generates_checksums_for_both_formats
FAILED test_multi_format_book_has_multiple_checksums
FAILED test_checksum_persists_after_container_restart
FAILED test_duplicate_book_updates_checksum
FAILED test_checksum_generated_before_metadata_fetch
```

All assertion-failing with `AssertionError: No checksums were generated` — six consecutive autopilot ticks blocked at the precondition gate because the repo had this WIP uncommitted.

## Root cause

PR #238 / fork #219 added `_is_koreader_sync_enabled()` to gate `generate_book_checksums(...)` in `scripts/ingest_processor.py` so disabled-sync instances skip the slow partial-MD5 work. The default for `cwa_settings.koreader_sync_enabled` in `scripts/cwa_schema.sql` is `0`, so a fresh test container reports zero rows in `book_format_checksums` after ingest — the assertion failure these tests hit.

The tests are explicitly about checksum generation. They assume the feature is on; the production gating moved that assumption.

## Why not the WIP approach

The WIP version of this branch added a `pytest.skip()` guard when the flag was 0 — that would have made CI green but stopped exercising the actual ingest -> checksum-write path. Coverage theater: tests can be green while the feature regresses, because the failure path is "skip" not "fail."

## Fix

Module-scoped autouse fixture flips `cwa_settings.koreader_sync_enabled=1` on the session container before any test in this module runs, and resets it to `0` on teardown so later modules sharing the same session container see the unmodified state.

`is_koreader_sync_enabled()` in `cps/progress_syncing/settings.py` re-reads the flag via a fresh `CWA_DB()` on every call, so the in-container ingest_processor picks up the flip immediately without a service restart.

## Verification

- Syntax: `ast.parse` clean
- The full integration suite has always run in CI against the same container. Once this lands, the six failing tests should go green and the autopilot tick block clears.
- No other integration test module reads `koreader_sync_enabled`; the teardown protects them anyway.

Closes #244