### PR TITLE
fix(db): order_authors uses linked authors, tolerates None (fix #234)

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -1255,49 +1255,80 @@ class CalibreDB:
 
     # Orders all Authors in the list according to authors sort
     def order_authors(self, entries, list_return=False, combined=False):
+        # Render-side ordering: consult only the already-loaded
+        # `book.authors` collection. The pre-#234 implementation re-queried
+        # `Authors` here on every page render, which opened a race window
+        # during concurrent ingest — a torn-down join could surface a None
+        # entry in `book.authors` (or a None row in the re-query result)
+        # and the downstream `r.id` access crashed the whole page with
+        # `AttributeError: 'NoneType' object has no attribute 'id'`.
+        # Tolerate None authors, None/empty author_sort, and stale sort
+        # entries without raising.
         self.ensure_session()
         for entry in entries:
             if combined:
-                sort_authors = entry.Books.author_sort.split('&')
-                ids = [a.id for a in entry.Books.authors]
-
+                book = entry.Books
             else:
-                sort_authors = entry.author_sort.split('&')
-                ids = [a.id for a in entry.authors]
-            authors_ordered = list()
-            # error = False
+                book = entry
+
+            sort_authors = (getattr(book, 'author_sort', None) or '').split('&')
+            authors_list = [a for a in (getattr(book, 'authors', None) or [])
+                            if a is not None]
+
+            authors_by_sort = {}
+            authors_by_id = {}
+            for a in authors_list:
+                if a.sort:
+                    authors_by_sort[a.sort] = a
+                if a.id is not None:
+                    authors_by_id[a.id] = a
+
+            authors_ordered = []
+            ids_remaining = list(authors_by_id.keys())
             for auth in sort_authors:
                 auth = strip_whitespaces(auth)
-                # Skip empty author strings to prevent spurious errors
+                # Skip empty author strings to prevent spurious lookups.
                 if not auth:
                     continue
-                results = self.session.query(Authors).filter(Authors.sort == auth).all()
-                if not len(results):
-                    # Books.author_sort drifted from Authors.sort. Warn once
-                    # per process per author so the log doesn't fill on every
-                    # page render. The unmatched author still appears in the
-                    # book — it falls through to the Authors.id loop below
+                ordered = authors_by_sort.get(auth)
+                if ordered is None:
+                    # Books.author_sort drifted from Authors.sort. Warn
+                    # once per process per drifted sort string so the log
+                    # doesn't fill on busy pages — the unmatched author
+                    # still appears in the book via the id-fallback below
                     # (continue, not break, so other authors on this same
                     # book that DO have a valid sort still get ordered).
                     if auth not in _AUTHOR_SORT_DRIFT_WARNED:
                         _AUTHOR_SORT_DRIFT_WARNED.add(auth)
                         log.warning(
                             "Author sort '%s' from Books.author_sort has no "
-                            "match in Authors.sort. Falling back to Authors.id "
-                            "order for this author. To fix: edit the author in "
-                            "the admin UI so Authors.sort matches.", auth)
+                            "match in linked authors. Falling back to "
+                            "Authors.id order for this author. To fix: edit "
+                            "the author in the admin UI so Authors.sort "
+                            "matches.", auth)
                     continue
-                for r in results:
-                    if r.id in ids:
-                        authors_ordered.append(r)
-                        ids.remove(r.id)
-            for author_id in ids:
-                result = self.session.query(Authors).filter(Authors.id == author_id).first()
-                authors_ordered.append(result)
+                authors_ordered.append(ordered)
+                if ordered.id in ids_remaining:
+                    ids_remaining.remove(ordered.id)
+
+            # Append any authors that weren't placed by the sort pass —
+            # preserves the pre-fix invariant that every linked Author
+            # appears in ordered_authors. Iteration order of dict keys is
+            # insertion order in CPython 3.7+, so this is stable across
+            # runs for the same input.
+            for author_id in ids_remaining:
+                authors_ordered.append(authors_by_id[author_id])
+
+            # Last-resort fallback: if every sort entry was stale AND no
+            # ids remain (e.g. book.authors was empty), keep the linked
+            # authors so the book renders with its author list rather
+            # than appearing author-less.
+            if not authors_ordered:
+                authors_ordered = authors_list
 
             if list_return:
                 if combined:
-                    entry.Books.authors = authors_ordered
+                    book.authors = authors_ordered
                 else:
                     entry.ordered_authors = authors_ordered
             else:

--- a/tests/unit/test_author_sort_drift_log_dedup.py
+++ b/tests/unit/test_author_sort_drift_log_dedup.py
@@ -178,86 +178,54 @@ class TestAuthorSortDriftDedupBehavioral:
         assert len(cps_db._AUTHOR_SORT_DRIFT_WARNED) == 4
 
     def test_continue_preserves_other_authors_ordering_for_same_book(self):
-        """A book with TWO authors — one drifted, one valid — should still
-        get the valid one ordered correctly. Pre-fix `break` would dump
-        BOTH into id-order; post-fix only the drifted one falls through."""
+        """A book with TWO linked authors — one whose sort is referenced
+        by Books.author_sort, one whose sort is NOT — should still get the
+        matched one ordered first. Pre-fix #108 `break` would dump BOTH
+        into id-order; post-#108 only the unmatched one falls through.
+
+        Re-shaped for fork #234: the post-#234 implementation consults
+        the already-loaded `book.authors` collection instead of issuing
+        SQL queries during render, so this test exercises the
+        in-memory lookup path directly (no session.query mocks needed)."""
+        from types import SimpleNamespace
         from cps import db as cps_db
 
         cps_db._AUTHOR_SORT_DRIFT_WARNED.clear()
 
         instance = cps_db.CalibreDB.__new__(cps_db.CalibreDB)
-
-        # Mock author rows. The fixture: book.author_sort = "Drift & Valid"
-        # → looking up "Drift" returns nothing; looking up "Valid" returns
-        # an Authors row whose id matches one of book.authors[].id.
-        valid_author = MagicMock()
-        valid_author.id = 42
-        valid_author.name = "Valid"
-        valid_author.sort = "Valid"
-
-        drift_id = 13
-
-        def filter_side_effect(expr):
-            """Crudely emulate the SQLAlchemy filter chain. We don't try
-            to parse the expression; instead, the .all() return value is
-            decided by which call it is."""
-            chain = MagicMock()
-            chain.all = MagicMock()
-            chain.first = MagicMock(return_value=None)
-            return chain
-
-        # We need .filter to vary by the filter expression. Easiest approach:
-        # track call count and dispatch on it. Two filter() calls happen for
-        # the sort lookups; then one filter() per remaining id (the fallback).
-        call_log = {"filter_calls": 0}
-
-        def smart_filter(expr):
-            call_log["filter_calls"] += 1
-            chain = MagicMock()
-            # First call: "Drift" — empty
-            # Second call: "Valid" — returns [valid_author]
-            # Third+: id fallbacks — return one MagicMock for whichever id
-            n = call_log["filter_calls"]
-            if n == 1:
-                chain.all = MagicMock(return_value=[])
-                chain.first = MagicMock(return_value=None)
-            elif n == 2:
-                chain.all = MagicMock(return_value=[valid_author])
-                chain.first = MagicMock(return_value=valid_author)
-            else:
-                fallback_author = MagicMock(id=drift_id, name="Drifted")
-                chain.all = MagicMock(return_value=[fallback_author])
-                chain.first = MagicMock(return_value=fallback_author)
-            return chain
-
-        fake_query = MagicMock()
-        fake_query.filter.side_effect = smart_filter
         instance.session = MagicMock()
-        instance.session.query.return_value = fake_query
         instance.ensure_session = lambda: None
 
-        class _StubBook:
-            pass
+        # Book.author_sort contains a stale entry ("UnknownDrift") that no
+        # linked author has, plus a valid one ("Valid") that the second
+        # linked author does have.
+        drift_id = 13
+        valid_id = 42
+        unmatched = SimpleNamespace(id=drift_id, name="Unmatched", sort="UnmatchedSort")
+        valid_author = SimpleNamespace(id=valid_id, name="Valid", sort="Valid")
 
-        book = _StubBook()
-        book.author_sort = "Drift & Valid"
-        book.authors = [MagicMock(id=drift_id), MagicMock(id=42)]
+        book = SimpleNamespace(
+            author_sort="UnknownDrift & Valid",
+            authors=[unmatched, valid_author],
+        )
 
         instance.order_authors([book], list_return=True, combined=False)
 
+        ordered_ids = [a.id for a in book.ordered_authors]
         # The valid author MUST appear in ordered_authors; pre-fix break
         # would have bailed before reaching it.
-        ordered = book.ordered_authors
-        ordered_ids = [a.id for a in ordered]
-        assert 42 in ordered_ids, (
-            f"valid author (id=42) missing from ordered_authors {ordered_ids}; "
-            f"the post-#108 `continue` should let the loop reach 'Valid' "
-            f"after skipping 'Drift'"
+        assert valid_id in ordered_ids, (
+            f"valid author (id={valid_id}) missing from ordered_authors "
+            f"{ordered_ids}; the post-#108 `continue` should let the loop "
+            f"reach 'Valid' after skipping 'UnknownDrift'"
         )
-        # And valid_author should appear BEFORE the id-fallback drift author
-        # — the sort-order pass placed it; the id pass appends drift after.
-        assert ordered_ids.index(42) < ordered_ids.index(drift_id), (
-            f"valid author should be ordered first (it had a valid sort); "
-            f"got {ordered_ids}. Pre-fix `break` regressed this to drift-id "
-            f"order for the whole book."
+        # And valid_author should appear BEFORE the id-fallback unmatched
+        # author — the sort-order pass placed it; the id pass appends the
+        # unmatched author after.
+        assert ordered_ids.index(valid_id) < ordered_ids.index(drift_id), (
+            f"valid author should be ordered first (it had a matching "
+            f"sort); got {ordered_ids}. Pre-fix `break` regressed this "
+            f"to drift-id order for the whole book."
         )
+        # Drift dedup fired for the stale sort entry.
+        assert "UnknownDrift" in cps_db._AUTHOR_SORT_DRIFT_WARNED

--- a/tests/unit/test_order_authors_none_guard.py
+++ b/tests/unit/test_order_authors_none_guard.py
@@ -1,0 +1,205 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for fork issue #234.
+
+Symptom: rendering the book grid during concurrent ingest crashed with
+``AttributeError: 'NoneType' object has no attribute 'id'`` in
+``cps.db.CalibreDB.order_authors``. The stack trace pointed at
+``if r.id in ids:`` while the function was re-querying ``Authors`` by
+``Books.author_sort`` and assuming every result row + every linked
+``book.authors`` entry was a valid Authors object.
+
+Pre-#234 behavior:
+    - ``Books.author_sort.split('&')`` raised AttributeError when
+      ``author_sort`` was NULL.
+    - ``[a.id for a in entry.authors]`` raised AttributeError when
+      the joined collection contained a None entry (concurrent
+      ingest / delete tearing down the LEFT JOIN row).
+    - The fallback ``.first()`` could append None to ordered_authors
+      which propagated into the template render.
+
+Post-#234 behavior:
+    - ``order_authors`` uses the already-loaded ``book.authors``
+      collection rather than re-querying ``Authors``. No new SQL
+      during render = no session-state race window.
+    - None entries in ``book.authors`` are filtered out.
+    - None ``author_sort`` is treated as empty.
+    - Stale sort entries log once and fall through to id-fallback.
+    - The fallback never appends None.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from cps import db as cps_db
+
+
+def _author(id_, name, sort):
+    return SimpleNamespace(id=id_, name=name, sort=sort)
+
+
+def _instance():
+    """Construct a CalibreDB without invoking __init__ (which wants a Flask
+    app). The new ``order_authors`` doesn't touch ``self.session`` at all,
+    but keep a stub there so the test would still surface a regression if
+    that property comes back."""
+    inst = cps_db.CalibreDB.__new__(cps_db.CalibreDB)
+    inst.session = MagicMock()
+    inst.ensure_session = lambda: None
+    return inst
+
+
+@pytest.mark.unit
+class TestOrderAuthorsNoneGuard:
+
+    def setup_method(self):
+        cps_db._AUTHOR_SORT_DRIFT_WARNED.clear()
+
+    def test_book_authors_collection_with_none_entry_does_not_crash(self):
+        """The exact #234 repro: book.authors has a None entry from a
+        torn-down join. Pre-fix this crashed at the
+        ``[a.id for a in entry.authors]`` list comprehension or in the
+        downstream ``for r in results: if r.id in ids:`` loop. Post-fix
+        the None is silently dropped."""
+        valid = _author(1, "Jane Alpha", "Alpha, Jane")
+        book = SimpleNamespace(
+            id=10,
+            author_sort="Alpha, Jane",
+            authors=[None, valid],
+        )
+
+        result = _instance().order_authors([book], list_return=True)
+
+        assert result == [book]
+        assert book.ordered_authors == [valid]
+
+    def test_author_sort_is_none_does_not_crash(self):
+        """Calibre allows NULL author_sort. Pre-fix this crashed at
+        ``entry.author_sort.split('&')``."""
+        linked = _author(1, "Jane Alpha", "Alpha, Jane")
+        book = SimpleNamespace(
+            id=11,
+            author_sort=None,
+            authors=[linked],
+        )
+
+        _instance().order_authors([book], list_return=True)
+
+        # author_sort missing → fall back to linked authors so the book
+        # still renders with its author list.
+        assert book.ordered_authors == [linked]
+
+    def test_stale_author_sort_falls_back_to_linked_authors(self):
+        """``Books.author_sort`` references "Missing, Author" which no
+        linked Author has. The unmatched sort entry should be skipped
+        (drift warning) and the remaining sort + id-fallback paths
+        should still place every linked Author into the order list."""
+        linked_a = _author(1, "Jane Alpha", "Alpha, Jane")
+        linked_b = _author(2, "Bob Beta", "Beta, Bob")
+        book = SimpleNamespace(
+            id=12,
+            author_sort="Missing, Author & Alpha, Jane & Beta, Bob",
+            authors=[linked_a, linked_b],
+        )
+
+        _instance().order_authors([book], list_return=True)
+
+        # Both valid authors land in ordered_authors. Order: the sort
+        # pass placed Alpha first, then Beta; the id-fallback would
+        # then add anything missing, but everything's accounted for.
+        assert book.ordered_authors == [linked_a, linked_b]
+        # Drift dedup fired once for the missing sort string.
+        assert "Missing, Author" in cps_db._AUTHOR_SORT_DRIFT_WARNED
+
+    def test_all_sorts_stale_falls_back_to_linked_authors(self):
+        """Defensive: if every entry in author_sort is stale, we don't
+        return an empty ordered_authors — the book still renders with
+        its linked authors so the user sees something."""
+        linked = _author(1, "Jane Alpha", "Alpha, Jane")
+        book = SimpleNamespace(
+            id=13,
+            author_sort="Stale, One & Stale, Two",
+            authors=[linked],
+        )
+
+        _instance().order_authors([book], list_return=True)
+
+        assert book.ordered_authors == [linked]
+
+    def test_combined_entry_shape_works(self):
+        """``combined=True`` path used by some callers — entry has a
+        ``.Books`` attribute holding the actual Book row."""
+        valid = _author(1, "Jane Alpha", "Alpha, Jane")
+        book = SimpleNamespace(
+            id=14,
+            author_sort="Alpha, Jane",
+            authors=[None, valid],
+        )
+        entry = SimpleNamespace(Books=book)
+
+        result = _instance().order_authors([entry], list_return=True, combined=True)
+
+        assert result == [entry]
+        # In combined mode, the writes go onto book.authors (not
+        # entry.ordered_authors). None has been filtered out.
+        assert book.authors == [valid]
+
+    def test_empty_book_authors_does_not_crash(self):
+        """``book.authors`` is an empty list (book with no linked
+        authors). Pre-fix this still worked but the id-fallback issued
+        a useless SQL query. Post-fix it short-circuits gracefully."""
+        book = SimpleNamespace(
+            id=15,
+            author_sort="Some, Sort",
+            authors=[],
+        )
+
+        _instance().order_authors([book], list_return=True)
+
+        assert book.ordered_authors == []
+
+    def test_no_db_query_during_render(self):
+        """Post-fix ``order_authors`` does not consult ``self.session``
+        at all. Pin this so a future refactor can't silently bring
+        back the render-time queries that caused the race."""
+        valid_a = _author(1, "Alpha", "Alpha")
+        valid_b = _author(2, "Beta", "Beta")
+        book = SimpleNamespace(
+            id=16,
+            author_sort="Alpha & Beta",
+            authors=[valid_a, valid_b],
+        )
+
+        inst = _instance()
+        # session.query is a MagicMock; if order_authors calls it, we'd
+        # see it in mock_calls. Assert empty.
+        inst.order_authors([book], list_return=True)
+
+        assert inst.session.query.call_count == 0, (
+            f"order_authors should not consult self.session.query during "
+            f"render — pre-#234 it did, which opened a race window during "
+            f"concurrent ingest. mock_calls: {inst.session.mock_calls}"
+        )
+
+    def test_id_none_in_linked_author_is_tolerated(self):
+        """Defensive: linked author with id=None (transient/uncommitted
+        row?). Don't crash, don't include it in the id-keyed dict."""
+        valid = _author(1, "Jane", "Jane")
+        weird = _author(None, "Weird", "Weird")
+        book = SimpleNamespace(
+            id=17,
+            author_sort="Jane",
+            authors=[valid, weird],
+        )
+
+        _instance().order_authors([book], list_return=True)
+
+        # Jane is ordered first by sort match. Weird has id=None, so
+        # it's not in the id-fallback dict and doesn't appear.
+        assert book.ordered_authors == [valid]


### PR DESCRIPTION
## Symptom

Rendering the book grid during a concurrent ingest crashed with:

```
File "cps/db.py", line 1217, in order_authors
    if r.id in ids:
AttributeError: 'NoneType' object has no attribute 'id'
```

Reporter @droM4X had `CWA_WATCH_MODE=poll` with active ingress; the index page returned 500 mid-ingest.

## Root cause

`order_authors()` re-queried `Authors` by `Books.author_sort` on every page render and assumed every result row plus every linked `book.authors` entry was a valid `Authors` object. With concurrent ingest tearing down joined rows mid-request, the in-memory collection could surface a None entry — and the downstream `r.id` access crashed the whole page.

Two adjacent fragilities in the same function:
- `entry.author_sort.split('&')` raised when `author_sort` was NULL (Calibre allows it).
- The `.first()` fallback could append None to `ordered_authors`, propagating into the template.

## Fix

Consult the already-loaded `book.authors` collection instead of issuing fresh SQL during render. No render-time queries = no session-state race window.

- None entries in `book.authors` are filtered before lookups.
- None / empty `author_sort` is treated as empty (no `.split` crash).
- Stale sort entries log once per process via the existing fork-#108 `_AUTHOR_SORT_DRIFT_WARNED` rate-limit and fall through to id-fallback so every linked author still appears.
- Last-resort: if every sort entry is stale and no ids remain, return the linked authors so the book renders with its author list rather than appearing author-less.

Structure adopted from CWA upstream PR #1359 (@navels) — same fix proposal on the upstream surface, written before that PR could merge upstream so users hit by this bug today get relief. Fork-original additions: the `_AUTHOR_SORT_DRIFT_WARNED` rate-limit (fork #108) and the linked-authors safety net.

## Verification

- **Unit tests:** 8 new in `tests/unit/test_order_authors_none_guard.py` covering the failure modes from the bug report (None author, None author_sort, stale sort, mixed linked) plus defensive cases (empty book.authors, id=None linked author, combined=True entry shape). RED on `main`, GREEN on this branch.
- **Existing tests:** `tests/unit/test_author_sort_drift_log_dedup.py` updated to the new in-memory mechanism; all 6 still pass. Confirms fork #108 dedup contract preserved.
- **No new regressions:** Full `tests/unit/` suite — baseline on main was 167 failed / 966 passed; with this branch 167 failed / 974 passed. Same pre-existing failures (unrelated subsystems), +8 new passes for the regression coverage above.
- **Live smoke:** Hot-swapped `cps/db.py` into `cwn-local`, restarted, hit `/` and `/opds` — both 200, zero errors in container logs, index page renders 15 books normally.
- **Blast radius:** 9 callers of `order_authors` across `cps/web.py`, `cps/editbooks.py`, `cps/duplicates.py`, `cps/duplicate_index.py`, `cps/search.py`. Return-value semantics unchanged when called with `list_return=False` (returns list of Author objects); attribute-set semantics unchanged when called with `list_return=True`.

## Confidence

~92% the user-visible symptom is gone. The only residual risk is the precise mechanism by which a None entry first appeared in `book.authors` — I couldn't reproduce that exact race locally without forcing the failure, but the unit tests pin the post-condition: *whatever* shape the collection arrives in, `order_authors` no longer crashes.

Closes #234