### PR TITLE
fix(kobo): cont_sync books branch must require count > SYNC_ITEM_LIMIT

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -349,8 +349,10 @@ def HandleSyncRequest():
 
     # no. of books returned
     book_count = changed_entries.count()
-    # last entry:
-    cont_sync = bool(book_count)
+    # Mirror the reading-states branch below: only signal `continue` when
+    # the result set exceeds the batch cap, so an exhaustive batch ends
+    # the session and the device persists the advanced synctoken.
+    cont_sync = bool(book_count > SYNC_ITEM_LIMIT)
     log.debug("Kobo Sync: remaining books to sync: {}".format(book_count))
     # generate reading state data
     changed_reading_states = ub.session.query(ub.KoboReadingState)


### PR DESCRIPTION
## Symptom

Kobo Forma FW 4.45.23684 stuck in a sync loop after factory reset and clean
re-registration. ~3 sync requests/sec sustained for 15+ hours against a
393-book library, with `kobo_synced_books` fully populated and a recent
device-side cursor (`books_last_modified = 2026-05-17 17:50:23`).

Representative DEBUG log block, repeated identically:

```
INFO  {cps.kobo:167} Kobo library sync request received
DEBUG {cps.kobo:290} Kobo Sync: changed entries: 2
DEBUG {cps.kobo:294} Kobo Sync: selected to sync: 1
DEBUG {cps.kobo:354} Kobo Sync: remaining books to sync: 2
DEBUG {cps.kobo:377} Kobo Sync: changed states: 0
```

Only 2 rows match (one unique book, duplicated by the join with `db.Data`
on `KOBO_FORMATS`), well below `SYNC_ITEM_LIMIT = 100`. Yet the response
carries `x-kobo-sync: continue` and the device refuses to persist the
advanced synctoken.

## Root Cause Analysis

`cps/kobo.py:353` sets `cont_sync = bool(book_count)`, which is `True` for
**any** non-zero count. The Kobo protocol treats `x-kobo-sync: continue` as
a paging signal — "more pages exist, keep your cursor pinned" — not a
freshness signal. When the current batch is exhaustive
(`book_count <= SYNC_ITEM_LIMIT`), emitting `continue` is a contract
violation that the firmware honors by suppressing local synctoken
persistence; the next request reuses the identical stale cursor, the server
returns the same rows with `continue` again, and the loop self-perpetuates.

The reading-states branch seventeen lines below already uses the correct
semantic:

```python
cont_sync |= bool(changed_reading_states.count() > SYNC_ITEM_LIMIT)
```

The books branch should mirror it.

Complementary to #226: that PR fixed the **cursor-advance** side
(`BookShelf.date_added` folded into `new_books_last_modified`). This PR
fixes the **signal** side. Without both, `else`-branch users (no
`kobo_only_shelves_sync`) still loop on any non-zero `changed_entries`.

## Solution

```diff
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -350,8 +350,10 @@
     # no. of books returned
     book_count = changed_entries.count()
-    # last entry:
-    cont_sync = bool(book_count)
+    # Mirror the reading-states branch below: only signal `continue` when
+    # the result set exceeds the batch cap, so an exhaustive batch ends
+    # the session and the device persists the advanced synctoken.
+    cont_sync = bool(book_count > SYNC_ITEM_LIMIT)
     log.debug("Kobo Sync: remaining books to sync: {}".format(book_count))
```

## Testing

Patched live in the running container via read-only bind-mount over
`/app/calibre-web-automated/cps/kobo.py`, then `podman restart calibre`:

- Sync session ended after a single response; `podman logs -f calibre | grep "Kobo library sync request received"` flat-lined within seconds.
- `curl -sI -H "x-kobo-synctoken: <recent-cursor>" .../v1/library/sync` response now omits `x-kobo-sync: continue`; body shrinks from ~210 KB (full 100-item page) to a few hundred bytes for residual matches.
- Multi-page initial sync unaffected: with `book_count > SYNC_ITEM_LIMIT`, intermediate pages still emit `continue` as before.

Bug pre-dates the fork; `git blame` points to upstream `janeczku/calibre-web`, so this is also a candidate for upstream backport.
