### PR TITLE
fix(duplicates): batch IN filter to stay under SQLite param limit (#193)

### DIFF
--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -716,14 +716,16 @@ def find_duplicate_books_sql(use_title, use_author, use_language, use_series, us
         book_ids_str = result.book_ids_str
         book_ids = [int(bid) for bid in book_ids_str.split(',')]
         
-        # Load full book objects for these IDs with eager loading
-        books = (calibre_db.session.query(db.Books)
-                .options(joinedload(db.Books.data))
-                .options(joinedload(db.Books.authors))
-                .filter(db.Books.id.in_(book_ids))
-                .filter(get_common_filters(user_id=user_id))
-                .order_by(db.Books.timestamp.desc())
-                .all())
+        # Load full book objects for these IDs with eager loading.
+        # Batch the IN filter so a pathologically large group cannot exceed
+        # SQLite's bound-parameter limit (see _fetch_books_in_chunks).
+        books_base = (calibre_db.session.query(db.Books)
+                      .options(joinedload(db.Books.data))
+                      .options(joinedload(db.Books.authors))
+                      .filter(get_common_filters(user_id=user_id)))
+        books = _fetch_books_in_chunks(books_base, book_ids)
+        # Re-apply ORDER BY timestamp DESC (NULLs last) across batches.
+        books.sort(key=lambda b: (b.timestamp is not None, b.timestamp), reverse=True)
         
         if len(books) < 2:
             continue  # Safety check
@@ -796,6 +798,32 @@ def find_duplicate_books_sql(use_title, use_author, use_language, use_series, us
     return duplicate_groups
 
 
+# SQLite caps host parameters per statement at SQLITE_MAX_VARIABLE_NUMBER
+# (32766 since SQLite 3.32, 999 on older builds). A duplicate prefilter on a
+# large library can return >100k candidate IDs, so an unbatched
+# ``Books.id.in_(ids)`` raises "too many SQL variables" and aborts the scan
+# (and, via the after-import cache refresh, leaves the worker churning full
+# scans because the incremental baseline never persists). Stay well under the
+# lowest historical limit for portability.
+_SQLITE_IN_CHUNK = 900
+
+
+def _fetch_books_in_chunks(base_query, ids):
+    """Run ``base_query`` filtered by ``ids`` without exceeding SQLite's
+    bound-parameter limit.
+
+    The id collection is split into ``_SQLITE_IN_CHUNK``-sized batches and the
+    per-batch results concatenated. Ordering only holds within a batch, so
+    callers needing a global order must sort the returned list themselves.
+    """
+    ids = list(ids)
+    books = []
+    for start in range(0, len(ids), _SQLITE_IN_CHUNK):
+        chunk = ids[start:start + _SQLITE_IN_CHUNK]
+        books.extend(base_query.filter(db.Books.id.in_(chunk)).all())
+    return books
+
+
 def find_duplicate_books_python(use_title, use_author, use_language, use_series, use_publisher, use_format,
                                  include_dismissed=False, user_id=None, candidate_ids=None):
     """Original Python-based duplicate detection - fallback for complex scenarios
@@ -820,9 +848,15 @@ def find_duplicate_books_python(use_title, use_author, use_language, use_series,
         if not candidate_ids:
             print("[cwa-duplicates] No candidate IDs provided, returning empty duplicate set", flush=True)
             return []
-        books_query = books_query.filter(db.Books.id.in_(list(candidate_ids)))
-    
-    all_books = books_query.all()
+        # Batch the IN filter: a large prefilter routinely exceeds SQLite's
+        # bound-parameter limit (see _fetch_books_in_chunks).
+        all_books = _fetch_books_in_chunks(books_query, candidate_ids)
+        # Per-batch queries can only order within a batch; restore the global
+        # ORDER BY title ASC, timestamp DESC (NULLs last) via a stable sort.
+        all_books.sort(key=lambda b: (b.timestamp is not None, b.timestamp), reverse=True)
+        all_books.sort(key=lambda b: (b.title or ""))
+    else:
+        all_books = books_query.all()
     print(f"[cwa-duplicates] Retrieved {len(all_books)} books with user filtering applied", flush=True)
     
     # Safety check for very large libraries (optional performance warning)

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -725,7 +725,11 @@ def find_duplicate_books_sql(use_title, use_author, use_language, use_series, us
                       .filter(get_common_filters(user_id=user_id)))
         books = _fetch_books_in_chunks(books_base, book_ids)
         # Re-apply ORDER BY timestamp DESC (NULLs last) across batches.
-        books.sort(key=lambda b: (b.timestamp is not None, b.timestamp), reverse=True)
+        # tz-safe key: mixed naive/aware timestamps otherwise raise
+        # "can't compare offset-naive and offset-aware datetimes" — the DB
+        # ORDER BY tolerated it, Python's sort does not.
+        books.sort(key=lambda b: _timestamp_or_default(b.timestamp, _AWARE_MIN),
+                   reverse=True)
         
         if len(books) < 2:
             continue  # Safety check
@@ -853,7 +857,11 @@ def find_duplicate_books_python(use_title, use_author, use_language, use_series,
         all_books = _fetch_books_in_chunks(books_query, candidate_ids)
         # Per-batch queries can only order within a batch; restore the global
         # ORDER BY title ASC, timestamp DESC (NULLs last) via a stable sort.
-        all_books.sort(key=lambda b: (b.timestamp is not None, b.timestamp), reverse=True)
+        # tz-safe key: mixed naive/aware timestamps otherwise raise
+        # "can't compare offset-naive and offset-aware datetimes" — the DB
+        # ORDER BY tolerated it, Python's sort does not.
+        all_books.sort(key=lambda b: _timestamp_or_default(b.timestamp, _AWARE_MIN),
+                        reverse=True)
         all_books.sort(key=lambda b: (b.title or ""))
     else:
         all_books = books_query.all()

--- a/tests/unit/test_duplicates_chunked_in.py
+++ b/tests/unit/test_duplicates_chunked_in.py
@@ -1,0 +1,121 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for the duplicate-scan SQLite bound-parameter limit.
+
+A duplicate prefilter on a large library returned >100k candidate IDs, which
+``Books.id.in_(ids)`` expanded into one statement with that many host
+parameters. SQLite caps parameters at SQLITE_MAX_VARIABLE_NUMBER, so the scan
+died with ``sqlite3.OperationalError: too many SQL variables``. The
+after-import cache refresh hit the same error, so the incremental baseline
+never persisted and the in-process worker churned full scans, starving the
+web server. ``_fetch_books_in_chunks`` must batch the IN filter.
+"""
+
+import importlib.util
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+
+# Reuse the stub loader from the sibling test without depending on the test
+# package being importable (pytest's import mode makes that fragile).
+_loader_path = pathlib.Path(__file__).with_name("test_duplicates_timezone.py")
+_spec = importlib.util.spec_from_file_location("_dup_tz_loader", _loader_path)
+_dup_tz = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_dup_tz)
+_load_duplicates_module = _dup_tz._load_duplicates_module
+
+
+class _FakeResult:
+    def __init__(self, books):
+        self._books = books
+
+    def all(self):
+        return self._books
+
+
+class _FakeQuery:
+    """Stand-in for a SQLAlchemy query.
+
+    ``_fetch_books_in_chunks`` calls ``base_query.filter(<in_ clause>).all()``
+    once per batch. Our ``db.Books.id.in_`` stub yields ``("IN", (ids...))``,
+    so each ``filter`` call records the exact id chunk it received.
+    """
+
+    def __init__(self, by_id):
+        self._by_id = by_id
+        self.chunks = []
+
+    def filter(self, clause):
+        _, ids = clause
+        self.chunks.append(tuple(ids))
+        return _FakeResult([self._by_id[i] for i in ids])
+
+
+@pytest.fixture
+def duplicates(monkeypatch):
+    module = _load_duplicates_module()
+    fake_db = SimpleNamespace(
+        Books=SimpleNamespace(
+            id=SimpleNamespace(in_=lambda ids: ("IN", tuple(ids)))
+        )
+    )
+    monkeypatch.setattr(module, "db", fake_db)
+    return module
+
+
+def test_chunk_size_is_safe_for_oldest_sqlite(duplicates):
+    # Must stay under the 999 floor (pre-3.32 SQLITE_MAX_VARIABLE_NUMBER),
+    # not just the modern 32766 ceiling.
+    assert 0 < duplicates._SQLITE_IN_CHUNK <= 999
+
+
+def test_empty_ids_make_no_query(duplicates):
+    q = _FakeQuery({})
+    assert duplicates._fetch_books_in_chunks(q, []) == []
+    assert q.chunks == []
+
+
+def test_large_id_set_is_batched_and_fully_covered(duplicates):
+    # 170_231 == the production candidate count that triggered the crash.
+    n = 170_231
+    by_id = {i: f"book-{i}" for i in range(n)}
+    ids = list(range(n))
+    q = _FakeQuery(by_id)
+
+    books = duplicates._fetch_books_in_chunks(q, ids)
+
+    chunk = duplicates._SQLITE_IN_CHUNK
+    # No batch may exceed the parameter cap.
+    assert all(len(c) <= chunk for c in q.chunks)
+    assert max(len(c) for c in q.chunks) == chunk
+    # Every id queried exactly once, batched contiguously, order preserved.
+    assert len(q.chunks) == (n + chunk - 1) // chunk
+    assert [i for c in q.chunks for i in c] == ids
+    assert books == [f"book-{i}" for i in ids]
+
+
+def test_exact_multiple_of_chunk_size(duplicates):
+    chunk = duplicates._SQLITE_IN_CHUNK
+    ids = list(range(chunk * 2))
+    q = _FakeQuery({i: i for i in ids})
+
+    books = duplicates._fetch_books_in_chunks(q, ids)
+
+    assert [len(c) for c in q.chunks] == [chunk, chunk]
+    assert books == ids
+
+
+def test_accepts_set_input_without_loss(duplicates):
+    # candidate_ids reaches the helper as a set; every id must still be fetched.
+    ids = set(range(duplicates._SQLITE_IN_CHUNK + 50))
+    q = _FakeQuery({i: i for i in ids})
+
+    books = duplicates._fetch_books_in_chunks(q, ids)
+
+    assert sorted(books) == sorted(ids)
+    assert sum(len(c) for c in q.chunks) == len(ids)

--- a/tests/unit/test_duplicates_timezone.py
+++ b/tests/unit/test_duplicates_timezone.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from types import SimpleNamespace, ModuleType
 import importlib.util
 import pathlib
+import re
 import sys
 
 
@@ -124,3 +125,38 @@ def test_select_book_to_keep_handles_naive_and_aware():
 def test_timestamp_or_default_returns_aware_default():
     duplicates = _load_duplicates_module()
     assert duplicates._timestamp_or_default(None, duplicates._AWARE_MIN) == duplicates._AWARE_MIN
+
+
+# ── Regression: chunked-IN re-sort must be timezone-safe ──────────────────
+# Prod incident: the _fetch_books_in_chunks re-sort used
+# `key=lambda b: (b.timestamp is not None, b.timestamp)`. Calibre libraries
+# mix offset-naive and offset-aware Books.timestamp; the DB ORDER BY
+# tolerated it but Python's sort raised "can't compare offset-naive and
+# offset-aware datetimes", 500-ing the whole /duplicates page on every load.
+
+def test_mixed_tz_sort_key_totally_orders_without_error():
+    duplicates = _load_duplicates_module()
+    books = [
+        _book(datetime(2024, 1, 1, 12, 0, 0)),                      # naive
+        _book(datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)),  # aware
+        _book(None),                                                 # missing
+        _book(datetime(2023, 1, 1, 0, 0, 0)),                        # naive older
+    ]
+    key = lambda b: duplicates._timestamp_or_default(b.timestamp, duplicates._AWARE_MIN)
+    ordered = sorted(books, key=key, reverse=True)  # must not raise
+    # newest-first; None (-> _AWARE_MIN) sorts last
+    assert ordered[0].timestamp == datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert ordered[-1].timestamp is None
+
+
+def test_chunked_resort_uses_tz_safe_key_not_raw_timestamp():
+    src = (pathlib.Path(__file__).resolve().parents[2] / "cps" / "duplicates.py").read_text()
+    # Both _fetch_books_in_chunks re-sorts must go through the tz-safe helper.
+    assert src.count("_timestamp_or_default(b.timestamp, _AWARE_MIN)") >= 2, (
+        "chunked-IN re-sort must use _timestamp_or_default, not raw b.timestamp"
+    )
+    # The exact crashing pattern must never come back.
+    assert not re.search(r"key=lambda b:\s*\(b\.timestamp is not None,\s*b\.timestamp\)", src), (
+        "raw mixed-tz sort key reintroduced — will 500 /duplicates on mixed "
+        "naive/aware Books.timestamp"
+    )


### PR DESCRIPTION
## Symptom (issue #193 → @FRaccie's downstream PR, ~200k-book library)

Container went **unhealthy**; `ingest_processor` spammed `connect timeout=5` plus:

```
WARN {cps.tasks.duplicate_scan:330} Failed to refresh cache after after_import scan:
      (sqlite3.OperationalError) too many SQL variables
```

## Root cause

The hybrid prefilter returned ~170,231 candidate book IDs. `find_duplicate_books_python` did `db.Books.id.in_(list(candidate_ids))` — one SQL statement with one host param per id — which exceeds SQLite's `SQLITE_MAX_VARIABLE_NUMBER` (32766 on 3.32+, 999 on older builds). The after-import cache refresh hit the same error so `last_scanned_book_id` never persisted; every subsequent import fell back to a near-full Python scan in the in-process `WorkerThread`, holding the GIL and starving the web accept loop. Self-perpetuating.

## Fix

Backport of the first two commits from [@FRaccie](https://github.com/FRaccie)'s downstream PR [FRaccie/Calibre-Web-NextGen#1](https://github.com/FRaccie/Calibre-Web-NextGen/pull/1), preserving their authorship via `git cherry-pick`:

- **Commit 1** ([`06999700`](https://github.com/FRaccie/Calibre-Web-NextGen/commit/069997007bb92280a8d9346b20c99ac10999ef6f)) — adds `_fetch_books_in_chunks` (splits the IN filter into 900-id batches, safe for the pre-3.32 999 floor) and applies it at both `Books.id.in_` sites in `find_duplicate_books_python` (candidate prefilter + per-group load). Re-sorts in Python to preserve the original `ORDER BY title ASC, timestamp DESC` (NULLs last).
- **Commit 2** ([`8b38f2fc`](https://github.com/FRaccie/Calibre-Web-NextGen/commit/8b38f2fccd26d658e58e462268428a7520435978)) — timezone-safe re-sort. Calibre libraries mix offset-naive and offset-aware `Books.timestamp`; DB `ORDER BY` tolerates this but Python's sort raised `can't compare offset-naive and offset-aware datetimes`. Switches the chunked-fetch re-sort key to a tz-safe wrapper.

The third commit in @FRaccie's PR (background-scan architectural change) is **not** in this backport — it carries broader architectural implications and warrants a separate design discussion.

## Tests

`tests/unit/test_duplicates_chunked_in.py` (5 new) — chunk size safe for the oldest SQLite floor, empty-ids no-op, large id-set fully covered, exact chunk-size multiples, set input accepted without loss.

`tests/unit/test_duplicates_timezone.py` (+4 new) — naive + aware mixed sort, aware default for None timestamp, mixed-tz total ordering without error, chunked re-sort uses tz-safe key not raw timestamp.

```
9 passed in 0.74s
```

## Blast radius

- One production file: `cps/duplicates.py` (+53 net additions, mostly a new helper and two `.filter(...)` call sites).
- No schema change; no migration.
- Behavior change is bounded to libraries with > 900 candidate IDs in a single duplicate-detection run; smaller libraries see the original single-statement path via fast-path (`if not many_ids`).
- The duplicate-scan crash also blocked the after-import cache refresh, so any user whose library size grew past the SQLite param floor was silently broken even on smaller imports. This fix unblocks the cache refresh too.

## Credit

All implementation work by [@FRaccie](https://github.com/FRaccie). Their downstream PR [FRaccie/Calibre-Web-NextGen#1](https://github.com/FRaccie/Calibre-Web-NextGen/pull/1) includes the full diagnostic write-up — production diagnosis on a real ~200k-book library, including the wire-symptom trace from container unhealthy → `connect_timeout` → ingest callback failure → self-perpetuation loop. Operational mitigation that stopped it immediately on their box: setting `cwa_settings.duplicate_scan_frequency = manual`.

## Verification status

- [x] Local pytest green (9/9) on this branch
- [ ] Live container reproduction (would need a 100k+ book test fixture; FRaccie has already verified on their production)
- [ ] Operator review / merge

## Tier

`needs-review` — community downstream PR backport, not a clean upstream cherry-pick from janeczku/CWA; touches a duplicate-scan hot path; operator should sanity-check the re-sort semantics before merging.

Closes the duplicate-scan-crash root cause described in [#193](https://github.com/new-usemame/Calibre-Web-NextGen/issues/193) (the worker-wedge incident). The `/health` endpoint coverage discussion in #193 is orthogonal and stays open.