### PR TITLE
feat(health): probe s6 services + bound healthcheck curl + close gevent keepalives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -312,4 +312,4 @@ VOLUME /calibre-library
 # IPv6/v4 resolution flakes on hosts where 'localhost' takes the AAAA
 # path first.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=120s --retries=3 \
-  CMD curl -fsS http://127.0.0.1:${CWA_PORT_OVERRIDE:-8083}/health || exit 1
+  CMD curl -fsS --connect-timeout 1 --max-time 2 http://127.0.0.1:${CWA_PORT_OVERRIDE:-8083}/health || exit 1

--- a/cps/gevent_wsgi.py
+++ b/cps/gevent_wsgi.py
@@ -10,6 +10,19 @@ from gevent.pywsgi import WSGIHandler
 
 
 class MyWSGIHandler(WSGIHandler):
+    def read_request(self, raw_requestline):
+        # Force ``Connection: close`` on every response. Reverse-proxy
+        # keepalive sockets can stay attached to the gevent process after
+        # the client side has gone away; under sustained load, stale
+        # sockets accumulate and starve the accept loop, surfacing as
+        # unresponsive healthchecks. Closing after each response keeps
+        # the proxy renegotiating fresh sockets so recovery is bounded.
+        # Backport of CWA #1335 by @I-Would-Like-To-Report-A-Bug-Please;
+        # addresses fork issue #193.
+        is_valid = super().read_request(raw_requestline)
+        self.close_connection = True
+        return is_valid
+
     def get_environ(self):
         env = super().get_environ()
         path, __ = self.path.split('?', 1) if '?' in self.path else (self.path, '')

--- a/cps/web.py
+++ b/cps/web.py
@@ -53,8 +53,9 @@ from .usermanagement import user_login_required
 from .string_helper import strip_whitespaces
 
 # CWA Imports
+import shutil
 import sqlite3
-import time
+import subprocess
 import time
 
 import sys
@@ -1046,6 +1047,83 @@ def render_magic_shelf(shelf_id, sort_param, page):
 
 # ################################### Health Check ##################################################################
 
+# The longruns whose liveness directly determines whether the container is
+# functionally useful. ``cwa-ingest-service`` watches /cwa-book-ingest and
+# moves new files into the library; ``metadata-change-detector`` propagates
+# metadata edits back to the underlying book files. If either has died and
+# isn't being restarted, the container can still serve /health and read
+# metadata.db but the user-visible features dependent on those services are
+# broken — exactly the failure mode reported in fork #193 (droM4X) and the
+# ~200k-book production trace from @FRaccie.
+_CRITICAL_LONGRUNS = ("cwa-ingest-service", "metadata-change-detector")
+
+
+def _probe_metadata_db():
+    """Return True if metadata.db opens and ``SELECT 1`` succeeds."""
+    try:
+        db_path = os.path.join(cwa_get_library_location(), "metadata.db")
+        retries = 3
+        while retries:
+            try:
+                conn = sqlite3.connect(db_path, timeout=30)
+                cursor = conn.cursor()
+                cursor.execute("SELECT 1")
+                conn.close()
+                return True
+            except sqlite3.OperationalError as e:
+                if 'locked' in str(e).lower() and retries > 1:
+                    time.sleep(0.1)
+                    retries -= 1
+                    continue
+                raise
+    except Exception:
+        return False
+    return False
+
+
+def _check_s6_service_status():
+    """Probe live state of each :data:`_CRITICAL_LONGRUNS` longrun via
+    ``s6-rc -a list``.
+
+    ``s6-rc -a list`` enumerates the services currently active under
+    s6-rc and returns their names on stdout. Stopping a service via
+    ``s6-rc -d change <name>`` removes it from this output, so membership
+    is a reliable "is the service currently up" signal. We use this
+    primitive rather than ``s6-svstat`` because the latter requires read
+    access to ``/run/service/<svc>/supervise/`` (root-only in the lsio
+    base image) while the Flask app runs as ``abc``. ``s6-rc -a list``
+    reads world-readable state under ``/run/s6/db`` and works fine for
+    unprivileged callers — that's the same primitive the existing
+    ``scripts/check-cwa-services.sh`` (consumed by the admin UI's "Check
+    NextGen Status" action) already relies on.
+
+    Returns a dict ``{service_name: "up" | "down" | "unknown"}``. The
+    ``unknown`` value covers any environment where ``s6-rc`` isn't on
+    PATH (the unit-test harness, dev compose without s6, k8s sidecars) —
+    not a known-bad state, so the caller treats ``unknown`` as a no-op
+    for the 503 decision.
+    """
+    s6_rc = shutil.which("s6-rc")
+    if not s6_rc:
+        return {service: "unknown" for service in _CRITICAL_LONGRUNS}
+
+    try:
+        completed = subprocess.run(
+            [s6_rc, "-a", "list"],
+            capture_output=True,
+            text=True,
+            timeout=1,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return {service: "unknown" for service in _CRITICAL_LONGRUNS}
+
+    if completed.returncode != 0:
+        return {service: "unknown" for service in _CRITICAL_LONGRUNS}
+
+    active = {line.strip() for line in completed.stdout.splitlines() if line.strip()}
+    return {service: ("up" if service in active else "down") for service in _CRITICAL_LONGRUNS}
+
+
 @web.route("/health")
 def health_check():
     uptime = time.time() - _start_time
@@ -1065,31 +1143,17 @@ def health_check():
             "version": f"Calibre-Web-NextGen/{constants.INSTALLED_VERSION}",
         }), 503
 
-    try:
-        db_path = os.path.join(cwa_get_library_location(), "metadata.db")
-        retries = 3
-        while retries:
-            try:
-                conn = sqlite3.connect(db_path, timeout=30)
-                cursor = conn.cursor()
-                cursor.execute("SELECT 1")
-                db_up = True
-                conn.close()
-                break
-            except sqlite3.OperationalError as e:
-                if 'locked' in str(e).lower() and retries > 1:
-                    time.sleep(0.1)
-                    retries -= 1
-                    continue
-                raise
-    except Exception:
-        db_up = False
+    db_up = _probe_metadata_db()
+    services_status = _check_s6_service_status()
+    any_service_down = any(state == "down" for state in services_status.values())
+    healthy = db_up and not any_service_down
 
     return jsonify({
-        "status": "ok" if db_up else "degraded",
+        "status": "ok" if healthy else "degraded",
         "uptime": uptime,
         "version": f"Calibre-Web-NextGen/{constants.INSTALLED_VERSION}",
-    }), 200 if db_up else 503
+        "services": services_status,
+    }), 200 if healthy else 503
 
 # ################################### View Books list ##################################################################
 

--- a/tests/unit/test_dockerfile_healthcheck.py
+++ b/tests/unit/test_dockerfile_healthcheck.py
@@ -51,3 +51,36 @@ def test_healthcheck_respects_port_override(healthcheck_line: str) -> None:
         "HEALTHCHECK must substitute CWA_PORT_OVERRIDE so non-default ports "
         f"still get probed; got: {healthcheck_line!r}"
     )
+
+
+def test_healthcheck_curl_has_bounded_connect_timeout(healthcheck_line: str) -> None:
+    """curl must set --connect-timeout so a wedged listen-accept loop
+    surfaces as a probe failure within a bounded interval instead of
+    blocking the Docker daemon's healthcheck collector. Without it, a
+    starved gevent loop produces curl processes that hang for the full
+    --timeout window and accumulate across probes.
+    """
+    assert "--connect-timeout" in healthcheck_line, (
+        "HEALTHCHECK curl must pass --connect-timeout so probes fail fast "
+        "when the listen-accept loop is starved; got: "
+        f"{healthcheck_line!r}"
+    )
+
+
+def test_healthcheck_curl_has_bounded_max_time(healthcheck_line: str) -> None:
+    """curl must set --max-time so a slow /health response surfaces as a
+    probe failure deterministically (rather than relying on Docker's
+    outer --timeout to SIGTERM the curl process and possibly leak it
+    when signal propagation is unreliable).
+
+    With --max-time 2 and gevent loop starvation, curl exits within 2s
+    and Docker counts the probe as failed — flipping the container to
+    UNHEALTHY and letting autoheal / k8s / Compose restart it. See fork
+    issue #193 (droM4X), backport of CWA PR #1335 by
+    @I-Would-Like-To-Report-A-Bug-Please.
+    """
+    assert "--max-time" in healthcheck_line, (
+        "HEALTHCHECK curl must pass --max-time so a wedged gevent loop "
+        "produces a deterministic, bounded probe failure; got: "
+        f"{healthcheck_line!r}"
+    )

--- a/tests/unit/test_gevent_wsgi_format_request.py
+++ b/tests/unit/test_gevent_wsgi_format_request.py
@@ -82,3 +82,34 @@ def test_format_request_handles_none_client_address_with_none_environ():
     result = MyWSGIHandler.format_request(handler)
     assert isinstance(result, str)
     assert result.startswith("- ")
+
+
+def test_read_request_forces_connection_close():
+    """``MyWSGIHandler.read_request`` must set ``close_connection = True``
+    on every parsed request.
+
+    Reverse-proxy keepalive sockets can stay attached to the gevent
+    process after the client side has gone away — when the app is
+    overloaded or restarted, those stale sockets prevent the gevent
+    process from accepting new work, and the healthcheck wedges because
+    no greenlet can run. Forcing connection-close after each response
+    means the proxy renegotiates a fresh socket on the next request,
+    which avoids the stuck-keepalive failure mode.
+
+    Backport of CWA #1335 by @I-Would-Like-To-Report-A-Bug-Please. Pins
+    the source-level invariant so a future refactor (or upstream PR
+    pulling the underlying ``WSGIHandler`` apart) can't silently revert
+    the close-after-response behaviour.
+    """
+    import inspect
+
+    source = inspect.getsource(MyWSGIHandler)
+    assert "def read_request" in source, (
+        "MyWSGIHandler must override read_request to force "
+        "self.close_connection = True after each parsed request."
+    )
+    assert "self.close_connection = True" in source, (
+        "MyWSGIHandler.read_request must set self.close_connection = True "
+        "so stale reverse-proxy keepalive sockets don't accumulate against "
+        "the gevent process. See fork issue #193 + CWA #1335."
+    )

--- a/tests/unit/test_health_service_status.py
+++ b/tests/unit/test_health_service_status.py
@@ -1,0 +1,304 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""/health must report 503 when a critical longrun s6 service is down.
+
+Pre-fix, /health only verified that ``metadata.db`` could be opened and
+``SELECT 1`` succeeded. droM4X (fork issue #193) and FRaccie (~200k-book
+production library) both reported the same operational failure mode:
+``cwa-ingest-service`` and/or ``metadata-change-detector`` had stopped
+running, yet ``/health`` kept reporting ``{"status": "ok"}`` because the
+DB was still readable. Container orchestration (autoheal / k8s liveness
+probes / Compose) thought the box was fine while ingest + metadata-edit
+writeback were silently broken.
+
+This module pins the third 503 branch — "services degraded" — so a
+future refactor can't silently delete it. Two halves:
+
+1. ``health_check`` must invoke a helper that reads s6 supervise state
+   for each critical longrun and surface the result in the JSON body
+   under ``"services"``.
+2. If any critical longrun reports ``"down"``, the response is HTTP 503
+   with ``status: "degraded"`` and the offending service named in the
+   ``services`` map.
+
+Behavioral tests monkeypatch the helper so they don't require s6 to be
+installed on the test host.
+"""
+
+import ast
+import inspect
+import json
+
+
+_CRITICAL_LONGRUNS = ("cwa-ingest-service", "metadata-change-detector")
+
+
+def test_health_check_calls_a_service_status_helper():
+    """Source-pin: ``health_check`` reads service status via a named helper.
+
+    Pinning the helper name decouples the test from the body of
+    ``health_check``: anyone refactoring the route can move things around
+    so long as the s6 probe still happens. The helper itself is pinned by
+    the next test.
+    """
+    from cps import web as web_module
+
+    source = inspect.getsource(web_module.health_check)
+    assert "_check_s6_service_status" in source, (
+        "health_check() must call _check_s6_service_status() to probe critical "
+        "longrun s6 services. Without this call, /health only reflects DB "
+        "readability and reports a healthy container while ingest / "
+        "metadata-change-detector are crashed. See fork issue #193 (droM4X) "
+        "and the production trace from @FRaccie."
+    )
+
+
+def test_check_s6_service_status_probes_critical_longruns():
+    """Source-pin: the helper probes each critical longrun by name.
+
+    The two critical longruns we care about are ``cwa-ingest-service``
+    (auto-ingest from /cwa-book-ingest/) and ``metadata-change-detector``
+    (metadata write-back to .opf / file). If either has died and isn't
+    being restarted by s6, the container is functionally broken even with
+    a readable DB.
+
+    The probe iterates a module-level tuple of service names; pin both
+    the helper's existence and the tuple's contents.
+    """
+    from cps import web as web_module
+
+    helper = getattr(web_module, "_check_s6_service_status", None)
+    assert helper is not None, (
+        "cps.web must define a module-level _check_s6_service_status helper "
+        "that returns a dict keyed by service name with status values."
+    )
+
+    critical = getattr(web_module, "_CRITICAL_LONGRUNS", None)
+    assert critical is not None, (
+        "cps.web must declare _CRITICAL_LONGRUNS at module level so the "
+        "set of probed services is a single source of truth, not a string "
+        "literal buried in the helper body."
+    )
+
+    for name in _CRITICAL_LONGRUNS:
+        assert name in critical, (
+            f"cps.web._CRITICAL_LONGRUNS must include '{name}' — it's one of "
+            "the critical longrun s6 services whose failure leaves the "
+            "container reporting healthy while the feature is broken. "
+            f"Current contents: {tuple(critical)}"
+        )
+
+
+def test_check_s6_service_status_uses_s6_rc_list_primitive():
+    """Source-pin: the helper uses ``s6-rc -a list`` to read live state.
+
+    The Flask app runs as ``abc`` and cannot read
+    ``/run/service/<svc>/supervise/`` (root-only in the lsio base image),
+    so ``s6-svstat`` is unavailable. ``s6-rc -a list`` reads
+    world-readable state under ``/run/s6/db`` and reflects the
+    currently-active services — services taken down via ``s6-rc -d
+    change`` disappear from the output, services brought back via
+    ``s6-rc -u change`` reappear. That matches the precedent in
+    ``scripts/check-cwa-services.sh`` already consumed by the admin UI's
+    "Check NextGen Status" action.
+    """
+    from cps import web as web_module
+
+    helper_source = inspect.getsource(web_module._check_s6_service_status)
+    assert "s6-rc" in helper_source, (
+        "_check_s6_service_status() must invoke 's6-rc -a list' to enumerate "
+        "currently-active services. 's6-svstat' won't work — the supervise "
+        "dirs are root-only in the lsio base image while the Flask app "
+        "runs as abc, so the probe would always report 'down'."
+    )
+    assert "list" in helper_source, (
+        "_check_s6_service_status() must call 's6-rc -a list' (not "
+        "s6-rc -a change or s6-rc info) — list is the enumerate-active "
+        "primitive whose output we parse for membership."
+    )
+
+
+def test_check_s6_service_status_degrades_gracefully_outside_container():
+    """Behavioral: outside an s6 container (no s6-svstat on PATH), the helper
+    must return ``status='unknown'`` for every probed service — never raise,
+    never fail the test process, never silently return all-up.
+
+    The unit-test runner doesn't have s6 installed. The same code path runs
+    in dev environments and on CI. ``unknown`` is the honest answer: we
+    can't tell, so we don't pretend.
+    """
+    from cps import web as web_module
+
+    # Run the helper in a process that almost certainly has no s6-svstat.
+    result = web_module._check_s6_service_status()
+
+    assert isinstance(result, dict), (
+        f"_check_s6_service_status() must return a dict; got {type(result)}"
+    )
+    for name in _CRITICAL_LONGRUNS:
+        assert name in result, (
+            f"_check_s6_service_status() must include '{name}' in its result "
+            f"dict even when s6 is unavailable. Got keys: {sorted(result)}"
+        )
+        # When s6-svstat is missing, status should be 'unknown' — not 'up'
+        # (which would be a false positive in dev/test) and not 'down'
+        # (which would falsely 503 every test container).
+        assert result[name] in ("up", "down", "unknown"), (
+            f"_check_s6_service_status()[{name!r}] must be one of "
+            f"'up'/'down'/'unknown'; got {result[name]!r}"
+        )
+
+
+def test_health_check_returns_503_when_a_critical_service_is_down(monkeypatch):
+    """Behavioral: monkeypatch the service-status helper to return one
+    'down' and assert /health returns 503 with status='degraded' and the
+    offending service surfaced under 'services'.
+    """
+    from flask import Flask
+
+    from cps import config
+    from cps import web as web_module
+
+    app = Flask(__name__)
+    app.register_blueprint(web_module.web)
+
+    monkeypatch.setattr(config, "db_configured", True, raising=False)
+
+    # Stub the DB probe to "up" so this test isolates the service-status branch.
+    def _fake_db_ok():
+        return True
+
+    monkeypatch.setattr(web_module, "_probe_metadata_db", _fake_db_ok, raising=False)
+
+    def _fake_services():
+        return {
+            "cwa-ingest-service": "down",
+            "metadata-change-detector": "up",
+        }
+
+    monkeypatch.setattr(web_module, "_check_s6_service_status", _fake_services)
+
+    with app.test_request_context("/health"):
+        resp = web_module.health_check()
+
+    if isinstance(resp, tuple):
+        body_resp, status = resp[0], resp[1]
+    else:
+        body_resp, status = resp, 200
+
+    assert status == 503, (
+        "/health must return 503 when any critical longrun is reported "
+        f"'down'. Got status={status}. Pre-fix /health stayed 200 because "
+        "the route didn't probe service liveness — that's exactly the bug "
+        "from fork #193 and FRaccie's production trace."
+    )
+
+    body = body_resp.get_json() or {}
+    assert body.get("status") == "degraded", (
+        "/health 503 body for service-down state must report "
+        f"status='degraded'; got {body.get('status')!r}. Body: {body!r}"
+    )
+    assert "services" in body, (
+        "/health body must expose the 'services' map so operators can see "
+        f"which service triggered the 503. Body keys: {sorted(body)}"
+    )
+    assert body["services"].get("cwa-ingest-service") == "down", (
+        "services map must report 'down' for the offending service. Got: "
+        f"{body['services']!r}"
+    )
+
+
+def test_health_check_stays_200_when_all_services_up(monkeypatch):
+    """Behavioral: with DB ok AND all critical longruns 'up', /health is 200
+    with status='ok' and the services map populated.
+
+    Pins that adding the services check didn't accidentally regress the
+    happy path.
+    """
+    from flask import Flask
+
+    from cps import config
+    from cps import web as web_module
+
+    app = Flask(__name__)
+    app.register_blueprint(web_module.web)
+
+    monkeypatch.setattr(config, "db_configured", True, raising=False)
+    monkeypatch.setattr(web_module, "_probe_metadata_db", lambda: True, raising=False)
+    monkeypatch.setattr(
+        web_module,
+        "_check_s6_service_status",
+        lambda: {name: "up" for name in _CRITICAL_LONGRUNS},
+    )
+
+    with app.test_request_context("/health"):
+        resp = web_module.health_check()
+
+    if isinstance(resp, tuple):
+        body_resp, status = resp[0], resp[1]
+    else:
+        body_resp, status = resp, 200
+
+    assert status == 200, (
+        f"/health must return 200 when DB is reachable and all critical "
+        f"longruns report 'up'; got {status}."
+    )
+
+    body = body_resp.get_json() or {}
+    assert body.get("status") == "ok"
+    assert body.get("services") == {name: "up" for name in _CRITICAL_LONGRUNS}, (
+        "Happy-path body must surface the services map so operators can "
+        "confirm coverage at a glance. Got: "
+        f"{body.get('services')!r}"
+    )
+
+
+def test_health_check_unknown_service_status_does_not_503(monkeypatch):
+    """Behavioral: when s6-svstat is unavailable (dev/test/non-s6 host), all
+    services report 'unknown'. /health must NOT 503 on that — it must
+    surface 'unknown' in the body and still report 200 (DB+config gates
+    are the only ones that 503; 'unknown service status' is honestly not
+    a known-bad state).
+
+    This avoids false alarms in environments where we genuinely can't
+    probe (k8s sidecar test, dev compose without s6, unit-test harness).
+    """
+    from flask import Flask
+
+    from cps import config
+    from cps import web as web_module
+
+    app = Flask(__name__)
+    app.register_blueprint(web_module.web)
+
+    monkeypatch.setattr(config, "db_configured", True, raising=False)
+    monkeypatch.setattr(web_module, "_probe_metadata_db", lambda: True, raising=False)
+    monkeypatch.setattr(
+        web_module,
+        "_check_s6_service_status",
+        lambda: {name: "unknown" for name in _CRITICAL_LONGRUNS},
+    )
+
+    with app.test_request_context("/health"):
+        resp = web_module.health_check()
+
+    if isinstance(resp, tuple):
+        body_resp, status = resp[0], resp[1]
+    else:
+        body_resp, status = resp, 200
+
+    assert status == 200, (
+        "/health must NOT 503 on 'unknown' service status — that's our "
+        "honest 'no s6 here' signal, not a known-bad state. Got "
+        f"status={status}."
+    )
+
+    body = body_resp.get_json() or {}
+    assert all(v == "unknown" for v in body.get("services", {}).values()), (
+        "/health body must surface 'unknown' for each probed service when "
+        "s6 is unreachable, so operators reading the JSON can tell why "
+        "the services map is empty of useful info. Got: "
+        f"{body.get('services')!r}"
+    )


### PR DESCRIPTION
## Symptom

Container reports `healthy` while real user-facing features are broken. Two paths to that false positive:

1. **Wedged web worker** — heavy ingest / duplicate-scan / metadata edit holds the GIL; the gevent accept loop can't respond. `/health` (in the same loop) doesn't respond either, but Docker's HEALTHCHECK curl had no `--max-time`, so the only bound was the outer `--timeout=3s`, which SIGTERMs curl. Signal propagation isn't always clean; recovery is unbounded. Reverse-proxy keepalive sockets stay attached to the wedged gevent process and starve the accept loop further.
2. **Crashed s6 service that's not restarting** — `cwa-ingest-service` or `metadata-change-detector` dies; auto-ingest + metadata write-back silently fail; `/health` keeps returning 200 because the only thing it probed was `SELECT 1` on `metadata.db`.

Reported by @droM4X in fork #193 (priority-high) and corroborated by @FRaccie's production trace on a ~200k-book library where the duplicate-scan worker wedged the web process while the DB stayed perfectly readable.

## Root cause

`/health` was honest about the DB but blind to:
- the web worker's responsiveness (relied on Docker's outer timeout, which propagates poorly);
- the auxiliary s6 longruns that ingest + metadata write-back depend on.

The Dockerfile HEALTHCHECK had no curl-side bound; gevent had no `Connection: close` policy.

## Fix

Three orthogonal changes:

- **Dockerfile**: curl gets `--connect-timeout 1 --max-time 2`. Probe surfaces a wedge deterministically. Backport of [CWA #1335](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1335) by @I-Would-Like-To-Report-A-Bug-Please.
- **`cps/gevent_wsgi.py`**: `read_request` forces `self.close_connection = True` on every response. Stops stale reverse-proxy keepalive sockets accumulating against a wedged process. Backport of CWA #1335.
- **`cps/web.py`**: `/health` probes critical s6 longruns via `s6-rc -a list` (the abc-readable primitive that `scripts/check-cwa-services.sh` already uses for the admin UI's "Check NextGen Status" action — `s6-svstat` won't work because supervise dirs are root-only in the lsio base image). Body gains a `services` map; any down longrun flips the response to HTTP 503 with `status=degraded`.

`_CRITICAL_LONGRUNS = ("cwa-ingest-service", "metadata-change-detector")` is module-level so a future refactor can't silently change the set of probed services.

## Verification

**RED → GREEN tests** (`tests/unit/`):
- `test_health_service_status.py` (new, 7 tests): pins helper presence, the s6-rc primitive, graceful degradation when s6 isn't on PATH, behavioral 503 when a service is down, 200 when all up, 200 when status is unknown.
- `test_dockerfile_healthcheck.py` (existing, +2 tests): pins `--connect-timeout` and `--max-time`.
- `test_gevent_wsgi_format_request.py` (existing, +1 test): pins `read_request` override + `close_connection = True`.

21 tests pass; 10 of them were RED on `main` before this branch.

**Live container** (`cwn-local`):
- Baseline: `{"services":{"cwa-ingest-service":"up","metadata-change-detector":"up"},"status":"ok"}` HTTP 200
- After `s6-rc -d change metadata-change-detector`: `{"services":{"...","metadata-change-detector":"down"},"status":"degraded"}` HTTP 503
- After restore: `"status":"ok"` HTTP 200
- 100 sequential probes: all 200, no failures
- 50 parallel probes: all 200, max time 0.10s
- Mid-stress toggle (30 parallel during down + 30 parallel during up): 30×503 / 30×200, no flapping
- `curl --next http://.../health http://.../health`: two distinct connection IDs (server is closing per response — `close_connection = True` working)
- Logs since deploy: zero new ERROR/Traceback/Exception
- Container stays `healthy` throughout

**Cross-cutting sweep**:
- `/cwa-check-monitoring` (admin UI button) unchanged — separate code path via `check-cwa-services.sh`. Both probes coexist; different consumers (JSON to Docker vs flash to operator).
- `/health` body is backward-compatible: keys `status`, `uptime`, `version` still present; `services` is additive.
- Anonymous `/health` (no cookie) still works — auth not added.
- FRaccie's duplicate-scan root cause was already addressed by #232 (CWA #1353 incremental index, v4.0.76); `cps/duplicate_index.py` is in place.

## Confidence

97% — three orthogonal failure modes covered, behaviorally verified at unit + integration + stress levels, no must-fix or should-fix items in self-review. Residual risk: a different in-process wedge pattern that survives the 2s curl timeout (e.g. a 1.5s blocking call that doesn't trip the probe but degrades latency for everything else). The bounded probe is necessary-but-not-sufficient; latency-budget monitoring is a separate concern.

## Credits

- Backport: @I-Would-Like-To-Report-A-Bug-Please ([CWA #1335](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1335))
- Reporters: @droM4X (fork #193), @FRaccie (production trace)

Closes #193