### PR TITLE
feat(profile): show new app password inline on /me (closes #223)

### DIFF
--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -376,6 +376,45 @@ def create_app():
             # Failsafe: let route-level code handle specific DB errors
             pass
 
+    @app.before_request
+    def _clear_pending_app_password():
+        """Drop a just-created app-password cleartext from session when
+        the user navigates away from the profile page. Fork issue #223:
+        the cleartext shows inline on /me and survives reloads of /me,
+        but disappears as soon as the user clicks anything else.
+
+        Scoped to **top-level HTML navigations** via the ``Sec-Fetch-Dest``
+        header (browsers send ``document`` for address-bar navigations
+        and link clicks; ``image``/``style``/``script``/``empty`` for
+        sub-resources). XHR + fetch requests count as sub-resources and
+        do not clear the session — only an actual page change does.
+        """
+        from flask import session, request
+        if "pending_app_password" not in session:
+            return
+        # Modern browsers send Sec-Fetch-Dest on every request. Treat
+        # missing header as "unknown — be conservative, don't clear"
+        # so curl / older clients can't accidentally pop the cleartext.
+        dest = request.headers.get("Sec-Fetch-Dest", "")
+        if dest and dest != "document":
+            return
+        if not dest:
+            # Fallback for clients without the header: only clear on
+            # text/html GETs that aren't static-file fetches.
+            if request.endpoint == "static" or request.method != "GET":
+                return
+            if not request.accept_mimetypes.accept_html:
+                return
+        # On a real top-level navigation, only the profile-section
+        # endpoints keep the cleartext alive.
+        keep_endpoints = {
+            "web.profile",
+            "web.app_password_create",
+            "web.app_password_revoke",
+        }
+        if request.endpoint not in keep_endpoints:
+            session.pop("pending_app_password", None)
+
     @app.teardown_appcontext
     def shutdown_session(exception=None):
         if calibre_db.session_factory:

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -595,6 +595,24 @@
     <h4 class="settings-section-header">{{_('App passwords for OPDS / KOReader Sync')}}</h4>
     <p class="settings-explanation">{{_("OPDS readers and KOReader can't sign in through your IdP — they only support HTTP Basic auth. Create an app password here, label it for the device that'll use it, and copy the token shown after creation. You can revoke any app password at any time without affecting your active web session.")}}</p>
 
+    {# Fork issue #223: show the just-created cleartext inline at the top
+       of this section. Survives reloads of /me; vanishes on navigation
+       to any other route (see _clear_pending_app_password in cps/__init__.py). #}
+    {% if pending_app_password %}
+    <div id="pending-app-password" role="region" aria-label="{{_('New app password')}}"
+         style="margin-top: 1rem; padding: 14px 16px; border-radius: 6px; background-color: #2f4a2f; border: 1px solid #5b8a5b;">
+      <div style="font-weight: 600; margin-bottom: 6px; color: #cfe9cf;">{{_("App password created for '%(label)s'. Copy it now — you won't see it again.", label=pending_app_password.label)}}</div>
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
+        <input type="text" readonly value="{{ pending_app_password.token }}"
+               style="flex: 1; min-width: 280px; font-family: monospace; padding: 8px 10px; background-color: #1a2418; border: 1px solid #5b8a5b; color: #e0f0e0;"
+               aria-label="{{_('New app password (cleartext)')}}"
+               onclick="this.select();"/>
+        <button type="button" class="btn btn-default"
+                onclick="(function(b){var i=b.previousElementSibling;i.select();document.execCommand('copy');b.textContent='{{_('Copied!')}}';setTimeout(function(){b.textContent='{{_('Copy')}}';},2000);})(this)">{{_('Copy')}}</button>
+      </div>
+    </div>
+    {% endif %}
+
     <form action="{{ url_for('web.app_password_create') }}" method="POST" style="margin-top: 1rem; display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       <input type="text" name="label" placeholder="{{_('e.g. Kobo Forma, KOReader iPad')}}" maxlength="64" required

--- a/cps/web.py
+++ b/cps/web.py
@@ -2954,6 +2954,7 @@ def profile():
                                  page="me",
                                  registered_oauth=local_oauth_check,
                                  oauth_status=oauth_status,
+                                 pending_app_password=flask_session.get("pending_app_password"),
                                  app_passwords=ub.session.query(ub.UserAppPassword).filter(
                                      ub.UserAppPassword.user_id == current_user.id,
                                      ub.UserAppPassword.revoked == False,  # noqa: E712
@@ -2985,9 +2986,10 @@ def app_password_create():
     )
     ub.session.add(row)
     ub.session.commit()
-    # Cleartext shown exactly once. The user must copy it now.
-    flash(_("App password created for '%(label)s'. Copy it now — you won't see it again: %(token)s",
-            label=label, token=cleartext), category="info")
+    # Cleartext shown inline on the profile page (fork issue #223). Survives
+    # reloads of /me; cleared on navigation to any other route by the
+    # _clear_pending_app_password before_request hook below.
+    flask_session["pending_app_password"] = {"label": label, "token": cleartext}
     return redirect(url_for("web.profile"))
 
 

--- a/tests/unit/test_app_password_inline_display.py
+++ b/tests/unit/test_app_password_inline_display.py
@@ -1,0 +1,242 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Acceptance tests for fork #223 — app password inline display.
+
+Reporter @droM4X observed that the newly-generated app password was shown
+in a 10-second toast at the bottom of the page. Hard to spot, hard to
+read, hard to copy. The fix moves the cleartext to a prominent inline
+box at the top of the app-password section on ``/me``, persistent across
+reloads of that page, and cleared automatically when the user navigates
+to any other route.
+
+Implementation contract pinned by these tests:
+
+1. ``app_password_create`` writes the generated cleartext (NOT the hash)
+   plus the label into ``session["pending_app_password"]`` before
+   redirecting. Existing label-validation flash path is preserved.
+2. The cleartext is never persisted to the database — only the hash is.
+3. A request to any non-profile route clears the session key
+   (``before_request`` hook). This is the "disappear once they navigate
+   away" half of the requirement.
+4. Reloading ``/me`` itself keeps the cleartext visible — refresh does
+   not consume it.
+5. The template includes the cleartext when ``pending_app_password`` is
+   set; does not include it otherwise.
+"""
+
+import inspect
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _web_py_source():
+    return (REPO_ROOT / "cps" / "web.py").read_text()
+
+
+def _user_edit_template_source():
+    return (REPO_ROOT / "cps" / "templates" / "user_edit.html").read_text()
+
+
+def _init_py_source():
+    return (REPO_ROOT / "cps" / "__init__.py").read_text()
+
+
+def test_app_password_create_writes_session_not_flash_token():
+    """``app_password_create`` must put the cleartext into the session,
+    not into a Flask flash message.
+
+    The previous shape `flash(...token...)` produced the 10-second toast
+    that @droM4X reported. Removing the token from the flash string and
+    routing it through the session is the user-visible behavior change.
+    """
+    src = _web_py_source()
+    # Find the function.
+    func_match = re.search(
+        r"def app_password_create\(\):(.*?)(?=^def |^@\w)",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert func_match, "Could not locate app_password_create in cps/web.py."
+    body = func_match.group(1)
+
+    # The pre-fix flash contained the token. The post-fix path must store
+    # cleartext in session keyed by 'pending_app_password' and the flash
+    # must not include the token variable.
+    assert "session[" in body and "pending_app_password" in body, (
+        "app_password_create must write the cleartext + label to "
+        "session['pending_app_password'] so the profile template can "
+        "render it inline. Current body did not reference "
+        "session['pending_app_password']."
+    )
+    # The flashed token form is gone — no `flash(...token...` line with
+    # the cleartext variable.
+    bad_flash = re.search(
+        r"flash\([^)]*token=cleartext[^)]*\)",
+        body,
+    )
+    assert not bad_flash, (
+        "Cleartext token must NOT appear in a flash() call anymore — the "
+        "whole point of fork #223 is to remove the bottom-toast surface. "
+        "Use session['pending_app_password'] + the inline template "
+        "render instead."
+    )
+
+
+def test_session_payload_includes_label_and_token():
+    """The session value must carry both the label (so the inline box
+    can say "for 'Kobo Forma'") and the token (the user-visible string
+    they need to copy). A future refactor that drops one or the other
+    breaks the UX promise.
+    """
+    src = _web_py_source()
+    func_match = re.search(
+        r"def app_password_create\(\):(.*?)(?=^def |^@\w)",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    body = func_match.group(1)
+    # Both 'label' and 'cleartext' (or 'token') must appear within the
+    # session assignment. Pin by proximity to the session write.
+    session_write = re.search(
+        r"session\[['\"]pending_app_password['\"]\]\s*=\s*(\{[^}]+\}|[^\n]+)",
+        body,
+    )
+    assert session_write, (
+        "Could not find a `session['pending_app_password'] = ...` "
+        "assignment in app_password_create. Add one carrying both "
+        "the label and the cleartext token."
+    )
+    payload = session_write.group(1)
+    assert "label" in payload, (
+        f"session['pending_app_password'] must carry the label so the "
+        f"inline box can identify which password was just created. "
+        f"Current payload: {payload}"
+    )
+    assert "cleartext" in payload or "token" in payload, (
+        f"session['pending_app_password'] must carry the cleartext "
+        f"token. Current payload: {payload}"
+    )
+
+
+def test_cleartext_never_persisted_to_db():
+    """The DB row must store only the hash. The cleartext only ever
+    lives in session + the inline render — never on disk.
+    """
+    src = _web_py_source()
+    func_match = re.search(
+        r"def app_password_create\(\):(.*?)(?=^def |^@\w)",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    body = func_match.group(1)
+    # Pin generate_password_hash(cleartext) is what goes to the DB row.
+    assert "generate_password_hash(cleartext)" in body, (
+        "The DB row must be created with `generate_password_hash(cleartext)` "
+        "(only the hash on disk). Current body did not show this exact call."
+    )
+    # And the raw cleartext is not passed to UserAppPassword constructor.
+    assert not re.search(
+        r"UserAppPassword\([^)]*password_hash\s*=\s*cleartext\b",
+        body,
+    ), (
+        "UserAppPassword must NEVER be constructed with the raw cleartext "
+        "in password_hash. Hash it first via generate_password_hash()."
+    )
+
+
+def test_profile_route_passes_pending_app_password_to_template():
+    """The ``/me`` profile route must read the session key and pass it
+    to the template as ``pending_app_password``. Template renders it
+    inline; if the route doesn't pass it, the box never appears.
+    """
+    src = _web_py_source()
+    # The profile route is the function decorated with the /me path.
+    profile_match = re.search(
+        r"def profile\(\):(.*?)(?=^def |^@web\.route)",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert profile_match, "Could not locate `def profile():` in cps/web.py."
+    body = profile_match.group(1)
+    assert "pending_app_password" in body, (
+        "The profile route must pass `pending_app_password=` to its "
+        "render_template / render_title_template call so the inline box "
+        "knows whether to render."
+    )
+
+
+def test_before_request_clears_session_on_non_profile_routes():
+    """A before_request hook must clear ``pending_app_password`` from
+    the session when the user navigates to any route other than the
+    profile page. This implements "disappear once they navigate away".
+    """
+    init_src = _init_py_source()
+    web_src = _web_py_source()
+    combined = init_src + "\n" + web_src
+    # The hook can live in either file. Pin its existence.
+    hook_present = (
+        "pending_app_password" in combined
+        and re.search(
+            r"session\.pop\(['\"]pending_app_password['\"]",
+            combined,
+        )
+    )
+    assert hook_present, (
+        "Could not find a `session.pop('pending_app_password', ...)` "
+        "call anywhere in cps/__init__.py or cps/web.py. Add a "
+        "before_request hook (or equivalent) that clears the session "
+        "key when the user navigates away from /me."
+    )
+
+
+def test_template_renders_pending_app_password_inline():
+    """The user_edit.html template must render
+    ``pending_app_password`` inline in the App passwords section when
+    the variable is truthy. Without this, the session value never
+    surfaces to the user.
+    """
+    src = _user_edit_template_source()
+    # The template branch shape: a conditional that gates on
+    # pending_app_password and renders the .token / cleartext.
+    assert "pending_app_password" in src, (
+        "cps/templates/user_edit.html must reference pending_app_password "
+        "in a conditional block that renders the cleartext + label inline "
+        "in the App passwords section."
+    )
+    # And the box must contain the actual cleartext value, not just the
+    # variable name.
+    rendered = re.search(
+        r"\{\{\s*pending_app_password\.(?:token|cleartext)\s*\}\}",
+        src,
+    )
+    assert rendered, (
+        "The template must render pending_app_password.token (or "
+        ".cleartext) inside a `{{ ... }}` Jinja expression so the user "
+        "actually sees the password. Current template did not include "
+        "the rendered token."
+    )
+
+
+def test_template_does_not_show_when_pending_app_password_missing():
+    """When pending_app_password is None/absent, the inline box must
+    not render. Conditional shape, not unconditional.
+
+    Pin the Jinja `{% if pending_app_password %}` guard.
+    """
+    src = _user_edit_template_source()
+    guard = re.search(
+        r"\{%\s*if\s+pending_app_password\s*%\}",
+        src,
+    )
+    assert guard, (
+        "The template must guard the inline cleartext render with "
+        "`{% if pending_app_password %}` — without the guard, an empty "
+        "box would appear on every /me visit."
+    )


### PR DESCRIPTION
## Symptom

Reporter @droM4X (fork [#223](https://github.com/new-usemame/Calibre-Web-NextGen/issues/223)) observed that when a user creates a new app password on `/me`, the cleartext shows in a Bootstrap toast at the bottom for ~10 seconds, then disappears. Hard to see, hard to read in time, hard to copy.

## Fix

`app_password_create` now writes `{label, token}` to `session['pending_app_password']` instead of using `flash(...token...)`. The profile route passes the session value to `user_edit.html`. The template renders a prominent green-highlighted inline box at the top of the App passwords section, with a Copy button. A `before_request` hook in `cps/__init__.py` pops the session key when the user navigates to any non-profile page — gated on `Sec-Fetch-Dest: document` so sub-resource fetches (CSS, JS, XHR, OPDS, Kobo sync) can't accidentally clear it mid-render.

## Verification

7 RED→GREEN source-pin tests in `tests/unit/test_app_password_inline_display.py` covering: session write shape, no-flash-with-token (the broken UX is forbidden), profile route passes the variable, before_request hook present and pops on non-profile endpoints, template renders inline with a Jinja conditional guard.

Playwright pilot on cwn-local end-to-end:
- Create password 'Sec-fetch-test' → POST → 302 → /me renders inline green box with cleartext `jBFHUJS1kJRa9baHcQG-6MYu8-0XR3MW31xs9dB9Tf4` ✅
- Reload /me → box persists with same token ✅
- Navigate to /admin/view → back to /me → box gone ✅

Cleartext is never persisted to the database (only the werkzeug hash).

Closes #223.