### PR TITLE
feat(layout): render paginator at end of book list (closes #256)

### DIFF
--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -8806,3 +8806,27 @@ button.close {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }
 }
+/* Fork issue #256 (@droM4X): in-flow paginator at the end of the book
+   list. The default .pagination rule above pins the paginator fixed at
+   the top-right; this modifier scopes a `position: static` override to
+   the bottom copy rendered in layout.html. Without this, the second
+   paginator would stack on top of the first as another fixed element. */
+body > div.container-fluid > div > div.col-sm-10 > div.pagination.pagination-bottom,
+.pagination.pagination-bottom {
+    position: static;
+    top: auto;
+    right: auto;
+    height: auto;
+    line-height: 1.5;
+    margin: 1.5rem 0 0.5rem;
+    padding: 0;
+    text-align: center;
+    z-index: auto;
+    display: block;
+}
+
+body > div.container-fluid > div > div.col-sm-10 > div.pagination.pagination-bottom > .page-item,
+.pagination.pagination-bottom > .page-item {
+    display: inline-block;
+    margin: 0 2px;
+}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -361,7 +361,34 @@
         <div class="col-sm-10">
           {% block body %}{% endblock %}
           {% if pagination and (pagination.has_next or pagination.has_prev) %}
+            {# Top paginator — caliBlur CSS pins this fixed at top-right. #}
             <div class="pagination">
+              {% if pagination.has_prev %}
+              <li class="page-item page-previous"><a class="page-link" aria-label="next page" href="{{ (pagination.page - 1)|url_for_other_page
+                }}">&laquo; {{_('Previous')}}</a></li>
+              {% endif %}
+            {% for page in pagination.iter_pages() %}
+              {% if page %}
+                {% if page != pagination.page %}
+                  <li class="page-item"><a class="page-link" aria-label="to page {{ page }}" href="{{ (page)|url_for_other_page }}">{{ page }}</a></li>
+                {% else %}
+                  <li class="page-item active"><a class="page-link" aria-label="to page {{ page }}" href="{{ (page)|url_for_other_page }}">{{ page }}</a></li>
+                {% endif %}
+              {% else %}
+                <li class="page-item page-last-separator disabled"><a class="page-link" aria-label="">…</a></li>
+              {% endif %}
+            {% endfor %}
+            {% if pagination.has_next %}
+              <li class="page-item page-next"><a class="page-link next" aria-label="next page" href="{{ (pagination.page + 1)|url_for_other_page
+                }}">{{_('Next')}} &raquo;</a></li>
+            {% endif %}
+            </div>
+            {# Fork issue #256 (droM4X): also render the paginator in-flow
+               at the end of the list, so users at the bottom of a long
+               scroll don't have to go back to the top to navigate. The
+               `.pagination-bottom` modifier scopes the `position: static`
+               override to this copy only (caliBlur.css). #}
+            <div class="pagination pagination-bottom">
               {% if pagination.has_prev %}
               <li class="page-item page-previous"><a class="page-link" aria-label="next page" href="{{ (pagination.page - 1)|url_for_other_page
                 }}">&laquo; {{_('Previous')}}</a></li>

--- a/tests/unit/test_pagination_bottom.py
+++ b/tests/unit/test_pagination_bottom.py
@@ -1,0 +1,93 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Acceptance tests for fork #256 — pagination at end of book list.
+
+Reporter @droM4X: book listing pages render the paginator at the top
+of the screen (caliBlur CSS positions ``.pagination`` as
+``position: fixed; top: 4.15em; right: 0``). After scrolling to the
+bottom of a long list, the user has to scroll back up to navigate.
+
+Fix: render a second copy of the paginator at the end of the list in
+normal document flow. The bottom copy carries a ``.pagination-bottom``
+class so it can override the fixed positioning via CSS.
+
+These tests pin:
+1. Both paginators exist in `cps/templates/layout.html`.
+2. The bottom one carries the `pagination-bottom` modifier.
+3. The CSS override for `.pagination-bottom` is present in caliBlur.css.
+4. The CSS override actually undoes the `position: fixed`.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _layout_template():
+    return (REPO_ROOT / "cps" / "templates" / "layout.html").read_text()
+
+
+def _caliblur_css():
+    return (REPO_ROOT / "cps" / "static" / "css" / "caliBlur.css").read_text()
+
+
+def test_layout_renders_two_pagination_blocks():
+    """Both the top (fixed via CSS) and bottom (in-flow) paginators
+    must exist in the layout template.
+    """
+    src = _layout_template()
+    # Count opening `<div class="pagination` occurrences inside the body
+    # section. Both top + bottom variants begin with this prefix.
+    count = src.count('<div class="pagination')
+    assert count >= 2, (
+        f"Expected at least 2 `<div class=\"pagination...\">` blocks in "
+        f"cps/templates/layout.html (top + bottom paginator). Found "
+        f"{count}. See fork issue #256 (@droM4X)."
+    )
+
+
+def test_layout_has_pagination_bottom_class():
+    """The bottom paginator must carry the `pagination-bottom` class so
+    its CSS can override the fixed-top positioning of the default
+    `.pagination` rule.
+    """
+    src = _layout_template()
+    assert "pagination-bottom" in src, (
+        "cps/templates/layout.html must include `class=\"pagination "
+        "pagination-bottom\"` on the bottom paginator block so the CSS "
+        "can scope the `position: static` override to that copy only. "
+        "Without the modifier, the override would apply to the top "
+        "paginator too and break the fixed-top behavior."
+    )
+
+
+def test_caliblur_overrides_pagination_bottom_position():
+    """The CSS must include a `.pagination-bottom` (or
+    `.pagination.pagination-bottom`) rule that undoes the
+    `position: fixed` of the default `.pagination` rule, so the bottom
+    paginator flows with the document.
+    """
+    src = _caliblur_css()
+    # Look for a CSS rule that targets pagination-bottom AND sets position
+    # to something other than fixed (static / relative / unset / auto).
+    # Loose match: the modifier name must appear in a selector somewhere.
+    assert "pagination-bottom" in src, (
+        "cps/static/css/caliBlur.css must include a `.pagination-bottom` "
+        "or `.pagination.pagination-bottom` rule that overrides the "
+        "default `.pagination { position: fixed }` so the bottom "
+        "paginator flows with the document instead of stacking on top "
+        "of the fixed-position paginator."
+    )
+    # Find a rule block that mentions pagination-bottom and confirm it
+    # sets position to static.
+    pb_idx = src.find("pagination-bottom")
+    rule_chunk = src[pb_idx:pb_idx + 400]
+    assert "position:" in rule_chunk and "static" in rule_chunk, (
+        f"The `.pagination-bottom` rule in caliBlur.css must set "
+        f"`position: static` (or similar) to undo the fixed positioning. "
+        f"Current rule chunk: {rule_chunk!r}"
+    )


### PR DESCRIPTION
## Symptom

Reporter @droM4X (fork [#256](https://github.com/new-usemame/Calibre-Web-NextGen/issues/256)): caliBlur pins `.pagination` at the top-right of the viewport via `position: fixed`. After scrolling through a long book list, the user has to scroll back up to navigate. Asked for the paginator to also appear at the end of the list in normal flow.

## Fix

`cps/templates/layout.html`: duplicate the existing paginator markup after the body block, with `class=\"pagination pagination-bottom\"`. `cps/static/css/caliBlur.css`: scope `position: static` to `.pagination.pagination-bottom` so the top copy keeps its fixed positioning and only the bottom copy flows with the document.

## Verification

3 RED→GREEN source-pin tests in `tests/unit/test_pagination_bottom.py`. Playwright pilot on cwn-local with `config_books_per_page=5`: two paginators render — top at `position:fixed top:58px`, bottom at `position:static top:586px`. Clicking the bottom Next link navigates to `/page/2`.

Closes #256.