### PR TITLE
fix(s6): cd into app dir before invoking sweeper via python -m

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/cwa-preview-cache-cleanup/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-preview-cache-cleanup/run
@@ -46,6 +46,9 @@ INITIAL_DELAY_SECONDS=${CWA_PREVIEW_CACHE_INITIAL_DELAY:-120}
 echo "[cwa-preview-cache-cleanup] Initial delay: ${INITIAL_DELAY_SECONDS}s; sweep interval: ${SWEEP_INTERVAL_SECONDS}s; cap (MB): ${CWA_PREVIEW_CACHE_MAX_MB:-1024}"
 sleep "$INITIAL_DELAY_SECONDS"
 
+# Python's `-m` only adds CWD to sys.path; cd so `cps` is importable.
+cd /app/calibre-web-automated || { echo "[cwa-preview-cache-cleanup] FATAL: /app/calibre-web-automated missing"; exit 1; }
+
 while true; do
     # Run as the abc service user so unlink permissions match what the
     # Flask endpoint wrote (write_to_cache runs in the gunicorn worker


### PR DESCRIPTION
## Symptom

`cwa-preview-cache-cleanup` (the s6 longrun that hourly invokes
`cps.services.cover_preview_cache_sweeper` to evict
`/config/.cwa-preview-cache/` files until total size drops under
`CWA_PREVIEW_CACHE_MAX_MB`) never executes a single sweep. Every
iteration logs:

    [cwa-preview-cache-cleanup] Starting cover-preview disk-cache LRU sweeper...
    [cwa-preview-cache-cleanup] Initial delay: 120s; sweep interval: 3600s; cap (MB): 1024
    /lsiopy/bin/python3: Error while finding module specification for 'cps.services.cover_preview_cache_sweeper' (ModuleNotFoundError: No module named 'cps')
    [cwa-preview-cache-cleanup] WARNING: sweeper exited non-zero; continuing schedule

The cap is therefore advisory only — the `/cover/<id>/preview` endpoint
keeps writing padded JPEG tiles into the cache and nothing ever evicts
them, so on heavily-browsed libraries the disk grows unbounded until
the operator notices.

## Root Cause Analysis

`root/etc/s6-overlay/s6-rc.d/cwa-preview-cache-cleanup/run:53` invokes:

    s6-setuidgid abc python3 -m cps.services.cover_preview_cache_sweeper

Python's `-m` only adds the **current working directory** to
`sys.path[0]`. The s6 supervisor exec's the run script with CWD = `/`,
so `cps` (which lives under `/app/calibre-web-automated/cps/`) is not
on the import path, the module-spec lookup fails, and the `while true`
loop falls through to the `|| echo …WARNING…` branch every cycle
without ever running the sweep.

The module's own docstring at
`cps/services/cover_preview_cache_sweeper.py:17` documents
`python -m cps.services.cover_preview_cache_sweeper` as the canonical
operator invocation, so the right fix is to make `cps` reachable rather
than abandon the `-m` entry point.

`svc-calibre-web-automated/run` and `cwa-init/run` already anchor Python
with `cd /app/calibre-web-automated` before exec. The sweeper's run
script should mirror that.

Alternatives considered and rejected:

*   `PYTHONPATH=/app/calibre-web-automated`: works, but introduces a new pattern not used elsewhere under `root/etc/s6-overlay/`, and a missing app dir surfaces as the same opaque `ModuleNotFoundError` rather than a clear FATAL line.
*   `python3 /app/calibre-web-automated/cps/services/cover_preview_cache_sweeper.py` as a plain script: would still need `PYTHONPATH`, because Python would put `cps/services/` on `sys.path` rather than the app root and `cover_preview_cache_sweeper.py:72`'s `from cps.services import cover_preview_cache as _cache_mod` would fail the same way. Strictly more verbose than the `-m` form for no upside.

## Solution

```diff
--- a/root/etc/s6-overlay/s6-rc.d/cwa-preview-cache-cleanup/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-preview-cache-cleanup/run
@@ -44,6 +44,9 @@ INITIAL_DELAY_SECONDS=${CWA_PREVIEW_CACHE_INITIAL_DELAY:-120}
 echo "[cwa-preview-cache-cleanup] Initial delay: ${INITIAL_DELAY_SECONDS}s; sweep interval: ${SWEEP_INTERVAL_SECONDS}s; cap (MB): ${CWA_PREVIEW_CACHE_MAX_MB:-1024}"
 sleep "$INITIAL_DELAY_SECONDS"
 
+# Python's `-m` only adds CWD to sys.path; cd so `cps` is importable.
+cd /app/calibre-web-automated || { echo "[cwa-preview-cache-cleanup] FATAL: /app/calibre-web-automated missing"; exit 1; }
+
 while true; do
     # Run as the abc service user so unlink permissions match what the
     # Flask endpoint wrote (write_to_cache runs in the gunicorn worker
```

## Testing

Patched live in the running container via a read-only bind-mount over
`/etc/s6-overlay/s6-rc.d/cwa-preview-cache-cleanup/run` from the NixOS
host, then container recreated (image
`ghcr.io/new-usemame/calibre-web-nextgen:latest`, `v4.0.94`, podman
backend):

*   Extracted the as-shipped script from the running container with `podman cp calibre:/etc/s6-overlay/s6-rc.d/cwa-preview-cache-cleanup/run /storage/calibre/patches/cwa-preview-cache-cleanup-run.orig` and confirmed it matches `root/etc/.../run` in the branch parent byte-for-byte.
*   Wrote the patched version to `/storage/calibre/patches/cwa-preview-cache-cleanup-run` and added `/storage/calibre/patches/cwa-preview-cache-cleanup-run:/etc/s6-overlay/s6-rc.d/cwa-preview-cache-cleanup/run:ro` to the host's calibre container module so s6 picks up the patched file at next start without rebuilding the image.
*   After `systemctl restart podman-calibre.service`, `podman logs --tail 200 calibre | grep cwa-preview-cache-cleanup` shows the "Starting…" + "Initial delay…" banner and then silence — no more `ModuleNotFoundError` across the initial delay + first sweep interval.
*   Sanity-checked the entry point separately with `podman exec -u abc calibre bash -c 'cd /app/calibre-web-automated && python3 -m cps.services.cover_preview_cache_sweeper'` — exits 0 and prints the `before=… after=… evicted=… errors=… cap=… root=…` summary from `main()`, confirming the breakage was purely the s6 invocation context.