### PR TITLE
Set timeout for smoke and unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,7 @@ jobs:
           touch /config/cwa.db
       
       - name: Run smoke and unit tests
+        timeout-minutes: 10  # Kill if stuck
         env:
           PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/scripts
         run: |


### PR DESCRIPTION
I added a timeout to the fast tests as well, because it is a recurring issue that they fail and can get stuck for hours, wasting build time. The other two tests already had a timeout configured; for some reason this one was missing it.

From what I can see, under normal conditions it completes within 2 minutes, so I suggest a 10-minute timeout, which should be more than enough.

Today I manually stopped one after 2 hours and 43 minutes. :/

https://github.com/new-usemame/Calibre-Web-NextGen/actions/runs/26149810821