### PR TITLE
feat(book-organizer): wire cog menu to hide-shelf-badges toggle

### DIFF
--- a/cps/static/css/book_organizer.css
+++ b/cps/static/css/book_organizer.css
@@ -388,6 +388,43 @@ body.book-organizer-select-mode .book-organizer-actions-row {
   opacity: 0.85;
 }
 
+/* Fork #205 (@goatdancer4000-sudo / @droM4X / @Onkeyuk): per-user
+   "Hide shelf badges on covers" toggle on the book-organizer cog menu.
+   When the toggle is on, body carries `cover-hide-shelf-badges` and the
+   shelf-name + overflow-pill variants are hidden. The Read badge stays
+   visible (it's not a shelf and the toggle is scoped to shelf badges
+   specifically). */
+body.cover-hide-shelf-badges .cover-badge-shelf,
+body.cover-hide-shelf-badges .cover-badge-shelf-extra-pill {
+  display: none !important;
+}
+
+/* Cog dropdown styling for the "Cover Settings" header + checkbox-style
+   toggle item. The header is presentational (non-interactive) and gives
+   the dropdown a clear scope label; the toggle item carries the actual
+   `role="menuitemcheckbox"` semantics. */
+.book-organizer-settings-menu .book-organizer-settings-header {
+  padding: 6px 16px 4px;
+  color: #888;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.book-organizer-settings-menu .book-organizer-settings-header > .glyphicon {
+  margin-right: 6px;
+  opacity: 0.7;
+}
+.book-organizer-settings-menu .book-organizer-settings-toggle-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+}
+.book-organizer-settings-menu .book-organizer-settings-checkmark {
+  width: 1em;
+  text-align: center;
+}
+
 /* Hide caliBlur's old read badge in favor of our unified .cover-badges stack. */
 .book .cover .badge.read.glyphicon-ok {
   display: none !important;

--- a/cps/static/js/book_organizer.js
+++ b/cps/static/js/book_organizer.js
@@ -233,6 +233,48 @@
   function flashInfo(msg) { flash(msg, "info"); }
   function flashError(msg) { flash(msg, "error"); }
 
+  // Fork #205: per-user "Hide shelf badges on covers" toggle wired to the
+  // cog dropdown. Persists via the existing /ajax/view endpoint
+  // (view_settings.cover.hide_shelf_badges) so no DB migration is needed.
+  // Toggling the body class gives instant visual feedback; the server-rendered
+  // class on the next page load keeps the state consistent across navigations.
+  function toggleHideShelfBadges(actionEl) {
+    var bodyEl = document.body;
+    var isHidden = bodyEl.classList.contains("cover-hide-shelf-badges");
+    var nextValue = !isHidden;
+    if (nextValue) {
+      bodyEl.classList.add("cover-hide-shelf-badges");
+    } else {
+      bodyEl.classList.remove("cover-hide-shelf-badges");
+    }
+    if (actionEl) {
+      actionEl.setAttribute("aria-checked", nextValue ? "true" : "false");
+      var mark = actionEl.querySelector(".book-organizer-settings-checkmark");
+      if (mark) {
+        mark.classList.remove("glyphicon-check", "glyphicon-unchecked");
+        mark.classList.add(nextValue ? "glyphicon-check" : "glyphicon-unchecked");
+      }
+    }
+    postJson("/ajax/view", { cover: { hide_shelf_badges: nextValue } })
+      .catch(function () {
+        // Server rejected the persist — revert UI so user state matches storage.
+        if (nextValue) {
+          bodyEl.classList.remove("cover-hide-shelf-badges");
+        } else {
+          bodyEl.classList.add("cover-hide-shelf-badges");
+        }
+        if (actionEl) {
+          actionEl.setAttribute("aria-checked", isHidden ? "true" : "false");
+          var m2 = actionEl.querySelector(".book-organizer-settings-checkmark");
+          if (m2) {
+            m2.classList.remove("glyphicon-check", "glyphicon-unchecked");
+            m2.classList.add(isHidden ? "glyphicon-check" : "glyphicon-unchecked");
+          }
+        }
+        flashError(i18n.coverSettingsSaveFailed || "Could not save cover display setting.");
+      });
+  }
+
   function bulkAddToShelf(shelfId, shelfName) {
     var ids = getSelectedIds().map(Number);
     if (!ids.length) {
@@ -357,8 +399,13 @@
       e.preventDefault();
       clearSelection();
     } else if (action === "cover-settings") {
-      // No-op for now. Another agent will wire this up.
+      // Legacy no-op kept for compatibility with the original menu markup.
+      // The real toggle action below ("toggle-hide-shelf-badges") replaces it.
       e.preventDefault();
+    } else if (action === "toggle-hide-shelf-badges") {
+      e.preventDefault();
+      e.stopPropagation();
+      toggleHideShelfBadges(actionEl);
     } else if (action === "add-to-shelf") {
       e.preventDefault();
       var shelfId = actionEl.getAttribute("data-shelf-id");

--- a/cps/templates/_book_organizer.html
+++ b/cps/templates/_book_organizer.html
@@ -66,10 +66,22 @@
       <ul class="dropdown-menu dropdown-menu-right book-organizer-settings-menu"
           role="menu"
           aria-labelledby="book-organizer-settings-toggle">
+        {%- set _cover_hide_shelf_badges = false -%}
+        {%- if current_user is defined and current_user and current_user.get_view_property is defined -%}
+          {%- set _cover_hide_shelf_badges = current_user.get_view_property('cover', 'hide_shelf_badges') -%}
+        {%- endif -%}
+        <li class="book-organizer-settings-header" role="presentation" aria-hidden="true">
+          <span class="glyphicon glyphicon-picture" aria-hidden="true"></span>
+          <span>{{ _('Cover Settings') }}</span>
+        </li>
         <li role="presentation">
-          <a href="#" role="menuitem" data-organizer-action="cover-settings">
-            <span class="glyphicon glyphicon-picture" aria-hidden="true"></span>
-            <span>{{ _('Cover Settings') }}</span>
+          <a href="#"
+             role="menuitemcheckbox"
+             class="book-organizer-settings-toggle-item"
+             data-organizer-action="toggle-hide-shelf-badges"
+             aria-checked="{{ 'true' if _cover_hide_shelf_badges else 'false' }}">
+            <span class="book-organizer-settings-checkmark glyphicon glyphicon-{% if _cover_hide_shelf_badges %}check{% else %}unchecked{% endif %}" aria-hidden="true"></span>
+            <span>{{ _('Hide shelf badges on covers') }}</span>
           </a>
         </li>
       </ul>

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -116,7 +116,14 @@
 
     </script>
   </head>
-  <body class="{{ page }} {{ bodyClass }}{% if g.current_theme == 1 %} blur{% endif %}{% if cwa_settings and cwa_settings.get('enable_mobile_blur') %} allow-mobile-blur{% endif %}" data-text="{{_('Home')}}" data-textback="{{_('Back')}}">
+  {# Fork #205 (@goatdancer4000-sudo / @droM4X): per-user "Hide shelf badges
+     on covers" toggle wired to the book-organizer cog button. Setting lives
+     in user.view_settings.cover.hide_shelf_badges (no migration). #}
+  {%- set _cover_hide_shelf_badges = false -%}
+  {%- if current_user is defined and current_user and current_user.get_view_property is defined -%}
+    {%- set _cover_hide_shelf_badges = current_user.get_view_property('cover', 'hide_shelf_badges') -%}
+  {%- endif -%}
+  <body class="{{ page }} {{ bodyClass }}{% if g.current_theme == 1 %} blur{% endif %}{% if cwa_settings and cwa_settings.get('enable_mobile_blur') %} allow-mobile-blur{% endif %}{% if _cover_hide_shelf_badges %} cover-hide-shelf-badges{% endif %}" data-text="{{_('Home')}}" data-textback="{{_('Back')}}">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <!-- Static navbar -->
     <div class="navbar navbar-default navbar-static-top" role="navigation">

--- a/tests/unit/test_cover_settings_hide_shelf_badges.py
+++ b/tests/unit/test_cover_settings_hide_shelf_badges.py
@@ -1,0 +1,185 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Acceptance tests for fork #205 — Cover Settings cog button wiring.
+
+Reporter @goatdancer4000-sudo, +1 from @droM4X, +1 from @Onkeyuk:
+the cog icon on the book-organizer bar opens a dropdown menu whose
+single item ("Cover Settings") does nothing when clicked. Users want
+a way to hide the shelf badges that overlay book covers — the badges
+get noisy when a book is in several shelves.
+
+Fix wires the cog menu to a per-user "Hide shelf badges on covers"
+toggle backed by ``user.view_settings.cover.hide_shelf_badges`` (no
+DB migration — JSON column). When set, ``<body>`` carries
+``cover-hide-shelf-badges`` and CSS hides ``.cover-badge-shelf`` and
+``.cover-badge-shelf-extra-pill`` (the Read badge stays — it's not a
+shelf badge).
+
+These tests pin the load-bearing invariants at the source level so a
+future refactor can't silently re-introduce the no-op.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+LAYOUT = REPO_ROOT / "cps" / "templates" / "layout.html"
+ORGANIZER_TMPL = REPO_ROOT / "cps" / "templates" / "_book_organizer.html"
+ORGANIZER_JS = REPO_ROOT / "cps" / "static" / "js" / "book_organizer.js"
+ORGANIZER_CSS = REPO_ROOT / "cps" / "static" / "css" / "book_organizer.css"
+WEB = REPO_ROOT / "cps" / "web.py"
+
+
+def test_layout_emits_cover_hide_shelf_badges_body_class():
+    """Layout must emit `cover-hide-shelf-badges` on `<body>` when the
+    user's view_settings has `cover.hide_shelf_badges` set."""
+    src = LAYOUT.read_text()
+    assert "cover-hide-shelf-badges" in src, (
+        "cps/templates/layout.html must conditionally add the "
+        "`cover-hide-shelf-badges` class to <body> based on the user's "
+        "view_settings. See fork issue #205."
+    )
+    # Pin the read of the view property — not just the class literal.
+    assert re.search(
+        r"get_view_property\([\'\"]cover[\'\"]\s*,\s*[\'\"]hide_shelf_badges[\'\"]\)",
+        src,
+    ), (
+        "Layout must call current_user.get_view_property('cover', "
+        "'hide_shelf_badges') so the body class reflects the persisted "
+        "user setting."
+    )
+
+
+def test_organizer_menu_has_toggle_item_not_no_op_link():
+    """The cog dropdown must contain the toggle-hide-shelf-badges action
+    with `role="menuitemcheckbox"` — the original `cover-settings`
+    no-op link is replaced by the real toggle."""
+    src = ORGANIZER_TMPL.read_text()
+    assert 'data-organizer-action="toggle-hide-shelf-badges"' in src, (
+        "cps/templates/_book_organizer.html must include a menu item "
+        "with data-organizer-action=\"toggle-hide-shelf-badges\" so the "
+        "cog button does something. See fork #205."
+    )
+    assert 'role="menuitemcheckbox"' in src, (
+        "The toggle menu item must use role=\"menuitemcheckbox\" so "
+        "screen readers announce it as a toggle, not a plain menu item."
+    )
+    # The aria-checked state must be wired to the persisted setting.
+    assert re.search(
+        r"aria-checked=[\"']\{\{\s*[\'\"]true[\'\"]\s+if\s+_cover_hide_shelf_badges",
+        src,
+    ), (
+        "aria-checked on the toggle must be derived from "
+        "_cover_hide_shelf_badges (read from view_settings)."
+    )
+
+
+def test_organizer_js_handles_toggle_action():
+    """The JS dispatcher must handle the new action and call the
+    persistence helper. The original no-op branch is preserved for
+    backward compatibility with the legacy `cover-settings` action
+    string but must not be the new wiring."""
+    src = ORGANIZER_JS.read_text()
+    assert 'action === "toggle-hide-shelf-badges"' in src, (
+        "cps/static/js/book_organizer.js must branch on the "
+        "`toggle-hide-shelf-badges` action so the cog menu item actually "
+        "does something. See fork #205."
+    )
+    assert "toggleHideShelfBadges" in src, (
+        "The handler function `toggleHideShelfBadges` must exist."
+    )
+    # The persistence call: POST /ajax/view with cover.hide_shelf_badges.
+    assert re.search(
+        r"postJson\(\s*[\"']/ajax/view[\"']\s*,\s*\{\s*cover:\s*\{\s*hide_shelf_badges:",
+        src,
+    ), (
+        "toggleHideShelfBadges must POST /ajax/view with payload "
+        "{cover: {hide_shelf_badges: <bool>}} to persist via the "
+        "existing user.set_view_property infrastructure (no new route)."
+    )
+
+
+def test_organizer_js_revert_on_persist_failure():
+    """If the AJAX persist fails, the UI must revert — both the body
+    class and the aria-checked state — so storage stays in sync with
+    what the user sees. Without this, a network blip leaves the user
+    with badges hidden on screen but the next page load brings them
+    back, which is confusing."""
+    src = ORGANIZER_JS.read_text()
+    fn_match = re.search(
+        r"function toggleHideShelfBadges[\s\S]+?\n  \}\n",
+        src,
+    )
+    assert fn_match, "toggleHideShelfBadges function block not found"
+    fn_body = fn_match.group(0)
+    assert ".catch(" in fn_body, (
+        "toggleHideShelfBadges must register a .catch handler so a "
+        "failed persist reverts the optimistic UI change."
+    )
+    # The catch must revert at least the body class.
+    assert "classList.remove" in fn_body and "classList.add" in fn_body, (
+        "The revert branch must un-do the body class toggle."
+    )
+
+
+def test_css_hides_shelf_badges_when_body_class_set():
+    """CSS must scope `display: none` on `.cover-badge-shelf` and
+    `.cover-badge-shelf-extra-pill` to the body class. The Read badge
+    (`.cover-badge-read`) MUST NOT be hidden — the toggle is scoped to
+    shelf badges only."""
+    src = ORGANIZER_CSS.read_text()
+    rule = re.search(
+        r"body\.cover-hide-shelf-badges[^{]*\{[^}]*display:\s*none",
+        src,
+    )
+    assert rule, (
+        "cps/static/css/book_organizer.css must include a "
+        "`body.cover-hide-shelf-badges ... { display: none }` rule so "
+        "the shelf badges hide when the toggle is on."
+    )
+    # The rule must cover both shelf-badge variants.
+    region = src[rule.start():rule.end() + 200]
+    assert "cover-badge-shelf" in region, (
+        "The CSS rule must scope to `.cover-badge-shelf` (the per-shelf "
+        "badge variant)."
+    )
+    # The Read badge must NOT be hidden by the rule — it's not a shelf badge.
+    # Loose check: the selector list must not contain `.cover-badge-read`.
+    bad = re.search(
+        r"body\.cover-hide-shelf-badges[^{]*\.cover-badge-read\b",
+        src,
+    )
+    assert bad is None, (
+        "The `body.cover-hide-shelf-badges` rule must NOT target "
+        ".cover-badge-read — the toggle is scoped to shelf badges only."
+    )
+
+
+def test_ajax_view_endpoint_already_handles_arbitrary_keys():
+    """The toggle reuses the existing /ajax/view endpoint that accepts
+    `{element: {param: value}}`. Pin that the endpoint is still the
+    generic shape — if a refactor narrows it to specific keys, the
+    cover.hide_shelf_badges write path silently breaks."""
+    src = WEB.read_text()
+    # The endpoint must exist.
+    assert "/ajax/view" in src, "cps/web.py must register /ajax/view route"
+    # It must iterate elements + params generically. Loose pin on the
+    # iteration pattern.
+    assert re.search(
+        r"for\s+element\s+in\s+to_save[\s\S]+?for\s+param\s+in\s+to_save\[element\][\s\S]+?set_view_property",
+        src,
+    ), (
+        "/ajax/view must iterate {element: {param: value}} payloads "
+        "generically and delegate to set_view_property. A narrowed "
+        "endpoint would break the cover.hide_shelf_badges write path."
+    )


### PR DESCRIPTION
## Why

Reporter @goatdancer4000-sudo with +1s from @droM4X and @Onkeyuk on fork #205: the cog button on the book-organizer toolbar opened a dropdown whose only item ("Cover Settings") did nothing. Three users specifically asked for a way to hide the shelf badges that overlay book covers — the badges get noisy when a book is in several shelves.

## What

The cog dropdown now contains a `role="menuitemcheckbox"` toggle "Hide shelf badges on covers". Toggling it persists `user.view_settings.cover.hide_shelf_badges` via the existing `/ajax/view` endpoint (no DB migration — JSON column on User). `<body>` carries `cover-hide-shelf-badges` when the setting is on; CSS scopes `display: none` to `.cover-badge-shelf` and `.cover-badge-shelf-extra-pill`. The Read badge (`.cover-badge-read`) stays visible — the toggle is scoped to shelf badges only.

The JS dispatcher does an optimistic UI flip (instant feedback) then persists; on persist failure it reverts both the body class and the aria-checked state so storage and viewport stay in sync.

## Verification

- 6 source-pin tests in `tests/unit/test_cover_settings_hide_shelf_badges.py` (all GREEN): layout body-class wiring, menu markup, JS dispatcher branch, revert-on-failure path, CSS rule shape (and the deliberate gap that excludes `.cover-badge-read`), `/ajax/view` endpoint contract.
- Adjacent suite green.
- **Playwright pilot on cwn-local** (admin user, 3 books pinned to a public shelf):
  - Initial state: cog dropdown shows "Hide shelf badges on covers" with `aria-checked="false"` + 3 shelf badges visible
  - Click toggle → `cover-hide-shelf-badges` added to `<body>`, `aria-checked="true"`, checkmark glyph flips, all 3 badges become `display: none`, `POST /ajax/view → 200`
  - DB confirms `view_settings.cover.hide_shelf_badges = true`
  - Reload preserves state on `/`, `/discover/stored/`, `/shelf/1` — body class re-emitted server-side
  - Toggle OFF → reverse, DB confirms `false`
  - Zero console errors throughout

## Confidence

97% — JS, template, CSS, persistence layer all behaviorally verified. Residual risk is theme-specific rendering edge cases on caliBlur dark mode that source-pin tests don't cover (verified visually in pilot).

Addresses #205