### PR TITLE
fix(upload): EPERM-tolerant copy fallback for cross-ownership mounts (CW #3437)

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -49,6 +49,7 @@ from . import gdriveutils as gd
 from .constants import (STATIC_DIR as _STATIC_DIR, CACHE_TYPE_THUMBNAILS, THUMBNAIL_TYPE_COVER, THUMBNAIL_TYPE_SERIES,
                         SUPPORTED_CALIBRE_BINARIES)
 from .subproc_wrapper import process_wait
+from .services.file_move import copy_with_metadata_fallback
 
 # Track books with pending thumbnail generation to prevent duplicate tasks
 _pending_thumbnail_books = set()
@@ -479,10 +480,11 @@ def rename_all_files_on_change(one_book, new_path, old_path, all_new_name, gdriv
                 log.debug("Successfully renamed %s to %s", old_file, new_file)
             except OSError as ex:
                 log.error("Failed to rename file from %s to %s: %s", old_file, new_file, ex)
-                # Try copy+delete as fallback for permission issues (e.g., network shares)
+                # Try copy+delete as fallback for permission issues (e.g., network shares,
+                # cross-ownership bind mounts — janeczku/calibre-web#3437).
                 try:
                     log.info("Attempting copy+delete fallback for %s", old_file)
-                    shutil.copy2(old_file, new_file)
+                    copy_with_metadata_fallback(old_file, new_file)
                     os.remove(old_file)
                     log.info("Successfully copied and removed old file: %s", old_file)
                 except (OSError, IOError) as fallback_ex:
@@ -621,12 +623,22 @@ def move_files_on_change(calibre_path, new_author_dir, new_titledir, localbook, 
             except OSError as ex:
                 log.error("Rename title from %s to %s failed with error: %s, trying copy+delete fallback",
                          path, new_path, ex)
+                dest_filepath = os.path.join(new_path, db_filename)
                 try:
-                    shutil.copy2(original_filepath, os.path.join(new_path, db_filename))
-                    os.remove(original_filepath)
+                    # copy_with_metadata_fallback handles the EPERM-on-chmod case that
+                    # affects cross-ownership bind mounts (janeczku/calibre-web#3437):
+                    # copy2's copystat() raises EPERM on restricted filesystems even
+                    # though copyfile() succeeded — the helper retries with a data-only
+                    # copy in that case, so the upload completes instead of surfacing
+                    # the confusing permission error to the user.
+                    copy_with_metadata_fallback(original_filepath, dest_filepath)
                 except (OSError, IOError) as fallback_ex:
                     log.error("Copy+delete fallback also failed: %s", fallback_ex)
                     raise
+                try:
+                    os.remove(original_filepath)
+                except (OSError, IOError) as rm_ex:
+                    log.warning("Failed to remove staging file after copy: %s", rm_ex)
             log.debug("Moving title: %s to %s", original_filepath, new_path)
         else:
             # Check new path is not valid path
@@ -662,7 +674,9 @@ def move_files_on_change(calibre_path, new_author_dir, new_titledir, localbook, 
                         except OSError as ex:
                             log.error("Failed to move file %s to %s: %s, trying copy+delete", src_file, dest_file, ex)
                             try:
-                                shutil.copy2(src_file, dest_file)
+                                # copy_with_metadata_fallback handles the EPERM-on-chmod case
+                                # that affects cross-ownership bind mounts (janeczku/calibre-web#3437).
+                                copy_with_metadata_fallback(src_file, dest_file)
                                 os.remove(src_file)
                             except (OSError, IOError) as fallback_ex:
                                 log.error("Copy+delete fallback failed for %s: %s", src_file, fallback_ex)

--- a/cps/services/file_move.py
+++ b/cps/services/file_move.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""File-move helpers that survive cross-ownership filesystem mounts.
+
+Container deployments commonly bind-mount the temp upload area
+(`/tmp/calibre_web`) and the library storage (`/books`) onto filesystems with
+different ownership semantics — LinuxServer-style PUID/PGID containers, NFS
+shares mounted with squashed root, SMB shares with mode restrictions. When
+`shutil.move` falls back from `os.rename` (Errno 18 EXDEV) to `shutil.copy2`,
+the `copystat` step's `os.chmod` can fail with Errno 1 EPERM (or Errno 13
+EACCES on some network filesystems) even though the file data was copied
+successfully. This module's :func:`copy_with_metadata_fallback` retries the
+data-only :func:`shutil.copyfile` when `copy2` raises, so the upload completes
+instead of surfacing a confusing permission error to the user.
+
+Canonical report: ``janeczku/calibre-web#3437``.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+from .. import logger
+
+log = logger.create()
+
+
+def copy_with_metadata_fallback(src: str, dst: str) -> None:
+    """Copy ``src`` to ``dst``, preserving metadata when the filesystem allows.
+
+    Tries :func:`shutil.copy2` first (data + mode + atime/mtime + xattr). If
+    the copy2 metadata step raises :class:`OSError` — typically EPERM on chmod
+    when ``dst`` lives on a differently-owned filesystem — falls back to
+    :func:`shutil.copyfile`, which copies the bytes only. The destination then
+    receives default permissions from the calling process's umask, which is
+    acceptable for the upload path because the file is about to be re-processed
+    by the Calibre ingest pipeline.
+
+    Raises whatever the fallback :func:`shutil.copyfile` raises if the data
+    copy itself fails (e.g., ENOSPC on dst filesystem, EACCES on dst dir).
+    """
+    try:
+        shutil.copy2(src, dst)
+    except OSError as ex:
+        log.info(
+            "copy2 metadata preservation failed (%s); falling back to data-only copy",
+            ex,
+        )
+        shutil.copyfile(src, dst)

--- a/tests/unit/test_file_move_metadata_fallback.py
+++ b/tests/unit/test_file_move_metadata_fallback.py
@@ -1,0 +1,192 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for cross-ownership filesystem upload fallback.
+
+Pins the behavior shipped for janeczku/calibre-web#3437: when shutil.copy2
+fails (typically EPERM on chmod when src and dst live on differently-owned
+filesystems — common in LinuxServer-style PUID/PGID containers with bind
+mounts), the upload path must still succeed by retrying with shutil.copyfile
+(data only, no metadata).
+"""
+
+from __future__ import annotations
+
+import ast
+import errno
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def file_move():
+    """Import the real `cps.services.file_move` module.
+
+    Earlier versions of this fixture stubbed `cps` / `cps.services` /
+    `cps.logger` via `types.ModuleType` to avoid triggering the full cps
+    package init. That worked when these tests ran alone but polluted
+    `sys.modules` for subsequent tests that imported `cps.helper` —
+    they would resolve to the stubs and fail with "no attribute X".
+    Importing the real module is fine; cps imports are already
+    side-effected by anything else that touches the package.
+    """
+    from cps.services import file_move as fm
+    return fm
+
+
+class TestCopyWithMetadataFallback:
+    """The data path itself."""
+
+    def test_happy_path_uses_copy2_only(self, file_move, tmp_path):
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("payload")
+        with patch.object(file_move.shutil, "copy2") as mock_copy2, \
+             patch.object(file_move.shutil, "copyfile") as mock_copyfile:
+            file_move.copy_with_metadata_fallback(str(src), str(dst))
+        mock_copy2.assert_called_once_with(str(src), str(dst))
+        mock_copyfile.assert_not_called()
+
+    def test_eperm_on_copy2_falls_back_to_copyfile(self, file_move, tmp_path):
+        """Errno 1 (EPERM) on chmod step — the janeczku#3437 symptom."""
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("payload")
+        with patch.object(
+            file_move.shutil,
+            "copy2",
+            side_effect=OSError(errno.EPERM, "Operation not permitted"),
+        ), patch.object(file_move.shutil, "copyfile") as mock_copyfile:
+            file_move.copy_with_metadata_fallback(str(src), str(dst))
+        mock_copyfile.assert_called_once_with(str(src), str(dst))
+
+    def test_eacces_on_copy2_also_falls_back(self, file_move, tmp_path):
+        """Errno 13 (EACCES) — what NFS / SMB shares often return for chmod denial."""
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("payload")
+        with patch.object(
+            file_move.shutil,
+            "copy2",
+            side_effect=OSError(errno.EACCES, "Permission denied"),
+        ), patch.object(file_move.shutil, "copyfile") as mock_copyfile:
+            file_move.copy_with_metadata_fallback(str(src), str(dst))
+        mock_copyfile.assert_called_once_with(str(src), str(dst))
+
+    def test_eperm_with_filename_arg_falls_back(self, file_move, tmp_path):
+        """Match the actual exception shape produced by shutil.copy2 → copystat → chmod."""
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("payload")
+        # shutil internals produce PermissionError with errno=EPERM + filename set
+        err = PermissionError(errno.EPERM, "Operation not permitted", str(dst))
+        with patch.object(file_move.shutil, "copy2", side_effect=err), \
+             patch.object(file_move.shutil, "copyfile") as mock_copyfile:
+            file_move.copy_with_metadata_fallback(str(src), str(dst))
+        mock_copyfile.assert_called_once_with(str(src), str(dst))
+
+    def test_copyfile_failure_propagates(self, file_move, tmp_path):
+        """If the data copy itself fails (ENOSPC, EACCES on dir), bubble up."""
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("payload")
+        with patch.object(
+            file_move.shutil,
+            "copy2",
+            side_effect=OSError(errno.EPERM, "Operation not permitted"),
+        ), patch.object(
+            file_move.shutil,
+            "copyfile",
+            side_effect=OSError(errno.ENOSPC, "No space left on device"),
+        ):
+            with pytest.raises(OSError) as exc_info:
+                file_move.copy_with_metadata_fallback(str(src), str(dst))
+        assert exc_info.value.errno == errno.ENOSPC
+
+    def test_real_data_is_copied(self, file_move, tmp_path):
+        """End-to-end smoke: actual bytes round-trip through the function."""
+        src = tmp_path / "src.bin"
+        dst = tmp_path / "dst.bin"
+        payload = b"\x00\x01\x02 calibre-web upload \xff\xfe\xfd"
+        src.write_bytes(payload)
+        file_move.copy_with_metadata_fallback(str(src), str(dst))
+        assert dst.read_bytes() == payload
+
+    def test_real_data_copied_even_with_eperm_simulated(self, file_move, tmp_path):
+        """Simulate the production failure mode: copy2 fails, copyfile succeeds, bytes present."""
+        src = tmp_path / "src.bin"
+        dst = tmp_path / "dst.bin"
+        payload = b"upload payload from /tmp\x00\xff"
+        src.write_bytes(payload)
+
+        original_copy2 = file_move.shutil.copy2
+
+        def copy2_fails_with_eperm(*_args, **_kwargs):
+            raise OSError(errno.EPERM, "Operation not permitted")
+
+        with patch.object(file_move.shutil, "copy2", side_effect=copy2_fails_with_eperm):
+            file_move.copy_with_metadata_fallback(str(src), str(dst))
+
+        assert dst.read_bytes() == payload
+        # Ensure we didn't actually call the real copy2 (would have succeeded in tmp_path)
+        assert original_copy2 is file_move.shutil.copy2  # patch restored
+
+
+class TestHelperCallSitesUseFallback:
+    """AST pin: every shutil.copy2 callsite in cps/helper.py should now route through
+    copy_with_metadata_fallback. If a future edit reverts a callsite back to
+    shutil.copy2(...) directly, this test fails."""
+
+    @pytest.fixture
+    def helper_source(self):
+        helper_path = Path(__file__).resolve().parents[2] / "cps" / "helper.py"
+        return helper_path.read_text()
+
+    def test_helper_imports_copy_with_metadata_fallback(self, helper_source):
+        assert "from .services.file_move import copy_with_metadata_fallback" in helper_source, (
+            "cps/helper.py must import copy_with_metadata_fallback to route upload-path "
+            "copies through the EPERM-aware fallback"
+        )
+
+    def test_no_direct_shutil_copy2_calls_in_helper(self, helper_source):
+        tree = ast.parse(helper_source)
+        direct_copy2_calls = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if (
+                    isinstance(func, ast.Attribute)
+                    and func.attr == "copy2"
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "shutil"
+                ):
+                    direct_copy2_calls.append(node.lineno)
+        assert direct_copy2_calls == [], (
+            f"cps/helper.py still has direct shutil.copy2(...) calls at lines "
+            f"{direct_copy2_calls}; these must use copy_with_metadata_fallback to "
+            f"survive cross-ownership filesystem mounts (janeczku/calibre-web#3437)"
+        )
+
+    def test_helper_uses_fallback_helper_at_least_three_times(self, helper_source):
+        # Three known fallback sites: rename_all_files_on_change,
+        # move_files_on_change upload path, move_files_on_change merge loop.
+        # Count paren-style call sites (excludes the bare-name `import`).
+        call_count = helper_source.count("copy_with_metadata_fallback(")
+        assert call_count >= 3, (
+            f"Expected ≥3 copy_with_metadata_fallback(...) call sites in "
+            f"helper.py (rename_all_files_on_change + 2 in "
+            f"move_files_on_change); found {call_count}"
+        )
+        # And the import must be present (defense against forgetting to wire
+        # after a refactor that removes a call but leaves the import alone).
+        assert "from .services.file_move import copy_with_metadata_fallback" in helper_source, (
+            "cps/helper.py must import copy_with_metadata_fallback alongside "
+            "its call sites."
+        )

--- a/tests/unit/test_move_files_chmod_eperm.py
+++ b/tests/unit/test_move_files_chmod_eperm.py
@@ -1,0 +1,193 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Pin the chmod-EPERM tolerance in `move_files_on_change`.
+
+Reporter scenario (janeczku/calibre-web#3437): user uploads a book on a
+restricted filesystem (CIFS, certain Docker bind mounts) where
+`os.rename` returns Errno 18 ("Invalid cross-device link") because the
+staging dir and library dir are on different devices. The existing
+fallback at `helper.py:625` is `shutil.copy2 + os.remove`.
+
+`shutil.copy2` does `copyfile` *then* `copystat`. On filesystems that
+disallow `chmod` for the running uid (CIFS without explicit
+file_mode/dir_mode, certain bind mounts with `nosuid,nodev,ro` semantics
+on metadata bits), `copystat` raises `PermissionError([Errno 1]
+Operation not permitted)`. Critically: **`copyfile` already succeeded
+by the time `copystat` fails** — the file IS at the destination,
+only the mode-preservation step blew up.
+
+Before this fix, that EPERM bubbled all the way to the user: they saw
+"Operation not permitted" in the UI, the DB row was created pointing
+at the new path, but the source file was never removed and the user
+saw their upload as "broken" even though the data was actually in
+place.
+
+The fix: in the copy+delete fallback path, if `copy2` raises
+`PermissionError` *after* the destination file exists, log a warning
+about the inability to preserve metadata and proceed with the delete.
+Data integrity is preserved; mode preservation is best-effort on
+filesystems that allow it.
+"""
+
+import os
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helper: minimal localbook stand-in
+# ---------------------------------------------------------------------------
+
+def _make_localbook():
+    """The function we test sets `localbook.path`; nothing else is read."""
+    return SimpleNamespace(id=1, path="")
+
+
+# ---------------------------------------------------------------------------
+# Mock copy2 that mirrors the real failure mode:
+#   1. copyfile succeeds — data IS written
+#   2. copystat fails with PermissionError(EPERM)
+# ---------------------------------------------------------------------------
+
+def _copy2_with_chmod_eperm(src, dst, **kwargs):
+    """Drop-in replacement for shutil.copy2 that writes data then errors."""
+    shutil.copyfile(src, dst)
+    raise PermissionError(1, "Operation not permitted", dst)
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+class TestMoveFilesChmodEperm:
+    """Pin: chmod-EPERM after successful copyfile must not fail the move."""
+
+    def test_chmod_eperm_after_copy_does_not_surface_as_error(self, tmp_path, monkeypatch):
+        """If copy2's copystat fails after data is at dest, treat as success."""
+        from cps.helper import move_files_on_change
+
+        # Set up source and destination dirs on a "different filesystem"
+        staging = tmp_path / "tmp" / "calibre_web"
+        staging.mkdir(parents=True)
+        library = tmp_path / "books"
+        library.mkdir()
+
+        src_file = staging / "abc123"
+        src_file.write_bytes(b"%PDF-1.4 fake-pdf-bytes")
+
+        def _raise_xdev(src, dst):
+            raise OSError(18, "Invalid cross-device link", src)
+
+        monkeypatch.setattr("cps.helper.shutil.move", _raise_xdev)
+        monkeypatch.setattr("cps.helper.shutil.copy2", _copy2_with_chmod_eperm)
+
+        result = move_files_on_change(
+            calibre_path=str(library),
+            new_author_dir="Test Author",
+            new_titledir="Test Book (1)",
+            localbook=_make_localbook(),
+            db_filename="Test Book.pdf",
+            original_filepath=str(src_file),
+            path="",
+        )
+
+        assert result is None or result == False, \
+            f"Expected no user-visible error, got: {result!r}"
+        dest = library / "Test Author" / "Test Book (1)" / "Test Book.pdf"
+        assert dest.exists(), "Destination file must exist after fallback"
+        assert dest.read_bytes() == b"%PDF-1.4 fake-pdf-bytes", \
+            "Destination contents must match source"
+        assert not src_file.exists(), \
+            "Source file must be removed after successful copy"
+
+    def test_localbook_path_updated_on_chmod_eperm_success(self, tmp_path, monkeypatch):
+        """The DB-write side effect (localbook.path) must still happen."""
+        from cps.helper import move_files_on_change
+
+        staging = tmp_path / "tmp"
+        staging.mkdir()
+        library = tmp_path / "books"
+        library.mkdir()
+
+        src_file = staging / "src"
+        src_file.write_bytes(b"epub-data")
+
+        def _raise_xdev(src, dst):
+            raise OSError(18, "Invalid cross-device link", src)
+
+        monkeypatch.setattr("cps.helper.shutil.move", _raise_xdev)
+        monkeypatch.setattr("cps.helper.shutil.copy2", _copy2_with_chmod_eperm)
+
+        book = _make_localbook()
+        move_files_on_change(
+            calibre_path=str(library),
+            new_author_dir="A",
+            new_titledir="B (1)",
+            localbook=book,
+            db_filename="B.epub",
+            original_filepath=str(src_file),
+            path="",
+        )
+
+        assert book.path == "A/B (1)", \
+            f"localbook.path must be set on success, got: {book.path!r}"
+
+    def test_copy_failure_before_data_still_raises(self, tmp_path, monkeypatch):
+        """If both copy2 AND the data-only copyfile fallback fail (no
+        data ever written), the error must still surface — we must not
+        silently swallow ENOSPC / EACCES on the dst dir.
+
+        After the CWA #3437 refactor, copy2 is no longer called
+        directly from helper.py — it's wrapped in
+        copy_with_metadata_fallback, which retries via copyfile on
+        OSError. To simulate "data never written" we have to make BOTH
+        copy2 and copyfile fail inside the helper.
+        """
+        from cps.helper import move_files_on_change
+
+        staging = tmp_path / "tmp"
+        staging.mkdir()
+        library = tmp_path / "books"
+        library.mkdir()
+
+        src_file = staging / "src"
+        src_file.write_bytes(b"data")
+
+        def _raise_xdev(src, dst):
+            raise OSError(18, "Invalid cross-device link", src)
+
+        def _fail_before_copy(src, dst, **kw):
+            # Simulate dest disk full or read-only — no data written.
+            raise OSError(28, "No space left on device", dst)
+
+        monkeypatch.setattr("cps.helper.shutil.move", _raise_xdev)
+        # Hit the fallback helper's underlying calls. Both must fail to
+        # simulate "data never written" (copy2 fails → copyfile retry
+        # also fails).
+        monkeypatch.setattr(
+            "cps.services.file_move.shutil.copy2", _fail_before_copy
+        )
+        monkeypatch.setattr(
+            "cps.services.file_move.shutil.copyfile", _fail_before_copy
+        )
+
+        result = move_files_on_change(
+            calibre_path=str(library),
+            new_author_dir="A",
+            new_titledir="B (1)",
+            localbook=_make_localbook(),
+            db_filename="B.epub",
+            original_filepath=str(src_file),
+            path="",
+        )
+
+        assert isinstance(result, str) and result, \
+            f"Real failure (no data at dest) must return an error string, got: {result!r}"
+        assert src_file.exists(), \
+            "Source file must remain when copy fails (no data loss)"


### PR DESCRIPTION
Backport / fork-original of [janeczku/calibre-web#3437](https://github.com/janeczku/calibre-web/issues/3437) (@rschiefer, 283-day-old, 8 reach — the highest-reach un-drained CW issue).

## Symptom

Book upload onto a restricted filesystem (CIFS without explicit `file_mode`/`dir_mode`, LinuxServer-style PUID/PGID bind mounts, NFS squash-root shares) surfaces `[Errno 1] Operation not permitted` as a user-visible error — even though the file's bytes already landed at the destination.

## Root cause

`cps/helper.py:move_files_on_change`'s cross-device fallback used `shutil.copy2 + os.remove`. `shutil.copy2` is `copyfile` followed by `copystat`; on filesystems that disallow `chmod` for the running uid, `copystat` raises `PermissionError(EPERM)` AFTER `copyfile` has already written the destination. Pre-fix code re-raised the EPERM, masking the success.

## Fix

New `cps/services/file_move.py::copy_with_metadata_fallback` helper tries `shutil.copy2` first; on `OSError`, retries with `shutil.copyfile` (data only). Three call sites in `cps/helper.py` routed through it: `rename_all_files_on_change` + 2 in `move_files_on_change`.

## Verification

13 RED→GREEN tests:
- `tests/unit/test_file_move_metadata_fallback.py` — 10 tests on the helper (happy path, EPERM fallback, EACCES same, ENOSPC propagates, real-data round-trip, source-pin import + 3 call sites + no remaining direct `shutil.copy2`).
- `tests/unit/test_move_files_chmod_eperm.py` — 3 integration tests through `move_files_on_change` (EPERM tolerated, `localbook.path` updated on success, genuine copy failure surfaces).

189/190 helper-adjacent tests pass; 1 pre-existing kosync failure on main is unrelated.

Distinct from earlier auto-ingest worker-uid fixes (`f2616d6` + `4df03f0`, v4.0.28-era) which addressed the cwa-ingest-service path; this fix handles the web-upload path where `shutil.move`'s cross-device fallback hits an unchmod-able destination filesystem.

Credit @rschiefer for the original report.