### PR TITLE
feat(reader): section progress indicator (backport CW PR #3370)

### DIFF
--- a/cps/static/js/reading/epub-progress.js
+++ b/cps/static/js/reading/epub-progress.js
@@ -23,6 +23,82 @@ function calculateProgress(){
     return Math.round(epub.locations.percentageFromCfi(data.cfi)*100);
 }
 
+/**
+ * Compute the user's progress within the CURRENT spine section (chapter),
+ * complementing the book-wide calculateProgress() above. Backport of
+ * janeczku/calibre-web#3370 (@ryan-c-scott) adapted to our split
+ * epub-progress.js architecture.
+ *
+ * Returns a number 0..100, or null if not enough state to compute.
+ * Uses the `epub` global's `locations._locations` (the array of CFIs
+ * that our `epub.locations.generate()` call in qFinished() produced).
+ * Note: upstream uses `reader.book.locations` because their PR runs
+ * inside epub.js where `reader.book === epub`. Our progress logic
+ * lives in a separate file and uses its own `epub` instance; the
+ * reader has a different ePub instance whose locations are never
+ * generated. We rely on the `epub` global throughout for consistency.
+ *
+ * The section's start CFI is the first locations-array entry whose
+ * string contains the spine item's `cfiBase`; the section's end CFI
+ * is the last such entry. We map
+ * (current - sectionStart) / (sectionEnd - sectionStart) to 0..100.
+ */
+function calculateSectionProgress(){
+    if (!reader || !reader.rendition || !reader.rendition.location) {
+        return null;
+    }
+    const loc = reader.rendition.location;
+    if (!loc.start || typeof loc.start.index !== "number" || !loc.start.cfi) {
+        return null;
+    }
+    // Use the `epub` global throughout — that's the instance whose
+    // locations we actually generate. `reader.book` is a separate ePub
+    // instance whose `locations._locations` stays empty in our setup.
+    if (!epub || !epub.spine || !epub.locations) {
+        return null;
+    }
+    const spineItem = epub.spine.get(loc.start.index);
+    if (!spineItem || !spineItem.cfiBase) {
+        return null;
+    }
+    const allLocations = epub.locations._locations;
+    if (!Array.isArray(allLocations) || allLocations.length === 0) {
+        return null;
+    }
+    const baseCfi = spineItem.cfiBase;
+    const sectionStartCfi = allLocations.find(cfi => cfi.includes(baseCfi));
+    // findLast is ES2023 (Safari 15.4+, Chrome 97+, Firefox 104+); the
+    // reader is a modern-browser surface anyway. Manual fallback via
+    // reverse iteration kept tight in case the runtime is older.
+    let sectionEndCfi;
+    if (typeof allLocations.findLast === "function") {
+        sectionEndCfi = allLocations.findLast(cfi => cfi.includes(baseCfi));
+    } else {
+        for (let i = allLocations.length - 1; i >= 0; i--) {
+            if (allLocations[i].includes(baseCfi)) {
+                sectionEndCfi = allLocations[i];
+                break;
+            }
+        }
+    }
+    if (!sectionStartCfi || !sectionEndCfi) {
+        return null;
+    }
+    if (sectionStartCfi === sectionEndCfi) {
+        // Single-location section: by definition we've covered all of it.
+        return 100;
+    }
+    const startNorm = epub.locations.percentageFromCfi(sectionStartCfi);
+    const endNorm = epub.locations.percentageFromCfi(sectionEndCfi);
+    const sectionSpan = endNorm - startNorm;
+    if (!sectionSpan || sectionSpan <= 0) {
+        return null;
+    }
+    const bookNorm = epub.locations.percentageFromCfi(loc.start.cfi);
+    const sectionNorm = (bookNorm - startNorm) / sectionSpan;
+    return Math.max(0, Math.min(100, Math.round(sectionNorm * 100)));
+}
+
 // register new event emitter locationchange that fires on urlchange
 // source: https://stackoverflow.com/a/52809105/21941129
 (() => {
@@ -48,9 +124,19 @@ function calculateProgress(){
 window.addEventListener('locationchange',()=>{
     let newPos=calculateProgress();
     if (progressDiv) {
-        progressDiv.textContent=newPos+"%";
+        // CW #3370 (@ryan-c-scott) backport: also show section progress
+        // alongside the book percentage. Falls back to book-only if
+        // section computation isn't ready yet (e.g. before
+        // locations.generate() finishes).
+        const sectionPct = calculateSectionProgress();
+        if (sectionPct !== null) {
+            progressDiv.textContent = sectionPct + "% (" + newPos + "% in book)";
+        } else {
+            progressDiv.textContent = newPos + "%";
+        }
     }
-    // Save progress to localStorage per book
+    // Save progress to localStorage per book (book percentage — keep the
+    // single-number contract so saved values stay readable across upgrades).
     if (window.calibre && window.calibre.bookUrl) {
         // Use bookUrl as a unique key, or use bookid if available
         let bookKey = window.calibre.bookUrl;

--- a/tests/unit/test_epub_section_progress_3370.py
+++ b/tests/unit/test_epub_section_progress_3370.py
@@ -1,0 +1,179 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Backport of janeczku/calibre-web#3370 (@ryan-c-scott) — section
+progress indicator in the web EPUB reader.
+
+Upstream shows ``XX%`` (book progress only); this backport extends to
+``XX% (YY% in book)`` — section progress alongside total. Adapted to
+our split ``epub-progress.js`` architecture (the upstream PR inlined
+the logic in ``epub.js``; ours splits progress handling out).
+
+These tests source-pin the JS-side contract:
+
+1. ``calculateSectionProgress`` function defined in epub-progress.js.
+2. The locationchange handler formats the dual-progress string when
+   ``calculateSectionProgress`` returns a number, falls back to the
+   book-only single-number when it returns null (before
+   ``locations.generate()`` resolves).
+3. The CW #3370 anchor comment is present so a future refactor knows
+   the rationale and the upstream link.
+4. The localStorage save still passes the BOOK percentage (single
+   number, contract preserved across upgrades — section% would change
+   the saved-state shape and break older sessions).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EPUB_PROGRESS_JS = REPO_ROOT / "cps" / "static" / "js" / "reading" / "epub-progress.js"
+
+
+def _source() -> str:
+    return EPUB_PROGRESS_JS.read_text()
+
+
+def test_calculate_section_progress_function_defined():
+    """The helper must be defined as a top-level function so it's
+    callable from the locationchange handler."""
+    src = _source()
+    assert re.search(
+        r"^function calculateSectionProgress\(\)\s*\{",
+        src,
+        re.MULTILINE,
+    ), (
+        "epub-progress.js must define `function calculateSectionProgress()` "
+        "so the locationchange handler can call it. See janeczku/calibre-web#3370."
+    )
+
+
+def test_section_progress_uses_spine_get_and_cfi_base():
+    """The algorithm walks the spine for the current location's `index`
+    and slices `book.locations._locations` by `cfiBase`. Source-pin
+    both calls so a future refactor doesn't silently switch to a
+    different (less accurate) computation."""
+    src = _source()
+    body_match = re.search(
+        r"function calculateSectionProgress\(\)\s*\{(?P<body>.*?)\n\}\n",
+        src,
+        re.DOTALL,
+    )
+    assert body_match, "Could not locate calculateSectionProgress body"
+    body = body_match.group("body")
+    # Note: upstream PR uses `reader.book.spine.get(...)` because it runs
+    # inside epub.js where `reader.book === epub`. Our adapter uses the
+    # `epub` global directly — `reader.book.locations._locations` stays
+    # empty in our split-file setup. Accept either form so a future
+    # refactor that consolidates files doesn't trip the source-pin.
+    assert ("epub.spine.get(" in body) or ("reader.book.spine.get(" in body), (
+        "calculateSectionProgress must resolve the current section via "
+        "`spine.get(loc.start.index)` on either the `epub` global "
+        "(our adapter) or `reader.book` (upstream PR shape). See CW #3370."
+    )
+    assert "cfiBase" in body, (
+        "calculateSectionProgress must slice the locations list by the "
+        "spine item's `cfiBase` to identify the section's start/end CFIs."
+    )
+    assert "percentageFromCfi" in body, (
+        "calculateSectionProgress must use `book.locations.percentageFromCfi` "
+        "to map CFIs to numeric percentages."
+    )
+
+
+def test_section_progress_handles_findlast_fallback():
+    """findLast is ES2023 (Safari 15.4+); the implementation must
+    provide a manual reverse-iteration fallback for older runtimes.
+    Defense-in-depth: even though our reader UI targets modern
+    browsers, the fallback prevents a hard ReferenceError on
+    older clients."""
+    src = _source()
+    body_match = re.search(
+        r"function calculateSectionProgress\(\)\s*\{(?P<body>.*?)\n\}\n",
+        src,
+        re.DOTALL,
+    )
+    body = body_match.group("body")
+    assert "findLast" in body, (
+        "calculateSectionProgress must use Array.prototype.findLast as "
+        "the fast path (per upstream PR)."
+    )
+    assert "typeof" in body and "findLast" in body, (
+        "calculateSectionProgress must gate `findLast` behind a `typeof` "
+        "check and provide a manual reverse-iteration fallback for "
+        "older runtimes that lack the ES2023 method."
+    )
+
+
+def test_locationchange_handler_emits_dual_progress_string():
+    """The handler must format `XX% (YY% in book)` when the section
+    helper returns a number, and fall back to `XX%` (book-only) when
+    it returns null (early calls before locations.generate() resolves)."""
+    src = _source()
+    handler_match = re.search(
+        r"window\.addEventListener\(['\"]locationchange['\"].*?\}\);",
+        src,
+        re.DOTALL,
+    )
+    assert handler_match, "Could not locate locationchange handler"
+    body = handler_match.group(0)
+    assert "calculateSectionProgress" in body, (
+        "locationchange handler must call calculateSectionProgress() "
+        "to drive the section-progress portion of the display."
+    )
+    assert "in book" in body, (
+        "locationchange handler must format `XX% (YY% in book)` per "
+        "ryan-c-scott's design in CW #3370."
+    )
+    # Fall-back path: when sectionPct is null, plain `XX%` book-only.
+    assert re.search(r"newPos\s*\+\s*['\"]%['\"]", body), (
+        "locationchange handler must preserve the `newPos+\"%\"` "
+        "book-only fallback for the early-call case where section "
+        "computation isn't ready."
+    )
+
+
+def test_localstorage_save_preserves_book_percentage_shape():
+    """The localStorage save value must remain a single book-percentage
+    integer. Switching to a composite shape would break older sessions
+    whose saved progress is `parseInt`-readable. The dual display is
+    a UI-only change."""
+    src = _source()
+    handler_match = re.search(
+        r"window\.addEventListener\(['\"]locationchange['\"].*?\}\);",
+        src,
+        re.DOTALL,
+    )
+    body = handler_match.group(0)
+    # The localStorage set must use `newPos` (the book percentage)
+    # directly — no concatenation with section%.
+    save_match = re.search(
+        r"localStorage\.setItem\([^,]+,\s*([^)]+)\)",
+        body,
+    )
+    assert save_match, "Could not find localStorage.setItem in handler"
+    value_arg = save_match.group(1).strip()
+    assert value_arg == "newPos", (
+        f"localStorage save must pass `newPos` (book percentage) verbatim — "
+        f"changing this shape would break saved-progress reads on next page "
+        f"load. Got: {value_arg!r}. See CW #3370 backport notes."
+    )
+
+
+def test_cw_3370_anchor_comment_present():
+    """A search anchor in the file lets future code archaeology find
+    why we have this composite display + why the localStorage save
+    intentionally stayed single-value."""
+    src = _source()
+    assert "CW #3370" in src or "calibre-web#3370" in src, (
+        "epub-progress.js must reference CW #3370 (the upstream PR) so a "
+        "future refactor can find the rationale for the dual-progress "
+        "display + the localStorage compatibility decision."
+    )


### PR DESCRIPTION
Backport of [janeczku/calibre-web#3370](https://github.com/janeczku/calibre-web/pull/3370) (@ryan-c-scott).

## Summary

The EPUB web reader's progress indicator now shows `XX% (YY% in book)` — section progress within the current chapter alongside the total book percentage.

## Adapter notes (vs upstream PR shape)

- Upstream PR inlines the logic in `epub.js`; our code has a separate `cps/static/js/reading/epub-progress.js` where progress is driven by `locationchange` event listener (not the rendition's `relocated` callback).
- Upstream uses `reader.book.locations._locations` directly because `reader.book === epub` in their setup. Our setup creates a separate `epub` global whose `locations.generate()` we call ourselves; `reader.book.locations` stays empty. The backport uses the `epub` global throughout.
- `localStorage` save still passes the book-percentage as a single number — switching shape would break older sessions whose saved progress is `parseInt`-readable.

## Defense-in-depth

- `findLast` is ES2023 (Safari 15.4+, Chrome 97+, Firefox 104+). Manual reverse-iteration fallback for older runtimes.
- Returns `null` on any missing state. The locationchange handler falls back to the original book-only `XX%` format in that case.

## Verification

- **6 source-pin tests** in `tests/unit/test_epub_section_progress_3370.py` cover function shape, spine.get + cfiBase + percentageFromCfi calls, findLast fallback, dual-format string, fallback when section returns null, localStorage compatibility constraint.
- **Playwright pilot on cwn-local** (Picture of Dorian Gray, 2981 locations generated):
  - Position 0: `0% (0% in book)` — both at start.
  - Jump to 50% of book: `77% (51% in book)` — at chapter 9 (loc_index=11), 77% through the chapter, 51% through the book. Section and book percentages diverge as expected.

Credit @ryan-c-scott. "in book" string not yet localized per upstream PR's own scope cap.