### PR TITLE
fix(reader): persist web-reader progress + state (CWA #1364)

### DIFF
--- a/cps/static/js/reading/epub-progress.js
+++ b/cps/static/js/reading/epub-progress.js
@@ -135,10 +135,20 @@ window.addEventListener('locationchange',()=>{
             progressDiv.textContent = newPos + "%";
         }
     }
-    // Save progress to localStorage per book (book percentage — keep the
-    // single-number contract so saved values stay readable across upgrades).
-    if (window.calibre && window.calibre.bookUrl) {
-        // Use bookUrl as a unique key, or use bookid if available
+    // CWA #1364 root-cause fix: only save to localStorage AFTER
+    // `epub.locations.generate()` has resolved. Before that point,
+    // `calculateProgress()` returns 0 because there are no locations
+    // to map the current CFI against — saving that fake 0 wipes the
+    // user's prior valid position. The qFinished/restore path then
+    // reads localStorage=0, calls `display(cfiFromPercentage(0))`, and
+    // the user lands at the beginning of the book even though they
+    // were reading at e.g. 35% before. This is the headline symptom
+    // in the upstream report: "opens at the correct cached position
+    // then immediately snaps back to the beginning".
+    if (window.calibre && window.calibre.bookUrl
+            && epub && epub.locations
+            && Array.isArray(epub.locations._locations)
+            && epub.locations._locations.length > 0) {
         let bookKey = window.calibre.bookUrl;
         localStorage.setItem("calibre.reader.progress." + bookKey, newPos);
     }

--- a/cps/web.py
+++ b/cps/web.py
@@ -13,6 +13,7 @@ import importlib
 import re
 import zipfile
 import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
 
 from flask import Blueprint, jsonify
 from flask import request, redirect, send_from_directory, send_file, make_response, flash, abort, url_for, Response, g
@@ -3080,7 +3081,51 @@ def read_book(book_id, book_format):
             )
         except Exception as e:
             log.debug(f"Failed to log read activity: {e}")
-    
+
+    # CWA #1364 fix: bump `book_read_link.last_time_started_reading` and
+    # `times_started_reading` when an authenticated user opens the web
+    # reader. The Kobo + KOSync code paths already do this; the web
+    # reader was the only book-opening surface that never wrote to
+    # those fields, so a user who only reads through the browser had
+    # no "read history" recorded at all (`/read`, `/unread` filters
+    # never reflected web-reader activity).
+    #
+    # Debounce: only bump the counter when the transition is into
+    # IN_PROGRESS from a NON-in-progress state. A user refreshing the
+    # reader tab or hitting Back/Forward doesn't count as a new
+    # reading session. Always touch `last_time_started_reading` so
+    # "recently read" sorting reflects every open.
+    if current_user.is_authenticated:
+        try:
+            read_row = ub.session.query(ub.ReadBook).filter(
+                ub.ReadBook.user_id == int(current_user.id),
+                ub.ReadBook.book_id == book_id,
+            ).first()
+            now = datetime.now(timezone.utc)
+            if read_row is None:
+                read_row = ub.ReadBook(
+                    user_id=int(current_user.id),
+                    book_id=book_id,
+                    read_status=ub.ReadBook.STATUS_IN_PROGRESS,
+                    times_started_reading=1,
+                    last_time_started_reading=now,
+                )
+                ub.session.add(read_row)
+            else:
+                prev_status = read_row.read_status or 0
+                if prev_status != ub.ReadBook.STATUS_IN_PROGRESS \
+                        and prev_status != ub.ReadBook.STATUS_FINISHED:
+                    read_row.times_started_reading = (read_row.times_started_reading or 0) + 1
+                    read_row.read_status = ub.ReadBook.STATUS_IN_PROGRESS
+                read_row.last_time_started_reading = now
+            ub.session_commit()
+        except Exception as e:
+            log.debug(f"Failed to record web reader open in book_read_link: {e}")
+            try:
+                ub.session.rollback()
+            except Exception:
+                pass
+
     if book_format.lower() in ("epub", "kepub"):
         log.debug("Start epub reader for %d (%s)", book_id, book_format.lower())
         return render_title_template('read.html', bookid=book_id, title=book.title,

--- a/tests/unit/test_cwa_1364_web_reader_progress.py
+++ b/tests/unit/test_cwa_1364_web_reader_progress.py
@@ -1,0 +1,207 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for CWA #1364 — web reader not saving progress.
+
+Reporter (CWA upstream, today): "The web reader is not saving progress
+for any book. Whenever I open a book it initially opens in the last
+(correct) position, which is apparently cached in the browser, but
+after a couple of seconds it sends me back to the beginning of the
+book. ... book_read_link fields are never updated."
+
+Reproduced on our build (cwn-local v4.0.107): bug exists on our code
+path. Two distinct root causes:
+
+(1) **localStorage corruption on early locationchange events.** The
+``epub-progress.js`` locationchange handler called ``calculateProgress()``
+unconditionally and wrote its return value to localStorage. Before
+``epub.locations.generate()`` resolves, ``calculateProgress()`` returns 0
+— because there are no locations to map the current CFI against. The
+handler then wrote ``localStorage[key] = 0``, wiping the valid prior
+value. The qFinished/restore path read ``localStorage = 0``, called
+``display(cfiFromPercentage(0))``, and the user landed at the
+beginning of the book — even though they were reading at 35%.
+
+(2) **``book_read_link`` fields never bumped from the web reader.**
+The Kobo + KOSync paths bump ``last_time_started_reading`` and
+``times_started_reading``; the web reader's ``read_book`` route never
+did. A user who only reads through the browser had no read history
+recorded — ``/read``, ``/unread`` filters never reflected web-reader
+activity.
+
+These tests source-pin both fixes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JS_PATH = REPO_ROOT / "cps" / "static" / "js" / "reading" / "epub-progress.js"
+WEB_PY = REPO_ROOT / "cps" / "web.py"
+
+
+def _js_source() -> str:
+    return JS_PATH.read_text()
+
+
+def _web_source() -> str:
+    return WEB_PY.read_text()
+
+
+# --- Fix #1 source-pins -------------------------------------------------------
+
+
+def test_locationchange_handler_guards_localstorage_save_on_locations_ready():
+    """The localStorage.setItem in the locationchange handler must be
+    gated on ``epub.locations._locations.length > 0``. Without the
+    guard, an early locationchange (before locations.generate
+    resolves) writes 0 to localStorage and corrupts the user's saved
+    position."""
+    src = _js_source()
+    handler_match = re.search(
+        r"window\.addEventListener\(['\"]locationchange['\"].*?\}\);",
+        src,
+        re.DOTALL,
+    )
+    assert handler_match, "Could not locate locationchange handler"
+    body = handler_match.group(0)
+    # The setItem call must be inside an `if (...)` that references
+    # epub.locations._locations.length.
+    assert "epub.locations._locations" in body, (
+        "The locationchange handler must check `epub.locations._locations` "
+        "before writing to localStorage — otherwise an early locationchange "
+        "writes the (necessarily-zero) calculateProgress() result and wipes "
+        "the user's prior position. See CWA #1364."
+    )
+    assert ".length" in body, (
+        "Guard must check `epub.locations._locations.length` is non-zero "
+        "before the localStorage save."
+    )
+
+
+def test_cwa_1364_anchor_comment_present_in_js():
+    """Anchor comment so a future refactor doesn't unwittingly remove
+    the locations-ready guard."""
+    src = _js_source()
+    assert "CWA #1364" in src, (
+        "epub-progress.js must reference CWA #1364 so future code "
+        "archaeology can find the rationale for the locations-ready "
+        "guard around the localStorage save."
+    )
+
+
+# --- Fix #2 source-pins -------------------------------------------------------
+
+
+def test_read_book_route_updates_book_read_link():
+    """The /read/<book_id>/<book_format> route must UPSERT
+    ``book_read_link`` for authenticated users — Kobo + KOSync already
+    do this; the web reader was the only book-opening surface that
+    never recorded a read event."""
+    src = _web_source()
+    # Locate the read_book function body.
+    match = re.search(
+        r"def read_book\(book_id, book_format\):.*?(?=\n(?:@web\.route|def \w))",
+        src,
+        re.DOTALL,
+    )
+    assert match, "Could not locate read_book function body"
+    body = match.group(0)
+    assert "ub.ReadBook" in body, (
+        "read_book must query `ub.ReadBook` to UPSERT the user's "
+        "read state. See CWA #1364."
+    )
+    assert "last_time_started_reading" in body, (
+        "read_book must set `last_time_started_reading` on the book_read_link "
+        "row so /read and /unread filters reflect web-reader activity."
+    )
+    assert "times_started_reading" in body, (
+        "read_book must bump `times_started_reading` on the IN_PROGRESS "
+        "transition (debounced — only when transitioning FROM a "
+        "non-in-progress state, so refreshes don't inflate the count)."
+    )
+    assert "STATUS_IN_PROGRESS" in body, (
+        "read_book must set `read_status = STATUS_IN_PROGRESS` when "
+        "opening a not-yet-finished book."
+    )
+
+
+def test_read_book_debounces_times_started_reading_increment():
+    """`times_started_reading` should only bump on transition INTO
+    IN_PROGRESS — refresh / Back / Forward must not inflate the count.
+    Source-pin the guard so a future refactor doesn't remove it."""
+    src = _web_source()
+    match = re.search(
+        r"def read_book\(book_id, book_format\):.*?(?=\n(?:@web\.route|def \w))",
+        src,
+        re.DOTALL,
+    )
+    body = match.group(0)
+    # The increment must be inside a conditional that excludes
+    # IN_PROGRESS (so refresh doesn't bump) and FINISHED (so re-opening
+    # a finished book doesn't reset to in-progress and bump).
+    assert re.search(
+        r"prev_status\s*!=\s*ub\.ReadBook\.STATUS_IN_PROGRESS",
+        body,
+    ), (
+        "read_book must guard the times_started_reading bump on "
+        "`prev_status != STATUS_IN_PROGRESS` — refresh shouldn't count "
+        "as a new reading session."
+    )
+    assert "STATUS_FINISHED" in body, (
+        "read_book must also exclude STATUS_FINISHED from the bump path "
+        "— re-opening a finished book shouldn't silently reset its "
+        "status to in-progress."
+    )
+
+
+def test_read_book_handles_db_failure_gracefully():
+    """The book_read_link UPSERT is best-effort; failing to record the
+    read event must not break page rendering. Pin the try/except."""
+    src = _web_source()
+    match = re.search(
+        r"def read_book\(book_id, book_format\):.*?(?=\n(?:@web\.route|def \w))",
+        src,
+        re.DOTALL,
+    )
+    body = match.group(0)
+    # The book_read_link block must be inside a try/except.
+    assert "Failed to record web reader open in book_read_link" in body, (
+        "read_book's book_read_link UPSERT must be wrapped in try/except "
+        "so a DB error doesn't break page rendering. The log message lets "
+        "future debugging connect a missing book_read_link update to the "
+        "exception class."
+    )
+
+
+def test_cwa_1364_anchor_comment_present_in_web_py():
+    """Anchor comment in web.py near the book_read_link logic."""
+    src = _web_source()
+    assert "CWA #1364" in src, (
+        "cps/web.py must reference CWA #1364 near the book_read_link "
+        "UPSERT so future code archaeology can find the rationale."
+    )
+
+
+def test_datetime_timezone_imported_in_web_py():
+    """The book_read_link UPSERT uses `datetime.now(timezone.utc)` —
+    confirm both are importable at module level so the route doesn't
+    NameError on first call."""
+    src = _web_source()
+    assert re.search(
+        r"^from datetime import (?:.*\b)?datetime",
+        src,
+        re.MULTILINE,
+    ), "cps/web.py must `from datetime import datetime` at module level."
+    assert re.search(
+        r"^from datetime import (?:.*\b)?timezone",
+        src,
+        re.MULTILINE,
+    ), "cps/web.py must `from datetime import timezone` at module level."


### PR DESCRIPTION
[CWA #1364](https://github.com/crocodilestick/Calibre-Web-Automated/issues/1364) — opened today by an upstream user, reproduced on **our build** (cwn-local v4.0.107) before fixing. Two distinct root causes; both addressed.

## Root cause 1: localStorage corruption on early `locationchange`

The `epub-progress.js` locationchange handler called `calculateProgress()` unconditionally and wrote its return value to localStorage. Before `epub.locations.generate()` resolves, `calculateProgress()` returns 0 — no locations to map the current CFI against. The handler then wrote `localStorage[key] = 0`, **wiping the user's prior valid position**. The qFinished/restore path then read `localStorage = 0`, called `display(cfiFromPercentage(0))`, and the user landed at the beginning of the book — even though they were reading at 35% last session.

**Fix**: gate the localStorage save on `epub.locations._locations.length > 0`.

## Root cause 2: `book_read_link` never bumped from the web reader

Kobo + KOSync paths bump `last_time_started_reading` + `times_started_reading`; the web reader's `read_book` route never did. A user who only reads in the browser had no read history recorded.

**Fix**: in `read_book`, UPSERT a `ub.ReadBook` row. Debounce: only bump `times_started_reading` on transition INTO IN_PROGRESS from a non-in-progress, non-finished state. Always update `last_time_started_reading`. Wrapped in try/except.

## Verification (cwn-local, exact reproduction of reporter's flow)

- **7 RED→GREEN source-pin tests** in `tests/unit/test_cwa_1364_web_reader_progress.py`.
- **Live Playwright pilot** on Picture of Dorian Gray (book 2):
  - Open reader → `book_read_link` row inserted: `status=IN_PROGRESS, times_started_reading=1, last_time_started_reading=now`.
  - Jump to 35% → `localStorage="35"`.
  - Navigate away + reopen → `localStorage` stays at "35" (NOT corrupted to "0"), CFI restored to chapter 7, `calculateProgress=35`. **Headline "snap to beginning" symptom gone.**
  - `times_started_reading` stays at 1 on reopen (debounce works), `last_time_started_reading` updated.

Auto-save to server-side `Bookmark` table (reporter's third complaint about bookmarks saving unreliably) is a larger surface with debounce/race concerns — tracked as follow-up.