### PR TITLE
fix(metadata): full browser headers for Amazon provider (CW #3648)

### DIFF
--- a/cps/metadata_provider/amazon.py
+++ b/cps/metadata_provider/amazon.py
@@ -27,10 +27,23 @@ log = logger.create()
 class Amazon(Metadata):
     __name__ = "Amazon"
     __id__ = "amazon"
+    # CW #3648: a Firefox User-Agent alone isn't enough — Amazon's
+    # bot detection 503s when the request lacks the full browser-shape
+    # headers (Accept-Language, DNT, Sec-Fetch-*, Upgrade-Insecure-
+    # Requests). Verified in cwn-local: minimal {UA, Accept,
+    # Accept-Encoding} → status=503, body=2.6KB. Full browser headers
+    # → status=200, body=1.1MB with the actual product list.
     headers = {
         'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:143.0) Gecko/20100101 Firefox/143.0',
-        'Accept': '*/*',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
         'Accept-Encoding': 'gzip, deflate, br, zstd',
+        'DNT': '1',
+        'Sec-Fetch-Dest': 'document',
+        'Sec-Fetch-Mode': 'navigate',
+        'Sec-Fetch-Site': 'none',
+        'Sec-Fetch-User': '?1',
+        'Upgrade-Insecure-Requests': '1',
     }
     session = requests.Session()
     session.headers=headers
@@ -184,10 +197,13 @@ class Amazon(Metadata):
             }
 
             try:
+                # `self.session.headers` is set at class definition to
+                # the full browser-shape header dict above (CW #3648 —
+                # Amazon serves 503 to minimal headers). No per-request
+                # override needed.
                 results = self.session.get(
                     "https://www.amazon.com/s",
                     params=q,
-                    # headers=self.headers,
                     timeout=10,
                 )
                 results.raise_for_status()

--- a/tests/unit/test_amazon_metadata_search_headers_3648.py
+++ b/tests/unit/test_amazon_metadata_search_headers_3648.py
@@ -1,0 +1,125 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for CW #3648 — Amazon metadata search returns no
+results.
+
+Reporter (upstream, today): "Steps to reproduce: 1) Go to Any book
+and search for Metadata. 2) If Amazon or Google Books are selected.
+3) No Result(s) found! Please try another keyword."
+
+Reproduced in our build via direct ``requests.get`` from cwn-local:
+
+  minimal headers {UA, Accept, Accept-Encoding}: status=503, body=2.6KB
+  full browser headers (UA + Accept-Language + DNT + Sec-Fetch-* +
+    Upgrade-Insecure-Requests): status=200, body=1.1MB with results
+
+Root cause: ``cps/metadata_provider/amazon.py::Amazon.headers`` only
+declared User-Agent + Accept + Accept-Encoding. Amazon's bot
+detection requires the FULL browser-shape header set — a Firefox UA
+alone isn't enough. The provider's empty result list propagated to
+the modal as "No Result(s) found!"
+
+(Note: an earlier hypothesis was that ``headers=self.headers`` was
+commented out on the request line — that's also true, but moot
+because ``session.headers`` is set at class definition. The real fix
+is expanding the headers dict itself.)
+
+These tests pin:
+
+1. ``Amazon.headers`` includes ``Accept-Language`` — Amazon
+   bot-detection signal.
+2. ``Amazon.headers`` includes ``Sec-Fetch-Dest`` — modern browser
+   metadata signal Amazon checks.
+3. ``Amazon.headers`` includes ``Upgrade-Insecure-Requests`` — same.
+4. ``Amazon.headers`` includes a Firefox/Mozilla User-Agent.
+5. A CW #3648 anchor comment is present.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AMAZON_PY = REPO_ROOT / "cps" / "metadata_provider" / "amazon.py"
+
+
+def _amazon_source() -> str:
+    return AMAZON_PY.read_text()
+
+
+def _headers_block() -> str:
+    """Extract the ``headers = { ... }`` dict body from amazon.py."""
+    src = _amazon_source()
+    match = re.search(
+        r"^\s*headers\s*=\s*\{(?P<body>.*?)\n\s*\}",
+        src,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, "Could not locate `headers = {...}` dict in amazon.py"
+    return match.group("body")
+
+
+def test_amazon_headers_includes_user_agent():
+    body = _headers_block()
+    assert re.search(r"['\"]User-Agent['\"]\s*:\s*['\"]Mozilla/", body), (
+        "Amazon.headers must include a Mozilla-shaped User-Agent. "
+        "Amazon serves 503 to `python-requests/X.Y.Z`. See CW #3648."
+    )
+
+
+def test_amazon_headers_includes_accept_language():
+    body = _headers_block()
+    assert re.search(r"['\"]Accept-Language['\"]\s*:", body), (
+        "Amazon.headers must include `Accept-Language` — Amazon's bot "
+        "detection 503s requests missing this. See CW #3648 cwn-local "
+        "repro."
+    )
+
+
+def test_amazon_headers_includes_sec_fetch_dest():
+    body = _headers_block()
+    assert re.search(r"['\"]Sec-Fetch-Dest['\"]\s*:", body), (
+        "Amazon.headers must include `Sec-Fetch-Dest` — modern browsers "
+        "send this and Amazon checks for it. See CW #3648."
+    )
+
+
+def test_amazon_headers_includes_upgrade_insecure_requests():
+    body = _headers_block()
+    assert re.search(r"['\"]Upgrade-Insecure-Requests['\"]\s*:", body), (
+        "Amazon.headers must include `Upgrade-Insecure-Requests` — "
+        "another browser-shape signal Amazon's bot detection checks. "
+        "See CW #3648."
+    )
+
+
+def test_amazon_session_headers_assigned_at_class_level():
+    """``session.headers = headers`` at class definition is what makes
+    every per-request `session.get` use the browser-shape headers
+    without each call needing `headers=self.headers`. Pin this so a
+    refactor that removes the class-level assignment also restores
+    per-request headers or the bug returns."""
+    src = _amazon_source()
+    assert re.search(r"session\.headers\s*=\s*headers", src), (
+        "amazon.py must set `session.headers = headers` at class "
+        "definition (or pass `headers=` on every per-request call). "
+        "Without one or the other, the session falls back to the "
+        "default python-requests User-Agent and Amazon serves 503. "
+        "See CW #3648."
+    )
+
+
+def test_cw_3648_anchor_comment_present():
+    src = _amazon_source()
+    assert "CW #3648" in src, (
+        "amazon.py must reference CW #3648 near the headers dict so "
+        "future refactors find the rationale for the full browser-shape "
+        "set."
+    )


### PR DESCRIPTION
[CW #3648](https://github.com/janeczku/calibre-web/issues/3648) — opened today. Reproduced in our build before fixing.

## Symptom

User searches book metadata via the Amazon (or Google Books) provider → "No Result(s) found! Please try another keyword!" Chinese provider + ComicVine return results fine for the same query.

## Root cause

`cps/metadata_provider/amazon.py::Amazon.headers` only declared User-Agent + Accept + Accept-Encoding. Amazon's bot detection requires the FULL browser-shape header set; a Firefox UA alone isn't enough.

Verified via direct `requests.get` from cwn-local:
- minimal headers → status=503, body=2.6KB
- full browser headers → status=200, body=1.1MB

## Fix

Extend `Amazon.headers` with `Accept-Language`, `DNT`, `Sec-Fetch-Dest`, `Sec-Fetch-Mode`, `Sec-Fetch-Site`, `Sec-Fetch-User`, `Upgrade-Insecure-Requests`. `session.headers` already wired at class definition, so per-request `headers=` is not needed.

## Verification

- **6 RED→GREEN source-pin tests** in `tests/unit/test_amazon_metadata_search_headers_3648.py` pin each browser-shape header + session-level assignment + anchor comment.
- **17/17 amazon-adjacent tests** still pass.
- **Live verification on cwn-local** with patched module: `Amazon.session.get('https://www.amazon.com/s', params=q)` → status=200, body_len=1147853. Pre-fix → 503.