### PR TITLE
feat(editbooks): reload metadata from disk endpoint (fork #218)

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -15,7 +15,7 @@ from shutil import copyfile
 from markupsafe import escape, Markup  # dependency of flask
 from functools import wraps
 
-from flask import Blueprint, request, flash, redirect, url_for, abort, Response
+from flask import Blueprint, request, flash, redirect, url_for, abort, Response, jsonify
 from flask_babel import gettext as _
 from flask_babel import lazy_gettext as N_
 from flask_babel import get_locale
@@ -2131,3 +2131,127 @@ def modify_identifiers(input_identifiers, db_identifiers, db_session):
             db_session.add(identifier)
             changed = True
     return changed, error
+
+
+@editbook.route("/admin/book/<int:book_id>/reload_metadata", methods=["POST"])
+@login_required_if_no_ano
+@edit_required
+def reload_metadata_from_disk(book_id):
+    """Re-read embedded metadata from the book's on-disk file and update
+    the Calibre catalog. Fork issue #218 (@yodatak): users who edit EPUB
+    metadata via external tools (grimmory etc.) saw the old cached
+    metadata in CWNG until manual re-ingest. This endpoint lets them
+    pull the on-disk file as source of truth without round-tripping
+    through ingest.
+
+    Updates: title, comments, publisher, pubdate, languages. Authors,
+    tags, and series are deferred — they involve relationship-table
+    bookkeeping (author_sort regeneration, tag dedup, series
+    create-on-demand) that's better handled through the full edit-book
+    save path. The fields we DO update are the common-case ask
+    ("I changed the description in grimmory and want CWNG to show it").
+
+    Authorization: @edit_required (admin OR edit role) — same gate as
+    /admin/book/<id> POST.
+    """
+    book = calibre_db.get_book(book_id)
+    if not book:
+        return jsonify(success=False, error=_("Book not found")), 404
+
+    if not getattr(book, 'data', None) or len(book.data) == 0:
+        return jsonify(success=False,
+                       error=_("Book has no file formats on disk to reload from")), 400
+
+    # Pick the format to re-read. EPUB is the canonical metadata source
+    # for embedded metadata; if no EPUB is available, fall back to the
+    # first format and let get_epub_info attempt — for non-EPUB formats
+    # it'll fail cleanly and we surface the error.
+    chosen_data = None
+    for d in book.data:
+        if (d.format or '').upper() in ('EPUB', 'KEPUB'):
+            chosen_data = d
+            break
+    if chosen_data is None:
+        chosen_data = book.data[0]
+
+    book_dir = os.path.join(config.get_book_path(), book.path)
+    file_ext = chosen_data.format.lower()
+    file_path = os.path.join(book_dir, chosen_data.name + '.' + file_ext)
+    if not os.path.isfile(file_path):
+        log.error("reload_metadata: file not found on disk: %s", file_path)
+        return jsonify(success=False,
+                       error=_("Book file not found on disk: %(path)s",
+                               path=file_path)), 404
+
+    try:
+        # get_epub_info also handles kepub (which IS an EPUB structurally).
+        from .epub import get_epub_info
+        meta = get_epub_info(file_path, chosen_data.name, file_ext,
+                             no_cover_processing=True)
+    except Exception as ex:
+        log.error_or_exception("reload_metadata: parse failed for %s: %s",
+                               file_path, ex)
+        return jsonify(success=False,
+                       error=_("Could not parse metadata from %(format)s file: %(err)s",
+                               format=file_ext.upper(), err=str(ex))), 500
+
+    updated = []
+    try:
+        with metadata_db_write_lock():
+            # Title.
+            if meta.title and meta.title != book.title:
+                book.title = strip_whitespaces(meta.title)
+                updated.append('title')
+
+            # Comments / description.
+            if meta.description is not None and isinstance(meta.description, str):
+                if edit_book_comments(meta.description, book):
+                    updated.append('comments')
+
+            # Publisher.
+            if meta.publisher:
+                if edit_book_publisher(meta.publisher, book):
+                    updated.append('publisher')
+
+            # Pubdate. Only update if parseable + different.
+            if meta.pubdate:
+                try:
+                    new_pub = datetime.strptime(meta.pubdate, "%Y-%m-%d")
+                    current_pub = getattr(book, 'pubdate', None)
+                    if current_pub is None or current_pub.date() != new_pub.date():
+                        book.pubdate = new_pub
+                        updated.append('pubdate')
+                except (TypeError, ValueError):
+                    log.debug("reload_metadata: unparseable pubdate %r", meta.pubdate)
+
+            # Languages — meta.languages is a string like 'eng'.
+            if meta.languages:
+                try:
+                    if edit_book_languages(meta.languages, book, upload_mode=True):
+                        updated.append('languages')
+                except Exception as ex:
+                    log.debug("reload_metadata: language update failed: %s", ex)
+
+            if updated:
+                book.last_modified = datetime.now(timezone.utc)
+                calibre_db.session_commit("Reload metadata for book {} from disk".format(book.id))
+            else:
+                calibre_db.session.rollback()
+    except Exception as ex:
+        log.error_or_exception("reload_metadata: commit failed for book %d: %s",
+                               book.id, ex)
+        try:
+            calibre_db.session.rollback()
+        except Exception:
+            pass
+        return jsonify(success=False,
+                       error=_("Could not save reloaded metadata: %(err)s",
+                               err=str(ex))), 500
+
+    return jsonify(success=True,
+                   updated_fields=updated,
+                   source_format=file_ext.upper(),
+                   message=(_("Reloaded %(n)d field(s) from on-disk %(fmt)s",
+                              n=len(updated), fmt=file_ext.upper())
+                            if updated
+                            else _("On-disk metadata matches current — no fields updated"))), 200

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -2234,7 +2234,9 @@ def reload_metadata_from_disk(book_id):
 
             if updated:
                 book.last_modified = datetime.now(timezone.utc)
-                calibre_db.session_commit("Reload metadata for book {} from disk".format(book.id))
+                calibre_db.session.commit()
+                log.info("Reloaded metadata for book %d from disk (fields: %s)",
+                         book.id, ', '.join(updated))
             else:
                 calibre_db.session.rollback()
     except Exception as ex:

--- a/tests/unit/test_reload_metadata_from_disk_218.py
+++ b/tests/unit/test_reload_metadata_from_disk_218.py
@@ -1,0 +1,201 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for fork issue #218 (@yodatak): reload embedded
+metadata from disk after an external tool (grimmory etc.) edits the
+EPUB. Adds a new endpoint:
+
+  POST /admin/book/<int:book_id>/reload_metadata
+
+@edit_required gate (admin OR edit role). Reads on-disk EPUB via
+``cps.epub.get_epub_info``, then updates Calibre Books fields:
+title, comments, publisher, pubdate, languages. Defers authors,
+tags, series — relationship tables are better handled through the
+full edit-book save path.
+
+These tests pin the source shape so a future refactor doesn't
+silently break the endpoint.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EDITBOOKS_PY = REPO_ROOT / "cps" / "editbooks.py"
+
+
+def _source() -> str:
+    return EDITBOOKS_PY.read_text()
+
+
+def test_reload_metadata_route_registered():
+    """Route registered at the canonical path under the editbook
+    blueprint with POST method."""
+    src = _source()
+    assert re.search(
+        r'@editbook\.route\(\s*["\']/admin/book/<int:book_id>/reload_metadata["\']\s*,\s*methods=\["POST"\]\s*\)',
+        src,
+    ), (
+        "POST /admin/book/<int:book_id>/reload_metadata route must be "
+        "registered under the editbook blueprint. See fork #218."
+    )
+
+
+def test_reload_metadata_requires_edit_role():
+    """@edit_required (admin OR edit role) — same gate as
+    /admin/book/<id> POST. Don't allow viewer-only users to mutate
+    the catalog via this endpoint."""
+    src = _source()
+    # Find the function definition and check the decorators above it.
+    match = re.search(
+        r"((?:@\w+(?:\([^)]*\))?\s*\n)+)def reload_metadata_from_disk",
+        src,
+    )
+    assert match, "Could not locate reload_metadata_from_disk function + decorators"
+    decorators = match.group(1)
+    assert "@edit_required" in decorators, (
+        "reload_metadata_from_disk must be guarded by @edit_required so "
+        "viewer-only users can't mutate the catalog."
+    )
+    assert "@login_required_if_no_ano" in decorators, (
+        "reload_metadata_from_disk must also be guarded by "
+        "@login_required_if_no_ano so anonymous users can't hit it."
+    )
+
+
+def test_reload_metadata_404_when_book_missing():
+    """The function must return JSON 404 when calibre_db.get_book returns
+    None. Pin the shape so a future refactor doesn't accidentally
+    propagate the None through to a 500."""
+    src = _source()
+    match = re.search(
+        r"def reload_metadata_from_disk\(book_id\):.*?(?=\n\Z)",
+        src,
+        re.DOTALL,
+    )
+    assert match, "Could not locate function body"
+    body = match.group(0)
+    assert re.search(r"if not book:", body), (
+        "reload_metadata_from_disk must guard against `book is None` "
+        "and return a clean 404."
+    )
+    assert "404" in body, (
+        "reload_metadata_from_disk must return 404 when the book is "
+        "missing — not a generic 500."
+    )
+
+
+def test_reload_metadata_uses_get_epub_info():
+    """Must delegate parsing to the existing ``cps.epub.get_epub_info``
+    helper — reusing the same parser the upload path already trusts
+    avoids drift between ingest-time and reload-time metadata
+    extraction."""
+    src = _source()
+    match = re.search(
+        r"def reload_metadata_from_disk\(book_id\):.*?(?=\n\Z)",
+        src,
+        re.DOTALL,
+    )
+    body = match.group(0)
+    assert "get_epub_info" in body, (
+        "reload_metadata_from_disk must call get_epub_info from cps.epub "
+        "so the parsing logic stays consistent with the upload path."
+    )
+
+
+def test_reload_metadata_updates_via_existing_edit_helpers():
+    """For comments, publisher, languages — must use the existing
+    `edit_book_*` helpers so the relationship-table bookkeeping
+    (modify_database_object etc.) stays consistent with the edit-book
+    save path."""
+    src = _source()
+    match = re.search(
+        r"def reload_metadata_from_disk\(book_id\):.*?(?=\n\Z)",
+        src,
+        re.DOTALL,
+    )
+    body = match.group(0)
+    for helper in ("edit_book_comments", "edit_book_publisher", "edit_book_languages"):
+        assert helper in body, (
+            f"reload_metadata_from_disk must call `{helper}` to update "
+            f"that field — going direct would skip the relationship "
+            f"bookkeeping the helpers do."
+        )
+
+
+def test_reload_metadata_writes_under_metadata_db_lock():
+    """The actual mutation must run inside ``metadata_db_write_lock()`` —
+    same coordination as other writers to prevent torn writes during
+    concurrent ingest / convert / edit operations."""
+    src = _source()
+    match = re.search(
+        r"def reload_metadata_from_disk\(book_id\):.*?(?=\n\Z)",
+        src,
+        re.DOTALL,
+    )
+    body = match.group(0)
+    assert "metadata_db_write_lock()" in body, (
+        "reload_metadata_from_disk must guard its writes with "
+        "metadata_db_write_lock() — concurrent ingest/edit can torn-write "
+        "the metadata.db otherwise. Same pattern as other writers."
+    )
+
+
+def test_reload_metadata_returns_updated_fields_list():
+    """The JSON response must include `updated_fields` (a list) so the
+    UI can show the user which fields actually changed, not just a
+    generic 'reloaded'."""
+    src = _source()
+    match = re.search(
+        r"def reload_metadata_from_disk\(book_id\):.*?(?=\n\Z)",
+        src,
+        re.DOTALL,
+    )
+    body = match.group(0)
+    assert "updated_fields" in body, (
+        "The JSON response must include `updated_fields` so the caller "
+        "knows what actually changed (not just 'reloaded'). Useful for "
+        "the UI toast + for any test/automation that calls this endpoint."
+    )
+
+
+def test_fork_218_anchor_comment_present():
+    """A search anchor in the function docstring so future code
+    archaeology finds the rationale for this endpoint (and the
+    deliberately-deferred authors/tags/series)."""
+    src = _source()
+    assert "#218" in src or "fork issue #218" in src or "fork #218" in src, (
+        "editbooks.py must reference fork #218 near the reload-metadata "
+        "function so a future refactor can find the rationale."
+    )
+
+
+def test_reload_metadata_defers_authors_tags_series():
+    """Verify the deferred-fields decision is documented in the
+    function — those involve relationship-table bookkeeping that the
+    full edit-book save path handles correctly. This test pins that
+    we DON'T silently start updating them through this endpoint."""
+    src = _source()
+    match = re.search(
+        r"def reload_metadata_from_disk\(book_id\):.*?(?=\n\Z)",
+        src,
+        re.DOTALL,
+    )
+    body = match.group(0)
+    # No edit_book_authors or edit_book_tags or edit_book_series call.
+    for forbidden in ("edit_book_authors(", "edit_book_tags(", "edit_book_series("):
+        assert forbidden not in body, (
+            f"reload_metadata_from_disk must NOT call `{forbidden}` — "
+            f"those fields involve relationship-table bookkeeping that "
+            f"is deliberately deferred to the full edit-book save path. "
+            f"Updating them here without the full bookkeeping risks "
+            f"orphaned tag rows / author_sort drift / series-index "
+            f"clashes."
+        )


### PR DESCRIPTION
Fork [#218](https://github.com/new-usemame/Calibre-Web-NextGen/issues/218) (@yodatak): when external tools (grimmory) edit embedded EPUB metadata, CWNG showed stale catalog data. New endpoint:

```
POST /admin/book/<int:book_id>/reload_metadata
```

`@edit_required` gate (admin OR edit role). Re-parses the EPUB via the existing `get_epub_info` helper and updates title, comments, publisher, pubdate, languages through the existing `edit_book_*` helpers (so the relationship-table bookkeeping stays consistent with the normal save path). Wrapped in `metadata_db_write_lock()`.

Authors / tags / series are **deliberately deferred** — they involve more relationship-table bookkeeping (author_sort regeneration, tag dedup, series create-on-demand) better handled through the full edit-book save path. The fields we DO update are the common-case ask ("I changed the description in grimmory and want CWNG to show it").

## Verification

- **9 source-pin tests** in `tests/unit/test_reload_metadata_from_disk_218.py` pin route registration, decorator stack, 404-on-missing-book, `get_epub_info` delegation, `edit_book_*` helper use, `metadata_db_write_lock` coordination, `updated_fields` response shape, and the deferred-fields invariant.
- **Parser verified live** in `cwn-local` container: modified an EPUB's OPF metadata on disk (injected `<dc:publisher>Fork218 TestPub</dc:publisher>` + `<dc:description>Reloaded-from-disk</dc:description>`); `get_epub_info()` read both back correctly: `publisher: Fork218 TestPub`, `description: Reloaded-from-disk via fork 218 endpoint.`
- Full HTTP-level round-trip test was blocked by a pre-existing template-render issue in cwn-local on `/admin/book/<id>` GET (CWA #1228-class identity-map race; unrelated to this PR). Flagged as follow-up; the endpoint itself is JSON-only and doesn't touch that template.

UI button on `book_edit.html` is a follow-up — the endpoint is operator-callable now and can be invoked by curl / scripts.

Addresses #218.