### PR TITLE
fix(ub): defensive guard on User.view_settings None for legacy rows

### DIFF
--- a/cps/ub.py
+++ b/cps/ub.py
@@ -232,11 +232,20 @@ class UserBase:
         return [strip_whitespaces(t) for t in mct.split(",")]
 
     def get_view_property(self, page, prop):
-        if not self.view_settings.get(page):
+        # Defensive against NULL view_settings on legacy user rows
+        # created before the JSON-column default existed. layout.html
+        # calls this on every page render (since v4.0.97 cover-settings
+        # cog toggle); a NULL row would 500 every page for that user.
+        vs = self.view_settings or {}
+        if not vs.get(page):
             return None
-        return self.view_settings[page].get(prop)
+        return vs[page].get(prop)
 
     def set_view_property(self, page, prop, value):
+        # Materialize the dict on legacy NULL rows so the in-place
+        # mutation + the SQLAlchemy onupdate fire correctly.
+        if not self.view_settings:
+            self.view_settings = {}
         if not self.view_settings.get(page):
             self.view_settings[page] = dict()
         self.view_settings[page][prop] = value

--- a/tests/unit/test_user_view_settings_null_defensive.py
+++ b/tests/unit/test_user_view_settings_null_defensive.py
@@ -1,0 +1,119 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for User.view_settings None handling.
+
+Discovered while exercising fork #218: hitting /admin/book/<id> as a
+user whose view_settings DB column is NULL returned 500 with
+AttributeError in User.get_view_property (called from layout.html
+since v4.0.97 cover-settings cog toggle). Legacy user rows created
+before view_settings had a JSON default were stored as NULL.
+
+Fix: vs = self.view_settings or {} guard before .get(page).
+set_view_property materializes the dict on NULL rows.
+"""
+
+from __future__ import annotations
+
+import re
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UB_PY = REPO_ROOT / "cps" / "ub.py"
+
+
+def _ub_source() -> str:
+    return UB_PY.read_text()
+
+
+def test_get_view_property_handles_none_view_settings():
+    src = _ub_source()
+    match = re.search(
+        r"def get_view_property\(self, page, prop\):.*?(?=\n    def )",
+        src, re.DOTALL,
+    )
+    assert match, "Could not locate get_view_property"
+    body = match.group(0)
+    assert (
+        re.search(r"self\.view_settings\s*or\s*\{\s*\}", body)
+        or re.search(r"if\s+self\.view_settings\s+is\s+None", body)
+    ), (
+        "get_view_property must tolerate self.view_settings being None. "
+        "Without this layout.html 500s for any user with NULL view_settings."
+    )
+
+
+def test_set_view_property_materializes_none_view_settings():
+    src = _ub_source()
+    match = re.search(
+        r"def set_view_property\(self, page, prop, value\):.*?(?=\n    def )",
+        src, re.DOTALL,
+    )
+    assert match, "Could not locate set_view_property"
+    body = match.group(0)
+    assert re.search(
+        r"if not self\.view_settings:\s*\n\s*self\.view_settings\s*=\s*\{\s*\}",
+        body,
+    ), "set_view_property must materialize self.view_settings = {} on NULL."
+
+
+def test_get_view_property_anchor_comment_present():
+    src = _ub_source()
+    match = re.search(
+        r"def get_view_property\(self, page, prop\):.*?(?=\n    def )",
+        src, re.DOTALL,
+    )
+    body = match.group(0)
+    assert any(s in body for s in ("v4.0.97", "legacy user", "NULL view_settings")), (
+        "get_view_property must reference v4.0.97 / legacy user / "
+        "NULL view_settings in a comment so code archaeology finds it."
+    )
+
+
+def test_get_view_property_returns_none_for_null_user():
+    """Behavioral check via inspect+rebind — avoids the cps import."""
+    src = _ub_source()
+    match = re.search(
+        r"def get_view_property\(self, page, prop\):.*?(?=\n    def )",
+        src, re.DOTALL,
+    )
+    body = match.group(0)
+    lines = body.split("\n")
+    dedented = "\n".join(
+        ln[4:] if ln.startswith("    ") else ln for ln in lines
+    )
+    ns: dict = {}
+    exec(dedented, ns)  # noqa: S102 — exec'ing fixture source, not user input
+    fn = ns["get_view_property"]
+    fake = types.SimpleNamespace(view_settings=None)
+    result = fn(fake, "cover", "hide_shelf_badges")
+    assert result is None, (
+        f"get_view_property with view_settings=None must return None, "
+        f"not raise. Got {result!r}."
+    )
+
+
+def test_get_view_property_returns_value_for_populated_user():
+    src = _ub_source()
+    match = re.search(
+        r"def get_view_property\(self, page, prop\):.*?(?=\n    def )",
+        src, re.DOTALL,
+    )
+    body = match.group(0)
+    lines = body.split("\n")
+    dedented = "\n".join(
+        ln[4:] if ln.startswith("    ") else ln for ln in lines
+    )
+    ns: dict = {}
+    exec(dedented, ns)  # noqa: S102
+    fn = ns["get_view_property"]
+    fake = types.SimpleNamespace(view_settings={"cover": {"hide_shelf_badges": True}})
+    assert fn(fake, "cover", "hide_shelf_badges") is True
+    assert fn(fake, "cover", "nonexistent") is None
+    assert fn(fake, "nonexistent", "x") is None


### PR DESCRIPTION
**Discovered while exercising fork #218 reload-metadata endpoint** — hitting `/admin/book/<id>` as a user whose `view_settings` DB column is NULL returned 500 with `AttributeError: 'NoneType' object has no attribute 'get'` deep in `User.get_view_property`, called from `layout.html` on every page render since **v4.0.97** added the cover-settings cog toggle.

## Root cause

The JSON-column default `lambda: {}` only fires on INSERT. Legacy user rows created before `view_settings` had the default were stored as NULL; the default isn't a coerce-on-read.

## Affected users

Any user whose row pre-dates v4.0.97 + has never explicitly written to `view_settings`. On cwn-local: `cwng84test` (id=3) was NULL while `admin` + `Guest` had `{}`. Every page render 500s for that user.

## Fix

`vs = self.view_settings or {}` guard before the `.get(page)` access. `set_view_property` materializes `self.view_settings = {}` on NULL so the in-place mutation triggers SQLAlchemy's onupdate + `flag_modified` has something to flag.

## Verification

- **5 source-pin + behavioral tests** in `tests/unit/test_user_view_settings_null_defensive.py` — pin both get/set guards, the anchor comment, behavioral round-trip (None user returns None; populated returns correct values).
- **Live verification on cwn-local**: pre-fix `/admin/book/2` GET as `cwng84test` (view_settings=NULL) → 500. Post-fix → 200. The fork #218 endpoint's full HTTP roundtrip now works end-to-end as a result.