### PR TITLE
ci(tests): pytest-timeout=120 so hung tests surface as named failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,15 +72,21 @@ jobs:
           touch /config/cwa.db
       
       - name: Run smoke and unit tests
-        timeout-minutes: 10  # Kill if stuck
+        timeout-minutes: 10  # Last-resort kill; --timeout below is the real gate.
         env:
           PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/scripts
         run: |
+          # --timeout=120 + --timeout-method=thread converts hung tests into named
+          # test failures instead of opaque step-level 10-min step timeouts. Without
+          # this, a stuck test on one xdist worker only manifests as a step timeout
+          # with no indication of which test or worker stalled.
           pytest -m "smoke or unit" \
             -n auto \
             --maxfail=3 \
             -v \
             --tb=short \
+            --timeout=120 \
+            --timeout-method=thread \
             --cov=cps \
             --cov-report=xml \
             --cov-report=term-missing


### PR DESCRIPTION
## Symptom

The PR #281 \`Fast Tests (Smoke + Unit)\` job timed out after 10 minutes
with no indication of which test or which xdist worker hung. The
visible stdout ended at \`[gw0] [97%]\` then 9 minutes of silence
broken only by GC \`ResourceWarning: unclosed database\` messages.
PRs #279, #280, #266 all exhibit the same shape.

Full diagnosis: \`notes/pr-281-ci-hang-diagnosis-2026-05-21.md\`.

## Fix

Add \`--timeout=120 --timeout-method=thread\` to the pytest invocation
in \`fast-tests\`. Any test hanging more than 120 seconds is killed and
reported as a named failure with a stack trace, instead of stalling
the whole step until the 10-minute job-level timeout fires.

\`--timeout-method=thread\` is required because pytest-xdist parallel
mode (\`-n auto\`) breaks the default \`signal\`-based timeout method.

\`pytest-timeout>=2.2.0\` is already installed via
\`requirements-dev.txt\` — no dependency change.

## Verification

- pytest-timeout 2.2+ documents the thread method as xdist-compatible.
- Step-level \`timeout-minutes: 10\` is retained as a last-resort kill.
- No app-code change. CI workflow only.

## Confidence

97% — only residual risk is that \`thread\` method has known
limitations with C extensions that ignore Python signals; in that
case the step-level timeout still fires as the safety net.

Tier: ci-only (\`safe-tier-2\` class — single workflow file, no app
code).