### PR TITLE
fix(table): three UI bugs in /table Comments wysihtml5 editor (fork #283)

### DIFF
--- a/cps/static/css/wysihtml5-fork-iframe.css
+++ b/cps/static/css/wysihtml5-fork-iframe.css
@@ -1,0 +1,37 @@
+/*
+ * Fork #283 (reporter @droM4X): wysihtml5 sandbox iframe content overrides.
+ *
+ * Loaded into the editor iframe via the `stylesheets` option set in
+ * book_table.html. Without this, wysihtml5 copies getComputedStyle(textarea)
+ * into the iframe body's inline style — which on the dark CWNG theme picks
+ * up `color: rgb(245, 245, 245)` (the theme's body text color) and pastes
+ * that onto a white iframe background. Result: light gray on white,
+ * effectively unreadable.
+ *
+ * The vendored wysihtml5 library injects its own bootstrap style block
+ * INSIDE the iframe that sets `body { background-color: white; ... }`
+ * but does NOT override color — that's left to whatever inline style ends
+ * up on the body. We override the color (and reassert background + cursor)
+ * with !important so the inline copy can't win.
+ */
+
+body.wysihtml5-editor {
+    color: #333 !important;
+    background-color: #ffffff !important;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.4;
+    cursor: text;
+}
+
+/* Keep the placeholder text visibly dim — wysihtml5 toggles .placeholder
+   on the body when the editor is empty. Without this rule it would
+   inherit our forced #333 above and look like real content. */
+body.wysihtml5-editor.placeholder {
+    color: #a9a9a9 !important;
+}
+
+/* Sensible link color when users paste content with links. */
+body.wysihtml5-editor a {
+    color: #337ab7;
+}

--- a/cps/static/css/wysihtml5-fork.css
+++ b/cps/static/css/wysihtml5-fork.css
@@ -1,0 +1,45 @@
+/*
+ * Fork #283 (reporter @droM4X): wysihtml5 toolbar host-page overrides.
+ *
+ * Loaded after bootstrap-wysihtml5-0.0.3.css so these rules win on
+ * specificity ties. Three things this file fixes:
+ *
+ * 1. Toolbar overflow — the vendor library's `float: left` on toolbar
+ *    items wraps awkwardly when the toolbar runs out of horizontal room
+ *    (some items stack vertically with extra whitespace). Switching to
+ *    flexbox gives even wrapping with consistent gaps regardless of
+ *    locale-translated button labels widening the row.
+ *
+ * 2. Insert Link button — hidden because the modal it opens uses
+ *    Bootstrap 2's `modal hide fade` class set (the inline `hide` class
+ *    is what kept it invisible against Bootstrap 3+). The metadata
+ *    editor doesn't render saved HTML links specially, so the
+ *    feature was vestigial anyway.
+ *
+ * 3. Upload Image button — same reason as Link: vendor modal is BS2,
+ *    and image upload isn't supported by the catalog comments field.
+ *
+ * `:has()` selector is required to target the parent `<li>` containing
+ * the button. Supported in Chrome 105+, Safari 15.4+, Firefox 121+ —
+ * all evergreen browsers since late 2023.
+ */
+
+ul.wysihtml5-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 5px;
+    padding: 0;
+    margin: 0 0 10px 0;
+}
+
+ul.wysihtml5-toolbar > li {
+    /* Override vendor `float: left; margin: 0 5px 10px 0;` so flex gap
+       controls spacing. */
+    float: none;
+    margin: 0;
+}
+
+ul.wysihtml5-toolbar > li:has(a[data-wysihtml5-command="createLink"]),
+ul.wysihtml5-toolbar > li:has(a[data-wysihtml5-command="insertImage"]) {
+    display: none !important;
+}

--- a/cps/templates/book_table.html
+++ b/cps/templates/book_table.html
@@ -28,6 +28,10 @@
 <link href="{{ url_for('static', filename='css/libs/bootstrap-table.min.css') }}" rel="stylesheet">
 <link href="{{ url_for('static', filename='css/libs/bootstrap-editable.css') }}" rel="stylesheet">
 <link href="{{ url_for('static', filename='css/libs/bootstrap-wysihtml5-0.0.3.css') }}" rel="stylesheet">
+<!-- Fork #283 (@droM4X): toolbar host-page overrides loaded AFTER vendor lib so
+     specificity wins. Adds flex-wrap on the toolbar and hides the vestigial
+     Insert Link / Upload Image buttons whose modals broke on Bootstrap 3+. -->
+<link href="{{ url_for('static', filename='css/wysihtml5-fork.css') }}" rel="stylesheet">
 <style>
   .pagination {
       position: static !important;
@@ -381,5 +385,20 @@
 <script src="{{ url_for('static', filename='js/libs/wysihtml5-0.3.0.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-wysihtml5-0.0.3.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/libs/wysihtml5-0.0.3.js') }}"></script>
+<script>
+    // Fork #283 (@droM4X): inject the iframe-content stylesheet so the
+    // wysihtml5 editor body shows dark text on white instead of inheriting
+    // the dark-theme body color (rgb(245,245,245)) into the iframe's inline
+    // style on a white iframe background. Must run after the x-editable
+    // wysihtml5 plugin registers itself (the .js file above) but before
+    // table.js renders any editable column. See cps/static/css/wysihtml5-fork-iframe.css.
+    if ($.fn.editabletypes && $.fn.editabletypes.wysihtml5) {
+        $.fn.editabletypes.wysihtml5.defaults.wysihtml5 = $.extend(
+            {},
+            $.fn.editabletypes.wysihtml5.defaults.wysihtml5 || {},
+            { stylesheets: ['{{ url_for("static", filename="css/wysihtml5-fork-iframe.css") }}'] }
+        );
+    }
+</script>
 <script src="{{ url_for('static', filename='js/table.js') }}"></script>
 {% endblock %}

--- a/tests/unit/test_283_wysihtml5_bulk_editor.py
+++ b/tests/unit/test_283_wysihtml5_bulk_editor.py
@@ -1,0 +1,194 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for fork issue #283 (@droM4X): UI bugs in the
+Books List (`/table`) bulk editor's Comments wysihtml5 dialog.
+
+Three bugs (all reproduced on cwn-local v4.0.111):
+
+1. **Light gray text on white background.** The wysihtml5 sandbox
+   copies the surrounding page's computed `color` (rgb(245, 245, 245)
+   from the CWNG dark theme) into the iframe body's inline style.
+   The iframe body background is forced to white. Result: nearly
+   unreadable text once the user types something.
+
+2. **Toolbar overflows the dialog.** Vendor lib uses `float: left` on
+   toolbar items; when the toolbar runs out of horizontal room the
+   wrap stacks items vertically with awkward whitespace.
+
+3. **Insert Link / Upload Image buttons are dead.** They DO open
+   their modals on click — but the modals are tagged with Bootstrap 2's
+   `modal hide fade` class set. Bootstrap 3+ (which CWNG uses) treats
+   `hide` as `display: none !important`, so the modal never becomes
+   visible. The metadata editor doesn't render links or accept image
+   uploads anyway, so the buttons are vestigial.
+
+These tests pin the three fix surfaces so a future refactor can't
+silently regress them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CSS_IFRAME = REPO_ROOT / "cps" / "static" / "css" / "wysihtml5-fork-iframe.css"
+CSS_FORK = REPO_ROOT / "cps" / "static" / "css" / "wysihtml5-fork.css"
+BOOK_TABLE = REPO_ROOT / "cps" / "templates" / "book_table.html"
+
+
+def _iframe_css() -> str:
+    return CSS_IFRAME.read_text()
+
+
+def _fork_css() -> str:
+    return CSS_FORK.read_text()
+
+
+def _template() -> str:
+    return BOOK_TABLE.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Bug #1 — iframe body color override
+# ---------------------------------------------------------------------------
+
+def test_iframe_css_file_exists():
+    assert CSS_IFRAME.is_file(), (
+        "cps/static/css/wysihtml5-fork-iframe.css must exist; it's the "
+        "stylesheet wysihtml5 loads INTO the editor's sandbox iframe to "
+        "override the gray-on-white color inherited from the dark theme."
+    )
+
+
+def test_iframe_css_forces_dark_text_on_white():
+    """Body must be readable: dark text, white background, both with
+    !important so the wysihtml5 inline-style copy can't override."""
+    css = _iframe_css()
+    assert re.search(
+        r"body\.wysihtml5-editor\s*\{[^}]*?color:\s*#3\d{2}\s*!important",
+        css, re.DOTALL,
+    ), "body.wysihtml5-editor must set color: #3?? !important"
+    assert re.search(
+        r"body\.wysihtml5-editor\s*\{[^}]*?background-color:\s*#fff(?:fff)?\s*!important",
+        css, re.DOTALL | re.I,
+    ), "body.wysihtml5-editor must set background-color: #ffffff !important"
+
+
+def test_iframe_css_preserves_placeholder_dim():
+    """Placeholder text should stay visibly dim (vendor convention),
+    not inherit our forced dark color."""
+    css = _iframe_css()
+    assert re.search(
+        r"body\.wysihtml5-editor\.placeholder\s*\{[^}]*color:\s*#a9a9a9\s*!important",
+        css, re.DOTALL,
+    ), "placeholder rule must keep #a9a9a9 with !important"
+
+
+# ---------------------------------------------------------------------------
+# Bug #2 — toolbar wraps cleanly
+# ---------------------------------------------------------------------------
+
+def test_fork_css_file_exists():
+    assert CSS_FORK.is_file()
+
+
+def test_toolbar_uses_flex_wrap_not_float():
+    """Replace vendor's `float: left` wrap with flexbox so wrapped rows
+    stay aligned with consistent gaps."""
+    css = _fork_css()
+    assert re.search(
+        r"ul\.wysihtml5-toolbar\s*\{[^}]*display:\s*flex",
+        css, re.DOTALL,
+    ), "ul.wysihtml5-toolbar must set display: flex"
+    assert re.search(
+        r"ul\.wysihtml5-toolbar\s*\{[^}]*flex-wrap:\s*wrap",
+        css, re.DOTALL,
+    ), "ul.wysihtml5-toolbar must set flex-wrap: wrap"
+    # Vendor uses `float: left` on > li; we must explicitly cancel it.
+    assert re.search(
+        r"ul\.wysihtml5-toolbar\s*>\s*li\s*\{[^}]*float:\s*none",
+        css, re.DOTALL,
+    ), "ul.wysihtml5-toolbar > li must set float: none to override vendor"
+
+
+# ---------------------------------------------------------------------------
+# Bug #3 — dead Insert Link / Upload Image buttons removed
+# ---------------------------------------------------------------------------
+
+def test_toolbar_hides_createlink_button():
+    css = _fork_css()
+    assert re.search(
+        r'li:has\(a\[data-wysihtml5-command="createLink"\]\)[^}]*display:\s*none\s*!important',
+        css, re.DOTALL,
+    ), 'createLink button li must be display: none !important via :has()'
+
+
+def test_toolbar_hides_insertimage_button():
+    css = _fork_css()
+    assert re.search(
+        r'li:has\(a\[data-wysihtml5-command="insertImage"\]\)[^}]*display:\s*none\s*!important',
+        css, re.DOTALL,
+    ), 'insertImage button li must be display: none !important via :has()'
+
+
+# ---------------------------------------------------------------------------
+# Template wiring
+# ---------------------------------------------------------------------------
+
+def test_template_loads_fork_toolbar_css():
+    """book_table.html must include wysihtml5-fork.css AFTER the vendor
+    bootstrap-wysihtml5 css so our overrides win on specificity ties."""
+    src = _template()
+    vendor_pos = src.find("bootstrap-wysihtml5-0.0.3.css")
+    fork_pos = src.find("wysihtml5-fork.css")
+    assert vendor_pos != -1, "vendor bootstrap-wysihtml5 css must be loaded"
+    assert fork_pos != -1, "fork-#283 wysihtml5-fork.css must be loaded"
+    assert fork_pos > vendor_pos, (
+        "wysihtml5-fork.css must be loaded AFTER vendor css so cascade wins"
+    )
+
+
+def test_template_injects_iframe_stylesheet_via_xeditable_defaults():
+    """The script block must configure x-editable's wysihtml5 plugin to
+    load wysihtml5-fork-iframe.css INTO the editor iframe via the
+    `stylesheets` option."""
+    src = _template()
+    assert "$.fn.editabletypes.wysihtml5" in src, (
+        "must reference $.fn.editabletypes.wysihtml5 to set defaults"
+    )
+    assert "stylesheets" in src, "must pass `stylesheets` option to wysihtml5"
+    assert "wysihtml5-fork-iframe.css" in src, (
+        "must reference the fork iframe stylesheet"
+    )
+
+
+def test_template_iframe_inject_runs_before_table_js():
+    """The defaults-override must run BEFORE table.js, since table.js
+    renders the editable column definitions on its very first init pass."""
+    src = _template()
+    inject_pos = src.find("$.fn.editabletypes.wysihtml5")
+    table_js_pos = src.find("js/table.js")
+    assert inject_pos != -1 and table_js_pos != -1
+    assert inject_pos < table_js_pos, (
+        "iframe-stylesheet inject must run before table.js loads/renders"
+    )
+
+
+def test_template_iframe_inject_runs_after_wysihtml5_xeditable_plugin():
+    """The x-editable wysihtml5 plugin (wysihtml5-0.0.3.js) defines
+    $.fn.editabletypes.wysihtml5. The inject must run AFTER that file
+    loads, otherwise the namespace doesn't exist yet."""
+    src = _template()
+    plugin_pos = src.find("js/libs/wysihtml5-0.0.3.js")
+    inject_pos = src.find("$.fn.editabletypes.wysihtml5")
+    assert plugin_pos != -1 and inject_pos != -1
+    assert plugin_pos < inject_pos, (
+        "x-editable wysihtml5 plugin script must load before the inject"
+    )


### PR DESCRIPTION
Fork [#283](https://github.com/new-usemame/Calibre-Web-NextGen/issues/283) (@droM4X): three UI bugs in the bulk editor's description dialog on `/table`.

## Symptom

1. **Light gray text on white background.** Saved or newly entered text in the wysihtml5 editor is almost invisible.
2. **Toolbar overflows the dialog.** Buttons stack awkwardly when they run out of horizontal room.
3. **Insert Link and Upload Image buttons do nothing on click.**

## Root cause

1. wysihtml5 copies `getComputedStyle(textarea)` into the iframe body's inline style — on the CWNG dark theme that picks up `color: rgb(245,245,245)` and pastes it onto a white iframe background.
2. Vendor lib `bootstrap-wysihtml5-0.0.3.css` sets `float: left` on toolbar `<li>` items. Wraps poorly when out of room.
3. Vendor `bootstrap-wysihtml5-0.0.3.min.js` tags its modals with Bootstrap 2 classes (`modal hide fade`). Bootstrap 3+ (which CWNG uses) treats the inline `hide` class as `display: none !important` — modal exists but stays invisible. The metadata editor doesn't render saved HTML links or accept image uploads anyway, so the buttons are vestigial.

## Fix

**Three parts, no vendor-file edits:**

- New `cps/static/css/wysihtml5-fork-iframe.css` — loaded INTO the editor's sandbox iframe via the x-editable wysihtml5 plugin's `stylesheets` option. Sets `body.wysihtml5-editor { color: #333 !important; background-color: #fff !important; }` so the wysihtml5 inline-style copy can't override. Preserves `#a9a9a9` placeholder color and picks a sensible link color.
- New `cps/static/css/wysihtml5-fork.css` — loaded into the host page AFTER vendor css. Toolbar becomes `display: flex; flex-wrap: wrap` with `gap` controlling spacing, `float: none` on `<li>` cancels vendor's `float: left`. Uses `:has()` to hide the `<li>` containing `a[data-wysihtml5-command=createLink]` and `[command=insertImage]`. `:has()` supported in all evergreen browsers since late 2023.
- `cps/templates/book_table.html` — adds the host-page CSS link and an inline `<script>` between the wysihtml5 plugin script and `table.js` that calls `$.fn.editabletypes.wysihtml5.defaults.wysihtml5 = { stylesheets: ['…wysihtml5-fork-iframe.css'] }` so every editable wysihtml5 column inherits the sandbox stylesheet.

## Verification

**11 source-pin tests** in `tests/unit/test_283_wysihtml5_bulk_editor.py` pin each fix surface: iframe css color + bg + placeholder rules, toolbar flex+wrap+float-none, createLink + insertImage hidden via `:has()`, template load order (vendor css before fork css, x-editable plugin script before defaults-override, defaults-override before `table.js`).

**Live verified on cwn-local via Playwright + JS evaluate**:

| Bug | Pre-fix | Post-fix |
|---|---|---|
| #1 body color | `rgb(245, 245, 245)` (light gray) | `rgb(51, 51, 51)` (dark) |
| #1 body bg | `rgb(255, 255, 255)` | `rgb(255, 255, 255)` |
| #2 toolbar layout | `float: left` (awkward stack) | `display: flex; flex-wrap: wrap` |
| #3 createLink button | visible | `display: none` |
| #3 insertImage button | visible | `display: none` |

Injected iframe stylesheet confirmed loaded at `http://localhost:8086/static/css/wysihtml5-fork-iframe.css` with 3 rules active.

## Confidence

97% — `:has()` selector requires modern browsers (Chrome 105+ / Safari 15.4+ / Firefox 121+, late 2023). Operators on browsers older than that would see the buttons still visible, but the buttons were broken before so the net experience is no worse.

Addresses #283.