### PR TITLE
feat(shelf): drag-to-reorder regular shelves in sidebar (fork #237)

### DIFF
--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -140,6 +140,12 @@ def get_sidebar_config(kwargs=None):
              "show_text": _('Show Duplicate Books'), "config_show": content})
     g.shelves_access = ub.session.query(ub.Shelf).filter(
         or_(ub.Shelf.is_public == 1, ub.Shelf.user_id == current_user.id)).order_by(ub.Shelf.name).all()
+    # Fork #237 (@new-usemame): apply per-user drag-to-reorder. Falls
+    # back to the alphabetical fetch above when no view_settings.shelves.order
+    # is stored. Function-scope import to avoid circular cps.shelf ↔
+    # cps.render_template at module load.
+    from .shelf import sort_shelves_for_user
+    sort_shelves_for_user(g.shelves_access, current_user)
 
     # Per-book shelf membership for cover badges. One query for all
     # accessible shelves' rows; lookups in templates are O(1).

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -618,3 +618,102 @@ def add_selected_to_shelf():
             'message': f'Successfully added {success_count} books to shelf {shelf.name}.',
             'added_count': success_count
         }), 200
+
+
+# ---------------------------------------------------------------------------
+# Fork #237 (@new-usemame): drag-to-reorder regular shelves in the sidebar.
+#
+# Mirrors the existing magic-shelf ordering pattern (see
+# cps/magic_shelf.py::sort_magic_shelves_for_user). Storage shape on
+# user.view_settings:
+#
+#     {"shelves": {"order": [shelf_id, shelf_id, ...]}}
+#
+# Missing / empty list → fall back to alphabetical (current behavior).
+# Stale IDs in the list are dropped on sort; new shelves not yet in the
+# list are appended after the stored prefix so they remain visible.
+# ---------------------------------------------------------------------------
+
+
+def normalize_shelf_order(order_list, available_ids):
+    """Normalize a stored shelf-order list against the actually-available
+    shelf IDs. Drops unknowns, de-duplicates (first-seen wins), and
+    appends any available IDs not yet in the list."""
+    normalized = []
+    seen = set()
+    available_set = set(available_ids or [])
+    for item in (order_list or []):
+        try:
+            sid = int(item)
+        except (TypeError, ValueError):
+            continue
+        if sid in available_set and sid not in seen:
+            normalized.append(sid)
+            seen.add(sid)
+    for sid in (available_ids or []):
+        if sid not in seen:
+            normalized.append(sid)
+            seen.add(sid)
+    return normalized
+
+
+def sort_shelves_for_user(shelves, user):
+    """Sort regular shelves for `user` in place. Applies the manual order
+    from `user.view_settings['shelves']['order']` if set; otherwise sorts
+    case-insensitive alphabetical by name."""
+    settings = (getattr(user, 'view_settings', None) or {}).get('shelves', {})
+    order_list = settings.get('order') or []
+    if order_list:
+        available_ids = [s.id for s in shelves]
+        normalized = normalize_shelf_order(order_list, available_ids)
+        index = {sid: idx for idx, sid in enumerate(normalized)}
+        shelves.sort(key=lambda s: index.get(s.id, len(index)))
+        return shelves
+    shelves.sort(key=lambda s: (s.name or "").casefold())
+    return shelves
+
+
+@shelf.route("/shelf/reorder", methods=["GET", "POST"])
+@user_login_required
+def reorder_shelves():
+    """Drag-to-reorder UI for the user's accessible regular shelves.
+
+    GET renders the list (own + public). POST accepts JSON
+    {"order": [id, id, ...]} and persists it into
+    user.view_settings['shelves']['order'].
+    """
+    accessible = ub.session.query(ub.Shelf).filter(
+        (ub.Shelf.is_public == 1) | (ub.Shelf.user_id == current_user.id)
+    ).all()
+    sort_shelves_for_user(accessible, current_user)
+
+    if request.method == "POST":
+        payload = request.get_json(silent=True) or {}
+        raw_order = payload.get("order")
+        if not isinstance(raw_order, list):
+            return jsonify(success=False,
+                           error=_("Invalid payload: 'order' must be a list")), 400
+        available_ids = [s.id for s in accessible]
+        normalized = normalize_shelf_order(raw_order, available_ids)
+        vs = dict(current_user.view_settings or {})
+        shelves_settings = dict(vs.get('shelves', {}))
+        shelves_settings['order'] = normalized
+        vs['shelves'] = shelves_settings
+        current_user.view_settings = vs
+        try:
+            from sqlalchemy.orm.attributes import flag_modified
+            flag_modified(current_user, 'view_settings')
+        except Exception:
+            pass
+        try:
+            ub.session.commit()
+        except (InvalidRequestError, OperationalError) as ex:
+            log.error("reorder_shelves: persist failed: %s", ex)
+            ub.session.rollback()
+            return jsonify(success=False, error=_("Could not save order")), 500
+        return jsonify(success=True, order=normalized), 200
+
+    return render_title_template('shelf_reorder.html',
+                                 title=_("Reorder Shelves"),
+                                 page="shelf_reorder",
+                                 shelves=accessible)

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -347,6 +347,10 @@
                 {% endfor %}
               {% if not current_user.is_anonymous %}
                 <li id="nav_createshelf" class="create-shelf"><a href="{{url_for('shelf.create_shelf')}}">{{_('Create Shelf')}}</a></li>
+                {# Fork #237 (@new-usemame): drag-to-reorder shelves. Surfaced only when the user has >1 shelf, since one shelf doesn't need reordering. #}
+                {% if g.shelves_access|length > 1 %}
+                  <li id="nav_reordershelves"><a href="{{url_for('shelf.reorder_shelves')}}">{{_('Reorder Shelves')}}</a></li>
+                {% endif %}
               {% endif %}
               {% endif %}
               {% if current_user.is_authenticated and magic_shelf_routes.render %}

--- a/cps/templates/shelf_reorder.html
+++ b/cps/templates/shelf_reorder.html
@@ -1,0 +1,74 @@
+{# Fork #237 (@new-usemame): drag-to-reorder regular shelves. Mirrors
+   the shelf_order.html shape but operates on the list of shelves the
+   user can access (own + public) rather than the books inside one shelf.
+   Save POSTs JSON {order:[id,...]} to /shelf/reorder. #}
+{% extends "layout.html" %}
+{% block body %}
+<div class="col-sm-8 col-lg-8 col-xs-12">
+  <h2>{{ title }}</h2>
+  <div>{{ _('Drag to rearrange the order of your shelves in the sidebar.') }}</div>
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+  {% if shelves|length == 0 %}
+    <p>{{ _('You do not have any shelves to reorder yet.') }}</p>
+  {% else %}
+    <div id="sortShelves" class="list-group" style="margin-top: 1em;">
+      {% for shelf in shelves %}
+        <div id="shelf-{{ shelf.id }}" data-shelf-id="{{ shelf.id }}" class="list-group-item" style="cursor: move;">
+          <span class="glyphicon glyphicon-list"></span>&nbsp;
+          {{ shelf.name }}
+          {% if shelf.is_public == 1 %}
+            <span style="font-size: 80%; color: #888;">{{ _('(Public)') }}</span>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+    <button id="saveOrderBtn" class="btn btn-default" style="margin-top: 1em;">{{ _('Save') }}</button>
+    <a href="{{ url_for('web.index') }}" class="btn btn-default" style="margin-top: 1em;">{{ _('Back') }}</a>
+    <div id="saveOrderFeedback" style="margin-top: 0.5em;"></div>
+  {% endif %}
+</div>
+{% endblock %}
+
+{% block js %}
+<script src="{{ url_for('static', filename='js/libs/Sortable.min.js') }}"></script>
+<script>
+  (function () {
+    var listEl = document.getElementById('sortShelves');
+    var saveBtn = document.getElementById('saveOrderBtn');
+    var feedback = document.getElementById('saveOrderFeedback');
+    if (!listEl || !saveBtn) return;
+
+    new Sortable(listEl, { animation: 150 });
+
+    saveBtn.addEventListener('click', function () {
+      var ids = Array.prototype.map.call(
+        listEl.querySelectorAll('[data-shelf-id]'),
+        function (el) { return parseInt(el.getAttribute('data-shelf-id'), 10); }
+      );
+      saveBtn.disabled = true;
+      feedback.textContent = '';
+      $.ajax({
+        url: '{{ url_for("shelf.reorder_shelves") }}',
+        method: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({ order: ids }),
+        success: function () {
+          feedback.style.color = 'green';
+          feedback.textContent = '{{ _("Order saved. The sidebar reflects the new order on next page load.") }}';
+          saveBtn.disabled = false;
+        },
+        error: function (xhr) {
+          feedback.style.color = 'red';
+          var msg = '{{ _("Could not save order.") }}';
+          if (xhr && xhr.responseJSON && xhr.responseJSON.error) {
+            msg += ' (' + xhr.responseJSON.error + ')';
+          }
+          feedback.textContent = msg;
+          saveBtn.disabled = false;
+        }
+      });
+    });
+  })();
+</script>
+{% endblock %}

--- a/cps/translations/ar/LC_MESSAGES/messages.po
+++ b/cps/translations/ar/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2025-06-07 14:44+0300\n"
 "Last-Translator: UsamaFoad <usamafoad@gmail.com>\n"
 "Language-Team: \n"
@@ -2229,6 +2229,19 @@ msgstr "الرف: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "خطأ في فتح الرف. الرف غير موجود أو غير قابل للوصول"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "استبعاد الرفوف"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2394,7 +2407,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "خطأ في حذف الرف"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "إنشاء رف"
@@ -2886,8 +2899,9 @@ msgstr "إضافة إلى الرف"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(عام)"
 
@@ -3320,8 +3334,8 @@ msgstr "موافق"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3494,8 +3508,8 @@ msgstr "تحويل الكتاب"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "إغلاق"
@@ -3634,7 +3648,7 @@ msgstr "جلب البيانات الوصفية"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "حفظ"
 
@@ -6349,7 +6363,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "سيتم مسح هذا الكتاب بشكل دائم من قاعدة البيانات"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "الكتب غير المقروءة"
@@ -6425,7 +6439,8 @@ msgid "Save and Send Test Email"
 msgstr "حفظ وإرسال بريد إلكتروني اختباري"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "رجوع"
 
@@ -6445,8 +6460,8 @@ msgstr "أدخل اسم النطاق"
 msgid "Denied Domains (Blacklist)"
 msgstr "النطاقات المرفوضة (القائمة السوداء)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "التالي"
 
@@ -6751,139 +6766,139 @@ msgstr "تصفح"
 msgid "Create Shelf"
 msgstr "إنشاء رف"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "حول"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "السابق"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "تفاصيل الكتاب"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "هل أنت متأكد أنك تريد إيقاف التشغيل؟"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "حذف هذا الرف"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "تحميل التنسيق"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "حذف التنسيقات:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "حذف الكتاب"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "لم يتم العثور على نتائج"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "مقياس إلى الأفضل"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "إلى:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "التهيئة"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "إضافة إلى الرف"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "وضع علامة كـ غير مقروء"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "وضع علامة كـ غير مقروء"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "حذف الكتاب"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "حذف الكتاب"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "إنشاء رف"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "خطأ في الاتصال"
@@ -7421,6 +7436,22 @@ msgstr "اسحب لإعادة ترتيب الترتيب"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "كتاب مخفي"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/cs/LC_MESSAGES/messages.po
+++ b/cps/translations/cs/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2020-06-09 21:11+0100\n"
 "Last-Translator: Lukas Heroudek <lukas.heroudek@gmail.com>\n"
 "Language-Team: \n"
@@ -2241,6 +2241,19 @@ msgstr "Police: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Chyba otevírání police. Police neexistuje nebo není přístupná"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Vynechat série"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2409,7 +2422,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Chyba stahování obalu"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Vytvořit polici"
@@ -2914,8 +2927,9 @@ msgstr "Přidat do police"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Veřejné)"
 
@@ -3352,8 +3366,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3527,8 +3541,8 @@ msgstr "Převést knihu"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Zavřít"
@@ -3668,7 +3682,7 @@ msgstr "Získat metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Uložit"
 
@@ -6406,7 +6420,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Tato kniha bude trvale odstraněna z databáze"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Nepřečtené knihy"
@@ -6487,7 +6501,8 @@ msgid "Save and Send Test Email"
 msgstr "Uložit nastavení a odeslat zkušební e-mail"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Zpět"
 
@@ -6507,8 +6522,8 @@ msgstr "Zadejte jméno domény"
 msgid "Denied Domains (Blacklist)"
 msgstr "Zakázané domény pro registraci"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Další"
 
@@ -6814,138 +6829,138 @@ msgstr "Procházet"
 msgid "Create Shelf"
 msgstr "Vytvořit polici"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "O knihovně"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Předchozí"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Podrobnosti o knize"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Opravdu chcete vypnout?"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Nahrát formát"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Smazat formáty:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nenalezeny žádné výsledky"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Změnit měřítko na nejlepší"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfigurace"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Přidat do police"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Označit jako nepřečtené"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Označit jako nepřečtené"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Vytvořit polici"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Chyba připojení"
@@ -7512,6 +7527,22 @@ msgstr "Přetažením uspořádáte pořadí"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Skrytá kniha"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2026-04-06 17:03+0000\n"
 "Last-Translator: Manuel Drescher\n"
 "Language-Team: German\n"
@@ -2308,6 +2308,18 @@ msgstr ""
 "Fehler beim Öffnen des Regals. Regal exisitert nicht oder ist nicht "
 "zugänglich"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr "Reihenfolge konnte nicht gespeichert werden"
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+msgid "Reorder Shelves"
+msgstr "Regale neu anordnen"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2476,7 +2488,7 @@ msgstr "Regalname zu lang (maximal 100 Zeichen)"
 msgid "Error creating shelf"
 msgstr "Fehler beim Erstellen des Regals"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 msgid "Create Magic Shelf"
 msgstr "Neues magisches Regal"
 
@@ -2970,8 +2982,9 @@ msgstr "Zu Regal hinzufügen"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Öffentlich)"
 
@@ -3397,8 +3410,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3572,8 +3585,8 @@ msgstr "Buch konvertieren"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Schließen"
@@ -3712,7 +3725,7 @@ msgstr "Metadaten laden"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Speichern"
 
@@ -6594,7 +6607,7 @@ msgstr "Diese Aktion kann nicht rückgängig gemacht werden!"
 msgid "The following books will be permanently deleted:"
 msgstr "Die folgenden Bücher werden permanent gelöscht:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 msgid "Merge Books"
 msgstr "Bücher zusammenführen"
 
@@ -6669,7 +6682,8 @@ msgid "Save and Send Test Email"
 msgstr "Einstellungen speichern und Test-E-Mail versenden"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Zurück"
 
@@ -6689,8 +6703,8 @@ msgstr "Domainnamen eingeben"
 msgid "Denied Domains (Blacklist)"
 msgstr "Verbotene Domains für eine Registrierung"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Nächste"
 
@@ -6997,124 +7011,124 @@ msgstr "Durchsuchen"
 msgid "Create Shelf"
 msgstr "Neues Regal"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr "Magische Regale ✨"
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Über"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Vorheriger Eintrag"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Buchdetails"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Diese Aktion kann nicht rückgängig gemacht werden!"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Ausgewählte löschen"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Zielformat"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Lösche Formate:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 msgid "Duplicate Books Detected"
 msgstr "Bücherduplikate erkannt"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr "Nicht aufgelöste Buch-Dubletten in der Bibliothek"
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 msgid "Duplicate Groups Found"
 msgstr "Duplikatgruppen gefunden"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr "Später erinnern"
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr "Duplikate anzeigen & bereinigen"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Optimale Skalierung"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Tipp"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Zu Regal hinzufügen"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Als gelesen markiert"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Als ungelesen markiert"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Buch löschen"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Buch löschen"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7122,12 +7136,12 @@ msgid ""
 msgstr ""
 "Dies wird Bücher dauerhaft löschen. Originaldateien werden gesichert unter"
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Bitte zuerst ein Buch auswählen"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Wiederherstellung fehlgeschlagen: %(err)s"
@@ -7676,6 +7690,22 @@ msgstr "Ziehen und ablegen um Reihenfolge zu ändern"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Verstecktes Buch"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr "Ziehen, um die Reihenfolge der Regale in der Seitenleiste zu ändern."
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr "Sie haben noch keine Regale zum Neuanordnen."
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr "Reihenfolge gespeichert. Die Seitenleiste wird beim nächsten Seitenaufruf aktualisiert."
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr "Reihenfolge konnte nicht gespeichert werden."
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"
@@ -8405,9 +8435,9 @@ msgstr "Zeige Gelesen/Ungelesen-Abschnitt"
 #~ "        <a href=\"https://github.com/crocodilestick/Calibre-Web-Automated/"
 #~ "wiki/Configuration#database-configuration\">see here</a>!"
 #~ msgstr ""
-#~ "CWA ist so konfiguriert, dass es deine Calibre-Datenbank (<code>metadata."
-#~ "db</code>-Datei) irgendwo in dem Pfad <code>/calibre-library</code> "
-#~ "sucht.\n"
+#~ "CWA ist so konfiguriert, dass es deine Calibre-Datenbank "
+#~ "(<code>metadata.db</code>-Datei) irgendwo in dem Pfad <code>/calibre-"
+#~ "library</code> sucht.\n"
 #~ "        CWA durchsucht automatisch das Verzeichnis, das du auf <code>/"
 #~ "calibre-library</code> in der docker-compose-Datei verbunden hast, um "
 #~ "eine existierende Calibre-\n"

--- a/cps/translations/el/LC_MESSAGES/messages.po
+++ b/cps/translations/el/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2025-09-03 14:59+0200\n"
 "Last-Translator: Depountis Georgios\n"
 "Language-Team: \n"
@@ -2227,8 +2227,8 @@ msgstr "Δημιούργησε ένα Ράφι"
 #, fuzzy
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr ""
-"Συγγνώμη αλλά δεν σου επιτρέπεται η αφαίρεση ενός βιβλίου από αυτό το ράφι: "
-"%(sname)s"
+"Συγγνώμη αλλά δεν σου επιτρέπεται η αφαίρεση ενός βιβλίου από αυτό το ράφι: %"
+"(sname)s"
 
 #: cps/shelf.py:263
 msgid "Edit a shelf"
@@ -2285,6 +2285,19 @@ msgstr "Ράφι: '%(name)s"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Σφάλμα κατά το άνοιγμα του ραφιού. Το ράφι δεν υπάρχει ή δεν είναι προσβάσιμο"
+
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Εξαίρεση Σειρών"
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2457,7 +2470,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Δημιούργησε ένα Ράφι"
@@ -2975,8 +2988,9 @@ msgstr "Προσθήκη στο ράφι"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Δημόσιο)"
 
@@ -3412,8 +3426,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3587,8 +3601,8 @@ msgstr "Μετατροπή βιβλίου"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Κλείσιμο"
@@ -3728,7 +3742,7 @@ msgstr "Συγκέντρωση Μεταδεδομένων"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Αποθήκευση"
 
@@ -6468,7 +6482,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Αυτό το βιβλίο θα διαγραφεί για πάντα από τη βάση δεδομένων"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Βιβλία που δεν Διαβάστηκαν"
@@ -6549,7 +6563,8 @@ msgid "Save and Send Test Email"
 msgstr "Αποθήκευση και Αποστολή E-mail Δοκιμής"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Πίσω"
 
@@ -6569,8 +6584,8 @@ msgstr "Όνομα domain"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domains που Απορρίφθηκαν (Μαύρη λίστα)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Επόμενο"
 
@@ -6878,138 +6893,138 @@ msgstr "Περιήγηση"
 msgid "Create Shelf"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Σχετικά"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Προηγούμενο"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Λεπτομέρειες Βιβλίου"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Είσαι σίγουρος/η πως θέλεις να κάνεις κλείσιμο;"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Μορφή Ανεβάσματος"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Διαγραφή μορφών:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Δεν Βρέθηκαν Αποτελέσματα"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Κλιμάκωση στο Καλυτερο"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Διαμόρφωση"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Προσθήκη στο ράφι"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Σήμανση ως Αδιάβαστο"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Σφάλμα σύνδεσης"
@@ -7576,6 +7591,22 @@ msgstr "Σύρε για Αναδιάταξη Σειράς"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Κρυμμένο Βιβλίο"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/es/LC_MESSAGES/messages.po
+++ b/cps/translations/es/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2025-11-17 12:21-0300\n"
 "Last-Translator: minakmostoles <xxx@xxx.com>\n"
 "Language-Team: es <LL@li.org>\n"
@@ -2338,6 +2338,19 @@ msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Error al abrir una estantería. La estantería no existe o no es accesible"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Excluir Estanterías"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2510,7 +2523,7 @@ msgstr "El nombre de la estantería es demasiado largo (máximo 100 caracteres).
 msgid "Error creating shelf"
 msgstr "Error al borrar la estantería"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Crear una Estantería"
@@ -3026,8 +3039,9 @@ msgstr "Agregar a la estantería"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Público)"
 
@@ -3457,8 +3471,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3632,8 +3646,8 @@ msgstr "Convertir libro"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Cerrar"
@@ -3773,7 +3787,7 @@ msgstr "Obtener Metadatos"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Guardar"
 
@@ -6724,7 +6738,7 @@ msgstr "¡Esta acción no se puede deshacer!"
 msgid "The following books will be permanently deleted:"
 msgstr "Los siguientes libros se eliminarán de forma permanente:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Libros No Leídos"
@@ -6802,7 +6816,8 @@ msgid "Save and Send Test Email"
 msgstr "Guardar y enviar un correo electrónico de prueba"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Regresar"
 
@@ -6822,8 +6837,8 @@ msgstr "Introducir nombre de dominio"
 msgid "Denied Domains (Blacklist)"
 msgstr "Dominios Prohibidos (Lista Negra)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Siguiente"
 
@@ -7145,127 +7160,127 @@ msgstr "Navegar"
 msgid "Create Shelf"
 msgstr "Crear una Estantería"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr "Estanterías mágicas ✨"
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Acerca de"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Anterior"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Detalles del libro"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "¡Esta acción no se puede deshacer!"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Eliminar Seleccionados"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Formato"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Borrar formatos:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Se han detectado libros duplicados"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr "Tienes libros duplicados sin resolver en tu biblioteca"
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Se han encontrado grupos de duplicados"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr "Recordármelo más tarde"
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Seleccionar duplicados"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Escala al máximo"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Tip"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Agregar a la estantería"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Fusionar libros seleccionados"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marcar como no leído"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Borrar Libro"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Borrar Libro"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7274,12 +7289,12 @@ msgstr ""
 "Esto eliminará libros de forma permanente. Los archivos originales se "
 "guardarán como copia de seguridad en"
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Selecciona una Estantería"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Error de conexión"
@@ -7832,6 +7847,22 @@ msgstr "Arrastra para Reorganizar"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Libro Oculto"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/fi/LC_MESSAGES/messages.po
+++ b/cps/translations/fi/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2020-01-12 13:56+0100\n"
 "Last-Translator: Samuli Valavuo <svalavuo@gmail.com>\n"
 "Language-Team: \n"
@@ -2239,6 +2239,19 @@ msgstr "Hylly: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Virhe hyllyn avauksessa. Hyllyä ei ole tai se ei ole saatavilla"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Poissulje sarja"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2405,7 +2418,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "luo hylly"
@@ -2902,8 +2915,9 @@ msgstr "Lisää hyllyyn"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr ""
 
@@ -3343,8 +3357,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3518,8 +3532,8 @@ msgstr "Muunna kirja"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Sulje"
@@ -3659,7 +3673,7 @@ msgstr "Hae metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr ""
 
@@ -6398,7 +6412,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Kirja poistetaan Calibren tietokannasta"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Lukemattomat kirjat"
@@ -6479,7 +6493,8 @@ msgid "Save and Send Test Email"
 msgstr "Tallenna asetukset ja testaa sähköpostia"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Palaa"
 
@@ -6500,8 +6515,8 @@ msgstr "Syötä domainnimi"
 msgid "Denied Domains (Blacklist)"
 msgstr "Rekisteröinnissä sallitut domainit"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Seuraava"
 
@@ -6804,138 +6819,138 @@ msgstr "Selaa"
 msgid "Create Shelf"
 msgstr "luo hylly"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Tietoja"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Edellinen"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Kirjan tiedot"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Haluatko varmasti pysäyttää Calibre-Webin?"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Lataa tiedostomuoto"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Poista tiedostomuodot:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Tulosket haulle:"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Skaalaa parhaaseen"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Asetukset"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Merkitse lukemattomaksi"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Merkitse lukemattomaksi"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "luo hylly"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Yhteysvirhe"
@@ -7505,6 +7520,22 @@ msgstr "Vedä ja pudota muuttaaksesi järjestystä"
 #, fuzzy
 msgid "Hidden Book"
 msgstr "Näytä ekirjat"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -25,7 +25,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2025-11-17 21:51+0100\n"
 "Last-Translator: Tex <tex@grosist.fr>\n"
 "Language-Team: \n"
@@ -2378,6 +2378,19 @@ msgstr ""
 "Erreur à l’ouverture de l’étagère. Elle n’existe plus ou n’est plus "
 "accessible"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Etagères exclues"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2544,7 +2557,7 @@ msgstr "Nom de l'étagère trop long (100 caractères maximum)"
 msgid "Error creating shelf"
 msgstr "Erreur lors de la création de l'étagère"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 msgid "Create Magic Shelf"
 msgstr "Créer une étagère magique"
 
@@ -3043,8 +3056,9 @@ msgstr "Ajouter à l'étagère"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Public)"
 
@@ -3472,8 +3486,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3647,8 +3661,8 @@ msgstr "Convertir le livre"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Fermer"
@@ -3790,7 +3804,7 @@ msgstr "Obtenir les métadonnées"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Sauvegarder"
 
@@ -5308,9 +5322,9 @@ msgid ""
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
-"Cet outil a été adapté à partir de l'outil <a href=\"https://kindle-epub-fix."
-"netlify.app/\">kindle-epub-fix.netlify.app</a> créé par <a href=\"https://"
-"github.com/innocenat\">innocenat</a>."
+"Cet outil a été adapté à partir de l'outil <a href=\"https://kindle-epub-"
+"fix.netlify.app/\">kindle-epub-fix.netlify.app</a> créé par <a "
+"href=\"https://github.com/innocenat\">innocenat</a>."
 
 #: cps/templates/cwa_settings.html:181
 msgid "Enable KOReader Sync (NextGen Plugin)"
@@ -6703,7 +6717,7 @@ msgstr "Cette action ne peut être défaite !"
 msgid "The following books will be permanently deleted:"
 msgstr "Les livres suivants vont être effacés de manière permanante :"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 msgid "Merge Books"
 msgstr "Fusionner les livres"
 
@@ -6778,7 +6792,8 @@ msgid "Save and Send Test Email"
 msgstr "Sauvegarder les réglages et tester l’envoi d’un courriel"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Retour"
 
@@ -6798,8 +6813,8 @@ msgstr "Saisir le nom de domaine"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domaines refusés (Liste noire)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Suivant"
 
@@ -7105,125 +7120,125 @@ msgstr "Explorer"
 msgid "Create Shelf"
 msgstr "Créer une étagère"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr "Étagères magiques ✨"
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "À propos"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Précédent"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Détails du livre"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Cette action ne peut être défaite !"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Effacer la sélection"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Format"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Supprimer les formats :"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 msgid "Duplicate Books Detected"
 msgstr "Livres en double détectés"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr "Vous avez des livres en double non résolus dans votre bibliothèque"
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 msgid "Duplicate Groups Found"
 msgstr "Groupes en double trouvés"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr "Rappelez-moi plus tard"
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr "Afficher et résoudre les doublons"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Mise à l’échelle optimale"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Astuce"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuration"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Ajouter à l'étagère"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Marquer les livres sélectionnés comme lus"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marqué comme non lu"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Supprimer le livre"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Supprimer le livre"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7232,12 +7247,12 @@ msgstr ""
 "Cela supprimera définitivement les livres. Les fichiers originaux seront "
 "sauvegardés sur"
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Sélectionner d'abord un livre"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Échec de la restauration : %(err)s"
@@ -7788,6 +7803,22 @@ msgstr "Glisser-déposer pour modifier l’ordre"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Livre caché"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/gl/LC_MESSAGES/messages.po
+++ b/cps/translations/gl/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2022-08-11 16:46+0200\n"
 "Last-Translator: pollitor <pollitor@gmx.com>\n"
 "Language-Team: gl\n"
@@ -2275,6 +2275,19 @@ msgstr "Andel: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Erro ao abrir un andel. O andel non existe ou non se pode acceder"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Excluir andeis"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2444,7 +2457,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Erro borrando o estante"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Crear un andel"
@@ -2957,8 +2970,9 @@ msgstr "Engadir ao andel"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Público)"
 
@@ -3393,8 +3407,8 @@ msgstr "Vale"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3568,8 +3582,8 @@ msgstr "Convertir libro"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Pechar"
@@ -3709,7 +3723,7 @@ msgstr "Obter metadatos"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Gardar"
 
@@ -6452,7 +6466,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "O libro borrarase permanentemente da base de datos"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Libros non lidos"
@@ -6532,7 +6546,8 @@ msgid "Save and Send Test Email"
 msgstr "Gardar e enviar un correo electrónico de proba"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Voltar"
 
@@ -6552,8 +6567,8 @@ msgstr "Introducir nome de dominio"
 msgid "Denied Domains (Blacklist)"
 msgstr "Dominios prohibidos (Blaclist)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Seguinte"
 
@@ -6861,139 +6876,139 @@ msgstr "Navegar"
 msgid "Create Shelf"
 msgstr "Crear un andel"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Acerca de"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Previo"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Detalles do libro"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "De verdade quere deter?"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Cargar formato"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Borrar formatos:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Borrar libro"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Non se atoparon resultados"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Escalar ao mellor"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Para:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuración"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Engadir ao andel"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marcar como non lido"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Borrar libro"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Borrar libro"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Crear un andel"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Erro de conexión"
@@ -7548,6 +7563,22 @@ msgstr "Arrastra para reorganizar a orde"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Libro agochado"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/hu/LC_MESSAGES/messages.po
+++ b/cps/translations/hu/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2026-05-12 00:06+0200\n"
 "Last-Translator: Gabor L. <nom@il.thx>\n"
 "Language-Team: \n"
@@ -2294,6 +2294,18 @@ msgstr "Polc: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Hiba a polc megnyitásakor. A polc nem létezik vagy nem elérhető"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr "Nem sikerült menteni a sorrendet"
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+msgid "Reorder Shelves"
+msgstr "Polcok átrendezése"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2460,7 +2472,7 @@ msgstr "Polc név túl hosszú (max. 100 karakter)"
 msgid "Error creating shelf"
 msgstr "Hiba polc létrehozásakor"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 msgid "Create Magic Shelf"
 msgstr "Varázspolc létrehozása"
 
@@ -2953,8 +2965,9 @@ msgstr "Hozzáadás polchoz"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Nyilvános)"
 
@@ -3380,8 +3393,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3555,8 +3568,8 @@ msgstr "Könyv konvertálása"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Bezárás"
@@ -3697,7 +3710,7 @@ msgstr "Metaadatok beszerzése"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Mentés"
 
@@ -6572,7 +6585,7 @@ msgstr "A művelet nem visszavonható!"
 msgid "The following books will be permanently deleted:"
 msgstr "A következő könyvek véglegesen törölve lesznek:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 msgid "Merge Books"
 msgstr "Könyvek egyesítése"
 
@@ -6646,7 +6659,8 @@ msgid "Save and Send Test Email"
 msgstr "Mentés és teszt e-mail küldése"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Vissza"
 
@@ -6666,8 +6680,8 @@ msgstr "Tartomány megadása"
 msgid "Denied Domains (Blacklist)"
 msgstr "Elutasított domainek (tiltólista)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Következő"
 
@@ -6970,125 +6984,125 @@ msgstr "Böngészés"
 msgid "Create Shelf"
 msgstr "Polc készítése"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr "Varázspolcok ✨"
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Névjegy"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Előző"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Könyv részletei"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "A művelet nem visszavonható!"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Kiválasztottak törlése"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Fájlformátum"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Formátumok törlése:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 msgid "Duplicate Books Detected"
 msgstr "Ismétlődő könyvek találva"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr "A könyvtáradban feloldatlan duplikált könyvek vannak."
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 msgid "Duplicate Groups Found"
 msgstr "Ismétlődő csoport találva"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr "Emlékeztess később"
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr "Ismétlődések megtekintése és megszüntetése"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Méretezés a legjobbra"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Tipp"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfiguráció"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Hozzáadás polchoz"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Olvasottnak jelölve"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Olvasatlannak jelölve"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Könyv törlése"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Könyv törlése"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7097,12 +7111,12 @@ msgstr ""
 "Ez véglegesen törli a könyveket. Az eredeti fájlokról biztonsági mentés "
 "készül ide:"
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Először válasszon ki könyvet"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Visszaállítás sikertelen: %(err)s"
@@ -7648,6 +7662,22 @@ msgstr "Húzd és dob a sorrend változtatásához"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Rejtett könyvek"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr "Húzd át a polcokat a kívánt sorrend kialakításához az oldalsávban."
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr "Még nincs átrendezhető polc."
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr "Sorrend mentve. Az oldalsáv a következő oldalbetöltéskor frissül."
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr "Nem sikerült menteni a sorrendet."
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"
@@ -8377,9 +8407,9 @@ msgstr "Olvasott/olvasatlan mutatása"
 #~ "        <a href=\"https://github.com/crocodilestick/Calibre-Web-Automated/"
 #~ "wiki/Configuration#database-configuration\">see here</a>!"
 #~ msgstr ""
-#~ "A CWA úgy van konfigurálva, hogy a Calibre adatbázisa (a <code>metadata."
-#~ "db</code> fájl) mindig a <code>/calibre-library</code> könyvtáron belül "
-#~ "helyezkedjen el. \n"
+#~ "A CWA úgy van konfigurálva, hogy a Calibre adatbázisa (a "
+#~ "<code>metadata.db</code> fájl) mindig a <code>/calibre-library</code> "
+#~ "könyvtáron belül helyezkedjen el. \n"
 #~ "Induláskor a CWA automatikusan átvizsgálja azt a könyvtárat, amelyet a "
 #~ "docker-compose fájlban a <code>/calibre-library</code> útvonalhoz "
 #~ "rendelt, és meglévő Calibre \n"

--- a/cps/translations/id/LC_MESSAGES/messages.po
+++ b/cps/translations/id/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2023-01-21 10:00+0700\n"
 "Last-Translator: Arief Hidayat<arihid95@gmail.com>\n"
 "Language-Team: Arief Hidayat <arihid95@gmail.com>\n"
@@ -2265,6 +2265,19 @@ msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Terjadi kesalahan saat membuka rak. Rak tidak ada atau tidak dapat diakses"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Kecualikan Rak"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2433,7 +2446,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Buat Rak"
@@ -2937,8 +2950,9 @@ msgstr "Tambah ke rak"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Publik)"
 
@@ -3373,8 +3387,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3548,8 +3562,8 @@ msgstr "Konversi buku"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Tutup"
@@ -3689,7 +3703,7 @@ msgstr "Ambil Metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Simpan"
 
@@ -6421,7 +6435,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Buku ini akan dihapus secara permanen dari basis data"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Buku yang Belum Dibaca"
@@ -6501,7 +6515,8 @@ msgid "Save and Send Test Email"
 msgstr "Simpan dan Kirim Email Percobaan"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Kembali"
 
@@ -6521,8 +6536,8 @@ msgstr "Masukkan Nama Domain"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domain yang Ditolak (Daftar Hitam)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Selanjutnya"
 
@@ -6828,139 +6843,139 @@ msgstr "Jelajahi"
 msgid "Create Shelf"
 msgstr "Buat Rak"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Tentang"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Sebelumnya"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Detail Buku"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Apa Anda yakin untuk mematikan layanan?"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Format Unggahan"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Hapus format:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Hapus"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Tidak ada hasil yang ditemukan"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Skala ke Terbaik"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Hingga:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Pengaturan"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Tambah ke rak"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Tandai sebagai Belum dibaca"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Hapus"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Hapus"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Buat Rak"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Kesalahan koneksi"
@@ -7515,6 +7530,22 @@ msgstr "Seret untuk Mengatur Ulang Urutan"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Buku Tersembunyi"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/it/LC_MESSAGES/messages.po
+++ b/cps/translations/it/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2025-11-24 17:12+0100\n"
 "Last-Translator: Massimo Pissarello <mapi68@gmail.com>\n"
 "Language-Team: Italian\n"
@@ -2271,6 +2271,19 @@ msgstr ""
 "Errore nell'apertura dello scaffale. Lo scaffale non esiste o non è "
 "accessibile"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Escludi scaffali"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2443,7 +2456,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Errore nell'eliminare lo scaffale"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Crea uno scaffale"
@@ -2939,8 +2952,9 @@ msgstr "Aggiungi allo scaffale"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Pubblico)"
 
@@ -3368,8 +3382,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3542,8 +3556,8 @@ msgstr "Converti libro"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Chiudi"
@@ -3683,7 +3697,7 @@ msgstr "Recupera i metadati"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Salva"
 
@@ -6460,7 +6474,7 @@ msgstr "Questa funzione non può essere annullata!"
 msgid "The following books will be permanently deleted:"
 msgstr "I libri seguenti verranno eliminati in modo permanente:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Libri da leggere"
@@ -6536,7 +6550,8 @@ msgid "Save and Send Test Email"
 msgstr "Salva e invia e-mail di prova"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Indietro"
 
@@ -6556,8 +6571,8 @@ msgstr "Inserisci nome del dominio"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domini non consentiti (lista nera)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Successivo"
 
@@ -6865,140 +6880,140 @@ msgstr "Naviga"
 msgid "Create Shelf"
 msgstr "Crea uno scaffale"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Informazioni su"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Precedente"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Dettagli del libro"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Questa funzione non può essere annullata!"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Elimina selezionati"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Formato Finale"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Elimina formati:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Libro duplicato"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nessun libro duplicato trovato"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Seleziona i duplicati"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Adatta al meglio"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "A:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Configurazione"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Aggiungi allo scaffale"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Segna i libri selezionati come letti"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Contrassegna come da leggere"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Elimina libro"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Elimina libro"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Seleziona uno scaffale"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Errore di connessione"
@@ -7540,6 +7555,22 @@ msgstr "Trascina per riordinare"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Libro nascosto"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/ja/LC_MESSAGES/messages.po
+++ b/cps/translations/ja/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2018-02-07 02:20-0500\n"
 "Last-Translator: subdiox <subdiox@gmail.com>\n"
 "Language-Team: ja <LL@li.org>\n"
@@ -2272,6 +2272,19 @@ msgstr "本棚: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "本棚を開けません。この本棚は存在しないかアクセスできません"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "除外する本棚"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2445,7 +2458,7 @@ msgstr "シェルフ名が長すぎます（最大100文字）"
 msgid "Error creating shelf"
 msgstr "本棚の削除中にエラーが発生しました"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Magic Shelfを作成"
@@ -2944,8 +2957,9 @@ msgstr "本棚に追加"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(公開)"
 
@@ -3372,8 +3386,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3547,8 +3561,8 @@ msgstr "本を変換"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "閉じる"
@@ -3686,7 +3700,7 @@ msgstr "メタデータを取得"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "保存"
 
@@ -5171,8 +5185,8 @@ msgid ""
 "innocenat\">innocenat</a>."
 msgstr ""
 "このツールは<a href=\"https://github.com/innocenat\">innocenat</a>氏が作成し"
-"た<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-fix.netlify."
-"app</a>ツールから移植されました。"
+"た<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-"
+"fix.netlify.app</a>ツールから移植されました。"
 
 #: cps/templates/cwa_settings.html:181
 msgid "Enable KOReader Sync (NextGen Plugin)"
@@ -6531,7 +6545,7 @@ msgstr "この操作は元に戻せません！"
 msgid "The following books will be permanently deleted:"
 msgstr "以下の書籍は完全に削除されます："
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "未読の本"
@@ -6607,7 +6621,8 @@ msgid "Save and Send Test Email"
 msgstr "保存してテストメールを送信"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "戻る"
 
@@ -6627,8 +6642,8 @@ msgstr "ドメイン名を入力"
 msgid "Denied Domains (Blacklist)"
 msgstr "拒否するドメイン名 (ブラックリスト)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "次"
 
@@ -6944,127 +6959,127 @@ msgstr "閲覧"
 msgid "Create Shelf"
 msgstr "本棚を作成する"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr "Magic Shelves ✨"
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "このサイトについて"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "前"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "本の詳細"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "この操作は元に戻せません！"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "選択を削除"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "アップロード形式"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "削除する形式:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "本を削除"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr "ライブラリに未解決の重複書籍があります"
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "結果が見つかりません"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr "あとで通知"
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr "重複を表示・解決"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "最適なサイズにする"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "TIP"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "設定"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "本棚に追加"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "未読に設定"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "未読に設定"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "本を削除"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "本を削除"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7073,12 +7088,12 @@ msgstr ""
 "これにより書籍が完全に削除されます。元のファイルは次の場所にバックアップされ"
 "ます："
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "本棚を選択"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "復元失敗：%(err)s"
@@ -7627,6 +7642,22 @@ msgstr "ドラッグして並び順を変更"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "非表示の本"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/km/LC_MESSAGES/messages.po
+++ b/cps/translations/km/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2018-08-27 17:06+0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -2219,6 +2219,19 @@ msgstr "ធ្នើ៖ ‘%(name)s’"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "មានបញ្ហាពេលបើកធ្នើ។ ពុំមានធ្នើ ឬមិនអាចបើកបាន"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "លើកលែងស៊េរី"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2380,7 +2393,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "បង្កើតធ្នើ"
@@ -2868,8 +2881,9 @@ msgstr "បន្ថែមទៅធ្នើ"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr ""
 
@@ -3309,8 +3323,8 @@ msgstr "បាទ/ចាស"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3482,8 +3496,8 @@ msgstr ""
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "បិទ"
@@ -3622,7 +3636,7 @@ msgstr "មើលទិន្នន័យមេតា"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr ""
 
@@ -6350,7 +6364,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "សៀវភៅនឹងត្រូវលុបចេញពី database របស់ Calibre"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "សៀវភៅដែលមិនទាន់បានអាន"
@@ -6427,7 +6441,8 @@ msgid "Save and Send Test Email"
 msgstr "ឧបករណ៍ Kindle"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "មកក្រោយ"
 
@@ -6448,8 +6463,8 @@ msgstr "ជ្រើសរើសឈ្មោះអ្នកប្រើប្រ
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "បន្ទាប់"
 
@@ -6753,136 +6768,136 @@ msgstr "រុករក"
 msgid "Create Shelf"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "អំពី"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "មុន"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "ព័ត៌មានលម្អិតរបស់សៀវភៅ"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "ទម្រង់អាប់ឡូដ"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "លុបឯកសារទម្រង់៖"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "លទ្ធផលសម្រាប់៖"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, python-brace-format
 msgid "Marked {n} books as read"
 msgstr ""
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr ""
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Ebook-converter បានបរាជ័យ៖ %(error)s"
@@ -7449,6 +7464,22 @@ msgstr "ទាញដើម្បីប្តូរលំដាប់"
 #, fuzzy
 msgid "Hidden Book"
 msgstr "សៀវភៅដែលមានប្រជាប្រិយភាព"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/ko/LC_MESSAGES/messages.po
+++ b/cps/translations/ko/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2025-09-08 00:53+0900\n"
 "Last-Translator: limeade23 <admin@limeade.me>\n"
 "Language-Team: Korean <>\n"
@@ -2204,6 +2204,19 @@ msgstr ""
 "서재를 여는 동안 오류가 발생했습니다. 서재가 존재하지 않거나 접근할 수 없습니"
 "다"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "서재 제외"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2373,7 +2386,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "서재를 삭제하는 중 오류가 발생했습니다."
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "서재 생성"
@@ -2867,8 +2880,9 @@ msgstr "책장에 추가"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(공개)"
 
@@ -3296,8 +3310,8 @@ msgstr "예"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3470,8 +3484,8 @@ msgstr "책 변환"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "닫기"
@@ -3609,7 +3623,7 @@ msgstr "메타데이터 가져오기"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "저장"
 
@@ -6341,7 +6355,7 @@ msgstr "되돌릴 수 없습니다!"
 msgid "The following books will be permanently deleted:"
 msgstr "다음 책이 영구히 삭제됩니다:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "읽지 않음"
@@ -6417,7 +6431,8 @@ msgid "Save and Send Test Email"
 msgstr "저장 및 테스트 메일 전송"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "뒤로"
 
@@ -6437,8 +6452,8 @@ msgstr "도메인 입력"
 msgid "Denied Domains (Blacklist)"
 msgstr "차단 도메인 (블랙리스트)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "다음"
 
@@ -6743,140 +6758,140 @@ msgstr "탐색"
 msgid "Create Shelf"
 msgstr "서재 생성"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "서재 정보"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "이전"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "책 상세정보"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "되돌릴 수 없습니다!"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "선택한 책 삭제"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "결과 형식"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "형식 삭제:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "책 복제"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "중복된 책이 없습니다"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "중복인 책을 선택"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "최적 크기"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "종료:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "설정"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "서재에 추가"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "선택한 책 병합"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "읽지 않음으로 표시"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "책 삭제"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "책 삭제"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "책장 생성"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "연결 오류가 발생했습니다."
@@ -7413,6 +7428,22 @@ msgstr "드래그하여 순서 변경"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "숨긴 책"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"
@@ -8134,8 +8165,8 @@ msgstr "읽음/읽지 않음 표시"
 #~ msgstr ""
 #~ "이 경로들은 CWA 내부에서만 사용됩니다. 콜론 왼쪽 경로는 자유롭게 변경가능"
 #~ "하나,\n"
-#~ "        오른쪽 경로는 변경할 이유가 없습니다.<br><br>만약 <code>metadata."
-#~ "db<code> 파일을 나머지 서재와 다른 위치에 두고 싶다면, \n"
+#~ "        오른쪽 경로는 변경할 이유가 없습니다.<br><br>만약 "
+#~ "<code>metadata.db<code> 파일을 나머지 서재와 다른 위치에 두고 싶다면, \n"
 #~ "<b>아래의 ‘책 파일을 서재와 분리하기’ 옵션을 사용하고, 거기에 라이브러리"
 #~ "의 나머지 경로를 입력하십시오.</b>"
 

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -10,10 +10,10 @@ msgstr ""
 "Project-Id-Version: Calibre-Web (GPLV3)\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2026-04-26 13:31+0200\n"
-"Last-Translator: Michiel Cornelissen <michiel.cornelissen+gitbhun at proton."
-"me>\n"
+"Last-Translator: Michiel Cornelissen <michiel.cornelissen+gitbhun at "
+"proton.me>\n"
 "Language-Team: ed.driesen@telenet.be\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -2276,6 +2276,19 @@ msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Kan boekenplank niet openen: de boekenplank bestaat niet of is ontoegankelijk"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Boekenplanken uitsluiten"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2445,7 +2458,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Fout bij aanmaken boekenplank"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 msgid "Create Magic Shelf"
 msgstr "Magische boekenplank maken"
 
@@ -2557,8 +2570,8 @@ msgstr "Kies e-mailadressen:"
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
-"Het boek is in de wachtrij geplaatst om te worden verstuurd aan "
-"%(eReadermail)s"
+"Het boek is in de wachtrij geplaatst om te worden verstuurd aan %"
+"(eReadermail)s"
 
 #: cps/web.py:2244
 msgid "Please wait one minute to register next user"
@@ -2938,8 +2951,9 @@ msgstr "Toevoegen aan boekenplank"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Openbaar)"
 
@@ -3375,8 +3389,8 @@ msgstr "Oké"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3549,8 +3563,8 @@ msgstr "Boek converteren"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Sluiten"
@@ -3688,7 +3702,7 @@ msgstr "Metagegevens ophalen"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Opslaan"
 
@@ -6431,7 +6445,7 @@ msgstr "Deze actie kan niet ongedaan worden gemaakt!"
 msgid "The following books will be permanently deleted:"
 msgstr "Het boek wordt verwijderd uit de Calibre-database"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Ongelezen boeken"
@@ -6507,7 +6521,8 @@ msgid "Save and Send Test Email"
 msgstr "Opslaan en test-e-mail versturen"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Annuleren"
 
@@ -6527,8 +6542,8 @@ msgstr "Voer domeinnaam in"
 msgid "Denied Domains (Blacklist)"
 msgstr "Geweigerde domeinen voor registratie"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Volgende"
 
@@ -6840,137 +6855,137 @@ msgstr "Verkennen"
 msgid "Create Shelf"
 msgstr "Boekenplank maken"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Informatie"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Vorige"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Boekgegevens"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Deze actie kan niet ongedaan worden gemaakt!"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Geselecteerde boeken verwijderen"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Uploadformaat"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Formaten verwijderen:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 msgid "Duplicate Books Detected"
 msgstr "Duplicaat boek gevonden"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 msgid "Duplicate Groups Found"
 msgstr "Duplicaat groepen gevonden"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr "Bekijken en oplossen Duplicaten"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Optimaal inpassen"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Tot:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Instellingen"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Toevoegen aan boekenplank"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Geselecteerde boeken samenvoegen"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Gemarkeerd als ongelezen"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Boek verwijderen"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Boek verwijderen"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Kies eerst een boek"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Hertel mislukt: %(err)s"
@@ -7512,6 +7527,22 @@ msgstr "Pas de volgorde aan middels slepen-en-neerzetten"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Verborgen boek"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"
@@ -8224,10 +8255,11 @@ msgstr "Toon gelezen/niet gelezen selectie"
 #~ msgstr ""
 #~ "Deze paden zijn alleen intern voor CWA, je kunt aan de linkerkant naar "
 #~ "hartenlust wijzigen waar ze aan gekoppeld zijn, maar er is geen reden om "
-#~ "de paden aan de rechterkant te wijzigen.<br><br>Als je je <code>metadata."
-#~ "db</code> bestand op een andere locatie wilt dan de rest van je "
-#~ "bibliotheek, gebruik dan de <b>Scheid Boekbestanden van Bibliotheek Optie "
-#~ "hieronder en voer daar het pad naar de rest van de bibliotheek in</b>"
+#~ "de paden aan de rechterkant te wijzigen.<br><br>Als je je "
+#~ "<code>metadata.db</code> bestand op een andere locatie wilt dan de rest "
+#~ "van je bibliotheek, gebruik dan de <b>Scheid Boekbestanden van "
+#~ "Bibliotheek Optie hieronder en voer daar het pad naar de rest van de "
+#~ "bibliotheek in</b>"
 
 #~ msgid "Enable CWA Auto-Convert"
 #~ msgstr "Schakel CWA Auto-Conversie in"

--- a/cps/translations/no/LC_MESSAGES/messages.po
+++ b/cps/translations/no/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2023-01-06 11:00+0000\n"
 "Last-Translator: Vegard Fladby <vegard.fladby@gmail.com>\n"
 "Language-Team: \n"
@@ -2272,6 +2272,19 @@ msgstr "Hylle: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Feil ved åpning av hylle. Hylle finnes ikke eller er ikke tilgjengelig"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Skriv inn Språk"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2443,7 +2456,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Lag en hylle"
@@ -2945,8 +2958,9 @@ msgstr "Rediger en hylle"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 #, fuzzy
 msgid "(Public)"
 msgstr "Offentlig hylle"
@@ -3386,8 +3400,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3561,8 +3575,8 @@ msgstr "Konverter bok"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Lukk"
@@ -3702,7 +3716,7 @@ msgstr "Hent metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Lagre"
 
@@ -6439,7 +6453,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Uleste bøker"
@@ -6516,7 +6530,8 @@ msgid "Save and Send Test Email"
 msgstr "Send til E-Reader E-postadresse"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr ""
 
@@ -6537,8 +6552,8 @@ msgstr "Skriv inn kommentarer"
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 #, fuzzy
 msgid "Next"
 msgstr "Admin side"
@@ -6850,138 +6865,138 @@ msgstr ""
 msgid "Create Shelf"
 msgstr "Lag en hylle"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr ""
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr ""
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 #, fuzzy
 msgid "Book Details"
 msgstr "Detaljer"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Er du sikker på at du vil slå av?"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Last opp format"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Slett formater:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Slett bok"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Merket ble ikke funnet"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfigurasjon"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Rediger en hylle"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Slett bok"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Slett bok"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Lag en hylle"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Tilkoblingsfeil"
@@ -7561,6 +7576,22 @@ msgstr ""
 #, fuzzy
 msgid "Hidden Book"
 msgstr "Se bøker"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 #, fuzzy

--- a/cps/translations/pl/LC_MESSAGES/messages.po
+++ b/cps/translations/pl/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre Web - polski (POT: 2021-06-12 08:52)\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2021-06-12 15:35+0200\n"
 "Last-Translator: Radosław Kierznowski <radek.kierznowski@outlook.com>\n"
 "Language-Team: \n"
@@ -2265,6 +2265,19 @@ msgstr "Półka: „%(name)s”"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Błąd otwierania półki. Półka nie istnieje lub jest niedostępna"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Z wyłączeniem półek"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2436,7 +2449,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Błąd podczas usuwania półki"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Utwórz półkę"
@@ -2939,8 +2952,9 @@ msgstr "Dodaj do półki"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(publiczna)"
 
@@ -3371,8 +3385,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3547,8 +3561,8 @@ msgstr "Konwertuj książkę"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Zamknij"
@@ -3688,7 +3702,7 @@ msgstr "Uzyskaj metadane"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Zapisz"
 
@@ -6450,7 +6464,7 @@ msgstr "Tej akcji nie można cofnąć!"
 msgid "The following books will be permanently deleted:"
 msgstr "Następujące książki zostaną trwale usunięte:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Nieprzeczytane"
@@ -6526,7 +6540,8 @@ msgid "Save and Send Test Email"
 msgstr "Zapisz i wyślij testowy e-mail"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Wróć"
 
@@ -6546,8 +6561,8 @@ msgstr "Podaj nazwę domeny"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domeny zabronione (czarna lista)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Następne"
 
@@ -6860,141 +6875,141 @@ msgstr "Przeglądaj"
 msgid "Create Shelf"
 msgstr "Utwórz półkę"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Informacje"
 
 # ???
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Poprzedni"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Szczegóły książki"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Tej akcji nie można cofnąć!"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Usuń zaznaczone"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Format końcowy"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Usuń formaty:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Zduplikowane książki"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nie znaleziono zduplikowanych książek"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Wybierz duplikaty"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Skaluj do najlepszego"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Do:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfiguracja"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Dodaj do półki"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Łączenie wybranych książek"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Oznacz jako nieprzeczytane"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Usuń książkę"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Usuń książkę"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Wybierz półkę"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Błąd połączenia"
@@ -7536,6 +7551,22 @@ msgstr "Przeciągnij i upuść, aby zmienić kolejność"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Ukryta książka"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/pt/LC_MESSAGES/messages.po
+++ b/cps/translations/pt/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2023-07-25 11:30+0100\n"
 "Last-Translator: horus68 <https://github.com/horus68>\n"
 "Language-Team: pt-PT <>\n"
@@ -2295,6 +2295,19 @@ msgstr "Estante: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Erro ao abrir estante. A estante não existe ou não está acessível"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Excluir estante"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2465,7 +2478,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Erro a eliminar a estante"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Criar estante"
@@ -2983,8 +2996,9 @@ msgstr "Adicionar à estante"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Público)"
 
@@ -3419,8 +3433,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3593,8 +3607,8 @@ msgstr "Converter livro"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Fechar"
@@ -3734,7 +3748,7 @@ msgstr "Obter metadados"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Guardar"
 
@@ -6480,7 +6494,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Este livro será apagado permanentemente da base de dados"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Livros não lidos"
@@ -6559,7 +6573,8 @@ msgid "Save and Send Test Email"
 msgstr "Guardar e enviar email de teste"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Voltar"
 
@@ -6579,8 +6594,8 @@ msgstr "Digite o nome do domínio"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domínios ngados (Lista Negra)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Seguinte"
 
@@ -6892,139 +6907,139 @@ msgstr "Navegar"
 msgid "Create Shelf"
 msgstr "Criar estante"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Sobre"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Anterior"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Detalhes do livro"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Tem certeza de que quer encerrar?"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Formato de carregamento"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Apagar formatos:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Apagar livro"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nenhum resultado encontrado"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Dimensionar para melhor"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Para:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuração"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Adicionar à estante"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marcar como não Lido"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Apagar livro"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Apagar livro"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Criar estante"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Erro de ligação"
@@ -7579,6 +7594,22 @@ msgstr "Arrastar para reordenar"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Livro oculto"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/cps/translations/pt_BR/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2025-12-02 12:00+0000\n"
 "Last-Translator: Alex <298750+alexantao@users.noreply.github.com>\n"
 "Language-Team: pt_BR <LL@li.org>\n"
@@ -2293,6 +2293,19 @@ msgstr "Estante: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Erro ao abrir estante. A estante não existe ou não está acessível"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Excluir Estante"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2463,7 +2476,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Erro apagando Estante"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Crie uma Estante"
@@ -2979,8 +2992,9 @@ msgstr "Adicionar à estante"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Público)"
 
@@ -3419,8 +3433,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3594,8 +3608,8 @@ msgstr "Converter livro"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Fechar"
@@ -3734,7 +3748,7 @@ msgstr "Buscar Metadados"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Salvar"
 
@@ -6537,7 +6551,7 @@ msgstr "Esta ação não pode ser desfeita!"
 msgid "The following books will be permanently deleted:"
 msgstr "Este livro será apagado permanentemente do banco de dados"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Livros Não Lidos"
@@ -6617,7 +6631,8 @@ msgid "Save and Send Test Email"
 msgstr "Salvar e enviar e-mail de teste"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Voltar"
 
@@ -6637,8 +6652,8 @@ msgstr "Digite o nome do domínio"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domínios Negados (Lista Negra)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Próximo"
 
@@ -6951,140 +6966,140 @@ msgstr "Navegue em"
 msgid "Create Shelf"
 msgstr "Crie uma Estante"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Sobre"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Anterior"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Detalhes do Livro"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Esta ação não pode ser desfeita!"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Apagar livros selecionados"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Formato Final"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Apagar formatos:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Duplicar Livro"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nenhum Livro Duplicado encontrado"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Selecionar Duplicatas"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Dimensionar para Melhor"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Para:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuração"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Adicionar à estante"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Marcar livros selecionados como lidos"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marcar como Não Lido"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Apagar Livro"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Apagar Livro"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Crie uma Estante"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Erro de conexão"
@@ -7640,6 +7655,22 @@ msgstr "Arrastar para Reorganizar a Ordem"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Livro Escondido"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/ru/LC_MESSAGES/messages.po
+++ b/cps/translations/ru/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2020-04-29 01:20+0400\n"
 "Last-Translator: ZIZA\n"
 "Language-Team: \n"
@@ -2319,6 +2319,19 @@ msgstr "Полка: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Ошибка открытия полки. Полка не существует или недоступна"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Исключить полки"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2489,7 +2502,7 @@ msgstr "Название полки слишком большое (макс. 100
 msgid "Error creating shelf"
 msgstr "Ошибка удаления полки"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Создать полку"
@@ -3004,8 +3017,9 @@ msgstr "Добавить на полку"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Публичная)"
 
@@ -3446,8 +3460,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3621,8 +3635,8 @@ msgstr "Конвертировать книгу"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Закрыть"
@@ -3762,7 +3776,7 @@ msgstr "Получить метаданные"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Сохранить"
 
@@ -6574,7 +6588,7 @@ msgstr "Это действие нельзя отменить!"
 msgid "The following books will be permanently deleted:"
 msgstr "Следующие книги будут удалены:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Непрочитанные книги"
@@ -6654,7 +6668,8 @@ msgid "Save and Send Test Email"
 msgstr "Сохранить и отправить тестовое письмо"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Назад"
 
@@ -6674,8 +6689,8 @@ msgstr "Введите доменное имя"
 msgid "Denied Domains (Blacklist)"
 msgstr "Запрещенные домены (черный список)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Следующая"
 
@@ -6986,140 +7001,140 @@ msgstr "Просмотр"
 msgid "Create Shelf"
 msgstr "Создать полку"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "О программе"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Предыдущий"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Подробнее о книге"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Это действие нельзя отменить!"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Удалить выбранные книги"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Конечный формат"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Удалить форматы:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Удалить книгу"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Результатов не найдено"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Выбрать дубликаты"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Масштаб по лучшему соответствию"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "До:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Настройки сервера"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Добавить на полку"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Пометить выбранные книги как прочитанные"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Пометить как непрочитанное"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Удалить книгу"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Удалить книгу"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Выберите полку"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Ошибка соединения: %(err)s"
@@ -7689,6 +7704,22 @@ msgstr "Перетащите для изменения порядка"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Скрытая книга"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"
@@ -8438,9 +8469,9 @@ msgstr "Показать раздел прочитанного/непрочит�
 #~ "metadata.db при запуске. Если найдена только одна библиотека, она "
 #~ "монтируется автоматически; если найдено несколько, по умолчанию будет "
 #~ "смонтирована самая большая, а если ни одной нет, будет автоматически "
-#~ "создана и смонтирована новая. Для подробностей, <a href=\"https://github."
-#~ "com/crocodilestick/Calibre-Web-Automated/wiki/Configuration#database-"
-#~ "configuration\">см. здесь</a>!"
+#~ "создана и смонтирована новая. Для подробностей, <a href=\"https://"
+#~ "github.com/crocodilestick/Calibre-Web-Automated/wiki/"
+#~ "Configuration#database-configuration\">см. здесь</a>!"
 
 #~ msgid ""
 #~ "Therefore, when configuring your docker-compose file for CWA, <b>DO NOT "

--- a/cps/translations/sk/LC_MESSAGES/messages.po
+++ b/cps/translations/sk/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2023-11-01 06:12+0100\n"
 "Last-Translator: Branislav Hanáček <brango@brango.sk>\n"
 "Language-Team: \n"
@@ -2249,6 +2249,19 @@ msgstr "Polica: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Chyba pri otváraní police. Polica neexistuje alebo je neprístupná"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Vylúčiť police"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2421,7 +2434,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Chyba pri mazaní police"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Vytvoriť policu"
@@ -2916,8 +2929,9 @@ msgstr "Pridať do police"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Verejné)"
 
@@ -3351,8 +3365,8 @@ msgstr "V poriadku"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3525,8 +3539,8 @@ msgstr "Previesť knihu"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Zatvoriť"
@@ -3664,7 +3678,7 @@ msgstr "Načítať metadáta"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Uložiť"
 
@@ -6397,7 +6411,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Táto kniha bude navždy vymazaná z databázy"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Neprečítané knihy"
@@ -6473,7 +6487,8 @@ msgid "Save and Send Test Email"
 msgstr "Uložiť a poslať testovací e-mail"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Naspäť"
 
@@ -6493,8 +6508,8 @@ msgstr "Zadajte doménové meno"
 msgid "Denied Domains (Blacklist)"
 msgstr "Zakázané domény (Čierny zoznam)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Ďalší"
 
@@ -6801,139 +6816,139 @@ msgstr "Prechádzať"
 msgid "Create Shelf"
 msgstr "Vytvoriť policu"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "O programe"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Predchádzajúci"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Detailu o knihe"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Skutočne chcete vypnúťť?"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Formát nahrávania"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Zmazať formáty:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Zmazať knihu"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nič sa nenašlo"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Zmeniť mierku na najlepšie"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Do:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfigurácia"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Pridať do police"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Označiť ako neprečítané"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Zmazať knihu"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Zmazať knihu"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Vytvoriť policu"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Chyba spojenia"
@@ -7485,6 +7500,22 @@ msgstr "Potiahnite pre zmenu poradia"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Skryté chyby"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/sl/LC_MESSAGES/messages.po
+++ b/cps/translations/sl/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2025-08-11 07:03+0000\n"
 "Last-Translator: Andrej Kralj\n"
 "Language-Team: Slovenian\n"
@@ -2310,6 +2310,19 @@ msgstr "Polica: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Napaka pri odpiranju police. Polica ne obstaja ali ni dostopna"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Izključi police"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2480,7 +2493,7 @@ msgstr "Ime police je predolgo (največ 100 znakov)"
 msgid "Error creating shelf"
 msgstr "Napaka pri brisanju police"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Ustvari polico"
@@ -2981,8 +2994,9 @@ msgstr "Dodaj na polico"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Javno)"
 
@@ -3418,8 +3432,8 @@ msgstr "V redu"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3593,8 +3607,8 @@ msgstr "Pretvori knjigo"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Zapri"
@@ -3734,7 +3748,7 @@ msgstr "Pridobivanje metapodatkov"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Shrani"
 
@@ -5260,8 +5274,8 @@ msgid ""
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
-"To orodje je bilo prilagojeno po orodju <a href=\"https://kindle-epub-fix."
-"netlify.app/\">kindle-epub-fix.netlify.app</a>, ki ga je izdelal <a "
+"To orodje je bilo prilagojeno po orodju <a href=\"https://kindle-epub-"
+"fix.netlify.app/\">kindle-epub-fix.netlify.app</a>, ki ga je izdelal <a "
 "href=\"https://github.com/innocenat\">innocenat</a>."
 
 #: cps/templates/cwa_settings.html:181
@@ -6643,7 +6657,7 @@ msgstr "Tega dejanja ni mogoče razveljaviti!"
 msgid "The following books will be permanently deleted:"
 msgstr "Naslednje knjige bodo izbrisane:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Neprebrane knjige"
@@ -6719,7 +6733,8 @@ msgid "Save and Send Test Email"
 msgstr "Shrani in pošlji testno e-pošto"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Nazaj"
 
@@ -6739,8 +6754,8 @@ msgstr "Vnesi ime domene"
 msgid "Denied Domains (Blacklist)"
 msgstr "Zavrnjene domene (črni seznam)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Naslednji"
 
@@ -7058,126 +7073,126 @@ msgstr "Brskaj"
 msgid "Create Shelf"
 msgstr "Ustvari polico"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr "Čarobne police ✨"
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "O programu"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Prejšnji"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Podrobnosti o knjigi"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Tega dejanja ni mogoče razveljaviti!"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Nalaganje vrsta"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Brisanje vrste:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Izbriši knjigo"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr "V vaši knjižnici so nerazrešeni dvojniki knjig"
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Ni bilo najdenih rezultatov"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr "Opomni me pozneje"
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr "Ogled in razreševanje dvojnikov"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Povečaj na najboljše"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Nasvet"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Dodaj na polico"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Označi kot neprebrano"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Izbriši knjigo"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Izbriši knjigo"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7185,12 +7200,12 @@ msgid ""
 msgstr ""
 "To bo trajno izbrisalo knjige. Izvirne datoteke bodo varnostno kopirane v"
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Ustvari polico"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Napaka povezave"
@@ -7741,6 +7756,22 @@ msgstr "Povlecite, da spremenite vrstni red"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Skrita knjiga"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/sv/LC_MESSAGES/messages.po
+++ b/cps/translations/sv/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2021-05-13 11:00+0000\n"
 "Last-Translator: Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>\n"
 "Language-Team: \n"
@@ -2263,6 +2263,19 @@ msgstr "Hylla: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Fel vid öppning av hyllan. Hylla finns inte eller är inte tillgänglig"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Uteslut hyllor"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2434,7 +2447,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Skapa en hylla"
@@ -2936,8 +2949,9 @@ msgstr "Lägg till hyllan"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Publik)"
 
@@ -3374,8 +3388,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3549,8 +3563,8 @@ msgstr "Konvertera boken"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Stäng"
@@ -3690,7 +3704,7 @@ msgstr "Hämta metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Spara"
 
@@ -6422,7 +6436,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Boken kommer att tas bort från Calibre-databasen"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Olästa böcker"
@@ -6502,7 +6516,8 @@ msgid "Save and Send Test Email"
 msgstr "Spara inställningarna och skicka test-e-post"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Tillbaka"
 
@@ -6522,8 +6537,8 @@ msgstr "Ange domännamn"
 msgid "Denied Domains (Blacklist)"
 msgstr "Avvisade domäner för registrering"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Nästa"
 
@@ -6832,138 +6847,138 @@ msgstr "Bläddra"
 msgid "Create Shelf"
 msgstr "Skapa en hylla"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Om"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Föregående"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Bokdetaljer"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Är du säker på att du vill stoppa Calibre-Web?"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Ladda upp format"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Ta bort format:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Ta bort boken"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Inga resultat hittades"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Skala till bäst"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfiguration"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Lägg till hyllan"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Markera som oläst"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Ta bort boken"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Ta bort boken"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Skapa en hylla"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Anslutningsfel"
@@ -7523,6 +7538,22 @@ msgstr "Drag och släpp för att ändra ordning"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Dold bok"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/tr/LC_MESSAGES/messages.po
+++ b/cps/translations/tr/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2020-04-23 22:47+0300\n"
 "Last-Translator: iz <iz7iz7iz@protonmail.ch>\n"
 "Language-Team: \n"
@@ -2237,6 +2237,19 @@ msgstr ""
 "Kitaplık açılırken hata oluştu. Kitaplık mevcut değil ya da erişilebilir "
 "değil"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Serileri Hariç Tut"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2403,7 +2416,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Kitaplık oluştur"
@@ -2899,8 +2912,9 @@ msgstr "Kitaplığa ekle"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr ""
 
@@ -3350,8 +3364,8 @@ msgstr ""
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3527,8 +3541,8 @@ msgstr "eKitabı dönüştür"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Kapak"
@@ -3669,7 +3683,7 @@ msgstr "metaveri düzenle"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr ""
 
@@ -6401,7 +6415,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Okunmamışlar"
@@ -6481,7 +6495,8 @@ msgid "Save and Send Test Email"
 msgstr "E-Posta adresiniz"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Geri"
 
@@ -6501,8 +6516,8 @@ msgstr "Servis adı girin"
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Sonraki"
 
@@ -6804,137 +6819,137 @@ msgstr "Gözat"
 msgid "Create Shelf"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Hakkında"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Önceki"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "eKitap Detayları"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 msgid "This cannot be undone."
 msgstr ""
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Yükleme"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Biçimleri Sil:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Sonuçlar:"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "En İyiye Ölçeklendir"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Ayarlar"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Okunmadı olarak işaretle"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Okunmadı olarak işaretle"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Bağlantı hatası"
@@ -7499,6 +7514,22 @@ msgstr ""
 #, fuzzy
 msgid "Hidden Book"
 msgstr "Popüler"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 #, fuzzy

--- a/cps/translations/uk/LC_MESSAGES/messages.po
+++ b/cps/translations/uk/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2017-04-30 00:47+0300\n"
 "Last-Translator: ABIS Team <biblio.if.abis@gmail.com>\n"
 "Language-Team: \n"
@@ -2230,6 +2230,19 @@ msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Помилка при відкриванні полиці. Полиця не існує або до неї відсутній доступ"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Виключити серії"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2393,7 +2406,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "створити книжкову полицю"
@@ -2884,8 +2897,9 @@ msgstr "Додати на книжкову полицю"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Публічно)"
 
@@ -3327,8 +3341,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3503,8 +3517,8 @@ msgstr "Конвертувати книгу"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Закрити"
@@ -3644,7 +3658,7 @@ msgstr "Отримати метадані"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Зберегти"
 
@@ -6379,7 +6393,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Книга буде видалена з БД Calibre"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Непрочитані книги"
@@ -6456,7 +6470,8 @@ msgid "Save and Send Test Email"
 msgstr "Kindle"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Назад"
 
@@ -6477,8 +6492,8 @@ msgstr "Введіть домен"
 msgid "Denied Domains (Blacklist)"
 msgstr "Заборонені домени (Чорний список)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Далі"
 
@@ -6782,138 +6797,138 @@ msgstr "Перегляд"
 msgid "Create Shelf"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "Про програму"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Попередній перегляд"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Деталі"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Впевнені що хочете перезавантажити?"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Формат завантаження"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Видалити формати:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Результати для:"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "До:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "Налаштування сервера"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Додати на книжкову полицю"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Відмітити як не прочитане"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Відмітити як не прочитане"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "створити книжкову полицю"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Помилка зʼєднання"
@@ -7487,6 +7502,22 @@ msgstr "Перетягніть для змінення порядку"
 #, fuzzy
 msgid "Hidden Book"
 msgstr "Популярні книги"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/vi/LC_MESSAGES/messages.po
+++ b/cps/translations/vi/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2022-09-20 21:36+0700\n"
 "Last-Translator: Ha Link <halink0803@gmail.com>\n"
 "Language-Team: \n"
@@ -2223,6 +2223,19 @@ msgstr ""
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "Giá sách"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2390,7 +2403,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Tạo một giá sách"
@@ -2887,8 +2900,9 @@ msgstr "Thêm vào giá sách"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(Công khai)"
 
@@ -3323,8 +3337,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3498,8 +3512,8 @@ msgstr "Chuyển đổi sách"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "Đóng"
@@ -3638,7 +3652,7 @@ msgstr "Fetch Metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Lưu"
 
@@ -6375,7 +6389,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "Sách chưa đọc"
@@ -6453,7 +6467,8 @@ msgid "Save and Send Test Email"
 msgstr "Lưu và gửi test E-mail"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Quay lại"
 
@@ -6473,8 +6488,8 @@ msgstr "Nhập tên domain"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domain bị từ chối (Blacklist)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "Tiếp tục"
 
@@ -6785,137 +6800,137 @@ msgstr "Tìm kiếm"
 msgid "Create Shelf"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "About"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "Trước"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "Chi tiết sách"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Bạn có chắc muốn tắt?"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "Định dạng tải lên"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Xoá định dạng:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Xoá sách"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Không tìm thấy kết quả"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "Tới:"
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Thêm vào giá sách"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Đánh dấu chưa đọc"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Xoá sách"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "Xoá sách"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Tạo một giá sách"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Lỗi kết nối"
@@ -7474,6 +7489,22 @@ msgstr "Kéo để thay đổi lại thứ tự"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "Sách ẩn"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2020-09-27 22:18+0800\n"
 "Last-Translator: xlivevil <xlivevil@aliyun.com>\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
@@ -2208,6 +2208,19 @@ msgstr "书架：%(name)s"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "打开书架出错。书架不存在或不可访问"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "排除书架"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2374,7 +2387,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "删除书架时出错"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "创建书架"
@@ -2866,8 +2879,9 @@ msgstr "添加到书架"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(公共)"
 
@@ -3302,8 +3316,8 @@ msgstr "确定"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3476,8 +3490,8 @@ msgstr "转换书籍"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "关闭"
@@ -3615,7 +3629,7 @@ msgstr "获取元数据"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "保存"
 
@@ -6362,7 +6376,7 @@ msgstr "此操作无法撤销！"
 msgid "The following books will be permanently deleted:"
 msgstr "此书籍将从数据库中永久删除"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "未读书籍"
@@ -6438,7 +6452,8 @@ msgid "Save and Send Test Email"
 msgstr "保存设置并发送测试邮件"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "后退"
 
@@ -6458,8 +6473,8 @@ msgstr "输入域名"
 msgid "Denied Domains (Blacklist)"
 msgstr "禁止注册的域名（黑名单）"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "下一个"
 
@@ -6764,140 +6779,140 @@ msgstr "按条件浏览"
 msgid "Create Shelf"
 msgstr "创建书架"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "关于"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "上一个"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "书籍详情"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "此操作无法撤销！"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "合并选中的书籍"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "上传格式"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "删除格式:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "删除书籍"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "无搜索结果"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "选择重复项"
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "缩放到最佳"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "到："
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "配置"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "添加到书架"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "合并选中的书籍"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "标为未读"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "删除书籍"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "删除书籍"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "创建书架"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "连接错误"
@@ -7445,6 +7460,22 @@ msgstr "拖拽以重新排序"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "隐藏书籍"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: 2020-09-27 22:18+0800\n"
 "Last-Translator: xlivevil <xlivevil@aliyun.com>\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
@@ -2223,6 +2223,19 @@ msgstr "書架：%(name)s"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "打開書架出錯。書架不存在或不可訪問"
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+#, fuzzy
+msgid "Reorder Shelves"
+msgstr "排除書架"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2388,7 +2401,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "下載封面時出錯"
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "創建書架"
@@ -2890,8 +2903,9 @@ msgstr "添加到書架"
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr "(公共)"
 
@@ -3327,8 +3341,8 @@ msgstr "確定"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3502,8 +3516,8 @@ msgstr "轉換書籍"
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr "關閉"
@@ -3641,7 +3655,7 @@ msgstr "獲取元數據"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "儲存"
 
@@ -6370,7 +6384,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "此書籍將從數據庫中永久刪除"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 #, fuzzy
 msgid "Merge Books"
 msgstr "未讀書籍"
@@ -6450,7 +6464,8 @@ msgid "Save and Send Test Email"
 msgstr "保存設置並發送測試郵件"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "後退"
 
@@ -6470,8 +6485,8 @@ msgstr "輸入網域名"
 msgid "Denied Domains (Blacklist)"
 msgstr "禁止註冊的網域名（黑名單）"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr "下一個"
 
@@ -6776,139 +6791,139 @@ msgstr "瀏覽"
 msgid "Create Shelf"
 msgstr "創建書架"
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr "關於"
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr "上一個"
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr "書籍詳情"
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "您確定要關閉嗎？"
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 #, fuzzy
 msgid "Will be deleted"
 msgstr "合併選中的書籍"
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 #, fuzzy
 msgid "Formats:"
 msgstr "上傳格式"
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "刪除格式:"
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "刪除書籍"
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "無搜索結果"
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 #, fuzzy
 msgid "Scroll to top"
 msgstr "縮放到最佳"
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 #, fuzzy
 msgid "Top"
 msgstr "到："
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 #, fuzzy
 msgid "Confirm"
 msgstr "配置"
 
-#: cps/templates/layout.html:694
+#: cps/templates/layout.html:698
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "添加到書架"
 
-#: cps/templates/layout.html:695
+#: cps/templates/layout.html:699
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:696
+#: cps/templates/layout.html:700
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:697
+#: cps/templates/layout.html:701
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "合併選中的書籍"
 
-#: cps/templates/layout.html:698
+#: cps/templates/layout.html:702
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "標為未讀"
 
-#: cps/templates/layout.html:699
+#: cps/templates/layout.html:703
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "刪除書籍"
 
-#: cps/templates/layout.html:700
+#: cps/templates/layout.html:704
 #, fuzzy
 msgid "Delete books?"
 msgstr "刪除書籍"
 
-#: cps/templates/layout.html:701
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "創建書架"
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "連接錯誤"
@@ -7458,6 +7473,22 @@ msgstr "拖拽以重新排序"
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
 msgstr "隱藏書籍"
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
+msgstr ""
 
 #: cps/templates/stats.html:8
 msgid "Library Statistics"

--- a/messages.pot
+++ b/messages.pot
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web Automated v4.0.6\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 17:42+0000\n"
+"POT-Creation-Date: 2026-05-21 14:39-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2159,6 +2159,18 @@ msgstr ""
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 
+#: cps/shelf.py:695
+msgid "Invalid payload: 'order' must be a list"
+msgstr ""
+
+#: cps/shelf.py:713
+msgid "Could not save order"
+msgstr ""
+
+#: cps/shelf.py:717 cps/templates/layout.html:352
+msgid "Reorder Shelves"
+msgstr ""
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2319,7 +2331,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:358 cps/web.py:1314
+#: cps/templates/layout.html:362 cps/web.py:1314
 msgid "Create Magic Shelf"
 msgstr ""
 
@@ -2778,8 +2790,9 @@ msgstr ""
 #: cps/templates/detail.html:625 cps/templates/detail.html:778
 #: cps/templates/detail.html:1290 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
-#: cps/templates/layout.html:355 cps/templates/listenmp3.html:201
+#: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
+#: cps/templates/shelf_reorder.html:21
 msgid "(Public)"
 msgstr ""
 
@@ -3194,8 +3207,8 @@ msgstr ""
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:951
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:532
-#: cps/templates/layout.html:687 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:536
+#: cps/templates/layout.html:691 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/schedule_edit.html:46
 #: cps/templates/shelf_edit.html:34 cps/templates/tasks.html:94
@@ -3366,8 +3379,8 @@ msgstr ""
 
 #: cps/templates/book_edit.html:52 cps/templates/book_edit.html:332
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:184 cps/templates/layout.html:432
-#: cps/templates/layout.html:569 cps/templates/modal_dialogs.html:34
+#: cps/templates/layout.html:184 cps/templates/layout.html:436
+#: cps/templates/layout.html:573 cps/templates/modal_dialogs.html:34
 #: cps/templates/user_edit.html:666
 msgid "Close"
 msgstr ""
@@ -3505,7 +3518,7 @@ msgstr ""
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr ""
 
@@ -6128,7 +6141,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:484
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:488
 msgid "Merge Books"
 msgstr ""
 
@@ -6201,7 +6214,8 @@ msgid "Save and Send Test Email"
 msgstr ""
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/user_table.html:176
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/user_table.html:176
 msgid "Back"
 msgstr ""
 
@@ -6221,8 +6235,8 @@ msgstr ""
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:390
-#: cps/templates/layout.html:416
+#: cps/templates/feed.xml:31 cps/templates/layout.html:394
+#: cps/templates/layout.html:420
 msgid "Next"
 msgstr ""
 
@@ -6509,128 +6523,128 @@ msgstr ""
 msgid "Create Shelf"
 msgstr ""
 
-#: cps/templates/layout.html:353
+#: cps/templates/layout.html:357
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:362 cps/templates/stats.html:3
+#: cps/templates/layout.html:366 cps/templates/stats.html:3
 msgid "About"
 msgstr ""
 
-#: cps/templates/layout.html:375 cps/templates/layout.html:401
+#: cps/templates/layout.html:379 cps/templates/layout.html:405
 msgid "Previous"
 msgstr ""
 
-#: cps/templates/layout.html:428
+#: cps/templates/layout.html:432
 msgid "Book Details"
 msgstr ""
 
-#: cps/templates/layout.html:490
+#: cps/templates/layout.html:494
 msgid "This cannot be undone."
 msgstr ""
 
-#: cps/templates/layout.html:496
+#: cps/templates/layout.html:500
 msgid "Will be deleted"
 msgstr ""
 
-#: cps/templates/layout.html:500 cps/templates/layout.html:513
+#: cps/templates/layout.html:504 cps/templates/layout.html:517
 msgid "Formats:"
 msgstr ""
 
-#: cps/templates/layout.html:509
+#: cps/templates/layout.html:513
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:521
+#: cps/templates/layout.html:525
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:527
+#: cps/templates/layout.html:531
 msgid "Result will have formats:"
 msgstr ""
 
-#: cps/templates/layout.html:536
+#: cps/templates/layout.html:540
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:574
 msgid "Duplicate Books Detected"
 msgstr ""
 
-#: cps/templates/layout.html:571
+#: cps/templates/layout.html:575
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:576
+#: cps/templates/layout.html:580
 msgid "Duplicate Groups Found"
 msgstr ""
 
-#: cps/templates/layout.html:584
+#: cps/templates/layout.html:588
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:587
+#: cps/templates/layout.html:591
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:596
+#: cps/templates/layout.html:600
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:598
+#: cps/templates/layout.html:602
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:688
+#: cps/templates/layout.html:692
 msgid "Confirm"
-msgstr ""
-
-#: cps/templates/layout.html:694
-#, python-brace-format
-msgid "Added {n} books to {shelf}"
-msgstr ""
-
-#: cps/templates/layout.html:695
-#, python-brace-format
-msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
-msgstr ""
-
-#: cps/templates/layout.html:696
-#, python-brace-format
-msgid "All {n} book(s) were already on {shelf}."
-msgstr ""
-
-#: cps/templates/layout.html:697
-#, python-brace-format
-msgid "Marked {n} books as read"
 msgstr ""
 
 #: cps/templates/layout.html:698
 #, python-brace-format
-msgid "Marked {n} books as unread"
+msgid "Added {n} books to {shelf}"
 msgstr ""
 
 #: cps/templates/layout.html:699
 #, python-brace-format
-msgid "Deleted {n} books"
+msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
 #: cps/templates/layout.html:700
-msgid "Delete books?"
+#, python-brace-format
+msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
 #: cps/templates/layout.html:701
+#, python-brace-format
+msgid "Marked {n} books as read"
+msgstr ""
+
+#: cps/templates/layout.html:702
+#, python-brace-format
+msgid "Marked {n} books as unread"
+msgstr ""
+
+#: cps/templates/layout.html:703
+#, python-brace-format
+msgid "Deleted {n} books"
+msgstr ""
+
+#: cps/templates/layout.html:704
+msgid "Delete books?"
+msgstr ""
+
+#: cps/templates/layout.html:705
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot "
 "be undone."
 msgstr ""
 
-#: cps/templates/layout.html:702
+#: cps/templates/layout.html:706
 msgid "Select at least one book first."
 msgstr ""
 
-#: cps/templates/layout.html:703
+#: cps/templates/layout.html:707
 #, python-brace-format
 msgid "Request failed: {err}"
 msgstr ""
@@ -7161,6 +7175,22 @@ msgstr ""
 
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:9
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:13
+msgid "You do not have any shelves to reorder yet."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:58
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:63
+msgid "Could not save order."
 msgstr ""
 
 #: cps/templates/stats.html:8

--- a/tests/unit/test_237_shelf_reorder.py
+++ b/tests/unit/test_237_shelf_reorder.py
@@ -1,0 +1,193 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for fork issue #237 (@new-usemame): drag-to-reorder
+regular Shelves in the sidebar.
+
+Magic shelves already supported user-ordered display since the
+v4.0.39 sort_magic_shelves_for_user work. Regular shelves were
+locked to alphabetical (order_by(ub.Shelf.name) in
+cps/render_template.py). This issue closes the gap for regular
+shelves using the same view_settings storage pattern.
+
+Storage: user.view_settings['shelves'] = {'order': [id, id, ...]}.
+Empty / missing keeps alphabetical default. Manual order applies
+when the list is non-empty. Sort is stable and tolerant of unknown
+or stale IDs in the list (drops them) and newly-added shelves not
+yet in the list (appends them at the end, preserving stored prefix).
+
+Endpoint: GET /shelf/reorder renders the drag-list, POST saves
+order. Both auth-gated by @user_login_required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHELF_PY = REPO_ROOT / "cps" / "shelf.py"
+RENDER_PY = REPO_ROOT / "cps" / "render_template.py"
+LAYOUT_HTML = REPO_ROOT / "cps" / "templates" / "layout.html"
+REORDER_HTML = REPO_ROOT / "cps" / "templates" / "shelf_reorder.html"
+
+
+def _shelf_src() -> str:
+    return SHELF_PY.read_text()
+
+
+def _render_src() -> str:
+    return RENDER_PY.read_text()
+
+
+def _layout_src() -> str:
+    return LAYOUT_HTML.read_text()
+
+
+# ---------------------------------------------------------------------------
+# normalize_shelf_order: list-validation contract
+# ---------------------------------------------------------------------------
+
+def test_normalize_shelf_order_function_exists():
+    src = _shelf_src()
+    assert re.search(r"def normalize_shelf_order\(", src), (
+        "cps/shelf.py must define normalize_shelf_order(order_list, available_ids)"
+    )
+
+
+def test_normalize_shelf_order_behavior():
+    """Exec the function body in isolation to avoid the full cps import."""
+    src = _shelf_src()
+    match = re.search(
+        r"(def normalize_shelf_order\(.*?)(?=\n(?:def |@|class ))",
+        src, re.DOTALL,
+    )
+    assert match, "normalize_shelf_order definition not isolated"
+    ns: dict = {}
+    exec(match.group(1), ns)  # noqa: S102 -- fixture source, not user input
+    fn = ns["normalize_shelf_order"]
+    assert fn([], []) == []
+    assert fn([1, 2, 3], [1, 2, 3]) == [1, 2, 3]
+    # Partial stored order: missing shelves appended at the end.
+    assert fn([2, 1], [1, 2, 3]) == [2, 1, 3]
+    # Stale / unknown IDs in stored order: dropped.
+    assert fn([99, 1, 2], [1, 2]) == [1, 2]
+    # Duplicates: de-duplicated, first occurrence wins.
+    assert fn([1, 1, 2], [1, 2]) == [1, 2]
+    # String IDs coerced to int.
+    assert fn(["2", "1"], [1, 2]) == [2, 1]
+    # None / non-coerceable input: ignored.
+    assert fn([None, "abc", 1], [1, 2]) == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# sort_shelves_for_user: applies the order, defaults to alpha
+# ---------------------------------------------------------------------------
+
+def test_sort_shelves_for_user_function_exists():
+    src = _shelf_src()
+    assert re.search(r"def sort_shelves_for_user\(", src)
+
+
+def test_sort_shelves_for_user_default_alpha():
+    """No view_settings.shelves → case-insensitive alphabetical."""
+    src = _shelf_src()
+    match = re.search(
+        r"(def sort_shelves_for_user\(.*?)(?=\n(?:def |@|class ))",
+        src, re.DOTALL,
+    )
+    assert match
+    body = match.group(1)
+    assert "view_settings" in body, "must consult user.view_settings"
+    assert "'shelves'" in body or '"shelves"' in body
+    assert "'order'" in body or '"order"' in body
+    assert "casefold" in body, "default sort must be case-insensitive"
+
+
+def test_sort_shelves_for_user_anon_safe():
+    """Anonymous user has view_settings=None per Anonymous.__init__."""
+    src = _shelf_src()
+    match = re.search(
+        r"(def sort_shelves_for_user\(.*?)(?=\n(?:def |@|class ))",
+        src, re.DOTALL,
+    )
+    body = match.group(1)
+    safe_pattern = (
+        r"getattr\(user,\s*['\"]view_settings['\"],\s*None\)\s*or\s*\{\s*\}"
+        r"|user\.view_settings\s+or\s+\{\s*\}"
+    )
+    assert re.search(safe_pattern, body), (
+        "must None-guard view_settings for Anonymous users"
+    )
+
+
+# ---------------------------------------------------------------------------
+# /shelf/reorder endpoint
+# ---------------------------------------------------------------------------
+
+def test_reorder_route_registered_get_and_post():
+    src = _shelf_src()
+    assert re.search(
+        r'@shelf\.route\(\s*["\']/shelf/reorder["\'].*methods=\[.*?["\']GET["\'].*?["\']POST["\'].*?\]',
+        src, re.DOTALL,
+    ) or re.search(
+        r'@shelf\.route\(\s*["\']/shelf/reorder["\'].*methods=\[.*?["\']POST["\'].*?["\']GET["\'].*?\]',
+        src, re.DOTALL,
+    ), "GET + POST /shelf/reorder must be registered under the shelf blueprint"
+
+
+def test_reorder_route_login_gated():
+    src = _shelf_src()
+    match = re.search(
+        r'@shelf\.route\(\s*["\']/shelf/reorder["\'].*?def (\w+)\(',
+        src, re.DOTALL,
+    )
+    assert match, "reorder route handler not found"
+    handler_name = match.group(1)
+    sig_idx = src.index(f"def {handler_name}(")
+    head = src[max(0, sig_idx - 800):sig_idx]
+    assert "@user_login_required" in head or "@login_required" in head, (
+        f"{handler_name} must be auth-gated"
+    )
+
+
+# ---------------------------------------------------------------------------
+# render_template.py applies the sort
+# ---------------------------------------------------------------------------
+
+def test_render_template_calls_sort_shelves_for_user():
+    src = _render_src()
+    assert "sort_shelves_for_user" in src, (
+        "render_template.py must import + call sort_shelves_for_user "
+        "to apply the user's stored order to g.shelves_access"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sidebar entry for the new page
+# ---------------------------------------------------------------------------
+
+def test_sidebar_has_reorder_link():
+    src = _layout_src()
+    assert "shelf.reorder_shelves" in src or "/shelf/reorder" in src, (
+        "layout.html sidebar must link to the reorder endpoint"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Template exists with the SortableJS hookup pattern
+# ---------------------------------------------------------------------------
+
+def test_reorder_template_exists():
+    assert REORDER_HTML.is_file(), "cps/templates/shelf_reorder.html must exist"
+
+
+def test_reorder_template_uses_sortable():
+    src = REORDER_HTML.read_text()
+    assert "Sortable" in src, "template must reference SortableJS"
+    assert "/shelf/reorder" in src or "shelf.reorder_shelves" in src


### PR DESCRIPTION
Fork [#237](https://github.com/new-usemame/Calibre-Web-NextGen/issues/237) (@new-usemame): regular shelves were locked to alphabetical sidebar order. Magic shelves already supported user-ordered display (via `sort_magic_shelves_for_user`). This closes the gap.

## What changes

- New helpers in `cps/shelf.py`:
  - `normalize_shelf_order(order_list, available_ids)` — drops unknown IDs, de-dupes, coerces strings, appends missing IDs.
  - `sort_shelves_for_user(shelves, user)` — applies `user.view_settings['shelves']['order']` if set; else casefold alphabetical. None-safe for the Anonymous user.
- New endpoint `GET/POST /shelf/reorder` (`@user_login_required`) — drag-to-reorder UI + JSON-POST persistence into `view_settings`.
- `cps/render_template.py:141` calls `sort_shelves_for_user` so the sidebar (and every page that renders it) picks up the order automatically.
- Sidebar link added below "Create Shelf" (only shown when the user has >1 shelf).
- 5 new i18n strings extracted; **Hungarian (reporter's locale) + German translations written** + all 28 .mo files recompiled.

## Tests

11 source-pin tests in `tests/unit/test_237_shelf_reorder.py` covering normalize behavior (8 cases), sort_shelves_for_user shape, route registration + login gate, render_template integration, sidebar link, template SortableJS hookup. All GREEN. 30 .po files compile cleanly per `test_translations_compile.py`.

## Live verification on cwn-local (Playwright + JS evaluate)

| Step | Outcome |
|---|---|
| Created 3 shelves for cwng84test | Alpha-shelf, KOBO_TEST_SHELF, Middle-shelf, Zebra-shelf rendered alphabetical on first load |
| POST `/shelf/reorder` `{order:[2,4,1,3]}` | 200 `{success:true, order:[2,4,1,3]}` |
| Reload `/shelf/reorder` | shelves now in `[Zebra, Middle, KOBO, Alpha]` |
| Sidebar on `/` after persist | also `[Zebra, Middle, KOBO, Alpha]` (cross-page consistency) |
| HU translations | title "Polcok átrendezése", drag hint translated, save "Mentés", sidebar link translated |

## Confidence

98% — pure new endpoint + helper + UI, no migration. The view_settings JSON column was already in use for magic-shelf ordering; same column. Live POST verified end-to-end.

Addresses #237.