### PR TITLE
feat(shelf): add order_mode picker to /shelf/reorder (fork #237 follow-up)

### DIFF
--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -627,12 +627,28 @@ def add_selected_to_shelf():
 # cps/magic_shelf.py::sort_magic_shelves_for_user). Storage shape on
 # user.view_settings:
 #
-#     {"shelves": {"order": [shelf_id, shelf_id, ...]}}
+#     {"shelves": {"order_mode": "manual|name_asc|...", "order": [shelf_id, ...]}}
 #
-# Missing / empty list → fall back to alphabetical (current behavior).
-# Stale IDs in the list are dropped on sort; new shelves not yet in the
+# `order_mode` chooses among the modes in SHELF_ORDER_MODES below; default
+# is name_asc (alphabetical, preserves prior-release behaviour). When
+# order_mode == 'manual', the `order` list is the canonical sequence.
+# Stale IDs in `order` are dropped on sort; new shelves not yet in the
 # list are appended after the stored prefix so they remain visible.
 # ---------------------------------------------------------------------------
+
+SHELF_ORDER_MODES = {
+    'manual',
+    'name_asc',
+    'name_desc',
+    'book_count_desc',
+    'book_count_asc',
+    'created_desc',
+    'created_asc',
+    'modified_desc',
+    'modified_asc',
+}
+
+DEFAULT_SHELF_ORDER_MODE = 'name_asc'
 
 
 def normalize_shelf_order(order_list, available_ids):
@@ -657,18 +673,80 @@ def normalize_shelf_order(order_list, available_ids):
     return normalized
 
 
+def _shelf_book_count(shelf):
+    """Best-effort book count without forcing a relationship load. Returns 0
+    when the relationship is detached or the query can't run."""
+    books = getattr(shelf, 'books', None)
+    if books is None:
+        return 0
+    try:
+        return int(books.count())
+    except Exception:
+        try:
+            return len(list(books))
+        except Exception:
+            return 0
+
+
 def sort_shelves_for_user(shelves, user):
-    """Sort regular shelves for `user` in place. Applies the manual order
-    from `user.view_settings['shelves']['order']` if set; otherwise sorts
-    case-insensitive alphabetical by name."""
+    """Sort regular shelves for `user` in place, honoring
+    `user.view_settings['shelves']['order_mode']`. Modes mirror
+    `cps.magic_shelf.MAGIC_SHELF_ORDER_MODES` so the sidebar feels
+    consistent across shelf kinds. Anonymous users (view_settings = None
+    per cps/ub.py) fall through to the default name_asc."""
     settings = (getattr(user, 'view_settings', None) or {}).get('shelves', {})
-    order_list = settings.get('order') or []
-    if order_list:
-        available_ids = [s.id for s in shelves]
-        normalized = normalize_shelf_order(order_list, available_ids)
-        index = {sid: idx for idx, sid in enumerate(normalized)}
-        shelves.sort(key=lambda s: index.get(s.id, len(index)))
+    order_mode = settings.get('order_mode', DEFAULT_SHELF_ORDER_MODE)
+    if order_mode not in SHELF_ORDER_MODES:
+        order_mode = DEFAULT_SHELF_ORDER_MODE
+
+    if order_mode == 'manual':
+        order_list = settings.get('order') or []
+        # If the user picked manual but never saved an order, fall through
+        # to alphabetical rather than rendering some arbitrary order.
+        if order_list:
+            available_ids = [s.id for s in shelves]
+            normalized = normalize_shelf_order(order_list, available_ids)
+            index = {sid: idx for idx, sid in enumerate(normalized)}
+            shelves.sort(key=lambda s: index.get(s.id, len(index)))
+            return shelves
+
+    if order_mode == 'name_desc':
+        shelves.sort(key=lambda s: (s.name or "").casefold(), reverse=True)
         return shelves
+
+    if order_mode == 'book_count_desc':
+        shelves.sort(key=lambda s: (_shelf_book_count(s), (s.name or "").casefold()),
+                     reverse=True)
+        return shelves
+
+    if order_mode == 'book_count_asc':
+        # Tie-break by name ascending so equal-count shelves are stable.
+        shelves.sort(key=lambda s: (_shelf_book_count(s), (s.name or "").casefold()))
+        return shelves
+
+    if order_mode == 'created_desc':
+        min_dt = datetime.min.replace(tzinfo=timezone.utc)
+        shelves.sort(key=lambda s: (s.created or min_dt, (s.name or "").casefold()),
+                     reverse=True)
+        return shelves
+
+    if order_mode == 'created_asc':
+        max_dt = datetime.max.replace(tzinfo=timezone.utc)
+        shelves.sort(key=lambda s: (s.created or max_dt, (s.name or "").casefold()))
+        return shelves
+
+    if order_mode == 'modified_desc':
+        min_dt = datetime.min.replace(tzinfo=timezone.utc)
+        shelves.sort(key=lambda s: (s.last_modified or min_dt, (s.name or "").casefold()),
+                     reverse=True)
+        return shelves
+
+    if order_mode == 'modified_asc':
+        max_dt = datetime.max.replace(tzinfo=timezone.utc)
+        shelves.sort(key=lambda s: (s.last_modified or max_dt, (s.name or "").casefold()))
+        return shelves
+
+    # Default: name_asc, case-insensitive.
     shelves.sort(key=lambda s: (s.name or "").casefold())
     return shelves
 
@@ -676,11 +754,11 @@ def sort_shelves_for_user(shelves, user):
 @shelf.route("/shelf/reorder", methods=["GET", "POST"])
 @user_login_required
 def reorder_shelves():
-    """Drag-to-reorder UI for the user's accessible regular shelves.
+    """Reorder UI for the user's accessible regular shelves.
 
-    GET renders the list (own + public). POST accepts JSON
-    {"order": [id, id, ...]} and persists it into
-    user.view_settings['shelves']['order'].
+    GET renders an order_mode picker + drag-list for manual mode.
+    POST accepts JSON {"order_mode": "...", "order": [id, id, ...]}
+    and persists into user.view_settings['shelves'].
     """
     accessible = ub.session.query(ub.Shelf).filter(
         (ub.Shelf.is_public == 1) | (ub.Shelf.user_id == current_user.id)
@@ -689,15 +767,27 @@ def reorder_shelves():
 
     if request.method == "POST":
         payload = request.get_json(silent=True) or {}
-        raw_order = payload.get("order")
+        # order_mode is the new contract; if missing, default to manual
+        # (back-compat: pre-modes clients posted just {order:[...]}).
+        order_mode = payload.get("order_mode", "manual")
+        if order_mode not in SHELF_ORDER_MODES:
+            return jsonify(success=False,
+                           error=_("Invalid order mode: %(mode)s", mode=order_mode)), 400
+        raw_order = payload.get("order", [])
         if not isinstance(raw_order, list):
             return jsonify(success=False,
                            error=_("Invalid payload: 'order' must be a list")), 400
         available_ids = [s.id for s in accessible]
-        normalized = normalize_shelf_order(raw_order, available_ids)
+        normalized = normalize_shelf_order(raw_order, available_ids) if order_mode == 'manual' else []
         vs = dict(current_user.view_settings or {})
         shelves_settings = dict(vs.get('shelves', {}))
-        shelves_settings['order'] = normalized
+        shelves_settings['order_mode'] = order_mode
+        # Keep the order list around even for non-manual modes — switching
+        # back to manual later restores the user's previous arrangement.
+        if order_mode == 'manual':
+            shelves_settings['order'] = normalized
+        elif 'order' not in shelves_settings:
+            shelves_settings['order'] = []
         vs['shelves'] = shelves_settings
         current_user.view_settings = vs
         try:
@@ -711,9 +801,25 @@ def reorder_shelves():
             log.error("reorder_shelves: persist failed: %s", ex)
             ub.session.rollback()
             return jsonify(success=False, error=_("Could not save order")), 500
-        return jsonify(success=True, order=normalized), 200
+        return jsonify(success=True, order_mode=order_mode, order=normalized), 200
 
+    current_settings = (getattr(current_user, 'view_settings', None) or {}).get('shelves', {})
+    current_mode = current_settings.get('order_mode', DEFAULT_SHELF_ORDER_MODE)
+    if current_mode not in SHELF_ORDER_MODES:
+        current_mode = DEFAULT_SHELF_ORDER_MODE
     return render_title_template('shelf_reorder.html',
                                  title=_("Reorder Shelves"),
                                  page="shelf_reorder",
-                                 shelves=accessible)
+                                 shelves=accessible,
+                                 current_order_mode=current_mode,
+                                 order_modes=[
+                                     ('name_asc',         _("Name (A → Z)")),
+                                     ('name_desc',        _("Name (Z → A)")),
+                                     ('book_count_desc',  _("Book count (most → fewest)")),
+                                     ('book_count_asc',   _("Book count (fewest → most)")),
+                                     ('created_desc',     _("Created (newest → oldest)")),
+                                     ('created_asc',      _("Created (oldest → newest)")),
+                                     ('modified_desc',    _("Modified (recent → oldest)")),
+                                     ('modified_asc',     _("Modified (oldest → recent)")),
+                                     ('manual',           _("Manual (drag below)")),
+                                 ])

--- a/cps/templates/shelf_reorder.html
+++ b/cps/templates/shelf_reorder.html
@@ -1,28 +1,40 @@
-{# Fork #237 (@new-usemame): drag-to-reorder regular shelves. Mirrors
-   the shelf_order.html shape but operates on the list of shelves the
-   user can access (own + public) rather than the books inside one shelf.
-   Save POSTs JSON {order:[id,...]} to /shelf/reorder. #}
+{# Fork #237 (@new-usemame): drag-to-reorder regular shelves with order_mode
+   picker. Mirrors the magic-shelf order-mode contract. Manual mode posts the
+   drag order; the named modes (name_*, book_count_*, created_*, modified_*)
+   apply server-side. #}
 {% extends "layout.html" %}
 {% block body %}
 <div class="col-sm-8 col-lg-8 col-xs-12">
   <h2>{{ title }}</h2>
-  <div>{{ _('Drag to rearrange the order of your shelves in the sidebar.') }}</div>
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
-  {% if shelves|length == 0 %}
-    <p>{{ _('You do not have any shelves to reorder yet.') }}</p>
-  {% else %}
-    <div id="sortShelves" class="list-group" style="margin-top: 1em;">
-      {% for shelf in shelves %}
-        <div id="shelf-{{ shelf.id }}" data-shelf-id="{{ shelf.id }}" class="list-group-item" style="cursor: move;">
-          <span class="glyphicon glyphicon-list"></span>&nbsp;
-          {{ shelf.name }}
-          {% if shelf.is_public == 1 %}
-            <span style="font-size: 80%; color: #888;">{{ _('(Public)') }}</span>
-          {% endif %}
-        </div>
+  <div style="margin-top: 1em;">
+    <label for="orderModeSelect"><strong>{{ _('Sort by') }}:</strong></label>
+    <select id="orderModeSelect" class="form-control" style="display: inline-block; width: auto; margin-left: 0.5em;">
+      {% for value, label in order_modes %}
+        <option value="{{ value }}"{% if value == current_order_mode %} selected{% endif %}>{{ label }}</option>
       {% endfor %}
+    </select>
+  </div>
+
+  {% if shelves|length == 0 %}
+    <p style="margin-top: 1em;">{{ _('You do not have any shelves to reorder yet.') }}</p>
+  {% else %}
+    <div id="manualSection" style="margin-top: 1em;{% if current_order_mode != 'manual' %} display: none;{% endif %}">
+      <div>{{ _('Drag to rearrange the order of your shelves in the sidebar.') }}</div>
+      <div id="sortShelves" class="list-group" style="margin-top: 0.6em;">
+        {% for shelf in shelves %}
+          <div id="shelf-{{ shelf.id }}" data-shelf-id="{{ shelf.id }}" class="list-group-item" style="cursor: move;">
+            <span class="glyphicon glyphicon-list"></span>&nbsp;
+            {{ shelf.name }}
+            {% if shelf.is_public == 1 %}
+              <span style="font-size: 80%; color: #888;">{{ _('(Public)') }}</span>
+            {% endif %}
+          </div>
+        {% endfor %}
+      </div>
     </div>
+
     <button id="saveOrderBtn" class="btn btn-default" style="margin-top: 1em;">{{ _('Save') }}</button>
     <a href="{{ url_for('web.index') }}" class="btn btn-default" style="margin-top: 1em;">{{ _('Back') }}</a>
     <div id="saveOrderFeedback" style="margin-top: 0.5em;"></div>
@@ -37,22 +49,35 @@
     var listEl = document.getElementById('sortShelves');
     var saveBtn = document.getElementById('saveOrderBtn');
     var feedback = document.getElementById('saveOrderFeedback');
-    if (!listEl || !saveBtn) return;
+    var modeSelect = document.getElementById('orderModeSelect');
+    var manualSection = document.getElementById('manualSection');
+    if (!saveBtn || !modeSelect) return;
 
-    new Sortable(listEl, { animation: 150 });
+    if (listEl) {
+      new Sortable(listEl, { animation: 150 });
+    }
+
+    function syncManualVisibility() {
+      if (!manualSection) return;
+      manualSection.style.display = modeSelect.value === 'manual' ? '' : 'none';
+    }
+    modeSelect.addEventListener('change', syncManualVisibility);
 
     saveBtn.addEventListener('click', function () {
-      var ids = Array.prototype.map.call(
-        listEl.querySelectorAll('[data-shelf-id]'),
-        function (el) { return parseInt(el.getAttribute('data-shelf-id'), 10); }
-      );
+      var mode = modeSelect.value;
+      var ids = listEl
+        ? Array.prototype.map.call(
+            listEl.querySelectorAll('[data-shelf-id]'),
+            function (el) { return parseInt(el.getAttribute('data-shelf-id'), 10); }
+          )
+        : [];
       saveBtn.disabled = true;
       feedback.textContent = '';
       $.ajax({
         url: '{{ url_for("shelf.reorder_shelves") }}',
         method: 'POST',
         contentType: 'application/json',
-        data: JSON.stringify({ order: ids }),
+        data: JSON.stringify({ order_mode: mode, order: ids }),
         success: function () {
           feedback.style.color = 'green';
           feedback.textContent = '{{ _("Order saved. The sidebar reflects the new order on next page load.") }}';

--- a/cps/translations/ar/LC_MESSAGES/messages.po
+++ b/cps/translations/ar/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2025-06-07 14:44+0300\n"
 "Last-Translator: UsamaFoad <usamafoad@gmail.com>\n"
 "Language-Team: \n"
@@ -2229,18 +2229,59 @@ msgstr "الرف: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "خطأ في فتح الرف. الرف غير موجود أو غير قابل للوصول"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "استبعاد الرفوف"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2901,7 +2942,7 @@ msgstr "إضافة إلى الرف"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(عام)"
 
@@ -3648,7 +3689,7 @@ msgstr "جلب البيانات الوصفية"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "حفظ"
 
@@ -6439,7 +6480,7 @@ msgid "Save and Send Test Email"
 msgstr "حفظ وإرسال بريد إلكتروني اختباري"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "رجوع"
@@ -7437,19 +7478,23 @@ msgstr "اسحب لإعادة ترتيب الترتيب"
 msgid "Hidden Book"
 msgstr "كتاب مخفي"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/cs/LC_MESSAGES/messages.po
+++ b/cps/translations/cs/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2020-06-09 21:11+0100\n"
 "Last-Translator: Lukas Heroudek <lukas.heroudek@gmail.com>\n"
 "Language-Team: \n"
@@ -2241,18 +2241,59 @@ msgstr "Police: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Chyba otevírání police. Police neexistuje nebo není přístupná"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Vynechat série"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2929,7 +2970,7 @@ msgstr "Přidat do police"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Veřejné)"
 
@@ -3682,7 +3723,7 @@ msgstr "Získat metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Uložit"
 
@@ -6501,7 +6542,7 @@ msgid "Save and Send Test Email"
 msgstr "Uložit nastavení a odeslat zkušební e-mail"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Zpět"
@@ -7528,19 +7569,23 @@ msgstr "Přetažením uspořádáte pořadí"
 msgid "Hidden Book"
 msgstr "Skrytá kniha"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2026-04-06 17:03+0000\n"
 "Last-Translator: Manuel Drescher\n"
 "Language-Team: German\n"
@@ -2308,17 +2308,58 @@ msgstr ""
 "Fehler beim Öffnen des Regals. Regal exisitert nicht oder ist nicht "
 "zugänglich"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr "Ungültiger Sortiermodus: %(mode)s"
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr "Reihenfolge konnte nicht gespeichert werden"
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 msgid "Reorder Shelves"
 msgstr "Regale neu anordnen"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr "Name (A → Z)"
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr "Name (Z → A)"
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr "Buchanzahl (meiste → wenigste)"
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr "Buchanzahl (wenigste → meiste)"
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr "Erstellt (neueste → älteste)"
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr "Erstellt (älteste → neueste)"
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr "Geändert (letzte → älteste)"
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr "Geändert (älteste → letzte)"
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr "Manuell (unten ziehen)"
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2984,7 +3025,7 @@ msgstr "Zu Regal hinzufügen"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Öffentlich)"
 
@@ -3725,7 +3766,7 @@ msgstr "Metadaten laden"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Speichern"
 
@@ -6682,7 +6723,7 @@ msgid "Save and Send Test Email"
 msgstr "Einstellungen speichern und Test-E-Mail versenden"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Zurück"
@@ -7691,19 +7732,25 @@ msgstr "Ziehen und ablegen um Reihenfolge zu ändern"
 msgid "Hidden Book"
 msgstr "Verstecktes Buch"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
-msgstr "Ziehen, um die Reihenfolge der Regale in der Seitenleiste zu ändern."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
+msgstr "Sortieren nach"
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr "Sie haben noch keine Regale zum Neuanordnen."
 
-#: cps/templates/shelf_reorder.html:58
-msgid "Order saved. The sidebar reflects the new order on next page load."
-msgstr "Reihenfolge gespeichert. Die Seitenleiste wird beim nächsten Seitenaufruf aktualisiert."
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr "Ziehen, um die Reihenfolge der Regale in der Seitenleiste zu ändern."
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:83
+msgid "Order saved. The sidebar reflects the new order on next page load."
+msgstr ""
+"Reihenfolge gespeichert. Die Seitenleiste wird beim nächsten Seitenaufruf "
+"aktualisiert."
+
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr "Reihenfolge konnte nicht gespeichert werden."
 

--- a/cps/translations/el/LC_MESSAGES/messages.po
+++ b/cps/translations/el/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2025-09-03 14:59+0200\n"
 "Last-Translator: Depountis Georgios\n"
 "Language-Team: \n"
@@ -2286,18 +2286,59 @@ msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Σφάλμα κατά το άνοιγμα του ραφιού. Το ράφι δεν υπάρχει ή δεν είναι προσβάσιμο"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Εξαίρεση Σειρών"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2990,7 +3031,7 @@ msgstr "Προσθήκη στο ράφι"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Δημόσιο)"
 
@@ -3742,7 +3783,7 @@ msgstr "Συγκέντρωση Μεταδεδομένων"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Αποθήκευση"
 
@@ -6563,7 +6604,7 @@ msgid "Save and Send Test Email"
 msgstr "Αποθήκευση και Αποστολή E-mail Δοκιμής"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Πίσω"
@@ -7592,19 +7633,23 @@ msgstr "Σύρε για Αναδιάταξη Σειράς"
 msgid "Hidden Book"
 msgstr "Κρυμμένο Βιβλίο"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/es/LC_MESSAGES/messages.po
+++ b/cps/translations/es/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2025-11-17 12:21-0300\n"
 "Last-Translator: minakmostoles <xxx@xxx.com>\n"
 "Language-Team: es <LL@li.org>\n"
@@ -2338,18 +2338,66 @@ msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Error al abrir una estantería. La estantería no existe o no es accesible"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Excluir Estanterías"
+
+#: cps/shelf.py:816
+#, fuzzy
+msgid "Name (A → Z)"
+msgstr "Nombre (A-Z)"
+
+#: cps/shelf.py:817
+#, fuzzy
+msgid "Name (Z → A)"
+msgstr "Nombre (Z-A)"
+
+#: cps/shelf.py:818
+#, fuzzy
+msgid "Book count (most → fewest)"
+msgstr "Cantidad de libros (de mayor a menor)"
+
+#: cps/shelf.py:819
+#, fuzzy
+msgid "Book count (fewest → most)"
+msgstr "Cantidad de libros (de mayor a menor)"
+
+#: cps/shelf.py:820
+#, fuzzy
+msgid "Created (newest → oldest)"
+msgstr "Creado (más reciente primero)"
+
+#: cps/shelf.py:821
+#, fuzzy
+msgid "Created (oldest → newest)"
+msgstr "Creado (el más antiguo primero)"
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+#, fuzzy
+msgid "Manual (drag below)"
+msgstr "Manual (arrastra para reordenar)"
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -3041,7 +3089,7 @@ msgstr "Agregar a la estantería"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Público)"
 
@@ -3787,7 +3835,7 @@ msgstr "Obtener Metadatos"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Guardar"
 
@@ -6816,7 +6864,7 @@ msgid "Save and Send Test Email"
 msgstr "Guardar y enviar un correo electrónico de prueba"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Regresar"
@@ -7848,19 +7896,23 @@ msgstr "Arrastra para Reorganizar"
 msgid "Hidden Book"
 msgstr "Libro Oculto"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/fi/LC_MESSAGES/messages.po
+++ b/cps/translations/fi/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2020-01-12 13:56+0100\n"
 "Last-Translator: Samuli Valavuo <svalavuo@gmail.com>\n"
 "Language-Team: \n"
@@ -2239,18 +2239,59 @@ msgstr "Hylly: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Virhe hyllyn avauksessa. Hyllyä ei ole tai se ei ole saatavilla"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Poissulje sarja"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2917,7 +2958,7 @@ msgstr "Lisää hyllyyn"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr ""
 
@@ -3673,7 +3714,7 @@ msgstr "Hae metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr ""
 
@@ -6493,7 +6534,7 @@ msgid "Save and Send Test Email"
 msgstr "Tallenna asetukset ja testaa sähköpostia"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Palaa"
@@ -7521,19 +7562,23 @@ msgstr "Vedä ja pudota muuttaaksesi järjestystä"
 msgid "Hidden Book"
 msgstr "Näytä ekirjat"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -25,7 +25,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2025-11-17 21:51+0100\n"
 "Last-Translator: Tex <tex@grosist.fr>\n"
 "Language-Team: \n"
@@ -2378,18 +2378,66 @@ msgstr ""
 "Erreur à l’ouverture de l’étagère. Elle n’existe plus ou n’est plus "
 "accessible"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Etagères exclues"
+
+#: cps/shelf.py:816
+#, fuzzy
+msgid "Name (A → Z)"
+msgstr "Nom (A-Z)"
+
+#: cps/shelf.py:817
+#, fuzzy
+msgid "Name (Z → A)"
+msgstr "Nom (Z-A)"
+
+#: cps/shelf.py:818
+#, fuzzy
+msgid "Book count (most → fewest)"
+msgstr "Nombre de livres (décroissant)"
+
+#: cps/shelf.py:819
+#, fuzzy
+msgid "Book count (fewest → most)"
+msgstr "Nombre de livres (décroissant)"
+
+#: cps/shelf.py:820
+#, fuzzy
+msgid "Created (newest → oldest)"
+msgstr "Création (plus récent en premier)"
+
+#: cps/shelf.py:821
+#, fuzzy
+msgid "Created (oldest → newest)"
+msgstr "Création (plus ancien en premier)"
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+#, fuzzy
+msgid "Manual (drag below)"
+msgstr "Manuel (glisser pour réorganiser)"
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -3058,7 +3106,7 @@ msgstr "Ajouter à l'étagère"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Public)"
 
@@ -3804,7 +3852,7 @@ msgstr "Obtenir les métadonnées"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Sauvegarder"
 
@@ -6792,7 +6840,7 @@ msgid "Save and Send Test Email"
 msgstr "Sauvegarder les réglages et tester l’envoi d’un courriel"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Retour"
@@ -7804,19 +7852,23 @@ msgstr "Glisser-déposer pour modifier l’ordre"
 msgid "Hidden Book"
 msgstr "Livre caché"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/gl/LC_MESSAGES/messages.po
+++ b/cps/translations/gl/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2022-08-11 16:46+0200\n"
 "Last-Translator: pollitor <pollitor@gmx.com>\n"
 "Language-Team: gl\n"
@@ -2275,18 +2275,59 @@ msgstr "Andel: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Erro ao abrir un andel. O andel non existe ou non se pode acceder"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Excluir andeis"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2972,7 +3013,7 @@ msgstr "Engadir ao andel"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Público)"
 
@@ -3723,7 +3764,7 @@ msgstr "Obter metadatos"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Gardar"
 
@@ -6546,7 +6587,7 @@ msgid "Save and Send Test Email"
 msgstr "Gardar e enviar un correo electrónico de proba"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Voltar"
@@ -7564,19 +7605,23 @@ msgstr "Arrastra para reorganizar a orde"
 msgid "Hidden Book"
 msgstr "Libro agochado"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/hu/LC_MESSAGES/messages.po
+++ b/cps/translations/hu/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2026-05-12 00:06+0200\n"
 "Last-Translator: Gabor L. <nom@il.thx>\n"
 "Language-Team: \n"
@@ -2294,17 +2294,58 @@ msgstr "Polc: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Hiba a polc megnyitásakor. A polc nem létezik vagy nem elérhető"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr "Érvénytelen rendezési mód: %(mode)s"
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr "Nem sikerült menteni a sorrendet"
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 msgid "Reorder Shelves"
 msgstr "Polcok átrendezése"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr "Név (A → Z)"
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr "Név (Z → A)"
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr "Könyvek száma (legtöbb → legkevesebb)"
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr "Könyvek száma (legkevesebb → legtöbb)"
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr "Létrehozva (legújabb → legrégebbi)"
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr "Létrehozva (legrégebbi → legújabb)"
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr "Módosítva (legutóbbi → legrégebbi)"
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr "Módosítva (legrégebbi → legutóbbi)"
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr "Kézi (húzd át alább)"
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2967,7 +3008,7 @@ msgstr "Hozzáadás polchoz"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Nyilvános)"
 
@@ -3710,7 +3751,7 @@ msgstr "Metaadatok beszerzése"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Mentés"
 
@@ -6659,7 +6700,7 @@ msgid "Save and Send Test Email"
 msgstr "Mentés és teszt e-mail küldése"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Vissza"
@@ -7663,19 +7704,23 @@ msgstr "Húzd és dob a sorrend változtatásához"
 msgid "Hidden Book"
 msgstr "Rejtett könyvek"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
-msgstr "Húzd át a polcokat a kívánt sorrend kialakításához az oldalsávban."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
+msgstr "Rendezés"
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr "Még nincs átrendezhető polc."
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr "Húzd át a polcokat a kívánt sorrend kialakításához az oldalsávban."
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr "Sorrend mentve. Az oldalsáv a következő oldalbetöltéskor frissül."
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr "Nem sikerült menteni a sorrendet."
 

--- a/cps/translations/id/LC_MESSAGES/messages.po
+++ b/cps/translations/id/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2023-01-21 10:00+0700\n"
 "Last-Translator: Arief Hidayat<arihid95@gmail.com>\n"
 "Language-Team: Arief Hidayat <arihid95@gmail.com>\n"
@@ -2265,18 +2265,59 @@ msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Terjadi kesalahan saat membuka rak. Rak tidak ada atau tidak dapat diakses"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Kecualikan Rak"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2952,7 +2993,7 @@ msgstr "Tambah ke rak"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Publik)"
 
@@ -3703,7 +3744,7 @@ msgstr "Ambil Metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Simpan"
 
@@ -6515,7 +6556,7 @@ msgid "Save and Send Test Email"
 msgstr "Simpan dan Kirim Email Percobaan"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Kembali"
@@ -7531,19 +7572,23 @@ msgstr "Seret untuk Mengatur Ulang Urutan"
 msgid "Hidden Book"
 msgstr "Buku Tersembunyi"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/it/LC_MESSAGES/messages.po
+++ b/cps/translations/it/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2025-11-24 17:12+0100\n"
 "Last-Translator: Massimo Pissarello <mapi68@gmail.com>\n"
 "Language-Team: Italian\n"
@@ -2271,18 +2271,59 @@ msgstr ""
 "Errore nell'apertura dello scaffale. Lo scaffale non esiste o non è "
 "accessibile"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Escludi scaffali"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2954,7 +2995,7 @@ msgstr "Aggiungi allo scaffale"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Pubblico)"
 
@@ -3697,7 +3738,7 @@ msgstr "Recupera i metadati"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Salva"
 
@@ -6550,7 +6591,7 @@ msgid "Save and Send Test Email"
 msgstr "Salva e invia e-mail di prova"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Indietro"
@@ -7556,19 +7597,23 @@ msgstr "Trascina per riordinare"
 msgid "Hidden Book"
 msgstr "Libro nascosto"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/ja/LC_MESSAGES/messages.po
+++ b/cps/translations/ja/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2018-02-07 02:20-0500\n"
 "Last-Translator: subdiox <subdiox@gmail.com>\n"
 "Language-Team: ja <LL@li.org>\n"
@@ -2272,18 +2272,66 @@ msgstr "本棚: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "本棚を開けません。この本棚は存在しないかアクセスできません"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "除外する本棚"
+
+#: cps/shelf.py:816
+#, fuzzy
+msgid "Name (A → Z)"
+msgstr "名前（A-Z）"
+
+#: cps/shelf.py:817
+#, fuzzy
+msgid "Name (Z → A)"
+msgstr "名前（Z-A）"
+
+#: cps/shelf.py:818
+#, fuzzy
+msgid "Book count (most → fewest)"
+msgstr "書籍数（多い順）"
+
+#: cps/shelf.py:819
+#, fuzzy
+msgid "Book count (fewest → most)"
+msgstr "書籍数（多い順）"
+
+#: cps/shelf.py:820
+#, fuzzy
+msgid "Created (newest → oldest)"
+msgstr "作成日（新しい順）"
+
+#: cps/shelf.py:821
+#, fuzzy
+msgid "Created (oldest → newest)"
+msgstr "作成日（古い順）"
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+#, fuzzy
+msgid "Manual (drag below)"
+msgstr "手動（ドラッグで並び替え）"
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2959,7 +3007,7 @@ msgstr "本棚に追加"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(公開)"
 
@@ -3700,7 +3748,7 @@ msgstr "メタデータを取得"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "保存"
 
@@ -6621,7 +6669,7 @@ msgid "Save and Send Test Email"
 msgstr "保存してテストメールを送信"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "戻る"
@@ -7643,19 +7691,23 @@ msgstr "ドラッグして並び順を変更"
 msgid "Hidden Book"
 msgstr "非表示の本"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/km/LC_MESSAGES/messages.po
+++ b/cps/translations/km/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2018-08-27 17:06+0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -2219,18 +2219,59 @@ msgstr "ធ្នើ៖ ‘%(name)s’"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "មានបញ្ហាពេលបើកធ្នើ។ ពុំមានធ្នើ ឬមិនអាចបើកបាន"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "លើកលែងស៊េរី"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2883,7 +2924,7 @@ msgstr "បន្ថែមទៅធ្នើ"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr ""
 
@@ -3636,7 +3677,7 @@ msgstr "មើលទិន្នន័យមេតា"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr ""
 
@@ -6441,7 +6482,7 @@ msgid "Save and Send Test Email"
 msgstr "ឧបករណ៍ Kindle"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "មកក្រោយ"
@@ -7465,19 +7506,23 @@ msgstr "ទាញដើម្បីប្តូរលំដាប់"
 msgid "Hidden Book"
 msgstr "សៀវភៅដែលមានប្រជាប្រិយភាព"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/ko/LC_MESSAGES/messages.po
+++ b/cps/translations/ko/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2025-09-08 00:53+0900\n"
 "Last-Translator: limeade23 <admin@limeade.me>\n"
 "Language-Team: Korean <>\n"
@@ -2204,18 +2204,59 @@ msgstr ""
 "서재를 여는 동안 오류가 발생했습니다. 서재가 존재하지 않거나 접근할 수 없습니"
 "다"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "서재 제외"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2882,7 +2923,7 @@ msgstr "책장에 추가"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(공개)"
 
@@ -3623,7 +3664,7 @@ msgstr "메타데이터 가져오기"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "저장"
 
@@ -6431,7 +6472,7 @@ msgid "Save and Send Test Email"
 msgstr "저장 및 테스트 메일 전송"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "뒤로"
@@ -7429,19 +7470,23 @@ msgstr "드래그하여 순서 변경"
 msgid "Hidden Book"
 msgstr "숨긴 책"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web (GPLV3)\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2026-04-26 13:31+0200\n"
 "Last-Translator: Michiel Cornelissen <michiel.cornelissen+gitbhun at "
 "proton.me>\n"
@@ -2276,18 +2276,59 @@ msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Kan boekenplank niet openen: de boekenplank bestaat niet of is ontoegankelijk"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Boekenplanken uitsluiten"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2953,7 +2994,7 @@ msgstr "Toevoegen aan boekenplank"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Openbaar)"
 
@@ -3702,7 +3743,7 @@ msgstr "Metagegevens ophalen"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Opslaan"
 
@@ -6521,7 +6562,7 @@ msgid "Save and Send Test Email"
 msgstr "Opslaan en test-e-mail versturen"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Annuleren"
@@ -7528,19 +7569,23 @@ msgstr "Pas de volgorde aan middels slepen-en-neerzetten"
 msgid "Hidden Book"
 msgstr "Verborgen boek"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/no/LC_MESSAGES/messages.po
+++ b/cps/translations/no/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2023-01-06 11:00+0000\n"
 "Last-Translator: Vegard Fladby <vegard.fladby@gmail.com>\n"
 "Language-Team: \n"
@@ -2272,18 +2272,59 @@ msgstr "Hylle: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Feil ved åpning av hylle. Hylle finnes ikke eller er ikke tilgjengelig"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Skriv inn Språk"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2960,7 +3001,7 @@ msgstr "Rediger en hylle"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 #, fuzzy
 msgid "(Public)"
 msgstr "Offentlig hylle"
@@ -3716,7 +3757,7 @@ msgstr "Hent metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Lagre"
 
@@ -6530,7 +6571,7 @@ msgid "Save and Send Test Email"
 msgstr "Send til E-Reader E-postadresse"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr ""
@@ -7577,19 +7618,23 @@ msgstr ""
 msgid "Hidden Book"
 msgstr "Se bøker"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/pl/LC_MESSAGES/messages.po
+++ b/cps/translations/pl/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre Web - polski (POT: 2021-06-12 08:52)\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2021-06-12 15:35+0200\n"
 "Last-Translator: Radosław Kierznowski <radek.kierznowski@outlook.com>\n"
 "Language-Team: \n"
@@ -2265,18 +2265,59 @@ msgstr "Półka: „%(name)s”"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Błąd otwierania półki. Półka nie istnieje lub jest niedostępna"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Z wyłączeniem półek"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2954,7 +2995,7 @@ msgstr "Dodaj do półki"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(publiczna)"
 
@@ -3702,7 +3743,7 @@ msgstr "Uzyskaj metadane"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Zapisz"
 
@@ -6540,7 +6581,7 @@ msgid "Save and Send Test Email"
 msgstr "Zapisz i wyślij testowy e-mail"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Wróć"
@@ -7552,19 +7593,23 @@ msgstr "Przeciągnij i upuść, aby zmienić kolejność"
 msgid "Hidden Book"
 msgstr "Ukryta książka"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/pt/LC_MESSAGES/messages.po
+++ b/cps/translations/pt/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2023-07-25 11:30+0100\n"
 "Last-Translator: horus68 <https://github.com/horus68>\n"
 "Language-Team: pt-PT <>\n"
@@ -2295,18 +2295,59 @@ msgstr "Estante: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Erro ao abrir estante. A estante não existe ou não está acessível"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Excluir estante"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2998,7 +3039,7 @@ msgstr "Adicionar à estante"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Público)"
 
@@ -3748,7 +3789,7 @@ msgstr "Obter metadados"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Guardar"
 
@@ -6573,7 +6614,7 @@ msgid "Save and Send Test Email"
 msgstr "Guardar e enviar email de teste"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Voltar"
@@ -7595,19 +7636,23 @@ msgstr "Arrastar para reordenar"
 msgid "Hidden Book"
 msgstr "Livro oculto"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/cps/translations/pt_BR/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2025-12-02 12:00+0000\n"
 "Last-Translator: Alex <298750+alexantao@users.noreply.github.com>\n"
 "Language-Team: pt_BR <LL@li.org>\n"
@@ -2293,18 +2293,59 @@ msgstr "Estante: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Erro ao abrir estante. A estante não existe ou não está acessível"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Excluir Estante"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2994,7 +3035,7 @@ msgstr "Adicionar à estante"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Público)"
 
@@ -3748,7 +3789,7 @@ msgstr "Buscar Metadados"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Salvar"
 
@@ -6631,7 +6672,7 @@ msgid "Save and Send Test Email"
 msgstr "Salvar e enviar e-mail de teste"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Voltar"
@@ -7656,19 +7697,23 @@ msgstr "Arrastar para Reorganizar a Ordem"
 msgid "Hidden Book"
 msgstr "Livro Escondido"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/ru/LC_MESSAGES/messages.po
+++ b/cps/translations/ru/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2020-04-29 01:20+0400\n"
 "Last-Translator: ZIZA\n"
 "Language-Team: \n"
@@ -2319,18 +2319,59 @@ msgstr "Полка: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Ошибка открытия полки. Полка не существует или недоступна"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Исключить полки"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -3019,7 +3060,7 @@ msgstr "Добавить на полку"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Публичная)"
 
@@ -3776,7 +3817,7 @@ msgstr "Получить метаданные"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Сохранить"
 
@@ -6668,7 +6709,7 @@ msgid "Save and Send Test Email"
 msgstr "Сохранить и отправить тестовое письмо"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Назад"
@@ -7705,19 +7746,23 @@ msgstr "Перетащите для изменения порядка"
 msgid "Hidden Book"
 msgstr "Скрытая книга"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/sk/LC_MESSAGES/messages.po
+++ b/cps/translations/sk/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2023-11-01 06:12+0100\n"
 "Last-Translator: Branislav Hanáček <brango@brango.sk>\n"
 "Language-Team: \n"
@@ -2249,18 +2249,59 @@ msgstr "Polica: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Chyba pri otváraní police. Polica neexistuje alebo je neprístupná"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Vylúčiť police"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2931,7 +2972,7 @@ msgstr "Pridať do police"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Verejné)"
 
@@ -3678,7 +3719,7 @@ msgstr "Načítať metadáta"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Uložiť"
 
@@ -6487,7 +6528,7 @@ msgid "Save and Send Test Email"
 msgstr "Uložiť a poslať testovací e-mail"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Naspäť"
@@ -7501,19 +7542,23 @@ msgstr "Potiahnite pre zmenu poradia"
 msgid "Hidden Book"
 msgstr "Skryté chyby"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/sl/LC_MESSAGES/messages.po
+++ b/cps/translations/sl/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2025-08-11 07:03+0000\n"
 "Last-Translator: Andrej Kralj\n"
 "Language-Team: Slovenian\n"
@@ -2310,18 +2310,59 @@ msgstr "Polica: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Napaka pri odpiranju police. Polica ne obstaja ali ni dostopna"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Izključi police"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2996,7 +3037,7 @@ msgstr "Dodaj na polico"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Javno)"
 
@@ -3748,7 +3789,7 @@ msgstr "Pridobivanje metapodatkov"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Shrani"
 
@@ -6733,7 +6774,7 @@ msgid "Save and Send Test Email"
 msgstr "Shrani in pošlji testno e-pošto"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Nazaj"
@@ -7757,19 +7798,23 @@ msgstr "Povlecite, da spremenite vrstni red"
 msgid "Hidden Book"
 msgstr "Skrita knjiga"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/sv/LC_MESSAGES/messages.po
+++ b/cps/translations/sv/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2021-05-13 11:00+0000\n"
 "Last-Translator: Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>\n"
 "Language-Team: \n"
@@ -2263,18 +2263,59 @@ msgstr "Hylla: '%(name)s'"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "Fel vid öppning av hyllan. Hylla finns inte eller är inte tillgänglig"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Uteslut hyllor"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2951,7 +2992,7 @@ msgstr "Lägg till hyllan"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Publik)"
 
@@ -3704,7 +3745,7 @@ msgstr "Hämta metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Spara"
 
@@ -6516,7 +6557,7 @@ msgid "Save and Send Test Email"
 msgstr "Spara inställningarna och skicka test-e-post"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Tillbaka"
@@ -7539,19 +7580,23 @@ msgstr "Drag och släpp för att ändra ordning"
 msgid "Hidden Book"
 msgstr "Dold bok"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/tr/LC_MESSAGES/messages.po
+++ b/cps/translations/tr/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2020-04-23 22:47+0300\n"
 "Last-Translator: iz <iz7iz7iz@protonmail.ch>\n"
 "Language-Team: \n"
@@ -2237,18 +2237,59 @@ msgstr ""
 "Kitaplık açılırken hata oluştu. Kitaplık mevcut değil ya da erişilebilir "
 "değil"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Serileri Hariç Tut"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2914,7 +2955,7 @@ msgstr "Kitaplığa ekle"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr ""
 
@@ -3683,7 +3724,7 @@ msgstr "metaveri düzenle"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr ""
 
@@ -6495,7 +6536,7 @@ msgid "Save and Send Test Email"
 msgstr "E-Posta adresiniz"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Geri"
@@ -7515,19 +7556,23 @@ msgstr ""
 msgid "Hidden Book"
 msgstr "Popüler"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/uk/LC_MESSAGES/messages.po
+++ b/cps/translations/uk/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2017-04-30 00:47+0300\n"
 "Last-Translator: ABIS Team <biblio.if.abis@gmail.com>\n"
 "Language-Team: \n"
@@ -2230,18 +2230,59 @@ msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 "Помилка при відкриванні полиці. Полиця не існує або до неї відсутній доступ"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Виключити серії"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2899,7 +2940,7 @@ msgstr "Додати на книжкову полицю"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Публічно)"
 
@@ -3658,7 +3699,7 @@ msgstr "Отримати метадані"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Зберегти"
 
@@ -6470,7 +6511,7 @@ msgid "Save and Send Test Email"
 msgstr "Kindle"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Назад"
@@ -7503,19 +7544,23 @@ msgstr "Перетягніть для змінення порядку"
 msgid "Hidden Book"
 msgstr "Популярні книги"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/vi/LC_MESSAGES/messages.po
+++ b/cps/translations/vi/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2022-09-20 21:36+0700\n"
 "Last-Translator: Ha Link <halink0803@gmail.com>\n"
 "Language-Team: \n"
@@ -2223,18 +2223,59 @@ msgstr ""
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Giá sách"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2902,7 +2943,7 @@ msgstr "Thêm vào giá sách"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(Công khai)"
 
@@ -3652,7 +3693,7 @@ msgstr "Fetch Metadata"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "Lưu"
 
@@ -6467,7 +6508,7 @@ msgid "Save and Send Test Email"
 msgstr "Lưu và gửi test E-mail"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "Quay lại"
@@ -7490,19 +7531,23 @@ msgstr "Kéo để thay đổi lại thứ tự"
 msgid "Hidden Book"
 msgstr "Sách ẩn"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2020-09-27 22:18+0800\n"
 "Last-Translator: xlivevil <xlivevil@aliyun.com>\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
@@ -2208,18 +2208,59 @@ msgstr "书架：%(name)s"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "打开书架出错。书架不存在或不可访问"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "排除书架"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2881,7 +2922,7 @@ msgstr "添加到书架"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(公共)"
 
@@ -3629,7 +3670,7 @@ msgstr "获取元数据"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "保存"
 
@@ -6452,7 +6493,7 @@ msgid "Save and Send Test Email"
 msgstr "保存设置并发送测试邮件"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "后退"
@@ -7461,19 +7502,23 @@ msgstr "拖拽以重新排序"
 msgid "Hidden Book"
 msgstr "隐藏书籍"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 14:39-0400\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: 2020-09-27 22:18+0800\n"
 "Last-Translator: xlivevil <xlivevil@aliyun.com>\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
@@ -2223,18 +2223,59 @@ msgstr "書架：%(name)s"
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr "打開書架出錯。書架不存在或不可訪問"
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "排除書架"
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
+msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
 #: cps/templates/tasks.html:7
@@ -2905,7 +2946,7 @@ msgstr "添加到書架"
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr "(公共)"
 
@@ -3655,7 +3696,7 @@ msgstr "獲取元數據"
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr "儲存"
 
@@ -6464,7 +6505,7 @@ msgid "Save and Send Test Email"
 msgstr "保存設置並發送測試郵件"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr "後退"
@@ -7474,19 +7515,23 @@ msgstr "拖拽以重新排序"
 msgid "Hidden Book"
 msgstr "隱藏書籍"
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/messages.pot
+++ b/messages.pot
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web Automated v4.0.6\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-05-21 18:49+0000\n"
+"POT-Creation-Date: 2026-05-21 15:09-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2159,16 +2159,57 @@ msgstr ""
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
 msgstr ""
 
-#: cps/shelf.py:695
+#: cps/shelf.py:775
+#, python-format
+msgid "Invalid order mode: %(mode)s"
+msgstr ""
+
+#: cps/shelf.py:779
 msgid "Invalid payload: 'order' must be a list"
 msgstr ""
 
-#: cps/shelf.py:713
+#: cps/shelf.py:803
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:717 cps/templates/layout.html:352
+#: cps/shelf.py:811 cps/templates/layout.html:352
 msgid "Reorder Shelves"
+msgstr ""
+
+#: cps/shelf.py:816
+msgid "Name (A → Z)"
+msgstr ""
+
+#: cps/shelf.py:817
+msgid "Name (Z → A)"
+msgstr ""
+
+#: cps/shelf.py:818
+msgid "Book count (most → fewest)"
+msgstr ""
+
+#: cps/shelf.py:819
+msgid "Book count (fewest → most)"
+msgstr ""
+
+#: cps/shelf.py:820
+msgid "Created (newest → oldest)"
+msgstr ""
+
+#: cps/shelf.py:821
+msgid "Created (oldest → newest)"
+msgstr ""
+
+#: cps/shelf.py:822
+msgid "Modified (recent → oldest)"
+msgstr ""
+
+#: cps/shelf.py:823
+msgid "Modified (oldest → recent)"
+msgstr ""
+
+#: cps/shelf.py:824
+msgid "Manual (drag below)"
 msgstr ""
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:195
@@ -2792,7 +2833,7 @@ msgstr ""
 #: cps/templates/feed.xml:111 cps/templates/layout.html:346
 #: cps/templates/layout.html:359 cps/templates/listenmp3.html:201
 #: cps/templates/listenmp3.html:218 cps/templates/search.html:23
-#: cps/templates/shelf_reorder.html:21
+#: cps/templates/shelf_reorder.html:31
 msgid "(Public)"
 msgstr ""
 
@@ -3518,7 +3559,7 @@ msgstr ""
 #: cps/templates/config_edit.html:659 cps/templates/config_view_edit.html:220
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:47
 #: cps/templates/shelf_edit.html:36 cps/templates/shelf_order.html:41
-#: cps/templates/shelf_reorder.html:26 cps/templates/user_edit.html:578
+#: cps/templates/shelf_reorder.html:38 cps/templates/user_edit.html:578
 msgid "Save"
 msgstr ""
 
@@ -6214,7 +6255,7 @@ msgid "Save and Send Test Email"
 msgstr ""
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:126
-#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:27
+#: cps/templates/shelf_order.html:42 cps/templates/shelf_reorder.html:39
 #: cps/templates/user_table.html:176
 msgid "Back"
 msgstr ""
@@ -7177,19 +7218,23 @@ msgstr ""
 msgid "Hidden Book"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:9
-msgid "Drag to rearrange the order of your shelves in the sidebar."
+#: cps/templates/shelf_reorder.html:12
+msgid "Sort by"
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:13
+#: cps/templates/shelf_reorder.html:21
 msgid "You do not have any shelves to reorder yet."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:58
+#: cps/templates/shelf_reorder.html:24
+msgid "Drag to rearrange the order of your shelves in the sidebar."
+msgstr ""
+
+#: cps/templates/shelf_reorder.html:83
 msgid "Order saved. The sidebar reflects the new order on next page load."
 msgstr ""
 
-#: cps/templates/shelf_reorder.html:63
+#: cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 

--- a/tests/unit/test_237_shelf_reorder.py
+++ b/tests/unit/test_237_shelf_reorder.py
@@ -191,3 +191,110 @@ def test_reorder_template_uses_sortable():
     src = REORDER_HTML.read_text()
     assert "Sortable" in src, "template must reference SortableJS"
     assert "/shelf/reorder" in src or "shelf.reorder_shelves" in src
+
+
+# ---------------------------------------------------------------------------
+# Order modes (follow-up v4.0.114): parity with magic-shelf modes
+# ---------------------------------------------------------------------------
+
+EXPECTED_MODES = {
+    'manual',
+    'name_asc',
+    'name_desc',
+    'book_count_desc',
+    'book_count_asc',
+    'created_desc',
+    'created_asc',
+    'modified_desc',
+    'modified_asc',
+}
+
+
+def test_shelf_order_modes_set_exposed():
+    src = _shelf_src()
+    assert "SHELF_ORDER_MODES" in src and "DEFAULT_SHELF_ORDER_MODE" in src, (
+        "cps/shelf.py must expose SHELF_ORDER_MODES set + DEFAULT_SHELF_ORDER_MODE"
+    )
+    match = re.search(r"SHELF_ORDER_MODES\s*=\s*\{([^}]*)\}", src, re.DOTALL)
+    assert match, "SHELF_ORDER_MODES literal not found"
+    block = match.group(1)
+    for mode in EXPECTED_MODES:
+        assert f"'{mode}'" in block or f'"{mode}"' in block, (
+            f"SHELF_ORDER_MODES is missing: {mode}"
+        )
+    # Default must be valid.
+    default_match = re.search(r"DEFAULT_SHELF_ORDER_MODE\s*=\s*['\"]([^'\"]+)['\"]", src)
+    assert default_match and default_match.group(1) in EXPECTED_MODES
+
+
+def test_sort_shelves_for_user_dispatches_on_order_mode():
+    """The function body must dispatch on each named mode, not just
+    handle 'manual' + alphabetical."""
+    src = _shelf_src()
+    match = re.search(
+        r"(def sort_shelves_for_user\(.*?)(?=\n(?:def |@|class ))",
+        src, re.DOTALL,
+    )
+    body = match.group(1)
+    # Each mode constant must appear in the dispatch.
+    for mode in ('name_desc', 'book_count_desc', 'book_count_asc',
+                 'created_desc', 'created_asc', 'modified_desc', 'modified_asc'):
+        assert f"'{mode}'" in body or f'"{mode}"' in body, (
+            f"sort_shelves_for_user must dispatch on '{mode}'"
+        )
+
+
+def test_sort_shelves_for_user_book_count_helper_exists():
+    """book_count modes need a helper that doesn't crash on detached
+    relationships."""
+    src = _shelf_src()
+    assert re.search(r"def _shelf_book_count\(", src), (
+        "cps/shelf.py must expose a helper for the book_count modes"
+    )
+
+
+def test_reorder_route_accepts_order_mode_payload():
+    """POST handler must read order_mode from the JSON body, validate
+    against SHELF_ORDER_MODES, and persist it into
+    view_settings['shelves']['order_mode']."""
+    src = _shelf_src()
+    # reorder_shelves is the last function in shelf.py — match through EOF.
+    match = re.search(
+        r"(def reorder_shelves\(.*)",
+        src, re.DOTALL,
+    )
+    assert match, "reorder_shelves definition not found"
+    body = match.group(1)
+    assert 'order_mode' in body, "POST handler must accept order_mode field"
+    assert "SHELF_ORDER_MODES" in body, "POST handler must validate against the set"
+    assert "'order_mode'" in body or '"order_mode"' in body, (
+        "must persist into view_settings['shelves']['order_mode']"
+    )
+
+
+def test_template_renders_order_mode_picker():
+    src = REORDER_HTML.read_text()
+    assert "orderModeSelect" in src, "template must include an order-mode <select>"
+    assert "order_modes" in src, (
+        "template must iterate the order_modes context list (passed by the route)"
+    )
+    # The route's `order_modes` context list (not the template) is the source
+    # of truth for the picker entries — verify the route passes each mode.
+    route_match = re.search(
+        r"(def reorder_shelves\(.*)", _shelf_src(), re.DOTALL,
+    )
+    route_body = route_match.group(1)
+    for mode in ('name_asc', 'name_desc', 'book_count_desc', 'book_count_asc',
+                 'created_desc', 'created_asc', 'modified_desc', 'modified_asc',
+                 'manual'):
+        assert f"'{mode}'" in route_body or f'"{mode}"' in route_body, (
+            f"route must pass {mode} in the order_modes picker list"
+        )
+
+
+def test_template_posts_order_mode_field():
+    src = REORDER_HTML.read_text()
+    # The XHR body must include order_mode (not just order).
+    assert 'order_mode' in src and 'JSON.stringify' in src, (
+        "save action must POST {order_mode, order} as JSON"
+    )


### PR DESCRIPTION
v4.0.113 shipped manual drag-to-reorder for the [#237](https://github.com/new-usemame/Calibre-Web-NextGen/issues/237) feature. Operator follow-up: "having an order mode would be great to add." This brings it to full parity with the existing magic-shelf order modes.

## What changes

- New `SHELF_ORDER_MODES` + `DEFAULT_SHELF_ORDER_MODE = 'name_asc'` in `cps/shelf.py` mirroring `cps/magic_shelf.py`.
- `sort_shelves_for_user` now dispatches on the configured mode: `name_asc`, `name_desc`, `book_count_desc`, `book_count_asc`, `created_desc`, `created_asc`, `modified_desc`, `modified_asc`, `manual`. Tie-break across all modes uses casefold name. Switching back to manual later restores the previously-stored order list.
- New `_shelf_book_count(shelf)` helper — tolerant of detached relationships + query failures (returns 0 fall-through).
- `POST /shelf/reorder` now reads `{order_mode, order}` JSON. Validates `order_mode` against the set (400 on unknown). Back-compat: payload without `order_mode` defaults to `manual` (matches v4.0.113 client).
- `shelf_reorder.html` adds a `<select id=orderModeSelect>` with all 9 i18n-wrapped mode labels. Manual drag-list is `display:none` when a named mode is selected; visible when manual is selected.
- 11 new i18n strings: `Sort by`, `Name (A → Z)`, ..., `Manual (drag below)`, plus `Invalid order mode: %(mode)s`. Hungarian + German translations written. All 28 .mo files recompile cleanly per `test_translations_compile.py`.

## Tests

6 new source-pin tests in `tests/unit/test_237_shelf_reorder.py` (17 total): SHELF_ORDER_MODES set membership + default validity, `sort_shelves_for_user` dispatch on each named mode, `_shelf_book_count` helper exists, POST handler reads + validates + persists `order_mode`, template renders the picker + posts the field. All GREEN.

## Live verification on cwn-local (Playwright + JS evaluate)

Seeded 4 shelves with varied `created` / `last_modified`. Each mode persisted via POST, then home-page sidebar reloaded and inspected:

| Mode | Sidebar order |
|---|---|
| `created_desc` | `[Zeta(5/20), Charlie(5/18), Bravo(5/16), KOBO(Jan)]` |
| `modified_desc` | `[Charlie(30min), Bravo(1h), Zeta(2h), KOBO]` |
| `book_count_desc` | `[KOBO(1), Zeta(0), Charlie(0), Bravo(0)]` |
| `name_desc` | `[Zeta, KOBO, Charlie, Bravo]` |
| `manual` (from v4.0.113) | persisted drag order |

Hungarian UI confirmed end-to-end: all 9 picker labels translated (`Név (A → Z)`, `Könyvek száma (legtöbb → legkevesebb)`, `Létrehozva (legújabb → legrégebbi)`, etc.), section header `Rendezés`, save button `Mentés`.

## Confidence

98% — same JSON column as v4.0.113 (no migration), pure dispatch + UI addition. `_shelf_book_count` calls `Shelf.books.count()` which is the standard CWA relationship; tolerant of detached state.

Addresses follow-up to #237.