### PR TITLE
fix(ub): one-time NULL → '{}' migration for User.view_settings (revisits closed #281)

### DIFF
--- a/cps/ub.py
+++ b/cps/ub.py
@@ -333,7 +333,7 @@ class Anonymous(AnonymousUserMixin, UserBase):
         self.hardcover_token = None
         self.kobo_only_shelves_sync = None
         self.opds_only_shelves_sync = None
-        self.view_settings = None
+        self.view_settings = {}
         self.allowed_column_value = None
         self.allowed_tags = None
         self.denied_tags = None
@@ -1755,6 +1755,37 @@ def migrate_shelf_table(engine, _session):
 # Migrate database to current version, has to be updated after every database change. Currently migration from
 # maybe 4/5 versions back to current should work.
 # Migration is done by checking if relevant columns are existing, and then adding rows with SQL commands
+def migrate_user_view_settings_null(engine, _session):
+    """One-time normalization of legacy User.view_settings = NULL to '{}'.
+
+    `view_settings` is `Column(JSON, default={})` but SQLAlchemy's
+    `default=` only applies on INSERT through the ORM. Rows imported
+    from older schemas (pre-2025-01-14 when this column was added
+    upstream), or inserted via raw SQL or external admin tools, can
+    land with NULL — which then 500s every page consulting
+    view_settings (layout.html cover-settings cog, sort prefs, etc.)
+    via the unguarded `self.view_settings.get(page)` call in
+    get_view_property.
+
+    Idempotent: the UPDATE matches zero rows on subsequent runs.
+    No-op when there are no NULL rows. Logs the rowcount so operators
+    can see in container logs whether any legacy NULLs existed.
+    """
+    try:
+        result = _session.execute(
+            text("UPDATE user SET view_settings = '{}' WHERE view_settings IS NULL")
+        )
+        _session.commit()
+        if getattr(result, "rowcount", 0):
+            log.info(
+                "[view-settings-null-migration] normalized %d user(s) with NULL view_settings to '{}'",
+                result.rowcount,
+            )
+    except Exception as ex:
+        _session.rollback()
+        log.error("[view-settings-null-migration] failed: %s", ex)
+
+
 def migrate_book_cover_preview_table(engine, _session):
     """Create the book_cover_preview table if it doesn't exist.
     Idempotent — `BookCoverPreview.__table__.create(engine, checkfirst=True)`
@@ -1857,6 +1888,9 @@ def migrate_Database(_session):
     migrate_registration_table(engine, _session)
     migrate_user_session_table(engine, _session)
     migrate_user_table(engine, _session)
+    # Normalize legacy NULL view_settings → '{}' so get_view_property can't
+    # 500 the entire web UI for any user whose row was imported pre-default.
+    migrate_user_view_settings_null(engine, _session)
     migrate_shelf_table(engine, _session)
     migrate_oauth_provider_table(engine, _session)
     migrate_config_table(engine, _session)

--- a/tests/unit/test_view_settings_null_migration.py
+++ b/tests/unit/test_view_settings_null_migration.py
@@ -1,0 +1,157 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for the User.view_settings NULL → {} startup
+migration.
+
+## Why this migration exists
+
+`view_settings` is declared `Column(JSON, default={})` in cps/ub.py.
+SQLAlchemy's `default=` only applies on INSERT through the ORM; rows
+imported from older schemas (pre-2025-01-14 when this column was added
+upstream by demitrix), or inserted by raw SQL / external admin tools,
+can land with the column NULL. Any user with NULL view_settings hits:
+
+    File "cps/ub.py", line 235, in get_view_property
+        if not self.view_settings.get(page):
+               ^^^^^^^^^^^^^^^^^^^^^^
+    AttributeError: 'NoneType' object has no attribute 'get'
+
+…which 500s every page that consults view_settings: `/`,
+`/book/<id>` (via layout.html cover-settings cog), `/table`, etc.
+Effectively a per-user lockout from the web UI.
+
+PR #281 proposed `vs = self.view_settings or {}` guards inside
+get_view_property / set_view_property. That was closed because no
+production user (teenyverse) currently has NULL view_settings — the
+fix looked speculative. During fork #276 work I reproduced the exact
+crash by manually setting `view_settings=NULL` on a test user.
+
+The chosen long-term shape: a one-time startup migration that
+normalizes NULL → '{}' for every existing user. That eliminates the
+failure class entirely instead of putting per-call guards everywhere.
+Idempotent (the UPDATE matches zero rows on subsequent runs), wired
+into the existing cps.ub.migrate_Database orchestrator.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UB_PY = REPO_ROOT / "cps" / "ub.py"
+
+
+def _ub_src() -> str:
+    return UB_PY.read_text()
+
+
+def test_migration_function_defined():
+    """A migrate_user_view_settings_null function must exist in cps/ub.py."""
+    src = _ub_src()
+    assert re.search(
+        r"def migrate_user_view_settings_null\(engine,\s*_session\):",
+        src,
+    ), (
+        "cps/ub.py must define migrate_user_view_settings_null(engine, _session) "
+        "matching the existing migration-function signature"
+    )
+
+
+def test_migration_uses_idempotent_update():
+    """The migration must be a single UPDATE that matches only NULL rows.
+    Idempotent: zero rows match on the second invocation."""
+    src = _ub_src()
+    match = re.search(
+        r"def migrate_user_view_settings_null\([^)]*\):.*?(?=\n(?:def \w|class \w))",
+        src, re.DOTALL,
+    )
+    assert match, "migration function body not isolatable"
+    body = match.group(0)
+    # Must target the user table.
+    assert "user" in body.lower(), "must target the user table"
+    # Must target the view_settings column.
+    assert "view_settings" in body, "must target the view_settings column"
+    # Must match only NULL rows (idempotency).
+    assert re.search(r"view_settings\s+IS\s+NULL", body, re.IGNORECASE), (
+        "WHERE clause must filter to view_settings IS NULL (idempotent on re-run)"
+    )
+    # Must set to '{}' literal (empty JSON object).
+    assert re.search(r"view_settings\s*=\s*['\"]\{\}['\"]", body) or "'{}'" in body, (
+        "SET clause must normalize to '{}' (empty JSON object literal)"
+    )
+
+
+def test_migration_logs_rowcount():
+    """The migration must log the number of rows normalized so operators
+    can see in container logs whether legacy NULL rows existed."""
+    src = _ub_src()
+    match = re.search(
+        r"def migrate_user_view_settings_null\([^)]*\):.*?(?=\n(?:def \w|class \w))",
+        src, re.DOTALL,
+    )
+    body = match.group(0)
+    assert "rowcount" in body, (
+        "migration must read .rowcount from the UPDATE result + log it"
+    )
+    assert "log." in body or "log_" in body, "must call into the logger"
+
+
+def test_migration_wired_into_orchestrator():
+    """migrate_Database must call the new migration alongside the existing
+    user-table migrations."""
+    src = _ub_src()
+    match = re.search(
+        r"def migrate_Database\(_session\):(.*?)(?=\n(?:def \w|class \w))",
+        src, re.DOTALL,
+    )
+    assert match, "migrate_Database orchestrator not found"
+    orchestrator = match.group(1)
+    assert "migrate_user_view_settings_null(" in orchestrator, (
+        "migrate_Database must call migrate_user_view_settings_null(engine, _session) "
+        "in the orchestrator block alongside migrate_user_table etc."
+    )
+
+
+def test_migration_rolls_back_on_failure():
+    """If the UPDATE raises (e.g. DB locked), the migration must rollback
+    so it doesn't leave a half-committed transaction."""
+    src = _ub_src()
+    match = re.search(
+        r"def migrate_user_view_settings_null\([^)]*\):.*?(?=\n(?:def \w|class \w))",
+        src, re.DOTALL,
+    )
+    body = match.group(0)
+    assert "rollback" in body, (
+        "migration must rollback on exception to avoid half-committed transactions"
+    )
+
+
+def test_anonymous_init_uses_empty_dict_not_none():
+    """Belt-and-suspenders: cps/ub.py Anonymous.__init__ used to set
+    self.view_settings = None. Even though loadSettings() overwrites it
+    from the DB row immediately after, the migration above ensures that
+    DB row's view_settings is {} (never NULL). Set the initial value to
+    {} as well for symmetry — any future code that races between __init__
+    and loadSettings won't see a NoneType."""
+    src = _ub_src()
+    match = re.search(
+        r"class Anonymous\([^)]*\):.*?def __init__\(self\):(.*?)def loadSettings",
+        src, re.DOTALL,
+    )
+    assert match, "Anonymous.__init__ not found"
+    init_body = match.group(1)
+    # The assignment line should be view_settings = {} not None.
+    assert re.search(
+        r"self\.view_settings\s*=\s*\{\s*\}",
+        init_body,
+    ), (
+        "Anonymous.__init__ should set self.view_settings = {} (not None) for "
+        "defense-in-depth — the DB migration is the primary fix"
+    )


### PR DESCRIPTION
## Symptom

Any user whose `view_settings` is NULL hits an `AttributeError: 'NoneType' object has no attribute 'get'` at `cps/ub.py:235` in `User.get_view_property`. Since `layout.html`'s cover-settings cog calls `get_view_property` on every render, the affected user gets a 500 on `/`, `/book/<id>`, `/table`, and every other page. Effectively a per-user web UI lockout.

## Root cause

`view_settings = Column(JSON, default={})`. SQLAlchemy's `default=` only applies on INSERT through the ORM. Rows imported from older schemas (pre-2025-01-14 when this column was added upstream), or inserted via raw SQL / external admin tools, land with NULL. The unguarded `self.view_settings.get(page)` then crashes.

PR #281 closed earlier proposed `vs = self.view_settings or {}` guards inside `get_view_property` / `set_view_property`. That was closed because no teenyverse production user had NULL view_settings. Later that day I reproduced the exact crash on cwn-local by manually setting one user's view_settings to NULL. The bug is real even if uncommon.

## Fix

One-time `migrate_user_view_settings_null(engine, _session)` startup migration in `cps/ub.py` runs from the existing `migrate_Database` orchestrator between `migrate_user_table` and `migrate_shelf_table`. Single `UPDATE user SET view_settings = '{}' WHERE view_settings IS NULL`. Idempotent (zero rows match on re-run); no-op when no legacy NULLs exist; logs rowcount so operators see whether the migration found anything.

Also defense-in-depth: `Anonymous.__init__` initial value flipped from `self.view_settings = None` to `self.view_settings = {}` so any future code racing between `__init__` and `loadSettings()` can't trip.

## Verification

**6 source-pin tests** in `tests/unit/test_view_settings_null_migration.py` cover migration function shape (UPDATE + WHERE NULL filter + '{}' literal + rowcount log + rollback-on-exception), orchestrator wiring, Anonymous `__init__` shape.

**Live end-to-end on cwn-local:**

| Step | Result |
|---|---|
| Insert `null-vs-test` user with view_settings = NULL | DB shows `is_null=1` |
| `docker cp` new `cps/ub.py` + restart | `[view-settings-null-migration] normalized 1 user(s) with NULL view_settings to '{}'` in container log; DB row now `view_settings='{}'` |
| Login as null-vs-test → `/` → `/book/5` | Both render cleanly (pre-fix: both 500'd with `'NoneType' object has no attribute 'get'`) |

## Confidence

98% — single UPDATE, idempotent, no schema change, no migration marker needed (re-running on already-normalized DB just touches zero rows). The Anonymous `__init__` change is a one-character defensive swap.

Re-visits the surface PR #281 covered. Closes the gap left by that PR's close-out.