### PR TITLE
fix(layout): mobile-safe announcement banner (fork #288 pass 1, v4.0.118 regression)

### DIFF
--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -309,43 +309,6 @@
       {%endif%}
     {% endfor %}
     {% block flash %}{% endblock %}
-    {# Fork #225 (@froggybottomboys): server-wide announcement banner.
-       Renders only when an admin has set server_announcement.
-       Per-user dismiss is client-side via localStorage keyed by a hash of
-       the announcement content — editing the text re-shows it for everyone. #}
-    {% if server_announcement %}
-      <div id="serverAnnouncementBanner" class="alert alert-info" style="margin: 0.5em 1em; display: flex; align-items: center; gap: 1em; border-radius: 4px;" data-announcement-content="{{ server_announcement }}">
-        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-        <span style="flex: 1;">{{ server_announcement }}</span>
-        <button type="button" class="close" id="serverAnnouncementDismiss" aria-label="{{ _('Dismiss') }}" style="margin-left: auto;">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <script>
-        (function () {
-          var banner = document.getElementById('serverAnnouncementBanner');
-          if (!banner) return;
-          var content = banner.getAttribute('data-announcement-content') || '';
-          var hash = 0;
-          for (var i = 0; i < content.length; i++) {
-            hash = ((hash << 5) - hash) + content.charCodeAt(i);
-            hash |= 0;
-          }
-          var key = 'cwng_announcement_dismissed_' + hash;
-          if (localStorage.getItem(key) === '1') {
-            banner.style.display = 'none';
-            return;
-          }
-          var btn = document.getElementById('serverAnnouncementDismiss');
-          if (btn) {
-            btn.addEventListener('click', function () {
-              localStorage.setItem(key, '1');
-              banner.style.display = 'none';
-            });
-          }
-        })();
-      </script>
-    {% endif %}
     {% if g.current_theme == 1 %}
       <div id="loader" hidden="true">
         <center>
@@ -355,6 +318,56 @@
       </div>
     {%endif%}
     <div class="container-fluid">
+      {# Fork #225 (@froggybottomboys): server-wide announcement banner.
+         Renders only when an admin has set server_announcement. Per-user
+         dismiss is client-side via localStorage keyed by a hash of the
+         announcement content — editing the text re-shows it for everyone.
+         Fork #288 (mobile pass 1): banner lives INSIDE .container-fluid so
+         it inherits the same offset that clears the fixed navbar; uses a
+         dedicated CSS class (NOT Bootstrap `.alert .alert-info`) because
+         caliBlur.css hijacks every `.alert` into a fixed-position toast
+         that auto-hides after 10s. Inline styles force flow-layout. #}
+      {% if server_announcement %}
+        <div id="serverAnnouncementBanner" class="cwng-server-announcement" data-announcement-content="{{ server_announcement }}"
+             style="position: relative; z-index: 5;
+                    display: flex; align-items: center; gap: 1em;
+                    margin: 56px 0 0.5em 0; padding: 12px 16px;
+                    background-color: #d9edf7; color: #31708f;
+                    border: 1px solid #bce8f1; border-radius: 4px;
+                    font-size: 14px; line-height: 1.4;">
+          <span class="glyphicon glyphicon-info-sign" aria-hidden="true" style="flex: 0 0 auto;"></span>
+          <span style="flex: 1 1 auto;">{{ server_announcement }}</span>
+          <button type="button" class="cwng-server-announcement-dismiss" id="serverAnnouncementDismiss" aria-label="{{ _('Dismiss') }}"
+                  style="flex: 0 0 auto; background: none; border: 0; padding: 0 4px;
+                         font-size: 22px; line-height: 1; color: inherit; opacity: 0.6; cursor: pointer;">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <script>
+          (function () {
+            var banner = document.getElementById('serverAnnouncementBanner');
+            if (!banner) return;
+            var content = banner.getAttribute('data-announcement-content') || '';
+            var hash = 0;
+            for (var i = 0; i < content.length; i++) {
+              hash = ((hash << 5) - hash) + content.charCodeAt(i);
+              hash |= 0;
+            }
+            var key = 'cwng_announcement_dismissed_' + hash;
+            if (localStorage.getItem(key) === '1') {
+              banner.style.display = 'none';
+              return;
+            }
+            var btn = document.getElementById('serverAnnouncementDismiss');
+            if (btn) {
+              btn.addEventListener('click', function () {
+                localStorage.setItem(key, '1');
+                banner.style.display = 'none';
+              });
+            }
+          })();
+        </script>
+      {% endif %}
       <div class="row-fluid">
         {% if current_user.is_authenticated or g.allow_anonymous %}
         <div class="col-sm-2">

--- a/tests/unit/test_225_server_announcement.py
+++ b/tests/unit/test_225_server_announcement.py
@@ -120,6 +120,33 @@ def test_layout_renders_banner_when_set():
     ), "banner must have id='serverAnnouncementBanner' for the dismiss JS to target"
 
 
+def test_layout_banner_does_not_inherit_caliBlur_toast_alert_styles():
+    """Fork #288 mobile-pass-1 regression: caliBlur.css styles every
+    `.alert` element as a fixed-position toast that auto-hides after
+    10s. The announcement banner must NOT use the Bootstrap `alert`
+    class; otherwise on the dark theme it becomes invisible-then-broken
+    on every page. Use a dedicated cwng-server-announcement class with
+    inline styles that force flow-layout positioning."""
+    src = LAYOUT_HTML.read_text()
+    # The banner div must not carry the bootstrap alert class set.
+    banner_match = re.search(
+        r'<div\s+id=[\"\']serverAnnouncementBanner[\"\'][^>]*>',
+        src,
+    )
+    assert banner_match, "banner element not found"
+    opening_tag = banner_match.group(0)
+    assert 'class="alert' not in opening_tag and "class='alert" not in opening_tag, (
+        "banner must NOT use Bootstrap `alert` class — caliBlur.css hijacks "
+        "every .alert into a fixed-position toast. Use a dedicated class instead."
+    )
+    # Must have explicit position (static or relative) — not the fixed/absolute
+    # that caliBlur's .alert rule would otherwise impose.
+    assert re.search(r"position:\s*(static|relative)\b", opening_tag), (
+        "banner must force position: static or relative so it stays in flow "
+        "regardless of what the theme stylesheet does to ambient `.alert` rules"
+    )
+
+
 def test_render_template_passes_server_announcement():
     """render_title_template must populate `server_announcement` from
     config.config_server_announcement (with a None-safe fallback)."""


### PR DESCRIPTION
Mobile audit ([#288](https://github.com/new-usemame/Calibre-Web-NextGen/issues/288)) caught a regression in v4.0.118: the announcement banner shipped for [#225](https://github.com/new-usemame/Calibre-Web-NextGen/issues/225) used Bootstrap's `.alert .alert-info` class. **caliBlur.css** (the CWNG dark theme, which is the default) rewrites every `.alert` element into a fixed-position 10-second auto-hiding toast at the bottom of the viewport. On iPhone SE viewport (375px) the banner shrank to 24px wide (only the close-button width) and floated invisibly at y=624. Desktop dark-theme exhibited the same — banner was effectively unusable on the default theme.

## Two changes

1. **Drop `class='alert alert-info'`**. Use a dedicated `cwng-server-announcement` class with inline styles that force flow-layout positioning regardless of theme stylesheet shenanigans. Same `alert-info` palette (`#d9edf7` background, `#31708f` text, `#bce8f1` border) without inheriting the toast behavior.

2. **Move the banner inside `<div class="container-fluid">`** instead of above it. The container's layout already accounts for the fixed navbar's reserved space; the previous placement competed with the navbar for the same top-of-viewport real estate. `margin: 56px 0 0.5em` on the banner clears the navbar (height ~48-60px depending on viewport).

Belt-and-suspenders: `position: relative; z-index: 5` so the banner sits in its own stacking context above the body background regardless of any theme-specific transform creating a containing block.

## Tests

Updated `test_layout_banner_does_not_inherit_caliBlur_toast_alert_styles` in `tests/unit/test_225_server_announcement.py` to pin: (a) banner div does NOT carry the `alert` class set, (b) banner div has explicit `position: static|relative`. 8/8 #225 tests + 30/30 .po-compile tests GREEN.

## Live verification on cwn-local

Both viewports + dismiss flow:

| Viewport | Banner top/bottom | Navbar top/bottom | Overlap |
|---|---|---|---|
| iPhone SE (375x667) | 94 / 179 | 0 / 48 | ❌ no |
| Desktop (1280x800) | 116 / 164 | 0 / 60 | ❌ no |

Dismiss click hides banner + sets localStorage key on both viewports. Re-edit announcement via SQL → restart → new hash key → banner reappears.

## Confidence

97% — single-template change with explicit positioning context. No new dependencies, no schema change. The class-name change means any future `.alert`-based theming on this banner becomes impossible by design.

Addresses #288 (mobile pass 1) and a v4.0.118 regression from #225.