### PR TITLE
fix(table): wysihtml5 popup — drop formatBlock dropdown + stack buttons below input (fork #283 follow-up)

### DIFF
--- a/cps/static/css/wysihtml5-fork.css
+++ b/cps/static/css/wysihtml5-fork.css
@@ -43,3 +43,71 @@ ul.wysihtml5-toolbar > li:has(a[data-wysihtml5-command="createLink"]),
 ul.wysihtml5-toolbar > li:has(a[data-wysihtml5-command="insertImage"]) {
     display: none !important;
 }
+
+/*
+ * Fork #283 follow-up (reporter @droM4X verified v4.0.112, posted 3 more
+ * issues):
+ *
+ * 4. The "Font Size" dropdown (data-wysihtml5-command="formatBlock" — it
+ *    actually picks paragraph style: H1/H2/H3/Paragraph) only affects
+ *    the entire description text since the metadata editor doesn't
+ *    distinguish heading levels in the rendered output. Hide it — frees
+ *    toolbar space so the remaining buttons stay on one row at narrower
+ *    widths.
+ */
+
+ul.wysihtml5-toolbar > li:has(a[data-wysihtml5-command="formatBlock"]) {
+    display: none !important;
+}
+
+/*
+ * 5 + 6. x-editable's popup puts the form's input and the
+ *        Cancel/Submit buttons as inline-block SIBLINGS in the same
+ *        row (.editable-input + .editable-buttons). At narrow widths
+ *        the buttons overflow the popup. Stack them BELOW the input.
+ *
+ *        Also swap order: x-editable defaults to Submit/Cancel; common
+ *        UX is Cancel-left, Submit-right. Use flex `order:` on the
+ *        buttons inside .editable-buttons.
+ *
+ *        Scope to the popup containing the wysihtml5 editor (the
+ *        comments column + custom-column wysihtml5 fields). Other
+ *        editable popups (text input, select, etc.) keep the default
+ *        inline layout — only the wysihtml5 surface needs the column
+ *        treatment.
+ */
+
+.editable-container .editableform:has(.wysihtml5-sandbox) {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.editable-container .editableform:has(.wysihtml5-sandbox) .control-group,
+.editable-container .editableform:has(.wysihtml5-sandbox) .form-group {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.editable-container .editableform:has(.wysihtml5-sandbox) .editable-input {
+    display: block;
+    width: 100%;
+}
+
+.editable-container .editableform:has(.wysihtml5-sandbox) .editable-buttons {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    margin-top: 10px;
+    margin-left: 0;
+}
+
+.editable-container .editableform:has(.wysihtml5-sandbox) .editable-cancel {
+    order: 1;
+    margin-left: 0 !important;
+}
+
+.editable-container .editableform:has(.wysihtml5-sandbox) .editable-submit {
+    order: 2;
+}

--- a/tests/unit/test_283_followup_toolbar.py
+++ b/tests/unit/test_283_followup_toolbar.py
@@ -1,0 +1,113 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for fork #283 (@droM4X) follow-up.
+
+After v4.0.112 shipped (contrast + toolbar wrap + dead Link/Image
+buttons), reporter @droM4X verified the original fixes and posted a
+follow-up with three more issues in the same /table Comments
+wysihtml5 dialog:
+
+1. **The first dropdown (formatBlock — H1/H2/H3/Paragraph) takes up
+   space without being useful** for the description field. He asked
+   for it to be removed too. That frees up toolbar real estate so the
+   remaining buttons fit on one row at more widths.
+
+2. **The last two buttons overflow at certain widths.** Those are
+   x-editable's Cancel + Submit buttons rendered INLINE with the input
+   (`.editable-input` + `.editable-buttons` are inline-block siblings
+   in the same row). On narrow popup widths they push past the right
+   edge. droM4X asked for the buttons to go UNDER the textarea
+   instead.
+
+3. **Button order is reversed**: currently Submit/Cancel (vendor
+   default); should be Cancel/Submit per common UX convention.
+
+This module pins the CSS that delivers all three.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FORK_CSS = REPO_ROOT / "cps" / "static" / "css" / "wysihtml5-fork.css"
+
+
+def _css() -> str:
+    return FORK_CSS.read_text()
+
+
+# ---------------------------------------------------------------------------
+# (1) formatBlock dropdown hidden
+# ---------------------------------------------------------------------------
+
+def test_toolbar_hides_format_block_dropdown():
+    """Like createLink + insertImage already hidden via :has(), the
+    formatBlock dropdown (H1/H2/H3/Paragraph) should also be display:
+    none on the description-field toolbar."""
+    css = _css()
+    assert re.search(
+        r'li:has\(a\[data-wysihtml5-command="formatBlock"\]\)[^}]*display:\s*none\s*!important',
+        css, re.DOTALL,
+    ), (
+        'formatBlock dropdown <li> must be display: none !important via '
+        ':has() selector'
+    )
+
+
+# ---------------------------------------------------------------------------
+# (2) Cancel + Submit buttons stack BELOW the textarea
+# ---------------------------------------------------------------------------
+
+def test_editable_form_stacks_buttons_below_input_for_wysihtml5():
+    """x-editable's `.editableform` puts `.editable-input` and
+    `.editable-buttons` as inline-block siblings. For the wysihtml5
+    popup (Comments column), we want the form to be a column flex
+    container so buttons stack below the input."""
+    css = _css()
+    # Look for an editable-form rule scoped to wysihtml5 / popover containing
+    # a wysihtml5 sandbox or our marker class. Either a direct sibling
+    # selector or a :has() check.
+    assert re.search(
+        r'\.editableform[^{]*:has\(.*wysihtml5.*\)|\.editable-popover\s+\.editableform[^{]*\{[^}]*flex-direction:\s*column',
+        css, re.DOTALL,
+    ) or re.search(
+        r'\.editable-popover[^{]*:has\([^)]*wysihtml5[^)]*\)[^{]*\{[^}]*flex-direction:\s*column',
+        css, re.DOTALL,
+    ), "form must stack buttons below input via flex-direction: column scoped to wysihtml5 popovers"
+    # The editable-input must take full width so the next-row buttons aren't
+    # forced into a tight column.
+    assert re.search(
+        r'\.editable-input[^{]*\{[^}]*width:\s*100%',
+        css, re.DOTALL,
+    ), ".editable-input must be width: 100% so the popup uses full width"
+
+
+# ---------------------------------------------------------------------------
+# (3) Cancel before Submit (flex order swap)
+# ---------------------------------------------------------------------------
+
+def test_editable_button_order_cancel_first_submit_second():
+    css = _css()
+    # Flex order trick: cancel order: 1; submit order: 2.
+    # Or use a different mechanism (margin-left:auto on submit etc).
+    assert re.search(
+        r'\.editable-cancel[^{]*\{[^}]*order:\s*1',
+        css, re.DOTALL,
+    ), ".editable-cancel must have order: 1 (renders first)"
+    assert re.search(
+        r'\.editable-submit[^{]*\{[^}]*order:\s*2',
+        css, re.DOTALL,
+    ), ".editable-submit must have order: 2 (renders after cancel)"
+    # editable-buttons container must use flex so order kicks in.
+    assert re.search(
+        r'\.editable-buttons[^{]*\{[^}]*display:\s*flex',
+        css, re.DOTALL,
+    ), ".editable-buttons must be display: flex so the order property applies"


### PR DESCRIPTION
After v4.0.112 fixed the original three #283 bugs (contrast, toolbar wrap, dead Link/Image buttons), reporter @droM4X [verified the fixes and posted three more](https://github.com/new-usemame/Calibre-Web-NextGen/issues/283#issuecomment-...).

## Three asks

1. **Drop the "Font Size" dropdown** (actually `data-wysihtml5-command='formatBlock'` — H1/H2/H3/Paragraph). The metadata editor doesn't distinguish heading levels in the rendered output, so this picker takes toolbar space without doing anything useful.

2. **Cancel + Submit overflow at narrow widths** because x-editable renders `.editable-input` + `.editable-buttons` as inline-block siblings. Move buttons UNDER the textarea.

3. **Button order is reversed** — currently Submit/Cancel; should be Cancel/Submit per common UX convention.

## Fix

Pure-CSS in `cps/static/css/wysihtml5-fork.css`:

- `ul.wysihtml5-toolbar > li:has(a[data-wysihtml5-command="formatBlock"])` → `display: none !important` (same pattern as the existing createLink + insertImage hides)
- `.editable-container .editableform:has(.wysihtml5-sandbox)` → `display: flex; flex-direction: column` so input + buttons stack vertically. Scoped to wysihtml5 popups only — other editable popups (text input, select) keep their default inline layout
- `.editable-input` inside such popups → `width: 100%`
- `.editable-buttons` → `flex-direction: row; gap: 8px; margin-top: 10px`
- `.editable-cancel` → `order: 1`; `.editable-submit` → `order: 2`

## Tests

3 new source-pin tests in `tests/unit/test_283_followup_toolbar.py`, plus the 11 from v4.0.112: **14/14 GREEN**.

## Live verification on cwn-local (Playwright + DOM evaluate)

| Selector | Computed |
|---|---|
| `ul.wysihtml5-toolbar > li:has(a[data-wysihtml5-command="formatBlock"])` | `display: none` ✅ |
| `.editableform:has(.wysihtml5-sandbox)` | `display: flex; flex-direction: column` ✅ |
| `.editable-input` | `display: block; width: 566px` (full popup) ✅ |
| `.editable-buttons` | `display: flex; flex-direction: row; margin-top: 10px` ✅ |
| `.editable-cancel` | `order: 1` ✅ |
| `.editable-submit` | `order: 2` ✅ |

## Confidence

97% — pure CSS, scoped to wysihtml5 popups via `:has(.wysihtml5-sandbox)` so no other editable surfaces affected. Test pins cover all three fixes.

Addresses #283 follow-up.