### PR TITLE
fix(layout): mobile pass 2 — flash toasts move to TOP on narrow viewports (fork #288)

### DIFF
--- a/cps/static/css/mobile-alert-toast-position.css
+++ b/cps/static/css/mobile-alert-toast-position.css
@@ -1,0 +1,24 @@
+/*
+ * Fork #288 mobile pass 2: caliBlur.css positions every `.alert` element
+ * as a fixed-bottom toast (`position: fixed; bottom: 20px`). On narrow
+ * viewports the toast frequently overlaps form buttons stacked at the
+ * bottom of the visible area — most visibly on /login where an error
+ * toast like "Wrong Username or Password" lands on top of the
+ * "LOG IN WITH MAGIC LINK" button.
+ *
+ * Move the toast to the TOP of the viewport on mobile so it floats above
+ * the page header instead of on top of bottom-of-form controls. Desktop
+ * keeps the bottom position — there's plenty of vertical room there for
+ * the toast to clear page content.
+ *
+ * Scoped to the standard Bootstrap 3 SM breakpoint (<=767px). The 80px
+ * top offset clears the fixed navbar (typical height 48-60px) plus a
+ * small visual margin.
+ */
+
+@media (max-width: 767px) {
+    .alert {
+        top: 80px !important;
+        bottom: auto !important;
+    }
+}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -23,6 +23,9 @@
       <link href="{{ url_for('static', filename='css/caliBlur.css') }}" rel="stylesheet" media="screen">
       <link href="{{ url_for('static', filename='css/caliBlur_override.css') }}" rel="stylesheet" media="screen">
     {% endif %}
+    {# Fork #288 mobile pass 2: move .alert toasts to TOP on mobile so they
+       don't overlap bottom-of-form buttons (e.g. /login magic-link button). #}
+    <link href="{{ url_for('static', filename='css/mobile-alert-toast-position.css') }}" rel="stylesheet" media="screen">
     <link href="{{ url_for('static', filename='css/cwa.css') }}" rel="stylesheet" media="screen">
     <link href="{{ url_for('static', filename='css/book_organizer.css') }}" rel="stylesheet" media="screen">
     {% if current_user.is_authenticated and (current_user.role_admin() or current_user.role_edit()) %}

--- a/tests/unit/test_288_mobile_alert_toast.py
+++ b/tests/unit/test_288_mobile_alert_toast.py
@@ -1,0 +1,63 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for fork #288 mobile pass 2 (login form).
+
+caliBlur.css positions every `.alert` as a fixed-bottom toast
+(`position: fixed; bottom: 20px`). On narrow viewports this collides
+with form buttons stacked at the bottom of the visible area — most
+visibly the "Wrong Username or Password" toast overlapping the
+"LOG IN WITH MAGIC LINK" button on /login.
+
+Fix: scoped media query (<=767px) that flips toast positioning to
+`top: 80px; bottom: auto` so toasts float above page content rather
+than on top of bottom-of-form controls.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MOBILE_CSS = REPO_ROOT / "cps" / "static" / "css" / "mobile-alert-toast-position.css"
+LAYOUT_HTML = REPO_ROOT / "cps" / "templates" / "layout.html"
+
+
+def test_mobile_alert_css_file_exists():
+    assert MOBILE_CSS.is_file(), (
+        "cps/static/css/mobile-alert-toast-position.css must exist"
+    )
+
+
+def test_mobile_alert_css_targets_mobile_breakpoint():
+    src = MOBILE_CSS.read_text()
+    # Bootstrap 3 'sm' breakpoint upper bound is 767px.
+    assert re.search(
+        r"@media[^{]*\(max-width:\s*767px\)",
+        src,
+    ), "rule must be scoped to (max-width: 767px)"
+
+
+def test_mobile_alert_css_flips_toast_to_top():
+    src = MOBILE_CSS.read_text()
+    assert re.search(
+        r"\.alert\s*\{[^}]*top:\s*\d+px\s*!important",
+        src, re.DOTALL,
+    ), ".alert media-scoped rule must set explicit top position with !important"
+    assert re.search(
+        r"\.alert\s*\{[^}]*bottom:\s*auto\s*!important",
+        src, re.DOTALL,
+    ), ".alert media-scoped rule must set bottom: auto !important to override caliBlur"
+
+
+def test_layout_loads_mobile_alert_css():
+    src = LAYOUT_HTML.read_text()
+    assert "mobile-alert-toast-position.css" in src, (
+        "layout.html must include the mobile-alert-toast-position.css <link>"
+    )


### PR DESCRIPTION
Pass 2 of the [#288](https://github.com/new-usemame/Calibre-Web-NextGen/issues/288) mobile audit. Found on /login at iPhone SE (375px): a failed-login error toast (`Wrong Username or Password`) completely obscures the `LOG IN WITH MAGIC LINK` button at the bottom of the form.

## Root cause

`caliBlur.css` positions every `.alert` element as `position: fixed; bottom: 20px` — fine on desktop where there's plenty of vertical room, but on narrow viewports the toast lands on top of bottom-of-form controls.

## Fix

Scoped media query in a new `cps/static/css/mobile-alert-toast-position.css`:

```css
@media (max-width: 767px) {
    .alert { top: 80px !important; bottom: auto !important; }
}
```

Bootstrap 3 SM breakpoint (≤767px) so phones + small portrait tablets get the top-of-viewport toast; desktop keeps the original caliBlur bottom position. 80px clears the fixed navbar with visual margin.

Loaded in `layout.html` AFTER `caliBlur.css` + `caliBlur_override.css` so the media-query `!important` wins on specificity tie.

## Tests

4 source-pin tests in `tests/unit/test_288_mobile_alert_toast.py`: file exists, media-query targets 767px, `.alert` rule sets explicit `top` + `bottom: auto` with `!important`, layout.html loads the file. All GREEN.

## Live verification on cwn-local

| Viewport | Failed-login toast position | Magic-link button | Overlap |
|---|---|---|---|
| iPhone SE 375×667 | `top: 80px` rect=(80, 139) | bottom of form, clear | ❌ no |
| Desktop 1280×800 | `top: 721px; bottom: 20px` (caliBlur default) | n/a | ❌ no |

## Confidence

97% — single-rule CSS with explicit `!important` to override caliBlur, scoped to the standard Bootstrap SM breakpoint. Desktop confirmed unchanged.

Addresses #288 mobile pass 2.