### PR TITLE
ci(tests): two mitigations for xdist worker-IPC hang flake

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,12 @@ name: Test Suite
 
 on:
   push:
-    branches: ['**']  # Run Job 1 on all branches
+    # Only fire on direct pushes to main/dev (auto-merge to main, hotfixes).
+    # PR branches get CI via the `pull_request:` trigger below — listing both
+    # `branches: ['**']` here AND `pull_request:` causes dual-trigger CI runs
+    # on the same SHA, which doubles the surface for the xdist worker-IPC
+    # hang documented in notes/xdist-worker-ipc-hang-followup-2026-05-21.md.
+    branches: [main, dev]
   pull_request:
     branches: [main, dev]  # Run Job 1 on PRs to main/dev
   workflow_dispatch:  # Manual trigger button in Actions tab
@@ -80,8 +85,16 @@ jobs:
           # test failures instead of opaque step-level 10-min step timeouts. Without
           # this, a stuck test on one xdist worker only manifests as a step timeout
           # with no indication of which test or worker stalled.
+          #
+          # --dist=loadfile pins all tests in a file to a single worker. This
+          # eliminates the work-stealing race that's been hanging fast-tests
+          # runs (one of two parallel triggers stalls at ~9 minutes with no
+          # currently-executing test for pytest-timeout to interrupt). See
+          # notes/xdist-worker-ipc-hang-followup-2026-05-21.md for diagnostic
+          # log signature + hypothesis. Fewer worker handoffs ≈ fewer races.
           pytest -m "smoke or unit" \
             -n auto \
+            --dist=loadfile \
             --maxfail=3 \
             -v \
             --tb=short \

--- a/tests/unit/test_ci_xdist_hang_mitigation.py
+++ b/tests/unit/test_ci_xdist_hang_mitigation.py
@@ -1,0 +1,86 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Pin the two CI mitigations for the xdist worker-IPC hang documented
+in notes/xdist-worker-ipc-hang-followup-2026-05-21.md.
+
+The hang ate roughly one in three CI runs across the v4.0.110–v4.0.121
+window: pytest-xdist's master would wait forever for a worker that's
+between assignments, with no currently-executing test for
+pytest-timeout to interrupt; only the step-level 10-minute kill
+caught it.
+
+Two complementary mitigations:
+
+1. **Push trigger scoped to `[main, dev]`**, NOT `['**']`. Previously a
+   fork branch push fired BOTH the `push` event AND the `pull_request`
+   event for the same SHA → two parallel Test Suite runs competing for
+   the same xdist resources. Halves the surface for the hang.
+
+2. **`--dist=loadfile`** pins every test in a file to a single xdist
+   worker, eliminating the work-stealing race. Fewer worker handoffs
+   = fewer races.
+
+Both must stay. If a future refactor drops either, these tests fail.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+
+
+def _yaml() -> str:
+    return WORKFLOW.read_text()
+
+
+def test_push_trigger_scoped_to_main_dev_only():
+    """The `push:` trigger must NOT use `branches: ['**']` (which is the
+    dual-trigger surface). Must be `branches: [main, dev]`."""
+    src = _yaml()
+    # Find the push: trigger's branches list.
+    match = re.search(
+        r"push:\s*\n(?:\s*#[^\n]*\n)*\s*branches:\s*\[([^\]]+)\]",
+        src,
+    )
+    assert match, "could not locate push.branches in tests.yml"
+    branches = [b.strip().strip("'\"") for b in match.group(1).split(",")]
+    assert "**" not in branches, (
+        "push.branches must NOT include '**' — that re-introduces the "
+        "dual-trigger CI surface for fork branches that doubles the xdist "
+        "worker-IPC hang rate. See notes/xdist-worker-ipc-hang-followup-2026-05-21.md"
+    )
+    assert "main" in branches, "push trigger must still fire on main"
+
+
+def test_pytest_invocation_pins_dist_loadfile():
+    """The Fast Tests pytest invocation must include `--dist=loadfile`
+    to eliminate work-stealing races between xdist workers."""
+    src = _yaml()
+    # The relevant pytest call lives under the fast-tests job.
+    assert re.search(
+        r"pytest -m \"smoke or unit\"[^&]*--dist=loadfile",
+        src, re.DOTALL,
+    ), (
+        "Fast Tests pytest invocation must include `--dist=loadfile` — "
+        "eliminates the xdist work-stealing race that hangs fast-tests "
+        "runs at the step-level timeout. See "
+        "notes/xdist-worker-ipc-hang-followup-2026-05-21.md"
+    )
+
+
+def test_pytest_invocation_still_has_pytest_timeout():
+    """Belt-and-suspenders: `--timeout=120 --timeout-method=thread` must
+    stay alongside `--dist=loadfile`. They cover different failure
+    modes (per-test hang vs worker-IPC hang)."""
+    src = _yaml()
+    assert "--timeout=120" in src, "must keep --timeout=120 (per-test hang gate)"
+    assert "--timeout-method=thread" in src, "must keep --timeout-method=thread"


### PR DESCRIPTION
PR after PR through v4.0.110–v4.0.121 has been hitting the documented xdist worker-IPC hang. The same code, on the same commit, in one of two parallel Test Suite runs stalls at the 10-minute step timeout with no currently-executing test for `pytest-timeout` to interrupt. The cumulative cost has been ~5–7 rerun cycles across this session.

## Two complementary mitigations

Per the prior investigation in `notes/xdist-worker-ipc-hang-followup-2026-05-21.md`:

1. **Halve the dual-trigger surface.** `push: branches: ['**']` AND `pull_request:` both fire on the same SHA when a branch is pushed to a fork. Scope `push.branches` to `[main, dev]` — PR branches only get CI via `pull_request:`. PRs to main still get exactly one CI run per push; main-branch pushes still trigger CI directly. Cuts CI hours in half too.

2. **`--dist=loadfile`** in the Fast Tests pytest invocation. Default xdist load-balancing work-steals individual tests between workers — the work-stealing race is exactly the failure mode the prior investigation fingered. `loadfile` pins each test file to a single worker → fewer handoffs → fewer races. Keeps `-n auto` so parallelism remains.

Both mitigations are scoped + reversible. The `--timeout=120 --timeout-method=thread` per-test gate stays (different failure mode).

## Tests

3 source-pin tests in `tests/unit/test_ci_xdist_hang_mitigation.py` so a future refactor can't silently drop either mitigation:
- `push.branches` does NOT include `'**'`
- pytest invocation includes `--dist=loadfile`
- pytest-timeout config preserved

## Verification

The push-trigger change only takes effect from the next PR onwards (workflow file changes apply to the merged main, not the PR head's own CI run). The `--dist=loadfile` change IS in effect for this PR's own CI — if this PR's two Test Suite runs both pass first try (no rerun needed), that's the first datapoint.

## Confidence

90% on the mitigation pair eliminating the bulk of the hangs (the prior investigation rated `--dist=loadfile` as "easiest mitigation"). 100% on the test pins not regressing. Residual risk: if a deeper issue exists (e.g. coverage instrumentation lifecycle), one of the two mitigations may not be sufficient and we'll see the hang continue at a lower rate. Acceptable to ship now and reassess after 10 more PRs of empirical data.

Addresses `notes/xdist-worker-ipc-hang-followup-2026-05-21.md`.