### PR TITLE
test(checksums): close sqlite connection in try/finally (xdist hang root cause)

### DIFF
--- a/tests/unit/test_book_format_checksums_table_creation.py
+++ b/tests/unit/test_book_format_checksums_table_creation.py
@@ -189,40 +189,51 @@ class TestStoreChecksumWorksAfterUnconditionalEnsure:
     def test_store_checksum_after_ensure_calibre_db_tables(self, tmp_path):
         # Stand up a metadata.db-shaped sqlite (just the `books` table is
         # needed for the foreign key).
+        #
+        # IMPORTANT: explicit conn.close() in a try/finally. Without it,
+        # the sqlite3 connection survives past the test function and gets
+        # cleaned up later — and that cleanup can deadlock on the C-level
+        # sqlite mutex during pytest-xdist worker IPC handoff. The hang
+        # was traced to this test in v4.0.121 CI runs (sometimes passes
+        # immediately, sometimes hangs ~9 minutes until the step-level
+        # kill fires). See notes/xdist-worker-ipc-hang-followup-2026-05-21.md.
         db_path = tmp_path / "metadata.db"
         conn = sqlite3.connect(str(db_path))
-        conn.execute(
-            "CREATE TABLE books (id INTEGER PRIMARY KEY AUTOINCREMENT, "
-            "title TEXT)"
-        )
-        conn.execute("INSERT INTO books (id, title) VALUES (42, 'Test Book')")
-        conn.commit()
+        try:
+            conn.execute(
+                "CREATE TABLE books (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "title TEXT)"
+            )
+            conn.execute("INSERT INTO books (id, title) VALUES (42, 'Test Book')")
+            conn.commit()
 
-        # Run the schema setup (this is what cps/db.py calls on startup).
-        from cps.progress_syncing.models import ensure_calibre_db_tables
-        ensure_calibre_db_tables(conn)
+            # Run the schema setup (this is what cps/db.py calls on startup).
+            from cps.progress_syncing.models import ensure_calibre_db_tables
+            ensure_calibre_db_tables(conn)
 
-        # Now exercise store_checksum directly against the same DB. This
-        # mimics the ingest-processor / cover-enforcer / kindle-epub-fixer
-        # path that fails in #219.
-        from cps.progress_syncing.checksums.manager import store_checksum
-        ok = store_checksum(
-            book_id=42,
-            book_format="EPUB",
-            checksum="deadbeef" * 4,
-            version="koreader",
-            db_connection=conn,
-        )
-        assert ok is True, (
-            "store_checksum must succeed after ensure_calibre_db_tables — "
-            "this is the user-visible symptom from #219."
-        )
+            # Now exercise store_checksum directly against the same DB. This
+            # mimics the ingest-processor / cover-enforcer / kindle-epub-fixer
+            # path that fails in #219.
+            from cps.progress_syncing.checksums.manager import store_checksum
+            ok = store_checksum(
+                book_id=42,
+                book_format="EPUB",
+                checksum="deadbeef" * 4,
+                version="koreader",
+                db_connection=conn,
+            )
+            assert ok is True, (
+                "store_checksum must succeed after ensure_calibre_db_tables — "
+                "this is the user-visible symptom from #219."
+            )
 
-        row = conn.execute(
-            "SELECT book, format, checksum FROM book_format_checksums "
-            "WHERE book = 42"
-        ).fetchone()
-        assert row is not None
-        assert row[0] == 42
+            row = conn.execute(
+                "SELECT book, format, checksum FROM book_format_checksums "
+                "WHERE book = 42"
+            ).fetchone()
+            assert row is not None
+            assert row[0] == 42
+        finally:
+            conn.close()
         assert row[1].upper() == "EPUB"
         assert row[2] == "deadbeef" * 4


### PR DESCRIPTION
PR #296 / v4.0.122 added two CI mitigations for the xdist worker-IPC hang flake. The push-trigger scope worked self-applied. The `--dist=loadfile` change reduced but didn't eliminate the hang — one of PR #296's own CI runs still timed out at exactly the same spot.

## Root cause traced

Bisecting the CI log: every observed hang happens on `test_book_format_checksums_table_creation.py::TestStoreChecksumWorksAfterUnconditionalEnsure::test_store_checksum_after_ensure_calibre_db_tables`. Worker `gw1` starts the test, never reports completion, master waits the full 9 minutes until the step-level 10-min kill fires.

The test does `sqlite3.connect(str(db_path))` but **never calls `conn.close()`**. When the test function returns, the connection becomes unreachable → gc'd → `__del__` runs `sqlite3_close` at the C level → can block on the sqlite mutex.

Under pytest-xdist, this gc happens *during* the worker → master IPC handoff. If sqlite's `__del__` blocks waiting on a mutex while xdist is also waiting for the worker's "finished" signal, the master deadlocks. The test "completes" (assertions pass) but the test runner never receives the signal.

## Fix

Wrap the test body in `try/finally` with explicit `conn.close()`. Connection closes synchronously at the end of the test, before the worker hands the result back to the master. sqlite mutex released before IPC.

Pure test hygiene — no production code change.

## Verification

11/11 tests in the file pass in 0.10s locally in isolation.

## Confidence

90% on this being the root cause based on the log signature (test starts, never reports done, mutex-class destructor smell). If the hang has ANOTHER root cause this won't help; if this IS the cause, it eliminates it. Either way, no downside — the change is unambiguously good test hygiene.

Addresses `notes/xdist-worker-ipc-hang-followup-2026-05-21.md`.