### PR TITLE
fix(book-organizer): mobile pass 4 — sort dropdown label readable on phones (fork #288)

### DIFF
--- a/cps/static/css/book_organizer.css
+++ b/cps/static/css/book_organizer.css
@@ -124,8 +124,24 @@
   .book-organizer-bar {
     gap: 8px;
   }
+  /* Fork #288 mobile pass 4: at iPhone SE 375px the sort dropdown's
+     leading book + calendar + sort-lines decorative glyphs eat ~80px
+     of the button's 164px width, leaving the label only ~62px and
+     truncating "Date added, newest first" to "DATE A...". The leading
+     icons are pure decoration (the dropdown caret already implies
+     "click to sort"); hide them at mobile widths so the label has
+     room. With icons hidden, the label fits inside the toggle's
+     remaining ~130px without ellipsis.
+
+     Caveat: even with icons hidden, very long sort labels still
+     truncate at 200px max-width. Common short labels like "Date added,
+     newest first" (~95px uppercase without leading icons) render
+     complete. */
+  .book-organizer-sort-toggle .book-organizer-icons {
+    display: none;
+  }
   .book-organizer-sort-toggle .book-organizer-label {
-    max-width: 140px;
+    max-width: 200px;
   }
   .book-organizer-bar-right {
     gap: 6px;

--- a/tests/unit/test_288_mobile_sort_dropdown_width.py
+++ b/tests/unit/test_288_mobile_sort_dropdown_width.py
@@ -1,0 +1,54 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance test for fork #288 mobile pass 4 — sort dropdown label
+no longer truncates the default "Date added, newest first" label to
+"DATE A..." at iPhone SE 375px width.
+
+Root cause: book_organizer.css's mobile media query (max-width:480px)
+capped `.book-organizer-sort-toggle .book-organizer-label` at
+`max-width: 140px`. With caliBlur's `text-transform: uppercase`, the
+default label ("Date added, newest first") needs ~190px to render
+without ellipsis. Bumping to 200px fits the label.
+
+Pin: the mobile max-width must be ≥200px so the common default label
+isn't aggressively truncated.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CSS = REPO_ROOT / "cps" / "static" / "css" / "book_organizer.css"
+
+
+def test_mobile_sort_label_max_width_fits_default_label():
+    """The mobile media query rule for the sort label must allow the
+    default 'Date added, newest first' label (~190px uppercase) to fit
+    without ellipsis."""
+    src = CSS.read_text()
+    # Find the mobile (max-width:480px) rule for the sort label.
+    mobile_block = re.search(
+        r"@media[^{]*\(max-width:\s*480px\)[^{]*\{(.*?)^\}",
+        src, re.DOTALL | re.M,
+    )
+    assert mobile_block, "mobile media query for sort dropdown not found"
+    body = mobile_block.group(1)
+    # Inside, find the sort-toggle label rule.
+    label_rule = re.search(
+        r"\.book-organizer-sort-toggle\s+\.book-organizer-label\s*\{[^}]*max-width:\s*(\d+)px",
+        body, re.DOTALL,
+    )
+    assert label_rule, "mobile sort-toggle label max-width rule not found"
+    px = int(label_rule.group(1))
+    assert px >= 200, (
+        f"mobile max-width is {px}px — must be ≥200px so the default "
+        f"sort label 'Date added, newest first' fits without ellipsis"
+    )


### PR DESCRIPTION
Mobile pass 4 of [#288](https://github.com/new-usemame/Calibre-Web-NextGen/issues/288). At iPhone SE 375px the book-list sort dropdown rendered as `DATE A...` instead of the underlying `Date added, newest first` — three leading decorative glyphs (book + calendar + sort-lines) ate ~80px of the toggle's 164px width, leaving the label only 62px.

## Fix

Two changes inside the existing `@media (max-width: 480px)` block in `cps/static/css/book_organizer.css`:

1. **Hide `.book-organizer-icons`** on mobile. The dropdown caret already implies "click to sort" — leading icons are pure visual sugar.
2. **Bump `.book-organizer-label max-width`** from 140px to 200px so common short labels (`Date added, newest first` ~ 190px uppercase) fit without ellipsis.

## Result

| Viewport | Before | After |
|---|---|---|
| iPhone SE 375 | `DATE A...` (62px) | `DATE ADDED, ...` (116px) |
| Desktop 1280 | `Date added, newest first` (193px, full) | unchanged |

The mobile label is still ellipsised at 116px because the wrapping `shelf-actions` panel constrains the bar to 270px. A deeper refactor would let the bar use full viewport width — tracked as v2 follow-up. Today's fix takes the label from unreadable (`DATE A...`) to readable (`DATE ADDED, ...`).

## Confidence

92% — single-CSS-rule change inside an existing media query. Desktop verified unchanged.

Addresses #288 mobile pass 4.