### PR TITLE
test(checksums): reclassify cps-import test as integration (xdist hang final fix)

### DIFF
--- a/tests/unit/test_book_format_checksums_table_creation.py
+++ b/tests/unit/test_book_format_checksums_table_creation.py
@@ -180,11 +180,24 @@ class TestKindleEpubFixerGatesChecksumRecalc(_ScriptWriteGuardCase):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestStoreChecksumWorksAfterUnconditionalEnsure:
     """End-to-end micro-test: a fresh DB + unconditional ensure_* call +
     store_checksum should write a row, not crash with 'no such table'.
-    This is the user-visible symptom from #219, rendered as a test."""
+    This is the user-visible symptom from #219, rendered as a test.
+
+    Classified as @pytest.mark.integration (NOT unit) because it imports
+    `cps.progress_syncing.models`, which transitively imports `cps.db`
+    and `cps.ub` at module level — the heavyweight cps package init.
+    Under pytest-xdist subprocess contexts (default Fast Tests pool)
+    those imports hang on resources that don't exist in the worker.
+    Two prior fixes (PR #297 conn.close, PR #298 deferred-import inside
+    store_checksum) reduced incidence but didn't eliminate it; the
+    hang root cause is the cps.progress_syncing.models module-level
+    imports of cps.db + cps.ub. Reclassifying to integration moves
+    the test out of the xdist pool entirely.
+
+    See notes/xdist-worker-ipc-hang-followup-2026-05-21.md."""
 
     def test_store_checksum_after_ensure_calibre_db_tables(self, tmp_path):
         # Stand up a metadata.db-shaped sqlite (just the `books` table is


### PR DESCRIPTION
PR #297 (conn.close) and PR #298 (deferred cps import inside `store_checksum`) reduced the xdist worker-IPC hang incidence but didn't eliminate it. The hang STILL fires on `test_store_checksum_after_ensure_calibre_db_tables` in roughly half of CI runs through v4.0.123–v4.0.125.

## Next-shallowest root cause traced

The test does `from cps.progress_syncing.models import ensure_calibre_db_tables`. `cps/progress_syncing/models.py` imports `cps.db` (full SQLAlchemy Base + heavy calibre-library wiring) and `cps.ub` (user database with all migrations) at module level. Both trigger the heavyweight cps package init — under pytest-xdist subprocess context those imports hang on resources that don't exist in the worker.

## Fix

Reclassify the test from `@pytest.mark.unit` to `@pytest.mark.integration`. The test isn't a unit test by definition — it does real sqlite I/O AND triggers heavyweight `cps` init. Integration Tests runs in a separate CI job without the same xdist parallelism issues.

## Series summary (4 PRs, hopefully done)

| PR | Mitigation | Effect |
|---|---|---|
| #296 | Drop dual-trigger CI surface + `--dist=loadfile` | Halved surface |
| #297 | Close sqlite3 connection in `try/finally` | Eliminated one deadlock source |
| #298 | Defer `cps` import inside `store_checksum` branch | Eliminated one heavy import |
| **#300** | **Move test out of Fast Tests xdist pool entirely** | **Eliminates the remaining hang** |

## Confidence

98% — moves the hanging test to a CI lane (Integration Tests) that doesn't parallelize the same way. Even if the underlying `cps.progress_syncing.models` module-level imports remain heavy, they won't be triggered in the parallel pool. Integration Tests is gated for tier-2 PRs only, so most PRs will see no run; tier-2 PRs run integration sequentially under Docker.

Addresses `notes/xdist-worker-ipc-hang-followup-2026-05-21.md`.