### PR TITLE
fix(table): wysihtml5 popup placement + button colors (fork #283 round 3)

### DIFF
--- a/cps/static/css/wysihtml5-fork.css
+++ b/cps/static/css/wysihtml5-fork.css
@@ -111,3 +111,45 @@ ul.wysihtml5-toolbar > li:has(a[data-wysihtml5-command="formatBlock"]) {
 .editable-container .editableform:has(.wysihtml5-sandbox) .editable-submit {
     order: 2;
 }
+
+/*
+ * Fork #283 round 3 (reporter @droM4X): swap Cancel/Submit colors so the
+ * primary action (Submit) is the orange accent, not the secondary action.
+ *
+ * The CWNG dark theme (caliBlur.css) inverts Bootstrap convention: it maps
+ * `.btn-default` to the orange accent (CWNG's `--color-secondary`) and
+ * `.btn-primary` to a dark muted color. Since x-editable generates the
+ * Cancel button as `.btn-default` and Submit as `.btn-primary`, the
+ * theme accidentally puts the warmer color on the destructive action
+ * (Cancel) and the muted color on the constructive one (Submit).
+ *
+ * Scope the fix to wysihtml5 popups so we don't touch caliBlur's
+ * theme-wide button color mapping (which other surfaces may rely on).
+ * In this surface only, force Cancel → muted dark, Submit → orange accent.
+ */
+
+.editable-container .editableform:has(.wysihtml5-sandbox) .editable-cancel {
+    background-color: #4a5563 !important;
+    border-color: #4a5563 !important;
+    color: #fff !important;
+}
+
+.editable-container .editableform:has(.wysihtml5-sandbox) .editable-cancel:hover,
+.editable-container .editableform:has(.wysihtml5-sandbox) .editable-cancel:focus {
+    background-color: #364150 !important;
+    border-color: #364150 !important;
+    color: #fff !important;
+}
+
+.editable-container .editableform:has(.wysihtml5-sandbox) .editable-submit {
+    background-color: var(--color-secondary, #e89b18) !important;
+    border-color: var(--color-secondary, #e89b18) !important;
+    color: #fff !important;
+}
+
+.editable-container .editableform:has(.wysihtml5-sandbox) .editable-submit:hover,
+.editable-container .editableform:has(.wysihtml5-sandbox) .editable-submit:focus {
+    background-color: var(--color-secondary-hover, #c98309) !important;
+    border-color: var(--color-secondary-hover, #c98309) !important;
+    color: #fff !important;
+}

--- a/cps/templates/book_table.html
+++ b/cps/templates/book_table.html
@@ -113,7 +113,7 @@
               {{ text_table_row('languages', _('Enter Languages'),_('Languages'), false, true) }}
               <!--th data-field="pubdate" data-type="date" data-visible="{{visiblility.get('pubdate')}}" data-viewformat="dd.mm.yyyy" id="pubdate" data-sortable="true">{{_('Publishing Date')}}</th-->
               {{ text_table_row('publishers', _('Enter Publishers'),_('Publishers'), false, true) }}
-              <th data-field="comments" id="comments" data-escape="true" data-editable-mode="popup"  data-visible="{{visiblility.get('comments')}}" data-sortable="false" {% if current_user.role_edit() %} data-editable-type="wysihtml5" data-editable-url="{{ url_for('edit-book.edit_list_book', param='comments')}}" data-edit="true" data-editable-title="{{_('Enter comments')}}"{% endif %}>{{_('Comments')}}</th>
+              <th data-field="comments" id="comments" data-escape="true" data-editable-mode="popup" data-editable-placement="bottom" data-visible="{{visiblility.get('comments')}}" data-sortable="false" {% if current_user.role_edit() %} data-editable-type="wysihtml5" data-editable-url="{{ url_for('edit-book.edit_list_book', param='comments')}}" data-edit="true" data-editable-title="{{_('Enter comments')}}"{% endif %}>{{_('Comments')}}</th>
               {% if current_user.check_visibility(32768) %}
                 {{ book_checkbox_row('is_archived', _('Archived?'), false)}}
               {%  endif %}
@@ -132,7 +132,7 @@
                 {% elif c.datatype == "text" %}
                   {{ text_table_row('custom_column_' + c.id|string, _('Enter ') + c.name, c.name, false, false) }}
                 {% elif c.datatype == "comments" %}
-                    <th data-field="custom_column_{{ c.id|string }}" id="custom_column_{{ c.id|string }}" data-escape="true" data-editable-mode="popup"  data-visible="{{visiblility.get('custom_column_'+ c.id|string)}}" data-sortable="false" {% if current_user.role_edit() %} data-editable-type="wysihtml5" data-editable-url="{{ url_for('edit-book.edit_list_book', param='custom_column_'+ c.id|string)}}" data-edit="true" data-editable-title="{{_('Enter ') + c.name}}"{% endif %}>{{c.name}}</th>
+                    <th data-field="custom_column_{{ c.id|string }}" id="custom_column_{{ c.id|string }}" data-escape="true" data-editable-mode="popup" data-editable-placement="bottom" data-visible="{{visiblility.get('custom_column_'+ c.id|string)}}" data-sortable="false" {% if current_user.role_edit() %} data-editable-type="wysihtml5" data-editable-url="{{ url_for('edit-book.edit_list_book', param='custom_column_'+ c.id|string)}}" data-edit="true" data-editable-title="{{_('Enter ') + c.name}}"{% endif %}>{{c.name}}</th>
                 {% elif c.datatype == "bool" %}
                     {{ book_checkbox_row('custom_column_' + c.id|string, c.name, false)}}
                 {% else %}

--- a/tests/unit/test_283_round3_zindex_colors.py
+++ b/tests/unit/test_283_round3_zindex_colors.py
@@ -1,0 +1,104 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for fork #283 round 3 (@droM4X).
+
+After v4.0.125 droM4X verified the previous round's fixes and posted
+three more:
+
+1. Popover clipped at top by the fixed navbar on the first ~3 rows of
+   the table (placement="top" default + navbar overlap).
+2. Asked for auto-flip / "open below" when there's no room above.
+3. Button colors should follow Bootstrap convention: primary action
+   (Submit) = orange accent, secondary action (Cancel) = muted gray.
+   Currently inverted because caliBlur maps btn-default to orange and
+   btn-primary to muted dark.
+
+Two fixes:
+- `data-editable-placement="bottom"` on the Comments column header
+  (and the custom-column wysihtml5 mirror at line ~135) — forces
+  popover to open BELOW the cell, eliminating navbar collision.
+- Scoped CSS overrides in wysihtml5-fork.css forcing Submit → orange,
+  Cancel → muted dark (only inside `.editableform:has(.wysihtml5-sandbox)`
+  so other surfaces don't see the theme inversion).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = REPO_ROOT / "cps" / "templates" / "book_table.html"
+CSS = REPO_ROOT / "cps" / "static" / "css" / "wysihtml5-fork.css"
+
+
+def test_comments_column_placement_bottom():
+    src = TEMPLATE.read_text()
+    # Find the comments column <th> definition
+    match = re.search(
+        r'<th[^>]*\bdata-field="comments"[^>]*>',
+        src, re.DOTALL,
+    )
+    assert match, "comments column <th> not found"
+    th = match.group(0)
+    assert 'data-editable-placement="bottom"' in th, (
+        "comments column must declare data-editable-placement=\"bottom\" "
+        "so the popover opens below the cell (avoids navbar clip on top rows)"
+    )
+
+
+def test_custom_column_wysihtml5_placement_bottom():
+    """Custom-column wysihtml5 columns must also get the bottom placement."""
+    src = TEMPLATE.read_text()
+    # Find custom_column TH with editable-type=wysihtml5
+    match = re.search(
+        r'<th[^>]*\bdata-field="custom_column[^"]*"[^>]*\bdata-editable-type="wysihtml5"[^>]*>',
+        src, re.DOTALL,
+    )
+    assert match, "custom-column wysihtml5 <th> not found"
+    th = match.group(0)
+    assert 'data-editable-placement="bottom"' in th, (
+        "custom-column wysihtml5 columns must also declare "
+        "data-editable-placement=\"bottom\""
+    )
+
+
+def test_submit_button_uses_accent_color():
+    """Submit button (primary action) must use the CWNG accent color
+    inside wysihtml5 popups, overriding caliBlur's btn-primary muted
+    dark mapping."""
+    css = CSS.read_text()
+    # Find the wysihtml5-scoped .editable-submit rule
+    assert re.search(
+        r'\.editableform:has\(\.wysihtml5-sandbox\)\s+\.editable-submit\s*\{[^}]*background-color:\s*var\(--color-secondary',
+        css, re.DOTALL,
+    ), ".editable-submit (scoped to wysihtml5) must use var(--color-secondary) for the accent color"
+
+
+def test_cancel_button_uses_muted_color():
+    """Cancel button (secondary) must use a muted dark color inside
+    wysihtml5 popups, overriding caliBlur's btn-default orange mapping.
+    There are two matching `.editable-cancel` rules in the file (the
+    earlier order:1 rule from PR #294 + the new color override) —
+    find the one that sets background-color."""
+    css = CSS.read_text()
+    matches = re.findall(
+        r'\.editableform:has\(\.wysihtml5-sandbox\)\s+\.editable-cancel\s*\{([^}]*)\}',
+        css, re.DOTALL,
+    )
+    color_rules = [m for m in matches if "background-color" in m]
+    assert color_rules, (
+        "no scoped .editable-cancel rule sets background-color — must "
+        "override caliBlur's btn-default orange mapping inside wysihtml5 popups"
+    )
+    body = color_rules[0]
+    # Should NOT be the accent variable (that's the orange we want on submit).
+    assert "var(--color-secondary" not in body, (
+        "cancel must NOT use the accent color — that's the submit color"
+    )


### PR DESCRIPTION
@droM4X tested v4.0.125 and verified PR #294's layout fixes, then posted three more concrete asks with a [screenshot](https://github.com/user-attachments/assets/a35a9282-ede8-4958-93d0-305b323ec4fe):

1. Popover clipped at top by the fixed navbar on the upper rows.
2. Auto-flip / "open below when no space above".
3. Button colors should follow Bootstrap convention — Submit (primary) should be the orange accent, not Cancel.

## Three fixes

**(1+2) `data-editable-placement="bottom"`** on the Comments column header AND the custom-column wysihtml5 mirror in `book_table.html`. Forces popover below the cell — no navbar overlap regardless of row position. Simpler than auto-flip (which would need popper.js / Bootstrap 4+).

**(3) Scoped button color overrides** in `wysihtml5-fork.css`. caliBlur inverts Bootstrap convention — `btn-default` maps to `var(--color-secondary)` (orange) and `btn-primary` maps to muted dark. x-editable correctly generates Cancel as `btn-default` and Submit as `btn-primary`, but the theme then puts orange on Cancel. Scoped CSS forces Submit → `var(--color-secondary)` and Cancel → muted `#4a5563`, only inside `.editableform:has(.wysihtml5-sandbox)` so other surfaces keep their theme colors.

## Tests

4 source-pin tests in `tests/unit/test_283_round3_zindex_colors.py` cover placement attributes (both columns) and button color overrides. All GREEN. The two prior #283 test files (15 tests) stay GREEN.

## Verification on cwn-local

| Selector | Computed |
|---|---|
| `.editable-container.popover` className | `bottom` placement (was `top`) |
| Popover top position (row 1 click) | `535` (was near top, behind navbar) |
| `.editable-submit` background | `rgb(204, 123, 25)` — CWNG orange ✅ |
| `.editable-cancel` background | `rgb(74, 85, 99)` — muted gray ✅ |

## Confidence

97% — three scoped changes, no global theme touch. Other editable surfaces (text inputs on other columns) keep their default styling since the CSS uses `:has(.wysihtml5-sandbox)`.

Addresses #283 round 3.