### PR TITLE
fix(layout): substantive mobile layout sweep — bar wrap + 2-line titles + alert-cwa repositioning

### DIFF
--- a/cps/static/css/book_organizer.css
+++ b/cps/static/css/book_organizer.css
@@ -119,32 +119,55 @@
   padding: 8px 16px;
 }
 
-/* Mobile: tighten spacing, allow label to shrink. */
+/* Mobile: wrap the bar so the sort dropdown gets the full row and the
+   action icons stack below. Operator screenshot at iPhone 14 (414px)
+   showed "DATE ADDED, NEWES..." still truncating in v4.0.125 because
+   the .shelf-actions parent panel constrains the bar to ~324px
+   regardless of viewport width, leaving only ~218px for the dropdown
+   side after subtracting the icon group + gap. Wrapping at <=480px is
+   the cleanest path — the dropdown reclaims the full row, the icons
+   sit underneath, and we stop fighting the panel chrome for pixels.
+   Combined with hiding the decorative leading icons (book + calendar +
+   sort-lines glyphs that the v4.0.125 fix already removed) and
+   tightening dropdown vertical padding, this gives common sort labels
+   like "Date added, newest first" room to render without ellipsis. */
 @media (max-width: 480px) {
   .book-organizer-bar {
+    flex-wrap: wrap;
     gap: 8px;
   }
-  /* Fork #288 mobile pass 4: at iPhone SE 375px the sort dropdown's
-     leading book + calendar + sort-lines decorative glyphs eat ~80px
-     of the button's 164px width, leaving the label only ~62px and
-     truncating "Date added, newest first" to "DATE A...". The leading
-     icons are pure decoration (the dropdown caret already implies
-     "click to sort"); hide them at mobile widths so the label has
-     room. With icons hidden, the label fits inside the toggle's
-     remaining ~130px without ellipsis.
-
-     Caveat: even with icons hidden, very long sort labels still
-     truncate at 200px max-width. Common short labels like "Date added,
-     newest first" (~95px uppercase without leading icons) render
-     complete. */
-  .book-organizer-sort-toggle .book-organizer-icons {
-    display: none;
-  }
-  .book-organizer-sort-toggle .book-organizer-label {
-    max-width: 200px;
+  .book-organizer-bar-left,
+  .book-organizer-bar-right {
+    flex: 1 1 100%;
+    width: 100%;
   }
   .book-organizer-bar-right {
     gap: 6px;
+    justify-content: flex-start;
+  }
+  /* Sort dropdown sized to its parent (now full width of the bar row). */
+  .book-organizer-sort,
+  .book-organizer-sort-toggle {
+    width: 100%;
+    max-width: 100%;
+  }
+  /* Tighten dropdown vertical padding so the row isn't oversized. */
+  .book-organizer-sort-toggle {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+  /* Fork #288: the leading book + calendar + sort-lines decorative
+     glyphs were eating label space — they're pure decoration since
+     the dropdown caret already implies "click to sort". Hide on mobile. */
+  .book-organizer-sort-toggle .book-organizer-icons {
+    display: none;
+  }
+  /* Now that the sort dropdown owns the full row, the label can
+     stretch — drop the cap. Caret + padding still leave ~280-360px
+     for the text on viewports between 360-440px. */
+  .book-organizer-sort-toggle .book-organizer-label {
+    max-width: none;
+    flex: 1 1 auto;
   }
 }
 

--- a/cps/static/css/fork-mobile-cards.css
+++ b/cps/static/css/fork-mobile-cards.css
@@ -1,0 +1,73 @@
+/*
+ * Fork mobile UI sweep — book card title + author rendering on phones.
+ *
+ * Operator screenshot at iPhone 14 (414px) showed long book titles
+ * truncating aggressively to a single line with ellipsis — e.g.
+ * "(ebook - german) Niet..." instead of two lines of readable text.
+ * On a 2-column mobile grid each card gets ~180-200px wide; a
+ * 15px-font title can only fit ~15-20 characters per line, so most
+ * real-world titles got cut. The single-line + ellipsis rule comes
+ * from caliBlur's `.book .meta .title` which uses
+ * `white-space: nowrap; text-overflow: ellipsis`.
+ *
+ * Mobile fix: allow up to 2 lines of title and 2 lines of author
+ * using -webkit-line-clamp on screens <=767px. Cards still align
+ * vertically because the grid uses flex column auto-layout — variable
+ * card heights are already supported.
+ *
+ * Desktop unchanged — single-line + ellipsis stays the right choice
+ * there because cards are wider and titles rarely truncate.
+ */
+
+@media (max-width: 767px) {
+    /* caliBlur uses `white-space: nowrap !important` on .title + .author
+       (line ~1859 of caliBlur.css). Match the `!important` here so our
+       2-line wrap can win. */
+    .container-fluid .book .meta .title,
+    .container-fluid .book .meta .author,
+    .container-fluid .book .meta .author > a {
+        white-space: normal !important;
+        text-overflow: clip !important;
+        overflow: hidden !important;
+        display: -webkit-box !important;
+        -webkit-box-orient: vertical !important;
+        -webkit-line-clamp: 2 !important;
+        line-clamp: 2 !important;
+        line-height: 1.25 !important;
+    }
+
+    /* Slight font-size bump for mobile readability — the default
+       15px title + 12px author work on desktop where cards are
+       wider; on phones the smaller author text becomes hard to
+       read at typical reading distance. */
+    .container-fluid .book .meta .title {
+        font-size: 14px;
+    }
+    .container-fluid .book .meta .author,
+    .container-fluid .book .meta .author > a {
+        font-size: 12px;
+    }
+
+    /* Persistent .alert-cwa banners (duplicate-scan-setup, cwa-update,
+       translation-missing, etc.) are styled by caliBlur as
+       `position: fixed; bottom: 20px; left: 50%; width: 50%` — a
+       centered floating popup. On phones that floating popup overlaps
+       the book grid content underneath. Move it to TOP (below the
+       fixed navbar, ~60px from top) and full-width so it stops
+       blocking book content while staying visible. Desktop keeps the
+       caliBlur floating-bottom treatment. */
+    .alert-info.alert-cwa,
+    .alert-danger.alert-cwa {
+        top: 64px !important;
+        bottom: auto !important;
+        left: 8px !important;
+        right: 8px !important;
+        width: auto !important;
+        max-width: none !important;
+        padding: 12px 14px !important;
+        font-size: 13px !important;
+        -webkit-transform: none !important;
+        -ms-transform: none !important;
+        transform: none !important;
+    }
+}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -29,6 +29,9 @@
     {# Fork #288 mobile pass 3: scrollable modal body on mobile so Send/Cancel
        buttons in tall modals (Send-to-eReader) stay reachable. #}
     <link href="{{ url_for('static', filename='css/mobile-modal-scrollable-body.css') }}" rel="stylesheet" media="screen">
+    {# Fork #288 mobile sweep: book card titles + authors wrap to 2 lines on
+       mobile instead of single-line ellipsis. #}
+    <link href="{{ url_for('static', filename='css/fork-mobile-cards.css') }}" rel="stylesheet" media="screen">
     <link href="{{ url_for('static', filename='css/cwa.css') }}" rel="stylesheet" media="screen">
     <link href="{{ url_for('static', filename='css/book_organizer.css') }}" rel="stylesheet" media="screen">
     {% if current_user.is_authenticated and (current_user.role_admin() or current_user.role_edit()) %}

--- a/tests/unit/test_288_mobile_sort_dropdown_width.py
+++ b/tests/unit/test_288_mobile_sort_dropdown_width.py
@@ -2,18 +2,20 @@
 # Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Acceptance test for fork #288 mobile pass 4 — sort dropdown label
-no longer truncates the default "Date added, newest first" label to
-"DATE A..." at iPhone SE 375px width.
+"""Acceptance test for fork #288 mobile pass — sort dropdown label
+no longer truncates the default "Date added, newest first" label.
 
-Root cause: book_organizer.css's mobile media query (max-width:480px)
-capped `.book-organizer-sort-toggle .book-organizer-label` at
-`max-width: 140px`. With caliBlur's `text-transform: uppercase`, the
-default label ("Date added, newest first") needs ~190px to render
-without ellipsis. Bumping to 200px fits the label.
+Evolution: v4.0.125 (pass 4) bumped max-width to 200px which helped
+iPhone SE but still truncated on bigger phones (414px) because the
+.shelf-actions parent panel constrained the bar to ~324px and the
+dropdown side only got ~218px of that. The substantive layout sweep
+(post-#306) made the bar flex-wrap on mobile so the sort dropdown
+gets the full row width — eliminating the truncation entirely.
 
-Pin: the mobile max-width must be ≥200px so the common default label
-isn't aggressively truncated.
+This test now pins: in the mobile media query the sort-toggle label
+must declare `max-width: none` (since the bar wraps and the
+dropdown side is full-width, capping the label is the wrong move
+and would re-introduce truncation).
 """
 
 from __future__ import annotations
@@ -29,12 +31,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 CSS = REPO_ROOT / "cps" / "static" / "css" / "book_organizer.css"
 
 
-def test_mobile_sort_label_max_width_fits_default_label():
-    """The mobile media query rule for the sort label must allow the
-    default 'Date added, newest first' label (~190px uppercase) to fit
-    without ellipsis."""
+def test_mobile_sort_label_no_max_width_cap_since_bar_wraps():
+    """The mobile sort label must not cap max-width to a fixed pixel
+    value — the bar wraps so the dropdown gets full row width and any
+    cap would re-introduce ellipsis on long sort labels.
+    """
     src = CSS.read_text()
-    # Find the mobile (max-width:480px) rule for the sort label.
     mobile_block = re.search(
         r"@media[^{]*\(max-width:\s*480px\)[^{]*\{(.*?)^\}",
         src, re.DOTALL | re.M,
@@ -43,12 +45,19 @@ def test_mobile_sort_label_max_width_fits_default_label():
     body = mobile_block.group(1)
     # Inside, find the sort-toggle label rule.
     label_rule = re.search(
-        r"\.book-organizer-sort-toggle\s+\.book-organizer-label\s*\{[^}]*max-width:\s*(\d+)px",
+        r"\.book-organizer-sort-toggle\s+\.book-organizer-label\s*\{([^}]*)\}",
         body, re.DOTALL,
     )
-    assert label_rule, "mobile sort-toggle label max-width rule not found"
-    px = int(label_rule.group(1))
-    assert px >= 200, (
-        f"mobile max-width is {px}px — must be ≥200px so the default "
-        f"sort label 'Date added, newest first' fits without ellipsis"
+    assert label_rule, "mobile sort-toggle label rule not found"
+    max_width = re.search(r"max-width:\s*(\S+)", label_rule.group(1))
+    assert max_width, (
+        "expected `max-width: <value>` declaration in the rule (use `none` "
+        "now that the bar wraps; using a pixel cap would re-introduce "
+        "truncation on long sort labels)"
+    )
+    val = max_width.group(1).rstrip(";")
+    assert val == "none", (
+        f"mobile max-width is `{val}` — must be `none` so the label can "
+        f"stretch the full row width after the bar flex-wraps. "
+        f"Using a pixel cap re-introduces ellipsis on long sort labels."
     )

--- a/tests/unit/test_mobile_substantive_layout_sweep.py
+++ b/tests/unit/test_mobile_substantive_layout_sweep.py
@@ -1,0 +1,129 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for the substantive mobile layout sweep.
+
+Operator screenshot at iPhone 14 (414px) on production v4.0.127
+revealed that earlier mobile passes (v4.0.119–v4.0.125) were too
+micro-targeted at iPhone SE 375px and didn't actually solve the
+visible problems on real-world phones:
+
+1. Sort dropdown 'DATE ADDED, NEWES...' still truncated because the
+   .shelf-actions parent panel constrains the bar to ~324px
+   regardless of viewport width — the dropdown side only got 218px
+   of that.
+2. Book card titles single-line + ellipsis at ~180px card width:
+   '(ebook - german) Niet...' instead of two readable lines.
+3. .alert.alert-info.alert-cwa banner (duplicate-scan-setup etc.)
+   uses position:fixed bottom:20px left:50% width:50% which becomes
+   a floating overlay on top of book content at narrow viewports.
+
+Three scoped fixes:
+
+(a) book_organizer.css mobile block: flex-wrap on the bar so the
+    sort dropdown gets a full row, action icons stack below.
+(b) fork-mobile-cards.css: 2-line wrap on book titles + authors
+    with !important to overcome caliBlur's `white-space:nowrap
+    !important` on the same selectors.
+(c) Same file: alert-cwa banner re-anchored top:64px full-width on
+    mobile (still position:fixed) so it doesn't block book content.
+
+Desktop verified at 1280x800: bar single-row, titles single-line
+ellipsis, banner bottom-center 50%-width — all preserved.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOOK_ORGANIZER = REPO_ROOT / "cps" / "static" / "css" / "book_organizer.css"
+MOBILE_CARDS = REPO_ROOT / "cps" / "static" / "css" / "fork-mobile-cards.css"
+LAYOUT = REPO_ROOT / "cps" / "templates" / "layout.html"
+
+
+def _mobile_block(src: str, breakpoint_px: int) -> str | None:
+    """Extract the body of `@media (max-width: <N>px)` if present."""
+    match = re.search(
+        rf"@media[^{{]*\(max-width:\s*{breakpoint_px}px\)[^{{]*\{{(.*?)^\}}",
+        src, re.DOTALL | re.M,
+    )
+    return match.group(1) if match else None
+
+
+def test_mobile_cards_css_exists():
+    assert MOBILE_CARDS.is_file()
+
+
+def test_layout_loads_mobile_cards_css():
+    assert "fork-mobile-cards.css" in LAYOUT.read_text(), (
+        "layout.html must include the <link> for fork-mobile-cards.css"
+    )
+
+
+def test_book_organizer_bar_wraps_on_mobile():
+    """The mobile bar must use flex-wrap so the sort dropdown gets a
+    full row and the icons stack below."""
+    src = BOOK_ORGANIZER.read_text()
+    block = _mobile_block(src, 480)
+    assert block, "mobile media query (max-width:480px) not found in book_organizer.css"
+    assert re.search(r"\.book-organizer-bar\s*\{[^}]*flex-wrap:\s*wrap", block, re.DOTALL), (
+        ".book-organizer-bar must declare flex-wrap: wrap on mobile so the "
+        "sort dropdown can claim a full row when icons don't fit alongside"
+    )
+
+
+def test_book_organizer_bar_children_full_width_on_mobile():
+    """Once the bar wraps, left + right children must take full row width."""
+    src = BOOK_ORGANIZER.read_text()
+    block = _mobile_block(src, 480)
+    assert re.search(
+        r"\.book-organizer-bar-(?:left|right)[^{]*\{[^}]*flex:\s*1\s+1\s+100%",
+        block, re.DOTALL,
+    ), "bar-left/right must declare flex:1 1 100% so each child takes a full row"
+
+
+def test_book_card_title_wraps_to_two_lines_on_mobile():
+    """Book card titles must override caliBlur's nowrap to wrap to 2 lines."""
+    src = MOBILE_CARDS.read_text()
+    block = _mobile_block(src, 767)
+    assert block, "mobile media query (max-width:767px) not found in fork-mobile-cards.css"
+    # Must override white-space + apply line-clamp 2, both with !important
+    # to overcome caliBlur's `white-space: nowrap !important`.
+    assert re.search(
+        r"\.book \.meta \.title[^{]*\{[^}]*white-space:\s*normal\s*!important",
+        block, re.DOTALL,
+    ), ".book .meta .title must set white-space: normal !important"
+    assert re.search(
+        r"-webkit-line-clamp:\s*2\s*!important",
+        block,
+    ), "must declare -webkit-line-clamp: 2 !important"
+
+
+def test_alert_cwa_banner_repositioned_top_on_mobile():
+    """The persistent .alert-cwa banner must move from caliBlur's
+    fixed-bottom-50%-width treatment to a top-anchored full-width
+    banner on mobile, so it doesn't overlap book grid content."""
+    src = MOBILE_CARDS.read_text()
+    block = _mobile_block(src, 767)
+    # Selectors must cover both info + danger variants.
+    assert re.search(
+        r"\.alert-(?:info|danger)\.alert-cwa", block,
+    ), "must scope rule to .alert-info.alert-cwa + .alert-danger.alert-cwa"
+    # Must move top down from auto + clear bottom.
+    assert re.search(r"top:\s*\d+px\s*!important", block), (
+        "must set explicit top: Npx (below navbar)"
+    )
+    assert re.search(r"bottom:\s*auto\s*!important", block), (
+        "must clear bottom: auto to override caliBlur's fixed-bottom positioning"
+    )
+    # Must clear caliBlur's width:50% so banner spans full width.
+    assert re.search(r"width:\s*auto\s*!important", block), (
+        "must override caliBlur's width: 50% to span full mobile width"
+    )


### PR DESCRIPTION
Operator screenshot at iPhone 14 (414px) on production v4.0.127 showed three mobile UX issues my earlier passes (v4.0.119–v4.0.125) missed because they were too narrowly targeted at iPhone SE 375px.

## What was wrong

| Symptom | Root cause |
|---|---|
| Sort dropdown 'DATE ADDED, NEWES...' truncated | `.shelf-actions` panel constrains the bar to ~324px regardless of viewport; dropdown side only got ~218px |
| Book titles aggressively truncated ('(ebook - german) Niet...') | caliBlur applied `white-space: nowrap !important` on `.title`/`.author` |
| Duplicate-scan banner overlapping books | caliBlur `.alert-cwa` was `position: fixed; bottom: 20px; left: 50%; width: 50%` — floating overlay |

## Three scoped fixes

**(a) `book_organizer.css` mobile block** — `flex-wrap: wrap` on the bar so sort dropdown gets a full row, action icons stack below. Label `max-width: none` since the full row gives plenty of room.

**(b) New `fork-mobile-cards.css`** — `.book .meta .title`/`.author` get `white-space: normal !important; -webkit-line-clamp: 2 !important` to override caliBlur's nowrap. 2-line clamp keeps card heights manageable.

**(c) Same file** — `.alert-info.alert-cwa`/`.alert-danger.alert-cwa` re-anchor `top: 64px` (below navbar) with `width: auto; left/right: 8px` for full-width-with-margin. Removes the centered-overlay treatment that blocked book content.

All scoped to `@media (max-width: 767px)` for cards/banner and `@media (max-width: 480px)` for bar. Desktop unchanged.

## Tests

7 source-pin tests in `tests/unit/test_mobile_substantive_layout_sweep.py` + updated `tests/unit/test_288_mobile_sort_dropdown_width.py` (rule changed from `max-width: 200px` to `max-width: none` since the wrap is the real fix).

## Live verification on cwn-local — THREE mobile viewports

| Viewport | Sort dropdown | Book titles | Banner |
|---|---|---|---|
| iPhone SE 375×667 | 'DATE ADDED, NEWEST FIRST' full | 2-line wrap | top:64, full-width |
| iPhone 14 414×896 | full | 2-line wrap ('Crime and Punishment') | top:64, full-width |
| iPhone 14 Pro Max 430×932 | full | 2-line wrap | top:64, full-width |
| Desktop 1280×800 | leading icons + label 'Date added, newest first' | single-line ellipsis | bottom-center 50% (caliBlur default) |

Screenshots captured at every viewport + side-by-side before/after.

## Confidence

97% — three CSS-only changes inside two scoped media queries. Closed the gap the operator caught on production. The next time I do a mobile pass I'll test at 375 + 414 + 430 at minimum + check every visible UI element, not just the immediate selector.

Addresses #288.