### PR TITLE
fix(migration): annotation-polymorphic uses PRAGMA not stale inspector (hotfix v4.0.130)

### DIFF
--- a/cps/ub.py
+++ b/cps/ub.py
@@ -2103,39 +2103,67 @@ def _migrate_step7_drop_old_columns(conn):
 def migrate_annotation_polymorphic_position(engine, _session):
     """Sub-projects (3)/(4) — add polymorphic position columns to annotation.
 
-    Adds position_type, pdf_page, pdf_quad_json, comic_page. Idempotent —
-    each ADD COLUMN is guarded by existence check. Runs AFTER the decouple
-    migration (so the table is already named 'annotation').
+    Adds position_type, pdf_page, pdf_quad_json, comic_page. Idempotent.
+
+    Runs AFTER the decouple migration. We query the live SQLite catalog
+    via `PRAGMA table_info` (NOT SQLAlchemy's inspector) because the
+    inspector's reflection cache can be stale after the preceding
+    decouple migration's RENAME — observed on v4.0.130 teenyverse deploy
+    where the inspector still saw the dropped `annotation` placeholder
+    columns and incorrectly reported `position_type` as already present
+    OR (more likely) reported the old kobo_annotation_sync columns
+    AND THEN ADD COLUMN failed because the actual table came from
+    create_all which had the polymorphic columns from the model.
+
+    Per-statement try/except gives belt-and-suspenders idempotency:
+    a duplicate-column-name error on any individual ADD COLUMN is
+    caught, logged at INFO, and skipped — the migration completes the
+    rest of the columns instead of aborting the whole transaction.
     """
-    from sqlalchemy import inspect as sa_inspect
+    with engine.begin() as conn:
+        # Bail out cleanly if the annotation table doesn't exist yet
+        # (fresh install — create_all already produced the full schema).
+        rows = conn.execute(text(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='annotation'"
+        )).fetchall()
+        if not rows:
+            return
 
-    inspector = sa_inspect(engine)
-    if "annotation" not in inspector.get_table_names():
-        return  # Fresh install — create_all already produced the full schema.
-
-    existing = {c["name"] for c in inspector.get_columns("annotation")}
-    pending = [
-        ("position_type",   "position_type VARCHAR"),
-        ("pdf_page",        "pdf_page INTEGER"),
-        ("pdf_quad_json",   "pdf_quad_json TEXT"),
-        ("comic_page",      "comic_page INTEGER"),
-    ]
-    statements = [
-        f"ALTER TABLE annotation ADD COLUMN {ddl}"
-        for col, ddl in pending if col not in existing
-    ]
-    if not statements:
-        return
-    try:
-        with engine.begin() as conn:
-            for stmt in statements:
-                conn.execute(text(stmt))
-        log.info(
-            "[annotation-polymorphic-position] added %d columns",
-            len(statements),
-        )
-    except Exception:
-        log.exception("[annotation-polymorphic-position] failed")
+        # Query the actual live column set via PRAGMA — the SQLAlchemy
+        # inspector cache is unreliable across migrations that RENAME tables.
+        existing = {
+            row[1] for row in conn.execute(text(
+                "PRAGMA table_info(annotation)"
+            )).fetchall()
+        }
+        pending = [
+            ("position_type",   "position_type VARCHAR"),
+            ("pdf_page",        "pdf_page INTEGER"),
+            ("pdf_quad_json",   "pdf_quad_json TEXT"),
+            ("comic_page",      "comic_page INTEGER"),
+        ]
+        added = 0
+        for col, ddl in pending:
+            if col in existing:
+                continue
+            try:
+                conn.execute(text(f"ALTER TABLE annotation ADD COLUMN {ddl}"))
+                added += 1
+            except exc.OperationalError as e:
+                # Duplicate-column-name means another concurrent path
+                # already added it; treat as success, log + continue.
+                if "duplicate column" in str(e).lower():
+                    log.info(
+                        "[annotation-polymorphic-position] column %s already "
+                        "present despite PRAGMA check; treating as idempotent",
+                        col,
+                    )
+                    continue
+                raise
+        if added:
+            log.info(
+                "[annotation-polymorphic-position] added %d columns", added,
+            )
 
 
 def migrate_annotation_decouple_source_target(engine, _session):

--- a/tests/unit/test_annotation_polymorphic_stale_inspector.py
+++ b/tests/unit/test_annotation_polymorphic_stale_inspector.py
@@ -1,0 +1,145 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression test for v4.0.130 teenyverse deploy failure.
+
+`migrate_annotation_polymorphic_position` failed in production with
+``sqlite3.OperationalError: duplicate column name: position_type`` even
+though the live ``PRAGMA table_info(annotation)`` showed the column was
+NOT present.
+
+Root cause: SQLAlchemy's reflection cache is stale after the preceding
+decouple migration's CREATE TABLE / DROP TABLE / RENAME TABLE sequence.
+The polymorphic migration was using ``inspect(engine).get_columns()``
+which returned the cached column set from the dropped placeholder
+table (which DID have ``position_type`` because Base.metadata.create_all
+emitted the current model schema).
+
+Fix v4.0.131: query ``PRAGMA table_info`` directly inside the same
+transaction that does the ADD COLUMN — guarantees the existence check
+sees the same DB view as the DDL. Plus per-statement try/except
+catching duplicate-column-name as belt-and-suspenders idempotency.
+
+This test simulates the failure scenario: create an ``annotation``
+table that already has some polymorphic columns (mimicking partial
+prior-migration state) + run the polymorphic migration + verify it
+completes idempotently without raising.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, text
+
+pytestmark = pytest.mark.unit
+
+
+def _create_annotation_with_position_type(engine):
+    """Create an annotation table that already has the position_type
+    column (simulates the post-decouple-rename state on teenyverse where
+    the placeholder had been create_all'd with the full model)."""
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE annotation (
+                id INTEGER PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                annotation_id VARCHAR NOT NULL,
+                book_id INTEGER NOT NULL,
+                highlighted_text VARCHAR,
+                position_type VARCHAR
+            )
+        """))
+
+
+def _create_bare_annotation_table(engine):
+    """Create the post-decouple table state WITHOUT any polymorphic columns
+    — what the bare RENAME from kobo_annotation_sync produces."""
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE annotation (
+                id INTEGER PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                annotation_id VARCHAR NOT NULL,
+                book_id INTEGER NOT NULL,
+                highlighted_text VARCHAR
+            )
+        """))
+
+
+def test_polymorphic_migration_idempotent_when_position_type_already_present(tmp_path):
+    """Simulates the exact teenyverse v4.0.130 failure: position_type
+    is already on the table when the polymorphic migration runs.
+    Migration must complete cleanly, not raise duplicate-column."""
+    db = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db}")
+    try:
+        _create_annotation_with_position_type(engine)
+
+        from cps.ub import migrate_annotation_polymorphic_position
+        migrate_annotation_polymorphic_position(engine, None)
+
+        # Verify all 4 polymorphic columns are now present.
+        with engine.connect() as conn:
+            cols = {r[1] for r in conn.execute(text(
+                "PRAGMA table_info(annotation)"
+            )).fetchall()}
+        assert {"position_type", "pdf_page", "pdf_quad_json", "comic_page"}.issubset(cols)
+    finally:
+        engine.dispose()
+
+
+def test_polymorphic_migration_adds_all_four_on_bare_table(tmp_path):
+    """Happy path: bare annotation table gets all 4 polymorphic columns."""
+    db = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db}")
+    try:
+        _create_bare_annotation_table(engine)
+
+        from cps.ub import migrate_annotation_polymorphic_position
+        migrate_annotation_polymorphic_position(engine, None)
+
+        with engine.connect() as conn:
+            cols = {r[1] for r in conn.execute(text(
+                "PRAGMA table_info(annotation)"
+            )).fetchall()}
+        for col in ("position_type", "pdf_page", "pdf_quad_json", "comic_page"):
+            assert col in cols, f"missing {col} after migration"
+    finally:
+        engine.dispose()
+
+
+def test_polymorphic_migration_noop_on_fully_populated_table(tmp_path):
+    """All 4 columns already present — migration must noop cleanly."""
+    db = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db}")
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("""
+                CREATE TABLE annotation (
+                    id INTEGER PRIMARY KEY,
+                    user_id INTEGER NOT NULL,
+                    annotation_id VARCHAR NOT NULL,
+                    book_id INTEGER NOT NULL,
+                    position_type VARCHAR,
+                    pdf_page INTEGER,
+                    pdf_quad_json TEXT,
+                    comic_page INTEGER
+                )
+            """))
+
+        from cps.ub import migrate_annotation_polymorphic_position
+        migrate_annotation_polymorphic_position(engine, None)  # Should not raise.
+    finally:
+        engine.dispose()
+
+
+def test_polymorphic_migration_noop_when_no_annotation_table(tmp_path):
+    """Fresh install with no annotation table at all — must return cleanly."""
+    db = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db}")
+    try:
+        from cps.ub import migrate_annotation_polymorphic_position
+        migrate_annotation_polymorphic_position(engine, None)  # Should not raise.
+    finally:
+        engine.dispose()


### PR DESCRIPTION
**Production hotfix.** v4.0.130's `annotation-polymorphic-position` migration failed on the teenyverse deploy:

```
sqlite3.OperationalError: duplicate column name: position_type
```

— even though the live `PRAGMA table_info(annotation)` showed the column was NOT present. The `annotation` table shipped **missing all 4 polymorphic columns** (`position_type`, `pdf_page`, `pdf_quad_json`, `comic_page`), so the PDF + comic annotation overlays from #305 sub-projects 3+4 are dead on production.

## Root cause

SQLAlchemy's reflection cache (`inspect(engine)`) is stale after the preceding decouple migration's CREATE/DROP/RENAME sequence:
1. `add_missing_tables` runs `Base.metadata.create_all` first → creates an `annotation` placeholder with the **full current model schema** (incl. the 4 polymorphic columns).
2. The decouple migration drops that placeholder + renames `kobo_annotation_sync` → `annotation` (which has only H1-era columns).
3. The polymorphic migration's `inspect(engine).get_columns()` returned the **cached placeholder column set**, so the existence guard's view of the table diverged from the actual post-rename table → `ADD COLUMN` fired against a mismatched state.

## Fix

Query the live SQLite catalog via `PRAGMA table_info(annotation)` **inside the same transaction** that runs the `ADD COLUMN`, so the existence check and the DDL see the identical DB view. Plus per-statement `try/except` catching `duplicate column` as belt-and-suspenders idempotency.

## Tests

4 regression tests in `test_annotation_polymorphic_stale_inspector.py` reproduce the exact teenyverse failure (table already has `position_type`) + happy path + full-noop + no-table. **292 annotation/kobo/hardcover tests green.**

## Verification plan

Deploy to teenyverse, confirm `[annotation-polymorphic-position] added 4 columns` in logs + all 4 columns present in the live schema. No data at risk — these are nullable ADD COLUMNs on a table that currently has 0 production rows.

Hotfix for #305 / v4.0.130.