### PR TITLE
fix(annotations): kepub CFI resolves with NULL child_index (web-reader overlay)

### DIFF
--- a/cps/services/kobo_position.py
+++ b/cps/services/kobo_position.py
@@ -146,12 +146,17 @@ def compute_cfi_range(epub_path: Path, position: KoboPosition) -> Optional[str]:
     start_id = _extract_kobospan_id(position.start_container_path)
     end_id = _extract_kobospan_id(position.end_container_path)
 
-    if (
-        start_id and end_id
-        and position.start_container_child_index == KOBO_SELECTOR_SENTINEL
-        and position.end_container_child_index == KOBO_SELECTOR_SENTINEL
-    ):
-        # The kepub fast path — selector format, KoboSpan IDs present.
+    if start_id and end_id:
+        # The kepub path — KoboSpan IDs present, anchor via the selector
+        # format. Kobo writes child_index=-99 in KoboReader.sqlite to
+        # signal "use the selector", but the LIVE reading-services PATCH
+        # omits StartContainerChildIndex entirely, so live-captured
+        # annotations store it as NULL. Either way, when the KoboSpan IDs
+        # are present they are the reliable anchor — the child-index walk
+        # below is only for plain EPUBs with no KoboSpan IDs. (Gating this
+        # on child_index == -99 meant every live-captured kepub highlight
+        # failed to resolve a CFI and never rendered as a web-reader
+        # overlay — found via real-device test 2026-05-24.)
         return f"epubcfi({spine_step}!/4[{start_id}]:{position.start_offset},/4[{end_id}]:{position.end_offset})"
 
     # Plain-EPUB fallback: no KoboSpan IDs to anchor on. Walk by child

--- a/tests/unit/test_kobo_position_converter.py
+++ b/tests/unit/test_kobo_position_converter.py
@@ -129,6 +129,31 @@ class TestComputeCfiRangeKepub:
         # /4[<start_id>]:<offset>,/4[<end_id>]:<offset>.
         assert cfi == "epubcfi(/6/2!/4[kobo.1.1]:0,/4[kobo.1.1]:15)"
 
+    def test_live_capture_null_child_index_uses_selector(self, synthetic_kepub):
+        """Live reading-services PATCH capture omits StartContainerChildIndex,
+        so child_index is stored as NULL (not the -99 sentinel). When the
+        KoboSpan IDs are present, the selector path must still be used —
+        a real-device test (2026-05-24) found that gating the selector
+        path on child_index == -99 meant every live-captured kepub
+        highlight resolved to None and never rendered as a web-reader
+        overlay."""
+        from cps.services.kobo_position import KoboPosition, compute_cfi_range
+
+        pos = KoboPosition(
+            content_id="00000000-0000-0000-0000-deadbeefcafe!!chapter1.html",
+            start_container_path="span#kobo\\.1\\.1",
+            start_container_child_index=None,   # live capture stores NULL
+            start_offset=0,
+            end_container_path="span#kobo\\.1\\.1",
+            end_container_child_index=None,
+            end_offset=15,
+        )
+        cfi = compute_cfi_range(synthetic_kepub, pos)
+        assert cfi == "epubcfi(/6/2!/4[kobo.1.1]:0,/4[kobo.1.1]:15)", (
+            "NULL child_index with KoboSpan IDs present must still resolve "
+            "via the selector path (live-captured kepub highlights)"
+        )
+
     def test_multi_span_highlight(self, synthetic_kepub):
         """Highlight spans two consecutive KoboSpans — about 40% of
         real highlights (design doc §3.6 finding 4). Pin that the CFI


### PR DESCRIPTION
Follow-on from the real-device test. After live Kobo capture started working (#313), the captured highlights **still didn't render as overlays** in the in-browser reader.

## Root cause

`compute_cfi_range` only took the KoboSpan **selector path** when `start/end_container_child_index == -99` (the `KOBO_SELECTOR_SENTINEL`). That sentinel is what Kobo writes in `KoboReader.sqlite`, but the **live reading-services PATCH omits `StartContainerChildIndex` entirely**, so live-captured kepub annotations store it as **NULL**. With NULL: the selector path was skipped → the child-index path produced `None` (no index) → the highlight resolved to **no CFI** → the web reader had nothing to anchor an overlay to. This hit every live-captured Kobo highlight.

## Fix

Take the selector path whenever both KoboSpan IDs are present (`start_id and end_id`), regardless of `child_index`. The span IDs are the reliable kepub anchor; the child-index DOM walk is only for plain EPUBs with no span IDs (unchanged, still gated by absence of IDs). The `-99` case is now a subset of "IDs present", so existing behavior is preserved.

## Verification (observed, against real prod data)

Ran the fixed converter against the real *Nineteen Eighty-Four* kepub (book 523). All four of Maggie's annotations — her 2 real Kobo highlights (NULL child_index) + 2 test annotations — now resolve to valid `epubcfi()`:
```
real features note:   epubcfi(/6/8!/4[kobo.0.7]:151,/4[kobo.0.7]:159)
new BIG BROTHER red:  epubcfi(/6/8!/4[kobo.0.15]:0,/4[kobo.0.15]:56)
```
The `data.json` endpoint computes + persists these on first read → no data migration needed.

New regression test `test_live_capture_null_child_index_uses_selector`. 284 kobo+annotation tests green; existing `-99` sentinel tests unchanged.

Addresses #305 sub-project 5 (web-reader overlay) + the #313 live-capture follow-up. Final confirmation is the in-reader overlay render after deploy.