### PR TITLE
Render Kobo highlights as overlays in the web reader (fix for #305)

### DIFF
--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -382,15 +382,32 @@ def _resolve_book_or_404(book_id: int):
 def _resolve_epub_path(book) -> Optional[str]:
     """Find the on-disk EPUB file for a book — mirrors the lookup
     pattern in ``cps/web.py``'s serve_book. Returns ``None`` if no
-    EPUB/KEPUB format exists or the file is missing on disk."""
+    EPUB/KEPUB format exists or the file is missing on disk.
+
+    Prefers KEPUB: Kobo highlights anchor on KoboSpan ids, which only
+    exist in the kepub. A plain EPUB has no KoboSpans, so computing a
+    CFI against it would never resolve the anchor."""
     from . import config
-    for fmt in book.data or []:
+
+    def _disk_path(fmt):
         ext = (fmt.format or "").upper()
         if ext not in ("EPUB", "KEPUB"):
-            continue
+            return None
         path = os.path.join(config.get_book_path(), book.path, fmt.name + "." + ext.lower())
-        if os.path.isfile(path):
-            return path
+        return path if os.path.isfile(path) else None
+
+    data = book.data or []
+    # KEPUB first (carries KoboSpans), then any EPUB as a fallback.
+    for fmt in data:
+        if (fmt.format or "").upper() == "KEPUB":
+            p = _disk_path(fmt)
+            if p:
+                return p
+    for fmt in data:
+        if (fmt.format or "").upper() == "EPUB":
+            p = _disk_path(fmt)
+            if p:
+                return p
     return None
 
 
@@ -433,6 +450,37 @@ def _ensure_cfi_range(row, book) -> Optional[str]:
     return cfi
 
 
+def _data_json_row(r, cfi, pdf_quad) -> dict:
+    """Project one annotation row to the web-reader's data.json shape.
+
+    Emits the canonical KoboSpan anchor (``start_kobospan`` /
+    ``end_kobospan`` + offsets + ``content_id``) — the reader regenerates
+    a wrapper-aware CFI client-side from these, because a server-authored
+    CFI can't account for epub.js's render-time wrapper divs. ``cfi_range``
+    is the portable source CFI, kept for the sidebar "jump" fallback and
+    export parity. Pure + dependency-free so the payload contract is
+    unit-testable without a Flask request context."""
+    from .services.kobo_position import _extract_kobospan_id
+    return {
+        "annotation_id": r.annotation_id,
+        "cfi_range": cfi,
+        "content_id": r.content_id,
+        "start_kobospan": _extract_kobospan_id(r.start_container_path or ""),
+        "start_offset": r.start_offset,
+        "end_kobospan": _extract_kobospan_id(r.end_container_path or ""),
+        "end_offset": r.end_offset,
+        "highlighted_text": r.highlighted_text,
+        "highlight_color": r.highlight_color or "yellow",
+        "note_text": r.note_text,
+        "chapter_progress": r.chapter_progress,
+        "source": r.source,
+        "position_type": getattr(r, "position_type", None),
+        "pdf_page": getattr(r, "pdf_page", None),
+        "pdf_quad": pdf_quad,
+        "comic_page": getattr(r, "comic_page", None),
+    }
+
+
 @annotations_bp.route("/annotations/<int:book_id>/data.json", methods=["GET"])
 @user_login_required
 def annotations_data(book_id):
@@ -459,19 +507,7 @@ def annotations_data(book_id):
                 pdf_quad = json.loads(r.pdf_quad_json)
             except (ValueError, TypeError):
                 pdf_quad = None
-        out.append({
-            "annotation_id": r.annotation_id,
-            "cfi_range": cfi,
-            "highlighted_text": r.highlighted_text,
-            "highlight_color": r.highlight_color or "yellow",
-            "note_text": r.note_text,
-            "chapter_progress": r.chapter_progress,
-            "source": r.source,
-            "position_type": getattr(r, "position_type", None),
-            "pdf_page": getattr(r, "pdf_page", None),
-            "pdf_quad": pdf_quad,
-            "comic_page": getattr(r, "comic_page", None),
-        })
+        out.append(_data_json_row(r, cfi, pdf_quad))
     return jsonify({"annotations": out, "annotation_count": len(out)})
 
 

--- a/cps/services/kobo_position.py
+++ b/cps/services/kobo_position.py
@@ -147,17 +147,39 @@ def compute_cfi_range(epub_path: Path, position: KoboPosition) -> Optional[str]:
     end_id = _extract_kobospan_id(position.end_container_path)
 
     if start_id and end_id:
-        # The kepub path — KoboSpan IDs present, anchor via the selector
-        # format. Kobo writes child_index=-99 in KoboReader.sqlite to
-        # signal "use the selector", but the LIVE reading-services PATCH
-        # omits StartContainerChildIndex entirely, so live-captured
-        # annotations store it as NULL. Either way, when the KoboSpan IDs
-        # are present they are the reliable anchor — the child-index walk
-        # below is only for plain EPUBs with no KoboSpan IDs. (Gating this
-        # on child_index == -99 meant every live-captured kepub highlight
-        # failed to resolve a CFI and never rendered as a web-reader
-        # overlay — found via real-device test 2026-05-24.)
-        return f"epubcfi({spine_step}!/4[{start_id}]:{position.start_offset},/4[{end_id}]:{position.end_offset})"
+        # The kepub path — KoboSpan IDs present. Walk the chapter DOM to
+        # produce a structurally valid, portable source-document CFI
+        # (proper 3-part range, offsets on text nodes). The KoboSpan id is
+        # the reliable anchor whenever it's present; child_index is only
+        # consulted for plain EPUBs below. (Kobo writes child_index=-99 in
+        # KoboReader.sqlite, but the live reading-services PATCH omits it,
+        # so live-captured annotations store NULL — gating the selector
+        # path on child_index==-99 broke every live capture, found via
+        # real-device test 2026-05-24.)
+        #
+        # The web reader does NOT consume this CFI — epub.js injects
+        # wrapper divs at render time, so it regenerates a wrapper-aware
+        # CFI client-side from the KoboSpan id (annotations.js). This
+        # string is for export portability / spec-compliant resolvers.
+        try:
+            tree = _get_chapter_dom(cache_key, epub_path, chapter_file)
+            if tree is not None:
+                cfi = _kepub_range_cfi(
+                    tree, spine_step, start_id, end_id,
+                    position.start_offset, position.end_offset,
+                )
+                if cfi:
+                    return cfi
+        except Exception as e:
+            log.warning(
+                "compute_cfi_range: kepub DOM walk failed for %s::%s — %s",
+                epub_path, chapter_file, e,
+            )
+        # KoboSpan ids present but unresolvable in the DOM (re-uploaded
+        # book with a different layout?) — fall through to context.
+        return _fallback_via_context(
+            epub_path, cache_key, chapter_file, spine_step, position,
+        )
 
     # Plain-EPUB fallback: no KoboSpan IDs to anchor on. Walk by child
     # index instead. The CFI step encoding for child-index walks is
@@ -237,6 +259,92 @@ def _extract_kobospan_id(container_path: str) -> Optional[str]:
     if not m:
         return None
     return m.group(1).replace("\\", "")
+
+
+def _cfi_element_step(el) -> str:
+    """One CFI step for an element relative to its parent, using
+    epub.js's numbering: element children are numbered 2, 4, 6, … (the
+    Nth element child, 1-based, times two), with the element's ``id``
+    appended as an assertion. Text nodes don't shift element numbering —
+    lxml only yields element/comment/PI children when iterating, so the
+    index is naturally element-only, matching epub.js's ``.children``."""
+    parent = el.getparent()
+    if parent is None:
+        return ""
+    sibs = [c for c in parent if isinstance(c.tag, str)]
+    try:
+        idx = sibs.index(el)
+    except ValueError:
+        idx = 0
+    step = f"/{2 * (idx + 1)}"
+    eid = el.get("id")
+    return step + (f"[{eid}]" if eid else "")
+
+
+def _element_chain_below_body(el):
+    """Return the element chain ``[body_child, …, el]`` — every element
+    from ``<body>``'s direct child down to ``el`` inclusive, excluding
+    ``<body>`` itself (the CFI anchors body as the literal ``/4`` prefix,
+    matching epub.js and the EPUB CFI convention for ``<html><head/>
+    <body/></html>``)."""
+    chain = []
+    cur = el
+    while cur is not None:
+        parent = cur.getparent()
+        if parent is None:
+            break
+        chain.append(cur)
+        ptag = parent.tag if isinstance(parent.tag, str) else ""
+        if ptag == "body" or ptag.endswith("}body"):
+            break
+        cur = parent
+    chain.reverse()
+    return chain
+
+
+def _kepub_range_cfi(tree, spine_step, start_id, end_id, start_offset, end_offset):
+    """Build a valid 3-part EPUB CFI range
+    (``epubcfi(<common>,<start>,<end>)``) anchoring a highlight between
+    two KoboSpans in the parsed chapter ``tree``.
+
+    The CFI is computed against the *source* document (no reader
+    wrappers), so it is portable — a spec-compliant resolver follows the
+    element path and validates the ``[kobo.x.y]`` id assertions. The web
+    reader does NOT consume this string: epub.js injects wrapper divs at
+    render time that shift every step, so the reader regenerates its own
+    wrapper-aware CFI client-side from the KoboSpan id (see
+    ``cps/static/js/reading/annotations.js``). Returns ``None`` if either
+    span is absent from the chapter."""
+    start_matches = tree.xpath("//*[@id=$v]", v=start_id)
+    end_matches = tree.xpath("//*[@id=$v]", v=end_id)
+    if not start_matches or not end_matches:
+        return None
+    start_el, end_el = start_matches[0], end_matches[0]
+
+    start_chain = _element_chain_below_body(start_el)
+    end_chain = _element_chain_below_body(end_el)
+    if not start_chain or not end_chain:
+        return None
+
+    # Deepest shared ancestor element (compare by identity).
+    common_len = 0
+    for a, b in zip(start_chain, end_chain):
+        if a is b:
+            common_len += 1
+        else:
+            break
+    common_chain = start_chain[:common_len]
+    start_rest = start_chain[common_len:]
+    end_rest = end_chain[common_len:]
+
+    base = f"{spine_step}!/4" + "".join(_cfi_element_step(e) for e in common_chain)
+    if not start_rest and not end_rest:
+        # Same KoboSpan — the common path already reaches it. Both ends
+        # are text-node offsets into that span's first text node (/1).
+        return f"epubcfi({base},/1:{start_offset},/1:{end_offset})"
+    start_path = "".join(_cfi_element_step(e) for e in start_rest) + f"/1:{start_offset}"
+    end_path = "".join(_cfi_element_step(e) for e in end_rest) + f"/1:{end_offset}"
+    return f"epubcfi({base},{start_path},{end_path})"
 
 
 def _child_index_to_cfi_step(child_index: Optional[int]) -> Optional[str]:

--- a/cps/static/js/reading/annotations.js
+++ b/cps/static/js/reading/annotations.js
@@ -2,33 +2,270 @@
  * the in-browser EPUB reader.
  *
  * Reads `/annotations/<book_id>/data.json` once on rendition ready,
- * iterates the result, and calls `rendition.annotations.highlight(cfi,
- * data, callback, className, styles)` for each annotation that has a
- * resolvable CFI. Annotations without a CFI (P2's converter couldn't
- * place them) still appear in the sidebar list — they just don't
- * overlay on the page.
+ * iterates the result, and overlays each highlight on the page.
  *
- * The annotations panel in the reader sidebar gets populated from
- * the same payload.
+ * Why the CFI is generated client-side
+ * ------------------------------------
+ * Kobo records a highlight as a KoboSpan id (`kobo.<p>.<s>`) plus a
+ * character offset. The server CANNOT author a CFI that epub.js will
+ * resolve, because epub.js resolves highlight CFIs via a
+ * position-constrained XPath against its *rendered* DOM — and at render
+ * time epub.js injects its own wrapper divs (`book-columns` /
+ * `book-inner`) that the server has no way to know about. A
+ * source-document CFI therefore never matches the rendered tree
+ * ("No startContainer found").
  *
- * Depends on the `calibre.annotationsApiBase` global set by read.html
- * (the per-book root, e.g. `/annotations/2`). The data endpoint is
- * `${base}/data.json`.
+ * The KoboSpan id, by contrast, survives rendering untouched. So the
+ * reader resolves the KoboSpan element in the live document via
+ * getElementById, builds a DOM Range with the stored offsets, and asks
+ * epub.js itself to generate the canonical (wrapper-aware) CFI through
+ * `contents.cfiFromRange(range)`. That CFI is by construction resolvable
+ * by the same epub.js that produced it, and re-resolves correctly every
+ * time the section re-renders.
+ *
+ * Section scoping: KoboSpan ids (`kobo.0.3`) are only unique within a
+ * chapter — the same id can appear in another chapter — so a highlight
+ * is only applied to the rendered contents whose section matches the
+ * annotation's `content_id` chapter file.
+ *
+ * Annotations without a KoboSpan anchor (and without a resolvable CFI)
+ * still appear in the sidebar list — they just don't overlay on the
+ * page.
+ *
+ * Depends on the `calibre.annotationsApiBase` global set by read.html.
  */
 /* global $, calibre, reader */
 (function () {
     "use strict";
 
-    var COLOR_RGBA = {
-        yellow: "rgba(240, 196, 25, 0.40)",
-        red:    "rgba(217, 83, 79, 0.40)",
-        green:  "rgba(92, 184, 92, 0.40)",
-        blue:   "rgba(91, 192, 222, 0.40)"
+    // Named highlight colors the web-reader create path emits. Real Kobo
+    // devices store a hex color instead (e.g. "#F6F3B3"); colorToRgba
+    // handles both. RGB triples here, alpha applied uniformly below.
+    var NAMED_RGB = {
+        yellow: [240, 196, 25],
+        red:    [217, 83, 79],
+        green:  [92, 184, 92],
+        blue:   [91, 192, 222],
+        pink:   [233, 30, 99],
+        purple: [156, 39, 176],
+        orange: [255, 152, 0]
     };
+    var HIGHLIGHT_ALPHA = 0.4;
+
+    // Map a color (named or "#rrggbb"/"#rgb") to an rgba() fill string.
+    // Falls back to yellow for anything unrecognized so a highlight is
+    // never silently dropped just because the color is odd.
+    function colorToRgba(color) {
+        var c = (color == null ? "" : String(color)).trim().toLowerCase();
+        var rgb = null;
+        if (c.charAt(0) === "#") {
+            var hex = c.slice(1);
+            if (hex.length === 3) {
+                hex = hex.charAt(0) + hex.charAt(0) + hex.charAt(1) + hex.charAt(1) + hex.charAt(2) + hex.charAt(2);
+            }
+            if (/^[0-9a-f]{6}$/.test(hex)) {
+                rgb = [parseInt(hex.slice(0, 2), 16), parseInt(hex.slice(2, 4), 16), parseInt(hex.slice(4, 6), 16)];
+            }
+        } else if (NAMED_RGB.hasOwnProperty(c)) {
+            rgb = NAMED_RGB[c];
+        }
+        if (!rgb) { rgb = NAMED_RGB.yellow; }
+        return "rgba(" + rgb[0] + "," + rgb[1] + "," + rgb[2] + "," + HIGHLIGHT_ALPHA + ")";
+    }
 
     function colorStyle(color) {
-        var c = (color in COLOR_RGBA) ? color : "yellow";
-        return { fill: COLOR_RGBA[c], "fill-opacity": "0.40", "mix-blend-mode": "multiply" };
+        return { fill: colorToRgba(color), "fill-opacity": String(HIGHLIGHT_ALPHA), "mix-blend-mode": "multiply" };
+    }
+
+    // CSS-safe class token from a color (strips "#", spaces, etc.) so the
+    // sidebar entry can be color-targeted without an invalid selector.
+    function safeColorToken(color) {
+        var c = (color == null ? "" : String(color)).trim().toLowerCase().replace(/[^a-z0-9]+/g, "");
+        return c || "yellow";
+    }
+
+    // Resolve a character offset within a KoboSpan to a (text node, offset)
+    // pair. Handles the common single-text-node span and nested inline
+    // markup (<i>, <b>) by walking descendant text nodes. Clamps to the
+    // span end if the stored offset overshoots (defensive — never throws).
+    function locateOffset(doc, span, charOffset) {
+        var walker = doc.createTreeWalker(span, NodeFilter.SHOW_TEXT, null, false);
+        var node = walker.nextNode();
+        if (!node) { return { node: span, offset: 0 }; }
+        var remaining = charOffset;
+        while (node) {
+            var len = node.nodeValue.length;
+            if (remaining <= len) { return { node: node, offset: remaining }; }
+            remaining -= len;
+            var next = walker.nextNode();
+            if (!next) { return { node: node, offset: len }; }
+            node = next;
+        }
+        return { node: node, offset: node.nodeValue.length };
+    }
+
+    // Does this annotation's chapter (from content_id "<uuid>!!<file>")
+    // match the rendered section's href? Tolerant of OEBPS/ prefixes the
+    // way the server-side spine resolver is.
+    function chapterMatches(contentId, sectionHref) {
+        if (!contentId || !sectionHref) { return true; } // no info → don't exclude
+        var bang = contentId.indexOf("!!");
+        if (bang < 0) { return true; }
+        var chap = contentId.slice(bang + 2);
+        if (!chap) { return true; }
+        if (chap === sectionHref) { return true; }
+        if (sectionHref.indexOf("/") >= 0 && sectionHref.split("/").pop() === chap.split("/").pop()) { return true; }
+        return sectionHref.indexOf(chap) >= 0 || chap.indexOf(sectionHref) >= 0;
+    }
+
+    function sectionHrefForContents(contents) {
+        try {
+            if (contents && reader.book && reader.book.spine && typeof reader.book.spine.get === "function") {
+                var sec = reader.book.spine.get(contents.sectionIndex);
+                if (sec && sec.href) { return sec.href; }
+            }
+        } catch (e) { /* fall through */ }
+        return null;
+    }
+
+    var appliedIds = {};   // annotation_id -> true once overlaid
+    var allRows = [];      // the data.json payload, kept for late renders
+
+    // Apply every not-yet-applied annotation whose KoboSpans live in this
+    // rendered `contents`. Called for the initial section and on every
+    // subsequent "rendered" event as the user navigates.
+    function applyToContents(contents) {
+        if (!contents || !contents.document || typeof contents.cfiFromRange !== "function") { return; }
+        if (!reader.rendition || !reader.rendition.annotations) { return; }
+        var doc = contents.document;
+        var sectionHref = sectionHrefForContents(contents);
+
+        allRows.forEach(function (row) {
+            if (appliedIds[row.annotation_id]) { return; }
+            if (!row.start_kobospan) { return; } // sidebar-only (no anchor)
+            if (!chapterMatches(row.content_id, sectionHref)) { return; }
+
+            var startSpan = doc.getElementById(row.start_kobospan);
+            var endSpan = doc.getElementById(row.end_kobospan || row.start_kobospan);
+            if (!startSpan || !endSpan) { return; } // not in this section
+
+            try {
+                var a = locateOffset(doc, startSpan, row.start_offset || 0);
+                var b = locateOffset(doc, endSpan, row.end_offset || 0);
+                var range = doc.createRange();
+                range.setStart(a.node, a.offset);
+                range.setEnd(b.node, b.offset);
+                if (range.collapsed) { return; }
+
+                var cfi = contents.cfiFromRange(range);
+                if (!cfi) { return; }
+
+                reader.rendition.annotations.highlight(
+                    cfi,
+                    { id: row.annotation_id, color: row.highlight_color },
+                    null,
+                    "cwa-annotation-overlay",
+                    colorStyle(row.highlight_color)
+                );
+                appliedIds[row.annotation_id] = true;
+            } catch (e) {
+                if (window.console) { console.warn("annotation overlay failed for " + row.annotation_id + ":", e); }
+            }
+        });
+    }
+
+    // Sweep whatever sections are currently rendered (covers the initial
+    // section that may already be on screen before our hook attaches).
+    function applyToRenderedContents() {
+        try {
+            var contentsList = reader.rendition.getContents();
+            (contentsList || []).forEach(applyToContents);
+        } catch (e) { /* nothing rendered yet */ }
+    }
+
+    function renderSidebarList(rows) {
+        var ol = document.getElementById("annotations-list");
+        if (!ol) { return; }
+        ol.replaceChildren();
+        if (!rows.length) {
+            var empty = document.createElement("li");
+            empty.className = "text-muted small";
+            empty.textContent = "No annotations on this book.";
+            ol.appendChild(empty);
+            return;
+        }
+        rows.forEach(function (row) {
+            var li = document.createElement("li");
+            li.className = "cwa-annotation cwa-annotation-" + safeColorToken(row.highlight_color);
+            li.dataset.annotationId = row.annotation_id;
+
+            var quote = document.createElement("blockquote");
+            quote.textContent = row.highlighted_text || "";
+            li.appendChild(quote);
+
+            if (row.note_text) {
+                var noteP = document.createElement("p");
+                noteP.className = "cwa-annotation-note";
+                noteP.textContent = row.note_text;
+                li.appendChild(noteP);
+            }
+            // Click the entry to jump to the highlight. Prefer the live
+            // KoboSpan (works regardless of wrapper layout); fall back to a
+            // stored cfi_range only if there's no anchor.
+            li.style.cursor = "pointer";
+            li.addEventListener("click", function () {
+                if (jumpToAnnotation(row)) { return; }
+                if (row.cfi_range) {
+                    try { reader.rendition.display(row.cfi_range); } catch (e) { /* unresolvable — ignore */ }
+                }
+            });
+            ol.appendChild(li);
+        });
+    }
+
+    // Navigate the reader to an annotation by resolving its start KoboSpan
+    // in whichever section currently holds it. If that section isn't
+    // rendered yet, display its chapter first, then re-resolve.
+    function jumpToAnnotation(row) {
+        if (!row.start_kobospan) { return false; }
+        var contentsList;
+        try { contentsList = reader.rendition.getContents() || []; } catch (e) { contentsList = []; }
+        for (var i = 0; i < contentsList.length; i++) {
+            var c = contentsList[i];
+            var el = c.document && c.document.getElementById(row.start_kobospan);
+            if (el && chapterMatches(row.content_id, sectionHrefForContents(c))) {
+                try {
+                    var loc = locateOffset(c.document, el, row.start_offset || 0);
+                    var range = c.document.createRange();
+                    range.setStart(loc.node, loc.offset);
+                    range.setEnd(loc.node, loc.offset);
+                    var cfi = c.cfiFromRange(range);
+                    if (cfi) { reader.rendition.display(cfi); return true; }
+                } catch (e) { /* fall through */ }
+            }
+        }
+        // Section not rendered — jump to the chapter; the rendered hook
+        // overlays the highlight once it loads.
+        if (row.content_id && row.content_id.indexOf("!!") >= 0) {
+            try { reader.rendition.display(row.content_id.split("!!")[1]); return true; } catch (e) { /* ignore */ }
+        }
+        return false;
+    }
+
+    var hookAttached = false;
+    function attachRenderHook() {
+        if (hookAttached || !reader.rendition || typeof reader.rendition.on !== "function") { return; }
+        hookAttached = true;
+        // Fires for the initial section and each section the user navigates
+        // to. view.contents is the rendered Contents for that section.
+        reader.rendition.on("rendered", function (section, view) {
+            var contents = view && view.contents ? view.contents : (view && typeof view.contents === "function" ? view.contents() : null);
+            if (contents) {
+                applyToContents(contents);
+            } else {
+                applyToRenderedContents();
+            }
+        });
     }
 
     function init() {
@@ -45,77 +282,14 @@
         fetch(dataUrl, { credentials: "same-origin" })
             .then(function (r) { return r.ok ? r.json() : { annotations: [] }; })
             .then(function (payload) {
-                var rows = (payload && payload.annotations) || [];
-                renderOverlays(rows);
-                renderSidebarList(rows);
+                allRows = (payload && payload.annotations) || [];
+                renderSidebarList(allRows);
+                attachRenderHook();
+                applyToRenderedContents();
             })
             .catch(function (err) {
                 if (window.console) { console.warn("annotations fetch failed:", err); }
             });
-    }
-
-    function renderOverlays(rows) {
-        if (!reader || !reader.rendition || !reader.rendition.annotations) {
-            return;
-        }
-        rows.forEach(function (row) {
-            if (!row.cfi_range) {
-                return; // No CFI — sidebar only, no page overlay.
-            }
-            try {
-                reader.rendition.annotations.highlight(
-                    row.cfi_range,
-                    { id: row.annotation_id },
-                    null,
-                    "cwa-annotation-overlay cwa-annotation-overlay-" + (row.highlight_color || "yellow"),
-                    colorStyle(row.highlight_color)
-                );
-            } catch (e) {
-                if (window.console) { console.warn("annotation overlay failed for " + row.annotation_id + ":", e); }
-            }
-        });
-    }
-
-    function renderSidebarList(rows) {
-        var ol = document.getElementById("annotations-list");
-        if (!ol) { return; }
-        ol.innerHTML = "";
-        if (!rows.length) {
-            var empty = document.createElement("li");
-            empty.className = "text-muted small";
-            empty.textContent = "No annotations on this book.";
-            ol.appendChild(empty);
-            return;
-        }
-        rows.forEach(function (row) {
-            var li = document.createElement("li");
-            li.className = "cwa-annotation cwa-annotation-" + (row.highlight_color || "yellow");
-            li.dataset.cfi = row.cfi_range || "";
-            li.dataset.annotationId = row.annotation_id;
-
-            var quote = document.createElement("blockquote");
-            quote.textContent = row.highlighted_text || "";
-            li.appendChild(quote);
-
-            if (row.note_text) {
-                var noteP = document.createElement("p");
-                noteP.className = "cwa-annotation-note";
-                noteP.textContent = row.note_text;
-                li.appendChild(noteP);
-            }
-            // Click the entry to jump to its CFI in the reader.
-            if (row.cfi_range) {
-                li.style.cursor = "pointer";
-                li.addEventListener("click", function () {
-                    try {
-                        reader.rendition.display(row.cfi_range);
-                    } catch (e) {
-                        // CFI may not resolve if the book has been reuploaded — silent fall-through.
-                    }
-                });
-            }
-            ol.appendChild(li);
-        });
     }
 
     if (document.readyState === "loading") {

--- a/cps/web.py
+++ b/cps/web.py
@@ -3051,12 +3051,47 @@ def read_book(book_id, book_format):
 
     book.ordered_authors = calibre_db.order_authors([book], False)
 
-    # check if book has a bookmark
+    # Kobo annotation overlays anchor on KoboSpan ids (`kobo.x.y`), which
+    # the reader resolves in the live document to regenerate each
+    # highlight's CFI (see annotations.js). Those spans only exist in the
+    # .kepub, not the plain .epub. When an authenticated user opens an
+    # EPUB-family book for which they have annotations AND a KEPUB format
+    # exists, serve the kepub so the highlights can anchor and render.
+    # Scoped to annotated books so we don't change the reader format (and
+    # orphan epub-keyed bookmarks) for everyone.
+    if (
+        current_user.is_authenticated
+        and book_format.lower() == "epub"
+        and any((d.format or "").upper() == "KEPUB" for d in (book.data or []))
+    ):
+        try:
+            has_annotations = ub.session.query(ub.Annotation).filter(
+                ub.Annotation.user_id == int(current_user.id),
+                ub.Annotation.book_id == book_id,
+                ub.Annotation.hidden == False,  # noqa: E712
+            ).first() is not None
+        except Exception as e:
+            log.debug("read_book: annotation lookup failed for %d: %s", book_id, e)
+            has_annotations = False
+        if has_annotations:
+            log.debug("read_book: serving kepub for %d so annotation overlays resolve", book_id)
+            book_format = "kepub"
+
+    # check if book has a bookmark. Position is keyed by format, but the
+    # epub<->kepub switch above must not orphan it — match either
+    # epub-family format so the reading position survives.
     bookmark = None
     if current_user.is_authenticated:
-        bookmark = ub.session.query(ub.Bookmark).filter(and_(ub.Bookmark.user_id == int(current_user.id),
+        bm_q = ub.session.query(ub.Bookmark).filter(and_(ub.Bookmark.user_id == int(current_user.id),
+                                                         ub.Bookmark.book_id == book_id,
+                                                         ub.Bookmark.format == book_format.upper())).first()
+        if bm_q is None and book_format.lower() in ("epub", "kepub"):
+            # fall back to the sibling epub-family format's bookmark
+            sibling = "EPUB" if book_format.lower() == "kepub" else "KEPUB"
+            bm_q = ub.session.query(ub.Bookmark).filter(and_(ub.Bookmark.user_id == int(current_user.id),
                                                              ub.Bookmark.book_id == book_id,
-                                                             ub.Bookmark.format == book_format.upper())).first()
+                                                             ub.Bookmark.format == sibling)).first()
+        bookmark = bm_q
 
     kosync_progress = None
     if current_user.is_authenticated:

--- a/tests/unit/test_annotations_data_endpoint.py
+++ b/tests/unit/test_annotations_data_endpoint.py
@@ -205,3 +205,71 @@ class TestEnsureCfiRange:
             lambda: str(tmp_path / "library"),
         )
         assert ann_mod._ensure_cfi_range(row, book) is None
+
+
+# ---------------------------------------------------------------------------
+# _data_json_row — web-reader payload contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDataJsonRow:
+    """The web reader regenerates a wrapper-aware CFI client-side from the
+    KoboSpan id + offset, so data.json MUST carry those anchors. This pins
+    the contract — dropping the anchor fields would silently break overlay
+    rendering (the reader would fall back to sidebar-only). Found the hard
+    way: the server-authored cfi_range never resolved in epub.js because of
+    its render-time wrapper divs (real-device test 2026-05-24/25)."""
+
+    def _row(self):
+        return SimpleNamespace(
+            annotation_id="abc-123",
+            content_id="uuid!!OEBPS/part0003.xhtml",
+            start_container_path="span#kobo\\.0\\.3",
+            start_offset=3,
+            end_container_path="span#kobo\\.0\\.6",
+            end_offset=18,
+            highlighted_text="was a bright cold day",
+            highlight_color="#F6F3B3",
+            note_text="a note",
+            chapter_progress=0.1,
+            source="kobo",
+            position_type=None,
+            pdf_page=None,
+            pdf_quad_json=None,
+            comic_page=None,
+        )
+
+    def test_emits_kobospan_anchors(self):
+        from cps.annotations import _data_json_row
+
+        d = _data_json_row(self._row(), "epubcfi(/6/8!/4/2,/2[kobo.0.3]/1:3,/4[kobo.0.6]/1:18)", None)
+        # The KoboSpan ids must be unescaped from the stored selector path.
+        assert d["start_kobospan"] == "kobo.0.3"
+        assert d["end_kobospan"] == "kobo.0.6"
+        assert d["start_offset"] == 3
+        assert d["end_offset"] == 18
+        assert d["content_id"] == "uuid!!OEBPS/part0003.xhtml"
+        # cfi_range is still carried (sidebar jump fallback / export parity).
+        assert d["cfi_range"].startswith("epubcfi(")
+
+    def test_hex_color_passed_through_verbatim(self):
+        from cps.annotations import _data_json_row
+
+        # Real Kobo stores a hex color; the JS layer maps it to rgba. The
+        # server must not mangle it into a CSS class or a name.
+        d = _data_json_row(self._row(), None, None)
+        assert d["highlight_color"] == "#F6F3B3"
+
+    def test_missing_anchor_yields_none_not_crash(self):
+        from cps.annotations import _data_json_row
+
+        row = self._row()
+        row.start_container_path = None
+        row.end_container_path = ""
+        d = _data_json_row(row, None, None)
+        assert d["start_kobospan"] is None
+        assert d["end_kobospan"] is None
+        # color falls back to a safe default when absent.
+        row.highlight_color = None
+        assert _data_json_row(row, None, None)["highlight_color"] == "yellow"

--- a/tests/unit/test_kobo_position_converter.py
+++ b/tests/unit/test_kobo_position_converter.py
@@ -125,9 +125,12 @@ class TestComputeCfiRangeKepub:
             end_offset=15,
         )
         cfi = compute_cfi_range(synthetic_kepub, pos)
-        # chapter1 is spine index 0 → /6/2; the kepub fast path emits
-        # /4[<start_id>]:<offset>,/4[<end_id>]:<offset>.
-        assert cfi == "epubcfi(/6/2!/4[kobo.1.1]:0,/4[kobo.1.1]:15)"
+        # chapter1 is spine index 0 → /6/2. The fixture chapter is
+        # <body><p><span id=kobo.1.1>…</span>…</p></body>, so the span is
+        # body(/4) > p(/2) > 1st span(/2). Same start/end span → a 3-part
+        # range CFI whose common path reaches the span and whose ends are
+        # text-node (/1) offsets.
+        assert cfi == "epubcfi(/6/2!/4/2/2[kobo.1.1],/1:0,/1:15)"
 
     def test_live_capture_null_child_index_uses_selector(self, synthetic_kepub):
         """Live reading-services PATCH capture omits StartContainerChildIndex,
@@ -149,7 +152,7 @@ class TestComputeCfiRangeKepub:
             end_offset=15,
         )
         cfi = compute_cfi_range(synthetic_kepub, pos)
-        assert cfi == "epubcfi(/6/2!/4[kobo.1.1]:0,/4[kobo.1.1]:15)", (
+        assert cfi == "epubcfi(/6/2!/4/2/2[kobo.1.1],/1:0,/1:15)", (
             "NULL child_index with KoboSpan IDs present must still resolve "
             "via the selector path (live-captured kepub highlights)"
         )
@@ -170,7 +173,10 @@ class TestComputeCfiRangeKepub:
             end_offset=21,
         )
         cfi = compute_cfi_range(synthetic_kepub, pos)
-        assert cfi == "epubcfi(/6/2!/4[kobo.1.1]:0,/4[kobo.1.3]:21)"
+        # Cross-span: common ancestor is the <p> (/4/2); the two ends
+        # diverge to the 1st (/2) and 3rd (/6) spans, each with a /1
+        # text-node offset.
+        assert cfi == "epubcfi(/6/2!/4/2,/2[kobo.1.1]/1:0,/6[kobo.1.3]/1:21)"
 
     def test_mid_span_start_offset(self, synthetic_kepub):
         """The "Comrade Napoleon" example from design doc §3.6 — start
@@ -188,8 +194,8 @@ class TestComputeCfiRangeKepub:
             end_offset=17,
         )
         cfi = compute_cfi_range(synthetic_kepub, pos)
-        # chapter2 is spine index 1 → /6/4
-        assert cfi == "epubcfi(/6/4!/4[kobo.2.1]:8,/4[kobo.2.1]:17)"
+        # chapter2 is spine index 1 → /6/4. Single span, mid-span offsets.
+        assert cfi == "epubcfi(/6/4!/4/2/2[kobo.2.1],/1:8,/1:17)"
 
     def test_three_digit_span_suffix_round_trips(self, tmp_path):
         """The prototype's 0.7% failure was on three-digit span ids —
@@ -224,7 +230,101 @@ class TestComputeCfiRangeKepub:
             end_offset=29,
         )
         cfi = compute_cfi_range(kepub, pos)
-        assert cfi == "epubcfi(/6/2!/4[kobo.4.11]:0,/4[kobo.4.13]:29)"
+        # 13 spans in one <p>: kobo.4.11 is the 11th element child (/22),
+        # kobo.4.13 the 13th (/26); common ancestor is the <p> (/4/2).
+        assert cfi == "epubcfi(/6/2!/4/2,/22[kobo.4.11]/1:0,/26[kobo.4.13]/1:29)"
+
+
+# ---------------------------------------------------------------------------
+# CFI round-trip — the generated CFI resolves back to the right span/text
+# ---------------------------------------------------------------------------
+
+
+def _walk_cfi_element_path(tree, path):
+    """Resolve a CFI element path like ``/4/2/2[kobo.1.1]`` against a
+    parsed lxml tree, returning the landed element. Even steps are the
+    Nth element child (1-based = step/2). ``/4`` is <body>. Used by the
+    round-trip tests to prove the converter's element numbering is
+    correct — independent of the string-equality assertions above."""
+    import re as _re
+    body = tree.xpath("//body")[0]
+    # The leading /4 anchors <body>; walk the remaining even steps.
+    steps = _re.findall(r"/(\d+)(?:\[([^\]]+)\])?", path)
+    # First step is /4 = body itself; skip it, then descend.
+    cur = body
+    for raw, assertion in steps[1:]:
+        n = int(raw)
+        if n % 2 != 0:
+            break  # reached a text step — element walk done
+        idx = n // 2 - 1
+        children = [c for c in cur if isinstance(c.tag, str)]
+        cur = children[idx]
+        if assertion:
+            assert cur.get("id") == assertion, (
+                f"CFI step /{n}[{assertion}] landed on id={cur.get('id')!r}"
+            )
+    return cur
+
+
+@pytest.mark.unit
+class TestCfiRoundTrip:
+    """The string assertions above pin the exact CFI; these prove that
+    string actually resolves back to the highlighted text when walked
+    against the source DOM — so a future numbering change can't pass by
+    updating only the expected-string constant."""
+
+    def test_single_span_roundtrip(self, synthetic_kepub):
+        from cps.services.kobo_position import (
+            KoboPosition, compute_cfi_range, _get_chapter_dom,
+        )
+
+        pos = KoboPosition(
+            content_id="00000000-0000-0000-0000-deadbeefcafe!!chapter1.html",
+            start_container_path="span#kobo\\.1\\.1",
+            start_container_child_index=-99,
+            start_offset=0,
+            end_container_path="span#kobo\\.1\\.1",
+            end_container_child_index=-99,
+            end_offset=15,
+        )
+        cfi = compute_cfi_range(synthetic_kepub, pos)
+        # epubcfi(common,start,end) — common reaches the span.
+        common = cfi[len("epubcfi("):-1].split(",")[0].split("!", 1)[1]
+        cache_key = (str(synthetic_kepub), synthetic_kepub.stat().st_mtime_ns)
+        tree = _get_chapter_dom(cache_key, synthetic_kepub, "chapter1.html")
+        span = _walk_cfi_element_path(tree, common)
+        assert span.get("id") == "kobo.1.1"
+        # /1:0 .. /1:15 over the span's text → the exact highlighted run.
+        assert span.text[0:15] == "Four legs good."
+
+    def test_multi_span_roundtrip(self, synthetic_kepub):
+        from cps.services.kobo_position import (
+            KoboPosition, compute_cfi_range, _get_chapter_dom,
+        )
+
+        pos = KoboPosition(
+            content_id="00000000-0000-0000-0000-deadbeefcafe!!chapter1.html",
+            start_container_path="span#kobo\\.1\\.1",
+            start_container_child_index=-99,
+            start_offset=0,
+            end_container_path="span#kobo\\.1\\.3",
+            end_container_child_index=-99,
+            end_offset=21,
+        )
+        cfi = compute_cfi_range(synthetic_kepub, pos)
+        parts = cfi[len("epubcfi("):-1].split(",")
+        common = parts[0].split("!", 1)[1]
+        cache_key = (str(synthetic_kepub), synthetic_kepub.stat().st_mtime_ns)
+        tree = _get_chapter_dom(cache_key, synthetic_kepub, "chapter1.html")
+        # Common ancestor is the <p>; start/end paths are relative to it.
+        common_el = _walk_cfi_element_path(tree, common)
+        assert common_el.tag == "p"
+        start_el = _walk_cfi_element_path(tree, common + parts[1])
+        end_el = _walk_cfi_element_path(tree, common + parts[2])
+        assert start_el.get("id") == "kobo.1.1"
+        assert end_el.get("id") == "kobo.1.3"
+        assert start_el.text.startswith("Four legs")
+        assert end_el.text[0:21] == "All animals are equal"
 
 
 # ---------------------------------------------------------------------------
@@ -318,7 +418,7 @@ class TestComputeCfiRangeEdgeCases:
             end_offset=11,
         )
         cfi = compute_cfi_range(minimal_epub, pos)
-        assert cfi == "epubcfi(/6/2!/4[kobo.4.1]:0,/4[kobo.4.1]:11)"
+        assert cfi == "epubcfi(/6/2!/4/2/2[kobo.4.1],/1:0,/1:11)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What users see

Highlights you made on your Kobo now actually appear, coloured, over the text when you open the book in the web reader. Until now they showed up in the annotations sidebar but the page itself stayed blank — and on books with a hex-coloured highlight the overlay code errored out before drawing anything.

## Why it was broken

The highlight position the server computed couldn't be understood by the in-browser reader (epub.js). It described the highlight as sitting directly on the document body with a character offset on an element — which the reader can't resolve, so it logged `No startContainer found` and drew nothing. Separately, real Kobo devices store a hex colour (`#F6F3B3`) rather than a name, and that value was being pushed straight into a CSS class, throwing `InvalidCharacterError`.

## The fix (root cause)

A highlight's exact coordinates depend on how the reader lays the page out, so only the reader can produce a position it can resolve. The stable anchor across all of that is the KoboSpan id. So the reader now finds that span in the live page, rebuilds the selection from the stored offsets, and lets epub.js generate its own canonical position before drawing the highlight. The colour (named *or* hex) is mapped to a proper fill and a safe class name.

Supporting changes:
- `data.json` carries the KoboSpan anchors the reader needs.
- The server-side converter (used for export) now emits a structurally valid source CFI instead of the invalid form, and prefers the KEPUB when locating the file.
- The reader serves the KEPUB to signed-in users who have annotations on an EPUB-family book (the spans only exist in the kepub); the reading position carries over across the epub/kepub pair so it isn't lost.

## Verification

Exercised on a live reader against four highlights (two hex-coloured, two named; one cross-paragraph): each renders with the correct text covered, survives paging away and back, and positions correctly on a 390px mobile viewport and in dark mode. Console clean of both prior errors. Unit tests updated to the valid CFI form with a round-trip check that walks the generated CFI back to the highlighted text, plus a data.json contract test.

Ships the real fix for #305 (v4.0.134 shipped the plumbing but the overlay still didn't paint).