### PR TITLE
Backport upstream #1371: KOReader sync plugin menu under "Tools"

### DIFF
--- a/koreader/plugins/cwasync.koplugin/main.lua
+++ b/koreader/plugins/cwasync.koplugin/main.lua
@@ -213,6 +213,7 @@ end
 function CWASync:addToMainMenu(menu_items)
     menu_items.cwa_progress_sync = {
         text = _("NextGen Progress Sync"),
+        sorting_hint = "tools",
         sub_item_table = {
             {
                 text = _("Set NextGen Server"),


### PR DESCRIPTION
Backport of upstream **crocodilestick/Calibre-Web-Automated#1371** by @SethMilliken (upstream commit `881528fc`).

## What it does
Adds `sorting_hint = "tools"` to the NextGen Progress Sync plugin's main-menu entry so it groups under KOReader's **Tools** menu instead of appearing unsorted at the top level. Plain-English effect for users: the sync plugin lands where you'd expect it in the KOReader menu.

## Diff
One line, byte-identical to upstream:
```lua
 menu_items.cwa_progress_sync = {
     text = _("NextGen Progress Sync"),
+    sorting_hint = "tools",
     sub_item_table = {
```

## Why a manual cherry-pick
A straight `git cherry-pick 881528fc` conflicted only on the 3-line context: our fork rebranded the menu `text` to `"NextGen Progress Sync"` (upstream says `"CWA Progress Sync"`), and the differing middle context line tripped the insertion. The line added is identical to upstream; resolved by hand on a fresh branch off `origin/main`.

## Tier
`safe-tier-2` — single isolated file, +1 LOC, declarative KOReader Lua menu hint. Not auth/csrf/session/admin/migration. No Python surface, so no regression-test target (closest to the tier-1 docs exemption — KOReader `.lua` is not covered by the Python suite).

## Release-time obligation
This touches `koreader/plugins/cwasync.koplugin/`, so per the plugin-versioning rule the **cwasync plugin version must be bumped to match the release tag** on whatever release ships this. Flagging so the release cut doesn't miss it.

Credit @SethMilliken for the original patch.