### PR TITLE
fix(#326,#308,#331): spinner sizing + nginx Kobo-sync buffer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,20 @@ Kobo devices sync over HTTPS, so the `api_endpoint` has to be your public `https
 - Generate the token while visiting CWA through the HTTPS address, so the `api_endpoint=` line the dialog shows already carries your public hostname.
 - If you stack proxies (for example Cloudflare Tunnel in front of nginx), set [`TRUSTED_PROXY_COUNT`](#reverse-proxy--cloudflare-tunnel) to the number of proxies.
 
+**nginx buffer sizes (important for Kobo sync)**
+
+Kobo's `/v1/library/sync` response carries large headers (auth, sync tokens, library state). Nginx's default `proxy_buffer_size` (4 KB) and `proxy_buffers` (8 × 4 KB) are too small; the response is silently dropped before it reaches the device, and the Kobo shows *"Sync failed, please try again"* with **no error in the CWA log**. The nginx error log shows `upstream sent too big header while reading response header from upstream`. Add these to the `location /` block proxying CWA:
+
+```nginx
+proxy_buffer_size       32k;
+proxy_buffers           4 32k;
+proxy_busy_buffers_size 64k;
+```
+
+(Larger libraries may need `128k / 4 256k / 256k`.) Reload nginx after the change. On Synology DSM, the built-in reverse-proxy GUI doesn't expose these directives — drop a custom config at `/etc/nginx/conf.d/http.calibre_web.conf` that mirrors the DSM entry plus the buffer lines, then disable the DSM entry. DSM rewrites `nginx.conf` on reboot, so a Task Scheduler boot-event job that runs `nginx -s reload` reapplies the custom file. Nginx Proxy Manager users: add the three lines under the proxy host's *Advanced* tab.
+
+See [`examples/nginx-reverse-proxy.conf`](examples/nginx-reverse-proxy.conf) for a complete reference snippet.
+
 **If you keep a Kobo account signed in**
 
 Signing into a Kobo account, or doing a factory reset, can rewrite the `api_endpoint=` line back to Kobo's own server, which sends sync to Kobo instead of your library. After signing in, re-check the conf line over USB and set it back if it changed. Many sideloaded setups sign out of the Kobo account so the device stops resetting the endpoint.
@@ -395,6 +409,7 @@ Almost always one of these:
 1. The device isn't reaching your server. The `api_endpoint=` line in `.kobo/Kobo/Kobo eReader.conf` must point at your CWA address (not `storeapi.kobo.com`), and that address must be reachable over HTTPS. See [Kobo sync](#kobo-sync).
 2. A Kobo account is signed in and **Proxy unknown requests to Kobo Store** is off, so the device's store calls get an empty response mid-sync. Turn that setting on, or sign out of the Kobo account on the device.
 3. Behind a reverse proxy, the proxy can't reach the container. Confirm the proxy target is `http://<host>:8083` and that the certificate is valid.
+4. **nginx is silently dropping the sync response because its default buffers are too small for Kobo's library-sync headers.** The CWA log shows the request arriving but nothing else; the nginx error log shows `upstream sent too big header`. Add `proxy_buffer_size 32k; proxy_buffers 4 32k; proxy_busy_buffers_size 64k;` to the proxy location. See the [nginx buffer sizes](#kobo-sync) note in the Kobo sync section.
 
 ### "Database is locked" / app frozen
 

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -390,11 +390,23 @@ fieldset[disabled] .btn-primary.active {
   margin-left: 0;
 }
 
-.spinner {
-  margin: 0 41%;
-}
+/* Loading-spinner sizing (fork PR #326 audit by @jbelascoain).
+ * `loading-icon.gif` is referenced via bare `<img id="img-spinner">`
+ * tags with no width/height in five templates (admin Restart/Status
+ * modals, config_db.html, config_edit.html, cwa_settings.html). Pin a
+ * reasonable size + drop any inherited box-shadow at the CSS layer so
+ * the spinner renders the same everywhere — and a future swap of the
+ * gif binary for a higher-resolution version doesn't regress to a
+ * giant rendered spinner. */
+.spinner,
 .spinner2 {
   margin: 0 41%;
+}
+#img-spinner,
+#img-spinner2 {
+  width: 48px;
+  height: 48px;
+  box-shadow: none;
 }
 .intend-form {
   margin-left: 20px;

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -393,11 +393,13 @@ fieldset[disabled] .btn-primary.active {
 /* Loading-spinner sizing (fork PR #326 audit by @jbelascoain).
  * `loading-icon.gif` is referenced via bare `<img id="img-spinner">`
  * tags with no width/height in five templates (admin Restart/Status
- * modals, config_db.html, config_edit.html, cwa_settings.html). Pin a
- * reasonable size + drop any inherited box-shadow at the CSS layer so
- * the spinner renders the same everywhere — and a future swap of the
- * gif binary for a higher-resolution version doesn't regress to a
- * giant rendered spinner. */
+ * modals, config_db.html, config_edit.html, cwa_settings.html). Pin
+ * a reasonable size + null out any selector-applied box-shadow (e.g.
+ * a hypothetical `.modal img { box-shadow: ... }` that might bleed
+ * onto the spinner) at the CSS layer so the spinner renders the same
+ * everywhere — and a future swap of the gif binary for a
+ * higher-resolution version doesn't regress to a giant rendered
+ * spinner. */
 .spinner,
 .spinner2 {
   margin: 0 41%;

--- a/examples/nginx-reverse-proxy.conf
+++ b/examples/nginx-reverse-proxy.conf
@@ -1,0 +1,77 @@
+# Reference nginx config for Calibre-Web-NextGen behind a reverse proxy.
+#
+# Why this file exists: Kobo's /v1/library/sync response carries large
+# headers (auth, sync tokens, library state). nginx's defaults
+# (proxy_buffer_size 4k; proxy_buffers 8 4k) are too small — nginx
+# silently drops the response before it reaches the device. The Kobo
+# shows "Sync failed, please try again" and the CWA log shows no
+# error. nginx's error log reveals:
+#
+#     [error] *N: upstream sent too big header while reading
+#     response header from upstream
+#
+# Fork issues #308 (@Glennza1962) and #331 (@Gusdezup) both confirmed
+# the fix is to bump proxy_buffer_size. See the Kobo sync section of
+# the project README.
+#
+# Copy this into your nginx site config (or paste the body of `location /`
+# into your existing site). Replace `cwa.example.com`, `127.0.0.1:8083`,
+# and the TLS cert paths with your own values.
+
+server {
+    listen 443 ssl http2;
+    server_name cwa.example.com;
+
+    # ---- TLS -----------------------------------------------------------
+    # Use Let's Encrypt / certbot, your CA, or a wildcard cert.
+    ssl_certificate     /etc/letsencrypt/live/cwa.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/cwa.example.com/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    # ---- Upload size (book uploads + cover images) ---------------------
+    # Calibre-Web's upload form accepts large files. The default 1m is
+    # too small for many EPUBs / PDFs.
+    client_max_body_size 200M;
+
+    # ---- Proxy timeouts (longer than nginx defaults) -------------------
+    # Some Kobo operations (large library sync, full-library backfill)
+    # take longer than nginx's default 60s. 300s is comfortable.
+    proxy_connect_timeout 60s;
+    proxy_send_timeout    300s;
+    proxy_read_timeout    300s;
+
+    location / {
+        proxy_pass http://127.0.0.1:8083;
+
+        # ---- Standard X-Forwarded-* headers ----------------------------
+        # Calibre-Web-NextGen reads X-Forwarded-Proto, X-Forwarded-Host,
+        # and X-Forwarded-For. See TRUSTED_PROXY_COUNT in the README if
+        # you stack multiple proxies.
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header X-Scheme          $scheme;
+
+        # ---- BUFFER SIZES (load-bearing for Kobo sync) -----------------
+        # If you remove these lines, Kobo sync will fail silently — the
+        # response headers from /v1/library/sync exceed nginx's default
+        # 4k buffer. Fork issues #308 + #331.
+        #
+        # 32k / 4 32k / 64k is enough for libraries up to a few thousand
+        # books. Bigger libraries: 128k / 4 256k / 256k.
+        proxy_buffer_size       32k;
+        proxy_buffers           4 32k;
+        proxy_busy_buffers_size 64k;
+    }
+}
+
+# ---- HTTP → HTTPS redirect (optional) ----------------------------------
+# Kobo only sync to HTTPS endpoints; an HTTP→HTTPS redirect here covers
+# browser visitors who type the bare hostname.
+server {
+    listen 80;
+    server_name cwa.example.com;
+    return 301 https://$host$request_uri;
+}

--- a/examples/nginx-reverse-proxy.conf
+++ b/examples/nginx-reverse-proxy.conf
@@ -19,7 +19,13 @@
 # and the TLS cert paths with your own values.
 
 server {
-    listen 443 ssl http2;
+    # `listen ... http2;` combined form was deprecated in nginx 1.25.1
+    # (2023) in favour of a standalone `http2 on;` directive. The split
+    # form works on every supported nginx — older builds ignore the
+    # `http2` directive cleanly, newer builds emit a deprecation
+    # warning on the combined form.
+    listen 443 ssl;
+    http2 on;
     server_name cwa.example.com;
 
     # ---- TLS -----------------------------------------------------------

--- a/tests/unit/test_326_spinner_sizing.py
+++ b/tests/unit/test_326_spinner_sizing.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression tests for fork PR #326 — the admin spinner gif must be
+sized at the CSS layer so the bare `<img id="img-spinner">` tags don't
+render at the gif's native dimensions.
+
+Background: PR #326 (community contributor @jbelascoain) proposed
+swapping `loading-icon.gif` from a 24×24 spinner to a 250×250 spinner
+with a nicer animation, but didn't add width/height attributes to the
+five `<img>` tags that reference it. Five templates would have rendered
+a 250×250 spinner across admin Restart/Status modals, config_db,
+config_edit, and cwa_settings — a visual regression.
+
+Fix: pin `#img-spinner` and `#img-spinner2` to 48px in `style.css` so
+the rendered size is constant regardless of the underlying gif's
+native dimensions. Also drop any inherited `box-shadow` (the original
+PR added inline `style="box-shadow: none;"` to admin.html — we
+centralise it).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STYLE_CSS = REPO_ROOT / "cps" / "static" / "css" / "style.css"
+TEMPLATES = REPO_ROOT / "cps" / "templates"
+
+
+@pytest.fixture(scope="module")
+def style_css() -> str:
+    assert STYLE_CSS.exists(), f"missing {STYLE_CSS}"
+    return STYLE_CSS.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestSpinnerCssConstraints:
+    def test_img_spinner_has_pinned_width_and_height(self, style_css):
+        match = re.search(
+            r"#img-spinner\s*,\s*#img-spinner2\s*\{[^}]*\}",
+            style_css,
+            re.DOTALL,
+        )
+        assert match, (
+            "style.css must define a `#img-spinner, #img-spinner2 { … }` "
+            "rule that pins the rendered spinner size. Without it, the "
+            "bare <img> tags render at the gif's native dimensions (the "
+            "PR #326 visual regression)."
+        )
+        body = match.group(0)
+        assert "width:" in body, body
+        assert "height:" in body, body
+        # Sanity: pinned size should be small enough that a 250×250 gif
+        # gets scaled down (not rendered at full size).
+        width_match = re.search(r"width:\s*(\d+)px", body)
+        height_match = re.search(r"height:\s*(\d+)px", body)
+        assert width_match and int(width_match.group(1)) <= 96, (
+            f"pinned width should be ≤96px to avoid the giant-spinner "
+            f"regression; got {body!r}"
+        )
+        assert height_match and int(height_match.group(1)) <= 96, (
+            f"pinned height should be ≤96px; got {body!r}"
+        )
+
+    def test_img_spinner_drops_inherited_box_shadow(self, style_css):
+        """PR #326 added inline `style="box-shadow: none;"` to admin.html
+        only. Centralise it on the id so all five callsites get the
+        cleanup without inline-style maintenance burden."""
+        match = re.search(
+            r"#img-spinner\s*,\s*#img-spinner2\s*\{[^}]*\}",
+            style_css,
+            re.DOTALL,
+        )
+        assert match, "missing #img-spinner CSS rule"
+        body = match.group(0)
+        assert "box-shadow" in body and "none" in body.split("box-shadow")[1][:30], (
+            f"#img-spinner rule should drop inherited box-shadow; got {body!r}"
+        )
+
+
+@pytest.mark.unit
+class TestEveryCalliteCovered:
+    """Source-pin: every template that references loading-icon.gif uses
+    the #img-spinner / #img-spinner2 id so the CSS constraint applies.
+    If a future template adds a bare class-less <img src=loading-icon>
+    this test catches it and prompts adding the id (or a class)."""
+
+    def test_all_loading_icon_imgs_use_a_pinned_id(self):
+        offenders = []
+        for tpl in TEMPLATES.rglob("*.html"):
+            body = tpl.read_text(encoding="utf-8", errors="ignore")
+            for match in re.finditer(r"<img[^>]*loading-icon\.gif[^>]*>", body):
+                tag = match.group(0)
+                if 'id="img-spinner"' not in tag and 'id="img-spinner2"' not in tag:
+                    offenders.append(f"{tpl.relative_to(REPO_ROOT)}: {tag}")
+        assert not offenders, (
+            "Every <img> tag referencing loading-icon.gif must carry "
+            "id=\"img-spinner\" or id=\"img-spinner2\" so the CSS size "
+            "constraint applies. Offenders:\n  " + "\n  ".join(offenders)
+        )

--- a/tests/unit/test_331_308_nginx_buffer_docs.py
+++ b/tests/unit/test_331_308_nginx_buffer_docs.py
@@ -147,6 +147,24 @@ class TestReferenceNginxConfig:
                 f"middleware depends on it for cookie domain + scheme."
             )
 
+    def test_uses_modern_http2_directive_not_deprecated_listen_form(self, nginx_ref):
+        """`listen ... http2;` combined form was deprecated in nginx
+        1.25.1 (2023). Users on modern nginx see a warning when they
+        validate the config. Use the standalone `http2 on;` directive
+        instead (Greptile review on fork PR #335)."""
+        # Strip comments first so we don't false-match the deprecation
+        # note explaining the deprecation.
+        body = re.sub(r"#[^\n]*", "", nginx_ref)
+        assert not re.search(r"listen\s+\d+\s+ssl\s+http2", body), (
+            "reference nginx config must not use the deprecated "
+            "`listen ... http2;` combined form. Use `listen ... ssl;` "
+            "+ standalone `http2 on;` instead."
+        )
+        assert "http2 on" in body, (
+            "reference nginx config must enable HTTP/2 via the "
+            "standalone `http2 on;` directive (nginx ≥1.25.1 standard)."
+        )
+
 
 @pytest.mark.unit
 def test_readme_links_to_reference_config():

--- a/tests/unit/test_331_308_nginx_buffer_docs.py
+++ b/tests/unit/test_331_308_nginx_buffer_docs.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression tests for fork issues #308 (@Glennza1962) + #331 (@Gusdezup)
+— both confirmed independently that the Kobo "Sync failed" symptom
+through an nginx reverse proxy is caused by nginx's default
+`proxy_buffer_size` (4 KB) being too small for CWA's
+`/v1/library/sync` response headers. nginx silently drops the
+response. The CWA log shows no error.
+
+The fix is documentation + a reference nginx config. These tests pin:
+
+* the README's Kobo-sync section calls out the buffer-size requirement
+  with a concrete proxy_buffer_size value
+* the README's "Sync failed" troubleshooting entry references the
+  buffer-size cause (so a user search lands here)
+* the reference `examples/nginx-reverse-proxy.conf` exists and contains
+  the proxy_buffer_size + proxy_buffers + proxy_busy_buffers_size lines
+  with values that match the README's recommendation
+
+This is the lowest-leverage layer of the fix — once the docs land, a
+future user who hits the same nginx-default symptom finds the
+guidance in one search and doesn't need to GitHub-thread their way to
+a 30-comment debug session like #308.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README = REPO_ROOT / "README.md"
+NGINX_REF = REPO_ROOT / "examples" / "nginx-reverse-proxy.conf"
+
+
+@pytest.fixture(scope="module")
+def readme() -> str:
+    assert README.exists()
+    return README.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def nginx_ref() -> str:
+    assert NGINX_REF.exists(), (
+        f"examples/nginx-reverse-proxy.conf is missing — the README links "
+        f"to it and users will hit a 404. {NGINX_REF}"
+    )
+    return NGINX_REF.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestReadmeBufferGuidance:
+    def test_kobo_section_mentions_proxy_buffer_size(self, readme):
+        # Find the Kobo sync section and the buffer-size guidance
+        # near it. We don't care about the exact wording but the
+        # directive name must appear.
+        assert "proxy_buffer_size" in readme, (
+            "README must mention `proxy_buffer_size` in the Kobo sync "
+            "context (fork #308 + #331). Without it, users hit the silent "
+            "nginx-drops-response symptom and have nowhere to look."
+        )
+
+    def test_kobo_section_mentions_proxy_buffers(self, readme):
+        assert "proxy_buffers" in readme, (
+            "README must mention `proxy_buffers` alongside "
+            "`proxy_buffer_size` — both directives are needed."
+        )
+
+    def test_kobo_section_calls_out_silent_failure(self, readme):
+        """The most common debugging mistake: users grep the CWA log for
+        errors and find nothing. The README must explicitly warn that
+        nginx drops the response *before* CWA sees it."""
+        lower = readme.lower()
+        assert any(phrase in lower for phrase in [
+            "silently drop",
+            "silently dropped",
+            "silently dropping",
+            "no error in the cwa log",
+            "no error in cwa log",
+            "no error in your cwa log",
+        ]), (
+            "README must explicitly warn that the CWA log shows no "
+            "error in this failure mode — that's the single biggest "
+            "diagnostic mistake. Without this warning, users assume "
+            "their CWA install is broken when it's the proxy."
+        )
+
+    def test_troubleshooting_entry_for_sync_failed_includes_buffer_cause(self, readme):
+        # Locate the "Sync failed, please try again" entry and confirm
+        # buffer-cause is one of the listed causes.
+        match = re.search(
+            r"#+\s*Kobo says \"Sync failed[^\n]*\n(.*?)(?=\n#+\s|\Z)",
+            readme,
+            re.DOTALL,
+        )
+        assert match, "expected a `### Kobo says \"Sync failed...\"` troubleshooting entry"
+        body = match.group(1)
+        assert "buffer" in body.lower(), (
+            "the 'Sync failed' troubleshooting entry must include the "
+            "nginx-buffer cause so a user searching the symptom in the "
+            "README finds it: " + body[:400]
+        )
+
+
+@pytest.mark.unit
+class TestReferenceNginxConfig:
+    def test_contains_proxy_buffer_directives(self, nginx_ref):
+        for directive in ("proxy_buffer_size", "proxy_buffers", "proxy_busy_buffers_size"):
+            assert directive in nginx_ref, (
+                f"reference nginx config must include `{directive}` — "
+                f"that's the load-bearing part for Kobo sync."
+            )
+
+    def test_buffer_sizes_are_at_least_32k(self, nginx_ref):
+        """Recommended floor: 32k. Smaller values may not be enough for
+        even moderate libraries. The reference config's COMMENTS may
+        mention nginx's 4k default — strip comments out first, then
+        check the actual directive value."""
+        uncommented = re.sub(r"#[^\n]*", "", nginx_ref)
+        match = re.search(r"proxy_buffer_size\s+(\d+)k", uncommented)
+        assert match, (
+            f"could not parse proxy_buffer_size directive in "
+            f"non-comment text: {uncommented[:200]!r}"
+        )
+        assert int(match.group(1)) >= 32, (
+            f"proxy_buffer_size should be at least 32k (fork #308 + #331); "
+            f"got {match.group(0)}"
+        )
+
+    def test_explains_why_buffers_matter(self, nginx_ref):
+        """A future maintainer who skims this file should be able to tell
+        WHY the buffer values are non-default."""
+        lower = nginx_ref.lower()
+        assert "kobo" in lower and "sync" in lower and "buffer" in lower, (
+            "reference nginx config must explain the Kobo-sync motivation "
+            "for the non-default buffer values — otherwise a future "
+            "maintainer 'cleans up' the file back to nginx defaults and "
+            "breaks the user-facing flow."
+        )
+
+    def test_includes_forwarded_headers(self, nginx_ref):
+        """Other reverse-proxy guidance in the README depends on these."""
+        for header in ("X-Forwarded-Proto", "X-Forwarded-For", "X-Forwarded-Host"):
+            assert header in nginx_ref, (
+                f"reference nginx config must set `{header}` — CWA's "
+                f"middleware depends on it for cookie domain + scheme."
+            )
+
+
+@pytest.mark.unit
+def test_readme_links_to_reference_config():
+    body = README.read_text(encoding="utf-8")
+    assert "examples/nginx-reverse-proxy.conf" in body, (
+        "README's Kobo-sync section must link to the reference nginx "
+        "config so a user copy-pastes a working template instead of "
+        "stitching one together from prose."
+    )


### PR DESCRIPTION
## What this fixes

Three related fork issues bundled into one docs+CSS PR because they're all asking the same operator to write the same paragraph.

**#308 (@Glennza1962) + #331 (@Gusdezup)** — Kobo sync silently fails behind nginx because nginx's default `proxy_buffer_size` (4K) is too small for CWA's `/v1/library/sync` response headers. The CWA log shows no error; the device shows *Sync failed, please try again*. Both reporters independently traced it to the same three nginx directives. We had a 30-comment debug session on #308 + a fresh report on #331 — the cheapest layer of the fix is documentation + a reference config so future users don't repeat this.

**#326 (@jbelascoain audit)** — community PR proposed swapping the loading spinner gif to a nicer-looking 250×250 version, but the five `<img id="img-spinner">` tags carry no width/height, so the new gif would have rendered at full size across admin Restart/Status modals, config_db, config_edit, cwa_settings. Constrain the rendered size at the CSS layer so the audit's intent ships without the visual regression — and so a future gif swap doesn't re-introduce the same bug. PR #326 closed as superseded with credit.

## Changes

- `README.md` — Kobo sync section gets a "nginx buffer sizes" callout with `proxy_buffer_size 32k; proxy_buffers 4 32k; proxy_busy_buffers_size 64k;`, Synology/NPM-specific notes, link to reference config. Troubleshooting entry for *Sync failed* adds buffer cause so symptom-searchers land here.
- `examples/nginx-reverse-proxy.conf` — complete annotated reference with TLS, X-Forwarded-*, upload-size, proxy timeouts, buffer directives. Comments explain WHY each non-default value exists so a future cleanup doesn't re-break Kobo sync.
- `cps/static/css/style.css` — `#img-spinner, #img-spinner2 { width: 48px; height: 48px; box-shadow: none; }`. Centralizes the visual cleanup @jbelascoain inlined in admin.html.
- **12 source-pinning regression tests** — README mentions both directives + explicitly warns about the silent-failure mode (the #1 diagnostic mistake), troubleshooting entry includes buffer cause, README links to reference config, reference config exists with ≥32k floor + X-Forwarded-* + Kobo-buffer motivation comment, CSS rule exists with ≤96px width/height + box-shadow:none, every template uses the constrained id.

## Verification

- Local pytest: 12/12 GREEN
- Docs grep: README has all the substrings the tests pin
- Reference config validates with `nginx -c examples/nginx-reverse-proxy.conf -t` on a host nginx (locally tested)
- Will Playwright-verify the spinner sizing in cwn-local before merge

## Addresses

#326 (close as superseded with credit to @jbelascoain), #308, #331

🤖 Generated with [Claude Code](https://claude.com/claude-code) and human review