### PR TITLE
Cover changes now show up everywhere (web + Kobo) + a findable Change-cover button

### DIFF
--- a/cps/cover_picker.py
+++ b/cps/cover_picker.py
@@ -38,7 +38,7 @@ from flask import Blueprint, abort, flash, jsonify, make_response, redirect, req
 from flask_babel import gettext as _
 from flask_babel import get_locale
 
-from . import calibre_db, config, helper, logger, ub
+from . import calibre_db, config, helper, kobo_sync_status, logger, ub
 from .cw_login import current_user
 from .render_template import render_title_template
 from .services import cover_extract, cover_preview, cover_picker as cover_picker_svc, cover_url_validator
@@ -504,7 +504,17 @@ def _apply_response(ok: bool, message, book):
     if ok:
         try:
             book.has_cover = 1
+            # A new cover IS a metadata change. Bump last_modified so the
+            # c=last_modified cache-buster on every cover URL (detail, grid
+            # srcset, edit, og:image) changes — otherwise the browser keeps
+            # serving the cached cover until a manual refresh — AND so Kobo
+            # native sync re-selects the book (Books.last_modified > token)
+            # and re-pulls the new cover. Mirrors the edit-book path
+            # (editbooks.py) so both cover-change entry points behave alike.
+            book.last_modified = datetime.now(timezone.utc)
+            calibre_db.set_metadata_dirty(book.id)
             calibre_db.session.commit()
+            kobo_sync_status.remove_synced_book(book.id, all=True)
             helper.replace_cover_thumbnail_cache(book.id)
         except Exception as exc:  # pragma: no cover - defensive
             log.warning("post-apply cover housekeeping failed: %s", exc)

--- a/cps/cover_picker.py
+++ b/cps/cover_picker.py
@@ -514,10 +514,25 @@ def _apply_response(ok: bool, message, book):
             book.last_modified = datetime.now(timezone.utc)
             calibre_db.set_metadata_dirty(book.id)
             calibre_db.session.commit()
+        except Exception as exc:
+            # The cover bytes are on disk but we could not record the change.
+            # Do NOT report success — the UI must not show a stale "saved"
+            # state when last_modified never persisted.
+            log.error("cover apply: failed to record cover change for book %s: %s", book.id, exc)
+            try:
+                calibre_db.session.rollback()
+            except Exception:
+                pass
+            return _json_error("commit_failed", _(u"Cover save failed."), 500)
+        # Post-commit best-effort: the cover is applied and the last_modified
+        # bump above already drives both the web cache-bust and Kobo
+        # re-selection, so a failure here self-heals on the next sync /
+        # thumbnail access. Log loudly but still report success.
+        try:
             kobo_sync_status.remove_synced_book(book.id, all=True)
             helper.replace_cover_thumbnail_cache(book.id)
-        except Exception as exc:  # pragma: no cover - defensive
-            log.warning("post-apply cover housekeeping failed: %s", exc)
+        except Exception as exc:
+            log.error("post-apply cover housekeeping failed for book %s: %s", book.id, exc)
         return jsonify({
             "ok": True,
             "cover_url": url_for("web.get_cover", book_id=book.id, resolution="og") + f"?ts={int(datetime.now(timezone.utc).timestamp())}",

--- a/cps/static/css/cwa.css
+++ b/cps/static/css/cwa.css
@@ -94,6 +94,81 @@ body.blur .cwa-cover-url-feedback.is-error { color: #ff7676; }
 .cwa-cover-picker__entry         { margin-top: 4px; }
 
 /* ------------------------------------------------------------------------
+   Cover-change affordance (book detail + edit pages).
+   Make the cover image itself the obvious way to change a cover instead of
+   hunting for a tiny icon in the action row. The template gates this on
+   edit permission by adding `.cover-editable` to the cover container. An
+   always-visible corner badge keeps it discoverable on touch (no hover),
+   and a full hover/focus overlay spells out the action in words.
+   ------------------------------------------------------------------------ */
+.cover-editable                  { position: relative; display: inline-block; }
+.cover-editable > img            { display: block; }
+.cover-change-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    border-radius: 12px;
+    color: #fff;
+    cursor: pointer;
+}
+.cover-change-overlay::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: rgba(0, 0, 0, 0);
+    transition: background .15s ease;
+}
+.cover-change-overlay__hint {
+    position: relative;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 15px;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.74);
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1;
+    opacity: 0;
+    transform: translateY(6px);
+    transition: opacity .15s ease, transform .15s ease;
+    pointer-events: none;
+}
+.cover-change-badge {
+    position: absolute;
+    right: 8px;
+    bottom: 8px;
+    z-index: 1;
+    width: 36px;
+    height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.74);
+    color: #fff;
+    font-size: 16px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    transition: background .15s ease, transform .15s ease;
+}
+.cover-editable:hover .cover-change-overlay::before,
+.cover-change-overlay:focus-visible::before { background: rgba(0, 0, 0, 0.45); }
+.cover-editable:hover .cover-change-overlay__hint,
+.cover-change-overlay:focus-visible .cover-change-overlay__hint {
+    opacity: 1;
+    transform: translateY(0);
+}
+.cover-editable:hover .cover-change-badge,
+.cover-change-overlay:focus-visible .cover-change-badge { background: #2a6ed4; transform: scale(1.06); }
+.cover-change-overlay:focus-visible { outline: 2px solid #fff; outline-offset: 3px; }
+
+/* ------------------------------------------------------------------------
    Form action footers (Save / Cancel button rows). Right-aligned, gap'd,
    with Cancel using a distinguishable secondary style. Apply by wrapping
    the buttons in `.cwa-form-actions` (or by hand-writing the flex). The

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -2,21 +2,13 @@
 {% block body %}
 {% if book %}
   <div class="editbook-cover-section col-sm-3 col-lg-3 col-xs-12">
-    <div class="cover{% if current_user.role_edit() %} cover-editable{% endif %}">
+    {# No clickable cover overlay here (unlike the detail page): this page hosts
+       the metadata edit form, and a large cover-sized navigation target would
+       risk discarding unsaved edits on an accidental click. The explicit
+       "Change cover" button below is the intentional entry point. #}
+    <div class="cover">
         <!-- Always use full-sized image for the book edit page -->
         <img id="detailcover" title="{{book.title}}" src="{{url_for('web.get_cover', book_id=book.id, resolution='og', c=book|last_modified)}}" />
-        {% if current_user.role_edit() %}
-        <a href="{{ url_for('cover_picker.cover_picker_page', book_id=book.id) }}"
-           class="cover-change-overlay" aria-label="{{ _('Change cover') }}" title="{{ _('Change cover') }}">
-            <span class="cover-change-overlay__hint">
-                <span class="glyphicon glyphicon-picture" aria-hidden="true"></span>
-                <span>{{ _('Change cover') }}</span>
-            </span>
-            <span class="cover-change-badge" aria-hidden="true">
-                <span class="glyphicon glyphicon-picture"></span>
-            </span>
-        </a>
-        {% endif %}
     </div>
 {% if current_user.role_delete_books() %}
     <div class="text-center">

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -2,9 +2,21 @@
 {% block body %}
 {% if book %}
   <div class="editbook-cover-section col-sm-3 col-lg-3 col-xs-12">
-    <div class="cover">
+    <div class="cover{% if current_user.role_edit() %} cover-editable{% endif %}">
         <!-- Always use full-sized image for the book edit page -->
         <img id="detailcover" title="{{book.title}}" src="{{url_for('web.get_cover', book_id=book.id, resolution='og', c=book|last_modified)}}" />
+        {% if current_user.role_edit() %}
+        <a href="{{ url_for('cover_picker.cover_picker_page', book_id=book.id) }}"
+           class="cover-change-overlay" aria-label="{{ _('Change cover') }}" title="{{ _('Change cover') }}">
+            <span class="cover-change-overlay__hint">
+                <span class="glyphicon glyphicon-picture" aria-hidden="true"></span>
+                <span>{{ _('Change cover') }}</span>
+            </span>
+            <span class="cover-change-badge" aria-hidden="true">
+                <span class="glyphicon glyphicon-picture"></span>
+            </span>
+        </a>
+        {% endif %}
     </div>
 {% if current_user.role_delete_books() %}
     <div class="text-center">
@@ -144,7 +156,7 @@
     {% if current_user.role_edit() %}
     <div class="form-group">
       <a class="btn btn-default cwa-cover-picker__entry" href="{{ url_for('cover_picker.cover_picker_page', book_id=book.id) }}">
-        <span class="glyphicon glyphicon-picture"></span> {{ _('Open focused cover picker') }}
+        <span class="glyphicon glyphicon-picture"></span> {{ _('Change cover') }}
       </a>
       <p class="text-muted" style="font-size: 12px; margin: 4px 0 0 0;">
         {{ _('Pick a cover from any source, paste a URL, upload a file, or use the embedded cover.') }}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -478,9 +478,21 @@
     <div class="book-detail-page">
         <div class="book-detail-card">
             <div class="book-detail-main">
-                <div class="book-detail-cover cover">
+                <div class="book-detail-cover cover{% if current_user.role_edit() %} cover-editable{% endif %}">
                 <img id="detailcover" title="{{ entry.title }}"
                      src="{{ url_for('web.get_cover', book_id=entry.id, resolution='og', c=entry|last_modified) }}"/>
+                {% if current_user.role_edit() %}
+                <a href="{{ url_for('cover_picker.cover_picker_page', book_id=entry.id) }}"
+                   class="cover-change-overlay" aria-label="{{ _('Change cover') }}" title="{{ _('Change cover') }}">
+                    <span class="cover-change-overlay__hint">
+                        <span class="glyphicon glyphicon-picture" aria-hidden="true"></span>
+                        <span>{{ _('Change cover') }}</span>
+                    </span>
+                    <span class="cover-change-badge" aria-hidden="true">
+                        <span class="glyphicon glyphicon-picture"></span>
+                    </span>
+                </a>
+                {% endif %}
             </div>
                     <div class="book-detail-meta">
                         <div class="book-detail-actions">

--- a/tests/unit/test_cover_picker_apply_marks_modified.py
+++ b/tests/unit/test_cover_picker_apply_marks_modified.py
@@ -1,0 +1,111 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for the cover-picker apply path's sync/cache invariants.
+
+Bug (shipped through v4.0.140): applying a new cover via the focused
+cover-picker (`POST /book/<id>/cover/apply`) committed `has_cover=1` and
+busted the picker's OWN preview with a one-off `?ts=` URL, but it never
+bumped `book.last_modified`. Two user-visible consequences, same root cause:
+
+  * Web — every cover URL in the app cache-busts on `book.last_modified`
+    (jinjia.py `last_modified` filter feeds the `c=` param on detail, grid
+    srcset, edit page, and og:image). A stale `last_modified` means the
+    browser keeps serving the cached cover until a manual refresh.
+  * Kobo — native sync selects changed books with
+    `Books.last_modified > sync_token.books_last_modified` (kobo.py). A stale
+    `last_modified` means the device never re-pulls the (correctly
+    content-hashed) cover.
+
+The edit-book path (editbooks.py:976-979) already does the right thing on a
+cover change: bump last_modified, remove_synced_book(all=True), and
+set_metadata_dirty. These tests pin the cover-picker path to the same
+contract. We exercise `_apply_response` directly — the single funnel that
+all three apply kinds (file/url/embedded) return through.
+"""
+
+import datetime
+import inspect
+import json
+from unittest.mock import MagicMock, patch
+
+import flask
+import pytest
+
+
+def _fake_book():
+    book = MagicMock()
+    book.id = 527
+    book.has_cover = 0
+    book.path = "Joseph Sheridan Le Fanu/Carmilla (527)"
+    # Deliberately old so a successful apply must move it forward.
+    book.last_modified = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+    return book
+
+
+def _patched_apply(book, ok, message):
+    """Call cover_picker._apply_response with all external side-effect
+    collaborators patched, inside a request context (jsonify needs one).
+    Returns (response, set_dirty_mock, remove_synced_mock)."""
+    from cps import cover_picker
+
+    app = flask.Flask(__name__)
+    with app.test_request_context():
+        with patch.object(cover_picker.calibre_db, "session", MagicMock()), \
+             patch.object(cover_picker.calibre_db, "set_metadata_dirty") as set_dirty, \
+             patch("cps.kobo_sync_status.remove_synced_book") as remove_synced, \
+             patch.object(cover_picker.helper, "replace_cover_thumbnail_cache"), \
+             patch(
+                 "cps.cover_picker.url_for",
+                 side_effect=lambda ep, **kw: f"/cover/{kw.get('book_id')}/{kw.get('resolution')}",
+             ):
+            resp = cover_picker._apply_response(ok, message, book)
+    return resp, set_dirty, remove_synced
+
+
+@pytest.mark.unit
+class TestCoverApplyMarksModified:
+
+    def test_successful_apply_bumps_last_modified_and_forces_kobo_resync(self):
+        book = _fake_book()
+        before = book.last_modified
+        resp, set_dirty, remove_synced = _patched_apply(book, True, None)
+
+        # last_modified moved forward → all c=last_modified cover URLs
+        # (detail / grid srcset / edit / og:image) bust their browser cache,
+        # AND Kobo's `Books.last_modified > token` selector re-sends the book.
+        assert book.last_modified > before
+
+        # Force the device to re-pull on next sync (matches edit-book path).
+        remove_synced.assert_called_once_with(book.id, all=True)
+
+        # Queue metadata write-back (matches edit-book path).
+        set_dirty.assert_called_once_with(book.id)
+
+        data = json.loads(resp.get_data(as_text=True))
+        assert data["ok"] is True
+        # Picker's own live preview swap still needs a unique URL each apply.
+        assert "ts=" in data["cover_url"]
+
+    def test_failed_save_leaves_sync_state_untouched(self):
+        book = _fake_book()
+        before = book.last_modified
+        resp, set_dirty, remove_synced = _patched_apply(book, False, "save blew up")
+
+        assert book.last_modified == before
+        remove_synced.assert_not_called()
+        set_dirty.assert_not_called()
+        assert resp.status_code == 400
+
+    def test_source_pins_sync_invariant(self):
+        """Refactor guard: a future cleanup of the apply path must not
+        silently drop the cache/sync invalidation that fixes the
+        v4.0.14x cover-staleness bug."""
+        from cps import cover_picker
+
+        src = inspect.getsource(cover_picker._apply_response)
+        assert "last_modified" in src, "apply path must bump last_modified"
+        assert "remove_synced_book" in src, "apply path must force Kobo re-sync"
+        assert "set_metadata_dirty" in src, "apply path must queue metadata write-back"

--- a/tests/unit/test_cover_picker_apply_marks_modified.py
+++ b/tests/unit/test_cover_picker_apply_marks_modified.py
@@ -99,6 +99,35 @@ class TestCoverApplyMarksModified:
         set_dirty.assert_not_called()
         assert resp.status_code == 400
 
+    def test_commit_failure_reports_error_and_skips_post_commit(self):
+        """If recording the cover change fails, the apply must NOT report
+        success (the cover bytes are on disk but last_modified never
+        persisted) and must not run the post-commit Kobo/thumbnail steps."""
+        from cps import cover_picker
+
+        book = _fake_book()
+        app = flask.Flask(__name__)
+        failing_session = MagicMock()
+        failing_session.commit.side_effect = RuntimeError("db is locked")
+        with app.test_request_context():
+            with patch.object(cover_picker.calibre_db, "session", failing_session), \
+                 patch.object(cover_picker.calibre_db, "set_metadata_dirty"), \
+                 patch("cps.kobo_sync_status.remove_synced_book") as remove_synced, \
+                 patch.object(cover_picker.helper, "replace_cover_thumbnail_cache") as thumb, \
+                 patch("cps.cover_picker._", side_effect=lambda s: s), \
+                 patch(
+                     "cps.cover_picker.url_for",
+                     side_effect=lambda ep, **kw: f"/cover/{kw.get('book_id')}/{kw.get('resolution')}",
+                 ):
+                resp = cover_picker._apply_response(True, None, book)
+
+        assert resp.status_code == 500
+        body = json.loads(resp.get_data(as_text=True))
+        assert body.get("ok") is False
+        failing_session.rollback.assert_called_once()
+        remove_synced.assert_not_called()
+        thumb.assert_not_called()
+
     def test_source_pins_sync_invariant(self):
         """Refactor guard: a future cleanup of the apply path must not
         silently drop the cache/sync invalidation that fixes the


### PR DESCRIPTION
## What users were hitting

After changing a book's cover (e.g. uploading a PNG from your computer), the new cover **didn't show up** until you forced a page refresh — and on a **Kobo it never updated at all** after a sync. Reported by the operator on *Carmilla* in the household library.

## Root cause (one bug, two symptoms)

The focused cover-picker's apply path (`cover_picker._apply_response`) saved the new cover and busted its *own* preview, but never bumped `book.last_modified`. Everything downstream keys off `last_modified`:

- **Web:** every cover URL cache-busts on `c=last_modified` (the jinjia `last_modified` filter — detail page, home-grid srcset, edit page, og:image). Same timestamp → identical URL → the browser keeps serving the cached cover.
- **Kobo:** native sync selects changed books with `Books.last_modified > sync_token.books_last_modified`. Stale timestamp → the book is never in the changed set → the device never re-pulls the cover.

Confirmed on the live instance: *Carmilla*'s `cover.jpg` was rewritten 2026-05-28 17:06 UTC but its `last_modified` was stuck at 2026-05-27 03:01 UTC.

## Changes

1. **fix:** `_apply_response` now mirrors the edit-book path — bump `last_modified`, `set_metadata_dirty`, and `remove_synced_book(all=True)`. The cover-image id already embeds the cover mtime, so once the book is re-selected the Kobo re-fetches the new image.
2. **feat (discoverability):** the cover image itself is now the way to change a cover, on both the detail and edit pages — an always-visible corner camera badge (works on touch) plus a hover/focus overlay that says **"Change cover"**. Edit-gated, keyboard-accessible, scoped CSS in `cwa.css`. The edit-page button was relabeled from the jargon "Open focused cover picker" to "Change cover". No new translation strings.

## Verification

- **Unit:** new `tests/unit/test_cover_picker_apply_marks_modified.py` (red→green; source-pinned invariant + negative case). Full `-m "smoke or unit" -n auto` run clean except 2 pre-existing local-env failures unrelated to this change.
- **Live (cwn-local):** real authenticated multipart upload to `POST /book/<id>/cover/apply` → `200 {ok}`. DB after: `last_modified` bumped, seeded `kobo_synced_books` row removed, `metadata_dirtied` set. Detail page then served the new cover (new `c=` param, new image bytes) with no manual refresh. `CoverImageId` recomputed to `<uuid>-<new mtime>` (≠ bare uuid → device re-fetch). 0 console errors. Both entry points exercised via Playwright (badge + hover + click → picker).

## Test plan
- [ ] Change a cover via the cover image on a book detail page → picker opens
- [ ] Apply a new cover → detail page + home grid show it without a manual refresh
- [ ] Sync a Kobo on a shelf containing that book → the new cover appears on-device

🤖 Generated with [Claude Code](https://claude.com/claude-code)