### PR TITLE
refactor: centralize the book mark-modified triplet (close the #340 class of bug)

### DIFF
--- a/cps/cover_picker.py
+++ b/cps/cover_picker.py
@@ -504,15 +504,12 @@ def _apply_response(ok: bool, message, book):
     if ok:
         try:
             book.has_cover = 1
-            # A new cover IS a metadata change. Bump last_modified so the
-            # c=last_modified cache-buster on every cover URL (detail, grid
-            # srcset, edit, og:image) changes — otherwise the browser keeps
-            # serving the cached cover until a manual refresh — AND so Kobo
-            # native sync re-selects the book (Books.last_modified > token)
-            # and re-pulls the new cover. Mirrors the edit-book path
-            # (editbooks.py) so both cover-change entry points behave alike.
-            book.last_modified = datetime.now(timezone.utc)
-            calibre_db.set_metadata_dirty(book.id)
+            # A new cover IS a metadata change: bump last_modified (drives the
+            # web cover cache-buster on every cover URL + Kobo sync
+            # re-selection) and queue the metadata write-back. remove_synced_book
+            # runs post-commit below (best-effort) so a commit failure can't
+            # leave it half-applied. Single source of truth: helper.mark_book_modified.
+            helper.mark_book_modified(book)
             calibre_db.session.commit()
         except Exception as exc:
             # The cover bytes are on disk but we could not record the change.

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -337,10 +337,7 @@ def edit_selected_books():
                     calibre_db.session.rollback()
                     continue # or return an error response
 
-            book.last_modified = datetime.now(timezone.utc)
-
-            if metadata_changed:
-                calibre_db.set_metadata_dirty(book.id)
+            helper.mark_book_modified(book, set_dirty=metadata_changed)
             try:
                 calibre_db.session.commit()
             except (OperationalError, IntegrityError, StaleDataError) as e:
@@ -607,10 +604,7 @@ def edit_book_param(param, vals):
             log_value = vals.get('value', '')
         else:
             return _("Parameter not found"), 400
-        book.last_modified = datetime.now(timezone.utc)
-
-        if metadata_changed:
-            calibre_db.set_metadata_dirty(book.id)
+        helper.mark_book_modified(book, set_dirty=metadata_changed)
 
         calibre_db.session.commit()
         # revert change for sort if automatic fields link is deactivated
@@ -839,8 +833,7 @@ def table_xchange_author_title():
                 # toDo: Handle error
                 edit_error = helper.update_dir_structure(edited_books_id, config.get_book_path(), input_authors[0])
             if modify_date:
-                book.last_modified = datetime.now(timezone.utc)
-                calibre_db.set_metadata_dirty(book.id)
+                helper.mark_book_modified(book)
             try:
                 calibre_db.session.commit()
             except (OperationalError, IntegrityError, StaleDataError) as e:
@@ -974,9 +967,7 @@ def do_edit_book(book_id, upload_formats=None):
 
         # Stage 3: Commit all changes to the database.
         if modify_date:
-            book.last_modified = datetime.now(timezone.utc)
-            kobo_sync_status.remove_synced_book(book.id, all=True)
-            calibre_db.set_metadata_dirty(book.id)
+            helper.mark_book_modified(book, unsync=True)
 
         # Hold the process-shared metadata.db write lock for the
         # duration of the commit. Coordinates with the ingest_processor
@@ -2245,7 +2236,7 @@ def reload_metadata_from_disk(book_id):
                     log.debug("reload_metadata: language update failed: %s", ex)
 
             if updated:
-                book.last_modified = datetime.now(timezone.utc)
+                helper.mark_book_modified(book, set_dirty=False)
                 calibre_db.session.commit()
                 log.info("Reloaded metadata for book %d from disk (fields: %s)",
                          book.id, ', '.join(updated))

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -68,6 +68,31 @@ from .embed_helper import do_calibre_export
 log = logger.create()
 
 
+def mark_book_modified(book, *, set_dirty=True, unsync=False):
+    """Single source of truth for "this book changed".
+
+    Stamps ``book.last_modified`` — the value that drives BOTH the web
+    cover/metadata cache-buster (the jinjia ``last_modified`` filter feeding
+    the ``c=`` param on every cover URL) AND Kobo native sync selection
+    (``Books.last_modified > sync_token.books_last_modified``). Forgetting it
+    is why a cover change could fail to propagate (fork #340).
+
+    Optional steps mirror what the various edit paths need:
+      * ``set_dirty``  → queue CWA metadata write-back (``set_metadata_dirty``).
+      * ``unsync``     → drop Kobo synced-book records for all users so every
+                         device re-pulls (``remove_synced_book(all=True)``).
+
+    The caller still owns the ``calibre_db.session.commit()``. ``kobo_sync_status``
+    is imported lazily to keep this module's import graph unchanged.
+    """
+    book.last_modified = datetime.now(timezone.utc)
+    if set_dirty:
+        calibre_db.set_metadata_dirty(book.id)
+    if unsync:
+        from . import kobo_sync_status
+        kobo_sync_status.remove_synced_book(book.id, all=True)
+
+
 def _directory_contains_only_nfs_placeholders(path):
     try:
         entries = os.listdir(path)

--- a/tests/unit/test_cover_picker_apply_marks_modified.py
+++ b/tests/unit/test_cover_picker_apply_marks_modified.py
@@ -129,12 +129,12 @@ class TestCoverApplyMarksModified:
         thumb.assert_not_called()
 
     def test_source_pins_sync_invariant(self):
-        """Refactor guard: a future cleanup of the apply path must not
-        silently drop the cache/sync invalidation that fixes the
-        v4.0.14x cover-staleness bug."""
+        """Refactor guard: the apply path must route the modified-stamp
+        through the shared helper and still force a Kobo re-sync. The full
+        triplet (last_modified + set_metadata_dirty + remove_synced_book) is
+        pinned in test_mark_book_modified.py now that it lives in the helper."""
         from cps import cover_picker
 
         src = inspect.getsource(cover_picker._apply_response)
-        assert "last_modified" in src, "apply path must bump last_modified"
+        assert "mark_book_modified" in src, "apply path must use helper.mark_book_modified"
         assert "remove_synced_book" in src, "apply path must force Kobo re-sync"
-        assert "set_metadata_dirty" in src, "apply path must queue metadata write-back"

--- a/tests/unit/test_mark_book_modified.py
+++ b/tests/unit/test_mark_book_modified.py
@@ -1,0 +1,100 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Pins the single source of truth for "this book changed".
+
+Marking a book modified is a coupled triplet:
+  1. bump ``book.last_modified``  → drives the web cover/metadata cache-buster
+     (the jinjia ``last_modified`` filter on every cover URL) AND Kobo native
+     sync selection (``Books.last_modified > sync_token.books_last_modified``).
+  2. ``set_metadata_dirty``        → queues CWA metadata write-back.
+  3. ``remove_synced_book(all=True)`` → forces all Kobo devices to re-pull.
+
+That triplet used to be copy-pasted across ~6 call sites with no shared
+helper, so a new write path could silently forget a step — exactly the bug
+that shipped through v4.0.140 (cover-picker apply never bumped last_modified).
+``helper.mark_book_modified`` consolidates it; these tests pin the helper's
+behavior AND assert the heterogeneous call sites route through it instead of
+re-implementing a raw ``last_modified = datetime.now(...)`` bump.
+"""
+
+import datetime
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _book():
+    b = MagicMock()
+    b.id = 42
+    b.last_modified = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+    return b
+
+
+@pytest.mark.unit
+class TestMarkBookModified:
+
+    def test_default_bumps_last_modified_and_sets_dirty_without_unsync(self):
+        from cps import helper
+        b = _book()
+        before = b.last_modified
+        with patch.object(helper.calibre_db, "set_metadata_dirty") as dirty, \
+             patch("cps.kobo_sync_status.remove_synced_book") as unsync:
+            helper.mark_book_modified(b)
+        assert b.last_modified > before
+        dirty.assert_called_once_with(42)
+        unsync.assert_not_called()
+
+    def test_set_dirty_false_skips_metadata_dirty(self):
+        from cps import helper
+        b = _book()
+        before = b.last_modified
+        with patch.object(helper.calibre_db, "set_metadata_dirty") as dirty, \
+             patch("cps.kobo_sync_status.remove_synced_book") as unsync:
+            helper.mark_book_modified(b, set_dirty=False)
+        assert b.last_modified > before
+        dirty.assert_not_called()
+        unsync.assert_not_called()
+
+    def test_unsync_true_removes_synced_books_for_all_users(self):
+        from cps import helper
+        b = _book()
+        before = b.last_modified
+        with patch.object(helper.calibre_db, "set_metadata_dirty") as dirty, \
+             patch("cps.kobo_sync_status.remove_synced_book") as unsync:
+            helper.mark_book_modified(b, unsync=True)
+        assert b.last_modified > before
+        dirty.assert_called_once_with(42)
+        unsync.assert_called_once_with(42, all=True)
+
+    def test_source_pins_the_triplet(self):
+        from cps import helper
+        src = inspect.getsource(helper.mark_book_modified)
+        assert "last_modified" in src
+        assert "set_metadata_dirty" in src
+        assert "remove_synced_book" in src
+
+
+@pytest.mark.unit
+class TestCallSitesRouteThroughHelper:
+    """The class-of-bug guard: no write path may re-implement a raw
+    last_modified bump. Every site goes through mark_book_modified so the
+    invariant lives in exactly one place."""
+
+    def test_editbooks_has_no_raw_last_modified_bump(self):
+        from cps import editbooks
+        src = inspect.getsource(editbooks)
+        assert "last_modified = datetime.now" not in src, (
+            "editbooks must route last_modified bumps through "
+            "helper.mark_book_modified, not a raw assignment"
+        )
+        assert "mark_book_modified" in src
+
+    def test_cover_picker_has_no_raw_last_modified_bump(self):
+        from cps import cover_picker
+        src = inspect.getsource(cover_picker)
+        assert "last_modified = datetime.now" not in src
+        assert "mark_book_modified" in src


### PR DESCRIPTION
## Why

#340 was caused by the cover-picker apply path forgetting to bump `book.last_modified`. The deeper reason it was easy to miss: marking a book changed is a coupled triplet —

1. `book.last_modified = now` → drives the web cover/metadata cache-buster (the jinjia `last_modified` filter on every cover URL) **and** Kobo native sync selection (`Books.last_modified > sync_token.books_last_modified`)
2. `set_metadata_dirty(book.id)` → queue CWA metadata write-back
3. `remove_synced_book(book.id, all=True)` → force Kobo devices to re-pull

— and that triplet was **copy-pasted across ~6 call sites with no shared helper**. Any new write path could silently forget a step. This closes the *class* of bug, not just the one instance.

## What

New `helper.mark_book_modified(book, *, set_dirty=True, unsync=False)` — the single source of truth. Every site routes through it, **preserving exact per-site behavior**:

| Site | Before | Call |
|---|---|---|
| editbooks single-field / ajax edits | lm + (dirty if metadata_changed) | `mark_book_modified(book, set_dirty=metadata_changed)` |
| editbooks main edit (`modify_date`) | full triplet | `mark_book_modified(book, unsync=True)` |
| editbooks reload-from-disk | lm only | `mark_book_modified(book, set_dirty=False)` |
| cover_picker apply | lm + dirty pre-commit | `mark_book_modified(book)` (remove_synced stays post-commit, per #340's split) |

No behavior change — pure consolidation.

## Recurrence guards
- The helper **source-pins** the triplet.
- New call-site tests assert `editbooks.py` and `cover_picker.py` contain **no raw `last_modified = datetime.now`** bump — every path must use the helper, so a future write path can't reintroduce the bug.

## Verification
- New `tests/unit/test_mark_book_modified.py` (helper behavior: default / set_dirty=False / unsync=True + source-pin + the two call-site guards). Cover-picker tests updated (the triplet pin moved into the helper).
- Full `-m "smoke or unit" -n auto` clean except the 2 known pre-existing local-env failures (`test_required_directories_exist`, `test_ingest_batch_dirty` — fail identically without this change).
- **Live on cwn-local**: a publisher edit (main edit path) bumped `last_modified` 18:20:33 → 01:35:00 + persisted + `metadata_dirtied` set; a cover apply (cover path) bumped 01:35:00 → 01:35:40, both via the helper. No errors.

Pure refactor — no user-facing change, rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)