### PR TITLE
docs(#336): document KOReader 'Use server filenames' for OPDS download naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ CWA has built-in KOReader progress sync; no separate kosync server is needed.
 2. Point the plugin at `http://your-cwa:8083` and log in with your CWA username and password.
 3. Read on any device. Progress syncs back to CWA, and from there to Kobo if Kobo sync is enabled.
 
+**Matching filenames across devices (OPDS downloads).** If you download books to KOReader over OPDS and sync progress by filename across several e-readers, turn on **Use server filenames** in KOReader's OPDS catalog settings (the checkbox when you add or edit the catalog). By default KOReader names a downloaded file `Author - Title.epub` from the catalog entry, which differs from the on-disk library name `Title - Author.epub` and forces a manual rename. CWA already sends the library name in the download's `Content-Disposition` header; with **Use server filenames** on, KOReader uses that name, so the file matches your library and your other devices without renaming.
+
 ### Kobo sync
 
 Read your CWA library on a Kobo e-reader, with reading progress syncing both ways. Sync runs against your own server, so your library never leaves your network.

--- a/tests/unit/test_336_opds_filename_docs.py
+++ b/tests/unit/test_336_opds_filename_docs.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Doc regression test for fork issue #336 (@batiti93).
+
+Reporter: OPDS downloads to KOReader land as `Author - Title.epub`, but the
+CWA library names files `Title - Author.epub`, so the names differ and
+cross-device read-status sync (filename-based) needs a manual rename each time.
+
+Investigation (verified against KOReader source, opds.koplugin/opdsbrowser.lua):
+
+* CWA's OPDS download endpoint already sends the correct library name in the
+  `Content-Disposition` header (`filename=...Title - Author.epub`). This is NOT
+  a server bug — confirmed by curling /opds/download/<id>/<fmt>/.
+* KOReader's `OPDSBrowser:getFileName` builds `item.author .. " - " .. item.title`
+  ("Author - Title") from the catalog entry by default, ignoring the header.
+* Only when the catalog's **Use server filenames** toggle (`raw_names`) is ON
+  does `getFileName` return nil and KOReader fall back to `getServerFileName`,
+  which reads the `Content-Disposition` filename — i.e. CWA's `Title - Author`.
+
+So the resolution is the KOReader **Use server filenames** setting, not a code
+change (swapping `<author>`/`<title>` in the feed would corrupt the catalog for
+every client). This test pins the README guidance so the answer isn't silently
+lost — a user hitting the same symptom finds it in one search instead of
+re-opening the issue.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README = REPO_ROOT / "README.md"
+
+
+@pytest.fixture(scope="module")
+def readme() -> str:
+    assert README.exists()
+    return README.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestOpdsFilenameGuidance:
+    def test_readme_documents_use_server_filenames(self, readme):
+        assert re.search(r"use server filenames", readme, re.IGNORECASE), (
+            "README must document KOReader's 'Use server filenames' OPDS "
+            "setting (#336): it's the resolution for OPDS downloads naming "
+            "files 'Author - Title' instead of the library's 'Title - Author'."
+        )
+
+    def test_readme_explains_the_default_mismatch(self, readme):
+        """The note must name BOTH orderings so a user recognizes their
+        symptom — KOReader's default Author-Title vs the library Title-Author."""
+        lower = readme.lower()
+        assert "author - title" in lower and "title - author" in lower, (
+            "README must contrast KOReader's default `Author - Title` naming "
+            "with the library's `Title - Author` so a user recognizes the "
+            "#336 symptom."
+        )
+
+    def test_guidance_lives_in_koreader_section(self, readme):
+        """Pin the note to the KOReader sync section (its logical home), so a
+        future README reshuffle doesn't orphan it under, say, Kobo sync."""
+        m = re.search(r"### KOReader sync\n(.*?)(?=\n### )", readme, re.DOTALL)
+        assert m, "expected a '### KOReader sync' section in README"
+        section = m.group(1).lower()
+        assert "use server filenames" in section, (
+            "the 'Use server filenames' guidance must live in the KOReader "
+            "sync README section (#336)."
+        )


### PR DESCRIPTION
## Symptom

@batiti93 (#336): OPDS downloads arrive on KOReader as `Author - Title.epub`, but the CWA library names files `Title - Author.epub`. The mismatch forces a manual rename and breaks filename-based read-status sync across e-readers.

## Investigation (verified, not a server bug)

- The OPDS download endpoint already sends the library name in `Content-Disposition` — confirmed by curling `/opds/download/<id>/<fmt>/` on a live container: `filename=The Picture of Dorian Gray - Oscar Wilde.epub` (i.e. `Title - Author`, matching the on-disk library name).
- KOReader's `OPDSBrowser:getFileName` (opds.koplugin/opdsbrowser.lua) builds `item.author .. " - " .. item.title` from the catalog entry and ignores the header — that's the `Author - Title` the reporter sees. It only falls back to the header (`getServerFileName`) when the catalog's **Use server filenames** toggle (`raw_names`) is on, which defaults off (opdsbrowser.lua, `getFileName` returns nil only under `root_catalog_raw_names`).
- Swapping `<author>`/`<title>` in the OPDS feed would change KOReader's output but corrupt the catalog display and every other OPDS client, so that's not the fix.

## Change

Document the resolution in the README KOReader-sync section: enable **Use server filenames** in KOReader's OPDS catalog settings, after which KOReader uses CWA's `Content-Disposition` name and downloads match the library. No code change — the server already does the right thing.

## Verification

- `tests/unit/test_336_opds_filename_docs.py` pins the README guidance (mentions the setting, contrasts both filename orderings, lives in the KOReader section). RED without the note, GREEN with it. 3/3 pass.
- The reporter has the full answer on the issue thread, including the exact KOReader steps.

## Confidence

Docs-only; the behavioural claim is verified against both the live server header and KOReader source. Whether it resolves the reporter's exact setup depends on their reader honouring the setting — asked them to confirm on the issue.

## Tier

`safe-tier-1` — README + a doc-pin test, no code.

Addresses #336.