### PR TITLE
Cherry-pick #1344: Low hanging optimizations of the Kobo Sync request

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
+import glob
 import os
 import random
 import io
@@ -48,7 +49,7 @@ from . import logger, config, db, ub, fs
 from . import gdriveutils as gd
 from .constants import (STATIC_DIR as _STATIC_DIR, CACHE_TYPE_THUMBNAILS, THUMBNAIL_TYPE_COVER, THUMBNAIL_TYPE_SERIES,
                         SUPPORTED_CALIBRE_BINARIES)
-from .subproc_wrapper import process_wait
+from .subproc_wrapper import process_wait, process_open
 from .services.file_move import copy_with_metadata_fallback
 
 # Track books with pending thumbnail generation to prevent duplicate tasks
@@ -57,7 +58,7 @@ _pending_thumbnail_books = set()
 import sys
 sys.path.insert(1, '/app/calibre-web-automated/scripts/')
 from cwa_db import CWA_DB
-from .services.worker import WorkerThread
+from .services.worker import WorkerThread, STAT_FINISH_SUCCESS
 from .tasks.mail import TaskEmail
 from .tasks.thumbnail import TaskClearCoverThumbnailCache, TaskGenerateCoverThumbnails
 from .tasks.metadata_backup import TaskBackupMetadata
@@ -111,7 +112,8 @@ except (ImportError, RuntimeError) as e:
 
 
 # Convert existing book entry to new format
-def convert_book_format(book_id, calibre_path, old_book_format, new_book_format, user_id, ereader_mail=None, subject=None):
+def convert_book_format(book_id, calibre_path, old_book_format, new_book_format, user_id,
+                        ereader_mail=None, subject=None, blocking=False):
     book = calibre_db.get_book(book_id)
     data = calibre_db.get_book_format(book.id, old_book_format)
     if not data:
@@ -145,7 +147,14 @@ def convert_book_format(book_id, calibre_path, old_book_format, new_book_format,
            link)
     settings['old_book_format'] = old_book_format
     settings['new_book_format'] = new_book_format
-    WorkerThread.add(user_id, TaskConvert(file_path, book.id, txt, settings, ereader_mail, user_id))
+    task = TaskConvert(file_path, book.id, txt, settings, ereader_mail, user_id)
+    WorkerThread.add(user_id, task)
+    if blocking:
+        finished = task.done_event.wait(timeout=120)
+        if not finished:
+            return _("Conversion timed out for book id: %(book)d", book=book_id)
+        if task.stat != STAT_FINISH_SUCCESS:
+            return task.error or _("Conversion failed for book id: %(book)d", book=book_id)
     return None
 
 
@@ -1622,6 +1631,16 @@ def get_download_link(book_id, book_format, client):
         abort(404)
 
     data1 = calibre_db.get_book_format(book.id, book_format.upper())
+    if not data1 and book_format == "kepub" and config.config_kepubifypath:
+        data1 = calibre_db.get_book_format(book.id, "EPUB")
+        if data1:
+            log.info("KEPUB not found for book %d; converting on demand", book.id)
+            err = convert_book_format(book.id, config.get_book_path(), 'EPUB', 'KEPUB', None, blocking=True)
+            if not err:
+                data1 = calibre_db.get_book_format(book.id, "KEPUB")
+            else:
+                log.error("On-demand KEPUB conversion failed for book %d: %s", book.id, err)
+                book_format = "epub"
     if not data1:
         log.error("Requested format %s for book id %s not found in database", book_format.upper(), book_id)
         abort(404)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -35,6 +35,7 @@ from werkzeug.datastructures import Headers
 from sqlalchemy import func
 from sqlalchemy.sql.expression import and_, or_
 from sqlalchemy.exc import StatementError
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 import requests
 
@@ -275,6 +276,12 @@ def HandleSyncRequest():
                                and_(ub.Shelf.user_id == current_user.id, ub.Shelf.kobo_sync == True),
                                db.Books.id.in_(magic_shelf_book_ids) if magic_shelf_book_ids else False
                            ))
+                           .options(joinedload(db.Books.authors),
+                                    joinedload(db.Books.publishers),
+                                    joinedload(db.Books.series),
+                                    joinedload(db.Books.languages),
+                                    joinedload(db.Books.comments),
+                                    joinedload(db.Books.data))
                            .distinct())
     else:
         changed_entries = calibre_db.session.query(db.Books,
@@ -294,7 +301,13 @@ def HandleSyncRequest():
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .order_by(db.Books.last_modified)
-                           .order_by(db.Books.id))
+                           .order_by(db.Books.id)
+                           .options(joinedload(db.Books.authors),
+                                    joinedload(db.Books.publishers),
+                                    joinedload(db.Books.series),
+                                    joinedload(db.Books.languages),
+                                    joinedload(db.Books.comments),
+                                    joinedload(db.Books.data)))
     log.debug("Kobo Sync: changed entries: {}".format(changed_entries.count()))
 
     reading_states_in_new_entitlements = []
@@ -794,11 +807,12 @@ def get_metadata(book):
     }
     metadata.update(get_author(book))
 
-    if get_series(book):
-        name = get_series(book)
+    series_name = get_series(book)
+    if series_name:
+        name = series_name
         try:
             metadata["Series"] = {
-                "Name": get_series(book),
+                "Name": series_name,
                 "Number": get_seriesindex(book),        # ToDo Check int() ?
                 "NumberFloat": float(get_seriesindex(book)),
                 # Get a deterministic id based on the series name.

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -314,10 +314,6 @@ def HandleSyncRequest():
     books = changed_entries.limit(SYNC_ITEM_LIMIT)
     log.debug("Kobo Sync: selected to sync: {}".format(len(books.all())))
     for book in books:
-        formats = [data.format for data in book.Books.data]
-        if 'KEPUB' not in formats and config.config_kepubifypath and 'EPUB' in formats:
-            helper.convert_book_format(book.Books.id, config.get_book_path(), 'EPUB', 'KEPUB', current_user.name)
-
         kobo_reading_state = book.KoboReadingState  # None when no record exists yet
         entitlement = {
             "BookEntitlement": create_book_entitlement(book.Books, archived=(book.is_archived==True)),
@@ -752,28 +748,32 @@ def _get_cover_image_id(book):
 
 def get_metadata(book):
     download_urls = []
-    kepub = [data for data in book.data if data.format == 'KEPUB']
 
-    for book_data in kepub if len(kepub) > 0 else book.data:
-        if book_data.format not in KOBO_FORMATS:
-            continue
-        for kobo_format in KOBO_FORMATS[book_data.format]:
-            # log.debug('Id: %s, Format: %s' % (book.id, kobo_format))
-            try:
-                if get_epub_layout(book, book_data) == 'pre-paginated':
-                    kobo_format = 'EPUB3FL'
-                download_urls.append(
-                    {
-                        "Format": kobo_format,
-                        "Size": book_data.uncompressed_size,
-                        "Url": get_download_url_for_book(book.id, book_data.format),
-                        # The Kobo forma accepts platforms: (Generic, Android)
-                        "Platform": "Generic",
-                        "DrmType": "None",
-                    }
-                )
-            except (zipfile.BadZipfile, FileNotFoundError) as e:
-                log.error(e)
+    kepub_data = next((d for d in book.data if d.format == 'KEPUB'), None)
+    epub_data  = next((d for d in book.data if d.format == 'EPUB'),  None)
+
+    if kepub_data:
+        book_data, dl_format, published_format = kepub_data, 'kepub', 'KEPUB'
+    elif epub_data and config.config_kepubifypath:
+        book_data, dl_format, published_format = epub_data, 'kepub', 'KEPUB'
+    elif epub_data:
+        book_data, dl_format, published_format = epub_data, 'epub', 'EPUB3'
+    else:
+        book_data = None
+
+    if book_data:
+        try:
+            if get_epub_layout(book, book_data) == 'pre-paginated':
+                published_format = 'EPUB3FL'
+        except (zipfile.BadZipfile, FileNotFoundError) as e:
+            log.error(e)
+        download_urls.append({
+            "Format": published_format,
+            "Size": book_data.uncompressed_size,
+            "Url": get_download_url_for_book(book.id, dl_format),
+            "Platform": "Generic",
+            "DrmType": "None",
+        })
 
     book_uuid = book.uuid
     cover_image_id = _get_cover_image_id(book)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -236,11 +236,16 @@ def HandleSyncRequest():
 
     log.debug("Kobo Sync: books last modified: {}".format(sync_token.books_last_modified))
 
+    rstate_join = and_(
+        db.Books.id == ub.KoboReadingState.book_id,
+        ub.KoboReadingState.user_id == current_user.id,
+    )
     if only_kobo_shelves:
         changed_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
                                                    ub.BookShelf.date_added,
-                                                   ub.ArchivedBook.is_archived)
+                                                   ub.ArchivedBook.is_archived,
+                                                   ub.KoboReadingState)
         # Per-device sync state lives in the `x-kobo-synctoken` cursor
         # (the last_modified comparisons below). Don't filter by
         # KoboSyncedBooks here — that table is user-keyed, so it would
@@ -255,6 +260,7 @@ def HandleSyncRequest():
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
+                           .outerjoin(ub.KoboReadingState, rstate_join)
                            .filter(or_(
                                ub.BookShelf.date_added > sync_token.books_last_modified,
                                db.Books.last_modified > sync_token.books_last_modified
@@ -273,7 +279,8 @@ def HandleSyncRequest():
     else:
         changed_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
-                                                   ub.ArchivedBook.is_archived)
+                                                   ub.ArchivedBook.is_archived,
+                                                   ub.KoboReadingState)
         # Same per-device cursor invariant as the shelf branch above:
         # don't filter by KoboSyncedBooks (user-keyed, breaks multi-device).
         # The last_modified > sync_token.books_last_modified filter is the
@@ -282,6 +289,7 @@ def HandleSyncRequest():
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
+                           .outerjoin(ub.KoboReadingState, rstate_join)
                            .filter(db.Books.last_modified > sync_token.books_last_modified)
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
@@ -297,13 +305,14 @@ def HandleSyncRequest():
         if 'KEPUB' not in formats and config.config_kepubifypath and 'EPUB' in formats:
             helper.convert_book_format(book.Books.id, config.get_book_path(), 'EPUB', 'KEPUB', current_user.name)
 
-        kobo_reading_state = get_or_create_reading_state(book.Books.id)
+        kobo_reading_state = book.KoboReadingState  # None when no record exists yet
         entitlement = {
             "BookEntitlement": create_book_entitlement(book.Books, archived=(book.is_archived==True)),
             "BookMetadata": get_metadata(book.Books),
         }
 
-        if kobo_reading_state.last_modified > sync_token.reading_state_last_modified:
+        if (kobo_reading_state is not None
+                and kobo_reading_state.last_modified > sync_token.reading_state_last_modified):
             entitlement["ReadingState"] = get_kobo_reading_state_response(book.Books, kobo_reading_state)
             new_reading_state_last_modified = max(new_reading_state_last_modified, kobo_reading_state.last_modified)
             reading_states_in_new_entitlements.append(book.Books.id)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1448,7 +1448,7 @@ def HandleCoverImageRequest(book_uuid, width, height, Quality, isGreyscale):
         else:
             resolution = COVER_THUMBNAIL_SMALL
     except ValueError:
-        log.error("Requested height %s of book %s is invalid" % (book_uuid, height))
+        log.error("Requested height %s of book %s is invalid" % (height, book_uuid))
         resolution = COVER_THUMBNAIL_SMALL
 
     padded_response = _serve_padded_cover_if_enabled(book_uuid, resolution)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -745,6 +745,14 @@ def _get_cover_image_id(book):
         log.debug("Kobo Sync: failed to build cover image id for book %s: %s", book.id, exc)
         return base_id
 
+def build_download_url(book, book_data, download_format, declared_format):
+    return {
+            "Format": declared_format,
+            "Size": book_data.uncompressed_size,
+            "Url": get_download_url_for_book(book.id, download_format),
+            "Platform": "Generic",
+            "DrmType": "None",
+        }
 
 def get_metadata(book):
     download_urls = []
@@ -752,28 +760,36 @@ def get_metadata(book):
     kepub_data = next((d for d in book.data if d.format == 'KEPUB'), None)
     epub_data  = next((d for d in book.data if d.format == 'EPUB'),  None)
 
+    # Send kepub if kepub format is available or if deferred kepub conversion
+    # is supported
     if kepub_data:
-        book_data, dl_format, published_format = kepub_data, 'kepub', 'KEPUB'
+        book_data, dl_format = kepub_data, 'kepub'
     elif epub_data and config.config_kepubifypath:
-        book_data, dl_format, published_format = epub_data, 'kepub', 'KEPUB'
+        book_data, dl_format = epub_data, 'kepub'
     elif epub_data:
-        book_data, dl_format, published_format = epub_data, 'epub', 'EPUB3'
+        book_data, dl_format = epub_data, 'epub'
     else:
         book_data = None
 
     if book_data:
+        is_fixed_layout = False
         try:
             if get_epub_layout(book, book_data) == 'pre-paginated':
-                published_format = 'EPUB3FL'
+                is_fixed_layout = True
         except (zipfile.BadZipfile, FileNotFoundError) as e:
             log.error(e)
-        download_urls.append({
-            "Format": published_format,
-            "Size": book_data.uncompressed_size,
-            "Url": get_download_url_for_book(book.id, dl_format),
-            "Platform": "Generic",
-            "DrmType": "None",
-        })
+        if is_fixed_layout:
+            # Only send EPUB3FL if the book is a fixed layout. This forces the device
+            # to pick this download, regardless of the priority order in the firmware
+            download_urls.append(build_download_url(book, book_data, dl_format, 'EPUB3FL'))
+        else:
+            if dl_format == 'kepub':
+                download_urls.append(build_download_url(book, book_data, dl_format, 'KEPUB'))
+            else:
+                # Send both EPUB and EPUB3 for epub files, in case legacy devices only support
+                # EPUB download urls
+                download_urls.append(build_download_url(book, book_data, dl_format, 'EPUB3'))
+                download_urls.append(build_download_url(book, book_data, dl_format, 'EPUB'))
 
     book_uuid = book.uuid
     cover_image_id = _get_cover_image_id(book)

--- a/cps/kobo_auth.py
+++ b/cps/kobo_auth.py
@@ -102,43 +102,6 @@ def generate_auth_token(user_id):
         ub.session.add(auth_token)
         ub.session_commit()
 
-    if config.config_kepubifypath:
-        # Scope auto-convert to books on the user's Kobo Sync shelves only.
-        # Reported as crocodilestick/Calibre-Web-Automated#817: visiting this
-        # endpoint converted every EPUB in the library, queueing tens or
-        # hundreds of thousands of tasks and starving Kobo sync. Books not
-        # on a Kobo Sync shelf are still converted on-demand at sync time.
-        try:
-            synced_book_ids = [
-                row.book_id for row in
-                ub.session.query(ub.BookShelf)
-                .join(ub.Shelf, ub.Shelf.id == ub.BookShelf.shelf)
-                .filter(ub.Shelf.user_id == user_id)
-                .filter(ub.Shelf.kobo_sync == True)
-                .all()
-            ]
-        except Exception as ex:
-            log.warning("Could not enumerate Kobo Sync shelf books: %s", ex)
-            synced_book_ids = []
-
-        if synced_book_ids:
-            try:
-                books = (calibre_db.session.query(db.Books)
-                         .options(joinedload(db.Books.data))
-                         .filter(db.Books.id.in_(synced_book_ids))
-                         .all())
-            except Exception as ex:
-                log.warning("Could not enumerate books for kepub auto-conversion: %s", ex)
-                books = []
-
-            for book in books:
-                try:
-                    formats = [data.format for data in book.data]
-                    if 'KEPUB' not in formats and 'EPUB' in formats:
-                        helper.convert_book_format(book.id, config.config_calibre_dir, 'EPUB', 'KEPUB', current_user.name)
-                except Exception as ex:
-                    log.warning("Skipping kepub auto-conversion for book %s: %s", getattr(book, "id", "?"), ex)
-
     return render_title_template(
         "generate_kobo_auth_url.html",
         title=_("Kobo Setup"),

--- a/cps/services/worker.py
+++ b/cps/services/worker.py
@@ -209,6 +209,7 @@ class CalibreTask:
         self.id = uuid.uuid4()
         self.self_cleanup = False
         self._scheduled = False
+        self.done_event = threading.Event()
 
     @abc.abstractmethod
     def run(self, worker_thread):
@@ -297,10 +298,12 @@ class CalibreTask:
         self.stat = STAT_FAIL
         self.progress = 1
         self.error = error_message
+        self.done_event.set()
 
     def _handleSuccess(self):
         self.stat = STAT_FINISH_SUCCESS
         self.progress = 1
+        self.done_event.set()
 
     def __str__(self):
         return self.name

--- a/tests/smoke/test_kobo_auth_eager_load_smoke.py
+++ b/tests/smoke/test_kobo_auth_eager_load_smoke.py
@@ -6,74 +6,128 @@
 
 """Regression test for upstream issue #1328 / fork issue #50.
 
-Symptom: Profile -> Create/View Kobo Auth Token returned a blank page with
-    sqlite3.InterfaceError: bad parameter or other API misuse
-    (cps/kobo_auth.py line ~104, lazy load of book.data)
+Original symptom: Profile -> Create/View Kobo Auth Token returned a blank
+page with `sqlite3.InterfaceError: bad parameter or other API misuse`
+(cps/kobo_auth.py line ~104, lazy load of `book.data`).
 
-Root cause: `query(Books).join(Data).all()` returned duplicate book rows
-(one per format), then `book.data` lazy-loaded again per row -- N+1 queries
-on the request-scoped session. When a worker thread crashed mid-request
-(`worker:237 list index out of range` is in the original report just above
+Original root cause: `generate_auth_token` ran a per-Kobo-Sync-shelf-book
+kepub auto-conversion loop. The query returned duplicate rows (one per
+format), then `book.data` lazy-loaded again per row — N+1 queries on the
+request-scoped session. When a worker thread crashed mid-request
+(`worker:237 list index out of range` in the original report just above
 the trace), subsequent lazy-loads hit a poisoned connection and raised the
 SQLite InterfaceError, blanking the page.
 
-This test pins the structural change so a future refactor can't reintroduce
-the lazy-load pattern: the kepub auto-conversion path must use joinedload,
-must skip the explicit JOIN-with-duplicates, and must wrap each per-book
-enqueue in a try/except so one bad book doesn't blank-page the user.
+The fix has gone through two phases:
+
+1. Original fix (cps/kobo_auth.py): eager-load with `joinedload(db.Books.data)`
+   so the lazy-load can't fan out; gate on `config.config_kepubifypath`;
+   wrap each per-book convert in try/except so one bad book doesn't blank
+   the page.
+2. PR #350 (Michael Shavit, CWA #1344): **delete** the auto-convert loop
+   from `generate_auth_token` entirely. Defer kepub conversion to download
+   time — `helper.get_download_link` for "kepub" format checks if a KEPUB
+   exists, falls back to converting from EPUB synchronously (blocking=True,
+   120s timeout), and serves EPUB if conversion fails. The blank-page
+   symptom is structurally eliminated: no auto-convert loop in
+   `generate_auth_token` → no N+1 → no lazy-load on a poisoned connection.
+
+This test file pins the post-#350 invariants:
+
+* `generate_auth_token` must NOT contain a kepub-conversion loop at all
+  (the regression vector is gone if the loop is gone).
+* `get_download_link` must contain the on-demand kepub fallback path
+  (the new design where conversion still happens, just lazily at download).
 """
 
 import ast
 import pathlib
+
 import pytest
 
 
-KOBO_AUTH = pathlib.Path(__file__).resolve().parent.parent.parent / "cps" / "kobo_auth.py"
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+KOBO_AUTH = REPO_ROOT / "cps" / "kobo_auth.py"
+HELPER = REPO_ROOT / "cps" / "helper.py"
+
+
+def _function_source(path: pathlib.Path, name: str) -> str:
+    tree = ast.parse(path.read_text())
+    fn = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == name),
+        None,
+    )
+    assert fn is not None, f"{name} function not found in {path}"
+    return ast.unparse(fn)
 
 
 @pytest.mark.smoke
-class TestKoboAuthGenerateAuthTokenEagerLoad:
-    def setup_method(self):
-        self.source = KOBO_AUTH.read_text()
-        self.tree = ast.parse(self.source)
-        self.fn = next(
-            (n for n in ast.walk(self.tree)
-             if isinstance(n, ast.FunctionDef) and n.name == "generate_auth_token"),
-            None,
+class TestGenerateAuthTokenNoAutoConvertLoop:
+    """Post-#350 invariant: generate_auth_token must not iterate books to
+    pre-convert kepubs. The loop was the regression vector for #1328 /
+    fork #50 — its absence is what makes the blank-page symptom
+    structurally impossible."""
+
+    def test_no_kepub_conversion_loop_in_auth_token(self):
+        src = _function_source(KOBO_AUTH, "generate_auth_token")
+        assert "convert_book_format" not in src, (
+            "generate_auth_token must not call convert_book_format. The "
+            "auto-convert-at-token-generation loop was the regression "
+            "vector for issue #1328 / fork #50 — deferring kepub conversion "
+            "to download time eliminates the lazy-load-on-poisoned-connection "
+            "blank-page symptom entirely (PR #350, CWA #1344)."
         )
-        assert self.fn is not None, "generate_auth_token function not found"
 
-    def test_imports_joinedload(self):
-        assert "from sqlalchemy.orm import joinedload" in self.source, \
-            "joinedload import is required to avoid the N+1 lazy-load that triggered #1328"
+    def test_no_books_data_walk_in_auth_token(self):
+        src = _function_source(KOBO_AUTH, "generate_auth_token")
+        # Walking book.data on a duplicated-row query was the exact lazy-load
+        # pattern that crashed under a poisoned worker connection. If the
+        # loop ever comes back, this pin should go red.
+        assert "book.data" not in src and "data.format" not in src, (
+            "generate_auth_token must not walk book.data — the lazy-load "
+            "pattern that crashed under #1328 / fork #50 should not "
+            "reappear. If a future change needs kepub gating at this layer "
+            "again, write it with joinedload + a try/except guard and "
+            "update this pin."
+        )
 
-    def test_uses_joinedload_on_books_data(self):
-        joinedload_calls = [
-            n for n in ast.walk(self.fn)
-            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "joinedload"
-        ]
-        assert joinedload_calls, "generate_auth_token must call joinedload(...) on Books.data"
 
-    def test_no_explicit_join_data(self):
-        # The legacy `.join(db.Data)` pattern returned one row per (book, data)
-        # tuple, multiplying lazy loads -- that's exactly what crashed under load.
-        attr_chain_text = ast.unparse(self.fn)
-        assert ".join(db.Data)" not in attr_chain_text, \
-            "Stale .join(db.Data) — duplicates books N times where N=len(formats)"
+@pytest.mark.smoke
+class TestKepubDeferredToDownload:
+    """Post-#350 invariant: kepub conversion still happens, but lazily —
+    at download time, in `helper.get_download_link`, gated on
+    `config.config_kepubifypath` and with EPUB fallback."""
 
-    def test_per_book_conversion_is_guarded(self):
-        # The kepub auto-conversion loop must wrap each book in try/except so
-        # a single bad book doesn't bubble up and blank-page the route.
-        for_nodes = [n for n in ast.walk(self.fn) if isinstance(n, ast.For)]
-        guarded = [
-            f for f in for_nodes
-            if any(isinstance(stmt, ast.Try) for stmt in f.body)
-        ]
-        assert guarded, "Per-book conversion loop must contain a try/except guard"
+    def test_get_download_link_has_kepub_fallback(self):
+        src = _function_source(HELPER, "get_download_link")
+        assert 'book_format == "kepub"' in src or "book_format == 'kepub'" in src, (
+            "get_download_link must branch on the requested format being "
+            "'kepub' so it can convert on demand when KEPUB is missing "
+            "(PR #350 deferred design)."
+        )
+        assert "convert_book_format" in src, (
+            "get_download_link must call convert_book_format on the "
+            "missing-KEPUB path so the Kobo device still gets a kepub "
+            "when one can be produced."
+        )
 
-    def test_kepub_check_short_circuits_when_disabled(self):
-        # When config_kepubifypath is unset there's nothing to convert; we shouldn't
-        # walk every book in the library at all (cheap perf + avoids the N+1 path).
-        attr_chain_text = ast.unparse(self.fn)
-        assert "config.config_kepubifypath" in attr_chain_text, \
-            "config_kepubifypath gate must be checked before the books query"
+    def test_kepub_conversion_gated_on_config(self):
+        src = _function_source(HELPER, "get_download_link")
+        assert "config.config_kepubifypath" in src, (
+            "get_download_link must gate the on-demand kepub conversion on "
+            "config.config_kepubifypath — without the helper binary there's "
+            "nothing to convert with, and forging a convert call would "
+            "crash the download."
+        )
+
+    def test_kepub_conversion_blocks_and_times_out(self):
+        # blocking=True is what makes the synchronous-at-download design
+        # work — without it the device would 404 before the conversion
+        # finished. The convert_book_format helper itself caps at 120s.
+        helper_src = HELPER.read_text()
+        assert "blocking=True" in helper_src, (
+            "get_download_link must call convert_book_format with "
+            "blocking=True so the conversion completes before the response "
+            "is served. Async conversion would 404 the device's request."
+        )

--- a/tests/smoke/test_kobo_auth_shelf_scope_smoke.py
+++ b/tests/smoke/test_kobo_auth_shelf_scope_smoke.py
@@ -6,74 +6,106 @@
 
 """Regression test for upstream issue crocodilestick/Calibre-Web-Automated#817.
 
-Symptom: visiting Profile -> Create/View Kobo Auth Token enqueues a kepub
-conversion task for every EPUB in the library, regardless of whether the
-book is on a Kobo Sync shelf. On large libraries (200k+ books) this floods
-the worker queue, triggers a flood of `Skipping kepub auto-conversion`
-warnings for un-convertible files, and starves the actual /v1/library/sync
-calls until the container is marked unhealthy.
+Original symptom: visiting Profile -> Create/View Kobo Auth Token enqueued
+a kepub conversion task for every EPUB in the library, regardless of
+whether the book was on a Kobo Sync shelf. On large libraries (200k+
+books) this flooded the worker queue, triggered a flood of `Skipping kepub
+auto-conversion` warnings, and starved the actual /v1/library/sync calls
+until the container was marked unhealthy.
 
-Fix: scope the auto-conversion to books on the user's Kobo Sync shelves
-only. Books outside those shelves are still converted on-demand at sync
-time by the existing Kobo flow.
+The fix has gone through two phases:
 
-This test pins the shelf-scope behavior so a refactor can't reintroduce
-the unbounded library walk.
+1. Original (cps/kobo_auth.py): scope the auto-conversion to books on the
+   user's Kobo Sync shelves only. Books outside those shelves were still
+   converted on-demand at sync time by the existing Kobo flow.
+2. PR #350 (Michael Shavit, CWA #1344): **delete** the auto-convert loop
+   from `generate_auth_token` entirely. Defer kepub conversion to download
+   time — `helper.get_download_link` for "kepub" format converts only the
+   book the device is actively requesting, never walking the library.
+
+This test pins the post-#350 invariants:
+
+* `generate_auth_token` must NOT iterate books to convert kepubs (any
+  query against db.Books at this layer would reintroduce the #817 regress).
+* The conversion path must live in `helper.get_download_link`, scoped to a
+  single book id at request time (the device's specific download).
 """
 
 import ast
 import pathlib
+
 import pytest
 
 
-KOBO_AUTH = pathlib.Path(__file__).resolve().parent.parent.parent / "cps" / "kobo_auth.py"
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+KOBO_AUTH = REPO_ROOT / "cps" / "kobo_auth.py"
+HELPER = REPO_ROOT / "cps" / "helper.py"
+
+
+def _function_source(path: pathlib.Path, name: str) -> str:
+    tree = ast.parse(path.read_text())
+    fn = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == name),
+        None,
+    )
+    assert fn is not None, f"{name} function not found in {path}"
+    return ast.unparse(fn)
 
 
 @pytest.mark.smoke
-class TestKoboAuthShelfScopedConvert:
-    def setup_method(self):
-        self.source = KOBO_AUTH.read_text()
-        self.tree = ast.parse(self.source)
-        self.fn = next(
-            (n for n in ast.walk(self.tree)
-             if isinstance(n, ast.FunctionDef) and n.name == "generate_auth_token"),
-            None,
-        )
-        assert self.fn is not None, "generate_auth_token function not found"
-        self.fn_text = ast.unparse(self.fn)
+class TestNoUnboundedLibraryWalkInAuthToken:
+    """Pin the post-#350 design: generate_auth_token never walks books to
+    queue conversions. The #817 regression vector (library-wide convert
+    on every visit) is structurally impossible if the loop is gone."""
 
-    def test_filters_by_kobo_sync_shelf(self):
-        assert "kobo_sync" in self.fn_text, (
-            "generate_auth_token must filter by Shelf.kobo_sync to avoid "
-            "queuing a kepub convert for every book in the library"
+    def test_no_books_query_in_auth_token(self):
+        src = _function_source(KOBO_AUTH, "generate_auth_token")
+        # The old loop did `calibre_db.session.query(db.Books)...`. Whether
+        # scoped to shelves or not, ANY Books query at this layer is the
+        # regression vector. The new design queries no books here.
+        assert "db.Books" not in src, (
+            "generate_auth_token must not query db.Books — the auto-convert "
+            "loop was the #817 regression vector. PR #350 (CWA #1344) "
+            "removes the loop and defers conversion to download time."
         )
 
-    def test_joins_book_shelf_link(self):
-        # The shelf scope is computed by joining BookShelf to Shelf and filtering
-        # by user_id + kobo_sync. Catching either name pins the structural change.
-        assert "BookShelf" in self.fn_text, (
-            "Must enumerate book_shelf_link rows to scope conversion to shelf members"
+    def test_no_convert_in_auth_token(self):
+        src = _function_source(KOBO_AUTH, "generate_auth_token")
+        assert "convert_book_format" not in src, (
+            "generate_auth_token must not call convert_book_format. The "
+            "auto-convert loop was the #817 regression vector and is now "
+            "deferred to download time (PR #350)."
         )
-        assert "Shelf" in self.fn_text
 
-    def test_no_unbounded_books_query(self):
-        # Legacy code did `query(Books).options(joinedload(...)).all()` with no
-        # filter, walking the entire library. Pin that exact pattern out.
-        for node in ast.walk(self.fn):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "all":
-                # Walk back through the chained call to find any .filter()
-                cursor = node.func.value
-                has_filter = False
-                while isinstance(cursor, ast.Call) and isinstance(cursor.func, ast.Attribute):
-                    if cursor.func.attr in ("filter", "filter_by"):
-                        has_filter = True
-                        break
-                    cursor = cursor.func.value
-                # Only enforce on calibre_db Books queries, not on the ub.session shelf query.
-                chain_text = ast.unparse(node)
-                if "db.Books" in chain_text:
-                    assert has_filter, (
-                        "calibre_db.session.query(db.Books).....all() must include a "
-                        ".filter(Books.id.in_(...)) to scope to shelf members; the "
-                        "unscoped .all() is the #817 regression."
-                    )
+
+@pytest.mark.smoke
+class TestPerBookConversionScopedToRequestedDownload:
+    """The on-demand replacement in helper.get_download_link must convert
+    only the single book the device is actively requesting — never walk
+    a shelf, library, or batch. That's what closes the #817 vector
+    structurally instead of by scope filter."""
+
+    def test_get_download_link_converts_one_book_per_call(self):
+        src = _function_source(HELPER, "get_download_link")
+        # The function takes a single book_id argument (its signature is
+        # `def get_download_link(book_id, book_format, client)`). The
+        # conversion happens against that exact book_id — no shelf
+        # enumeration, no batch loop.
+        assert "convert_book_format(book.id" in src, (
+            "On-demand conversion in get_download_link must target the "
+            "single requested book (book.id), not a batch."
+        )
+
+    def test_no_shelf_enumeration_in_get_download_link(self):
+        src = _function_source(HELPER, "get_download_link")
+        # Shelf enumeration in the download path would defeat the
+        # per-request scope and re-introduce the #817 flood vector.
+        assert "BookShelf" not in src, (
+            "get_download_link must not enumerate shelves — the on-demand "
+            "conversion is scoped strictly to the requested download."
+        )
+        assert "kobo_sync" not in src, (
+            "get_download_link must not filter on Shelf.kobo_sync — the "
+            "scoping is by request, not by shelf membership."
+        )

--- a/tests/unit/test_kobo_android_app_compat.py
+++ b/tests/unit/test_kobo_android_app_compat.py
@@ -28,6 +28,7 @@ silently drops one of the four behaviors.
 """
 
 import inspect
+from pathlib import Path
 
 import pytest
 
@@ -85,13 +86,19 @@ class TestKoboAndroidAppCompat:
         )
 
     def test_metadata_payload_includes_drmtype_none(self):
-        from cps.kobo import get_metadata
-        src = inspect.getsource(get_metadata)
+        # The Android-compat invariant is "DrmType=None ships in the
+        # per-format download_url dict". The dict construction may live
+        # in get_metadata directly or in a helper it calls
+        # (build_download_url, introduced by PR #350's refactor). Inspect
+        # the whole module to keep the pin valid across helper extraction.
+        import cps.kobo
+        src = Path(cps.kobo.__file__).read_text(encoding="utf-8")
         assert '"DrmType": "None"' in src, (
-            "get_metadata must include 'DrmType': 'None' in the per-format "
-            "metadata block. The field was previously commented out as "
-            "'not required' but the Kobo Android app rejects payloads "
-            "without it. See crocodilestick/Calibre-Web-Automated#1343."
+            "cps.kobo must include 'DrmType': 'None' in the per-format "
+            "download_url block (get_metadata directly or a helper it "
+            "calls). The field was previously commented out as 'not "
+            "required' but the Kobo Android app rejects payloads without "
+            "it. See crocodilestick/Calibre-Web-Automated#1343."
         )
 
     def test_metadata_payload_defaults_series_to_empty_dict(self):


### PR DESCRIPTION
Cherry-picking [#1344](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1344) from cwa repo. This was extensively tested on cwa, but comparitevely little testing on nextgen. Note that the numbers below are from testing on cwa:

-------

This pull request is part of a larger rewrite of the Kobo sync request handler. Specifically, this defers or otherwise avoids some of the unnecessary side-effects comitted by the sync request handler (such as book conversion, default database entry creation, etc).

Over-all, these save ~15 seconds on a single request to the Sync endpoint. On the first request from a new device, the request can be paginated into multiple rounds, in which case these savings apply to every round.