### PR TITLE
fix(#352): drag-merge no longer blocks text selection (cover-only handle)

### DIFF
--- a/cps/static/js/drag-drop-merge.js
+++ b/cps/static/js/drag-drop-merge.js
@@ -19,8 +19,18 @@
 
   if (!window.cwaUserData || !window.cwaUserData.canEditBooks) return;
 
-  var BOOK_SELECTOR = ".book";
+  // Scoped to grid cards only (which carry both `book` and `session` classes
+  // on the index/search/author/shelf templates). Stops drag-merge init from
+  // running on the book detail page, which renders a different `.book` element
+  // for the cover and has no merge use-case. Fork #352 (@SethMilliken).
+  var BOOK_SELECTOR = ".book.session";
   var COVER_LINK_SELECTOR = ".book-cover-link";
+  // Drag SOURCE handle within each card. The whole card was the source in
+  // PR #161, but `draggable="true"` on an ancestor suppresses native text
+  // selection of descendants in Safari/WebKit — breaking title/author
+  // selection for every user. Scoping the draggable attribute to the cover
+  // restores selection on the meta column. Fork #352.
+  var COVER_SELECTOR = ".cover";
   var DRAGGING_CLASS = "drag-merge-dragging";
   var OVER_CLASS = "drag-merge-over";
   var DRAG_ENABLED_CLASS = "drag-merge-enabled";
@@ -341,9 +351,18 @@
   function enableDrag(bookEl) {
     if (bookEl.classList.contains(DRAG_ENABLED_CLASS)) return;
     bookEl.classList.add(DRAG_ENABLED_CLASS);
-    bookEl.setAttribute("draggable", "true");
-    bookEl.addEventListener("dragstart", onDragStart);
-    bookEl.addEventListener("dragend", onDragEnd);
+    // Drag SOURCE on the cover only — keeps title/author text selectable in
+    // the .meta column (fork #352). The drag handlers walk up via
+    // getBookEl(e.target).closest(BOOK_SELECTOR) to find the card, so they
+    // work identically with the listener on the cover.
+    var cover = bookEl.querySelector(COVER_SELECTOR);
+    if (cover) {
+      cover.setAttribute("draggable", "true");
+      cover.addEventListener("dragstart", onDragStart);
+      cover.addEventListener("dragend", onDragEnd);
+    }
+    // Drop TARGET stays the whole card: drop the source cover onto any part
+    // of the target card (cover or meta area) and the merge fires.
     bookEl.addEventListener("dragenter", onDragEnter);
     bookEl.addEventListener("dragover", onDragOver);
     bookEl.addEventListener("dragleave", onDragLeave);

--- a/cps/static/js/drag-drop-merge.js
+++ b/cps/static/js/drag-drop-merge.js
@@ -360,6 +360,11 @@
       cover.setAttribute("draggable", "true");
       cover.addEventListener("dragstart", onDragStart);
       cover.addEventListener("dragend", onDragEnd);
+    } else if (typeof console !== "undefined" && console.warn) {
+      // Should be impossible — every .book.session in the grid templates
+      // renders a `.cover` child. Surface a warning if a future template
+      // refactor drops it, otherwise the card is silently a drop-only target.
+      console.warn("drag-drop-merge: .book.session card has no .cover child; drag source not wired", bookEl);
     }
     // Drop TARGET stays the whole card: drop the source cover onto any part
     // of the target card (cover or meta area) and the merge fires.

--- a/scripts/manual/probe_352_drag_merge.py
+++ b/scripts/manual/probe_352_drag_merge.py
@@ -15,8 +15,7 @@ Chromium asserts:
   - title text is selectable
 
 Run:
-  CWN_TEST_PW=cwng-test-84 /Users/acoundou/.pyenv/versions/3.12.7/bin/python3 \
-    scripts/manual/probe_352_drag_merge.py
+  CWN_TEST_PW=cwng-test-84 python3 scripts/manual/probe_352_drag_merge.py
 """
 
 MEASURE_JS = r"""

--- a/scripts/manual/probe_352_drag_merge.py
+++ b/scripts/manual/probe_352_drag_merge.py
@@ -1,0 +1,128 @@
+"""Cross-engine DOM probe for fork #352 drag-merge text-selection fix.
+
+Logs in to cwn-local as cwng84test, then for both WebKit (Safari engine) and
+Chromium asserts:
+
+* grid view `/`:
+  - .book cards do NOT carry draggable=true (Safari text-selection unblocked)
+  - .cover element inside each card DOES carry draggable=true (drag source moved)
+  - card class includes `drag-merge-enabled` (init still ran on grid)
+  - title element is text-selectable: Range.toString() returns the title text
+    after programmatically selecting it
+* detail view `/book/<id>`:
+  - script does NOT mark any element with `drag-merge-enabled` (selector
+    `.book.session` does not match detail-page `.book`)
+  - title text is selectable
+
+Run:
+  CWN_TEST_PW=cwng-test-84 /Users/acoundou/.pyenv/versions/3.12.7/bin/python3 \
+    scripts/manual/probe_352_drag_merge.py
+"""
+
+MEASURE_JS = r"""
+() => {
+  const grid = Array.from(document.querySelectorAll('.book.session'));
+  const out = grid.slice(0, 4).map(b => {
+    const cover = b.querySelector('.cover');
+    const title = b.querySelector('.meta .title');
+    // Programmatically select the title text and read what was selected.
+    let selected = null;
+    if (title) {
+      const range = document.createRange();
+      range.selectNodeContents(title);
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+      selected = sel.toString();
+      sel.removeAllRanges();
+    }
+    return {
+      cardDraggable: b.getAttribute('draggable'),
+      cardHasMergeEnabled: b.classList.contains('drag-merge-enabled'),
+      coverDraggable: cover ? cover.getAttribute('draggable') : null,
+      titleText: title ? title.textContent.trim().slice(0, 40) : null,
+      titleSelected: selected ? selected.trim().slice(0, 40) : null,
+    };
+  });
+  return { count: grid.length, books: out };
+}
+"""
+
+DETAIL_JS = r"""
+() => {
+  const any = document.querySelectorAll('.drag-merge-enabled');
+  const title = document.querySelector('h2#title') || document.querySelector('.book-detail-meta h2');
+  let titleSelected = null;
+  if (title) {
+    const range = document.createRange();
+    range.selectNodeContents(title);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    titleSelected = sel.toString().trim().slice(0, 80);
+    sel.removeAllRanges();
+  }
+  return {
+    mergeEnabledCount: any.length,
+    titleSelected,
+  };
+}
+"""
+
+
+def _login(pg, base, user, pw):
+    pg.goto(f"{base}/login", wait_until="networkidle")
+    pg.fill('#username', user)
+    pg.fill('#password', pw)
+    pg.press('#password', 'Enter')
+    pg.wait_for_load_state("networkidle")
+
+
+def _run(engine_name, browser_type, viewport, base, user, pw):
+    b = browser_type.launch(headless=True)
+    ctx = b.new_context(viewport=viewport)
+    pg = ctx.new_page()
+    _login(pg, base, user, pw)
+    pg.goto(f"{base}/", wait_until="networkidle"); pg.wait_for_timeout(600)
+    grid = pg.evaluate(MEASURE_JS)
+    print(f"\n===== {engine_name} grid ({viewport['width']}x{viewport['height']}) =====")
+    print(f"  card count: {grid['count']}")
+    for i, b_ in enumerate(grid['books']):
+        ok_card = b_['cardDraggable'] is None and b_['cardHasMergeEnabled'] is True
+        ok_cover = b_['coverDraggable'] == 'true'
+        ok_sel = b_['titleSelected'] == b_['titleText']
+        flag = "✓" if (ok_card and ok_cover and ok_sel) else "✗"
+        print(f"  [{i}] {flag} card.draggable={b_['cardDraggable']!s:>5} "
+              f"card.mergeEnabled={b_['cardHasMergeEnabled']} "
+              f"cover.draggable={b_['coverDraggable']!s:>5} "
+              f"title=\"{b_['titleText']}\" selected=\"{b_['titleSelected']}\"")
+    # detail page
+    if grid['books']:
+        # Need a book id — grab the first card's link
+        bid = pg.evaluate("() => document.querySelector('.book.session .book-cover-link')?.getAttribute('data-book-id')")
+        if bid:
+            pg.goto(f"{base}/book/{bid}", wait_until="networkidle"); pg.wait_for_timeout(600)
+            detail = pg.evaluate(DETAIL_JS)
+            ok_no_merge = detail['mergeEnabledCount'] == 0
+            print(f"  detail: drag-merge-enabled count={detail['mergeEnabledCount']} "
+                  f"{'✓' if ok_no_merge else '✗'} (must be 0); "
+                  f"titleSelected=\"{detail['titleSelected']}\"")
+    b.close()
+
+
+def main():
+    import os, sys
+    from playwright.sync_api import sync_playwright
+    base = os.getenv("CWN_TEST_BASE", "http://localhost:8086")
+    user = os.getenv("CWN_TEST_USER", "cwng84test")
+    pw = os.getenv("CWN_TEST_PW")
+    if not pw:
+        sys.exit("Set CWN_TEST_PW before running.")
+    with sync_playwright() as p:
+        _run("WebKit/Safari desktop", p.webkit, {"width": 1440, "height": 900}, base, user, pw)
+        _run("Chromium desktop", p.chromium, {"width": 1440, "height": 900}, base, user, pw)
+        _run("WebKit/Safari mobile", p.webkit, {"width": 390, "height": 844}, base, user, pw)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_352_drag_merge_text_selection.py
+++ b/tests/unit/test_352_drag_merge_text_selection.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression test for fork #352 (@SethMilliken).
+
+Symptom: PR #161 (drag-and-drop book merge) shipped with `draggable="true"`
+set on the whole `.book` grid card. On Safari/WebKit (the reporter's browser,
+also the household's) a `draggable="true"` ancestor suppresses native text
+selection of its descendants, so users can't select the title/author text in
+the grid. The same script also ran on the book detail page (`<body data-page="book">`),
+adding a pointless drag source to the cover there.
+
+Browser repro (cwn-local, 2026-06-01T22:09Z): all 4 grid `.book` cards carried
+`draggable="true"` and the title's ancestor chain hit the draggable card —
+confirms the selection block.
+
+Root cause (cps/static/js/drag-drop-merge.js):
+  * `BOOK_SELECTOR = ".book"` matches both grid cards and the lone `.book`
+    that exists in the detail template, so init runs on both surfaces.
+  * `enableDrag(bookEl)` sets `draggable="true"` on the whole `.book` card.
+
+Fix:
+  A. Move the drag SOURCE off the whole card and onto the `.cover` element,
+     so the title/author text in `.meta` stays selectable. Drop target stays
+     the whole card (you can drop the source cover onto any part of the
+     target card).
+  B. Tighten the selector to `.book.session` so the script only initialises
+     on the grid (the index/search/author/shelf templates render the card
+     with both `book` and `session` classes; the detail page does not).
+
+These pins are deliberately at the source level — the JS is delivered as a
+static asset, so a pytest hitting Flask wouldn't catch a regression. The
+behavioural proof lives in the Playwright run in the PR; this guard catches
+a future refactor that re-broadens the selector or re-binds drag at the card
+level.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JS_PATH = REPO_ROOT / "cps" / "static" / "js" / "drag-drop-merge.js"
+
+
+@pytest.fixture(scope="module")
+def js_src() -> str:
+    assert JS_PATH.exists(), f"missing {JS_PATH}"
+    return JS_PATH.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestDragMergeTextSelectionRegression:
+    def test_book_selector_scoped_to_grid_session_class(self, js_src):
+        """Fix B: the selector must NOT match the lone `.book` element on the
+        book detail template. Tightening to `.book.session` excludes detail
+        (grid cards always carry both classes; detail doesn't carry `session`)."""
+        m = re.search(r'(?:^|\s)var\s+BOOK_SELECTOR\s*=\s*"([^"]+)"\s*;', js_src, re.MULTILINE)
+        assert m is not None, "could not find BOOK_SELECTOR declaration"
+        sel = m.group(1)
+        assert sel != ".book", (
+            "BOOK_SELECTOR is still bare '.book' — that matches the lone "
+            "`.book` on the detail template and runs drag-merge init there "
+            "(#352 complaint #2). Tighten to '.book.session' to scope it "
+            "to the grid."
+        )
+        assert "session" in sel, (
+            f"BOOK_SELECTOR must restrict to grid cards (which carry the "
+            f"`session` class). Got: {sel!r}"
+        )
+
+    def test_drag_source_is_cover_not_whole_card(self, js_src):
+        """Fix A: `draggable="true"` must NOT be set on the `.book` card —
+        Safari/WebKit suppresses text selection of any descendant of a
+        draggable ancestor. Move the drag source to `.cover` so the title
+        and author text in `.meta` stay selectable (#352 complaint #1)."""
+        # Match the full enableDrag body, anchored on the 2-space-indented
+        # closing brace so an inner `if (cover) { ... }` block doesn't
+        # truncate the capture.
+        m = re.search(
+            r"function\s+enableDrag\s*\([^)]*\)\s*\{(.*?)\n  \}\s*\n",
+            js_src,
+            re.DOTALL,
+        )
+        assert m is not None, "could not find enableDrag function body"
+        body = m.group(1)
+
+        # The card itself must not be made draggable.
+        assert not re.search(
+            r'bookEl\.setAttribute\(\s*["\']draggable["\']\s*,\s*["\']true["\']\s*\)',
+            body,
+        ), (
+            "enableDrag still sets `draggable=\"true\"` on the whole .book "
+            "card (#352): Safari suppresses text selection of any "
+            "descendant of a draggable ancestor. Move the drag source onto "
+            "the cover element instead."
+        )
+
+        # And the cover-scoped drag source must be wired in.
+        assert re.search(
+            r'\.setAttribute\(\s*["\']draggable["\']\s*,\s*["\']true["\']\s*\)',
+            body,
+        ), (
+            "enableDrag should set draggable=true on the cover element — "
+            "the title/author text stays selectable, but the cover is still "
+            "a valid drag source."
+        )
+        assert "cover" in body.lower() or "COVER" in body, (
+            "enableDrag must reference the cover element to scope the drag "
+            "source there (e.g. querySelector('.cover'))."
+        )
+
+    def test_dragstart_and_dragend_bound_on_cover_not_card(self, js_src):
+        """The dragstart/dragend events fire from where draggable is set;
+        binding them on the card is dead weight after the move, and binding
+        them on the card again would re-introduce the symptom."""
+        # Match the full enableDrag body, anchored on the 2-space-indented
+        # closing brace so an inner `if (cover) { ... }` block doesn't
+        # truncate the capture.
+        m = re.search(
+            r"function\s+enableDrag\s*\([^)]*\)\s*\{(.*?)\n  \}\s*\n",
+            js_src,
+            re.DOTALL,
+        )
+        assert m is not None
+        body = m.group(1)
+        assert not re.search(
+            r'bookEl\.addEventListener\(\s*["\']dragstart["\']', body,
+        ), (
+            "dragstart must NOT be bound on the .book card after #352 — "
+            "the card is no longer the drag source. Bind dragstart on the "
+            "cover element."
+        )
+
+    def test_drop_target_still_whole_card(self, js_src):
+        """The drop TARGET stays the whole card so the user can drop the
+        source cover onto any part of the target (cover + meta area).
+        Without this, dropping onto title/author text would be a no-op."""
+        # Match the full enableDrag body, anchored on the 2-space-indented
+        # closing brace so an inner `if (cover) { ... }` block doesn't
+        # truncate the capture.
+        m = re.search(
+            r"function\s+enableDrag\s*\([^)]*\)\s*\{(.*?)\n  \}\s*\n",
+            js_src,
+            re.DOTALL,
+        )
+        assert m is not None
+        body = m.group(1)
+        assert re.search(
+            r'bookEl\.addEventListener\(\s*["\']drop["\']', body,
+        ), (
+            "drop listener must remain bound on the whole .book card so the "
+            "card stays a full drop target."
+        )


### PR DESCRIPTION
## Symptom

@SethMilliken (#352): PR #161 (drag-and-drop book merge) made the book title and author text unselectable in the grid view, and the same script ran on the book detail page where merge isn't usable. The grid block is load-bearing — Safari/WebKit suppresses native text selection of every descendant of a `draggable="true"` ancestor.

## Root cause

`cps/static/js/drag-drop-merge.js`:
- `BOOK_SELECTOR = ".book"` matched both grid cards and the lone `.book` rendered on the detail template, so init ran on both surfaces.
- `enableDrag()` set `draggable="true"` on the whole `.book` card. The title/author elements in `.meta` are descendants — Safari refuses to select their text.

Browser-confirmed at 2026-06-01T22:09Z (cron tick): grid cards carried `draggable="true"`; `titleHasDraggableAncestor` returned the card's class string.

## Fix

- Tighten `BOOK_SELECTOR` to `.book.session`. Grid templates (index/search/author/shelf) render `book session`; the detail page renders `book blur ...` with no `session`. Init now scopes to the grid only.
- Move the drag SOURCE from the whole card to the inner `.cover` element. `draggable="true"` only applies to the cover, so title/author text in `.meta` stays selectable. The drag handlers walk up via `getBookEl(e.target).closest(BOOK_SELECTOR)` to find the card, so they work identically with the listener on the cover.
- Keep the drop TARGET on the whole card so the source cover can be released onto any part of the target (cover or meta area).

## Verification

Cross-engine DOM probe (cwn-local, `scripts/manual/probe_352_drag_merge.py`):

| Engine / viewport | card.draggable | cover.draggable | drag-merge-enabled | title text selectable | detail .drag-merge-enabled count |
|---|---|---|---|---|---|
| WebKit desktop 1440x900 | `None` ✓ | `"true"` ✓ | `true` ✓ | yes ✓ | 0 ✓ |
| WebKit mobile 390x844 | `None` ✓ | `"true"` ✓ | `true` ✓ | yes ✓ | 0 ✓ |
| Chromium desktop 1440x900 | `None` ✓ | `"true"` ✓ | `true` ✓ | yes ✓ | 0 ✓ |

`titleSelected == titleText` confirms `range.selectNodeContents(title)` returns the title's text — the reporter's exact complaint resolved on the actual Safari engine.

- ✅ Source-pin tests: `tests/unit/test_352_drag_merge_text_selection.py` (4/4 — selector tightening, card NOT draggable, dragstart NOT bound on card, drop target stays on card). RED on PR #161 baseline.
- ✅ Full unit suite: 1223 passing.
- ✅ Cross-cutting: MutationObserver also uses `BOOK_SELECTOR`, so dynamic load-more cards are scoped correctly; non-edit users skip the whole script (line 20 gate, unchanged); detail page now has zero drag-merge-enabled elements.

## Scope

A+B from the autopilot's design note (`notes/fork-352-drag-merge-text-selection.md`). The reporter also asked for option C — an opt-in toggle with a visible "merge mode" indicator. Holding that as a follow-up: A+B materially addresses the "UX hijacking" objection (text selection restored, detail page no longer affected), and a config flag is a separate product decision. Happy to add C in a follow-up if you'd still prefer opt-in.

## Tier

`safe-tier-2` — JS-only change in one file, no auth/CSRF/schema/server surface; source-pinned + cross-engine verified.

Addresses #352. Thanks @SethMilliken for the report — the design objection drove the precise scoping (cover handle + grid-only).