### PR TITLE
fix(#354): repair partial oauthProvider schema so /admin/config stops 500ing

### DIFF
--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -440,7 +440,7 @@
           <p class="text-danger" style="margin-top: 2rem; background: #ffe9ec; padding: 1rem; border-left: 4px solid #a94442; padding-inline: 2rem; margin-bottom: 2rem;">
             <strong>{{_('Important:')}}</strong> {{_('OAuth authentication requires this server to be accessed via HTTPS. If you are using HTTP, login will fail.')}}
           </p>
-          {% set generic = provider | selectattr('provider_name', 'equalto', 'generic') | first %}
+          {% set generic = (provider | selectattr('provider_name', 'equalto', 'generic') | first) or {} %}
           <p>{{ _('Generic OAuth Provider') }}</p>
           
           <!-- Metadata URL for auto-discovery -->
@@ -468,7 +468,7 @@
             
             <div class="form-group">
               <label for="config_generic_oauth_server_url">{{_('OAuth Base URL')}}</label>
-              <input type="text" class="form-control" id="config_generic_oauth_server_url" name="config_generic_oauth_server_url" value="{% if generic['oauth_base_url'] != None %}{{ generic['oauth_base_url'] }}{% endif %}" autocomplete="off">
+              <input type="text" class="form-control" id="config_generic_oauth_server_url" name="config_generic_oauth_server_url" value="{% if generic.get('oauth_base_url') != None %}{{ generic['oauth_base_url'] }}{% endif %}" autocomplete="off">
             </div>
             
             <div class="form-group">
@@ -517,11 +517,11 @@
           
           <div class="form-group">
             <label for="config_generic_oauth_client_id">{{_('OAuth Client Id')}}</label>
-            <input type="text" class="form-control" id="config_generic_oauth_client_id" name="config_generic_oauth_client_id" value="{% if generic['oauth_client_id'] != None %}{{ generic['oauth_client_id'] }}{% endif %}" autocomplete="off">
+            <input type="text" class="form-control" id="config_generic_oauth_client_id" name="config_generic_oauth_client_id" value="{% if generic.get('oauth_client_id') != None %}{{ generic['oauth_client_id'] }}{% endif %}" autocomplete="off">
           </div>
           <div class="form-group">
             <label for="config_generic_oauth_client_secret">{{_('OAuth Client Secret')}}</label>
-            <input type="text" class="form-control" id="config_generic_oauth_client_secret" name="config_generic_oauth_client_secret" value="{% if generic['oauth_client_secret'] != None %}{{ generic['oauth_client_secret'] }}{% endif %}" autocomplete="off">
+            <input type="text" class="form-control" id="config_generic_oauth_client_secret" name="config_generic_oauth_client_secret" value="{% if generic.get('oauth_client_secret') != None %}{{ generic['oauth_client_secret'] }}{% endif %}" autocomplete="off">
           </div>
           
           <!-- Field Mapping Configuration -->
@@ -538,7 +538,7 @@
           </div>
           <div class="form-group">
             <label for="config_generic_oauth_admin_group">{{_('OAuth group for Admin')}}</label>
-            <input type="text" class="form-control" id="config_generic_oauth_admin_group" name="config_generic_oauth_admin_group" value="{% if generic['oauth_admin_group'] != None %}{{ generic['oauth_admin_group'] }}{% endif %}" autocomplete="off">
+            <input type="text" class="form-control" id="config_generic_oauth_admin_group" name="config_generic_oauth_admin_group" value="{% if generic.get('oauth_admin_group') != None %}{{ generic['oauth_admin_group'] }}{% endif %}" autocomplete="off">
             <div class="help-block">{{_('Name of the OAuth group that grants admin privileges. Leave empty to disable group-based admin management, or use the global setting in Security Settings for more control.')}}</div>
           </div>
           <div class="form-group">

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1416,8 +1416,17 @@ def migrate_oauth_provider_table(engine, _session):
     ]
     for col, coltype in managed_columns:
         if col not in existing:
-            # one ALTER per call so a stray duplicate column can't roll back the rest
-            _run_ddl_with_retry(engine, "ALTER TABLE oauthProvider ADD column '{}' {}".format(col, coltype))
+            # One ALTER per call so a stray duplicate column can't roll back the
+            # rest, and tolerate "duplicate column name" per column: a concurrent
+            # boot (gunicorn pre-fork) or a column present-but-absent-from-snapshot
+            # can make ADD COLUMN raise it. Without swallowing it here the error
+            # propagates and aborts every remaining column for a full boot cycle
+            # (fork #354 / PR #355 hardening). Treat it as already-applied.
+            try:
+                _run_ddl_with_retry(engine, "ALTER TABLE oauthProvider ADD column '{}' {}".format(col, coltype))
+            except exc.OperationalError as e:
+                if "duplicate column name" not in str(e).lower():
+                    raise
 
 
 def migrate_config_table(engine, _session):

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1384,38 +1384,40 @@ def migrate_user_table(engine, _session):
         _run_ddl_with_retry(engine, "ALTER TABLE user ADD column 'preview_default_color' String")
 
 def migrate_oauth_provider_table(engine, _session):
-    try:
-        _session.query(exists().where(OAuthProvider.oauth_base_url)).scalar()
-        _session.commit()
-    except exc.OperationalError:  # Database is not compatible, some columns are missing
-        _safe_session_rollback(_session, "oauthProvider.base_urls")
-        _run_ddl_with_retry(
-            engine,
-            [
-                "ALTER TABLE oauthProvider ADD column 'oauth_base_url' String DEFAULT NULL",
-                "ALTER TABLE oauthProvider ADD column 'oauth_authorize_url' String DEFAULT NULL",
-                "ALTER TABLE oauthProvider ADD column 'oauth_token_url' String DEFAULT NULL",
-                "ALTER TABLE oauthProvider ADD column 'oauth_userinfo_url' String DEFAULT NULL",
-                "ALTER TABLE oauthProvider ADD column 'oauth_admin_group' String DEFAULT NULL",
-            ],
-        )
+    """Ensure every migration-managed column on oauthProvider exists.
 
-    # Add new OAuth enhancement fields
-    try:
-        _session.query(exists().where(OAuthProvider.metadata_url)).scalar()
-        _session.commit()
-    except exc.OperationalError:  # New columns are missing
-        _safe_session_rollback(_session, "oauthProvider.metadata_url")
-        _run_ddl_with_retry(
-            engine,
-            [
-                "ALTER TABLE oauthProvider ADD column 'metadata_url' String DEFAULT NULL",
-                "ALTER TABLE oauthProvider ADD column 'scope' String DEFAULT 'openid profile email'",
-                "ALTER TABLE oauthProvider ADD column 'username_mapper' String DEFAULT 'preferred_username'",
-                "ALTER TABLE oauthProvider ADD column 'email_mapper' String DEFAULT 'email'",
-                "ALTER TABLE oauthProvider ADD column 'login_button' String DEFAULT 'OpenID Connect'",
-            ],
-        )
+    Instances upgraded across several releases can reach a *partial* column
+    state — e.g. ``oauth_base_url`` present but ``oauth_authorize_url`` missing.
+    Introspect the live schema and add only the columns that are actually
+    missing, one ALTER per statement, so the migration repairs any partial
+    state and stays idempotent across restarts (fork #354).
+
+    The old probe-by-proxy form queried a single column as a stand-in for its
+    whole group, so a partially-migrated DB passed the probe and the missing
+    columns were never added — OAuth init then failed on the missing column
+    and ``/admin/config`` returned 500.
+    """
+    from sqlalchemy import inspect as sa_inspect
+    inspector = sa_inspect(engine)
+    if "oauthProvider" not in inspector.get_table_names():
+        return  # table is created fresh from the model with every column present
+    existing = {c["name"] for c in inspector.get_columns("oauthProvider")}
+    managed_columns = [
+        ("oauth_base_url", "String DEFAULT NULL"),
+        ("oauth_authorize_url", "String DEFAULT NULL"),
+        ("oauth_token_url", "String DEFAULT NULL"),
+        ("oauth_userinfo_url", "String DEFAULT NULL"),
+        ("oauth_admin_group", "String DEFAULT NULL"),
+        ("metadata_url", "String DEFAULT NULL"),
+        ("scope", "String DEFAULT 'openid profile email'"),
+        ("username_mapper", "String DEFAULT 'preferred_username'"),
+        ("email_mapper", "String DEFAULT 'email'"),
+        ("login_button", "String DEFAULT 'OpenID Connect'"),
+    ]
+    for col, coltype in managed_columns:
+        if col not in existing:
+            # one ALTER per call so a stray duplicate column can't roll back the rest
+            _run_ddl_with_retry(engine, "ALTER TABLE oauthProvider ADD column '{}' {}".format(col, coltype))
 
 
 def migrate_config_table(engine, _session):

--- a/tests/unit/test_354_oauth_provider_migration.py
+++ b/tests/unit/test_354_oauth_provider_migration.py
@@ -1,0 +1,190 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for fork #354 — 500 on /admin/config from a partial
+oauthProvider schema that ``migrate_oauth_provider_table`` cannot repair.
+
+## Why these tests exist
+
+Reporter @Neuromancien59 (v4.0.144, Debian) hit ``GET /admin/config`` →
+HTTP 500. Their startup log shows OAuth init failing with::
+
+    (sqlite3.OperationalError) no such column: oauthProvider.oauth_authorize_url
+
+i.e. their ``oauthProvider`` table has ``oauth_base_url`` but is missing
+``oauth_authorize_url`` (and the rest of that group). The boot catch leaves
+``oauth_bb.oauthblueprints`` empty; ``config_edit.html`` then does
+``provider | selectattr(...) | first`` on an empty sequence and raises
+``UndefinedError: No first item, sequence was empty`` → 500.
+
+The root cause is in ``cps.ub.migrate_oauth_provider_table`` (cps/ub.py:1386):
+
+1. **Probe-by-proxy.** The first probe queries only ``oauth_base_url`` as a
+   stand-in for its whole 5-column group. A DB that has ``oauth_base_url`` but
+   is missing ``oauth_authorize_url`` *passes* the probe, so the group-1 ALTER
+   block is skipped and the missing columns are never added. The second group
+   has the identical flaw (``metadata_url`` proxies for ``scope`` /
+   ``username_mapper`` / ``email_mapper`` / ``login_button``).
+2. **All-or-nothing batch** (``_run_ddl_with_retry``): every ALTER in a group
+   runs in one transaction; a stray ``duplicate column`` re-raises and rolls
+   back the rest.
+
+Net: the migration cannot repair a database in a *partial* column state — the
+exact shape an instance upgraded across several releases lands in.
+
+## What these tests pin
+
+Real SQLite engines (not mocks) — the bug is SQL-semantic. After
+``migrate_oauth_provider_table`` runs against any starting state, all ten
+migration-managed columns must be present and the run must be idempotent.
+
+- ``test_partial_group1_repaired`` and ``test_partial_group2_repaired`` and
+  ``test_partial_double_run_idempotent`` are **red on main** (they reproduce
+  the reporter's symptom: a column stays missing) and turn green once the
+  migration introspects actual columns and adds only the missing ones.
+- ``test_all_old_schema_repaired`` and ``test_all_new_schema_noop`` are
+  behaviour-preservation pins (green on both main and the fix): the migration
+  must still repair an all-old DB and no-op cleanly on an all-new DB.
+
+Parked ahead of the fix per test-driven discipline (red baseline confirmed).
+The fix (per-column introspecting migration) lands in the same release that
+turns the first three green; see notes/fork-354-oauth-migration-500.md.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+from sqlalchemy import create_engine, inspect as sa_inspect, text
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
+
+pytestmark = pytest.mark.unit
+
+
+# The ten columns migrate_oauth_provider_table is responsible for ensuring
+# exist (cps/ub.py OAuthProvider model). Base columns created with the table
+# itself (id, provider_name, oauth_client_id, oauth_client_secret, active) are
+# never migration-managed.
+MANAGED_COLUMNS = {
+    "oauth_base_url",
+    "oauth_authorize_url",
+    "oauth_token_url",
+    "oauth_userinfo_url",
+    "oauth_admin_group",
+    "metadata_url",
+    "scope",
+    "username_mapper",
+    "email_mapper",
+    "login_button",
+}
+
+GROUP1 = [
+    "oauth_base_url",
+    "oauth_authorize_url",
+    "oauth_token_url",
+    "oauth_userinfo_url",
+    "oauth_admin_group",
+]
+GROUP2 = ["metadata_url", "scope", "username_mapper", "email_mapper", "login_button"]
+
+
+def _make_partial_db(extra_columns):
+    """Create a temp SQLite DB whose oauthProvider table has the base columns
+    plus exactly ``extra_columns`` of the migration-managed set. Returns
+    (engine, path). Caller disposes the engine and unlinks the path.
+    """
+    fd, path = tempfile.mkstemp(suffix="-app.db")
+    os.close(fd)
+    engine = create_engine(f"sqlite:///{path}")
+    col_defs = [
+        "id INTEGER PRIMARY KEY",
+        "provider_name VARCHAR",
+        "oauth_client_id VARCHAR",
+        "oauth_client_secret VARCHAR",
+        "active BOOLEAN",
+    ]
+    for col in extra_columns:
+        col_defs.append(f"'{col}' VARCHAR DEFAULT NULL")
+    with engine.begin() as conn:
+        conn.execute(text(f"CREATE TABLE oauthProvider ({', '.join(col_defs)})"))
+    return engine, path
+
+
+def _columns(engine):
+    return {c["name"] for c in sa_inspect(engine).get_columns("oauthProvider")}
+
+
+def _run_migration(engine):
+    """Run the real migration against the engine, mirroring how migrate_Database
+    invokes it (a live session bound to the same engine)."""
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        ub.migrate_oauth_provider_table(engine, session)
+    finally:
+        session.close()
+
+
+def _with_db(extra_columns):
+    """Build a partial DB, run the migration, return the post-migration column
+    set. Cleans up the engine + temp file."""
+    engine, path = _make_partial_db(extra_columns)
+    try:
+        _run_migration(engine)
+        return _columns(engine)
+    finally:
+        engine.dispose()
+        os.unlink(path)
+
+
+def test_partial_group1_repaired():
+    """Reporter's exact case: oauth_base_url present, rest of group 1 missing.
+    The proxy-probe passes on oauth_base_url and skips the group-1 ALTERs, so
+    oauth_authorize_url et al. stay missing → 500. RED on main."""
+    cols = _with_db(extra_columns=["oauth_base_url"])
+    missing = MANAGED_COLUMNS - cols
+    assert not missing, f"migration left managed columns missing: {sorted(missing)}"
+
+
+def test_partial_group2_repaired():
+    """Group 1 fully present + metadata_url present, but scope/username_mapper/
+    email_mapper/login_button missing. The second proxy-probe passes on
+    metadata_url and skips its ALTERs. RED on main."""
+    cols = _with_db(extra_columns=GROUP1 + ["metadata_url"])
+    missing = MANAGED_COLUMNS - cols
+    assert not missing, f"migration left managed columns missing: {sorted(missing)}"
+
+
+def test_partial_double_run_idempotent():
+    """A partial DB run through the migration twice must end fully repaired and
+    must not raise on the second pass (restart idempotency). RED on main (first
+    run never repairs group 1, so it stays missing across both runs)."""
+    engine, path = _make_partial_db(extra_columns=["oauth_base_url"])
+    try:
+        _run_migration(engine)
+        _run_migration(engine)  # must be a clean no-op, never raise
+        missing = MANAGED_COLUMNS - _columns(engine)
+        assert not missing, f"migration left managed columns missing: {sorted(missing)}"
+    finally:
+        engine.dispose()
+        os.unlink(path)
+
+
+def test_all_old_schema_repaired():
+    """An all-old DB (none of the ten managed columns present) must be fully
+    repaired. Behaviour-preservation pin — green on main and on the fix."""
+    cols = _with_db(extra_columns=[])
+    missing = MANAGED_COLUMNS - cols
+    assert not missing, f"migration left managed columns missing: {sorted(missing)}"
+
+
+def test_all_new_schema_noop():
+    """An all-new DB (all ten present) must survive the migration unchanged and
+    without error. Behaviour-preservation pin — green on main and on the fix."""
+    cols = _with_db(extra_columns=sorted(MANAGED_COLUMNS))
+    assert MANAGED_COLUMNS <= cols

--- a/tests/unit/test_354_oauth_provider_migration.py
+++ b/tests/unit/test_354_oauth_provider_migration.py
@@ -188,3 +188,65 @@ def test_all_new_schema_noop():
     without error. Behaviour-preservation pin — green on main and on the fix."""
     cols = _with_db(extra_columns=sorted(MANAGED_COLUMNS))
     assert MANAGED_COLUMNS <= cols
+
+
+def test_duplicate_column_midloop_does_not_abort_remaining(monkeypatch):
+    """A managed column that physically exists but is absent from the
+    introspected snapshot makes ``ADD COLUMN`` raise ``duplicate column name``
+    mid-loop. The migration must treat that as already-applied and keep adding
+    the remaining columns, not abort the loop.
+
+    This is the concurrent-startup race (Greptile P2 on PR #355): two workers
+    boot together, both snapshot the same ``existing`` set, one adds a column
+    and the other's ALTER then hits ``duplicate column name`` — a non-lock
+    ``OperationalError`` that ``_run_ddl_with_retry`` re-raises. Before the
+    hardening the exception propagates out of the for-loop and every column
+    *after* the racy one stays missing for a full boot cycle (so OAuth init
+    keeps failing and ``/admin/config`` keeps 500ing); afterwards the loop
+    swallows duplicate-column and continues.
+
+    We reproduce it deterministically: ``oauth_token_url`` (middle of the
+    managed list) physically exists, but a wrapper inspector hides it from the
+    snapshot, so the loop tries to re-add it and SQLite raises the real
+    ``duplicate column name`` error. RED before the fix (the seven columns
+    after ``oauth_token_url`` stay missing); GREEN after.
+    """
+    engine, path = _make_partial_db(
+        extra_columns=["oauth_base_url", "oauth_authorize_url", "oauth_token_url"]
+    )
+    try:
+        import sqlalchemy
+
+        real_inspect = sqlalchemy.inspect
+
+        class _StaleInspector:
+            """Delegates to the real inspector but drops ``oauth_token_url``
+            from the oauthProvider column snapshot — i.e. a stale/racy view in
+            which a column the table actually has looks missing."""
+
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def get_columns(self, table_name, *a, **k):
+                cols = self._real.get_columns(table_name, *a, **k)
+                if table_name == "oauthProvider":
+                    return [c for c in cols if c["name"] != "oauth_token_url"]
+                return cols
+
+        monkeypatch.setattr(
+            sqlalchemy, "inspect", lambda bind: _StaleInspector(real_inspect(bind))
+        )
+        _run_migration(engine)
+        monkeypatch.undo()  # verify the real schema with the real inspector
+
+        missing = MANAGED_COLUMNS - _columns(engine)
+        assert not missing, (
+            "migration aborted on a duplicate-column ALTER and left managed "
+            f"columns missing: {sorted(missing)}"
+        )
+    finally:
+        engine.dispose()
+        os.unlink(path)


### PR DESCRIPTION
Addresses #354 (reported by @Neuromancien59 on Debian/x86, v4.0.144).

## Symptom
`GET /admin/config` returns HTTP 500. The admin can no longer reach the config page to fix anything from the UI. Reporter's traceback ends in `config_edit.html` rendering the generic-OAuth section with an empty provider list.

## Root cause (observed end-to-end from the reporter's startup log + code trace)
Two layers:

1. **DB migration gap (primary).** `migrate_oauth_provider_table` used probe-by-proxy: it queried a single column (`oauth_base_url`) as a stand-in for its whole 5-column group, and added the group only if that one probe threw. An instance upgraded across several releases can reach a *partial* column state — `oauth_base_url` present but `oauth_authorize_url` missing. That DB passes the probe, so the missing columns are never added. The ALTERs also ran as one all-or-nothing batch, so a single `duplicate column` would roll the whole group back. The second column group (`metadata_url` gating `scope`/`username_mapper`/`email_mapper`/`login_button`) had the same shape.
2. **Template can't survive an empty provider list (secondary).** With a column still missing, `oauth_bb.init_oauth_blueprints()` fails on the missing column at boot, the exception is caught, and `oauthblueprints` is left empty. `config_edit.html` then does `provider | selectattr(...) | first` → Jinja `Undefined`, and `generic.get(...)` on `Undefined` raises `UndefinedError: No first item, sequence was empty` → 500.

## Fix
- `cps/ub.py`: rewrite `migrate_oauth_provider_table` to introspect the live schema with `sa_inspect` (the existing in-repo idiom) and add only the columns that are actually missing, one ALTER per statement. This repairs any partial state and stays idempotent across restarts. `_run_ddl_with_retry` already normalizes a single string to a list, so per-column calls are safe.
- `cps/templates/config_edit.html`: fall back to `{}` when no generic provider is configured (`(... | first) or {}`) so the page renders even if OAuth init left the list empty. Defense in depth — once the migration is fixed the list is populated, but the page should never 500 on an empty list.

## Reproduction → validation (closed loop)
`tests/unit/test_354_oauth_provider_migration.py` (real in-memory SQLite engines, imports the live `cps.ub.migrate_oauth_provider_table`):

- On **main** the partial-schema tests fail — `test_partial_group1_repaired` leaves `oauth_authorize_url` missing, matching the reporter's exact error string.
- On this branch all 5 pass:
  - `test_partial_group1_repaired`, `test_partial_group2_repaired` — partial states for both column groups get fully repaired.
  - `test_partial_double_run_idempotent` — running the migration twice adds nothing the second time.
  - `test_all_old_schema_repaired` — a fully-pre-OIDC DB gets all 10 columns.
  - `test_all_new_schema_noop` — an up-to-date DB is left untouched.

```
5 passed in 0.54s
```

## Remaining pre-merge gate (operator-owned, needs-review)
Unit verification of the migration logic is closed-loop. The container end-to-end pass is not yet attached: seed a partial `oauthProvider` schema in a real instance, restart so the migration runs on cold boot, confirm the columns are repaired and `/admin/config` returns 200 via Playwright. That belongs to the release drive (`/CWNG_goal_act`) before this merges.

**Tier:** needs-review (auth/oauth code + DB migration, multi-file).
**Release target:** next v4.0.x.

Blast radius: one caller (`migrate_Database`), signature unchanged. The `_session` parameter is now unused in this function but kept for the caller's call shape.