### PR TITLE
fix(kobo): composite-keyset sync cursor + magic-shelf membership arm (#347 + #359)

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -156,6 +156,36 @@ def get_magic_shelf_book_ids_for_kobo(user_id):
     return book_ids
 
 
+def get_magic_shelf_membership_added_at(user_id):
+    """Return the most-recent MagicShelfCache.created_at across the user's
+    kobo-sync magic shelves, or ``None`` if no cache rows exist.
+
+    Plays the role ``BookShelf.date_added`` plays for regular shelves —
+    a "membership added" timestamp that lets the sync cursor emit
+    magic-shelf-only books once when the cache (re)builds, then fall
+    out of the cursor on subsequent syncs.
+
+    Returning ``None`` (rather than ``datetime.min``) lets the caller
+    distinguish "no kobo-sync magic shelves at all" from "shelves
+    exist but never cached" — the former should skip the magic-shelf
+    arm entirely; the latter falls through to normal cursor behavior.
+    """
+    if not config.config_kobo_sync_magic_shelves:
+        return None
+
+    max_created_at = (
+        ub.session.query(func.max(ub.MagicShelfCache.created_at))
+        .join(ub.MagicShelf, ub.MagicShelf.id == ub.MagicShelfCache.shelf_id)
+        .filter(ub.MagicShelf.user_id == user_id, ub.MagicShelf.kobo_sync == True)  # noqa: E712
+        .scalar()
+    )
+    if max_created_at is None:
+        return None
+    if hasattr(max_created_at, "replace") and getattr(max_created_at, "tzinfo", None) is not None:
+        max_created_at = max_created_at.replace(tzinfo=None)
+    return max_created_at
+
+
 @kobo.route("/v1/library/sync")
 @requires_kobo_auth
 # @download_required
@@ -189,8 +219,10 @@ def HandleSyncRequest():
 
     # Two-Way-Sync Deletion Logic
     magic_shelf_book_ids = set()
+    magic_shelf_membership_added_at = None
     if current_user.kobo_only_shelves_sync:
         magic_shelf_book_ids = get_magic_shelf_book_ids_for_kobo(current_user.id)
+        magic_shelf_membership_added_at = get_magic_shelf_membership_added_at(current_user.id)
         try:
             # Check all books that are on Kobo according to the database
             synced_books_query = ub.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)
@@ -241,6 +273,46 @@ def HandleSyncRequest():
         db.Books.id == ub.KoboReadingState.book_id,
         ub.KoboReadingState.user_id == current_user.id,
     )
+    # Composite-keyset cursor: filter rows after (books_last_modified, books_last_id)
+    # in lexicographic order. This walks paginated batches through blocks of books
+    # that share one last_modified (fork #347 — 4458 books all stamped one second
+    # in a bulk import; the timestamp-only cursor either re-sent the same first
+    # SYNC_ITEM_LIMIT forever or skipped the remainder). For pre-upgrade tokens
+    # books_last_id defaults to -1, so the keyset arm 'id > -1' is True for every
+    # valid book id and no books at exactly books_last_modified are dropped on
+    # the first post-upgrade sync.
+    cursor_lm = sync_token.books_last_modified
+    cursor_id = sync_token.books_last_id
+    composite_keyset_books_only = or_(
+        db.Books.last_modified > cursor_lm,
+        and_(db.Books.last_modified == cursor_lm, db.Books.id > cursor_id),
+    )
+
+    # Magic-shelf membership arm (fork #359): magic-shelf-only books are not in
+    # book_shelf_link, so BookShelf.date_added is NULL and Books.last_modified is
+    # usually in the past — the standard cursor arms filter them out before the
+    # outer (kobo_sync shelf OR magic-shelf) membership filter is evaluated, and
+    # they never reach the device. The cache row's created_at is the membership
+    # timestamp: when the cache (re)builds, emit all magic-shelf books once;
+    # cursor then advances past created_at and the arm goes False so the device
+    # doesn't re-emit (the #213 termination guard, preserved structurally).
+    magic_shelf_arm_active = bool(
+        magic_shelf_book_ids
+        and magic_shelf_membership_added_at is not None
+        and magic_shelf_membership_added_at > cursor_lm
+    )
+    if magic_shelf_arm_active:
+        inner_cursor_filter = or_(
+            ub.BookShelf.date_added > cursor_lm,
+            composite_keyset_books_only,
+            db.Books.id.in_(magic_shelf_book_ids),
+        )
+    else:
+        inner_cursor_filter = or_(
+            ub.BookShelf.date_added > cursor_lm,
+            composite_keyset_books_only,
+        )
+
     if only_kobo_shelves:
         changed_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
@@ -254,18 +326,17 @@ def HandleSyncRequest():
         # books another device already synced.
         #
         # Magic-shelf membership is enforced by the OUTER filter
-        # (kobo_sync shelf OR magic-shelf) further down. Don't add
-        # magic_shelf_book_ids to the inner OR — that bypasses the
-        # timestamp cursor and produces an infinite cont_sync loop on
-        # paginated sync.
+        # (kobo_sync shelf OR magic-shelf) further down. The INNER
+        # cursor includes a magic-shelf arm ONLY when the cache was
+        # (re)built after the device's cursor, then advances cursor
+        # past the cache's created_at — same termination guarantee as
+        # #213 (cont_sync goes False once the cache stops moving) but
+        # without the original "infinite loop" failure mode.
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .outerjoin(ub.KoboReadingState, rstate_join)
-                           .filter(or_(
-                               ub.BookShelf.date_added > sync_token.books_last_modified,
-                               db.Books.last_modified > sync_token.books_last_modified
-                           ))
+                           .filter(inner_cursor_filter)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .order_by(db.Books.last_modified)
@@ -290,14 +361,15 @@ def HandleSyncRequest():
                                                    ub.KoboReadingState)
         # Same per-device cursor invariant as the shelf branch above:
         # don't filter by KoboSyncedBooks (user-keyed, breaks multi-device).
-        # The last_modified > sync_token.books_last_modified filter is the
-        # per-device throttle — without it, this branch returns every book
-        # on every sync and keeps cont_sync True forever.
+        # The composite keyset (Books.last_modified, Books.id) is the per-device
+        # throttle — without it, this branch returns every book on every sync
+        # and keeps cont_sync True forever. The 'else' branch's SELECT does
+        # not join BookShelf, so the date_added arm is dropped here.
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .outerjoin(ub.KoboReadingState, rstate_join)
-                           .filter(db.Books.last_modified > sync_token.books_last_modified)
+                           .filter(composite_keyset_books_only)
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .order_by(db.Books.last_modified)
@@ -311,9 +383,12 @@ def HandleSyncRequest():
     log.debug("Kobo Sync: changed entries: {}".format(changed_entries.count()))
 
     reading_states_in_new_entitlements = []
-    books = changed_entries.limit(SYNC_ITEM_LIMIT)
-    log.debug("Kobo Sync: selected to sync: {}".format(len(books.all())))
-    for book in books:
+    # Materialize the limited result set ONCE — the prior shape called .all()
+    # twice (once for the debug log, once for the for-loop) which round-tripped
+    # the joined-load query twice per sync request.
+    books_list = changed_entries.limit(SYNC_ITEM_LIMIT).all()
+    log.debug("Kobo Sync: selected to sync: {}".format(len(books_list)))
+    for book in books_list:
         kobo_reading_state = book.KoboReadingState  # None when no record exists yet
         entitlement = {
             "BookEntitlement": create_book_entitlement(book.Books, archived=(book.is_archived==True)),
@@ -356,6 +431,43 @@ def HandleSyncRequest():
 
         new_books_last_created = max(ts_created, new_books_last_created)
         kobo_sync_status.add_synced_books(book.Books.id)
+
+    # Composite-keyset cursor: keep books_last_id aligned with new_books_last_modified.
+    # The query ORDER BY (last_modified, id) means books_list iteration is sorted, so
+    # the last emitted row is the highest (last_modified, id) tuple in the batch.
+    #   - If new_books_last_modified == that row's last_modified, store the row's id so
+    #     the next sync's keyset arm `id > books_last_id` walks past it.
+    #   - If new_books_last_modified got pushed past the batch's max ts (via the
+    #     date_added fold from fork #220 or via the magic-shelf cache fold below),
+    #     reset id to -1 — there are no books at the new ts in this batch, so any
+    #     valid id passes the next sync's keyset arm.
+    #   - If the batch was empty, keep the existing cursor id (no emission).
+    if books_list:
+        last_book = books_list[-1]
+        last_book_lm = last_book.Books.last_modified
+        if hasattr(last_book_lm, "replace") and getattr(last_book_lm, "tzinfo", None) is not None:
+            last_book_lm = last_book_lm.replace(tzinfo=None)
+        if new_books_last_modified == last_book_lm:
+            new_books_last_id = last_book.Books.id
+        else:
+            new_books_last_id = -1
+    else:
+        new_books_last_id = sync_token.books_last_id
+
+    # If the magic-shelf membership arm was active this round, advance the cursor
+    # past the cache's created_at so the arm goes False next sync — same termination
+    # guarantee as fork #213 (cont_sync goes False once cache.created_at stops
+    # advancing), but without the original "infinite loop" failure mode. If the
+    # cache.created_at advances cursor past the batch's max book ts, reset id to -1
+    # (no books at the new ts in this batch).
+    if magic_shelf_arm_active and magic_shelf_membership_added_at is not None:
+        if magic_shelf_membership_added_at > new_books_last_modified:
+            new_books_last_modified = magic_shelf_membership_added_at
+            new_books_last_id = -1
+        elif magic_shelf_membership_added_at == new_books_last_modified and not books_list:
+            # Cache rebuilt but no books actually changed past the old cursor — still
+            # advance to prevent the arm from firing again (idempotent re-trigger).
+            new_books_last_id = -1
 
     max_change = changed_entries.filter(ub.ArchivedBook.is_archived)\
         .filter(ub.ArchivedBook.user_id == current_user.id) \
@@ -524,6 +636,7 @@ def HandleSyncRequest():
     if not cont_sync:
         sync_token.books_last_created = new_books_last_created
     sync_token.books_last_modified = new_books_last_modified
+    sync_token.books_last_id = new_books_last_id
     sync_token.archive_last_modified = new_archived_last_modified
     sync_token.reading_state_last_modified = new_reading_state_last_modified
 

--- a/cps/services/SyncToken.py
+++ b/cps/services/SyncToken.py
@@ -44,10 +44,15 @@ class SyncToken:
     Attributes:
         books_last_created: Datetime representing the newest book that the device knows about.
         books_last_modified: Datetime representing the last modified book that the device knows about.
+        books_last_id: Composite-keyset tiebreaker — the last Books.id emitted at exactly
+            books_last_modified. Walks paginated batches through blocks of books that share one
+            last_modified (e.g. a bulk import). Default -1 means "no tiebreaker"; any valid book
+            id is > -1, so old tokens still see every book at exactly books_last_modified on the
+            first post-upgrade sync.
     """
 
     SYNC_TOKEN_HEADER = "x-kobo-synctoken"  # nosec
-    VERSION = "1-1-0"
+    VERSION = "1-2-0"
     LAST_MODIFIED_ADDED_VERSION = "1-1-0"
     MIN_VERSION = "1-0-0"
 
@@ -67,8 +72,8 @@ class SyncToken:
             "books_last_created": {"type": "number"},
             "archive_last_modified": {"type": "number"},
             "reading_state_last_modified": {"type": "number"},
-            "tags_last_modified": {"type": "number"}
-            # "books_last_id": {"type": "integer", "optional": True}
+            "tags_last_modified": {"type": "number"},
+            "books_last_id": {"type": "integer"},
         },
     }
 
@@ -79,8 +84,8 @@ class SyncToken:
         books_last_modified=datetime.min,
         archive_last_modified=datetime.min,
         reading_state_last_modified=datetime.min,
-        tags_last_modified=datetime.min
-        # books_last_id=-1
+        tags_last_modified=datetime.min,
+        books_last_id=-1,
     ):  # nosec
         self.raw_kobo_store_token = raw_kobo_store_token
         self.books_last_created = books_last_created
@@ -88,7 +93,7 @@ class SyncToken:
         self.archive_last_modified = archive_last_modified
         self.reading_state_last_modified = reading_state_last_modified
         self.tags_last_modified = tags_last_modified
-        # self.books_last_id = books_last_id
+        self.books_last_id = books_last_id
 
     @staticmethod
     def from_headers(headers):
@@ -126,6 +131,10 @@ class SyncToken:
             log.error("SyncToken timestamps don't parse to a datetime.")
             return SyncToken(raw_kobo_store_token=raw_kobo_store_token)
 
+        books_last_id = data_json.get("books_last_id", -1)
+        if not isinstance(books_last_id, int):
+            books_last_id = -1
+
         return SyncToken(
             raw_kobo_store_token=raw_kobo_store_token,
             books_last_created=books_last_created,
@@ -133,6 +142,7 @@ class SyncToken:
             archive_last_modified=archive_last_modified,
             reading_state_last_modified=reading_state_last_modified,
             tags_last_modified=tags_last_modified,
+            books_last_id=books_last_id,
         )
 
     def set_kobo_store_header(self, store_headers):
@@ -156,14 +166,16 @@ class SyncToken:
                 "archive_last_modified": to_epoch_timestamp(self.archive_last_modified),
                 "reading_state_last_modified": to_epoch_timestamp(self.reading_state_last_modified),
                 "tags_last_modified": to_epoch_timestamp(self.tags_last_modified),
+                "books_last_id": self.books_last_id,
             },
         }
         return b64encode_json(token)
 
     def __str__(self):
-        return "{},{},{},{},{},{}".format(self.books_last_created,
-                                          self.books_last_modified,
-                                          self.archive_last_modified,
-                                          self.reading_state_last_modified,
-                                          self.tags_last_modified,
-                                          self.raw_kobo_store_token)
+        return "{},{},{},{},{},{},{}".format(self.books_last_created,
+                                             self.books_last_modified,
+                                             self.archive_last_modified,
+                                             self.reading_state_last_modified,
+                                             self.tags_last_modified,
+                                             self.books_last_id,
+                                             self.raw_kobo_store_token)

--- a/tests/unit/test_kobo_sync_composite_keyset_cursor.py
+++ b/tests/unit/test_kobo_sync_composite_keyset_cursor.py
@@ -1,0 +1,375 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for fork #347 (Kobo sync stuck) + #359 (Magic Shelves
+kobo_sync don't deliver) — unified composite-keyset cursor.
+
+#347 symptom (@andree392): full Kobo sync never finishes. Device "My Books"
+counter climbs past real library size; debug log shows
+``changed entries: 4458 / selected to sync: 50 / remaining: 4458`` repeating.
+Three users hit it on the thread (@andree392, @shavitmichael, @Glennza1962).
+
+#347 root cause: keyset pagination on a non-unique sort key. The cursor was
+``books_last_modified`` alone, but the ORDER BY is ``(last_modified, id)``.
+When >SYNC_ITEM_LIMIT books share one ``last_modified`` (classic bulk-import
+signature, all rows stamped with one second from a SQL import), the cursor
+can either re-send the same first SYNC_ITEM_LIMIT forever (observed loop)
+or skip the remainder.
+
+#359 symptom (@recruiterguy): Magic Shelves with ``kobo_sync=1`` never put
+their books on the Kobo, even with ``magic_shelf_cache`` populated. Regular
+``kobo_sync=1`` shelves work for the same user/device/session.
+
+#359 root cause: the inner cursor (``last_modified > token`` OR
+``date_added > token``) ran before the outer ``(kobo_sync shelf OR
+magic-shelf membership)`` filter. Magic-shelf-only books had NULL
+``BookShelf.date_added`` (not in book_shelf_link) and old ``last_modified``,
+so both arms returned false and the rows were excluded before the outer
+filter ever saw them.
+
+#213 constraint (the trap): @raphi011's earlier CWA #1351 fix DELIBERATELY
+removed ``magic_shelf_book_ids`` from the inner OR because adding it
+unconditionally produces an infinite ``cont_sync`` loop — magic books
+re-emit every sync, ``cont_sync`` never goes False, the device syncs
+forever. The new arm must respect this constraint structurally.
+
+Unified fix (this test file pins):
+
+1. SyncToken gains ``books_last_id`` (tested in
+   ``test_kobo_synctoken_books_last_id.py``).
+2. Both cursor sites in ``HandleSyncRequest`` use a composite keyset:
+   ``(last_modified > token.lm) OR (last_modified == token.lm AND id > token.lid)``.
+3. The magic-shelf branch adds a THIRD inner-OR arm:
+   ``id IN magic_shelf_book_ids`` — gated on
+   ``magic_shelf_membership_added_at > token.books_last_modified`` (so the
+   arm goes False once the cursor advances past the cache's created_at,
+   preserving the #213 termination guarantee).
+4. Cursor advance folds ``max(magic_shelf_membership_added_at, ...)`` into
+   ``new_books_last_modified`` to make (3) terminate.
+5. ``sync_token.books_last_id`` is written at the end of HandleSyncRequest.
+"""
+
+import ast
+import pathlib
+import sqlite3
+
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+KOBO_PY = REPO_ROOT / "cps" / "kobo.py"
+
+
+def _function_source(path: pathlib.Path, name: str) -> str:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    fn = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == name),
+        None,
+    )
+    assert fn is not None, f"{name} function not found in {path}"
+    return ast.unparse(fn)
+
+
+def _module_source() -> str:
+    return KOBO_PY.read_text(encoding="utf-8")
+
+
+SYNC_ITEM_LIMIT = 100
+
+
+# --------------------------------------------------------------------------
+# Source-pin invariants on HandleSyncRequest — the inline query, the cursor
+# advance, the wire-token write. If any of these regress, the entire fix
+# falls back to one or both of the original bug shapes.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCompositeKeysetCursorPinned:
+    def test_composite_keyset_filter_construction_exists(self):
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        assert "composite_keyset_books_only" in src, (
+            "HandleSyncRequest must build the composite-keyset filter "
+            "'composite_keyset_books_only' that combines "
+            "(last_modified > cursor_lm) OR (last_modified == cursor_lm AND "
+            "id > cursor_id). Without it, fork #347 regresses — bulk-imported "
+            "books sharing one last_modified can't be walked past."
+        )
+
+    def test_composite_keyset_uses_strictly_greater_or_id_tiebreaker(self):
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        # The fix's composite is `(lm > cursor_lm) OR (lm == cursor_lm AND id > cursor_id)`.
+        # Pin both arms exactly so a future edit can't silently revert one.
+        assert "db.Books.last_modified > cursor_lm" in src, (
+            "Composite-keyset filter must include the strict-greater arm "
+            "on last_modified (fork #347)."
+        )
+        assert "db.Books.last_modified == cursor_lm" in src, (
+            "Composite-keyset filter must include the equal-cursor-lm arm "
+            "so paginated batches can walk through ties (fork #347)."
+        )
+        assert "db.Books.id > cursor_id" in src, (
+            "Composite-keyset filter must include the id tiebreaker — "
+            "the whole point of fork #347 is that ORDER BY (lm, id) "
+            "needs cursor (lm, id) to walk through last_modified ties."
+        )
+
+    def test_else_branch_uses_composite_keyset_not_old_strict_greater_only(self):
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        # The pre-fix 'else' branch was: `.filter(db.Books.last_modified >
+        # sync_token.books_last_modified)`. The fix replaces it with the
+        # composite filter. If a future change reverts to the old call shape
+        # for the non-kobo-shelves user, fork #347 regresses for them too.
+        assert ".filter(db.Books.last_modified > sync_token.books_last_modified)" not in src, (
+            "The 'else' branch (kobo_only_shelves_sync=False) must use the "
+            "composite-keyset filter, not the old timestamp-only strict-greater "
+            "filter that drops books at the bulk-import boundary (fork #347)."
+        )
+
+    def test_magic_shelf_branch_does_not_use_old_inline_strict_greater_or(self):
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        # The pre-fix magic-shelf branch was an inline `or_(date_added > token,
+        # last_modified > token)`. The fix moves it into `inner_cursor_filter`
+        # which composes the date_added arm + composite keyset + (conditionally)
+        # the magic-shelf membership arm. If a future change re-inlines the
+        # OR with only the two original arms, both fork #347 and fork #359
+        # regress.
+        assert "inner_cursor_filter" in src, (
+            "HandleSyncRequest must build the named 'inner_cursor_filter' that "
+            "composes the date_added arm + composite keyset + conditional "
+            "magic-shelf membership arm. Replacing it with an inline OR "
+            "regresses #347 and/or #359."
+        )
+
+
+@pytest.mark.unit
+class TestMagicShelfMembershipArmPinned:
+    def test_magic_shelf_arm_active_flag_is_computed(self):
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        assert "magic_shelf_arm_active" in src, (
+            "HandleSyncRequest must compute 'magic_shelf_arm_active' to gate "
+            "the third inner-OR arm (fork #359). The arm must only be active "
+            "when the cache was rebuilt after the device's cursor — "
+            "otherwise it's #213's infinite-loop trap."
+        )
+
+    def test_magic_shelf_arm_gated_on_membership_added_at_greater_than_cursor(self):
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        # The gate is: only add the arm when cache.created_at > cursor.lm.
+        # Removing the gate is the #213 regression vector (every sync re-emits,
+        # cont_sync never goes False).
+        assert "magic_shelf_membership_added_at > cursor_lm" in src, (
+            "The magic-shelf arm must be gated on 'magic_shelf_membership_added_at "
+            "> cursor_lm'. Without the gate, the arm fires on every sync, "
+            "magic books re-emit forever, and cont_sync never goes False — "
+            "the exact #213 regression CWA #1351 was written to fix."
+        )
+
+    def test_magic_shelf_membership_added_at_helper_exists(self):
+        src = _module_source()
+        assert "def get_magic_shelf_membership_added_at" in src, (
+            "Helper 'get_magic_shelf_membership_added_at(user_id)' must exist. "
+            "It computes the max MagicShelfCache.created_at across the user's "
+            "kobo-sync magic shelves — the membership timestamp that plays the "
+            "role BookShelf.date_added plays for regular shelves."
+        )
+
+    def test_membership_helper_filters_on_kobo_sync_true(self):
+        src = _function_source(KOBO_PY, "get_magic_shelf_membership_added_at")
+        # Must only include shelves the user has explicitly marked for Kobo
+        # sync — otherwise it triggers magic-shelf arm activation on shelves
+        # the user never authorized for Kobo delivery.
+        assert "kobo_sync == True" in src or "kobo_sync=True" in src, (
+            "get_magic_shelf_membership_added_at must filter on "
+            "MagicShelf.kobo_sync == True. Otherwise non-Kobo magic shelves "
+            "trigger the arm and contaminate the sync cursor."
+        )
+
+    def test_membership_helper_returns_none_when_config_disabled(self):
+        src = _function_source(KOBO_PY, "get_magic_shelf_membership_added_at")
+        assert "config_kobo_sync_magic_shelves" in src, (
+            "Helper must short-circuit to None when "
+            "config.config_kobo_sync_magic_shelves is False — the magic-shelf "
+            "feature being globally disabled must NOT advance the cursor."
+        )
+
+
+@pytest.mark.unit
+class TestCursorAdvanceWritesBooksLastId:
+    def test_sync_token_books_last_id_is_written(self):
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        assert "sync_token.books_last_id = new_books_last_id" in src, (
+            "HandleSyncRequest must write sync_token.books_last_id at the end "
+            "of the request alongside sync_token.books_last_modified. Without "
+            "the write, the keyset cursor is dead-code — every sync sees "
+            "books_last_id == -1, and the bulk-import block re-emits forever."
+        )
+
+    def test_books_last_id_resets_to_minus_one_when_cursor_advances_past_batch(self):
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        # When new_books_last_modified gets pushed past the batch's max ts
+        # (via date_added fold or magic_shelf_membership fold), the batch's
+        # last id is no longer relevant — reset to -1 so all books at the
+        # new ts pass next sync's keyset arm.
+        assert "new_books_last_id = -1" in src, (
+            "When new_books_last_modified advances past the batch's max book "
+            "ts (date_added fold from #220 or magic_shelf_cache fold from "
+            "#359), the cursor id must reset to -1 — there are no books at "
+            "the new ts in this batch, so the next sync's keyset arm "
+            "'id > -1' must match every valid id at that ts."
+        )
+
+    def test_batch_materialized_once_into_books_list(self):
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        # The pre-fix shape called `books = changed_entries.limit(...)` then
+        # `len(books.all())` for logging, then `for book in books` — that
+        # round-tripped the joined-load query twice per sync request.
+        assert "books_list = changed_entries.limit(SYNC_ITEM_LIMIT).all()" in src, (
+            "The query must materialize into 'books_list' exactly once. "
+            "Iterating a lazy .limit() result twice (once for the count log, "
+            "once for the for-loop) runs the joined-load query twice — "
+            "doubles DB load on every Kobo sync request."
+        )
+        assert "for book in books_list:" in src, (
+            "The for-loop must iterate over 'books_list' (the materialized "
+            "result), not a fresh .limit() query."
+        )
+
+
+# --------------------------------------------------------------------------
+# Behavioral test on a real SQLite engine that re-implements the cursor
+# arithmetic in isolation. This proves the algorithm itself is correct, in
+# the same engine the production code runs against. The container e2e
+# (Phase 6 in goal_act) verifies the inline query in kobo.py wires up to
+# this algorithm correctly.
+#
+# Same shape as notes/fork-347-repro/cursor_keyset_repro.py — promoted into
+# a pinned CI test so a future cursor refactor cannot silently regress it.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCompositeKeysetAlgorithm:
+    @staticmethod
+    def _seed_collision(collide_count, later_timestamps):
+        con = sqlite3.connect(":memory:")
+        con.execute("CREATE TABLE books (id INTEGER PRIMARY KEY, last_modified TEXT NOT NULL)")
+        T0 = "2021-03-29 13:31:44.163290"  # @andree392's stuck timestamp
+        rows = [(i, T0) for i in range(1, collide_count + 1)]
+        for j, ts in enumerate(later_timestamps):
+            rows.append((collide_count + 1 + j, ts))
+        con.executemany("INSERT INTO books (id, last_modified) VALUES (?, ?)", rows)
+        con.commit()
+        return con, len(rows), T0
+
+    @staticmethod
+    def _drive_timestamp_only(con, limit, max_rounds=200):
+        """The PRE-FIX cursor — pins the original bug shape."""
+        cursor_ts = "0000-00-00 00:00:00.000000"
+        synced, rounds = [], 0
+        while rounds < max_rounds:
+            rounds += 1
+            batch = con.execute(
+                "SELECT id, last_modified FROM books WHERE last_modified > ? "
+                "ORDER BY last_modified, id LIMIT ?", (cursor_ts, limit)).fetchall()
+            if not batch:
+                break
+            synced.extend(r[0] for r in batch)
+            new_ts = max([r[1] for r in batch] + [cursor_ts])
+            cursor_ts = new_ts
+            remaining = con.execute(
+                "SELECT COUNT(*) FROM books WHERE last_modified > ?", (cursor_ts,)).fetchone()[0]
+            if remaining == 0:
+                break
+        return synced, rounds
+
+    @staticmethod
+    def _drive_composite_keyset(con, limit, max_rounds=200):
+        """The POST-FIX cursor — pins the keyset algorithm correctness."""
+        cursor_ts, cursor_id = "0000-00-00 00:00:00.000000", -1
+        synced, rounds = [], 0
+        while rounds < max_rounds:
+            rounds += 1
+            batch = con.execute(
+                "SELECT id, last_modified FROM books "
+                "WHERE last_modified > ? OR (last_modified = ? AND id > ?) "
+                "ORDER BY last_modified, id LIMIT ?",
+                (cursor_ts, cursor_ts, cursor_id, limit)).fetchall()
+            if not batch:
+                break
+            synced.extend(r[0] for r in batch)
+            cursor_ts, cursor_id = batch[-1][1], batch[-1][0]
+            if len(batch) < limit:
+                break
+        return synced, rounds
+
+    def test_timestamp_only_cursor_drops_books_at_boundary_block(self):
+        """Pins the pre-fix BUG: this is what fork #347 actually observed."""
+        con, total, _ = self._seed_collision(
+            collide_count=250,
+            later_timestamps=["2024-01-01 00:00:00.000000",
+                              "2024-06-15 09:30:00.000000",
+                              "2025-02-20 12:00:00.000000"])
+        synced, rounds = self._drive_timestamp_only(con, limit=100)
+        con.close()
+        dropped = total - len(set(synced))
+        assert dropped > 0, (
+            "The PRE-FIX timestamp-only cursor MUST drop books at the bulk-"
+            "import boundary. If this assertion fails, either the cursor is "
+            "no longer timestamp-only (good, but rewrite this test) or the "
+            "test seed isn't actually exercising the boundary."
+        )
+        # Specifically: 250 books at T0 + limit=100 = exactly 150 dropped
+        # (the first 100 are emitted, cursor advances to T0, next round
+        # filters strictly > T0 and the remaining 150 are gone forever).
+        assert dropped == 150, (
+            f"Expected exactly 150 books dropped at the T0 boundary "
+            f"(250 - SYNC_ITEM_LIMIT=100), got {dropped}."
+        )
+
+    def test_composite_keyset_cursor_syncs_every_book_exactly_once(self):
+        """Pins the FIX: every book delivered once, cursor monotonic."""
+        con, total, _ = self._seed_collision(
+            collide_count=250,
+            later_timestamps=["2024-01-01 00:00:00.000000",
+                              "2024-06-15 09:30:00.000000",
+                              "2025-02-20 12:00:00.000000"])
+        synced, rounds = self._drive_composite_keyset(con, limit=100)
+        con.close()
+        uniq = set(synced)
+        assert len(uniq) == total, (
+            f"Composite keyset must deliver every book — expected {total} "
+            f"unique, got {len(uniq)}. Dropped: "
+            f"{sorted(set(range(1, total + 1)) - uniq)[:10]}..."
+        )
+        assert len(synced) == total, (
+            f"Composite keyset must deliver each book EXACTLY once — "
+            f"got {len(synced)} sends for {total} books "
+            f"({len(synced) - total} duplicate sends)."
+        )
+        # 253 books / 100 limit = 3 batches (100 + 100 + 53), so 3 rounds.
+        assert rounds <= 4, (
+            f"Composite keyset must walk through 253 books in ~3 rounds at "
+            f"limit=100, got {rounds}."
+        )
+
+    def test_composite_keyset_handles_giant_collision_block(self):
+        """The reporter's actual case: 4458 books all sharing one second."""
+        con, total, _ = self._seed_collision(
+            collide_count=4458,
+            later_timestamps=[])
+        synced, rounds = self._drive_composite_keyset(con, limit=50)
+        con.close()
+        assert len(set(synced)) == total, (
+            f"4458-book collision (the @andree392 case) must deliver every "
+            f"book. Got {len(set(synced))}/{total}."
+        )
+        # 4458 / 50 = 89.16 → 90 batches max
+        assert rounds <= 90, (
+            f"4458-book collision must walk through in <= 90 batches at "
+            f"SYNC_ITEM_LIMIT=50, got {rounds}."
+        )

--- a/tests/unit/test_kobo_synctoken_books_last_id.py
+++ b/tests/unit/test_kobo_synctoken_books_last_id.py
@@ -1,0 +1,147 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for SyncToken composite-keyset support (fork #347).
+
+The Kobo sync cursor used to track ``books_last_modified`` alone.
+When more than SYNC_ITEM_LIMIT books share one ``last_modified``
+(typical bulk-import signature — 4458 books all stamped one second
+in @andree392's case), the cursor cannot step past the tied block:
+it either re-sends the same first 50 forever (the observed loop)
+or skips the remainder.
+
+The fix adds an ID tiebreaker to the cursor. SyncToken gains
+``books_last_id`` so the wire format can carry it. This file pins:
+
+- The field exists, defaults to ``-1``, round-trips through the
+  base64-encoded JSON token format.
+- Old tokens (pre-upgrade, no ``books_last_id`` in the payload)
+  parse cleanly and default the field to ``-1``. Backward-compat:
+  a device on a pre-upgrade token does NOT force a full re-sync
+  and does NOT drop books at exactly ``books_last_modified`` —
+  ``id > -1`` is True for every valid book id, so all books at the
+  cursor's exact timestamp are emitted on the first post-upgrade
+  sync.
+- A garbage ``books_last_id`` value (string, list, null) defaults
+  to -1 rather than crashing.
+- The VERSION advanced to "1-2-0"; MIN_VERSION stays "1-0-0"
+  so devices on older tokens still parse without forced re-sync.
+"""
+
+import base64
+import json
+from datetime import datetime
+
+import pytest
+
+from cps.services.SyncToken import SyncToken
+
+
+def _encode(payload):
+    return base64.b64encode(json.dumps(payload).encode()).decode("utf-8")
+
+
+@pytest.mark.unit
+class TestSyncTokenBooksLastIdField:
+    def test_field_defaults_to_minus_one(self):
+        token = SyncToken()
+        assert token.books_last_id == -1, (
+            "Default must be -1 so the keyset arm 'id > books_last_id' "
+            "matches every valid book id at the cursor's timestamp — "
+            "old tokens (pre-upgrade) must not drop books."
+        )
+
+    def test_field_accepts_explicit_value(self):
+        token = SyncToken(books_last_id=42)
+        assert token.books_last_id == 42
+
+    def test_field_round_trips_through_build_and_from_headers(self):
+        original = SyncToken(books_last_id=1234)
+        encoded = original.build_sync_token()
+        rehydrated = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: encoded})
+        assert rehydrated.books_last_id == 1234
+
+    def test_default_round_trips(self):
+        original = SyncToken()
+        encoded = original.build_sync_token()
+        rehydrated = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: encoded})
+        assert rehydrated.books_last_id == -1
+
+
+@pytest.mark.unit
+class TestSyncTokenBackwardCompat:
+    def test_old_token_missing_books_last_id_defaults_to_minus_one(self):
+        """A device that last synced pre-upgrade sends a token with no
+        ``books_last_id`` key. Must parse cleanly and default to -1, NOT
+        crash and NOT force a full re-sync."""
+        encoded = _encode({
+            "version": "1-1-0",
+            "data": {
+                "raw_kobo_store_token": "",
+                "books_last_modified": 1735689600.0,
+                "books_last_created": 1735689600.0,
+                "archive_last_modified": 1735689600.0,
+                "reading_state_last_modified": 1735689600.0,
+                "tags_last_modified": 1735689600.0,
+                # NB: no books_last_id key — pre-upgrade token shape
+            },
+        })
+        token = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: encoded})
+        assert token.books_last_id == -1
+        # Other fields must still parse correctly
+        assert token.books_last_modified == datetime(2025, 1, 1, 0, 0, 0)
+
+    def test_garbage_books_last_id_string_defaults_to_minus_one(self):
+        encoded = _encode({
+            "version": SyncToken.VERSION,
+            "data": {
+                "raw_kobo_store_token": "",
+                "books_last_modified": 0,
+                "books_last_id": "not-an-int",
+            },
+        })
+        token = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: encoded})
+        # jsonschema rejects {"type": "integer"} for a string, so the
+        # whole data block fails validation -> default SyncToken returned.
+        assert token.books_last_id == -1
+
+    def test_garbage_books_last_id_null_defaults_to_minus_one(self):
+        encoded = _encode({
+            "version": SyncToken.VERSION,
+            "data": {
+                "raw_kobo_store_token": "",
+                "books_last_modified": 0,
+                "books_last_id": None,
+            },
+        })
+        token = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: encoded})
+        # jsonschema rejects null for {"type": "integer"} -> default SyncToken.
+        assert token.books_last_id == -1
+
+
+@pytest.mark.unit
+class TestSyncTokenVersion:
+    def test_version_advanced_to_one_two_zero(self):
+        assert SyncToken.VERSION == "1-2-0", (
+            "VERSION bumped because the wire data schema gained books_last_id."
+        )
+
+    def test_min_version_unchanged_at_one_zero_zero(self):
+        assert SyncToken.MIN_VERSION == "1-0-0", (
+            "MIN_VERSION must NOT change — devices on pre-1-2-0 tokens "
+            "must still parse without forced re-sync; the new field is "
+            "additive and defaults to -1 (compatible) if absent."
+        )
+
+    def test_token_built_carries_advanced_version(self):
+        encoded = SyncToken().build_sync_token()
+        wrapper = json.loads(base64.b64decode(encoded + "=" * (-len(encoded) % 4)))
+        assert wrapper["version"] == "1-2-0"
+
+    def test_books_last_id_present_in_built_data_payload(self):
+        encoded = SyncToken(books_last_id=99).build_sync_token()
+        wrapper = json.loads(base64.b64decode(encoded + "=" * (-len(encoded) % 4)))
+        assert wrapper["data"]["books_last_id"] == 99


### PR DESCRIPTION
## Symptom

Two faces of one defect — the Kobo sync cursor was missing arms.

### #347 (3 affected users: @andree392, @shavitmichael, @Glennza1962)

Full Kobo sync never finishes. The device's "My Books" counter climbs past the real library size (2000 books → 5000+) because the server keeps re-sending the same first 50 books and the cursor never advances. Debug log loops:

```
{cps.kobo:290} Kobo Sync: changed entries: 4458
{cps.kobo:294} Kobo Sync: selected to sync: 50
{cps.kobo:356} Kobo Sync: remaining books to sync: 4458   <-- never decreases
```

### #359 (@recruiterguy)

Magic Shelves with `kobo_sync=1` never put their books on the Kobo, even when `magic_shelf_cache` is populated with valid book IDs. Regular `kobo_sync=1` shelves work for the same user, same device, same session. SQL evidence in the issue: shelf 9's cache holds `[2051, 2050, 2048, 2047, 2044]`; none reach the device.

## Root cause

The cursor was `books_last_modified` alone, but ORDER BY in `HandleSyncRequest` is `(last_modified, id)`. Two failure modes follow:

1. **#347** — When >SYNC_ITEM_LIMIT books share one `last_modified` (classic bulk-import signature, e.g. all 4458 books stamped 2021-03-29 13:31:44 from a SQL import), the cursor can't step past the tied block. Either it re-sends the same first batch forever (the observed loop) or skips the remainder.
2. **#359** — Magic-shelf-only books are not in `book_shelf_link`, so `BookShelf.date_added` is NULL. Their `Books.last_modified` is usually in the past. Both arms of the inner OR (`date_added > token`, `last_modified > token`) return false, so the rows are excluded BEFORE the outer `(kobo_sync shelf OR magic-shelf membership)` filter ever sees them.

The trap that constrains the fix (from #213 / CWA #1351 by @raphi011): adding `magic_shelf_book_ids` unconditionally to the inner OR produces an infinite `cont_sync` loop — magic books re-emit every sync, `cont_sync` never goes False, the device syncs forever. The new arm must terminate structurally.

## Fix

- **`SyncToken`** gains `books_last_id` (default `-1`). `VERSION` advances `1-1-0` → `1-2-0`. `MIN_VERSION` stays `1-0-0` so devices on older tokens parse cleanly without forced re-sync. Backward-compat: `id > -1` is True for every valid book id, so no books at exactly `cursor_lm` are dropped on the first post-upgrade sync.
- **Both `HandleSyncRequest` cursor sites** use a composite keyset:
  ```python
  (Books.last_modified > cursor_lm) OR (Books.last_modified == cursor_lm AND Books.id > cursor_id)
  ```
  Walks paginated batches through tied `last_modified`. Standard keyset pagination — ORDER BY `(last_modified, id)` paired with cursor `(cursor_lm, cursor_id)`.
- **Magic-shelf branch** gains a third inner-OR arm: `Books.id IN magic_shelf_book_ids`, gated on `MagicShelfCache.created_at > cursor_lm`. The cursor then folds `magic_shelf_membership_added_at` into `new_books_last_modified` so the arm goes False on the next sync — preserves the #213 / CWA #1351 termination guarantee structurally without the original "infinite loop" failure mode.
- **Cursor advance** resets `new_books_last_id` to `-1` when `new_books_last_modified` is pushed past the batch's max book ts (via the #220 `date_added` fold OR the #359 `magic_shelf_cache` fold).
- **`changed_entries` batch materialized once** into `books_list` (was double-queried — `.all()` for the count log + `for book in books` re-ran the joined-load query).

## Verification

- **RED → GREEN unit tests (26 new, 423 kobo/sync passing):**
  - `tests/unit/test_kobo_synctoken_books_last_id.py` (11 tests) — field, default, round-trip, backward-compat with pre-`1-2-0` tokens, garbage-input defaults, VERSION/MIN_VERSION constants.
  - `tests/unit/test_kobo_sync_composite_keyset_cursor.py` (15 tests) — source-pins on the inline query (composite_keyset_books_only + inner_cursor_filter + magic_shelf_arm_active gate + cursor write), batch materialization, and a real-SQLite behavioral test that reproduces the pre-fix 150-book drop on a 250-book collision and proves the post-fix exhaustively walks @andree392's actual 4458-book collision (4458/50 = 90 batches).
- **Cross-cutting adjacency sweep** documented in `notes/fix-kobo-sync-composite-keyset-347-359-adjacency.md`: reading-state, archive, and tags cursors share the same non-unique-key trap class but with much lower collision likelihood — v2-track. Magic-shelf-only collections > SYNC_ITEM_LIMIT books may need a follow-up cache rebuild to fully deliver — v2-track sub-cursor.
- **Container Kobo-sync e2e** (separate verification pass: drive `/v1/library/sync` with a seeded library having >SYNC_ITEM_LIMIT books at one `last_modified` + a populated magic-shelf cache — pending Docker daemon recovery on the dev machine).

## Confidence

~93% — algorithm proven exhaustively at the SQLite layer (matching the production engine), inline query source-pinned, SyncToken backward-compat tested. Residual risk is the container e2e gate; will be filled before merge.

Addresses #347
Addresses #359