### PR TITLE
feat(detail): reload-metadata button on book detail page (#218)

### DIFF
--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -573,6 +573,25 @@
                                            class="btn btn-primary action-icon-btn" role="button" title="{{ _('Edit Metadata') }}" aria-label="{{ _('Edit Metadata') }}">
                                             <span class="glyphicon glyphicon-pencil"></span>
                                         </a>
+                                        {# Reload-metadata-from-disk button — fork issue #218.
+                                           Replaces the manual `curl -X POST /admin/book/<id>/reload_metadata`
+                                           workflow that @yodatak (400 — CSRF token missing) and
+                                           @magdalar (405 — Chrome sent GET) were both stuck on. Posts
+                                           via $.ajax with X-CSRFToken so the @csrf_protect gate sees the
+                                           token, then reloads the page on success so the user immediately
+                                           sees the refreshed title/comments/publisher/pubdate/languages.
+                                           Same role_edit() gate as the route's @edit_required. #}
+                                        <button type="button"
+                                                class="btn btn-primary action-icon-btn"
+                                                id="reload-metadata-btn"
+                                                data-book-id="{{ entry.id }}"
+                                                data-toast-success="{{ _('Reloaded metadata from disk') }}"
+                                                data-toast-no-change="{{ _('On-disk metadata matches — nothing to update') }}"
+                                                data-toast-error="{{ _('Could not reload metadata') }}"
+                                                title="{{ _('Reload metadata from disk') }}"
+                                                aria-label="{{ _('Reload metadata from disk') }}">
+                                            <span id="reload-metadata-icon" class="glyphicon glyphicon-refresh"></span>
+                                        </button>
                                         <a href="{{ url_for('cover_picker.cover_picker_page', book_id=entry.id) }}"
                                            class="btn btn-primary action-icon-btn" role="button" title="{{ _('Change cover') }}" aria-label="{{ _('Change cover') }}">
                                             <span class="glyphicon glyphicon-picture"></span>
@@ -1108,6 +1127,58 @@
                 },
                 error: function () {
                     $cb.prop("checked", !nextChecked);
+                }
+            });
+        });
+
+        // Reload-metadata handler — fork issue #218. Replaces the manual
+        // curl invocation @yodatak/@magdalar were attempting (400/405).
+        // POSTs with X-CSRFToken (CSRF gate on the route), shows a spinner
+        // on the refresh icon while in flight, then a toast + page reload
+        // so the user sees the refreshed title/comments/publisher.
+        $("#reload-metadata-btn").on("click", function () {
+            var $btn = $("#reload-metadata-btn");
+            if ($btn.prop("disabled")) {
+                return;
+            }
+            var bookId = $btn.data("book-id");
+            var $icon = $("#reload-metadata-icon");
+            $btn.prop("disabled", true);
+            $icon.removeClass("glyphicon-refresh").addClass("glyphicon-hourglass");
+            $.ajax({
+                url: "/admin/book/" + bookId + "/reload_metadata",
+                method: "post",
+                headers: {
+                    "X-CSRFToken": $('meta[name="csrf-token"]').attr("content") || ""
+                },
+                success: function (data) {
+                    if (data && data.success) {
+                        var updated = (data.updated_fields || []).length;
+                        var msg = updated > 0 ? $btn.data("toast-success")
+                                              : $btn.data("toast-no-change");
+                        showActionToast(msg, $btn[0]);
+                        if (updated > 0) {
+                            // Page reload so refreshed metadata renders.
+                            setTimeout(function () { location.reload(); }, 800);
+                        } else {
+                            $icon.removeClass("glyphicon-hourglass").addClass("glyphicon-refresh");
+                            $btn.prop("disabled", false);
+                        }
+                    } else {
+                        var err = (data && data.error) ? data.error : $btn.data("toast-error");
+                        showActionToast(err, $btn[0]);
+                        $icon.removeClass("glyphicon-hourglass").addClass("glyphicon-refresh");
+                        $btn.prop("disabled", false);
+                    }
+                },
+                error: function (xhr) {
+                    var err = $btn.data("toast-error");
+                    if (xhr && xhr.responseJSON && xhr.responseJSON.error) {
+                        err = xhr.responseJSON.error;
+                    }
+                    showActionToast(err, $btn[0]);
+                    $icon.removeClass("glyphicon-hourglass").addClass("glyphicon-refresh");
+                    $btn.prop("disabled", false);
                 }
             });
         });

--- a/tests/unit/test_reload_metadata_ui_button_218.py
+++ b/tests/unit/test_reload_metadata_ui_button_218.py
@@ -1,0 +1,164 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for fork #218 reload-metadata UI button.
+
+@yodatak originally asked for a way to reload embedded EPUB metadata
+into the catalog when editing externally (grimmory etc.). v4.0.110
+shipped the POST /admin/book/<id>/reload_metadata endpoint, but the
+follow-up surfaced two UX gaps:
+
+- @yodatak (2026-05-27): trying to call it manually with curl, got
+  HTTP 400 — no CSRF token in their request, but the endpoint is
+  CSRF-protected like the other edit-book routes.
+- @magdalar (2026-05-29): opened the URL in Chrome, got 405 — the
+  route is POST-only and Chrome sent GET.
+
+The endpoint works correctly. The missing piece was a UI button so
+the user doesn't have to construct the call themselves. This file
+pins that:
+
+1. The button exists in the book detail template (`detail.html`),
+   gated on `current_user.role_edit()` — same gate as the route's
+   `@edit_required`.
+2. The button is a real `<button type="button">` (not an `<a href>`)
+   so the browser doesn't navigate-on-GET like @magdalar's case.
+3. The click handler POSTs to /admin/book/<id>/reload_metadata with
+   X-CSRFToken so the CSRF protect gate doesn't 400 it like
+   @yodatak's curl.
+4. The handler reloads the page on a successful update so the user
+   sees the refreshed metadata immediately (the whole point of
+   pulling the on-disk file as source of truth).
+"""
+
+import pathlib
+
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DETAIL_HTML = REPO_ROOT / "cps" / "templates" / "detail.html"
+
+
+@pytest.fixture(scope="module")
+def detail_template() -> str:
+    return DETAIL_HTML.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestReloadMetadataButtonInTemplate:
+    def test_button_exists_with_id(self, detail_template: str):
+        assert 'id="reload-metadata-btn"' in detail_template, (
+            "The reload-metadata button must have id='reload-metadata-btn' "
+            "so the click handler can bind to it. Without the button, the "
+            "user has to construct the POST manually — @yodatak's curl 400 "
+            "and @magdalar's Chrome 405 are both symptoms of this."
+        )
+
+    def test_button_is_a_button_not_an_anchor(self, detail_template: str):
+        # Pin that the element is `<button type="button">`, not `<a href>`.
+        # An anchor with href would let a user open the URL in a new tab
+        # via GET, which the route rejects with 405 (matched @magdalar's
+        # exact error).
+        import re
+        match = re.search(
+            r'<button[^>]*id="reload-metadata-btn"[^>]*type="button"',
+            detail_template,
+        )
+        if match is None:
+            # Order-insensitive: type may come before id.
+            match = re.search(
+                r'<button[^>]*type="button"[^>]*id="reload-metadata-btn"',
+                detail_template,
+            )
+        assert match is not None, (
+            "The reload-metadata UI element must be a <button "
+            "type='button'>, not an <a href> — an anchor would let a "
+            "user open the URL in a new tab via GET, which the route "
+            "405s (the @magdalar Chrome reproduction)."
+        )
+
+    def test_button_gated_on_role_edit(self, detail_template: str):
+        # The button must live inside a `{% if current_user.role_edit() %}`
+        # block — same gate as the route's @edit_required. Search for
+        # the button id and check the surrounding gate context.
+        idx = detail_template.find('id="reload-metadata-btn"')
+        assert idx != -1, "button must exist in template"
+        # Walk backward looking for the nearest `{% if %}` / `{% endif %}`.
+        # The button is inside the same `if current_user.role_edit()` block
+        # as the Edit Metadata link.
+        backward = detail_template[:idx]
+        last_if = backward.rfind("{% if ")
+        last_endif = backward.rfind("{% endif %}")
+        assert last_if > last_endif, (
+            "The reload-metadata button must be inside an `{% if %}` "
+            "block — same role gate as Edit Metadata."
+        )
+        # The opening if condition must reference role_edit (the route's
+        # @edit_required gate).
+        if_block_start = detail_template[last_if:last_if + 200]
+        assert "role_edit()" in if_block_start, (
+            "The button's enclosing if block must check "
+            "current_user.role_edit() — same gate as the route's "
+            f"@edit_required. Found: {if_block_start[:150]}"
+        )
+
+
+@pytest.mark.unit
+class TestReloadMetadataClickHandler:
+    def test_handler_posts_to_reload_metadata_endpoint(self, detail_template: str):
+        # POST URL must match the route declared in cps/editbooks.py
+        # (`/admin/book/<int:book_id>/reload_metadata`).
+        assert '"/admin/book/" + bookId + "/reload_metadata"' in detail_template, (
+            "Click handler must POST to /admin/book/<id>/reload_metadata. "
+            "If the URL drifts, the @yodatak / @magdalar workaround stays "
+            "broken."
+        )
+
+    def test_handler_sets_xcsrf_token_header(self, detail_template: str):
+        # @yodatak's curl 400 happened because the CSRF token wasn't
+        # included. The handler must read the csrf meta tag and put it
+        # in the X-CSRFToken header on every POST.
+        assert '"X-CSRFToken":' in detail_template, (
+            "Handler must send X-CSRFToken header on the POST. Without "
+            "it, the route returns 400 (the @yodatak curl reproduction). "
+            "Pattern: \"X-CSRFToken\": $('meta[name=\"csrf-token\"]')..."
+        )
+        assert 'meta[name="csrf-token"]' in detail_template, (
+            "Handler must read the CSRF token from the standard "
+            "<meta name='csrf-token' content='...'> tag so the same "
+            "token rotates across in-flight requests."
+        )
+
+    def test_handler_disables_button_during_request(self, detail_template: str):
+        # The reload re-parses an EPUB on disk — not instant. Without
+        # the disable, an impatient double-click would fire two POSTs
+        # against the same book, doubling the metadata-db write workload.
+        assert ".prop(\"disabled\", true);" in detail_template, (
+            "Click handler must disable the button while the AJAX is in "
+            "flight to prevent double-submit (re-reading the EPUB twice)."
+        )
+
+    def test_handler_reloads_page_on_successful_update(self, detail_template: str):
+        # If the user reloaded title/comments/publisher, the rendered
+        # page is now stale. A page reload is the simplest, lowest-risk
+        # way to surface the refreshed metadata to the user.
+        assert "location.reload()" in detail_template, (
+            "Click handler must reload the page on a successful update "
+            "(updated_fields not empty). Without it, the user sees the "
+            "toast 'Reloaded' but the rendered title/comments/publisher "
+            "stays stale until they manually refresh — defeats the point."
+        )
+
+    def test_handler_surfaces_route_error_message_when_provided(self, detail_template: str):
+        # The route returns helpful errors (file-not-found, parse-fail,
+        # commit-fail) in `data.error`. The handler must surface them
+        # rather than show a generic "could not reload" — otherwise the
+        # user has no idea why it failed.
+        assert "responseJSON" in detail_template, (
+            "Click handler must check xhr.responseJSON.error to surface "
+            "the route's specific error message (404 for missing file, "
+            "500 for parse fail) instead of a generic 'could not reload'. "
+            "Without this, the user has no actionable signal."
+        )


### PR DESCRIPTION
## Symptom

@yodatak and @magdalar were both blocked trying to call the `POST /admin/book/<id>/reload_metadata` endpoint (shipped v4.0.110) manually:

- @yodatak's curl: HTTP 400 — no CSRF token in the request.
- @magdalar's Chrome: HTTP 405 — the route is POST-only and Chrome sent GET when the URL was opened in a tab.

The endpoint works; the missing piece was a UI button so users don't have to construct the call by hand.

## Fix

Adds a Refresh-icon button on the book detail page next to Edit Metadata, gated on `current_user.role_edit()` (matches the route's `@edit_required`). Click handler POSTs with `X-CSRFToken` (so the CSRF gate doesn't 400 like @yodatak's curl), disables the button + swaps the icon to hourglass during the in-flight request (prevents double-submit re-parsing the EPUB twice), and reloads the page on a successful field update so the refreshed title/comments/publisher/pubdate/languages render immediately. Errors are surfaced from `responseJSON.error` so the user sees the route's specific message (404 missing file, 500 parse fail) rather than a generic "could not reload".

## Verification

- **8 RED→GREEN tests** in `tests/unit/test_reload_metadata_ui_button_218.py` pin: button shape is `<button type="button">` not `<a href>` (so GET-in-browser-tab can't reproduce @magdalar's 405); role_edit gate; endpoint URL match; X-CSRFToken header; in-flight disable; page reload on update; `responseJSON.error` surfacing.
- **Live `cwn-local` Playwright**: clicked the button as `cwng84test` (edit role); network panel confirmed `POST /admin/book/2/reload_metadata` returned **200 OK**; no console errors. Screenshot in `notes/fix-218-detail-with-reload-button.jpeg`.

## Confidence

95% — the v4.0.110 route already has tests; this PR adds the missing UI affordance + new tests pin the wire-up. Residual: file-size refresh (@magdalar's "Send to eReader size indicator" ask) is V2-track — separate endpoint that needs to stat() the on-disk file.

Addresses #218