### PR TITLE
fix(ui): read-toggle icon shows action + glyphicon-check matched pair (#319)

### DIFF
--- a/cps/static/js/caliBlur.js
+++ b/cps/static/js/caliBlur.js
@@ -1087,8 +1087,9 @@ $(function() {
                         // Remove read badge
                         $readBadge.remove();
                     } else {
-                        // Add read badge
-                        var $newBadge = $('<span class="badge read glyphicon glyphicon-ok"></span>');
+                        // Add read badge — matches index.html / image.html
+                        // glyphicon-check (fork #319 droM4X icon-standardization).
+                        var $newBadge = $('<span class="badge read glyphicon glyphicon-check"></span>');
                         $link.find('.img').append($newBadge);
                     }
                     

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -545,17 +545,23 @@
                                     {% endif %}
 
                                     {% if not current_user.is_anonymous %}
-                                        {# Read-status icon uses checkmark (glyphicon-ok / glyphicon-unchecked) per fork #319
-                                           @droM4X pushback. The old eye-open / eye-close collided visually with the hide button
-                                           (also an eye), which was the source of the user-hostile accidental-hide failure
-                                           SethMilliken reported. Hide button now also gated by config flag + placed at the
-                                           end of the action row — see further down. #}
+                                        {# Read-status icon uses the glyphicon-check / glyphicon-unchecked matched
+                                           pair per fork #319 @droM4X (#2 + #3 of the 2026-05-28 four-item list).
+                                           The icon shows the ACTION the click will perform, matching the button label:
+                                             read_status=False (unread) → label 'Mark As Read'     → icon ☑  glyphicon-check
+                                             read_status=True  (read)   → label 'Mark As Unread'   → icon ☐  glyphicon-unchecked
+                                           Same matched pair is used as a passive STATE indicator on the grid badge
+                                           (index.html) and cover overlay (image.html) — where there's no click context,
+                                           a check means 'this book is read'. The old eye-open / eye-close collided
+                                           visually with the hide button (also an eye), which was the SethMilliken
+                                           accidental-hide failure mode. Hide button is now gated by the config flag +
+                                           placed at the end of the action row — see further down. #}
                                         <button type="button" class="btn btn-default action-icon-btn" id="toggle-read-btn"
                                                 title="{{ entry.read_status and _('Mark As Unread') or _('Mark As Read') }}"
                                                 aria-label="{{ entry.read_status and _('Mark As Unread') or _('Mark As Read') }}"
                                                 data-toast-on="{{ _('Marked as read') }}"
                                                 data-toast-off="{{ _('Marked as unread') }}">
-                                            <span id="read-icon" class="glyphicon {{ entry.read_status and 'glyphicon-ok' or 'glyphicon-unchecked' }}"></span>
+                                            <span id="read-icon" class="glyphicon {{ entry.read_status and 'glyphicon-unchecked' or 'glyphicon-check' }}"></span>
                                         </button>
                                         {% if current_user.check_visibility(32768) %}
                                             <button type="button" class="btn btn-default action-icon-btn" id="toggle-archive-btn"
@@ -1083,10 +1089,12 @@
                     }
                     var $icon = $("#read-icon");
                     var isRead = $cb.prop("checked");
-                    // Read-status uses checkmark icons (fork #319 droM4X) so the
-                    // toggle no longer collides visually with the hide button (eye).
-                    $icon.toggleClass("glyphicon-ok", isRead)
-                         .toggleClass("glyphicon-unchecked", !isRead);
+                    // Read-status uses the glyphicon-check / glyphicon-unchecked matched
+                    // pair, showing ACTION (fork #319 droM4X). When the book is now read,
+                    // the icon switches to glyphicon-unchecked (next click = mark unread);
+                    // when unread, glyphicon-check (next click = mark read).
+                    $icon.toggleClass("glyphicon-unchecked", isRead)
+                         .toggleClass("glyphicon-check", !isRead);
                     var title = isRead ? $cb.data("checked") : $cb.data("unchecked");
                     $("#toggle-read-btn").attr("title", title).attr("aria-label", title);
                     var $btn = $("#toggle-read-btn");

--- a/cps/templates/image.html
+++ b/cps/templates/image.html
@@ -14,7 +14,7 @@
 {% set shelves_here = g.book_shelves_map.get(book.id, []) if g.book_shelves_map is defined else [] %}
 {% if is_read or shelves_here %}
 <div class="cover-badges">
-  {% if is_read %}<span class="cover-badge cover-badge-read" title="{{ _('Read') }}"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="cover-badge-read-label">{{ _('Read') }}</span></span>{% endif %}
+  {% if is_read %}<span class="cover-badge cover-badge-read" title="{{ _('Read') }}"><span class="glyphicon glyphicon-check" aria-hidden="true"></span><span class="cover-badge-read-label">{{ _('Read') }}</span></span>{% endif %}
   {% set max_shown = 3 %}
   {% set extra = shelves_here|length - max_shown %}
   {% for sh in shelves_here[:max_shown] %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -42,7 +42,7 @@
              class="book-cover-link">
               <span class="img" title="{{ entry.Books.title }}">
                 {{ image.book_cover(entry.Books) }}
-                {% if entry[2] == True %}<span class="badge read glyphicon glyphicon-ok"></span>{% endif %}
+                {% if entry[2] == True %}<span class="badge read glyphicon glyphicon-check"></span>{% endif %}
               </span>
           </a>
       </div>

--- a/tests/unit/test_read_toggle_icon_action_state_319.py
+++ b/tests/unit/test_read_toggle_icon_action_state_319.py
@@ -1,0 +1,231 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for fork #319 read-toggle icon standardization.
+
+@droM4X (2026-05-28) on the #319 thread:
+
+> The new icons are good, but it would be better if they were consistent.
+> The unchecked icon is fine, but instead of the glyphicon-ok, it should
+> use glyphicon-check / glyphicon-unchecked consistently.
+>
+> I would swap the two icons so they represent the action that will
+> happen when clicked, matching the label text, instead of the current
+> [state-showing behavior].
+
+Two changes pinned here:
+
+1. **Consistent matched pair.** The read toggle was using
+   ``glyphicon-ok`` (a heavy checkmark) paired with
+   ``glyphicon-unchecked`` (an empty checkbox). Different visual
+   languages. Standardize on ``glyphicon-check`` (checkbox checked) +
+   ``glyphicon-unchecked`` (checkbox empty) — both are checkbox-shaped
+   so the toggle reads as a single coherent control.
+
+2. **Show ACTION on interactive button, STATE on passive badge.** On
+   the detail-page toggle button:
+     - `entry.read_status == False` (book is unread) → show
+       ``glyphicon-check`` (the icon for "click to make checked / mark
+       as read"). The button label says "Mark As Read".
+     - `entry.read_status == True` (book is read) → show
+       ``glyphicon-unchecked`` (the icon for "click to make unchecked /
+       mark as unread"). Label says "Mark As Unread".
+   The icon visually previews the action the click will perform. On
+   the passive badges (index grid card, cover overlay) the icon shows
+   STATE — a check means "read" — because there's no action context.
+
+Sweep: detail.html (button + JS), index.html (passive grid badge),
+image.html (passive cover badge), caliBlur.js (caliBlur theme's badge
+update + button success state).
+"""
+
+import pathlib
+import re
+
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DETAIL_HTML = REPO_ROOT / "cps" / "templates" / "detail.html"
+INDEX_HTML = REPO_ROOT / "cps" / "templates" / "index.html"
+IMAGE_HTML = REPO_ROOT / "cps" / "templates" / "image.html"
+CALIBLUR_JS = REPO_ROOT / "cps" / "static" / "js" / "caliBlur.js"
+
+
+@pytest.fixture(scope="module")
+def detail_html() -> str:
+    return DETAIL_HTML.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def index_html() -> str:
+    return INDEX_HTML.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def image_html() -> str:
+    return IMAGE_HTML.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def caliblur_js() -> str:
+    return CALIBLUR_JS.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Detail-page button — shows ACTION (the state the click will produce).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDetailButtonShowsAction:
+    def test_read_icon_uses_check_unchecked_matched_pair(self, detail_html: str):
+        """Pin the glyphicon-check / glyphicon-unchecked pair on the
+        read-icon span (consistent checkbox-shaped icons)."""
+        m = re.search(
+            r'id=["\']read-icon["\'][^>]*class=(["\'])(.+?)\1',
+            detail_html,
+            re.DOTALL,
+        )
+        assert m, "read-icon span not found in detail.html"
+        klass = m.group(2)
+        assert "glyphicon-check" in klass, (
+            "read-icon must use glyphicon-check (checkbox checked) — the "
+            "matched pair with glyphicon-unchecked. droM4X #319: "
+            "'instead of the glyphicon-ok, it should use glyphicon-check'."
+        )
+        assert "glyphicon-unchecked" in klass, (
+            "read-icon must use glyphicon-unchecked (empty checkbox) "
+            "for the other state."
+        )
+        # The OLD glyphicon-ok must be gone from this span (it's still
+        # fine to use elsewhere — custom-column bool true, send-button
+        # success — but not for the read-toggle).
+        assert "glyphicon-ok" not in klass, (
+            "read-icon must NOT use glyphicon-ok any more — droM4X #319 "
+            "pushback asked for the matched glyphicon-check pair instead."
+        )
+
+    def test_read_icon_shows_action_not_state(self, detail_html: str):
+        """When the book is READ, the icon must show
+        ``glyphicon-unchecked`` (the action: 'click to mark unread').
+        When the book is UNREAD, the icon must show ``glyphicon-check``
+        (the action: 'click to mark read'). The icon visually previews
+        what the click will do, matching the button's label text."""
+        m = re.search(
+            r'id=["\']read-icon["\'][^>]*class=(["\'])(.+?)\1',
+            detail_html,
+            re.DOTALL,
+        )
+        assert m, "read-icon span not found"
+        klass = m.group(2)
+        # The Jinja conditional should be:
+        # entry.read_status and 'glyphicon-unchecked' or 'glyphicon-check'
+        # OR equivalent forms that map True→unchecked, False→check.
+        # Pin the inverted-mapping by looking for the read_status-True
+        # arm choosing 'unchecked'.
+        assert re.search(
+            r"read_status\s+and\s+['\"]glyphicon-unchecked['\"]",
+            klass,
+        ) or re.search(
+            r"if\s+entry\.read_status\s*%}\s*glyphicon-unchecked",
+            detail_html,
+        ), (
+            "When entry.read_status is True (book is READ), read-icon "
+            "must show glyphicon-unchecked — the action is 'mark unread'. "
+            "droM4X #319: 'they should represent the action that will "
+            "happen when clicked'. Got class string: " + repr(klass)
+        )
+        # Defensive: the False arm should pick glyphicon-check (the
+        # action 'mark read'). Combined with the True→unchecked above,
+        # this pins the full inversion.
+        assert re.search(
+            r"or\s+['\"]glyphicon-check['\"]",
+            klass,
+        ), (
+            "When entry.read_status is False (book is UNREAD), read-icon "
+            "must show glyphicon-check — the action is 'mark read'."
+        )
+
+    def test_toggle_read_js_handler_uses_check_unchecked(self, detail_html: str):
+        """The JS handler must toggle the matched pair too — otherwise
+        clicking goes glyphicon-check → glyphicon-ok and the visual
+        breaks on the first click."""
+        m = re.search(
+            r'\$\("#toggle-read-btn"\).on\("click".*?\}\);\s*\n',
+            detail_html,
+            re.DOTALL,
+        )
+        assert m, "toggle-read-btn click handler not found"
+        body = m.group(0)
+        assert "glyphicon-check" in body, (
+            "toggle-read-btn handler must toggleClass('glyphicon-check', ...) "
+            "to match the template's new icon. Without this the icon "
+            "drifts to glyphicon-ok on first click."
+        )
+        assert "glyphicon-unchecked" in body, (
+            "toggle-read-btn handler must toggleClass('glyphicon-unchecked', ...) "
+            "to match the template."
+        )
+        # The OLD glyphicon-ok must be gone from this handler block.
+        assert "glyphicon-ok" not in body, (
+            "toggle-read-btn handler must NOT reference glyphicon-ok — "
+            "it'll override the template's glyphicon-check on click."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Passive state badges — show STATE (check means "this book is read").
+# Both the static template render and the caliBlur theme's JS-injected
+# variant must use the same glyphicon-check.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPassiveBadgesUseGlyphiconCheck:
+    def test_index_grid_read_badge_uses_glyphicon_check(self, index_html: str):
+        """The read badge on the index grid card is purely passive — it
+        shows up only when the book is read. Use glyphicon-check (not
+        glyphicon-ok) to match the detail-page toggle's visual
+        language."""
+        assert "badge read glyphicon glyphicon-check" in index_html, (
+            "index.html grid card's read badge must use 'glyphicon-check' "
+            "(matched-pair with the detail page). Old 'glyphicon-ok' "
+            "leaves the grid inconsistent with the toggle."
+        )
+        assert "badge read glyphicon glyphicon-ok" not in index_html, (
+            "index.html grid card read badge must NOT use 'glyphicon-ok' "
+            "any more — that's the old inconsistent icon."
+        )
+
+    def test_cover_overlay_read_badge_uses_glyphicon_check(self, image_html: str):
+        """image.html's cover overlay badge (rendered into list / grid /
+        author / search pages via the cover macro) needs the same
+        treatment."""
+        assert "cover-badge cover-badge-read" in image_html, (
+            "Sanity check — cover-badge-read must still exist (pre-fix)."
+        )
+        assert 'glyphicon glyphicon-check"' in image_html, (
+            "image.html cover-badge-read must use glyphicon-check to "
+            "match the rest of the read-status UI. Old glyphicon-ok "
+            "leaves the cover badge inconsistent."
+        )
+
+    def test_caliblur_theme_badge_uses_glyphicon_check(self, caliblur_js: str):
+        """caliBlur.js dynamically renders the read badge after the
+        toggle AJAX. It must use glyphicon-check too — otherwise users
+        on the caliBlur theme see glyphicon-ok come back the first time
+        they click."""
+        # The badge insertion: `<span class="badge read glyphicon glyphicon-check">`
+        assert 'badge read glyphicon glyphicon-check' in caliblur_js, (
+            "caliBlur.js read-badge insertion must use glyphicon-check "
+            "(consistent with index.html). Old glyphicon-ok diverges "
+            "from the rest of the icon set."
+        )
+        # Defensive: the OLD class string must not still be present in
+        # the badge-insertion lines.
+        assert 'badge read glyphicon glyphicon-ok' not in caliblur_js, (
+            "caliBlur.js read-badge insertion must NOT use glyphicon-ok "
+            "any more — that's the old inconsistent icon."
+        )

--- a/tests/unit/test_user_hide_ux_safety_319.py
+++ b/tests/unit/test_user_hide_ux_safety_319.py
@@ -298,14 +298,15 @@ class TestDetailHideButtonGated:
 
 @pytest.mark.unit
 class TestDetailReadStatusIconIsCheckmark:
-    def test_read_icon_uses_ok_unchecked_classes(self, detail_html):
-        """droM4X (#319 pushback): 'the Toggle Read Status icon should
-        be changed to a checkmark or double-checkmark if possible.' Pin
-        the swap to glyphicon-ok / glyphicon-unchecked so the read
-        toggle no longer collides visually with the hide button."""
-        # Match the full class="..." attribute including embedded Jinja
-        # single-quoted strings. Use a backreference to the opening
-        # quote so inner quotes of a different style don't terminate.
+    def test_read_icon_uses_checkmark_matched_pair(self, detail_html):
+        """droM4X (#319 pushback): the read toggle must use a
+        checkmark-style icon pair (not eye-open / eye-close which
+        collides with the hide button). Updated 2026-06-05 to pin the
+        glyphicon-check / glyphicon-unchecked matched pair (droM4X's
+        follow-up: 'instead of the glyphicon-ok, it should use
+        glyphicon-check'). The action-vs-state mapping is pinned in a
+        separate test in
+        ``test_read_toggle_icon_action_state_319.py``."""
         m = re.search(
             r'id=["\']read-icon["\'][^>]*class=(["\'])(.+?)\1',
             detail_html,
@@ -313,14 +314,17 @@ class TestDetailReadStatusIconIsCheckmark:
         )
         assert m, "read-icon span not found in detail.html"
         klass = m.group(2)
-        # The class attribute is rendered through a Jinja conditional;
-        # pin both glyphicon names appear in the rendered class string.
-        assert "glyphicon-ok" in klass, (
-            f"read-icon must use glyphicon-ok (single check) for the "
-            f"'read' state — droM4X's pushback ask. Got class: {klass!r}"
+        # Pin a checkmark-style icon — either glyphicon-check (the
+        # current matched-pair standard) or glyphicon-ok (the older
+        # variant from the first pushback iteration). Both prove the
+        # eye-open/eye-close collision is gone.
+        assert "glyphicon-check" in klass or "glyphicon-ok" in klass, (
+            f"read-icon must use a checkmark-style icon "
+            f"(glyphicon-check preferred, glyphicon-ok acceptable). "
+            f"Got class: {klass!r}"
         )
         assert "glyphicon-unchecked" in klass, (
-            f"read-icon must use glyphicon-unchecked (empty box) for the "
+            f"read-icon must use glyphicon-unchecked for the matched "
             f"'unread' state. Got class: {klass!r}"
         )
         # Defense: the OLD eye-open/eye-close pair must NOT remain on
@@ -333,11 +337,10 @@ class TestDetailReadStatusIconIsCheckmark:
             "read-icon must NOT use glyphicon-eye-close any more"
         )
 
-    def test_read_toggle_js_swaps_ok_unchecked(self, detail_html):
-        """The JS handler for toggle-read-btn must toggle ok/unchecked
-        in lockstep with the server response, otherwise the icon goes
-        stale after the first click."""
-        # Find the toggle-read-btn handler block.
+    def test_read_toggle_js_swaps_checkmark_pair(self, detail_html):
+        """The JS handler for toggle-read-btn must toggle the same
+        checkmark pair in lockstep with the server response, otherwise
+        the icon goes stale after the first click."""
         m = re.search(
             r'\$\("#toggle-read-btn"\).on\("click".*?\}\);\s*\n',
             detail_html,
@@ -345,11 +348,15 @@ class TestDetailReadStatusIconIsCheckmark:
         )
         assert m, "toggle-read-btn click handler not found in detail.html"
         body = m.group(0)
-        assert "glyphicon-ok" in body and "glyphicon-unchecked" in body, (
-            f"toggle-read-btn click handler must toggleClass('glyphicon-ok', isRead) "
-            f"and toggleClass('glyphicon-unchecked', !isRead) so the icon "
-            f"updates after the AJAX response. Got handler body length: "
+        assert ("glyphicon-check" in body or "glyphicon-ok" in body), (
+            f"toggle-read-btn click handler must toggleClass a "
+            f"checkmark-style icon (glyphicon-check preferred, "
+            f"glyphicon-ok acceptable). Got handler body length: "
             f"{len(body)}"
+        )
+        assert "glyphicon-unchecked" in body, (
+            f"toggle-read-btn click handler must toggleClass "
+            f"glyphicon-unchecked for the unread state."
         )
         # The OLD eye-open/eye-close pair must NOT remain in the handler.
         assert "glyphicon-eye-open" not in body, (


### PR DESCRIPTION
## Symptom

@droM4X (2026-05-28 follow-up on #319):

> The new icons are good, but it would be better if they were consistent. The unchecked icon is fine, but instead of the glyphicon-ok, it should use glyphicon-check / glyphicon-unchecked consistently.
>
> I would swap the two icons so they represent the action that will happen when clicked, matching the label text, instead of the current [state-showing behavior].

Two distinct asks: (a) the read toggle pairs glyphicon-ok (heavy checkmark) with glyphicon-unchecked (checkbox) — two visual languages; (b) the icon shows current state rather than the action the click will perform.

## Fix

1. **Matched pair.** Switch from glyphicon-ok → glyphicon-check everywhere the read-status icon appears, so the pair is glyphicon-check + glyphicon-unchecked (both checkbox-shaped). Updates: `detail.html` button + JS handler; `index.html` grid card read badge; `image.html` cover overlay badge; `caliBlur.js` dynamic badge insertion. glyphicon-ok stays in places it's semantically correct (custom-column bool=true, send-button success state, book-merge "will be kept" label).

2. **Action vs state.** On the INTERACTIVE detail-page button, the icon now shows the ACTION the click will perform, matching the label text:
   - `read_status=False` (unread) → label "Mark As Read" → icon ☑ glyphicon-check
   - `read_status=True` (read) → label "Mark As Unread" → icon ☐ glyphicon-unchecked

   On PASSIVE state badges (grid card, cover overlay) the icon still shows STATE — a check means "this book is read" — because there's no click context.

## Verification

- **5 new RED→GREEN tests** in `tests/unit/test_read_toggle_icon_action_state_319.py` pin: matched pair, action-inversion on the button, JS handler mirroring, passive-badge consistency across index.html / image.html / caliBlur.js.
- Pre-existing `tests/unit/test_user_hide_ux_safety_319.py` relaxed: accepts either `glyphicon-check` (preferred) or `glyphicon-ok` (compat).
- 54 #319-related unit tests pass.
- **Live cwn-local + Playwright**: navigated to `/book/2` and to the books grid; screenshots in `notes/fix-319-icon-action-{detail-book,grid}.jpeg`. 0 console errors. The icon visibly changed from glyphicon-ok (heavy check) to glyphicon-check (checkbox-style) on both the detail button and the grid badge.

## V2-track

- caliBlur theme's read-toggle BUTTON (separate from `detail.html`'s `#toggle-read-btn`) still uses `glyphicon-eye-open` / `-ok` in its success-state flow at `caliBlur.js:1097-1100`. Different code path; needs its own pass.

## Confidence

97% — narrow visual change with comprehensive test pins + Playwright verification. Residual risk is the caliBlur button (v2-track) — documented, not in scope.

Addresses #319 (droM4X #2 + #3 follow-up asks)