### PR TITLE
fix(kobo): magic-shelf sub-cursor for shelves >= SYNC_ITEM_LIMIT (Greptile #366 P1)

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -211,6 +211,9 @@ def HandleSyncRequest():
         # keeping the two cursor components consistent makes the keyset
         # behavior easier to reason about for future readers.
         sync_token.books_last_id = -1
+        # Reset the magic-shelf sub-cursor too — a fresh-device sync
+        # should re-deliver every magic book.
+        sync_token.magic_shelf_last_id = -1
 
     new_books_last_modified = sync_token.books_last_modified  # needed for sync selected shelfs only
     new_books_last_created = sync_token.books_last_created  # needed to distinguish between new and changed entitlement
@@ -322,6 +325,20 @@ def HandleSyncRequest():
         and magic_shelf_membership_added_at > cursor_lm
     )
 
+    # Magic-shelf SUB-CURSOR: the bare `id IN magic_shelf_book_ids` arm is
+    # cursor-unaware — for magic shelves with >= SYNC_ITEM_LIMIT books, it
+    # emits the same first SYNC_ITEM_LIMIT ids every round (Greptile P1 on
+    # PR #366). Filtering `id > magic_shelf_last_id` walks the arm via a
+    # second-tier keyset across batches. The fold resets
+    # magic_shelf_last_id = -1 when it fires (cache.created_at is past
+    # cursor.lm only on cache rebuilds, so each rebuild starts the
+    # sub-cursor fresh).
+    magic_shelf_last_id = sync_token.magic_shelf_last_id
+    magic_shelf_arm = and_(
+        db.Books.id.in_(magic_shelf_book_ids),
+        db.Books.id > magic_shelf_last_id,
+    )
+
     # only_kobo_shelves branch joins BookShelf, so its inner filter includes
     # the BookShelf.date_added arm (fork #220) alongside the composite keyset
     # and (when active) the magic-shelf membership arm.
@@ -329,7 +346,7 @@ def HandleSyncRequest():
         inner_cursor_filter_with_bookshelf = or_(
             ub.BookShelf.date_added > cursor_lm,
             composite_keyset_books_only,
-            db.Books.id.in_(magic_shelf_book_ids),
+            magic_shelf_arm,
         )
     else:
         inner_cursor_filter_with_bookshelf = or_(
@@ -345,7 +362,7 @@ def HandleSyncRequest():
     if magic_shelf_arm_active:
         inner_cursor_filter_sync_all = or_(
             composite_keyset_books_only,
-            db.Books.id.in_(magic_shelf_book_ids),
+            magic_shelf_arm,
         )
     else:
         inner_cursor_filter_sync_all = composite_keyset_books_only
@@ -472,6 +489,20 @@ def HandleSyncRequest():
         new_books_last_created = max(ts_created, new_books_last_created)
         kobo_sync_status.add_synced_books(book.Books.id)
 
+    # Magic-shelf sub-cursor: advance to the highest magic-shelf book id
+    # emitted this round. magic_shelf_book_ids may be empty when the arm
+    # wasn't active, in which case the comprehension is empty and we keep
+    # the existing sub-cursor unchanged.
+    magic_book_ids_emitted = [
+        b.Books.id for b in books_list
+        if magic_shelf_book_ids and b.Books.id in magic_shelf_book_ids
+    ]
+    if magic_book_ids_emitted:
+        new_magic_shelf_last_id = max(sync_token.magic_shelf_last_id,
+                                       max(magic_book_ids_emitted))
+    else:
+        new_magic_shelf_last_id = sync_token.magic_shelf_last_id
+
     # Composite-keyset cursor: keep books_last_id aligned with new_books_last_modified.
     # The query ORDER BY (last_modified, id) means books_list iteration is sorted, so
     # the last emitted row is the highest (last_modified, id) tuple in the batch.
@@ -518,10 +549,15 @@ def HandleSyncRequest():
         if magic_shelf_membership_added_at > new_books_last_modified:
             new_books_last_modified = magic_shelf_membership_added_at
             new_books_last_id = -1
+            # Cache-rebuild epoch closed — reset the sub-cursor so the next
+            # rebuild (which advances cache.created_at > cursor.lm again)
+            # starts walking the magic books from id=0.
+            new_magic_shelf_last_id = -1
         elif magic_shelf_membership_added_at == new_books_last_modified and not books_list:
             # Cache rebuilt but no books actually changed past the old cursor — still
             # advance to prevent the arm from firing again (idempotent re-trigger).
             new_books_last_id = -1
+            new_magic_shelf_last_id = -1
 
     max_change = changed_entries.filter(ub.ArchivedBook.is_archived)\
         .filter(ub.ArchivedBook.user_id == current_user.id) \
@@ -691,6 +727,7 @@ def HandleSyncRequest():
         sync_token.books_last_created = new_books_last_created
     sync_token.books_last_modified = new_books_last_modified
     sync_token.books_last_id = new_books_last_id
+    sync_token.magic_shelf_last_id = new_magic_shelf_last_id
     sync_token.archive_last_modified = new_archived_last_modified
     sync_token.reading_state_last_modified = new_reading_state_last_modified
 

--- a/cps/services/SyncToken.py
+++ b/cps/services/SyncToken.py
@@ -49,10 +49,16 @@ class SyncToken:
             last_modified (e.g. a bulk import). Default -1 means "no tiebreaker"; any valid book
             id is > -1, so old tokens still see every book at exactly books_last_modified on the
             first post-upgrade sync.
+        magic_shelf_last_id: Sub-cursor for the magic-shelf membership arm — the last Books.id
+            emitted via that arm in the current cache-rebuild epoch. Pagination through magic
+            shelves with > SYNC_ITEM_LIMIT books otherwise looped forever because the arm
+            (id IN magic_shelf_book_ids) is cursor-unaware and emits the same first
+            SYNC_ITEM_LIMIT ids every round. Default -1; reset to -1 whenever the fold fires
+            (cursor advances past T_magic) so the next cache rebuild starts fresh.
     """
 
     SYNC_TOKEN_HEADER = "x-kobo-synctoken"  # nosec
-    VERSION = "1-2-0"
+    VERSION = "1-3-0"
     LAST_MODIFIED_ADDED_VERSION = "1-1-0"
     MIN_VERSION = "1-0-0"
 
@@ -74,6 +80,7 @@ class SyncToken:
             "reading_state_last_modified": {"type": "number"},
             "tags_last_modified": {"type": "number"},
             "books_last_id": {"type": "integer"},
+            "magic_shelf_last_id": {"type": "integer"},
         },
     }
 
@@ -86,6 +93,7 @@ class SyncToken:
         reading_state_last_modified=datetime.min,
         tags_last_modified=datetime.min,
         books_last_id=-1,
+        magic_shelf_last_id=-1,
     ):  # nosec
         self.raw_kobo_store_token = raw_kobo_store_token
         self.books_last_created = books_last_created
@@ -94,6 +102,7 @@ class SyncToken:
         self.reading_state_last_modified = reading_state_last_modified
         self.tags_last_modified = tags_last_modified
         self.books_last_id = books_last_id
+        self.magic_shelf_last_id = magic_shelf_last_id
 
     @staticmethod
     def from_headers(headers):
@@ -135,6 +144,10 @@ class SyncToken:
         if not isinstance(books_last_id, int):
             books_last_id = -1
 
+        magic_shelf_last_id = data_json.get("magic_shelf_last_id", -1)
+        if not isinstance(magic_shelf_last_id, int):
+            magic_shelf_last_id = -1
+
         return SyncToken(
             raw_kobo_store_token=raw_kobo_store_token,
             books_last_created=books_last_created,
@@ -143,6 +156,7 @@ class SyncToken:
             reading_state_last_modified=reading_state_last_modified,
             tags_last_modified=tags_last_modified,
             books_last_id=books_last_id,
+            magic_shelf_last_id=magic_shelf_last_id,
         )
 
     def set_kobo_store_header(self, store_headers):
@@ -167,15 +181,17 @@ class SyncToken:
                 "reading_state_last_modified": to_epoch_timestamp(self.reading_state_last_modified),
                 "tags_last_modified": to_epoch_timestamp(self.tags_last_modified),
                 "books_last_id": self.books_last_id,
+                "magic_shelf_last_id": self.magic_shelf_last_id,
             },
         }
         return b64encode_json(token)
 
     def __str__(self):
-        return "{},{},{},{},{},{},{}".format(self.books_last_created,
-                                             self.books_last_modified,
-                                             self.archive_last_modified,
-                                             self.reading_state_last_modified,
-                                             self.tags_last_modified,
-                                             self.books_last_id,
-                                             self.raw_kobo_store_token)
+        return "{},{},{},{},{},{},{},{}".format(self.books_last_created,
+                                                self.books_last_modified,
+                                                self.archive_last_modified,
+                                                self.reading_state_last_modified,
+                                                self.tags_last_modified,
+                                                self.books_last_id,
+                                                self.magic_shelf_last_id,
+                                                self.raw_kobo_store_token)

--- a/tests/unit/test_kobo_magic_shelf_sub_cursor_large_shelves.py
+++ b/tests/unit/test_kobo_magic_shelf_sub_cursor_large_shelves.py
@@ -1,0 +1,288 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for the Greptile-surfaced infinite-loop bug on
+PR #366: magic-shelf arm is cursor-unaware for shelves with
+``>= SYNC_ITEM_LIMIT`` books, so the same first SYNC_ITEM_LIMIT ids
+re-emit forever once the natural cursor is past them.
+
+Greptile's analysis on PR #366:
+
+> When ``len(magic_shelf_book_ids) >= SYNC_ITEM_LIMIT`` (100), the
+> deferred fold never fires. The ``id IN magic_shelf_book_ids`` arm
+> unconditionally re-introduces all magic books on every round
+> regardless of cursor position. With N=200 magic books at T_bulk:
+> Round 1 delivers ids 1–100 (lm-ordered), cursor advances to
+> ``(T_bulk, 100)``. Round 2 sees ``id IN (1…200)`` OR
+> ``lm=T_bulk AND id>100`` → 200 books total → ORDER BY (lm, id) →
+> LIMIT 100 yields ids 1–100 *again*. ``batch_drained = False`` every
+> round; cursor never changes; ``cont_sync = True`` forever.
+
+Fix: add a ``magic_shelf_last_id`` sub-cursor to ``SyncToken``
+(VERSION 1-2-0 → 1-3-0). The arm becomes::
+
+    Books.id IN magic_shelf_book_ids AND Books.id > magic_shelf_last_id
+
+After each batch, advance ``magic_shelf_last_id`` to the max id of
+magic-shelf books emitted. When the fold fires (cache.created_at
+window closes), reset ``magic_shelf_last_id = -1`` so the next cache
+rebuild starts walking the arm from id=0.
+"""
+
+import ast
+import pathlib
+import sqlite3
+
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+KOBO_PY = REPO_ROOT / "cps" / "kobo.py"
+
+
+def _function_source(path: pathlib.Path, name: str) -> str:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    fn = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == name),
+        None,
+    )
+    assert fn is not None, f"{name} function not found in {path}"
+    return ast.unparse(fn)
+
+
+SYNC_ITEM_LIMIT = 100
+
+
+@pytest.mark.unit
+class TestMagicShelfArmHasIdCursor:
+    def test_arm_includes_id_greater_than_magic_shelf_last_id(self):
+        """The magic-shelf arm must include ``Books.id > magic_shelf_last_id``
+        in addition to ``Books.id IN magic_shelf_book_ids``. The bare
+        membership check is cursor-unaware and re-emits the same first
+        SYNC_ITEM_LIMIT ids forever (Greptile P1 on PR #366)."""
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        # The arm is now constructed once as a named `magic_shelf_arm`
+        # filter that combines the membership check with the sub-cursor.
+        assert "magic_shelf_arm" in src, (
+            "HandleSyncRequest must build a named 'magic_shelf_arm' "
+            "filter combining the membership check with the sub-cursor."
+        )
+        assert "db.Books.id > magic_shelf_last_id" in src, (
+            "magic-shelf arm must filter `Books.id > magic_shelf_last_id` "
+            "to walk through magic books across batches. Without it, "
+            "shelves with >= SYNC_ITEM_LIMIT books re-emit the same "
+            "first SYNC_ITEM_LIMIT ids forever (Greptile #366 P1)."
+        )
+
+    def test_sub_cursor_sourced_from_sync_token(self):
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        assert "magic_shelf_last_id = sync_token.magic_shelf_last_id" in src, (
+            "magic_shelf_last_id local must be sourced from "
+            "sync_token.magic_shelf_last_id at the top of HandleSyncRequest."
+        )
+
+
+@pytest.mark.unit
+class TestSubCursorAdvanceAndReset:
+    def test_new_magic_shelf_last_id_computed_from_batch(self):
+        """After the batch loop, the new sub-cursor must advance to the
+        highest magic-shelf book id emitted."""
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        assert "new_magic_shelf_last_id" in src, (
+            "HandleSyncRequest must compute a new_magic_shelf_last_id "
+            "for the sub-cursor advance."
+        )
+        # Walking via `max(... for b in books_list if b.Books.id in magic_shelf_book_ids)`
+        # is one acceptable shape; another is collecting into a list. Both
+        # must reference `magic_shelf_book_ids` in the comprehension/filter.
+        assert "magic_shelf_book_ids" in src
+
+    def test_fold_resets_sub_cursor_to_minus_one(self):
+        """When the fold fires (cursor advances past T_magic), the
+        sub-cursor must reset so the next cache rebuild starts fresh."""
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        assert "new_magic_shelf_last_id = -1" in src, (
+            "The fold's `new_books_last_modified = T_magic` branch must "
+            "also reset `new_magic_shelf_last_id = -1` so the next "
+            "cache rebuild walks magic books from id=0 again."
+        )
+
+    def test_sync_token_writes_magic_shelf_last_id(self):
+        src = _function_source(KOBO_PY, "HandleSyncRequest")
+        assert "sync_token.magic_shelf_last_id = new_magic_shelf_last_id" in src, (
+            "HandleSyncRequest must write the updated sub-cursor back to "
+            "sync_token at the end of the request."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavioral test against a real SQLite engine — the 200-book magic shelf
+# scenario that Greptile flagged. PRE-FIX: infinite loop. POST-FIX: every
+# book delivers exactly once.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSubCursorAlgorithm:
+    @staticmethod
+    def _seed_large_magic_shelf(magic_count, regular_count=0):
+        """Seed a magic shelf with `magic_count` books + optionally
+        `regular_count` regular books. All books share one timestamp."""
+        con = sqlite3.connect(":memory:")
+        con.execute("CREATE TABLE books (id INTEGER PRIMARY KEY, last_modified TEXT NOT NULL)")
+        T_BULK = "2021-03-29 13:31:44.163290"
+        magic_ids = set(range(1, magic_count + 1))
+        for i in magic_ids:
+            con.execute("INSERT INTO books (id, last_modified) VALUES (?, ?)", (i, T_BULK))
+        for i in range(magic_count + 1, magic_count + regular_count + 1):
+            con.execute("INSERT INTO books (id, last_modified) VALUES (?, ?)", (i, T_BULK))
+        con.commit()
+        return con, magic_ids
+
+    @staticmethod
+    def _drive_pre_subcursor(con, magic_ids, T_magic, limit=SYNC_ITEM_LIMIT, max_rounds=10):
+        """The PRE-FIX shape (PR #366 v4.0.152): magic-shelf arm has no
+        id-cursor. For >= limit magic books, this loops forever."""
+        cursor_ts = "0000-00-00 00:00:00.000000"
+        cursor_id = -1
+        synced, rounds = [], 0
+        magic_set_clause = "(" + ",".join(str(i) for i in sorted(magic_ids)) + ")"
+        while rounds < max_rounds:
+            rounds += 1
+            arm_active = T_magic > cursor_ts
+            if arm_active:
+                where = (
+                    f"last_modified > ? "
+                    f"OR (last_modified = ? AND id > ?) "
+                    f"OR id IN {magic_set_clause}"
+                )
+            else:
+                where = "last_modified > ? OR (last_modified = ? AND id > ?)"
+            batch = con.execute(
+                f"SELECT id, last_modified FROM books WHERE {where} "
+                f"ORDER BY last_modified, id LIMIT ?",
+                (cursor_ts, cursor_ts, cursor_id, limit)).fetchall()
+            if not batch:
+                break
+            synced.extend(r[0] for r in batch)
+            last_id, last_ts = batch[-1][0], batch[-1][1]
+            new_ts = last_ts
+            new_id = last_id
+            batch_drained = len(batch) < limit
+            if arm_active and batch_drained and T_magic > new_ts:
+                new_ts = T_magic
+                new_id = -1
+            cursor_ts, cursor_id = new_ts, new_id
+            if len(batch) < limit:
+                break
+        return synced, rounds
+
+    @staticmethod
+    def _drive_post_subcursor(con, magic_ids, T_magic, limit=SYNC_ITEM_LIMIT, max_rounds=10):
+        """The POST-FIX shape (v4.0.153): magic-shelf arm has the
+        sub-cursor `AND id > magic_shelf_last_id`. Walks magic shelves
+        of any size."""
+        cursor_ts = "0000-00-00 00:00:00.000000"
+        cursor_id = -1
+        magic_shelf_last_id = -1
+        synced, rounds = [], 0
+        magic_set_clause = "(" + ",".join(str(i) for i in sorted(magic_ids)) + ")"
+        while rounds < max_rounds:
+            rounds += 1
+            arm_active = T_magic > cursor_ts
+            if arm_active:
+                where = (
+                    f"last_modified > ? "
+                    f"OR (last_modified = ? AND id > ?) "
+                    f"OR (id IN {magic_set_clause} AND id > ?)"
+                )
+                params = (cursor_ts, cursor_ts, cursor_id, magic_shelf_last_id, limit)
+            else:
+                where = "last_modified > ? OR (last_modified = ? AND id > ?)"
+                params = (cursor_ts, cursor_ts, cursor_id, limit)
+            batch = con.execute(
+                f"SELECT id, last_modified FROM books WHERE {where} "
+                f"ORDER BY last_modified, id LIMIT ?", params).fetchall()
+            if not batch:
+                break
+            synced.extend(r[0] for r in batch)
+            last_id, last_ts = batch[-1][0], batch[-1][1]
+            new_ts = last_ts
+            new_id = last_id
+            # Advance sub-cursor by max magic-shelf book id in batch
+            magic_in_batch = [r[0] for r in batch if r[0] in magic_ids]
+            new_magic_shelf_last_id = (
+                max(magic_shelf_last_id, max(magic_in_batch))
+                if magic_in_batch else magic_shelf_last_id
+            )
+            batch_drained = len(batch) < limit
+            if arm_active and batch_drained and T_magic > new_ts:
+                new_ts = T_magic
+                new_id = -1
+                new_magic_shelf_last_id = -1
+            cursor_ts, cursor_id = new_ts, new_id
+            magic_shelf_last_id = new_magic_shelf_last_id
+            if len(batch) < limit:
+                break
+        return synced, rounds
+
+    def test_pre_subcursor_loops_forever_on_large_magic_shelf(self):
+        """Pin Greptile's exact scenario: 200 magic books, no regulars.
+        The pre-fix algorithm re-emits ids 1-100 every round."""
+        con, magic_ids = self._seed_large_magic_shelf(magic_count=200)
+        T_MAGIC = "9999-12-31 23:59:59.999999"
+        synced, rounds = self._drive_pre_subcursor(con, magic_ids, T_MAGIC, max_rounds=5)
+        con.close()
+        # We capped at max_rounds=5 so the loop terminates artificially;
+        # without the cap it'd loop forever. Check that the same 100 ids
+        # repeat across at least 2 rounds — the signature of the bug.
+        first_round = synced[:100]
+        second_round = synced[100:200]
+        assert first_round == second_round, (
+            f"Pre-subcursor bug: round 2 emits the SAME 100 books as "
+            f"round 1 (Greptile #366 P1). round1={first_round[:5]}..., "
+            f"round2={second_round[:5]}..."
+        )
+        # Books 101-200 are never delivered with the buggy algorithm.
+        delivered = set(synced)
+        missing = set(range(101, 201)) - delivered
+        assert len(missing) == 100, (
+            f"Pre-subcursor must miss books 101-200, got "
+            f"{100 - len(missing)} of them delivered."
+        )
+
+    def test_post_subcursor_delivers_every_book_in_large_shelf(self):
+        """Pin the FIX: with the sub-cursor, all 200 magic books deliver
+        in 3 rounds (200 / 100 + final fold-fire round)."""
+        con, magic_ids = self._seed_large_magic_shelf(magic_count=200)
+        T_MAGIC = "9999-12-31 23:59:59.999999"
+        synced, rounds = self._drive_post_subcursor(con, magic_ids, T_MAGIC, max_rounds=10)
+        con.close()
+        delivered = set(synced)
+        assert delivered == set(range(1, 201)), (
+            f"Post-subcursor must deliver all 200 magic books exactly "
+            f"once. Got {len(delivered)} distinct, "
+            f"missing={sorted(set(range(1, 201)) - delivered)[:10]}..."
+        )
+        assert rounds <= 4, (
+            f"Should terminate in <=4 rounds (200/100 batches + fold), "
+            f"got {rounds}"
+        )
+
+    def test_post_subcursor_handles_mixed_large_library(self):
+        """Greptile's exact scenario but scaled: 200 magic books + 100
+        regular books. All must deliver."""
+        con, magic_ids = self._seed_large_magic_shelf(
+            magic_count=200, regular_count=100,
+        )
+        T_MAGIC = "9999-12-31 23:59:59.999999"
+        synced, rounds = self._drive_post_subcursor(con, magic_ids, T_MAGIC, max_rounds=10)
+        con.close()
+        delivered = set(synced)
+        assert delivered == set(range(1, 301)), (
+            f"Post-subcursor must deliver all 300 books (200 magic + 100 "
+            f"regular). Missing: "
+            f"{sorted(set(range(1, 301)) - delivered)[:10]}..."
+        )

--- a/tests/unit/test_kobo_synctoken_books_last_id.py
+++ b/tests/unit/test_kobo_synctoken_books_last_id.py
@@ -124,9 +124,13 @@ class TestSyncTokenBackwardCompat:
 
 @pytest.mark.unit
 class TestSyncTokenVersion:
-    def test_version_advanced_to_one_two_zero(self):
-        assert SyncToken.VERSION == "1-2-0", (
-            "VERSION bumped because the wire data schema gained books_last_id."
+    def test_version_is_one_dash_three_zero_or_greater(self):
+        """VERSION advanced 1-2-0 → 1-3-0 when the schema gained
+        magic_shelf_last_id (fork #359 v4.0.153 follow-up).
+        Accept >= 1-3-0 so this test doesn't go red on the next bump."""
+        v = SyncToken.VERSION
+        assert v >= "1-3-0", (
+            f"VERSION must be >= 1-3-0 (added magic_shelf_last_id), got {v}"
         )
 
     def test_min_version_unchanged_at_one_zero_zero(self):
@@ -139,9 +143,52 @@ class TestSyncTokenVersion:
     def test_token_built_carries_advanced_version(self):
         encoded = SyncToken().build_sync_token()
         wrapper = json.loads(base64.b64decode(encoded + "=" * (-len(encoded) % 4)))
-        assert wrapper["version"] == "1-2-0"
+        assert wrapper["version"] >= "1-3-0"
 
     def test_books_last_id_present_in_built_data_payload(self):
         encoded = SyncToken(books_last_id=99).build_sync_token()
         wrapper = json.loads(base64.b64decode(encoded + "=" * (-len(encoded) % 4)))
         assert wrapper["data"]["books_last_id"] == 99
+
+
+@pytest.mark.unit
+class TestSyncTokenMagicShelfLastId:
+    def test_field_defaults_to_minus_one(self):
+        assert SyncToken().magic_shelf_last_id == -1
+
+    def test_round_trip_through_build_and_from_headers(self):
+        original = SyncToken(magic_shelf_last_id=987)
+        encoded = original.build_sync_token()
+        rehydrated = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: encoded})
+        assert rehydrated.magic_shelf_last_id == 987
+
+    def test_old_token_missing_magic_shelf_last_id_defaults_to_minus_one(self):
+        encoded = _encode({
+            "version": "1-2-0",
+            "data": {
+                "raw_kobo_store_token": "",
+                "books_last_modified": 0,
+                "books_last_id": 42,
+                # no magic_shelf_last_id — pre-1-3-0 token shape
+            },
+        })
+        token = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: encoded})
+        assert token.magic_shelf_last_id == -1
+        assert token.books_last_id == 42
+
+    def test_garbage_magic_shelf_last_id_defaults_to_minus_one(self):
+        encoded = _encode({
+            "version": SyncToken.VERSION,
+            "data": {
+                "raw_kobo_store_token": "",
+                "books_last_modified": 0,
+                "magic_shelf_last_id": "not-an-int",
+            },
+        })
+        token = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: encoded})
+        assert token.magic_shelf_last_id == -1
+
+    def test_present_in_built_data_payload(self):
+        encoded = SyncToken(magic_shelf_last_id=555).build_sync_token()
+        wrapper = json.loads(base64.b64decode(encoded + "=" * (-len(encoded) % 4)))
+        assert wrapper["data"]["magic_shelf_last_id"] == 555


### PR DESCRIPTION
## Symptom

Greptile follow-up review on PR #366 surfaced a real correctness bug in v4.0.152's `batch_drained`-gated fold: when `len(magic_shelf_book_ids) >= SYNC_ITEM_LIMIT` (100), the deferred fold never fires. The bare `id IN magic_shelf_book_ids` arm is cursor-unaware — it unconditionally re-introduces ALL magic books on every round regardless of cursor position.

**Concrete failure (Greptile's scenario):** 200 magic books at one T_bulk. Round 1 emits ids 1-100; cursor → (T_bulk, 100). Round 2 query is `(lm > T_bulk) OR (lm == T_bulk AND id > 100) OR (id IN {1..200})` → matches 200 → ORDER BY (lm, id) LIMIT 100 yields ids 1-100 AGAIN. `batch_drained = False` every round; cursor never changes; `cont_sync = True` forever.

## Fix

Add a magic-shelf sub-cursor. New SyncToken field `magic_shelf_last_id` (default -1; VERSION 1-2-0 → 1-3-0; MIN_VERSION unchanged for backward-compat). The arm becomes:

```python
Books.id IN magic_shelf_book_ids AND Books.id > magic_shelf_last_id
```

After each batch, advance `magic_shelf_last_id` to the max id of magic-shelf books emitted. When the fold fires (cursor advances past T_magic — cache.created_at window closed), reset `magic_shelf_last_id = -1` so the next cache rebuild starts walking the arm from id=0.

With the fix on Greptile's scenario:
- Round 1: emits ids 1-100; cursor → (T_bulk, 100); `magic_shelf_last_id → 100`
- Round 2: `... OR (id IN {1..200} AND id > 100)` → matches ids 101-200; cursor → (T_bulk, 200); `magic_shelf_last_id → 200`
- Round 3: arm matches nothing (no ids > 200 in set); composite returns nothing. `batch_drained = True`. fold fires. cursor → T_magic; `magic_shelf_last_id → -1`. Termination achieved.

## Verification

- **8 new RED→GREEN tests** in `tests/unit/test_kobo_magic_shelf_sub_cursor_large_shelves.py`: AST pins for the new arm shape + sub-cursor source + advance + reset + write back to token; behavioral SQLite test reproducing PRE-FIX infinite loop (200 magic books, round 1 == round 2 output) and POST-FIX correctness (all 200 deliver in ≤4 rounds; mixed 200 magic + 100 regular delivers all 300).
- **5 new tests** in `tests/unit/test_kobo_synctoken_books_last_id.py` for `magic_shelf_last_id` — default, round-trip, pre-1-3-0 token backward-compat, garbage-input defaults, presence in built data payload. VERSION pin relaxed to >= 1-3-0.
- **447 Kobo+sync unit tests pass.**
- **Live cwn-local**: VERSION = 1-3-0, magic_shelf_last_id default = -1, all 4 runtime markers present; HTTP /v1/library/sync returns 200 with v1-3-0 token shape; decoded data carries `magic_shelf_last_id: -1` alongside the other fields.

## Confidence

97% — Greptile's exact scenario reproduced PRE-FIX (infinite loop) and proven GREEN POST-FIX. Wire-format change is backward-compatible (default -1, pre-1-3-0 tokens parse cleanly).

Addresses Greptile PR #366 P1 (infinite loop on large magic shelves)