### PR TITLE
fix(kobo): honor per-shelf magic-shelf Kobo intent — kill the global-flag trap

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -7,6 +7,7 @@
 # See CONTRIBUTORS for full list of authors.
 
 import base64
+import logging
 from datetime import datetime, timezone
 from cps import cw_babel
 from kobo_sync_utils import get_kobo_created_ts
@@ -136,6 +137,19 @@ def convert_to_kobo_timestamp_string(timestamp):
 
 def get_magic_shelf_book_ids_for_kobo(user_id):
     if not config.config_kobo_sync_magic_shelves:
+        # Per-shelf kobo_sync intent with the global flag off is the #359
+        # trap — surface it in debug logs so support can spot it instantly.
+        # (A one-time boot migration enables the global flag where intent
+        # already exists; this log covers shelves marked afterwards, e.g.
+        # via API, while the flag is deliberately off.)
+        if log.isEnabledFor(logging.DEBUG):
+            swallowed = ub.session.query(ub.MagicShelf).filter_by(
+                user_id=user_id, kobo_sync=True).count()
+            if swallowed:
+                log.debug(
+                    "Kobo Sync: %s magic shelves are marked kobo_sync but the "
+                    "global 'Sync Magic Shelves to Kobo' setting is off — not "
+                    "delivering (#359)", swallowed)
         return set()
 
     magic_shelves = ub.session.query(ub.MagicShelf).filter_by(user_id=user_id, kobo_sync=True).all()

--- a/cps/templates/magic_shelf_edit.html
+++ b/cps/templates/magic_shelf_edit.html
@@ -385,10 +385,14 @@ div.help-panel > .panel-body {
                     <!-- Kobo Sync Checkbox -->
                     <div class="form-group" style="background: #21252b; padding: 2rem; padding-inline: 4rem; border-radius: 4px;">
                         <label>
-                            <input style="margin-right: 2rem !important;" type="checkbox" id="shelf-kobo-sync" {{ 'checked' if shelf and shelf.kobo_sync else '' }}>
+                            <input style="margin-right: 2rem !important;" type="checkbox" id="shelf-kobo-sync" {{ 'checked' if shelf and shelf.kobo_sync else '' }} {{ 'disabled' if not kobo_magic_sync_enabled else '' }}>
                             Enable Kobo sync (shelf appears on Kobo devices)
                         </label>
+                        {% if not kobo_magic_sync_enabled %}
+                        <small class="form-text" style="color: #e2b93d;">Turn on “Sync Magic Shelves to Kobo” in CWA Settings first — until then this checkbox has no effect and the shelf won't reach your Kobo.</small>
+                        {% else %}
                         <small class="form-text text-muted">Only works if Kobo integration is enabled</small>
+                        {% endif %}
                     </div>
 
                     {% if opds_expose_enabled %}

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1886,6 +1886,11 @@ def migrate_kobo_magic_shelf_intent(engine, _session):
     if os.path.isfile(marker_path):
         return
 
+    def _write_marker():
+        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+        with open(marker_path, "w", encoding="utf-8") as fh:
+            fh.write(datetime.now(timezone.utc).isoformat())
+
     try:
         with engine.connect() as conn:
             intent = conn.execute(text(
@@ -1897,6 +1902,22 @@ def migrate_kobo_magic_shelf_intent(engine, _session):
                     "WHERE config_kobo_sync_magic_shelves = 0 "
                     "   OR config_kobo_sync_magic_shelves IS NULL"
                 ))
+                # Marker BEFORE commit: the flip and its never-again guard
+                # must land together. If the marker can't be written (e.g.
+                # read-only /config), abort WITHOUT committing — flipping
+                # while unable to record it would re-override a deliberate
+                # admin disable on every subsequent boot (Greptile P1 on
+                # PR #372). Not flipping is the safe failure: the gated
+                # checkbox UI tells users how to enable the setting manually.
+                try:
+                    _write_marker()
+                except OSError as e:
+                    log.warning(
+                        "[kobo-magic-shelf-intent-migration] marker %s not "
+                        "writable (%s) — NOT applying the flag flip; will "
+                        "retry next boot.", marker_path, e,
+                    )
+                    return  # no commit → UPDATE rolls back with the connection
                 conn.commit()
                 if getattr(flipped, "rowcount", 0):
                     log.info(
@@ -1906,6 +1927,7 @@ def migrate_kobo_magic_shelf_intent(engine, _session):
                         "existing per-shelf intent takes effect (#359).",
                         intent,
                     )
+                return  # marker already written above
     except exc.OperationalError as e:
         # magic_shelf table or settings column missing — pre-flag schema
         # mid-upgrade. Retry next boot (marker intentionally not written).
@@ -1915,10 +1937,11 @@ def migrate_kobo_magic_shelf_intent(engine, _session):
         )
         return
 
+    # No-intent path: record the decision so it isn't re-evaluated every
+    # boot. A marker-write failure here is harmless (re-evaluating "no
+    # intent" is a no-op) — log and move on.
     try:
-        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
-        with open(marker_path, "w", encoding="utf-8") as fh:
-            fh.write(datetime.now(timezone.utc).isoformat())
+        _write_marker()
     except OSError as e:
         log.warning(
             "[kobo-magic-shelf-intent-migration] could not write marker %s: %s",

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1863,6 +1863,69 @@ def migrate_kobo_deleted_book(engine, _session):
         )
 
 
+def migrate_kobo_magic_shelf_intent(engine, _session):
+    """One-time: turn on the global 'Sync Magic Shelves to Kobo' setting on
+    installs where per-shelf intent already exists (fork #359).
+
+    config_kobo_sync_magic_shelves ships default-False, but the magic-shelf
+    edit UI let users tick the per-shelf "Enable Kobo sync" checkbox with the
+    global flag off — the intent was then silently swallowed: no delivery, no
+    collections, and a DeletedTag tombstone per shelf on every sync.
+    @recruiterguy lived this across v4.0.76 → v4.0.155 (#359). The per-shelf
+    checkbox IS the user's expressed intent; where any shelf carries it, the
+    feature should be on.
+
+    Runs once per install (marker file), so an admin who later disables the
+    global setting deliberately is never re-flipped. If the settings table
+    doesn't yet have the column (upgrade from a pre-flag schema — config_sql
+    adds it AFTER ub migrations on first boot), the OperationalError path
+    leaves the marker unwritten so the flip retries on the next boot.
+    """
+    marker_path = os.path.join(constants.CONFIG_DIR, ".cwa_migrations",
+                               "kobo_magic_shelf_intent_v1")
+    if os.path.isfile(marker_path):
+        return
+
+    try:
+        with engine.connect() as conn:
+            intent = conn.execute(text(
+                "SELECT COUNT(*) FROM magic_shelf WHERE kobo_sync = 1"
+            )).scalar()
+            if intent:
+                flipped = conn.execute(text(
+                    "UPDATE settings SET config_kobo_sync_magic_shelves = 1 "
+                    "WHERE config_kobo_sync_magic_shelves = 0 "
+                    "   OR config_kobo_sync_magic_shelves IS NULL"
+                ))
+                conn.commit()
+                if getattr(flipped, "rowcount", 0):
+                    log.info(
+                        "[kobo-magic-shelf-intent-migration] %s magic shelves "
+                        "are marked for Kobo sync but the global 'Sync Magic "
+                        "Shelves to Kobo' setting was off — enabled it so the "
+                        "existing per-shelf intent takes effect (#359).",
+                        intent,
+                    )
+    except exc.OperationalError as e:
+        # magic_shelf table or settings column missing — pre-flag schema
+        # mid-upgrade. Retry next boot (marker intentionally not written).
+        log.warning(
+            "[kobo-magic-shelf-intent-migration] deferred (schema not ready "
+            "yet, will retry next boot): %s", e,
+        )
+        return
+
+    try:
+        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+        with open(marker_path, "w", encoding="utf-8") as fh:
+            fh.write(datetime.now(timezone.utc).isoformat())
+    except OSError as e:
+        log.warning(
+            "[kobo-magic-shelf-intent-migration] could not write marker %s: %s",
+            marker_path, e,
+        )
+
+
 def migrate_shelf_table(engine, _session):
     """Ensure Shelf.kobo_sync column exists; backfill DDL if not (legacy
     fork branch — predates the dedicated kobo_sync migrations elsewhere).
@@ -2297,6 +2360,10 @@ def migrate_Database(_session):
     migrate_magic_shelf_table(engine, _session)
     migrate_kobo_unique_constraints(engine, _session)
     migrate_kobo_deleted_book(engine, _session)
+    # Must run before config_sql.load_configuration (it does — ub.init_db
+    # precedes config load in cps/__init__.py) so the flipped value is live
+    # the same boot.
+    migrate_kobo_magic_shelf_intent(engine, _session)
     migrate_kobo_annotation_sync_h1_columns(engine, _session)
     migrate_annotation_decouple_source_target(engine, _session)
     migrate_annotation_polymorphic_position(engine, _session)

--- a/cps/web.py
+++ b/cps/web.py
@@ -1344,11 +1344,12 @@ def create_magic_shelf():
         except:
             language_map[lang.lang_code] = lang.lang_code
 
-    return render_title_template('magic_shelf_edit.html', 
-                                 title=_("Create Magic Shelf"), 
+    return render_title_template('magic_shelf_edit.html',
+                                 title=_("Create Magic Shelf"),
                                  page="magic_shelf_create",
                                  opds_expose_enabled=current_user.opds_only_shelves_sync,
                                  opds_expose_checked=False,
+                                 kobo_magic_sync_enabled=bool(config.config_kobo_sync_magic_shelves),
                                  allowed_icons=ALLOWED_ICONS,
                                  languages=language_map)
 
@@ -1460,12 +1461,13 @@ def edit_magic_shelf(shelf_id):
         except:
             language_map[lang.lang_code] = lang.lang_code
 
-    return render_title_template('magic_shelf_edit.html', 
-                                 shelf=shelf, 
-                                 title=_("Edit Magic Shelf"), 
+    return render_title_template('magic_shelf_edit.html',
+                                 shelf=shelf,
+                                 title=_("Edit Magic Shelf"),
                                  page="magic_shelf_edit",
                                  opds_expose_enabled=current_user.opds_only_shelves_sync,
                                  opds_expose_checked=opds_expose_checked,
+                                 kobo_magic_sync_enabled=bool(config.config_kobo_sync_magic_shelves),
                                  allowed_icons=ALLOWED_ICONS,
                                  languages=language_map)
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -1327,6 +1327,25 @@ def create_magic_shelf():
                 )
             ub.session_commit()
             log.info(f"User {current_user.id} created magic shelf '{name}' (ID: {new_shelf.id})")
+            # Per-shelf Kobo intent is persisted even while the global
+            # 'Sync Magic Shelves to Kobo' setting is off (so enabling the
+            # setting later honors it) — but it is inert until then, so be
+            # honest with API callers who never saw the gated checkbox
+            # (#359 follow-up; the UI disables the checkbox in this state).
+            if kobo_sync and not config.config_kobo_sync_magic_shelves:
+                log.info(
+                    "Magic shelf %s saved with kobo_sync=1 while the global "
+                    "'Sync Magic Shelves to Kobo' setting is off — intent "
+                    "stored but inert until the setting is enabled (#359)",
+                    new_shelf.id,
+                )
+                return jsonify({
+                    "success": True,
+                    "shelf_id": new_shelf.id,
+                    "warning": _("Kobo sync for Magic Shelves is disabled globally — "
+                                 "this shelf won't reach your Kobo until 'Sync Magic "
+                                 "Shelves to Kobo' is enabled in CWA Settings."),
+                })
             return jsonify({"success": True, "shelf_id": new_shelf.id})
         except Exception as e:
             log.error(f"Error creating magic shelf: {e}")
@@ -1444,6 +1463,21 @@ def edit_magic_shelf(shelf_id):
                     flask_session.modified = True
             
             log.info(f"User {current_user.id} updated magic shelf {shelf_id} ('{name}') with icon '{icon}'")
+            # Mirror of the create path: persisted-but-inert kobo intent gets
+            # an explicit warning instead of a silent no-op (#359 follow-up).
+            if kobo_sync and not config.config_kobo_sync_magic_shelves:
+                log.info(
+                    "Magic shelf %s saved with kobo_sync=1 while the global "
+                    "'Sync Magic Shelves to Kobo' setting is off — intent "
+                    "stored but inert until the setting is enabled (#359)",
+                    shelf_id,
+                )
+                return jsonify({
+                    "success": True,
+                    "warning": _("Kobo sync for Magic Shelves is disabled globally — "
+                                 "this shelf won't reach your Kobo until 'Sync Magic "
+                                 "Shelves to Kobo' is enabled in CWA Settings."),
+                })
             return jsonify({"success": True})
         except Exception as e:
             log.error(f"Error updating magic shelf {shelf_id}: {e}")

--- a/scripts/manual/kobo_sync_simulator.py
+++ b/scripts/manual/kobo_sync_simulator.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Kobo device sync simulator — drives /kobo/<token>/v1/library/sync the way a
+real device does (round-tripping x-kobo-synctoken, honoring the continuation
+header) and reports exactly what a device would receive.
+
+Built for fork #359 live verification: distinguishes book entitlements
+(new/changed/removed), reading states, and collection Tags (new/changed/
+deleted) per round, and decodes the synctoken cursor so cursor advancement
+is observable.
+
+Usage:
+  python3 scripts/manual/kobo_sync_simulator.py --token <kobo_auth_token> \
+      [--base http://localhost:8086] [--max-rounds 30] [--synctoken '']
+
+Prints one line per round plus a final JSON summary to stdout.
+"""
+import argparse
+import base64
+import json
+import urllib.request
+
+
+def decode_token(tok):
+    if not tok:
+        return {}
+    try:
+        return json.loads(base64.b64decode(tok + "=" * (-len(tok) % 4)))
+    except Exception:
+        return {"undecodable": tok[:40]}
+
+
+def sync_round(base, token, synctoken):
+    url = "{}/kobo/{}/v1/library/sync".format(base, token)
+    req = urllib.request.Request(url)
+    if synctoken:
+        req.add_header("x-kobo-synctoken", synctoken)
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        body = json.loads(resp.read())
+        headers = {k.lower(): v for k, v in resp.headers.items()}
+    return body, headers
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="http://localhost:8086")
+    ap.add_argument("--token", required=True)
+    ap.add_argument("--max-rounds", type=int, default=30)
+    ap.add_argument("--synctoken", default="")
+    ap.add_argument("--quiet", action="store_true", help="suppress per-round lines")
+    args = ap.parse_args()
+
+    synctoken = args.synctoken
+    books = {}   # title -> [(round, kind)]
+    tags = []    # (round, kind, name_or_id, item_count)
+    rounds = 0
+    while rounds < args.max_rounds:
+        rounds += 1
+        body, headers = sync_round(args.base, args.token, synctoken)
+        counts = {"new": 0, "changed": 0, "removed": 0, "rstate": 0,
+                  "ntag": 0, "ctag": 0, "dtag": 0}
+        for item in body:
+            if "NewEntitlement" in item:
+                counts["new"] += 1
+                md = item["NewEntitlement"].get("BookMetadata", {})
+                books.setdefault(md.get("Title", "?"), []).append((rounds, "new"))
+            elif "ChangedEntitlement" in item:
+                ent = item["ChangedEntitlement"].get("BookEntitlement", {})
+                md = item["ChangedEntitlement"].get("BookMetadata", {})
+                kind = "removed" if ent.get("IsRemoved") else "changed"
+                counts[kind] += 1
+                books.setdefault(md.get("Title", "?"), []).append((rounds, kind))
+            elif "ChangedReadingState" in item:
+                counts["rstate"] += 1
+            elif "NewTag" in item:
+                counts["ntag"] += 1
+                t = item["NewTag"].get("Tag", {})
+                tags.append((rounds, "new", t.get("Name", t.get("Id")),
+                             len(t.get("Items", []))))
+            elif "ChangedTag" in item:
+                counts["ctag"] += 1
+                t = item["ChangedTag"].get("Tag", {})
+                tags.append((rounds, "changed", t.get("Name", t.get("Id")),
+                             len(t.get("Items", []))))
+            elif "DeletedTag" in item:
+                counts["dtag"] += 1
+                t = item["DeletedTag"].get("Tag", {})
+                tags.append((rounds, "deleted", t.get("Id"), 0))
+        cont = headers.get("x-kobo-sync", "")
+        synctoken = headers.get("x-kobo-synctoken", synctoken)
+        tok = decode_token(synctoken).get("data", {})
+        if not args.quiet:
+            print("round {}: items={} new={} chg={} rm={} rstate={} "
+                  "tags(n/c/d)={}/{}/{} cont={!r} cursor(lm={}, id={}, "
+                  "msli={}, msat={})".format(
+                      rounds, len(body), counts["new"], counts["changed"],
+                      counts["removed"], counts["rstate"], counts["ntag"],
+                      counts["ctag"], counts["dtag"], cont,
+                      tok.get("books_last_modified"), tok.get("books_last_id"),
+                      tok.get("magic_shelf_last_id"),
+                      tok.get("magic_shelf_membership_at")))
+        if cont != "continue":
+            break
+
+    summary = {
+        "rounds": rounds,
+        "unique_books": len(books),
+        "books": {k: v for k, v in sorted(books.items())},
+        "tags": tags,
+        "final_synctoken_data": decode_token(synctoken).get("data", {}),
+    }
+    print(json.dumps(summary, indent=1, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_kobo_magic_shelf_intent_migration_359.py
+++ b/tests/unit/test_kobo_magic_shelf_intent_migration_359.py
@@ -1,0 +1,208 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for the REAL root cause of fork #359.
+
+``config_kobo_sync_magic_shelves`` ships default-False, every Kobo-side
+magic-shelf path is gated on it (delivery arm, collections, cache refresh),
+and — worse — when it's off, a DeletedTag tombstone is emitted for every
+magic shelf the user owns on every sync. Meanwhile the magic-shelf edit UI
+happily let users tick the per-shelf "Enable Kobo sync" checkbox, silently
+swallowing the intent. @recruiterguy ran this configuration across
+v4.0.76 → v4.0.155: five cursor-arithmetic releases were correct but sat
+behind a dead flag, and his symptom never changed.
+
+Live reproduction (2026-06-06, cwn-local on main @ e1d36fac2):
+  flag=0, magic shelf kobo_sync=1 matching all 19 library books,
+  regular shelf with 1 book, fresh device, shelf-only mode
+  → sync delivered exactly 1 book, 1 NewTag (regular shelf),
+    9 DeletedTags (every magic shelf), 0 magic collections.
+
+The fix is three-pronged; these tests pin each prong:
+  1. One-time boot migration enables the global flag where per-shelf
+     intent already exists (runs before config load, so same-boot live).
+  2. The magic-shelf edit template disables the per-shelf checkbox and
+     explains why when the global flag is off (no new silent swallowing).
+  3. kobo.py logs swallowed intent at debug level.
+"""
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UB_PY = REPO_ROOT / "cps" / "ub.py"
+KOBO_PY = REPO_ROOT / "cps" / "kobo.py"
+WEB_PY = REPO_ROOT / "cps" / "web.py"
+TEMPLATE = REPO_ROOT / "cps" / "templates" / "magic_shelf_edit.html"
+
+MARKER_NAME = "kobo_magic_shelf_intent_v1"
+
+
+def _make_app_db(path, *, flag_value=0, intent_rows=0, with_flag_column=True):
+    """Minimal app.db with just the two tables the migration touches."""
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE magic_shelf (id INTEGER PRIMARY KEY, name VARCHAR, "
+        "user_id INTEGER, kobo_sync BOOLEAN)"
+    )
+    if with_flag_column:
+        cur.execute(
+            "CREATE TABLE settings (id INTEGER PRIMARY KEY, "
+            "config_kobo_sync_magic_shelves INTEGER)"
+        )
+        cur.execute(
+            "INSERT INTO settings (id, config_kobo_sync_magic_shelves) "
+            "VALUES (1, ?)", (flag_value,)
+        )
+    else:
+        cur.execute("CREATE TABLE settings (id INTEGER PRIMARY KEY)")
+        cur.execute("INSERT INTO settings (id) VALUES (1)")
+    for i in range(intent_rows):
+        cur.execute(
+            "INSERT INTO magic_shelf (name, user_id, kobo_sync) "
+            "VALUES (?, 3, 1)", (f"shelf-{i}",)
+        )
+    conn.commit()
+    conn.close()
+
+
+def _run_migration(db_path, config_dir, monkeypatch):
+    """Invoke migrate_kobo_magic_shelf_intent against a real SQLite file
+    with constants.CONFIG_DIR pointed at a temp dir for the marker."""
+    from sqlalchemy import create_engine
+    from cps import constants as cps_constants
+    from cps import ub as cps_ub
+
+    monkeypatch.setattr(cps_constants, "CONFIG_DIR", str(config_dir))
+    engine = create_engine(f"sqlite:///{db_path}")
+    try:
+        cps_ub.migrate_kobo_magic_shelf_intent(engine, None)
+    finally:
+        engine.dispose()
+
+
+def _flag(db_path):
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute(
+            "SELECT config_kobo_sync_magic_shelves FROM settings WHERE id=1"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+class TestIntentMigration:
+    def test_flips_flag_when_per_shelf_intent_exists(self, tmp_path, monkeypatch):
+        """The recruiterguy state: flag off, shelves marked kobo_sync=1.
+        Migration must enable the global flag."""
+        db = tmp_path / "app.db"
+        _make_app_db(db, flag_value=0, intent_rows=2)
+        _run_migration(db, tmp_path, monkeypatch)
+        assert _flag(db) == 1, (
+            "per-shelf kobo_sync intent must enable the global flag (#359)"
+        )
+        assert (tmp_path / ".cwa_migrations" / MARKER_NAME).is_file()
+
+    def test_no_flip_without_intent(self, tmp_path, monkeypatch):
+        """Installs with no magic-shelf Kobo intent stay opted out."""
+        db = tmp_path / "app.db"
+        _make_app_db(db, flag_value=0, intent_rows=0)
+        _run_migration(db, tmp_path, monkeypatch)
+        assert _flag(db) == 0, "no intent → flag must stay off"
+        # marker still written: the decision is made, don't re-evaluate
+        assert (tmp_path / ".cwa_migrations" / MARKER_NAME).is_file()
+
+    def test_marker_respects_later_admin_disable(self, tmp_path, monkeypatch):
+        """An admin who deliberately disables the flag after the migration
+        ran must NOT be re-flipped on subsequent boots."""
+        db = tmp_path / "app.db"
+        _make_app_db(db, flag_value=0, intent_rows=1)
+        _run_migration(db, tmp_path, monkeypatch)
+        assert _flag(db) == 1
+        # admin disables deliberately
+        conn = sqlite3.connect(db)
+        conn.execute("UPDATE settings SET config_kobo_sync_magic_shelves=0")
+        conn.commit()
+        conn.close()
+        # next boot
+        _run_migration(db, tmp_path, monkeypatch)
+        assert _flag(db) == 0, (
+            "marker must prevent re-flipping a deliberate admin disable"
+        )
+
+    def test_already_enabled_is_untouched_and_marked(self, tmp_path, monkeypatch):
+        db = tmp_path / "app.db"
+        _make_app_db(db, flag_value=1, intent_rows=3)
+        _run_migration(db, tmp_path, monkeypatch)
+        assert _flag(db) == 1
+        assert (tmp_path / ".cwa_migrations" / MARKER_NAME).is_file()
+
+    def test_missing_column_defers_without_marker(self, tmp_path, monkeypatch):
+        """Pre-flag schema (settings column not added yet — config_sql adds
+        it after ub migrations on first boot): must not crash, must NOT
+        write the marker, so the flip retries next boot."""
+        db = tmp_path / "app.db"
+        _make_app_db(db, intent_rows=1, with_flag_column=False)
+        _run_migration(db, tmp_path, monkeypatch)  # must not raise
+        assert not (tmp_path / ".cwa_migrations" / MARKER_NAME).exists(), (
+            "marker must not be written when the schema isn't ready — "
+            "the migration needs to retry next boot"
+        )
+
+    def test_registered_in_migrate_database(self):
+        src = UB_PY.read_text(encoding="utf-8")
+        body = src.split("def migrate_Database(", 1)[1]
+        assert "migrate_kobo_magic_shelf_intent(engine, _session)" in body, (
+            "migration must be wired into migrate_Database"
+        )
+
+
+@pytest.mark.unit
+class TestUiHonesty:
+    """The per-shelf checkbox must not silently swallow intent again."""
+
+    def test_template_gates_checkbox_on_global_flag(self):
+        tpl = TEMPLATE.read_text(encoding="utf-8")
+        assert "kobo_magic_sync_enabled" in tpl, (
+            "magic_shelf_edit.html must consult kobo_magic_sync_enabled"
+        )
+        # the checkbox itself carries the disabled gate
+        for line in tpl.splitlines():
+            if 'id="shelf-kobo-sync"' in line:
+                assert "disabled" in line and "kobo_magic_sync_enabled" in line, (
+                    "the kobo-sync checkbox must be disabled when the global "
+                    "flag is off"
+                )
+                break
+        else:
+            pytest.fail("shelf-kobo-sync checkbox not found in template")
+
+    def test_template_explains_why_disabled(self):
+        tpl = TEMPLATE.read_text(encoding="utf-8")
+        assert "Sync Magic Shelves to Kobo" in tpl, (
+            "the disabled state must name the exact CWA Settings toggle "
+            "the user needs"
+        )
+
+    def test_both_render_routes_pass_the_flag(self):
+        src = WEB_PY.read_text(encoding="utf-8")
+        assert src.count("kobo_magic_sync_enabled=bool(config.config_kobo_sync_magic_shelves)") >= 2, (
+            "both magic_shelf_edit.html render calls (create + edit) must "
+            "pass kobo_magic_sync_enabled"
+        )
+
+
+@pytest.mark.unit
+class TestSwallowedIntentLog:
+    def test_kobo_logs_swallowed_intent_at_debug(self):
+        src = KOBO_PY.read_text(encoding="utf-8")
+        assert "isEnabledFor(logging.DEBUG)" in src and "#359" in src, (
+            "get_magic_shelf_book_ids_for_kobo must debug-log swallowed "
+            "per-shelf intent when the global flag is off"
+        )

--- a/tests/unit/test_kobo_magic_shelf_intent_migration_359.py
+++ b/tests/unit/test_kobo_magic_shelf_intent_migration_359.py
@@ -143,6 +143,30 @@ class TestIntentMigration:
         assert _flag(db) == 1
         assert (tmp_path / ".cwa_migrations" / MARKER_NAME).is_file()
 
+    def test_marker_unwritable_aborts_flip_then_recovers(self, tmp_path, monkeypatch):
+        """Greptile P1 on PR #372: if the marker can't be written, the flag
+        flip must NOT commit — otherwise a persistent filesystem problem
+        re-overrides a deliberate admin disable on every boot. The flip and
+        its never-again guard land together or not at all."""
+        db = tmp_path / "app.db"
+        _make_app_db(db, flag_value=0, intent_rows=1)
+        ro_config = tmp_path / "ro-config"
+        ro_config.mkdir()
+        ro_config.chmod(0o500)  # .cwa_migrations/ not creatable inside
+        try:
+            _run_migration(db, ro_config, monkeypatch)  # must not raise
+            assert _flag(db) == 0, (
+                "flag must NOT flip when the marker is unwritable — "
+                "flip + marker land together or not at all"
+            )
+            assert not (ro_config / ".cwa_migrations").exists()
+        finally:
+            ro_config.chmod(0o700)
+        # Filesystem fixed → next boot applies the flip and the marker.
+        _run_migration(db, ro_config, monkeypatch)
+        assert _flag(db) == 1
+        assert (ro_config / ".cwa_migrations" / MARKER_NAME).is_file()
+
     def test_missing_column_defers_without_marker(self, tmp_path, monkeypatch):
         """Pre-flag schema (settings column not added yet — config_sql adds
         it after ub migrations on first boot): must not crash, must NOT
@@ -196,6 +220,49 @@ class TestUiHonesty:
             "both magic_shelf_edit.html render calls (create + edit) must "
             "pass kobo_magic_sync_enabled"
         )
+
+
+@pytest.mark.unit
+class TestApiHonesty:
+    """Greptile gap 2 on PR #372: the create/edit POST handlers accept
+    kobo_sync=True from the JSON body without consulting the global flag —
+    a direct API call recreates the silent-swallow state the UI gating
+    fixed. The handlers must persist the intent (so enabling the global
+    setting later honors it — and so rule edits on previously-marked
+    shelves don't get rejected via the disabled-but-checked checkbox) but
+    return an explicit warning instead of a silent success."""
+
+    def test_create_handler_warns_on_inert_kobo_intent(self):
+        src = WEB_PY.read_text(encoding="utf-8")
+        create_body = src.split('@web.route("/magicshelf", methods=["GET", "POST"])', 1)[1]
+        create_body = create_body.split('@web.route("/magicshelf/<int:shelf_id>/edit"', 1)[0]
+        assert "kobo_sync and not config.config_kobo_sync_magic_shelves" in create_body, (
+            "create handler must detect persisted-but-inert kobo intent"
+        )
+        assert '"warning"' in create_body, (
+            "create handler must return a warning for inert kobo intent"
+        )
+
+    def test_edit_handler_warns_on_inert_kobo_intent(self):
+        src = WEB_PY.read_text(encoding="utf-8")
+        edit_body = src.split('@web.route("/magicshelf/<int:shelf_id>/edit"', 1)[1]
+        edit_body = edit_body.split('@web.route("/magicshelf/<int:shelf_id>/duplicate"', 1)[0]
+        assert "kobo_sync and not config.config_kobo_sync_magic_shelves" in edit_body, (
+            "edit handler must detect persisted-but-inert kobo intent"
+        )
+        assert '"warning"' in edit_body, (
+            "edit handler must return a warning for inert kobo intent"
+        )
+
+    def test_intent_is_persisted_not_rejected_or_coerced(self):
+        """Rejecting would break rule-edits on previously-marked shelves
+        (the disabled-but-checked checkbox still posts kobo_sync=true);
+        coercing to False would silently erase intent. The shelf keeps the
+        value the client sent."""
+        src = WEB_PY.read_text(encoding="utf-8")
+        # The assignment into the model must remain unconditional.
+        assert "kobo_sync=kobo_sync" in src, "create must persist intent as sent"
+        assert "shelf.kobo_sync = kobo_sync" in src, "edit must persist intent as sent"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## The real root cause of #359

After five releases of correct-but-latent cursor fixes (v4.0.147–155), @recruiterguy's symptom never changed: **no Magic Shelf books, no Magic Shelf collections**. The actual cause sits in front of all that machinery: `config_kobo_sync_magic_shelves` ships **default-False** and gates every Kobo-side magic-shelf path — delivery arm, collections, cache refresh — while the magic-shelf edit UI happily lets users tick the per-shelf **Enable Kobo sync** checkbox with the global flag off. The intent is silently swallowed, and worse: with the flag off, a `DeletedTag` tombstone is emitted for **every** magic shelf the user owns on **every** sync, so collections are actively suppressed.

Evidence this matches the report: the `Found 1 books to remove` log line he captured only executes in the shelf-only branch; his device holds only shelf books (a true sync-all device would hold the whole library); his cache-refresh timestamps predate the release he credited and align with his own UI visits.

## Fix (three prongs)

1. **One-time boot migration** (`migrate_kobo_magic_shelf_intent`, marker-gated): where any magic shelf already carries `kobo_sync=1`, enable the global flag. Runs in `ub.init_db` *before* `config_sql.load_configuration`, so it's live the same boot. Admins who later disable deliberately are never re-flipped (marker). Pre-flag schemas defer without writing the marker and retry next boot.
2. **UI honesty**: `magic_shelf_edit.html` disables the per-shelf checkbox when the global flag is off and names the exact CWA Settings toggle to turn on. No new silent swallowing.
3. **Supportability**: kobo.py debug-logs swallowed intent.

## Verification (live cwn-local, image rebuilt from main @ `e1d36fac2`)

| Gate | Result |
|---|---|
| RED repro (flag=0, magic shelf kobo_sync=1 over 19 books, shelf-only, fresh device) | 1 book delivered, **0 magic collections, 9 DeletedTags** — recruiterguy's exact symptom |
| RED sync-all variant | books sweep delivers, **collections still absent** |
| Migration on boot | flag 0→1, marker written, INFO log line present |
| GREEN same sync | **17 entitlements + NewTag collection (19 items)**; tombstones only for genuinely-unsynced shelves |
| Token-carried re-sync | 0 books — termination holds |
| **150-book magic shelf, single shared `last_modified`** | 2-round walk (100+67), composite keyset parks mid-collision (`id=103`), sub-cursor advances (`msli=103`) then folds/resets — **150/150 delivered exactly once** (first live-scale validation of the v4.0.147–155 cursor stack) |
| Sync-all mode GREEN | collections emit alongside library sweep |
| Playwright admin round-trip | CWA Settings toggle off → per-shelf checkbox disabled + amber hint (JPEG in notes/); toggle on → re-enabled. 0 console errors |
| Unit suites | 439 passed (10 new in `test_kobo_magic_shelf_intent_migration_359.py`), 0 failures |

Also adds `scripts/manual/kobo_sync_simulator.py` — a reusable Kobo device simulator (token round-trip, continuation, per-round cursor decode) used for the evidence above.

Addresses #359