### PR TITLE
chore(release): dev-channel auto-build + user-facing CHANGELOG + label-aware validate-author

### DIFF
--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -8,7 +8,19 @@ name: Build & Push - Dev - Split Strategy
 # step because the secrets were empty; this gating fixes that.
 
 on:
-  workflow_dispatch:  # auto-trigger disabled by intent; operator dispatches manually
+  # Dev channel (release-train policy, 2026-06-06): every merge to main builds
+  # and pushes :dev + :dev-<n> to GHCR. teenyverse (the operator's household
+  # instance) tracks :dev as the canary; public releases batch via the daily
+  # release train (see LOOP.md / CLAUDE.md "Release policy"). Docs- and
+  # tests-only changes skip the build — they can't change the image behavior.
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'tests/**'
+      - '.github/**'
+  workflow_dispatch:
     inputs:
       ref:
         description: "Commit SHA or branch to build (defaults to github.ref if empty)"

--- a/.github/workflows/validate-author.yml
+++ b/.github/workflows/validate-author.yml
@@ -33,6 +33,10 @@ name: validate-author
 on:
   pull_request:
     branches: [main]
+    # labeled/unlabeled included so applying `community-contribution` re-runs
+    # the check with fresh label data — re-running the old failed run replays
+    # a frozen event payload that predates the label (hit on PR #371).
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Changelog
+
+All notable user-facing changes to Calibre-Web NextGen. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+**Docker tags:** `:latest` = newest stable release · `:dev` = every merge to main
+(canary channel — what the maintainers run at home) · `:vX.Y.Z` = immutable pins
+for rollback.
+
+**Compatibility promise:** patch releases (`vX.Y.Z` → `vX.Y.Z+1`) are safe to
+auto-update — no breaking config, database, or API changes without a `BREAKING`
+callout at the top of the release notes.
+
+Internal refactors, CI changes, and test-only work don't appear here — this file
+is for things you can see or feel when running the app.
+
+## [Unreleased]
+
+### Fixed
+- **Magic Shelves marked for Kobo sync now actually reach your Kobo** — books
+  deliver and the shelf appears as a collection on the device. Previously a
+  global setting (off by default) silently swallowed the per-shelf "Enable Kobo
+  sync" checkbox; if you'd ever ticked that checkbox, the upgrade enables the
+  global setting for you automatically. The checkbox now also tells you when the
+  global setting is off instead of silently doing nothing. (#359, reported with
+  excellent diagnostics by @recruiterguy)
+
+### Security
+- `POST /duplicates/invalidate-cache` now requires authentication — previously
+  it accepted unauthenticated requests on internet-facing deployments (limited
+  impact: it could only force a duplicate-scan refresh). (#370, found and fixed
+  by @8bitgentleman)
+
+## [v4.0.155] – 2026-06-06
+
+### Fixed
+- Kobo sync: after a Magic Shelf cache rebuild, the per-shelf delivery cursor
+  could silently revert to a stale value, leaving newly-added low-numbered books
+  undelivered until the next shelf change. (#368 follow-up)
+
+## [v4.0.154] – 2026-06-06
+
+### Fixed
+- Kobo sync: adding a book to a Magic Shelf between syncs now reliably delivers
+  it — the sync cursor detects the cache rebuild and re-walks the shelf. (#367
+  follow-up)
+
+## [v4.0.153] – 2026-06-06
+
+### Fixed
+- Kobo sync: Magic Shelves with more than 100 books no longer re-send the same
+  first 100 books forever — delivery now pages through the whole shelf. (#366
+  follow-up)
+
+## [v4.0.152] – 2026-06-06
+
+### Fixed
+- Kobo sync: when more than 100 books were pending at once alongside a Magic
+  Shelf refresh, some regular books could be skipped permanently. Nothing is
+  dropped anymore. (#361 follow-up)
+
+## [v4.0.151] – 2026-06-06
+
+### Fixed
+- Kobo sync: Magic Shelf delivery and cache refresh now work in
+  sync-entire-library mode, not just "selected shelves only" mode. (#359)
+
+## [v4.0.150] – 2026-06-05
+
+### Changed
+- Read/unread toggle on the book detail page now shows the action you're about
+  to take (checkmark = "mark as read") instead of the current state, and the
+  read badge uses a consistent checkmark icon everywhere. (#319)
+
+## [v4.0.149] – 2026-06-05
+
+### Added
+- "Reload Metadata" button on the book detail page — re-reads title, author,
+  and other metadata from the book file on disk after you've changed it
+  externally (e.g. in Calibre desktop). (#218, requested by @yodatak)
+
+## [v4.0.148] – 2026-06-05
+
+### Fixed
+- Sorting the Hidden Books page no longer dumps you into the unfiltered
+  library. (#319, reported by @SethMilliken)
+
+## [v4.0.147] – 2026-06-05
+
+### Fixed
+- Kobo sync: libraries with thousands of books imported in one batch (all
+  sharing one timestamp) now sync completely — previously the device could loop
+  on the same batch or skip the remainder. (#347, reported by @andree392)
+- Kobo sync: first delivery pass for Magic Shelf membership. (#359)
+
+---
+
+Older releases: see the [GitHub releases page](https://github.com/new-usemame/Calibre-Web-NextGen/releases).


### PR DESCRIPTION
Implements the release-train policy: every merge to main auto-builds the `:dev` GHCR tag (canary — teenyverse tracks it); public releases batch to **at most one per day** with humanized notes drained from the new `CHANGELOG.md` `[Unreleased]` buffer (keepachangelog format, symptom-first, no commit dumps).

Also makes `validate-author` re-evaluate on label events — applying `community-contribution` previously couldn't unblock a PR without close/reopen because rerunning the failed run replays the frozen pre-label event payload (hit on #371).

Rationale + sources in `notes/RESEARCH-autonomous-maintenance-best-practices.md` (LinuxServer tag taxonomy, Immich/Home-Assistant batched cadence, keepachangelog).