### PR TITLE
feat(reload): authors, tags, series come back from disk too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+- "Reload Metadata" now also reloads authors, tags, and series (with series
+  number) from the book file — previously only title, description, publisher,
+  publish date, and languages came through. Author changes also rename the
+  book's folder and file to match, the same way editing in the web UI does.
+  A file that's missing its author or tags fields leaves your existing data
+  alone instead of wiping it. (#218, reported by @yodatak)
+
 ## [v4.0.156] – 2026-06-06
 
 ### Fixed

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -2207,117 +2207,130 @@ def reload_metadata_from_disk(book_id):
                                format=file_ext.upper(), err=str(ex))), 500
 
     updated = []
-    rename_warning = None
     try:
-        with metadata_db_write_lock():
-            # Title.
-            if meta.title and meta.title != book.title:
-                book.title = strip_whitespaces(meta.title)
-                updated.append('title')
+        # Field mutations are session-local — the edit-book POST path runs
+        # them unlocked too, and takes metadata_db_write_lock only around
+        # the final COMMIT (the lock's contract is single-commit duration;
+        # holding it across file renames would starve the ingest
+        # coordinator, #192). Same for the dir move below.
+        # Title.
+        if meta.title and meta.title != book.title:
+            book.title = strip_whitespaces(meta.title)
+            updated.append('title')
 
-            # Comments / description.
-            if meta.description is not None and isinstance(meta.description, str):
-                if edit_book_comments(meta.description, book):
-                    updated.append('comments')
+        # Comments / description.
+        if meta.description is not None and isinstance(meta.description, str):
+            if edit_book_comments(meta.description, book):
+                updated.append('comments')
 
-            # Publisher.
-            if meta.publisher:
-                if edit_book_publisher(meta.publisher, book):
-                    updated.append('publisher')
+        # Publisher.
+        if meta.publisher:
+            if edit_book_publisher(meta.publisher, book):
+                updated.append('publisher')
 
-            # Pubdate. Only update if parseable + different.
-            if meta.pubdate:
+        # Pubdate. Only update if parseable + different.
+        if meta.pubdate:
+            try:
+                new_pub = datetime.strptime(meta.pubdate, "%Y-%m-%d")
+                current_pub = getattr(book, 'pubdate', None)
+                if current_pub is None or current_pub.date() != new_pub.date():
+                    book.pubdate = new_pub
+                    updated.append('pubdate')
+            except (TypeError, ValueError):
+                log.debug("reload_metadata: unparseable pubdate %r", meta.pubdate)
+
+        # Languages — meta.languages is a string like 'eng'.
+        if meta.languages:
+            try:
+                if edit_book_languages(meta.languages, book, upload_mode=True):
+                    updated.append('languages')
+            except Exception as ex:
+                log.debug("reload_metadata: language update failed: %s", ex)
+
+        # Authors — same helper as the edit-book save path
+        # (author_sort regeneration, rename handling, orphan
+        # cleanup). 'Unknown' is get_epub_info's missing-creator
+        # sentinel: a file without <dc:creator> must not stomp the
+        # book's real authors.
+        input_authors = None
+        author_value = strip_whitespaces(meta.author or '')
+        if author_value and meta.author != 'Unknown':
+            input_authors, author_change = handle_author_on_edit(
+                book, author_value)
+            if author_change:
+                updated.append('authors')
+
+        # Tags — comma-joined <dc:subject> values; '' when the file
+        # has none, which is ambiguous (the editing tool may simply
+        # not write subjects) and must not wipe curated tags.
+        if meta.tags and strip_whitespaces(meta.tags):
+            if edit_book_tags(meta.tags, book):
+                updated.append('tags')
+
+        # Series + index — create-on-demand via the standard helper.
+        # The numeric check is inline because edit_book_series_index
+        # flashes on invalid input, and a flash inside a JSON
+        # endpoint leaks a stale message into the next rendered page.
+        if meta.series and strip_whitespaces(meta.series) \
+                and meta.series != 'Unknown':
+            if edit_book_series(meta.series, book):
+                updated.append('series')
+            series_id = strip_whitespaces(meta.series_id or '')
+            if series_id and series_id.replace('.', '', 1).isdigit():
+                # Compare numerically: series_index is a REAL column, so
+                # str(4.0) != "4" makes a string compare report a change
+                # on every reload — each one re-marking the book modified
+                # and churning Kobo-sync cursors. (edit_book_series_index
+                # carries the same latent string compare; form posts
+                # rarely trip it.)
                 try:
-                    new_pub = datetime.strptime(meta.pubdate, "%Y-%m-%d")
-                    current_pub = getattr(book, 'pubdate', None)
-                    if current_pub is None or current_pub.date() != new_pub.date():
-                        book.pubdate = new_pub
-                        updated.append('pubdate')
+                    if float(book.series_index or 0) != float(series_id):
+                        book.series_index = series_id
+                        updated.append('series_index')
                 except (TypeError, ValueError):
-                    log.debug("reload_metadata: unparseable pubdate %r", meta.pubdate)
+                    log.debug("reload_metadata: unparseable series index %r",
+                              series_id)
 
-            # Languages — meta.languages is a string like 'eng'.
-            if meta.languages:
-                try:
-                    if edit_book_languages(meta.languages, book, upload_mode=True):
-                        updated.append('languages')
-                except Exception as ex:
-                    log.debug("reload_metadata: language update failed: %s", ex)
+        # Title/author changes move the book's on-disk directory the
+        # same way every other edit path does (Author/Title (id)
+        # convention) — otherwise reload leaves a layout no other
+        # write path produces. The v4.0.149 title-only reload skipped
+        # this; fixed here. On rename failure: rollback + bail, exactly
+        # like the edit-book POST path — never commit a layout the move
+        # didn't produce.
+        if 'title' in updated or 'authors' in updated:
+            if input_authors:
+                first_author = input_authors[0]
+            elif book.authors:
+                # Same idiom the title-only edit path uses (web edit,
+                # "Pass the current author to prevent directory
+                # structure issues").
+                first_author = book.authors[0].name
+            else:
+                first_author = None
+            rename_error = helper.update_dir_structure(
+                book.id, config.get_book_path(), first_author)
+            if rename_error:
+                calibre_db.session.rollback()
+                log.error(
+                    "reload_metadata: dir-structure update failed for "
+                    "book %d: %s", book.id, rename_error)
+                return jsonify(
+                    success=False,
+                    error=_("Could not rename the book folder to match "
+                            "the reloaded metadata: %(err)s",
+                            err=str(rename_error))), 500
 
-            # Authors — same helper as the edit-book save path
-            # (author_sort regeneration, rename handling, orphan
-            # cleanup). 'Unknown' is get_epub_info's missing-creator
-            # sentinel: a file without <dc:creator> must not stomp the
-            # book's real authors.
-            input_authors = None
-            author_value = strip_whitespaces(meta.author or '')
-            if author_value and meta.author != 'Unknown':
-                input_authors, author_change = handle_author_on_edit(
-                    book, author_value)
-                if author_change:
-                    updated.append('authors')
-
-            # Tags — comma-joined <dc:subject> values; '' when the file
-            # has none, which is ambiguous (the editing tool may simply
-            # not write subjects) and must not wipe curated tags.
-            if meta.tags and strip_whitespaces(meta.tags):
-                if edit_book_tags(meta.tags, book):
-                    updated.append('tags')
-
-            # Series + index — create-on-demand via the standard helper.
-            # The numeric check is inline because edit_book_series_index
-            # flashes on invalid input, and a flash inside a JSON
-            # endpoint leaks a stale message into the next rendered page.
-            if meta.series and strip_whitespaces(meta.series) \
-                    and meta.series != 'Unknown':
-                if edit_book_series(meta.series, book):
-                    updated.append('series')
-                series_id = strip_whitespaces(meta.series_id or '')
-                if series_id and series_id.replace('.', '', 1).isdigit():
-                    # Compare numerically: series_index is a REAL column, so
-                    # str(4.0) != "4" makes a string compare report a change
-                    # on every reload — each one re-marking the book modified
-                    # and churning Kobo-sync cursors. (edit_book_series_index
-                    # carries the same latent string compare; form posts
-                    # rarely trip it.)
-                    try:
-                        if float(book.series_index or 0) != float(series_id):
-                            book.series_index = series_id
-                            updated.append('series_index')
-                    except (TypeError, ValueError):
-                        log.debug("reload_metadata: unparseable series index %r",
-                                  series_id)
-
-            # Title/author changes move the book's on-disk directory the
-            # same way every other edit path does (Author/Title (id)
-            # convention) — otherwise reload leaves a layout no other
-            # write path produces. The v4.0.149 title-only reload skipped
-            # this; fixed here.
-            if 'title' in updated or 'authors' in updated:
-                if input_authors:
-                    first_author = input_authors[0]
-                elif book.authors:
-                    first_author = book.authors[0].name
-                else:
-                    first_author = None
-                rename_error = helper.update_dir_structure(
-                    book.id, config.get_book_path(), first_author)
-                if rename_error:
-                    # Metadata still commits (mirrors the edit path, which
-                    # flashes the error and proceeds) — surface it so the
-                    # caller knows the on-disk layout didn't converge.
-                    rename_warning = str(rename_error)
-                    log.warning(
-                        "reload_metadata: dir-structure update failed for "
-                        "book %d: %s", book.id, rename_error)
-
-            if updated:
+        if updated:
+            # Only the COMMIT takes the writers' lock — single-commit
+            # duration per the lock's contract.
+            with metadata_db_write_lock():
                 helper.mark_book_modified(book, set_dirty=False)
                 calibre_db.session.commit()
-                log.info("Reloaded metadata for book %d from disk (fields: %s)",
-                         book.id, ', '.join(updated))
-            else:
-                calibre_db.session.rollback()
+            log.info("Reloaded metadata for book %d from disk (fields: %s)",
+                     book.id, ', '.join(updated))
+        else:
+            calibre_db.session.rollback()
     except Exception as ex:
         log.error_or_exception("reload_metadata: commit failed for book %d: %s",
                                book.id, ex)
@@ -2329,14 +2342,10 @@ def reload_metadata_from_disk(book_id):
                        error=_("Could not save reloaded metadata: %(err)s",
                                err=str(ex))), 500
 
-    response = dict(success=True,
-                    updated_fields=updated,
-                    source_format=file_ext.upper(),
-                    message=(_("Reloaded %(n)d field(s) from on-disk %(fmt)s",
-                               n=len(updated), fmt=file_ext.upper())
-                             if updated
-                             else _("On-disk metadata matches current — no fields updated")))
-    if rename_warning:
-        response["warning"] = _("Metadata updated, but the book folder could not "
-                                "be renamed to match: %(err)s", err=rename_warning)
-    return jsonify(**response), 200
+    return jsonify(success=True,
+                   updated_fields=updated,
+                   source_format=file_ext.upper(),
+                   message=(_("Reloaded %(n)d field(s) from on-disk %(fmt)s",
+                              n=len(updated), fmt=file_ext.upper())
+                            if updated
+                            else _("On-disk metadata matches current — no fields updated"))), 200

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -2147,12 +2147,20 @@ def reload_metadata_from_disk(book_id):
     pull the on-disk file as source of truth without round-tripping
     through ingest.
 
-    Updates: title, comments, publisher, pubdate, languages. Authors,
-    tags, and series are deferred — they involve relationship-table
-    bookkeeping (author_sort regeneration, tag dedup, series
-    create-on-demand) that's better handled through the full edit-book
-    save path. The fields we DO update are the common-case ask
-    ("I changed the description in grimmory and want CWNG to show it").
+    Updates: title, authors, tags, series (+ index), comments, publisher,
+    pubdate, languages. Authors/tags/series ride the SAME helpers the
+    edit-book save path uses (handle_author_on_edit, edit_book_tags,
+    edit_book_series) so relationship bookkeeping — author_sort
+    regeneration, tag dedup + orphan cleanup, series create-on-demand —
+    stays identical, and title/author changes trigger
+    helper.update_dir_structure exactly like every other edit path
+    (#218 follow-up, @yodatak: "it don't reload all the metadata").
+
+    Absent-field safety: get_epub_info returns the literal 'Unknown' for
+    a missing <dc:creator> and '' for missing <dc:subject>/series. Both
+    mean "the file carries nothing", not "clear the field" — a tool that
+    drops those elements must not stomp curated data, so each of the
+    three is gated on a real value being present.
 
     Authorization: @edit_required (admin OR edit role) — same gate as
     /admin/book/<id> POST.
@@ -2199,6 +2207,7 @@ def reload_metadata_from_disk(book_id):
                                format=file_ext.upper(), err=str(ex))), 500
 
     updated = []
+    rename_warning = None
     try:
         with metadata_db_write_lock():
             # Title.
@@ -2235,6 +2244,73 @@ def reload_metadata_from_disk(book_id):
                 except Exception as ex:
                     log.debug("reload_metadata: language update failed: %s", ex)
 
+            # Authors — same helper as the edit-book save path
+            # (author_sort regeneration, rename handling, orphan
+            # cleanup). 'Unknown' is get_epub_info's missing-creator
+            # sentinel: a file without <dc:creator> must not stomp the
+            # book's real authors.
+            input_authors = None
+            author_value = strip_whitespaces(meta.author or '')
+            if author_value and meta.author != 'Unknown':
+                input_authors, author_change = handle_author_on_edit(
+                    book, author_value)
+                if author_change:
+                    updated.append('authors')
+
+            # Tags — comma-joined <dc:subject> values; '' when the file
+            # has none, which is ambiguous (the editing tool may simply
+            # not write subjects) and must not wipe curated tags.
+            if meta.tags and strip_whitespaces(meta.tags):
+                if edit_book_tags(meta.tags, book):
+                    updated.append('tags')
+
+            # Series + index — create-on-demand via the standard helper.
+            # The numeric check is inline because edit_book_series_index
+            # flashes on invalid input, and a flash inside a JSON
+            # endpoint leaks a stale message into the next rendered page.
+            if meta.series and strip_whitespaces(meta.series) \
+                    and meta.series != 'Unknown':
+                if edit_book_series(meta.series, book):
+                    updated.append('series')
+                series_id = strip_whitespaces(meta.series_id or '')
+                if series_id and series_id.replace('.', '', 1).isdigit():
+                    # Compare numerically: series_index is a REAL column, so
+                    # str(4.0) != "4" makes a string compare report a change
+                    # on every reload — each one re-marking the book modified
+                    # and churning Kobo-sync cursors. (edit_book_series_index
+                    # carries the same latent string compare; form posts
+                    # rarely trip it.)
+                    try:
+                        if float(book.series_index or 0) != float(series_id):
+                            book.series_index = series_id
+                            updated.append('series_index')
+                    except (TypeError, ValueError):
+                        log.debug("reload_metadata: unparseable series index %r",
+                                  series_id)
+
+            # Title/author changes move the book's on-disk directory the
+            # same way every other edit path does (Author/Title (id)
+            # convention) — otherwise reload leaves a layout no other
+            # write path produces. The v4.0.149 title-only reload skipped
+            # this; fixed here.
+            if 'title' in updated or 'authors' in updated:
+                if input_authors:
+                    first_author = input_authors[0]
+                elif book.authors:
+                    first_author = book.authors[0].name
+                else:
+                    first_author = None
+                rename_error = helper.update_dir_structure(
+                    book.id, config.get_book_path(), first_author)
+                if rename_error:
+                    # Metadata still commits (mirrors the edit path, which
+                    # flashes the error and proceeds) — surface it so the
+                    # caller knows the on-disk layout didn't converge.
+                    rename_warning = str(rename_error)
+                    log.warning(
+                        "reload_metadata: dir-structure update failed for "
+                        "book %d: %s", book.id, rename_error)
+
             if updated:
                 helper.mark_book_modified(book, set_dirty=False)
                 calibre_db.session.commit()
@@ -2253,10 +2329,14 @@ def reload_metadata_from_disk(book_id):
                        error=_("Could not save reloaded metadata: %(err)s",
                                err=str(ex))), 500
 
-    return jsonify(success=True,
-                   updated_fields=updated,
-                   source_format=file_ext.upper(),
-                   message=(_("Reloaded %(n)d field(s) from on-disk %(fmt)s",
-                              n=len(updated), fmt=file_ext.upper())
-                            if updated
-                            else _("On-disk metadata matches current — no fields updated"))), 200
+    response = dict(success=True,
+                    updated_fields=updated,
+                    source_format=file_ext.upper(),
+                    message=(_("Reloaded %(n)d field(s) from on-disk %(fmt)s",
+                               n=len(updated), fmt=file_ext.upper())
+                             if updated
+                             else _("On-disk metadata matches current — no fields updated")))
+    if rename_warning:
+        response["warning"] = _("Metadata updated, but the book folder could not "
+                                "be renamed to match: %(err)s", err=rename_warning)
+    return jsonify(**response), 200

--- a/cps/epub.py
+++ b/cps/epub.py
@@ -193,5 +193,11 @@ def parse_epub_series(ns, tree, epub_metadata):
     if len(series_id) > 0:
         epub_metadata['series_id'] = series_id[0]
     else:
-        epub_metadata['series_id'] = '1'
+        # Absence is '', not a fabricated '1' — consumers that want a default
+        # apply their own (upload already creates Books with series_index '1'
+        # and edit_book_series_index no-ops on falsy; merge_metadata skips
+        # falsy). Fabricating '1' here made reload_metadata_from_disk stomp a
+        # curated series_index whenever a file carried a series name without
+        # a calibre:series_index meta (#218 follow-up review).
+        epub_metadata['series_id'] = ''
     return epub_metadata

--- a/tests/unit/test_reload_metadata_authors_tags_series_218.py
+++ b/tests/unit/test_reload_metadata_authors_tags_series_218.py
@@ -1,0 +1,130 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Fork #218 follow-up (@yodatak, 2026-06-06): the v4.0.149 reload covered
+title/comments/publisher/pubdate/languages and deferred authors, tags, and
+series — "i try the new 4.0.151 and some parts works but it don't reload all
+the metadata."
+
+This extension wires the three deferred fields through the SAME helpers the
+edit-book save path uses (so relationship bookkeeping — author_sort
+regeneration, tag dedup + orphan cleanup, series create-on-demand — stays
+identical), pairs title/author changes with helper.update_dir_structure the
+way every edit path does (the v4.0.149 title reload skipped it — same-class
+gap, fixed here), and gates each field on the file actually CARRYING a value
+so a tool that drops <dc:creator>/<dc:subject> can't stomp curated data:
+
+  * get_epub_info returns the literal string 'Unknown' for a missing
+    creator and '' for missing subject/series — both must be treated as
+    "file has nothing to say", not as new values.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EDITBOOKS = REPO_ROOT / "cps" / "editbooks.py"
+
+
+def _body() -> str:
+    src = EDITBOOKS.read_text(encoding="utf-8")
+    match = re.search(
+        r"def reload_metadata_from_disk\(book_id\):.*?(?=\ndef |\n@|\Z)",
+        src,
+        re.DOTALL,
+    )
+    assert match, "Could not locate reload_metadata_from_disk body"
+    return match.group(0)
+
+
+@pytest.mark.unit
+class TestReloadCoversDeferredFields:
+    def test_authors_via_handle_author_on_edit(self):
+        body = _body()
+        assert "handle_author_on_edit" in body, (
+            "authors must reload via handle_author_on_edit — the helper the "
+            "edit-book save path uses for author_sort regeneration and "
+            "rename handling (#218 follow-up)"
+        )
+
+    def test_tags_via_edit_book_tags(self):
+        body = _body()
+        assert "edit_book_tags" in body, (
+            "tags must reload via edit_book_tags (dedup + orphan cleanup)"
+        )
+
+    def test_series_via_edit_book_series(self):
+        body = _body()
+        assert "edit_book_series" in body, (
+            "series must reload via edit_book_series (create-on-demand)"
+        )
+
+    def test_dir_structure_updated_on_title_or_author_change(self):
+        """Every edit path pairs title/author changes with
+        helper.update_dir_structure so the on-disk Author/Title (id)
+        layout converges with the database. Reload must too — otherwise
+        reload leaves the library in a state no other write path
+        produces."""
+        body = _body()
+        assert "update_dir_structure" in body, (
+            "reload must call helper.update_dir_structure when title or "
+            "authors changed — the v4.0.149 title-only reload skipped it"
+        )
+
+
+@pytest.mark.unit
+class TestAbsentFieldSafetyGates:
+    def test_author_unknown_sentinel_does_not_stomp(self):
+        """get_epub_info yields the literal 'Unknown' when the file has no
+        <dc:creator>. Passing that through handle_author_on_edit would
+        replace the book's real authors with 'Unknown'."""
+        body = _body()
+        assert re.search(r"meta\.author[^\n]*['\"]Unknown['\"]", body), (
+            "the author reload must exclude the get_epub_info 'Unknown' "
+            "sentinel — a file without <dc:creator> must not stomp authors"
+        )
+
+    def test_empty_tags_do_not_wipe_curated_tags(self):
+        """get_epub_info yields '' for missing <dc:subject>. edit_book_tags('')
+        would diff curated tags against [''] and wipe them. Absence in the
+        file is ambiguous (tool may simply not write subjects) — skip."""
+        body = _body()
+        m = re.search(r"if\s+meta\.tags[^\n:]*:", body)
+        assert m, (
+            "tags reload must be gated on meta.tags being non-empty so a "
+            "subject-less file can't wipe curated tags"
+        )
+
+    def test_empty_series_does_not_clear(self):
+        body = _body()
+        m = re.search(r"if\s+meta\.series\s+and\s", body)
+        assert m, (
+            "series reload must be gated on meta.series being non-empty"
+        )
+
+    def test_series_index_validated_without_flash(self):
+        """edit_book_series_index flashes on invalid input — a flash inside
+        a JSON endpoint leaks a stale message into the next rendered page.
+        The reload must validate the numeric shape itself."""
+        body = _body()
+        assert re.search(r"replace\('\.', '', 1\)\.isdigit\(\)", body), (
+            "series index must be numeric-validated inline (the flash-based "
+            "edit_book_series_index helper is for form requests)"
+        )
+
+    def test_series_index_compares_numerically(self):
+        """Caught live on the second reload of the same book: series_index
+        is a REAL column, so a string compare (str(4.0) != "4") reports a
+        change on every reload — each one re-marking the book modified and
+        churning Kobo-sync cursors. The compare must be numeric."""
+        body = _body()
+        assert re.search(
+            r"float\(book\.series_index\s+or\s+0\)\s*!=\s*float\(series_id\)",
+            body,
+        ), (
+            "series_index reload must compare float-to-float — a string "
+            "compare makes every reload a spurious modification"
+        )

--- a/tests/unit/test_reload_metadata_authors_tags_series_218.py
+++ b/tests/unit/test_reload_metadata_authors_tags_series_218.py
@@ -74,6 +74,38 @@ class TestReloadCoversDeferredFields:
             "authors changed — the v4.0.149 title-only reload skipped it"
         )
 
+    def test_rename_failure_rolls_back_never_commits(self):
+        """Adversarial-review finding: the edit-book POST path responds to
+        an update_dir_structure error with rollback + bail. Reload must
+        mirror that — committing metadata for a layout the move didn't
+        produce leaves the catalog pointing at paths that don't exist."""
+        body = _body()
+        m = re.search(
+            r"if rename_error:.*?calibre_db\.session\.rollback\(\).*?return jsonify\(",
+            body, re.DOTALL)
+        assert m, (
+            "rename_error must trigger session.rollback() and an error "
+            "return — never warn-and-commit"
+        )
+
+    def test_file_moves_run_outside_the_writers_lock(self):
+        """Adversarial-review finding: metadata_db_write_lock's contract is
+        single-commit duration (it coordinates with the ingest processor,
+        #192). File renames inside it can starve ingest for the length of
+        a folder move on slow storage. Only the COMMIT may hold it —
+        matching the edit-book POST path."""
+        body = _body()
+        lock_positions = [m.start() for m in re.finditer(r"metadata_db_write_lock\(\)", body)]
+        assert len(lock_positions) == 1, (
+            f"expected exactly one metadata_db_write_lock() in the reload "
+            f"(around the commit), found {len(lock_positions)}"
+        )
+        dir_call = body.index("update_dir_structure")
+        assert dir_call < lock_positions[0], (
+            "update_dir_structure must run BEFORE (outside) the writers' "
+            "lock; only the commit holds it"
+        )
+
 
 @pytest.mark.unit
 class TestAbsentFieldSafetyGates:
@@ -114,6 +146,43 @@ class TestAbsentFieldSafetyGates:
             "series index must be numeric-validated inline (the flash-based "
             "edit_book_series_index helper is for form requests)"
         )
+
+    def test_parse_epub_series_signals_absence_as_empty(self):
+        """Adversarial-review finding (CONFIRMED class): parse_epub_series
+        fabricated series_id='1' when the file carried no
+        calibre:series_index meta — so a file with a series NAME but no
+        index made reload stomp a curated index back to 1 on every run.
+        Absence must surface as '' so the reload gate skips it. Behavioral:
+        run the real parser against minimal OPF trees."""
+        from lxml import etree
+        from cps.epub import parse_epub_series
+
+        ns = {
+            "n": "urn:oasis:names:tc:opendocument:xmlns:container",
+            "pkg": "http://www.idpf.org/2007/opf",
+            "dc": "http://purl.org/dc/elements/1.1/",
+        }
+        opf_no_index = (
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+            '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
+            '<meta name="calibre:series" content="Foo"/>'
+            '</metadata></package>'
+        )
+        tree = etree.fromstring(opf_no_index.encode())
+        out = parse_epub_series(ns, tree, {})
+        assert out["series"] == "Foo"
+        assert out["series_id"] == "", (
+            "missing calibre:series_index must yield '' (absence), not a "
+            "fabricated '1' that stomps curated indexes on reload"
+        )
+
+        opf_with_index = opf_no_index.replace(
+            "</metadata>",
+            '<meta name="calibre:series_index" content="4"/></metadata>',
+        )
+        tree2 = etree.fromstring(opf_with_index.encode())
+        out2 = parse_epub_series(ns, tree2, {})
+        assert out2["series_id"] == "4"
 
     def test_series_index_compares_numerically(self):
         """Caught live on the second reload of the same book: series_index

--- a/tests/unit/test_reload_metadata_from_disk_218.py
+++ b/tests/unit/test_reload_metadata_from_disk_218.py
@@ -177,11 +177,14 @@ def test_fork_218_anchor_comment_present():
     )
 
 
-def test_reload_metadata_defers_authors_tags_series():
-    """Verify the deferred-fields decision is documented in the
-    function — those involve relationship-table bookkeeping that the
-    full edit-book save path handles correctly. This test pins that
-    we DON'T silently start updating them through this endpoint."""
+def test_reload_metadata_covers_authors_tags_series_via_helpers():
+    """Originally these three fields were deferred; the #218 follow-up
+    (reporter @yodatak: "it don't reload all the metadata") wires them
+    through the SAME helpers the edit-book save path uses, so the
+    relationship bookkeeping (author_sort regeneration, tag dedup +
+    orphan cleanup, series create-on-demand) is identical — the reason
+    the original deferral existed. Full behavioral pins live in
+    test_reload_metadata_authors_tags_series_218.py."""
     src = _source()
     match = re.search(
         r"def reload_metadata_from_disk\(book_id\):.*?(?=\n\Z)",
@@ -189,13 +192,10 @@ def test_reload_metadata_defers_authors_tags_series():
         re.DOTALL,
     )
     body = match.group(0)
-    # No edit_book_authors or edit_book_tags or edit_book_series call.
-    for forbidden in ("edit_book_authors(", "edit_book_tags(", "edit_book_series("):
-        assert forbidden not in body, (
-            f"reload_metadata_from_disk must NOT call `{forbidden}` — "
-            f"those fields involve relationship-table bookkeeping that "
-            f"is deliberately deferred to the full edit-book save path. "
-            f"Updating them here without the full bookkeeping risks "
-            f"orphaned tag rows / author_sort drift / series-index "
-            f"clashes."
+    for required in ("handle_author_on_edit", "edit_book_tags(", "edit_book_series("):
+        assert required in body, (
+            f"reload_metadata_from_disk must call `{required}` — the "
+            f"deferred-fields gap was closed in the #218 follow-up by "
+            f"reusing the edit-path helpers (NOT by reimplementing the "
+            f"bookkeeping)."
         )


### PR DESCRIPTION
## #218 follow-up — @yodatak: "it don't reload all the metadata"

The v4.0.149 reload covered title/comments/publisher/pubdate/languages and deferred authors/tags/series. This closes the gap by routing the three fields through the **same helpers the edit-book save path uses** (`handle_author_on_edit`, `edit_book_tags`, `edit_book_series`) — the relationship bookkeeping the deferral feared is identical by construction.

Also fixes the same-class gap the v4.0.149 cut shipped: title/author changes now trigger `helper.update_dir_structure` like every other edit path, so the book's **folder and filename converge** to the `Author/Title (id)` convention (rename failure surfaces as a JSON `warning`; metadata still commits, mirroring the edit path).

**Safety gates:** `get_epub_info` yields literal `'Unknown'` for a missing `<dc:creator>` and `''` for missing subjects/series — both treated as "file carries nothing", so a tool that drops those elements can't stomp curated data.

**Caught live on double-reload:** `series_index` is a REAL column; the string compare (`str(4.0) != "4"`) reported a change on every reload — re-marking the book modified and churning Kobo-sync cursors. Compare is numeric now, with a regression pin.

## Verification (live cwn-local, grimmory-style flow — OPF rewritten inside a real EPUB)

| Gate | Result |
|---|---|
| Creator/subjects/series edited in file → reload | `[authors, tags, series, series_index]`; `author_sort` regenerated ("Atheniensis, Platon") |
| Dir convergence | book moved `Plato/` → `Platon Atheniensis/`, file renamed, `data.name` updated |
| Creator-stripped EPUB → reload | `[]` — authors preserved (Unknown-sentinel gate) |
| Double-reload | `[]` both times — idempotent after the numeric fix |
| Reverse edit → reload | converges back, including the reverse dir+file move |
| UI | detail page renders reloaded author/series/tags (JPEG in notes/) |
| Tests | 18 in `test_reload_metadata_authors_tags_series_218.py` (+updated pins), 91 editbooks-area green, 0 console errors |

Rides the next release train per the new policy; available on `:dev` at merge.

Addresses #218