### PR TITLE
feat(ingest): capture + show the original imported filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+- The book detail and edit pages now show the filename a book was imported
+  with ("Imported as: …"). Ingest renames files to match their metadata —
+  including wrong auto-matches — so the original name is the one stable
+  reference for recognizing misidentified books while you fix their tags.
+  Captured automatically for new imports from this version on. (#346,
+  requested by @BakaPhoenix and @magdalar)
+
 ### Fixed
 - "Reload Metadata" now also reloads authors, tags, and series (with series
   number) from the book file — previously only title, description, publisher,

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -1341,6 +1341,7 @@ def delete_whole_book(book_id, book):
     ub.session.query(ub.BookShelf).filter(ub.BookShelf.book_id == book_id).delete()
     ub.session.query(ub.ReadBook).filter(ub.ReadBook.book_id == book_id).delete()
     ub.session.query(ub.ArchivedBook).filter(ub.ArchivedBook.book_id == book_id).delete()
+    ub.session.query(ub.BookOriginalFilename).filter(ub.BookOriginalFilename.book_id == book_id).delete()
     ub.delete_download(book_id)
     ub.session_commit()
 
@@ -1540,7 +1541,11 @@ def render_edit_book(book_id):
     hardcover_blacklist = ub.session.query(ub.HardcoverBookBlacklist).filter(
         ub.HardcoverBookBlacklist.book_id == book.id
     ).first()
+    original_filename_row = ub.session.query(ub.BookOriginalFilename).filter(
+        ub.BookOriginalFilename.book_id == book.id).first()
     return render_title_template('book_edit.html', book=book, authors=author_names, cc=cc,
+                                 original_filename=(original_filename_row.filename
+                                                    if original_filename_row else None),
                                  title=_("edit metadata"), page="editbook",
                                  conversion_formats=allowed_conversion_formats,
                                  config=config,

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -86,6 +86,9 @@
     <div class="form-group">
       <label for="title">{{_('Book Title')}}</label>
       <input type="text" class="form-control" name="title" id="title" value="{{book.title}}">
+      {% if original_filename %}
+      <small class="form-text text-muted" style="display: block; margin-top: 0.5rem;">{{ _('Imported as') }}: {{ original_filename }}</small>
+      {% endif %}
     </div>
     <div class="text-center">
         <button type="button" class="btn btn-default" id="xchange" ><span class="glyphicon glyphicon-arrow-up"></span><span class="glyphicon glyphicon-arrow-down"></span></button>

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -741,6 +741,12 @@
                                     </button>
                                 </div>
                             {% endif %}
+                            {% if original_filename %}
+                                <div class="book-original-filename meta-chip">
+                                    <span>{{ _('Imported as') }}:</span>
+                                    <span class="meta-value">{{ original_filename }}</span>
+                                </div>
+                            {% endif %}
                             <div class="book-date-added meta-chip">
                                 <span>{{ _('Date added') }}:</span>
                                 <span class="meta-value">{{ entry.timestamp|formatdate }}</span>

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -724,6 +724,26 @@ class KoboSyncedBooks(Base):
     )
 
 
+class BookOriginalFilename(Base):
+    """The filename a book arrived with in the ingest folder, captured at
+    import time (fork #346, @BakaPhoenix + @magdalar). Ingest renames files
+    to match their (possibly wrongly auto-matched) metadata, so the
+    as-imported name is the one stable reference a user has for recognizing
+    misidentified books while fixing tags.
+
+    One row per book — the import that CREATED the book; later format
+    additions never overwrite it (the ingest writer uses ON CONFLICT
+    DO NOTHING). book_id refers to calibre's metadata.db (cross-database,
+    so no FK). Row is removed by delete_whole_book with the other
+    book-scoped ub rows.
+    """
+    __tablename__ = 'book_original_filename'
+
+    book_id = Column(Integer, primary_key=True)
+    filename = Column(String, nullable=False)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+
 class KoboDeletedBook(Base):
     """Tombstone table for books deleted from CW that need to be reported
     to Kobo devices as DeletedEntitlement on next sync.
@@ -1206,6 +1226,8 @@ def add_missing_tables(engine, _session):
         MagicShelfCache.__table__.create(bind=engine, checkfirst=True)
     if not engine.dialect.has_table(engine.connect(), "opds_shelf_exposure"):
         OpdsShelfExposure.__table__.create(bind=engine, checkfirst=True)
+    if not engine.dialect.has_table(engine.connect(), "book_original_filename"):
+        BookOriginalFilename.__table__.create(bind=engine, checkfirst=True)
     if not engine.dialect.has_table(engine.connect(), "opds_magic_shelf_exposure"):
         OpdsMagicShelfExposure.__table__.create(bind=engine, checkfirst=True)
     if not engine.dialect.has_table(engine.connect(), "hidden_magic_shelf_templates"):

--- a/cps/web.py
+++ b/cps/web.py
@@ -3412,8 +3412,12 @@ def show_book(book_id):
                 ub.User.kindle_mail != "",
             ).order_by(ub.User.name).all()
 
+        original_filename_row = ub.session.query(ub.BookOriginalFilename).filter(
+            ub.BookOriginalFilename.book_id == book_id).first()
         return render_title_template('detail.html',
                                      entry=entry,
+                                     original_filename=(original_filename_row.filename
+                                                        if original_filename_row else None),
                                      cc=cc,
                                      is_xhr=request.headers.get('X-Requested-With') == 'XMLHttpRequest',
                                      title=entry.title,

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -967,11 +967,16 @@ class NewBookProcessor:
         effort: a failure (e.g. table missing on a first boot where the web
         app hasn't run its migrations yet) must never block the import.
         """
-        book_ids = self.last_added_book_ids or (
-            [self.last_added_book_id] if self.last_added_book_id else [])
-        if not book_ids or not self.original_filename:
+        # getattr defaults: tests (and any future code path) construct
+        # NewBookProcessor via object.__new__ without running __init__ —
+        # a missing attribute must mean "nothing to record", never an
+        # AttributeError that trips the import's failure branch.
+        book_ids = getattr(self, 'last_added_book_ids', None) or (
+            [self.last_added_book_id]
+            if getattr(self, 'last_added_book_id', None) else [])
+        if not book_ids or not getattr(self, 'original_filename', None):
             return
-        if self.last_added_ids_are_fallback:
+        if getattr(self, 'last_added_ids_are_fallback', False):
             # The id is a most-recently-modified guess (calibredb output
             # parsing failed) — under concurrent ingest it can belong to a
             # DIFFERENT book, and a wrong "Imported as" is worse than none.

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -793,6 +793,10 @@ class NewBookProcessor:
         # Current file
         self.filepath = filepath
         self.filename = os.path.basename(filepath)
+        # As-imported basename, snapshotted before any conversion/rename can
+        # touch it — recorded into app.db after a successful add so users can
+        # recognize misidentified auto-matches (fork #346).
+        self.original_filename = Path(filepath).name
         self.can_convert, self.input_format = self.can_convert_check()
         # Determine if the file is already in the desired target format using normalized extensions
         self.is_target_format = (self.input_format.lower() == str(self.target_format).lower())
@@ -939,6 +943,37 @@ class NewBookProcessor:
             return True
         else:
             return False
+
+
+    def record_original_filename(self) -> None:
+        """Persist the as-imported filename for every book id this add
+        produced (fork #346) — the one stable reference for recognizing
+        misidentified auto-matches after ingest renames the file.
+
+        Direct sqlite write to app.db with a busy timeout — the processor's
+        established pattern for app.db access (_load_cps_settings_from_app_db).
+        ON CONFLICT(book_id) DO NOTHING: the CREATING import wins; format
+        additions to an existing book never overwrite the original. Best
+        effort: a failure (e.g. table missing on a first boot where the web
+        app hasn't run its migrations yet) must never block the import.
+        """
+        book_ids = self.last_added_book_ids or (
+            [self.last_added_book_id] if self.last_added_book_id else [])
+        if not book_ids or not self.original_filename:
+            return
+        try:
+            with sqlite3.connect(get_app_db_path(), timeout=30) as con:
+                for bid in book_ids:
+                    con.execute(
+                        "INSERT INTO book_original_filename "
+                        "(book_id, filename, created_at) "
+                        "VALUES (?, ?, datetime('now')) "
+                        "ON CONFLICT(book_id) DO NOTHING",
+                        (int(bid), self.original_filename),
+                    )
+        except (sqlite3.Error, ValueError, TypeError) as e:
+            print(f"[ingest-processor] WARN: could not record original "
+                  f"filename for {book_ids}: {e}", flush=True)
 
     def backup(self, input_file, backup_type):
         output_path = None
@@ -1208,6 +1243,7 @@ class NewBookProcessor:
                 else:
                     self._fallback_last_added_book_id()
             print(f"[ingest-processor] Added {staged_path.stem} to Calibre database", flush=True)
+            self.record_original_filename()
 
             if self.cwa_settings['auto_backup_imports']:
                 self.backup(str(staged_path), backup_type="imported")

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -797,6 +797,9 @@ class NewBookProcessor:
         # touch it — recorded into app.db after a successful add so users can
         # recognize misidentified auto-matches (fork #346).
         self.original_filename = Path(filepath).name
+        # True when last_added_book_id(s) came from the most-recently-modified
+        # fallback guess rather than parsed calibredb output.
+        self.last_added_ids_are_fallback = False
         self.can_convert, self.input_format = self.can_convert_check()
         # Determine if the file is already in the desired target format using normalized extensions
         self.is_target_format = (self.input_format.lower() == str(self.target_format).lower())
@@ -871,6 +874,11 @@ class NewBookProcessor:
                 if row:
                     self.last_added_book_id = int(row[0])
                     self.last_added_book_ids = [self.last_added_book_id]
+                    # Guess, not parsed output — under concurrent ingest this
+                    # can be ANOTHER processor's book. Consumers that would
+                    # mis-attribute on a wrong id (original-filename capture)
+                    # check this flag and skip.
+                    self.last_added_ids_are_fallback = True
                     print(
                         "[ingest-processor] WARN: Could not parse calibredb output; using most recently modified book ID.",
                         flush=True,
@@ -950,8 +958,10 @@ class NewBookProcessor:
         produced (fork #346) — the one stable reference for recognizing
         misidentified auto-matches after ingest renames the file.
 
-        Direct sqlite write to app.db with a busy timeout — the processor's
-        established pattern for app.db access (_load_cps_settings_from_app_db).
+        Direct sqlite write to app.db with a busy timeout. Note: the
+        processor's other app.db access is read-only; this is its first
+        WRITE — kept safe by app.db's WAL mode (writers don't block the web
+        app's readers), the 30s busy timeout, and the best-effort except.
         ON CONFLICT(book_id) DO NOTHING: the CREATING import wins; format
         additions to an existing book never overwrite the original. Best
         effort: a failure (e.g. table missing on a first boot where the web
@@ -960,6 +970,14 @@ class NewBookProcessor:
         book_ids = self.last_added_book_ids or (
             [self.last_added_book_id] if self.last_added_book_id else [])
         if not book_ids or not self.original_filename:
+            return
+        if self.last_added_ids_are_fallback:
+            # The id is a most-recently-modified guess (calibredb output
+            # parsing failed) — under concurrent ingest it can belong to a
+            # DIFFERENT book, and a wrong "Imported as" is worse than none.
+            print("[ingest-processor] Skipping original-filename record: "
+                  "book id came from fallback inference, not calibredb "
+                  "output", flush=True)
             return
         try:
             with sqlite3.connect(get_app_db_path(), timeout=30) as con:

--- a/tests/unit/test_book_original_filename_346.py
+++ b/tests/unit/test_book_original_filename_346.py
@@ -1,0 +1,145 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Fork #346 (@BakaPhoenix, +1 @magdalar): show a book's original imported
+filename. Ingest renames files to match their (possibly wrongly auto-matched)
+metadata, so the as-imported name is the one stable reference for recognizing
+misidentified books while fixing tags.
+
+Three prongs, pinned here:
+  1. Capture — ingest_processor snapshots the ingest-folder basename at
+     processor construction (the filepath never mutates, but capturing at
+     __init__ makes that immune to future refactors) and records it for
+     every book id a successful add produced. Best-effort direct sqlite
+     write to app.db (the processor's established pattern for app.db
+     access) with ON CONFLICT(book_id) DO NOTHING — the CREATING import
+     wins; later format additions never overwrite the original.
+  2. Display — read-only on the book detail page and the edit page.
+  3. Hygiene — delete_whole_book removes the row with the other ub
+     book-scoped rows.
+"""
+
+import re
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UB_PY = REPO_ROOT / "cps" / "ub.py"
+WEB_PY = REPO_ROOT / "cps" / "web.py"
+EDITBOOKS = REPO_ROOT / "cps" / "editbooks.py"
+INGEST = REPO_ROOT / "scripts" / "ingest_processor.py"
+DETAIL = REPO_ROOT / "cps" / "templates" / "detail.html"
+BOOK_EDIT = REPO_ROOT / "cps" / "templates" / "book_edit.html"
+
+
+@pytest.mark.unit
+class TestModel:
+    def test_model_exists_with_expected_columns(self):
+        src = UB_PY.read_text(encoding="utf-8")
+        assert "class BookOriginalFilename(Base)" in src
+        body = src.split("class BookOriginalFilename(Base)", 1)[1][:1500]
+        assert "__tablename__ = 'book_original_filename'" in body
+        assert "book_id" in body and "filename" in body and "created_at" in body
+
+    def test_table_created_by_add_missing_tables(self):
+        src = UB_PY.read_text(encoding="utf-8")
+        body = src.split("def add_missing_tables(", 1)[1]
+        body = body.split("\ndef ", 1)[0]
+        assert "book_original_filename" in body, (
+            "add_missing_tables must create book_original_filename so the "
+            "table exists before the ingest processor's first write"
+        )
+
+
+@pytest.mark.unit
+class TestIngestCapture:
+    def test_basename_captured_at_init(self):
+        src = INGEST.read_text(encoding="utf-8")
+        init = src.split("class NewBookProcessor", 1)[1]
+        init = init.split("def ", 2)[2] if False else init
+        assert re.search(r"self\.original_filename\s*=\s*Path\(filepath\)\.name", init), (
+            "NewBookProcessor must snapshot the ingest-folder basename at "
+            "__init__ — before any conversion/rename can touch it"
+        )
+
+    def test_record_method_uses_on_conflict_do_nothing(self):
+        src = INGEST.read_text(encoding="utf-8")
+        assert "def record_original_filename" in src
+        body = src.split("def record_original_filename", 1)[1]
+        body = body.split("\n    def ", 1)[0]
+        assert "ON CONFLICT(book_id) DO NOTHING" in body, (
+            "the CREATING import wins; format additions must never "
+            "overwrite the original filename"
+        )
+        assert "get_app_db_path()" in body, (
+            "must resolve app.db the same way the processor's other "
+            "app.db reads do"
+        )
+
+    def test_record_called_after_successful_add(self):
+        src = INGEST.read_text(encoding="utf-8")
+        assert re.search(
+            r"Added \{staged_path\.stem\} to Calibre database.*?self\.record_original_filename\(\)",
+            src, re.DOTALL), (
+            "record_original_filename must run after the calibredb add "
+            "succeeds (both text and audiobook branches converge there)"
+        )
+
+    def test_insert_semantics_behavioral(self, tmp_path):
+        """Run the real SQL against a real SQLite file: first write wins,
+        second (format-add) is a no-op, different book id inserts."""
+        db = tmp_path / "app.db"
+        con = sqlite3.connect(db)
+        con.execute(
+            "CREATE TABLE book_original_filename ("
+            "book_id INTEGER PRIMARY KEY, filename VARCHAR NOT NULL, "
+            "created_at DATETIME)"
+        )
+        sql = ("INSERT INTO book_original_filename (book_id, filename, created_at) "
+               "VALUES (?, ?, datetime('now')) ON CONFLICT(book_id) DO NOTHING")
+        con.execute(sql, (7, "fan_translation_v2_FINAL.epub"))
+        con.execute(sql, (7, "renamed_by_format_add.kepub"))
+        con.execute(sql, (8, "other.epub"))
+        con.commit()
+        rows = dict(con.execute(
+            "SELECT book_id, filename FROM book_original_filename").fetchall())
+        assert rows == {7: "fan_translation_v2_FINAL.epub", 8: "other.epub"}
+
+
+@pytest.mark.unit
+class TestDisplayAndHygiene:
+    def test_show_book_passes_original_filename(self):
+        src = WEB_PY.read_text(encoding="utf-8")
+        assert "BookOriginalFilename" in src and "original_filename=" in src, (
+            "show_book must query ub.BookOriginalFilename and pass "
+            "original_filename to detail.html"
+        )
+
+    def test_detail_template_renders_it(self):
+        tpl = DETAIL.read_text(encoding="utf-8")
+        assert "original_filename" in tpl, (
+            "detail.html must render the imported-as filename (read-only)"
+        )
+
+    def test_edit_template_renders_it(self):
+        tpl = BOOK_EDIT.read_text(encoding="utf-8")
+        assert "original_filename" in tpl, (
+            "book_edit.html must render the imported-as filename (read-only)"
+        )
+
+    def test_edit_render_passes_it(self):
+        src = EDITBOOKS.read_text(encoding="utf-8")
+        assert src.count("original_filename=") >= 1 and "BookOriginalFilename" in src, (
+            "render_edit_book must pass original_filename"
+        )
+
+    def test_delete_whole_book_cleans_row(self):
+        src = EDITBOOKS.read_text(encoding="utf-8")
+        body = src.split("def delete_whole_book(", 1)[1].split("\ndef ", 1)[0]
+        assert "BookOriginalFilename" in body, (
+            "delete_whole_book must remove the book_original_filename row "
+            "alongside the other ub book-scoped rows"
+        )

--- a/tests/unit/test_book_original_filename_346.py
+++ b/tests/unit/test_book_original_filename_346.py
@@ -79,6 +79,24 @@ class TestIngestCapture:
             "app.db reads do"
         )
 
+    def test_fallback_ids_never_recorded(self):
+        """Adversarial-review finding: _fallback_last_added_book_id guesses
+        the most-recently-modified book when calibredb output parsing
+        fails — under concurrent ingest that can be ANOTHER processor's
+        book. A wrong 'Imported as' is worse than none, so recording is
+        gated on ids that came from parsed output."""
+        src = INGEST.read_text(encoding="utf-8")
+        body = src.split("def record_original_filename", 1)[1]
+        body = body.split("\n    def ", 1)[0]
+        assert "last_added_ids_are_fallback" in body, (
+            "record_original_filename must skip fallback-inferred book ids"
+        )
+        fb = src.split("def _fallback_last_added_book_id", 1)[1]
+        fb = fb.split("\n    def ", 1)[0]
+        assert "last_added_ids_are_fallback = True" in fb, (
+            "_fallback_last_added_book_id must mark its ids as guesses"
+        )
+
     def test_record_called_after_successful_add(self):
         src = INGEST.read_text(encoding="utf-8")
         assert re.search(


### PR DESCRIPTION
## #346 — @BakaPhoenix + @magdalar

Ingest renames files to match their (possibly wrongly auto-matched) metadata, so there was nothing stable to recognize a misidentified book by. Now the as-imported filename is captured at ingest and shown read-only on the **detail page** ("Imported as" chip) and **edit page** (muted line under the title field) — exactly where you are while fixing tags.

**Mechanics:** new `book_original_filename` app.db table (auto-created at boot); `NewBookProcessor` snapshots the ingest-folder basename at construction and records it for every book id a successful add produced, via the processor's established direct-sqlite pattern with `ON CONFLICT(book_id) DO NOTHING` — the **creating** import wins, format additions never overwrite, and a write failure never blocks an import. `delete_whole_book` cleans the row. Applies to new imports from this version on (no backfill possible — the originals are gone).

## Verification (live, through the real pipeline)

| Gate | Result |
|---|---|
| Dropped `totally_wrong_name_v2_FINAL.epub` into the watched ingest folder | auto-ingest created book 171, row recorded: `171\|totally_wrong_name_v2_FINAL.epub` |
| Detail page | "Imported as: totally_wrong_name_v2_FINAL.epub" chip renders (JPEG in notes/) |
| Edit page | muted line renders (JPEG in notes/) |
| Delete the book | row removed (count 0) |
| Boot | table auto-created by add_missing_tables |
| Tests | 11 in `test_book_original_filename_346.py` incl. behavioral ON CONFLICT semantics on real SQLite |

Rides the next release train; on `:dev` at merge.

Addresses #346