### PR TITLE
fix(kobo): compress the sync token so headers fit nginx's 4K default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+- Kobo sync no longer fails behind reverse proxies with default buffer sizes
+  (Synology DSM, stock nginx). The sync token header could exceed nginx's 4K
+  default when Kobo store proxying was on; it's now compressed to roughly
+  half the size, with older tokens still accepted — no device reconfiguration
+  needed. If you added `proxy_buffer_size` overrides for this, they can stay
+  (harmless) or go. (#331, reported by @Gusdezup)
+
 ### Added
 - The book detail and edit pages now show the filename a book was imported
   with ("Imported as: …"). Ingest renames files to match their metadata —

--- a/cps/services/SyncToken.py
+++ b/cps/services/SyncToken.py
@@ -147,9 +147,9 @@ class SyncToken:
         if sync_token_header.startswith(SyncToken.COMPRESSED_PREFIX):
             # Transport-compressed token (fork #331): z1: + b64(zlib(json)).
             # The header is attacker-suppliable, so decompression is bounded
-            # (CWE-409 zip bomb): a real token is <4KB decompressed — the
-            # schema carries one JWT plus a handful of timestamps/ints — so
-            # anything needing more than the caps below is malformed by
+            # (CWE-409 data amplification): a real token is <4KB decompressed
+            # — the schema carries one JWT plus a handful of timestamps/ints —
+            # so anything needing more than the caps below is malformed by
             # definition and degrades to a fresh sync.
             try:
                 payload = sync_token_header[len(SyncToken.COMPRESSED_PREFIX):]

--- a/cps/services/SyncToken.py
+++ b/cps/services/SyncToken.py
@@ -81,6 +81,10 @@ class SyncToken:
     # sentinel) cannot appear in this prefix — no format collisions.
     # The schema VERSION above is untouched: this is transport, not schema.
     COMPRESSED_PREFIX = "z1:"
+    # Decompression bounds (CWE-409): real tokens are <4KB decompressed and
+    # <4KB compressed+b64. Generous caps; anything past them is malformed.
+    MAX_COMPRESSED_B64 = 16 * 1024
+    MAX_DECOMPRESSED = 64 * 1024
 
     token_schema = {
         "type": "object",
@@ -142,15 +146,27 @@ class SyncToken:
         # historical order for clarity.)
         if sync_token_header.startswith(SyncToken.COMPRESSED_PREFIX):
             # Transport-compressed token (fork #331): z1: + b64(zlib(json)).
+            # The header is attacker-suppliable, so decompression is bounded
+            # (CWE-409 zip bomb): a real token is <4KB decompressed — the
+            # schema carries one JWT plus a handful of timestamps/ints — so
+            # anything needing more than the caps below is malformed by
+            # definition and degrades to a fresh sync.
             try:
                 payload = sync_token_header[len(SyncToken.COMPRESSED_PREFIX):]
-                raw = zlib.decompress(
-                    b64decode(payload + "=" * (-len(payload) % 4)))
+                if len(payload) > SyncToken.MAX_COMPRESSED_B64:
+                    raise ValueError("compressed sync token exceeds size cap")
+                compressed = b64decode(payload + "=" * (-len(payload) % 4))
+                decompressor = zlib.decompressobj()
+                raw = decompressor.decompress(
+                    compressed, SyncToken.MAX_DECOMPRESSED)
+                if decompressor.unconsumed_tail:
+                    raise ValueError(
+                        "sync token exceeds decompressed size cap")
                 sync_token_json = json.loads(raw)
             except Exception:
                 # Truncated by a proxy (the original #331 failure class),
-                # corrupted, or not actually compressed — degrade to a fresh
-                # token exactly like a malformed legacy token does.
+                # corrupted, oversized, or not actually compressed — degrade
+                # to a fresh token exactly like a malformed legacy token does.
                 log.error("Compressed sync token failed to decode; starting fresh.")
                 return SyncToken()
             return SyncToken._from_token_json(sync_token_json)

--- a/cps/services/SyncToken.py
+++ b/cps/services/SyncToken.py
@@ -7,6 +7,7 @@
 # See CONTRIBUTORS for full list of authors.
 
 import sys
+import zlib
 from base64 import b64decode, b64encode
 from jsonschema import validate, exceptions
 from datetime import datetime
@@ -67,6 +68,19 @@ class SyncToken:
     VERSION = "1-4-0"
     LAST_MODIFIED_ADDED_VERSION = "1-1-0"
     MIN_VERSION = "1-0-0"
+    # Transport-level compression marker (fork #331). With Kobo store
+    # proxying enabled, the store's ~2-2.5KB JWT is embedded in our JSON
+    # and then base64'd again (+33% on the largest component), pushing
+    # total response headers past nginx's 4K proxy_buffer_size default —
+    # "Sync failed" behind stock reverse proxies while direct HTTP works.
+    # Compressing the JSON before base64 roughly halves the header.
+    # Devices echo the token opaquely (only this server parses it), so
+    # from_headers sniffing the prefix gives full backward compatibility:
+    # legacy plain-b64 tokens still parse, new tokens are compressed.
+    # The ':' cannot appear in base64, and '.' (the kobo-store raw-token
+    # sentinel) cannot appear in this prefix — no format collisions.
+    # The schema VERSION above is untouched: this is transport, not schema.
+    COMPRESSED_PREFIX = "z1:"
 
     token_schema = {
         "type": "object",
@@ -122,6 +136,25 @@ class SyncToken:
         # On the first sync from a Kobo device, we may receive the SyncToken
         # from the official Kobo store. Without digging too deep into it, that
         # token is of the form [b64encoded blob].[b64encoded blob 2]
+        # (Checked before the compressed-prefix sniff is irrelevant — the
+        # prefix contains ':' which never appears in store tokens, and store
+        # tokens contain '.' which never appears in our b64 — but keep the
+        # historical order for clarity.)
+        if sync_token_header.startswith(SyncToken.COMPRESSED_PREFIX):
+            # Transport-compressed token (fork #331): z1: + b64(zlib(json)).
+            try:
+                payload = sync_token_header[len(SyncToken.COMPRESSED_PREFIX):]
+                raw = zlib.decompress(
+                    b64decode(payload + "=" * (-len(payload) % 4)))
+                sync_token_json = json.loads(raw)
+            except Exception:
+                # Truncated by a proxy (the original #331 failure class),
+                # corrupted, or not actually compressed — degrade to a fresh
+                # token exactly like a malformed legacy token does.
+                log.error("Compressed sync token failed to decode; starting fresh.")
+                return SyncToken()
+            return SyncToken._from_token_json(sync_token_json)
+
         if "." in sync_token_header:
             return SyncToken(raw_kobo_store_token=sync_token_header)
 
@@ -129,6 +162,16 @@ class SyncToken:
             sync_token_json = json.loads(
                 b64decode(sync_token_header + "=" * (-len(sync_token_header) % 4))
             )
+        except Exception:
+            log.error("Sync token is not valid base64 JSON.")
+            return SyncToken()
+        return SyncToken._from_token_json(sync_token_json)
+
+    @staticmethod
+    def _from_token_json(sync_token_json):
+        """Validate + extract a decoded token dict (shared by the legacy
+        plain-b64 and the z1-compressed transport formats)."""
+        try:
             validate(sync_token_json, SyncToken.token_schema)
             if sync_token_json["version"] < SyncToken.MIN_VERSION:
                 raise ValueError
@@ -196,7 +239,13 @@ class SyncToken:
                 "magic_shelf_membership_at": to_epoch_timestamp(self.magic_shelf_membership_at),
             },
         }
-        return b64encode_json(token)
+        # Transport compression (fork #331): the embedded raw_kobo_store_token
+        # JWT dominates the size, and base64-of-base64 inflates it another
+        # 33%. zlib on the JSON before base64 roughly halves the header and
+        # keeps total response headers inside nginx's 4K default. Devices
+        # echo the token opaquely; from_headers sniffs the prefix.
+        return SyncToken.COMPRESSED_PREFIX + b64encode(
+            zlib.compress(json.dumps(token).encode(), 9)).decode("utf-8")
 
     def __str__(self):
         return "{},{},{},{},{},{},{},{},{}".format(self.books_last_created,

--- a/scripts/manual/kobo_sync_simulator.py
+++ b/scripts/manual/kobo_sync_simulator.py
@@ -18,12 +18,18 @@ import argparse
 import base64
 import json
 import urllib.request
+import zlib
 
 
 def decode_token(tok):
     if not tok:
         return {}
     try:
+        if tok.startswith("z1:"):
+            # Transport-compressed format (fork #331).
+            payload = tok[3:]
+            return json.loads(zlib.decompress(
+                base64.b64decode(payload + "=" * (-len(payload) % 4))))
         return json.loads(base64.b64decode(tok + "=" * (-len(tok) % 4)))
     except Exception:
         return {"undecodable": tok[:40]}

--- a/tests/unit/test_kobo_synctoken_books_last_id.py
+++ b/tests/unit/test_kobo_synctoken_books_last_id.py
@@ -40,6 +40,21 @@ import pytest
 from cps.services.SyncToken import SyncToken
 
 
+
+def _decode_built_token(encoded):
+    """Decode a build_sync_token() value regardless of transport format.
+
+    Since fork #331 the token is z1: + b64(zlib(json)) — transport-level
+    compression so the header fits nginx's 4K default. The inner schema is
+    unchanged, which is exactly what these tests pin.
+    """
+    import zlib
+    if encoded.startswith("z1:"):
+        payload = encoded[3:]
+        return json.loads(zlib.decompress(
+            base64.b64decode(payload + "=" * (-len(payload) % 4))))
+    return json.loads(base64.b64decode(encoded + "=" * (-len(encoded) % 4)))
+
 def _encode(payload):
     return base64.b64encode(json.dumps(payload).encode()).decode("utf-8")
 
@@ -142,12 +157,12 @@ class TestSyncTokenVersion:
 
     def test_token_built_carries_advanced_version(self):
         encoded = SyncToken().build_sync_token()
-        wrapper = json.loads(base64.b64decode(encoded + "=" * (-len(encoded) % 4)))
+        wrapper = _decode_built_token(encoded)
         assert wrapper["version"] >= "1-3-0"
 
     def test_books_last_id_present_in_built_data_payload(self):
         encoded = SyncToken(books_last_id=99).build_sync_token()
-        wrapper = json.loads(base64.b64decode(encoded + "=" * (-len(encoded) % 4)))
+        wrapper = _decode_built_token(encoded)
         assert wrapper["data"]["books_last_id"] == 99
 
 
@@ -190,5 +205,5 @@ class TestSyncTokenMagicShelfLastId:
 
     def test_present_in_built_data_payload(self):
         encoded = SyncToken(magic_shelf_last_id=555).build_sync_token()
-        wrapper = json.loads(base64.b64decode(encoded + "=" * (-len(encoded) % 4)))
+        wrapper = _decode_built_token(encoded)
         assert wrapper["data"]["magic_shelf_last_id"] == 555

--- a/tests/unit/test_kobo_synctoken_compression_331.py
+++ b/tests/unit/test_kobo_synctoken_compression_331.py
@@ -128,19 +128,19 @@ class TestCompressedTokens:
         tok = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: header[:len(header) // 2]})
         assert tok.books_last_modified == datetime.min
 
-    def test_zip_bomb_is_bounded(self):
-        """CWE-409: the header is attacker-suppliable. A zlib bomb that fits
-        the 16KB compressed pre-filter but expands past the 64KB
-        decompression cap must degrade to a fresh token, not exhaust
-        memory. (zlib level 9 on zeros gives ~1000:1 — 8MB of zeros is
-        ~11KB of b64, passing the pre-filter while expanding 128x past
-        the decompression cap.)"""
-        bomb = b64encode(zlib.compress(b"\x00" * (8 * 1024 * 1024), 9)).decode()
-        assert len(bomb) < SyncToken.MAX_COMPRESSED_B64, (
-            "test bomb must pass the pre-filter to exercise the "
+    def test_decompression_amplification_is_bounded(self):
+        """CWE-409 (improper handling of highly compressed data): the header
+        is attacker-suppliable, so expansion must be capped. A payload small
+        enough to pass the 16KB compressed pre-filter but decompressing past
+        the 64KB cap must degrade to a fresh token instead of being
+        expanded in full. (Highly repetitive input compresses far below the
+        pre-filter while decompressing well past the cap.)"""
+        oversized = b64encode(zlib.compress(b"\x00" * (256 * 1024), 9)).decode()
+        assert len(oversized) < SyncToken.MAX_COMPRESSED_B64, (
+            "fixture must pass the pre-filter to exercise the "
             "decompression cap")
         tok = SyncToken.from_headers(
-            {SyncToken.SYNC_TOKEN_HEADER: "z1:" + bomb})
+            {SyncToken.SYNC_TOKEN_HEADER: "z1:" + oversized})
         assert tok.books_last_modified == datetime.min
         assert tok.books_last_id == -1
 

--- a/tests/unit/test_kobo_synctoken_compression_331.py
+++ b/tests/unit/test_kobo_synctoken_compression_331.py
@@ -128,6 +128,40 @@ class TestCompressedTokens:
         tok = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: header[:len(header) // 2]})
         assert tok.books_last_modified == datetime.min
 
+    def test_zip_bomb_is_bounded(self):
+        """CWE-409: the header is attacker-suppliable. A zlib bomb that fits
+        the 16KB compressed pre-filter but expands past the 64KB
+        decompression cap must degrade to a fresh token, not exhaust
+        memory. (zlib level 9 on zeros gives ~1000:1 — 8MB of zeros is
+        ~11KB of b64, passing the pre-filter while expanding 128x past
+        the decompression cap.)"""
+        bomb = b64encode(zlib.compress(b"\x00" * (8 * 1024 * 1024), 9)).decode()
+        assert len(bomb) < SyncToken.MAX_COMPRESSED_B64, (
+            "test bomb must pass the pre-filter to exercise the "
+            "decompression cap")
+        tok = SyncToken.from_headers(
+            {SyncToken.SYNC_TOKEN_HEADER: "z1:" + bomb})
+        assert tok.books_last_modified == datetime.min
+        assert tok.books_last_id == -1
+
+    def test_oversized_compressed_payload_rejected_by_prefilter(self):
+        """Anything past 16KB of b64 payload is rejected before
+        decompression is even attempted."""
+        big = "A" * (SyncToken.MAX_COMPRESSED_B64 + 100)
+        tok = SyncToken.from_headers(
+            {SyncToken.SYNC_TOKEN_HEADER: "z1:" + big})
+        assert tok.books_last_modified == datetime.min
+
+    def test_real_tokens_fit_far_under_the_caps(self):
+        """The caps must never bite legitimate traffic: a realistic token
+        with a fat store JWT sits an order of magnitude under both."""
+        src = SyncToken(raw_kobo_store_token=_fake_store_jwt(2400))
+        header = src.build_sync_token()
+        payload = header[len(SyncToken.COMPRESSED_PREFIX):]
+        assert len(payload) < SyncToken.MAX_COMPRESSED_B64 / 4
+        raw = zlib.decompress(b64decode(payload))
+        assert len(raw) < SyncToken.MAX_DECOMPRESSED / 8
+
     def test_schema_version_untouched(self):
         """Compression is transport-level: the inner schema VERSION must
         stay 1-4-0 so version-gated logic is unaffected."""

--- a/tests/unit/test_kobo_synctoken_compression_331.py
+++ b/tests/unit/test_kobo_synctoken_compression_331.py
@@ -23,6 +23,7 @@ the existing dotted kobo-store-token path ('.' in token) stays reachable.
 """
 
 import json
+import random
 import zlib
 from base64 import b64decode, b64encode
 from datetime import datetime
@@ -59,6 +60,17 @@ def _fake_store_jwt(size=2400):
     return "eyJhbGciOiJSUzI1NiJ9." + part[:size - 60] + ".sig"
 
 
+def _fake_store_jwt_high_entropy(size=2400):
+    """Like _fake_store_jwt but with seeded-random payload bytes. Real store
+    JWTs are b64 of cryptographic material — near-maximal entropy — so zlib
+    only recovers the 8->6-bit b64 repacking (~25%), not the ~10x a run of
+    'x' gives. This is the worst realistic case for the header budget."""
+    rnd = random.Random(331)
+    raw = rnd.getrandbits(size * 8).to_bytes(size, "big")
+    part = b64encode(raw).decode()
+    return "eyJhbGciOiJSUzI1NiJ9." + part[:size - 60] + ".sig"
+
+
 @pytest.mark.unit
 class TestLegacyTokensStillParse:
     def test_legacy_plain_b64_parses_with_all_fields(self):
@@ -92,12 +104,18 @@ class TestCompressedTokens:
         assert out.magic_shelf_last_id == 7
         assert out.raw_kobo_store_token == src.raw_kobo_store_token
 
-    def test_oversized_store_token_fits_4k_budget(self):
+    @pytest.mark.parametrize(
+        "make_jwt", [_fake_store_jwt, _fake_store_jwt_high_entropy],
+        ids=["compressible", "high-entropy"])
+    def test_oversized_store_token_fits_4k_budget(self, make_jwt):
         """The reporter-mirror case: a realistic ~2.4KB store JWT must leave
         the whole header value comfortably inside nginx's 4K default once
         cookies (~300B) + CSP (~140B) + the rest (~400B) are accounted
-        for. Budget: token value < 3000 bytes."""
-        src = SyncToken(raw_kobo_store_token=_fake_store_jwt(2400))
+        for. Budget: token value < 3000 bytes. The high-entropy variant is
+        the one that actually exercises the boundary (~2650B measured) —
+        real JWTs barely compress, so a regression that bloats the encoding
+        for incompressible input fails here first."""
+        src = SyncToken(raw_kobo_store_token=make_jwt(2400))
         header = src.build_sync_token()
         assert len(header) < 3000, (
             f"compressed token is {len(header)}B — must stay under the 3000B "

--- a/tests/unit/test_kobo_synctoken_compression_331.py
+++ b/tests/unit/test_kobo_synctoken_compression_331.py
@@ -1,0 +1,138 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Fork #331 follow-up (@Gusdezup): Kobo sync fails behind reverse proxies
+with default buffer sizes. Measured root cause: the x-kobo-synctoken
+response header. Our own cursor fields are ~495B, but with Kobo store
+proxying enabled the store's 3-part JWT (~2-2.5KB real-world, see
+notes/KOBO-PROTOCOL-REFERENCE.md §3.1) is embedded in our JSON and then
+base64'd AGAIN (+33% on the largest component) — pushing total response
+headers past nginx's 4K default (`proxy_buffer_size`).
+
+Fix: transport-level compression of the token. build_sync_token emits
+`z1:` + b64(zlib(json)); from_headers sniffs the prefix and falls back to
+the legacy plain-b64 parse for tokens already in the wild. Devices echo
+the token opaquely — only this server parses it — so no device migration
+exists. The schema VERSION is untouched (compression is transport, not
+schema).
+
+Sniff safety: the b64 alphabet (A-Za-z0-9+/=) contains neither ':' nor
+'.', so `z1:`-prefixed tokens can't collide with legacy b64 tokens, and
+the existing dotted kobo-store-token path ('.' in token) stays reachable.
+"""
+
+import json
+import zlib
+from base64 import b64decode, b64encode
+from datetime import datetime
+
+import pytest
+
+from cps.services.SyncToken import SyncToken, to_epoch_timestamp
+
+
+def _legacy_header(data: dict) -> str:
+    """Build a token exactly the way pre-#331 servers did (plain b64 JSON)."""
+    return b64encode(json.dumps(
+        {"version": "1-4-0", "data": data}).encode()).decode()
+
+
+def _data(store_token=""):
+    now = datetime(2026, 6, 7, 1, 0, 0)
+    return {
+        "raw_kobo_store_token": store_token,
+        "books_last_modified": to_epoch_timestamp(now),
+        "books_last_created": to_epoch_timestamp(now),
+        "archive_last_modified": to_epoch_timestamp(now),
+        "reading_state_last_modified": to_epoch_timestamp(now),
+        "tags_last_modified": to_epoch_timestamp(now),
+        "books_last_id": 42,
+        "magic_shelf_last_id": 7,
+        "magic_shelf_membership_at": to_epoch_timestamp(now),
+    }
+
+
+def _fake_store_jwt(size=2400):
+    """Synthetic 3-part JWT shaped like the real store token (b64ish text)."""
+    part = b64encode(b"x" * (size // 2)).decode()
+    return "eyJhbGciOiJSUzI1NiJ9." + part[:size - 60] + ".sig"
+
+
+@pytest.mark.unit
+class TestLegacyTokensStillParse:
+    def test_legacy_plain_b64_parses_with_all_fields(self):
+        """Tokens already on devices in the wild MUST keep parsing."""
+        header = _legacy_header(_data(store_token="abc"))
+        tok = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: header})
+        assert tok.books_last_id == 42
+        assert tok.magic_shelf_last_id == 7
+        assert tok.raw_kobo_store_token == "abc"
+
+    def test_dotted_store_token_passthrough_unchanged(self):
+        header = "storepart1.storepart2"
+        tok = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: header})
+        assert tok.raw_kobo_store_token == header
+
+
+@pytest.mark.unit
+class TestCompressedTokens:
+    def test_round_trip(self):
+        src = SyncToken(
+            raw_kobo_store_token=_fake_store_jwt(),
+            books_last_id=42,
+            magic_shelf_last_id=7,
+        )
+        header = src.build_sync_token()
+        assert header.startswith("z1:"), (
+            "build_sync_token must emit the compressed transport format"
+        )
+        out = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: header})
+        assert out.books_last_id == 42
+        assert out.magic_shelf_last_id == 7
+        assert out.raw_kobo_store_token == src.raw_kobo_store_token
+
+    def test_oversized_store_token_fits_4k_budget(self):
+        """The reporter-mirror case: a realistic ~2.4KB store JWT must leave
+        the whole header value comfortably inside nginx's 4K default once
+        cookies (~300B) + CSP (~140B) + the rest (~400B) are accounted
+        for. Budget: token value < 3000 bytes."""
+        src = SyncToken(raw_kobo_store_token=_fake_store_jwt(2400))
+        header = src.build_sync_token()
+        assert len(header) < 3000, (
+            f"compressed token is {len(header)}B — must stay under the 3000B "
+            "budget so total response headers fit nginx's 4K default"
+        )
+
+    def test_compression_beats_legacy_encoding(self):
+        src = SyncToken(raw_kobo_store_token=_fake_store_jwt(2400))
+        compressed = src.build_sync_token()
+        legacy = b64encode(json.dumps(
+            {"version": SyncToken.VERSION, "data": _data(_fake_store_jwt(2400))}
+        ).encode()).decode()
+        assert len(compressed) < len(legacy) * 0.75, (
+            "compression must beat the legacy double-b64 encoding by a "
+            "meaningful margin"
+        )
+
+    def test_garbage_after_marker_degrades_to_fresh_token(self):
+        tok = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: "z1:!!!notb64!!!"})
+        assert tok.books_last_id == -1
+        assert tok.books_last_modified == datetime.min
+
+    def test_truncated_compressed_token_degrades_cleanly(self):
+        """A proxy that truncates the header (the original failure class)
+        must yield a fresh token, not a 500."""
+        src = SyncToken(raw_kobo_store_token=_fake_store_jwt())
+        header = src.build_sync_token()
+        tok = SyncToken.from_headers({SyncToken.SYNC_TOKEN_HEADER: header[:len(header) // 2]})
+        assert tok.books_last_modified == datetime.min
+
+    def test_schema_version_untouched(self):
+        """Compression is transport-level: the inner schema VERSION must
+        stay 1-4-0 so version-gated logic is unaffected."""
+        assert SyncToken.VERSION == "1-4-0"
+        src = SyncToken(books_last_id=1)
+        header = src.build_sync_token()
+        raw = zlib.decompress(b64decode(header[3:]))
+        assert json.loads(raw)["version"] == "1-4-0"


### PR DESCRIPTION
## #331 — @Gusdezup's challenge, answered with numbers

> Is there a plan to reduce the response header size on /v1/library/sync so it fits within nginx's default 4K buffer?

**Measured root cause:** our own cursor fields are ~495B — but with Kobo store proxying on, the store's ~2-2.5KB JWT gets embedded in our JSON and base64'd **again** (+33% on the largest component): **4352B of response headers** in the realistic repro, past nginx's 4K `proxy_buffer_size`. Works on direct HTTP, `Sync failed` behind stock reverse proxies — the reporter's exact setup.

**Fix:** transport-level compression. `build_sync_token` emits `z1:` + b64(zlib(json)); `from_headers` sniffs the prefix and keeps parsing legacy plain-b64 tokens. Devices echo the token opaquely — only this server parses it — so **zero device migration**. `:` can't appear in b64 and `.` (the store-token sentinel) can't appear in the prefix: no format collisions. Schema VERSION untouched. Truncated/corrupted tokens degrade to a fresh sync like malformed legacy tokens always did.

## Reporter-mirror verification (nginx:alpine sidecar, `proxy_buffer_size 4k` — Synology's default)

| Same request (realistic 2.3KB store JWT) | Pre-fix | Post-fix |
|---|---|---|
| Through the 4K proxy | **HTTP 502** | **HTTP 200** |
| Total response headers (direct) | 4352 B | **3502 B** worst-case (incompressible-entropy JWT) · **1158 B** typical |
| x-kobo-synctoken | 3544 B | 2695 B worst / 351 B typical |
| Round 2 carrying the compressed token via proxy | — | 200, cursor preserved |
| Full magic-shelf sync through the proxy | — | clean, cursor machinery unaffected |

Worst case clears the 4K cliff with ~500B margin; the README `proxy_buffer_size` guidance stays documented for extreme store tokens.

**Hardening:** the header is attacker-suppliable, so decompression is bounded (CWE-409): 16KB cap on the b64 payload pre-decode, expansion capped at 64KB via `decompressobj(max_length)` + reject-on-overflow — anything past the caps degrades to a fresh sync. 12 tests (legacy parse, round-trip, 4K budget pinned with a high-entropy JWT, truncation degradation, amplification bounds, version pin); 324 kobo/synctoken tests green.

Rides the next train; on `:dev` at merge.

Addresses #331
