### PR TITLE
fix(db): break the GIL↔sqlite-mutex deadlock that froze the app and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,13 @@ jobs:
           # currently-executing test for pytest-timeout to interrupt). See
           # notes/xdist-worker-ipc-hang-followup-2026-05-21.md for diagnostic
           # log signature + hypothesis. Fewer worker handoffs ≈ fewer races.
+          #
+          # --faulthandler-timeout: last line of defense for whole-process
+          # freezes (e.g. the GIL↔sqlite-mutex AB-BA deadlock, see
+          # notes/fix-udf-gil-deadlock-DESIGN.md). faulthandler's watchdog
+          # writes every thread's stack WITHOUT needing the GIL, so a freeze
+          # that starves pytest-timeout still produces named stacks in the
+          # log instead of a silent 10-minute step wall.
           pytest -m "smoke or unit" \
             -n auto \
             --dist=loadfile \
@@ -100,6 +107,7 @@ jobs:
             --tb=short \
             --timeout=120 \
             --timeout-method=thread \
+            --faulthandler-timeout=90 \
             --cov=cps \
             --cov-report=xml \
             --cov-report=term-missing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,12 +93,15 @@ jobs:
           # notes/xdist-worker-ipc-hang-followup-2026-05-21.md for diagnostic
           # log signature + hypothesis. Fewer worker handoffs ≈ fewer races.
           #
-          # --faulthandler-timeout: last line of defense for whole-process
-          # freezes (e.g. the GIL↔sqlite-mutex AB-BA deadlock, see
+          # faulthandler_timeout (INI option, set via -o — there is no CLI
+          # flag): last line of defense for whole-process freezes (e.g. the
+          # GIL↔sqlite-mutex AB-BA deadlock, see
           # notes/fix-udf-gil-deadlock-DESIGN.md). faulthandler's watchdog
           # writes every thread's stack WITHOUT needing the GIL, so a freeze
           # that starves pytest-timeout still produces named stacks in the
-          # log instead of a silent 10-minute step wall.
+          # log instead of a silent 10-minute step wall. 90 < the 120s
+          # pytest-timeout on purpose: a hung test logs stacks first, then
+          # pytest-timeout attempts the interrupt.
           pytest -m "smoke or unit" \
             -n auto \
             --dist=loadfile \
@@ -107,7 +110,7 @@ jobs:
             --tb=short \
             --timeout=120 \
             --timeout-method=thread \
-            --faulthandler-timeout=90 \
+            -o faulthandler_timeout=90 \
             --cov=cps \
             --cov-report=xml \
             --cov-report=term-missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ is for things you can see or feel when running the app.
   requested by @BakaPhoenix and @magdalar)
 
 ### Fixed
+- Fixed a rare freeze where the whole app could lock up — pages never loading
+  until the container was restarted — when a background task (thumbnail
+  generation, metadata backup, duplicate scan…) hit the database at the same
+  moment as a page load. Database access is now coordinated so the standoff
+  can't happen.
 - "Reload Metadata" now also reloads authors, tags, and series (with series
   number) from the book file — previously only title, description, publisher,
   publish date, and languages came through. Author changes also rename the

--- a/cps/db.py
+++ b/cps/db.py
@@ -233,6 +233,18 @@ class _SerializedSqliteConnection(sqlite3.Connection):
         with self._cwa_sqlite_lock:
             return super().backup(*args, **kwargs)
 
+    def set_authorizer(self, *args, **kwargs):
+        with self._cwa_sqlite_lock:
+            return super().set_authorizer(*args, **kwargs)
+
+    def set_progress_handler(self, *args, **kwargs):
+        with self._cwa_sqlite_lock:
+            return super().set_progress_handler(*args, **kwargs)
+
+    def set_trace_callback(self, *args, **kwargs):
+        with self._cwa_sqlite_lock:
+            return super().set_trace_callback(*args, **kwargs)
+
     @property
     def isolation_level(self):
         return sqlite3.Connection.isolation_level.__get__(self)

--- a/cps/db.py
+++ b/cps/db.py
@@ -15,6 +15,7 @@ import unidecode
 from weakref import WeakSet
 from uuid import uuid4
 
+import sqlite3
 from sqlite3 import OperationalError as sqliteOperationalError
 from sqlalchemy import create_engine, event
 from sqlalchemy import Table, Column, ForeignKey, CheckConstraint
@@ -103,6 +104,146 @@ def _register_sqlite_udfs(dbapi_connection, _connection_record):
         dbapi_connection.create_function("title_sort", 1, _title_sort)
     except Exception:
         pass
+
+
+class _SerializedSqliteCursor(sqlite3.Cursor):
+    """Cursor half of the GIL↔sqlite-mutex deadlock guard.
+
+    Every method that enters sqlite C code takes the owning connection's
+    re-entrant lock first — see ``_SerializedSqliteConnection`` for the
+    deadlock this breaks.
+    """
+
+    def execute(self, *args, **kwargs):
+        with self.connection._cwa_sqlite_lock:
+            return super().execute(*args, **kwargs)
+
+    def executemany(self, *args, **kwargs):
+        with self.connection._cwa_sqlite_lock:
+            return super().executemany(*args, **kwargs)
+
+    def executescript(self, *args, **kwargs):
+        with self.connection._cwa_sqlite_lock:
+            return super().executescript(*args, **kwargs)
+
+    def fetchone(self):
+        with self.connection._cwa_sqlite_lock:
+            return super().fetchone()
+
+    def fetchmany(self, *args, **kwargs):
+        with self.connection._cwa_sqlite_lock:
+            return super().fetchmany(*args, **kwargs)
+
+    def fetchall(self):
+        with self.connection._cwa_sqlite_lock:
+            return super().fetchall()
+
+    def __next__(self):
+        with self.connection._cwa_sqlite_lock:
+            return super().__next__()
+
+    def close(self):
+        with self.connection._cwa_sqlite_lock:
+            return super().close()
+
+
+class _SerializedSqliteConnection(sqlite3.Connection):
+    """sqlite3.Connection whose C entry points are serialized behind one
+    re-entrant per-connection lock — passed as ``factory`` in ``connect_args``
+    on both calibre engines.
+
+    Why: with sqlite compiled in serialized mode (Linux CPython builds,
+    ``sqlite3.threadsafety == 3``), EVERY ``sqlite3_*`` API call internally
+    takes the per-connection mutex — including the short calls pysqlite makes
+    while HOLDING the GIL (``sqlite3_reset``/``bind``/``finalize``/
+    ``create_function``); only prepare/step release it. With ``StaticPool``
+    sharing one connection across real OS threads (web greenlets live on the
+    main thread; ``WorkerThread``/APScheduler tasks are real threads) and
+    Python UDFs registered (``lower``/``title_sort``/``uuid4``), this AB-BA
+    deadlock becomes reachable:
+
+      thread A: holds GIL → blocks on connection mutex (GIL-held short call)
+      thread B: holds connection mutex mid-step → UDF trampoline waits for GIL
+
+    Neither yields; every other thread starves on the GIL; the entire process
+    freezes until SIGKILL. Observed live: CI runs 27071666487 + 27074461288
+    (silent 10-minute walls pytest-timeout couldn't interrupt) and reproduced
+    in <20s with py-spy stack evidence in
+    ``notes/fix-udf-gil-deadlock-DESIGN.md``.
+
+    Taking THIS lock (GIL released while waiting) before entering C means no
+    thread ever blocks on the sqlite mutex while holding the GIL, so the UDF
+    trampoline's GIL wait always completes. RLock so a UDF callback that
+    re-enters the same connection on the same thread can't self-deadlock.
+    ``interrupt()`` is deliberately NOT wrapped: ``sqlite3_interrupt`` is
+    documented mutex-free-safe to call cross-thread, and wrapping it would
+    defeat its purpose (breaking a stuck statement).
+
+    Any new code path that touches the raw DBAPI connection must either use
+    these wrapped methods or take ``_cwa_sqlite_lock`` itself.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Lock first: cursor()/execute() may be entered as soon as any other
+        # thread can see this object.
+        self._cwa_sqlite_lock = threading.RLock()
+        super().__init__(*args, **kwargs)
+
+    def cursor(self, factory=None):
+        with self._cwa_sqlite_lock:
+            return super().cursor(factory or _SerializedSqliteCursor)
+
+    def execute(self, *args, **kwargs):
+        with self._cwa_sqlite_lock:
+            return super().execute(*args, **kwargs)
+
+    def executemany(self, *args, **kwargs):
+        with self._cwa_sqlite_lock:
+            return super().executemany(*args, **kwargs)
+
+    def executescript(self, *args, **kwargs):
+        with self._cwa_sqlite_lock:
+            return super().executescript(*args, **kwargs)
+
+    def commit(self):
+        with self._cwa_sqlite_lock:
+            return super().commit()
+
+    def rollback(self):
+        with self._cwa_sqlite_lock:
+            return super().rollback()
+
+    def close(self):
+        with self._cwa_sqlite_lock:
+            return super().close()
+
+    def create_function(self, *args, **kwargs):
+        with self._cwa_sqlite_lock:
+            return super().create_function(*args, **kwargs)
+
+    def create_aggregate(self, *args, **kwargs):
+        with self._cwa_sqlite_lock:
+            return super().create_aggregate(*args, **kwargs)
+
+    def create_collation(self, *args, **kwargs):
+        with self._cwa_sqlite_lock:
+            return super().create_collation(*args, **kwargs)
+
+    def backup(self, *args, **kwargs):
+        with self._cwa_sqlite_lock:
+            return super().backup(*args, **kwargs)
+
+    @property
+    def isolation_level(self):
+        return sqlite3.Connection.isolation_level.__get__(self)
+
+    @isolation_level.setter
+    def isolation_level(self, value):
+        # The C setter can run an implicit commit (reset/finalize short calls,
+        # GIL-held) — same hazard class as the methods above.
+        with self._cwa_sqlite_lock:
+            sqlite3.Connection.isolation_level.__set__(self, value)
+
 
 cc_exceptions = ['composite', 'series']
 cc_classes = {}
@@ -796,7 +937,10 @@ class CalibreDB:
             check_engine = create_engine('sqlite://',
                                          echo=False,
                                          isolation_level="SERIALIZABLE",
-                                         connect_args={'check_same_thread': False, 'timeout': 30},
+                                         # factory: GIL↔sqlite-mutex deadlock
+                                         # guard, see _SerializedSqliteConnection
+                                         connect_args={'check_same_thread': False, 'timeout': 30,
+                                                       'factory': _SerializedSqliteConnection},
                                          poolclass=StaticPool)
             event.listen(check_engine, "connect", _register_sqlite_udfs)
             with check_engine.begin() as connection:
@@ -865,7 +1009,10 @@ class CalibreDB:
                 cls.engine = create_engine('sqlite://',
                                            echo=False,
                                            isolation_level="SERIALIZABLE",
-                                           connect_args={'check_same_thread': False, 'timeout': 30},
+                                           # factory: GIL↔sqlite-mutex deadlock
+                                           # guard, see _SerializedSqliteConnection
+                                           connect_args={'check_same_thread': False, 'timeout': 30,
+                                                         'factory': _SerializedSqliteConnection},
                                            poolclass=StaticPool)
                 event.listen(cls.engine, "connect", _register_sqlite_udfs)
                 with cls.engine.begin() as connection:

--- a/tests/unit/test_sqlite_udf_registration_listener.py
+++ b/tests/unit/test_sqlite_udf_registration_listener.py
@@ -181,7 +181,11 @@ class TestEngineConnectListenerBehavior:
         engine = sa.create_engine(
             "sqlite://",
             poolclass=StaticPool,
-            connect_args={"check_same_thread": False, "timeout": 30},
+            # Mirror production connect_args exactly — including the
+            # GIL↔sqlite-mutex deadlock-guard factory — so any divergence
+            # between this harness and setup_db is caught here.
+            connect_args={"check_same_thread": False, "timeout": 30,
+                          "factory": cps_db._SerializedSqliteConnection},
         )
         sa.event.listen(engine, "connect", cps_db._register_sqlite_udfs)
         return engine, cps_db
@@ -305,7 +309,13 @@ class TestConcurrentLowerQueriesNoDeadlock:
         engine = sa.create_engine(
             "sqlite://",
             poolclass=StaticPool,
-            connect_args={"check_same_thread": False, "timeout": 30},
+            # Mirror production connect_args exactly (incl. the deadlock-guard
+            # factory): without it, this class's true-thread fan-out can
+            # reproduce the GIL↔sqlite-mutex AB-BA freeze on serialized-mode
+            # sqlite builds (the CI 10-minute silent walls — see
+            # notes/fix-udf-gil-deadlock-DESIGN.md).
+            connect_args={"check_same_thread": False, "timeout": 30,
+                          "factory": cps_db._SerializedSqliteConnection},
         )
         sa.event.listen(engine, "connect", cps_db._register_sqlite_udfs)
         return engine

--- a/tests/unit/test_udf_gil_deadlock_serialized_connection.py
+++ b/tests/unit/test_udf_gil_deadlock_serialized_connection.py
@@ -1,0 +1,218 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression pin for the GIL↔sqlite-mutex AB-BA deadlock.
+
+With sqlite compiled in serialized mode (``sqlite3.threadsafety == 3`` — Linux
+CPython builds, i.e. CI and the Docker image), every ``sqlite3_*`` call takes
+the per-connection mutex internally, including the short calls pysqlite makes
+while HOLDING the GIL (``create_function``, ``reset``, ``bind``, ``finalize``).
+If thread B is mid-``step`` (mutex held, GIL released) inside a Python UDF
+trampoline waiting for the GIL, and thread A holds the GIL while entering any
+such short call on the same connection, the whole process freezes: A waits for
+the mutex holding the GIL, B waits for the GIL holding the mutex. No Python
+watchdog (pytest-timeout included) can fire — every thread starves.
+
+Observed live as CI runs 27071666487 / 27074461288 (silent 10-minute step
+walls) and reachable in production: web greenlets on the main OS thread vs
+``WorkerThread``/APScheduler tasks on real threads, all sharing the calibre
+StaticPool connection with UDFs registered.
+
+The fix: ``cps.db._SerializedSqliteConnection`` — a per-connection RLock taken
+(GIL released while waiting) before every C entry point, wired into both
+calibre engines via ``connect_args['factory']``.
+
+These tests drive the EXACT deadlock interleave in a child process (so a
+regression can never freeze the test runner itself):
+  - thread B steps a query through a slow Python UDF (mutex held for ~1.2s,
+    trampoline GIL traffic guaranteed);
+  - thread A calls ``create_function`` (the proven GIL-held short call) inside
+    that window, then runs a short query.
+With the guard factory the child must exit cleanly. Without it (control case,
+serialized builds only) the child must freeze — proving the harness actually
+detects the deadlock rather than passing vacuously.
+"""
+
+import re
+import sqlite3
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The deadlock needs sqlite's per-connection mutex, which only exists on
+# serialized-mode builds (threadsafety == 3). macOS dev builds are typically
+# multi-thread mode (== 1) where the interleave is harmless by construction.
+SERIALIZED_BUILD = sqlite3.threadsafety == 3
+
+CHILD_TEMPLATE = textwrap.dedent("""
+    import sys
+    import threading
+    import time
+
+    sys.path.insert(0, {repo_root!r})
+    sys.path.insert(0, {scripts_dir!r})
+
+    import sqlite3
+
+    USE_GUARD = {use_guard!r}
+
+    if USE_GUARD:
+        from cps.db import _SerializedSqliteConnection
+        conn = sqlite3.connect(
+            ":memory:", check_same_thread=False,
+            factory=_SerializedSqliteConnection)
+    else:
+        conn = sqlite3.connect(":memory:", check_same_thread=False)
+
+    WINDOW = 1.2
+
+    def slow_udf():
+        # Holds the connection mutex for the whole step; sleeps with the GIL
+        # released so the registrar thread is guaranteed to run meanwhile.
+        time.sleep(WINDOW)
+        return 1
+
+    conn.create_function("slow_udf", 0, slow_udf)
+
+    def stepper():
+        cur = conn.execute("SELECT slow_udf()")
+        cur.fetchall()
+
+    def registrar():
+        time.sleep(0.3)  # let the stepper acquire the mutex first
+        # The proven GIL-held short call (and, behind the guard, a wrapped one):
+        conn.create_function("other", 0, lambda: 2)
+        # ...followed by the everyday short-call path:
+        conn.execute("SELECT other()").fetchall()
+
+    t_step = threading.Thread(target=stepper)
+    t_reg = threading.Thread(target=registrar)
+    t_step.start(); t_reg.start()
+    t_step.join(); t_reg.join()
+    print("CHILD-OK", flush=True)
+""")
+
+
+def _run_child(use_guard, timeout):
+    code = CHILD_TEMPLATE.format(
+        repo_root=str(REPO_ROOT),
+        scripts_dir=str(REPO_ROOT / "scripts"),
+        use_guard=use_guard,
+    )
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+@pytest.mark.unit
+class TestSerializedConnectionBreaksDeadlock:
+    def test_guarded_connection_survives_the_deadlock_interleave(self):
+        """With the factory, the exact AB-BA interleave completes cleanly.
+
+        15s budget vs a ~1.5s happy path (plus cps import time): generous
+        enough to never flake, tight enough that a reintroduced deadlock
+        fails here as a NAMED test instead of a silent CI step wall.
+        """
+        try:
+            result = _run_child(use_guard=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            pytest.fail(
+                "guarded child froze: the GIL↔sqlite-mutex deadlock is back "
+                "despite _SerializedSqliteConnection — see "
+                "notes/fix-udf-gil-deadlock-DESIGN.md"
+            )
+        assert result.returncode == 0, (
+            f"guarded child failed: stdout={result.stdout!r} "
+            f"stderr={result.stderr!r}"
+        )
+        assert "CHILD-OK" in result.stdout
+
+    @pytest.mark.skipif(
+        not SERIALIZED_BUILD,
+        reason="deadlock needs serialized-mode sqlite (threadsafety==3); "
+               "this build has no per-connection mutex to deadlock on",
+    )
+    def test_unguarded_connection_freezes_proving_harness_detects(self):
+        """Control: WITHOUT the factory the same interleave must freeze.
+
+        This proves the guarded test above passes because the fix works, not
+        because the harness lost the ability to construct the deadlock
+        (e.g. a future pysqlite releasing the GIL in create_function would
+        make this control fail — at which point the guard can be retired).
+        """
+        try:
+            result = _run_child(use_guard=False, timeout=8)
+        except subprocess.TimeoutExpired:
+            return  # frozen, as the deadlock predicts — harness is sharp
+        pytest.fail(
+            "unguarded control child exited (rc={}, stdout={!r}) — the "
+            "deadlock interleave no longer reproduces, so the guarded test "
+            "is not actually exercising the fix. Re-evaluate whether the "
+            "platform changed (pysqlite GIL behavior?) before trusting "
+            "this suite's coverage.".format(result.returncode, result.stdout)
+        )
+
+
+@pytest.mark.unit
+class TestFactoryWiredIntoProductionEngines:
+    """Source-pin: both calibre engines pass the guard factory."""
+
+    def test_both_create_engine_sites_use_the_factory(self):
+        src = (REPO_ROOT / "cps" / "db.py").read_text(encoding="utf-8")
+        sites = re.findall(
+            r"create_engine\('sqlite://',.*?poolclass=StaticPool\)",
+            src,
+            flags=re.DOTALL,
+        )
+        assert len(sites) == 2, (
+            f"expected exactly 2 StaticPool calibre engines in cps/db.py, "
+            f"found {len(sites)} — update this pin if the architecture changed"
+        )
+        for site in sites:
+            assert "'factory': _SerializedSqliteConnection" in site, (
+                "calibre engine missing the GIL↔sqlite-mutex deadlock-guard "
+                "factory in connect_args:\n" + site
+            )
+
+    def test_wrapped_surface_covers_the_dbapi_calls_sqlalchemy_uses(self):
+        """The guard only works if the wrapped surface stays complete."""
+        from cps.db import _SerializedSqliteConnection, _SerializedSqliteCursor
+
+        for name in ("execute", "executemany", "executescript", "commit",
+                     "rollback", "close", "create_function", "cursor"):
+            assert name in _SerializedSqliteConnection.__dict__, (
+                f"_SerializedSqliteConnection must wrap {name}()"
+            )
+        for name in ("execute", "executemany", "fetchone", "fetchmany",
+                     "fetchall", "__next__", "close"):
+            assert name in _SerializedSqliteCursor.__dict__, (
+                f"_SerializedSqliteCursor must wrap {name}()"
+            )
+
+    def test_default_cursor_factory_is_the_serialized_cursor(self):
+        from cps.db import _SerializedSqliteConnection, _SerializedSqliteCursor
+
+        conn = sqlite3.connect(
+            ":memory:", check_same_thread=False,
+            factory=_SerializedSqliteConnection)
+        try:
+            cur = conn.cursor()
+            assert isinstance(cur, _SerializedSqliteCursor), (
+                "cursor() must default to the lock-wrapped cursor class, "
+                "otherwise fetch/step paths bypass the guard"
+            )
+            # And the wrapped surface actually works end-to-end:
+            assert conn.execute("SELECT 1").fetchone()[0] == 1
+        finally:
+            conn.close()

--- a/tests/unit/test_udf_gil_deadlock_serialized_connection.py
+++ b/tests/unit/test_udf_gil_deadlock_serialized_connection.py
@@ -120,7 +120,7 @@ class TestSerializedConnectionBreaksDeadlock:
     def test_guarded_connection_survives_the_deadlock_interleave(self):
         """With the factory, the exact AB-BA interleave completes cleanly.
 
-        15s budget vs a ~1.5s happy path (plus cps import time): generous
+        30s budget vs a ~1.5s happy path (plus cps import time): generous
         enough to never flake, tight enough that a reintroduced deadlock
         fails here as a NAMED test instead of a silent CI step wall.
         """
@@ -169,21 +169,25 @@ class TestFactoryWiredIntoProductionEngines:
     """Source-pin: both calibre engines pass the guard factory."""
 
     def test_both_create_engine_sites_use_the_factory(self):
+        """Arg-order-agnostic pin: count the calibre engine sites, then count
+        connect_args dicts carrying the guard factory — both must be 2."""
         src = (REPO_ROOT / "cps" / "db.py").read_text(encoding="utf-8")
-        sites = re.findall(
-            r"create_engine\('sqlite://',.*?poolclass=StaticPool\)",
+        engine_sites = re.findall(r"create_engine\('sqlite://'", src)
+        assert len(engine_sites) == 2, (
+            f"expected exactly 2 in-memory calibre engines in cps/db.py, "
+            f"found {len(engine_sites)} — update this pin if the architecture "
+            f"changed"
+        )
+        guarded_connect_args = re.findall(
+            r"connect_args=\{[^}]*'factory':\s*_SerializedSqliteConnection",
             src,
-            flags=re.DOTALL,
         )
-        assert len(sites) == 2, (
-            f"expected exactly 2 StaticPool calibre engines in cps/db.py, "
-            f"found {len(sites)} — update this pin if the architecture changed"
+        assert len(guarded_connect_args) == 2, (
+            f"expected the deadlock-guard factory in both calibre engines' "
+            f"connect_args, found {len(guarded_connect_args)} — a calibre "
+            f"engine without _SerializedSqliteConnection reopens the "
+            f"GIL↔sqlite-mutex freeze"
         )
-        for site in sites:
-            assert "'factory': _SerializedSqliteConnection" in site, (
-                "calibre engine missing the GIL↔sqlite-mutex deadlock-guard "
-                "factory in connect_args:\n" + site
-            )
 
     def test_wrapped_surface_covers_the_dbapi_calls_sqlalchemy_uses(self):
         """The guard only works if the wrapped surface stays complete."""


### PR DESCRIPTION
## Symptom

Three CI runs in 24h (#374 once, #376 twice) hit silent 10-minute step walls inside `TestConcurrentLowerQueriesNoDeadlock` — no FAILED line, no stacks, `--timeout=120 --timeout-method=thread` never fired. In production the same mechanism can freeze the whole app (pages never load until container restart) when a background task and a page load hit the database simultaneously.

## Root cause — every link observed, not assumed

AB-BA deadlock between the **Python GIL** and **sqlite's per-connection mutex**:

1. Linux CPython links sqlite in serialized mode (`sqlite3.threadsafety == 3`): every `sqlite3_*` call takes the connection mutex internally — including the short calls pysqlite makes **while holding the GIL** (`reset`/`bind`/`finalize`/`create_function`). Only prepare/step release it.
2. Thread B mid-`step` (mutex held, GIL released) hits a Python UDF (`lower`/`title_sort`) → trampoline waits for the GIL.
3. Thread A, GIL held, enters any short call on the same connection → blocks on the mutex.
4. Every other thread starves on the GIL — pytest-timeout's timer, xdist IPC, the gevent hub. Only SIGKILL ends it. That's why CI showed nothing.

Evidence (full writeup with py-spy stacks in `notes/fix-udf-gil-deadlock-DESIGN.md` project-side):
- Reproduced in <20s on `python:3.13 --cpus=2` with real SQLAlchemy StaticPool + the production listener; GIL-liveness heartbeat stopped at iteration 1.
- py-spy: the GIL holder spinning in an adaptive pthread mutex; six threads parked on a **free** lock they can't acquire without the GIL.
- macOS builds are multi-thread mode (`threadsafety == 1`, no connection mutex) — 3000 hammer iterations clean. The deadlock is unreproducible on dev machines, which is why it only ever showed in CI.
- Test exists since May 16 (#212); freezes started ~June 5 with no code change — runner-image timing shift, not a regression.

**Production exposure**: web greenlets share one OS thread, but `WorkerThread` + APScheduler are real threads and 7 task modules (thumbnail, metadata_backup, duplicate_scan, convert…) query `calibre_db` — the same StaticPool shared connection with UDFs. Same symptom class as upstream CWA #1256's hub stall; the #1256 listener fix removed one GIL-held call site, not the class.

## Fix

`_SerializedSqliteConnection`/`_SerializedSqliteCursor`: a per-connection RLock taken (GIL released while waiting) before every pysqlite C entry point, wired via `connect_args['factory']` into both calibre engines. No thread can block on the sqlite mutex while holding the GIL → the trampoline's GIL wait always completes. `interrupt()` deliberately unwrapped (documented mutex-free-safe; must stay usable to break a stuck statement). No new stall surface: the locked region contains no greenlet switch points, and cross-thread waits move from the C mutex to the Python lock one frame earlier — same blocking semantics, minus the deadlock.

Rejected alternatives: per-thread connections (QueuePool) — the calibre engine is `sqlite://` in-memory with per-connection ATTACH; making that multi-connection-safe is a much larger re-architecture. Softening the test — it caught a real production-reachable bug.

## Verification (serialized build, `python:3.13 --cpus=2`)

| Check | Result |
|---|---|
| New deterministic regression test (child-process isolated — a red run can't hang CI) | guarded child survives the exact interleave; **unguarded control freezes**, proving the harness detects the deadlock rather than passing vacuously |
| Previously-freezing concurrency tests (now mirroring production connect_args incl. factory) | pass in 0.02s |
| Stampede hammer, production classes, 16 true threads × fresh engine | **2000 iterations clean @ 160/s** vs frozen at iteration 1 unpatched |
| Full smoke+unit suite (local) | 1453 passed; 2 macOS-only pre-existing env failures, identical line+error on main |

## CI hardening

`--faulthandler-timeout=90` on Fast Tests: faulthandler's watchdog writes all thread stacks **without the GIL**, so any future whole-process freeze yields named stacks instead of a silent wall.

Unblocks #376 (its two CI failures were this freeze, unrelated to its diff).