### PR TITLE
test: stop booting docker compose for unit tests in the Fast job

### DIFF
--- a/tests/integration/test_ingest_checksums.py
+++ b/tests/integration/test_ingest_checksums.py
@@ -25,7 +25,7 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def _enable_koreader_sync(cwa_container, container_name):
     """Flip `cwa_settings.koreader_sync_enabled` to 1 for this module's lifetime.
 
@@ -42,6 +42,13 @@ def _enable_koreader_sync(cwa_container, container_name):
     `is_koreader_sync_enabled()` re-reads cwa_settings via a fresh
     `CWA_DB()` instance on every call, so the in-container ingest_processor
     picks up the flip immediately without a service restart.
+
+    Deliberately NOT autouse: it pulls in ``cwa_container``, and as a
+    module-autouse fixture it booted the full docker compose stack for the
+    unit-marked ``TestIngestChecksumLogic`` tests too — 33s of wasted setup
+    in every Fast Tests run, and 2 job-failing ERRORS whenever compose boot
+    flaked on the runner (PR #376's third CI failure, run 27076038060). The
+    docker_integration classes opt in via ``@pytest.mark.usefixtures``.
     """
     subprocess.run(
         ["docker", "exec", container_name, "sqlite3", "/config/cwa.db",
@@ -94,6 +101,7 @@ def get_latest_book_id(db_path):
 
 @pytest.mark.docker_integration
 @pytest.mark.slow
+@pytest.mark.usefixtures("_enable_koreader_sync")
 class TestIngestChecksumGeneration:
     """Test automatic checksum generation during book ingest."""
 
@@ -223,6 +231,7 @@ class TestIngestChecksumGeneration:
 
 @pytest.mark.docker_integration
 @pytest.mark.slow
+@pytest.mark.usefixtures("_enable_koreader_sync")
 class TestChecksumGenerationEdgeCases:
     """Test edge cases in checksum generation during ingest."""
 
@@ -323,6 +332,7 @@ class TestIngestChecksumLogic:
 
 @pytest.mark.docker_integration
 @pytest.mark.slow
+@pytest.mark.usefixtures("_enable_koreader_sync")
 class TestChecksumInitialization:
     """Test the one-time checksum generation at container startup."""
 


### PR DESCRIPTION
The Fast Tests job selects `-m "smoke or unit"`, which picks up the two unit-marked `TestIngestChecksumLogic` tests inside `tests/integration/test_ingest_checksums.py`. The module-**autouse** `_enable_koreader_sync` fixture there requests `cwa_container`, so those two trivial tests (a `hasattr` check and an always-skip placeholder) boot the entire docker compose stack:

- **When it works**: 33s of dead setup time in every Fast run (the green #377 run shows `32.96s setup` on the hasattr test).
- **When compose boot flakes**: 2 setup ERRORS that fail the whole job — that was PR #376's third CI failure (run 27076038060), after its first two were the now-fixed GIL↔sqlite-mutex freeze (#377).

Fix: the fixture is no longer autouse; the three `docker_integration` classes that actually need the flag flip opt in via `@pytest.mark.usefixtures`. No behavior change for the Integration job.

Verified:
- `pytest tests/integration/test_ingest_checksums.py -m "smoke or unit"` → 1 passed, 1 skipped, **0.06s**, no docker invoked
- `--setup-plan` on a docker class confirms `_enable_koreader_sync` still wraps every test in it
- The other integration file with unit-marked tests (`test_progress_syncing_kosync.py`) has no autouse fixture — not exposed.

Unblocks #376.