### PR TITLE
feat(shelf): add a whole series to a shelf in one action (#334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,21 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+- You can now add a whole series to a shelf in one click: series pages have an
+  "Add Series to Shelf" button that adds every book in series order, skipping
+  ones already on the shelf. (#334, requested by @Glennza1962)
+
+### Changed
+- Series pages now list books in series order by default (1, 2, 3…) instead of
+  newest-first — matching what the OPDS feed always did. Choosing a different
+  sort still sticks for next time.
+
 ### Fixed
+- Adding a single book to a Kobo-synced shelf without JavaScript now syncs it
+  to Hardcover the same way the normal button does.
+- Bulk shelf adds no longer claim books were added when a database error
+  actually rolled everything back.
 - Kobo sync no longer fails behind reverse proxies with default buffer sizes
   (Synology DSM, stock nginx). The sync token header could exceed nginx's 4K
   default when Kobo store proxying was on; it's now compressed to roughly

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -95,13 +95,10 @@ def add_to_shelf(shelf_id, book_id):
             return redirect(request.environ["HTTP_REFERER"])
         else:
             return redirect(url_for('web.index'))
-    if not xhr:
-        log.debug("Book has been added to shelf: {}".format(shelf.name))
-        flash(_("Book has been added to shelf: %(sname)s", sname=shelf.name), category="success")
-        if "HTTP_REFERER" in request.environ:
-            return redirect(request.environ["HTTP_REFERER"])
-        else:
-            return redirect(url_for('web.index'))
+    # Hardcover sync runs for BOTH response flavors — it used to sit after
+    # the non-XHR early-return below, so plain form adds (no JS) silently
+    # skipped Hardcover while XHR adds synced. Same book, same shelf, same
+    # user intent — the transport must not change the outcome.
     if shelf.kobo_sync and config.config_hardcover_sync and bool(hardcover):
         try:
             hardcoverClient = hardcover.HardcoverClient(current_user.hardcover_token)
@@ -115,6 +112,14 @@ def add_to_shelf(shelf_id, book_id):
             log.info(f"User {current_user.name} has no Hardcover token, cannot add to Hardcover")
         except Exception as e:
             log.debug(f"Failed to create Hardcover client for {current_user.name}: {e}")
+
+    if not xhr:
+        log.debug("Book has been added to shelf: {}".format(shelf.name))
+        flash(_("Book has been added to shelf: %(sname)s", sname=shelf.name), category="success")
+        if "HTTP_REFERER" in request.environ:
+            return redirect(request.environ["HTTP_REFERER"])
+        else:
+            return redirect(url_for('web.index'))
 
     return "", 204
 
@@ -169,6 +174,80 @@ def search_to_shelf(shelf_id):
         log.error("Could not add books to shelf: {}".format(shelf.name))
         flash(_("Could not add books to shelf: %(sname)s", sname=shelf.name), category="error")
     return redirect(url_for('web.index'))
+
+
+@shelf.route("/shelf/add_series/<int:shelf_id>/<int:series_id>", methods=["POST"])
+@user_login_required
+def add_series_to_shelf(shelf_id, series_id):
+    """Add every book of a series to a shelf in series order (fork #334).
+
+    Form POST from the series page's shelf dropdown (same ``postAction``
+    plumbing as the search page's "add all" dropdown): flash + redirect back.
+    Books land in ``series_index`` order so the shelf reads 1, 2, 3…; books
+    already on the shelf are skipped. ``common_filters()`` applies, so a
+    user can only bulk-add books they are allowed to see. Hardcover sync is
+    deliberately not attempted inline — both existing bulk paths skip it
+    too, and a per-book external API loop doesn't belong in a request
+    handler (tracked as the bulk-shelf Hardcover parity follow-up).
+    """
+    def _back():
+        if "HTTP_REFERER" in request.environ:
+            return redirect(request.environ["HTTP_REFERER"])
+        return redirect(url_for('web.index'))
+
+    shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.id == shelf_id).first()
+    if shelf is None:
+        log.error("Invalid shelf specified: %s", shelf_id)
+        flash(_("Invalid shelf specified"), category="error")
+        return redirect(url_for('web.index'))
+
+    if not check_shelf_edit_permissions(shelf):
+        log.warning("User %s not allowed to add a series to shelf: %s", current_user.id, shelf.name)
+        flash(_("Sorry you are not allowed to add a book to that shelf"), category="error")
+        return _back()
+
+    series = calibre_db.session.query(db.Series).filter(db.Series.id == series_id).first()
+    if series is None:
+        log.error("Invalid series specified: %s", series_id)
+        flash(_("Invalid series specified"), category="error")
+        return _back()
+
+    books = (calibre_db.session.query(db.Books)
+             .filter(db.Books.series.any(db.Series.id == series_id))
+             .filter(calibre_db.common_filters())
+             .order_by(db.Books.series_index.asc(), db.Books.id.asc())
+             .all())
+    if not books:
+        flash(_("Series has no books you can see: %(name)s", name=series.name), category="error")
+        return _back()
+
+    existing = {row.book_id for row in
+                ub.session.query(ub.BookShelf.book_id).filter(ub.BookShelf.shelf == shelf_id).all()}
+    to_add = [book for book in books if book.id not in existing]
+    if not to_add:
+        flash(_("All books of series '%(name)s' are already on shelf: %(sname)s",
+                name=series.name, sname=shelf.name), category="info")
+        return _back()
+
+    max_order = ub.session.query(func.max(ub.BookShelf.order)).filter(
+        ub.BookShelf.shelf == shelf_id).scalar() or 0
+    for book in to_add:
+        max_order += 1
+        shelf.books.append(ub.BookShelf(shelf=shelf.id, book_id=book.id, order=max_order))
+    shelf.last_modified = datetime.now(timezone.utc)
+    try:
+        ub.session.merge(shelf)
+        ub.session.commit()
+    except (OperationalError, InvalidRequestError) as e:
+        ub.session.rollback()
+        log.error_or_exception("Settings Database error: {}".format(e))
+        flash(_("Oops! Database Error: %(error)s.", error=e.orig), category="error")
+        return _back()
+
+    log.debug("Series %s (%d books) added to shelf: %s", series.name, len(to_add), shelf.name)
+    flash(_("%(count)d books of series '%(name)s' added to shelf: %(sname)s",
+            count=len(to_add), name=series.name, sname=shelf.name), category="success")
+    return _back()
 
 
 @shelf.route("/shelf/remove/<int:shelf_id>/<int:book_id>", methods=["POST"])
@@ -557,6 +636,12 @@ def add_selected_to_shelf():
     if not book_ids:
         return jsonify({'status': 'error', 'message': 'No books selected'}), 400
 
+    # One max(order) query up front, incremented in memory — the previous
+    # per-book max() re-query only worked through autoflush and cost a
+    # flush + query per book.
+    maxOrder = ub.session.query(func.max(ub.BookShelf.order)).filter(
+        ub.BookShelf.shelf == shelf_id).scalar() or 0
+
     for book_id in book_ids:
         book = calibre_db.session.query(db.Books).filter(db.Books.id == book_id).one_or_none()
         if not book:
@@ -571,11 +656,8 @@ def add_selected_to_shelf():
             log.info(f"Book {book_id} is already part of {shelf.name}")
             continue
 
-        maxOrder = ub.session.query(func.max(ub.BookShelf.order)).filter(ub.BookShelf.shelf == shelf_id).scalar()
-        if maxOrder is None:
-            maxOrder = 0
-
-        new_entry = ub.BookShelf(shelf=shelf.id, book_id=book_id, order=maxOrder + 1)
+        maxOrder += 1
+        new_entry = ub.BookShelf(shelf=shelf.id, book_id=book_id, order=maxOrder)
         shelf.books.append(new_entry)
         success_count += 1
 
@@ -588,15 +670,12 @@ def add_selected_to_shelf():
         except (OperationalError, InvalidRequestError) as e:
             ub.session.rollback()
             log.error_or_exception(f"Database error while adding books to shelf {shelf.name}: {e}")
-            # Check if any books were actually added before this error, if so, it's a partial success
-            if success_count > len(errors): # if some books were added before the error
-                 return jsonify({
-                     'status': 'partial_success',
-                     'message': f'Successfully added {success_count - len(errors)} books, but a database error occurred. Please try again.',
-                     'errors': errors,
-                     'added_count': success_count - len(errors) # Adjust count if error happened mid-process
-                 }), 207 # Multi-Status
-            return jsonify({'status': 'error', 'message': f'Database error: {e.orig}'}), 500
+            # The rollback reverted EVERYTHING appended above — nothing was
+            # persisted, so this must report a plain failure. (It previously
+            # claimed a partial success with a positive added_count here,
+            # telling users books were added when zero were.)
+            return jsonify({'status': 'error', 'message': f'Database error: {e.orig}',
+                            'errors': errors, 'added_count': 0}), 500
 
     if errors:
         if success_count > 0:

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -90,7 +90,7 @@ def add_to_shelf(shelf_id, book_id):
     except (OperationalError, InvalidRequestError) as e:
         ub.session.rollback()
         log.error_or_exception("Settings Database error: {}".format(e))
-        flash(_("Oops! Database Error: %(error)s.", error=e.orig), category="error")
+        flash(_("Oops! Database Error: %(error)s.", error=getattr(e, 'orig', e)), category="error")
         if "HTTP_REFERER" in request.environ:
             return redirect(request.environ["HTTP_REFERER"])
         else:
@@ -169,7 +169,7 @@ def search_to_shelf(shelf_id):
         except (OperationalError, InvalidRequestError) as e:
             ub.session.rollback()
             log.error_or_exception("Settings Database error: {}".format(e))
-            flash(_("Oops! Database Error: %(error)s.", error=e.orig), category="error")
+            flash(_("Oops! Database Error: %(error)s.", error=getattr(e, 'orig', e)), category="error")
     else:
         log.error("Could not add books to shelf: {}".format(shelf.name))
         flash(_("Could not add books to shelf: %(sname)s", sname=shelf.name), category="error")
@@ -241,7 +241,7 @@ def add_series_to_shelf(shelf_id, series_id):
     except (OperationalError, InvalidRequestError) as e:
         ub.session.rollback()
         log.error_or_exception("Settings Database error: {}".format(e))
-        flash(_("Oops! Database Error: %(error)s.", error=e.orig), category="error")
+        flash(_("Oops! Database Error: %(error)s.", error=getattr(e, 'orig', e)), category="error")
         return _back()
 
     log.debug("Series %s (%d books) added to shelf: %s", series.name, len(to_add), shelf.name)
@@ -304,7 +304,7 @@ def remove_from_shelf(shelf_id, book_id):
         except (OperationalError, InvalidRequestError) as e:
             ub.session.rollback()
             log.error_or_exception("Settings Database error: {}".format(e))
-            flash(_("Oops! Database Error: %(error)s.", error=e.orig), category="error")
+            flash(_("Oops! Database Error: %(error)s.", error=getattr(e, 'orig', e)), category="error")
             if "HTTP_REFERER" in request.environ:
                 return redirect(request.environ["HTTP_REFERER"])
             else:
@@ -354,7 +354,7 @@ def delete_shelf(shelf_id):
     except InvalidRequestError as e:
         ub.session.rollback()
         log.error_or_exception("Settings Database error: {}".format(e))
-        flash(_("Oops! Database Error: %(error)s.", error=e.orig), category="error")
+        flash(_("Oops! Database Error: %(error)s.", error=getattr(e, 'orig', e)), category="error")
     return redirect(url_for('web.index'))
 
 
@@ -394,7 +394,7 @@ def order_shelf(shelf_id):
             except (OperationalError, InvalidRequestError) as e:
                 ub.session.rollback()
                 log.error_or_exception("Settings Database error: {}".format(e))
-                flash(_("Oops! Database Error: %(error)s.", error=e.orig), category="error")
+                flash(_("Oops! Database Error: %(error)s.", error=getattr(e, 'orig', e)), category="error")
 
         result = list()
         if shelf:
@@ -474,7 +474,7 @@ def create_edit_shelf(shelf, page_title, page, shelf_id=False):
                 ub.session.rollback()
                 log.error_or_exception(ex)
                 log.error_or_exception("Settings Database error: {}".format(ex))
-                flash(_("Oops! Database Error: %(error)s.", error=ex.orig), category="error")
+                flash(_("Oops! Database Error: %(error)s.", error=getattr(ex, 'orig', ex)), category="error")
             except Exception as ex:
                 ub.session.rollback()
                 log.error_or_exception(ex)
@@ -599,7 +599,7 @@ def render_show_shelf(shelf_type, shelf_id, page_no, sort_param):
             except (OperationalError, InvalidRequestError) as e:
                 ub.session.rollback()
                 log.error_or_exception("Settings Database error: {}".format(e))
-                flash(_("Oops! Database Error: %(error)s.", error=e.orig), category="error")
+                flash(_("Oops! Database Error: %(error)s.", error=getattr(e, 'orig', e)), category="error")
 
         return render_title_template(page,
                                      entries=result,
@@ -674,7 +674,7 @@ def add_selected_to_shelf():
             # persisted, so this must report a plain failure. (It previously
             # claimed a partial success with a positive added_count here,
             # telling users books were added when zero were.)
-            return jsonify({'status': 'error', 'message': f'Database error: {e.orig}',
+            return jsonify({'status': 'error', 'message': f"Database error: {getattr(e, 'orig', e)}",
                             'errors': errors, 'added_count': 0}), 500
 
     if errors:

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -148,6 +148,23 @@
         {% endif %}
     </div>
     {% endif %}
+    {% if page == 'series' and id|string != '-1' and g.shelves_access %}
+    {# fork #334: add every book of this series to a shelf, in series order #}
+    <div class="btn-group series-to-shelf" role="group">
+      <button id="add-series-to-shelf" type="button" class="btn btn-default dropdown-toggle"
+              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span class="glyphicon glyphicon-list"></span> {{_('Add Series to Shelf')}} <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" aria-labelledby="add-series-to-shelf">
+        {% for shelf in g.shelves_access %}
+          {% if not shelf.is_public or current_user.role_edit_shelfs() %}
+            <li><a class="postAction" role="button"
+                   data-action="{{ url_for('shelf.add_series_to_shelf', shelf_id=shelf.id, series_id=id) }}">{{shelf.name}}{% if shelf.is_public == 1 %} {{_('(Public)')}}{% endif %}</a></li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
 
    {% if page != 'discover' %}
     {{ organizer.books_list_organizer(page, id, order,

--- a/cps/web.py
+++ b/cps/web.py
@@ -441,6 +441,11 @@ def get_sort_function(sort_param, data):
     if sort_param == 'hotasc':
         order = [func.count(ub.Downloads.book_id).asc()]
     if sort_param is None:
+        if data == "series":
+            # A series page reads in series order by default — matching the
+            # OPDS series feed — not newest-first. An explicitly chosen sort
+            # is stored above and honored on the next visit. (fork #334 audit)
+            return [db.Books.series_index.asc()], "seriesasc"
         sort_param = "new"
     return order, sort_param
 

--- a/tests/unit/test_shelf_add_series_334.py
+++ b/tests/unit/test_shelf_add_series_334.py
@@ -1,0 +1,281 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Fork #334 (@Glennza1962): add a whole series to a shelf in one action,
+plus the series/shelf audit fixes that rode along:
+
+- A1: add_to_shelf's Hardcover sync ran only for XHR requests — plain form
+  adds silently skipped it. The block now precedes the response split.
+- A3: add_selected_to_shelf reported 'partial_success' with a positive
+  added_count after a commit failure whose rollback persisted NOTHING.
+- A4: add_selected_to_shelf re-queried max(order) per book (correct only
+  through autoflush); single query + in-memory increment now.
+- A5: the series page defaulted to newest-first; it now defaults to series
+  order (matching the OPDS series feed) when the user has no stored sort.
+
+Route-level end-to-end (real HTTP, real UI) happens in the container per the
+verification standard; these tests pin the logic and the wiring.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine, func
+from sqlalchemy.orm import sessionmaker
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHELF_PY = (REPO_ROOT / "cps" / "shelf.py").read_text()
+WEB_PY = (REPO_ROOT / "cps" / "web.py").read_text()
+INDEX_HTML = (REPO_ROOT / "cps" / "templates" / "index.html").read_text()
+
+
+# ---------------------------------------------------------------- fixtures
+
+@pytest.fixture
+def ub_session():
+    from cps import ub
+    engine = create_engine("sqlite:///:memory:", future=True)
+    ub.Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine, future=True)()
+    original = ub.session
+    ub.session = s
+    try:
+        yield s
+    finally:
+        ub.session = original
+        s.close()
+
+
+@pytest.fixture
+def calibre_session():
+    """Mirror production's engine shape: StaticPool single connection with
+    the calibre schema ATTACHed (db.py models are schema-qualified)."""
+    from sqlalchemy.pool import StaticPool
+    from cps import db
+    engine = create_engine(
+        "sqlite://", future=True, poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    with engine.connect() as conn:
+        conn.exec_driver_sql("attach database ':memory:' as calibre")
+        conn.commit()
+    db.Base.metadata.create_all(engine)
+    with engine.connect() as conn:
+        # Rebuild books with series_index REAL, exactly like calibre's real
+        # metadata.db. The ORM declares the column String (inherited from
+        # upstream), so create_all gives it TEXT affinity, which would
+        # string-order series ('10.0' < '2.0'). Real installs order
+        # numerically only because the genuine calibre schema's REAL
+        # affinity wins — the fixture must mirror production, not the
+        # model's footgun. (Models map the UNQUALIFIED 'books' name; in
+        # production main is empty and SQLite falls through to the attached
+        # calibre schema — here main.books is the live table.)
+        conn.exec_driver_sql("DROP TABLE books")
+        conn.exec_driver_sql(
+            "CREATE TABLE books ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " title TEXT NOT NULL DEFAULT 'Unknown' COLLATE NOCASE,"
+            " sort TEXT COLLATE NOCASE,"
+            " author_sort TEXT COLLATE NOCASE,"
+            " timestamp TIMESTAMP,"
+            " pubdate TIMESTAMP,"
+            " series_index REAL NOT NULL DEFAULT 1.0,"
+            " last_modified TIMESTAMP,"
+            " path TEXT NOT NULL DEFAULT '',"
+            " has_cover BOOL DEFAULT 0,"
+            " uuid TEXT)"
+        )
+        conn.commit()
+    s = sessionmaker(bind=engine, future=True)()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def _mk_series_books(s, series_id=1, name="Chronicles", indexes=(3.0, 1.0, 2.0)):
+    """Books inserted OUT of series order on purpose — ordering must come
+    from the query, not insertion order."""
+    from cps import db
+    series = db.Series(name=name, sort=name)
+    series.id = series_id
+    s.add(series)
+    s.flush()
+    books = []
+    for i, idx in enumerate(indexes, start=1):
+        b = db.Books(
+            title=f"{name} {idx}", sort=f"{name} {idx}",
+            author_sort="A", timestamp=None, pubdate=None,
+            series_index=idx, last_modified=None, path=f"p/{i}",
+            has_cover=0, authors=[], tags=[],
+        )
+        b.id = i * 10
+        s.add(b)
+        s.flush()
+        s.execute(db.books_series_link.insert().values(book=b.id, series=series_id))
+        books.append(b)
+    s.commit()
+    return books
+
+
+# ------------------------------------------------- series-order insertion
+
+class TestSeriesOrderQuery:
+    def test_books_come_back_in_series_index_order(self, calibre_session):
+        """The route's exact query shape returns series order regardless of
+        insertion order — including index 10 after index 2, which separates
+        numeric ordering (calibre's REAL column) from the string ordering
+        the ORM's String declaration would produce ('10.0' < '2.0')."""
+        from cps import db
+        _mk_series_books(calibre_session, indexes=(10.0, 1.0, 2.0))
+        rows = (calibre_session.query(db.Books)
+                .filter(db.Books.series.any(db.Series.id == 1))
+                .order_by(db.Books.series_index.asc(), db.Books.id.asc())
+                .all())
+        assert [float(r.series_index) for r in rows] == [1.0, 2.0, 10.0]
+
+    def test_shelf_append_preserves_series_order_and_continues_max(self, ub_session, calibre_session):
+        """Dedup + order continuation: an existing entry keeps its slot, new
+        books append after current max(order), in series order."""
+        from cps import db, ub
+        books = _mk_series_books(calibre_session, indexes=(2.0, 1.0, 3.0))
+        shelf = ub.Shelf(name="S", is_public=0, user_id=1)
+        shelf.id = 5
+        ub_session.add(shelf)
+        # Book with series_index 1.0 (id 20) is already on the shelf at order
+        # 7 — appended through the relationship, exactly like the route does
+        # (ub.py's flush hook walks BookShelf.ub_shelf and crashes on bare-FK
+        # inserts; the relationship path is the supported one).
+        shelf.books.append(ub.BookShelf(shelf=5, book_id=20, order=7))
+        ub_session.commit()
+
+        ordered = (calibre_session.query(db.Books)
+                   .filter(db.Books.series.any(db.Series.id == 1))
+                   .order_by(db.Books.series_index.asc(), db.Books.id.asc()).all())
+        existing = {row.book_id for row in
+                    ub_session.query(ub.BookShelf.book_id).filter(ub.BookShelf.shelf == 5).all()}
+        to_add = [b for b in ordered if b.id not in existing]
+        assert [b.series_index for b in to_add] == [2.0, 3.0], "dedup must skip the shelved book"
+
+        max_order = ub_session.query(func.max(ub.BookShelf.order)).filter(
+            ub.BookShelf.shelf == 5).scalar() or 0
+        assert max_order == 7
+        for b in to_add:
+            max_order += 1
+            shelf.books.append(ub.BookShelf(shelf=5, book_id=b.id, order=max_order))
+        ub_session.commit()
+
+        rows = (ub_session.query(ub.BookShelf).filter(ub.BookShelf.shelf == 5)
+                .order_by(ub.BookShelf.order).all())
+        assert [(r.book_id, r.order) for r in rows] == [(20, 7), (10, 8), (30, 9)], (
+            "series additions must extend the shelf after existing entries, in series order"
+        )
+
+
+# ------------------------------------------------------------ source pins
+
+class TestRouteWiring:
+    def test_route_exists_post_only_and_login_gated(self):
+        m = re.search(
+            r'@shelf\.route\("/shelf/add_series/<int:shelf_id>/<int:series_id>",\s*methods=\["POST"\]\)\s*'
+            r'@user_login_required\s*\ndef add_series_to_shelf\(',
+            SHELF_PY,
+        )
+        assert m, "POST-only, login-gated /shelf/add_series/<shelf>/<series> route must exist"
+
+    def test_route_applies_common_filters_and_series_order(self):
+        body = SHELF_PY.split("def add_series_to_shelf", 1)[1].split("\n@shelf.route", 1)[0]
+        assert "common_filters()" in body, (
+            "bulk series add must apply common_filters so restricted users "
+            "can't shelf books they can't see"
+        )
+        assert "series_index.asc()" in body, "books must be appended in series order"
+        assert "check_shelf_edit_permissions" in body
+
+    def test_template_dropdown_only_on_real_series_pages(self):
+        assert "add_series_to_shelf" in INDEX_HTML
+        guard = re.search(r"{%\s*if page == 'series' and id\|string != '-1' and g\.shelves_access", INDEX_HTML)
+        assert guard, (
+            "dropdown must be gated to real series pages (not the 'None' "
+            "series view) and to users with shelf access"
+        )
+
+    def test_dropdown_respects_public_shelf_role(self):
+        block = INDEX_HTML.split("add_series_to_shelf", 1)[1][:800]
+        assert "role_edit_shelfs()" in block, (
+            "public shelves must only be offered to users with the edit-public-shelves role"
+        )
+
+
+# ---------------------------------------------------- A5: series page sort
+
+class TestSeriesDefaultSort:
+    def _call(self, monkeypatch, stored, data="series", sort_param="stored"):
+        from cps import web
+        stub = SimpleNamespace(
+            get_view_property=lambda d, k: stored,
+            set_view_property=lambda d, k, v: None,
+        )
+        monkeypatch.setattr(web, "current_user", stub)
+        return web.get_sort_function(sort_param, data)
+
+    def test_series_page_defaults_to_series_order(self, monkeypatch):
+        from cps import db
+        order, name = self._call(monkeypatch, stored=None)
+        assert name == "seriesasc"
+        assert str(order[0]) == str(db.Books.series_index.asc())
+
+    def test_explicit_stored_sort_still_honored(self, monkeypatch):
+        order, name = self._call(monkeypatch, stored="new")
+        assert name == "new"
+
+    def test_other_pages_keep_newest_first(self, monkeypatch):
+        order, name = self._call(monkeypatch, stored=None, data="author")
+        assert name == "new"
+
+
+# ------------------------------------------- A3: honest bulk-add failures
+
+class TestBulkAddFailureHonesty:
+    def test_commit_failure_reports_error_not_partial_success(self):
+        """Source pin on the corrected block: after rollback the response is
+        a plain 500 with added_count 0 — never 'partial_success'."""
+        body = SHELF_PY.split("def add_selected_to_shelf", 1)[1].split("\n@shelf.route", 1)[0]
+        failure_zone = body.split("except (OperationalError, InvalidRequestError)", 1)[1]
+        commit_failure = failure_zone.split("if errors:", 1)[0]
+        assert "'added_count': 0" in commit_failure, (
+            "a failed commit rolled back EVERYTHING — added_count must be 0"
+        )
+        assert "partial_success" not in commit_failure, (
+            "commit failure must not be reported as partial success"
+        )
+
+    def test_max_order_hoisted_out_of_loop(self):
+        body = SHELF_PY.split("def add_selected_to_shelf", 1)[1].split("\n@shelf.route", 1)[0]
+        loop = body.split("for book_id in book_ids:", 1)[1]
+        assert "func.max" not in loop, (
+            "max(order) must be computed once before the loop, not per book"
+        )
+
+
+# -------------------------------------------- A1: hardcover transport parity
+
+class TestHardcoverTransportParity:
+    def test_hardcover_block_precedes_response_split(self):
+        """In add_to_shelf, the Hardcover sync must run before the xhr/non-xhr
+        response branches — both transports get the same outcome."""
+        body = SHELF_PY.split("def add_to_shelf", 1)[1].split("\n@shelf.route", 1)[0]
+        hardcover_pos = body.find("config.config_hardcover_sync")
+        response_split_pos = body.find('flash(_("Book has been added to shelf')
+        assert hardcover_pos != -1 and response_split_pos != -1
+        assert hardcover_pos < response_split_pos, (
+            "Hardcover sync sat behind the non-XHR early return, so plain "
+            "form adds silently skipped it — it must precede the response split"
+        )

--- a/tests/unit/test_shelf_add_series_334.py
+++ b/tests/unit/test_shelf_add_series_334.py
@@ -265,6 +265,19 @@ class TestBulkAddFailureHonesty:
         )
 
 
+# ------------------------------------- Greptile P1: .orig on the wrong class
+
+class TestDbErrorMessageNeverCrashes:
+    def test_no_bare_orig_access_in_shelf_error_paths(self):
+        """InvalidRequestError is a plain SQLAlchemyError — it has no .orig.
+        Every error message in shelf.py must use getattr(e, 'orig', e), or a
+        session-state error turns the friendly flash into its own 500."""
+        assert not re.search(r"\be(?:x)?\.orig\b", SHELF_PY), (
+            "bare .orig access found — InvalidRequestError has no .orig; "
+            "use getattr(e, 'orig', e)"
+        )
+
+
 # -------------------------------------------- A1: hardcover transport parity
 
 class TestHardcoverTransportParity:


### PR DESCRIPTION
Addresses #334 — requested by @Glennza1962 (he'd asked upstream long ago; it never landed).

## The feature

Series pages get an **Add Series to Shelf** dropdown: every book in the series, in series order (1, 2, 3…), skipping books already there, appended after the shelf's current max order. Permission model mirrors the search page's bulk add: login-gated, shelf-edit check, public shelves only for the edit-public-shelves role, `common_filters()` so restricted users can't bulk-add books they can't see.

## Series-subsystem audit (per the feature-depth standard)

Shipped here:
- **Series pages default to series order** when no sort is stored — the OPDS series feed always did; the web UI disagreeing was the tell. Explicit sorts still stick.
- **Hardcover transport parity**: `add_to_shelf`'s Hardcover sync sat behind the non-XHR early return — plain form adds silently skipped it.
- **Honest bulk-add failures**: `add_selected_to_shelf` claimed `partial_success` with a positive count after a rollback that persisted nothing.
- **One max(order) query** instead of per-book re-queries in `add_selected_to_shelf`.

Documented, deliberately not shipped:
- Bulk paths skip Hardcover entirely (needs a worker task, not an in-request API loop) — follow-up issue coming.
- `Books.series_index` is declared String over calibre's REAL column — production orders numerically by schema-affinity luck. High blast radius to change, zero production symptom; the new test fixture mirrors the REAL schema and pins the discriminating 10-vs-2 case.

## Verification

- **Live (cwn-local from this branch)**: series with indexes 1.0/2.0/3.5/10.0 renders in series order, sort chip shows "Series number, ascending"; POST → 4 rows in series order; re-POST → unchanged (dedup); partial re-add appends at max+1; success flash with correct count; shelf page renders in series order.
- **Playwright** desktop 1280px + mobile 375px (button visible/sized/in-viewport) — JPEGs in `notes/feat-334-*.jpeg` project-side.
- **12 unit tests** incl. numeric-vs-string ordering discriminator, dedup + order continuation through the real relationship path (ub.py's flush hook requires it), A5 sort behavior, failure-honesty pins.
- **Full suite**: 1477 passed; 2 pre-existing macOS env failures, identical on main.