### PR TITLE
feat(shelf): reorder shelves in the cover grid, saving on every drop (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ is for things you can see or feel when running the app.
   ones already on the shelf. (#334, requested by @Glennza1962)
 
 ### Changed
+- Rearranging a shelf now happens in the same cover grid as the regular shelf
+  view — drag a cover where it belongs, on desktop or phone (long-press to
+  lift), or move it with the keyboard arrows. The order saves by itself on
+  every change; the old cramped list and its Save button are gone. A shelf
+  that changed in another tab no longer breaks saving. (#320, requested by
+  @SpookyUSAF with design input from @droM4X)
 - Series pages now list books in series order by default (1, 2, 3…) instead of
   newest-first — matching what the OPDS feed always did. Choosing a different
   sort still sticks for next time.

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -375,26 +375,64 @@ def show_shelf(shelf_id, sort_param, page):
 @shelf.route("/shelf/order/<int:shelf_id>", methods=["GET", "POST"])
 @user_login_required
 def order_shelf(shelf_id):
+    """Render the cover-grid reorder page; persist order on POST (fork #320).
+
+    POST accepts JSON ``{"order": [book_id, ...]}`` from the grid's
+    save-on-drop fetch. The payload is normalized against the books actually
+    on the shelf (``normalize_shelf_order``): unknown ids are dropped,
+    duplicates collapse to first-seen, and shelved books missing from the
+    payload keep their relative order at the end — a stale page can never
+    error out or orphan a book's position (the legacy form handler raised
+    KeyError → 500 when the shelf changed between page load and save).
+    The legacy form-dict shape is still accepted for one release so a page
+    cached mid-deploy can save.
+    """
     shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.id == shelf_id).first()
     if shelf and check_shelf_view_permissions(shelf):
         if request.method == "POST":
+            wants_json = request.is_json
             if not check_shelf_edit_permissions(shelf):
+                if wants_json:
+                    return jsonify({'status': 'error',
+                                    'message': 'You are not allowed to edit this shelf'}), 403
                 flash(_("Sorry you are not allowed to edit this shelf"), category="error")
                 return redirect(url_for('web.index'))
-            to_save = request.form.to_dict()
             books_in_shelf = ub.session.query(ub.BookShelf).filter(ub.BookShelf.shelf == shelf_id).order_by(
                 ub.BookShelf.order.asc()).all()
-            counter = 0
-            for book in books_in_shelf:
-                setattr(book, 'order', to_save[str(book.book_id)])
-                counter += 1
-                # if order different from before -> shelf.last_modified = datetime.now(timezone.utc)
+            available_ids = [entry.book_id for entry in books_in_shelf]
+            if wants_json:
+                payload = request.get_json(silent=True) or {}
+                ordered_ids = payload.get('order', [])
+            else:
+                # Legacy form shape: {book_id: order_value}. Sort the pairs by
+                # the submitted value; ints win over junk, junk sinks stably.
+                to_save = request.form.to_dict()
+
+                def _form_key(book_id):
+                    try:
+                        return (0, int(to_save.get(str(book_id), '')))
+                    except (TypeError, ValueError):
+                        return (1, 0)
+                ordered_ids = sorted(available_ids, key=_form_key)
+            positions = compute_shelf_positions(ordered_ids, available_ids)
+            changed = False
+            for entry in books_in_shelf:
+                new_order = positions[entry.book_id]
+                if entry.order != new_order:
+                    entry.order = new_order
+                    changed = True
             try:
-                ub.session.commit()
+                if changed:
+                    ub.session.commit()
             except (OperationalError, InvalidRequestError) as e:
                 ub.session.rollback()
                 log.error_or_exception("Settings Database error: {}".format(e))
+                if wants_json:
+                    return jsonify({'status': 'error', 'message': 'Database error'}), 500
                 flash(_("Oops! Database Error: %(error)s.", error=getattr(e, 'orig', e)), category="error")
+            if wants_json:
+                return jsonify({'status': 'ok',
+                                'order': sorted(positions, key=positions.get)})
 
         result = list()
         if shelf:
@@ -728,6 +766,17 @@ SHELF_ORDER_MODES = {
 }
 
 DEFAULT_SHELF_ORDER_MODE = 'name_asc'
+
+
+def compute_shelf_positions(ordered_ids, available_ids):
+    """1-based position map for reorder persistence (fork #320).
+
+    Built on ``normalize_shelf_order``: every id in ``available_ids`` gets a
+    position even if the payload omitted it (stale page), unknown ids are
+    dropped, duplicates collapse to first-seen.
+    """
+    normalized = normalize_shelf_order(ordered_ids, available_ids)
+    return {book_id: idx + 1 for idx, book_id in enumerate(normalized)}
 
 
 def normalize_shelf_order(order_list, available_ids):

--- a/cps/static/js/shelforder.js
+++ b/cps/static/js/shelforder.js
@@ -1,5 +1,6 @@
 /* This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
  *    Copyright (C) 2018 jkrehm, OzzieIsaacs
+ *    Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,40 +16,141 @@
  *  along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* global Sortable,sortTrue */
+/* Shelf reorder as a responsive cover grid (fork #320, @SpookyUSAF +
+ * @droM4X's save-on-drop suggestion).
+ *
+ * Input modalities:
+ *  - Mouse: drag a cover between two others (Sortable.js, grid-aware).
+ *  - Touch: long-press (150ms) then drag — plain swipes keep scrolling,
+ *    so reordering never fights the scroll gesture.
+ *  - Keyboard: Tab focuses a cover; arrow keys move it one position;
+ *    changes are announced via the aria-live status line.
+ *
+ * Every change saves automatically (debounced 400ms) via JSON POST to the
+ * data-save-url; failures surface in the status line, which becomes a
+ * click-to-retry control. No Save button.
+ */
 
-Sortable.create(sortTrue, {
-    group: "sorting",
-    sort: true
-});
+/* global Sortable */
 
-// eslint-disable-next-line no-unused-vars
-function sendData(path) {
-    var elements;
-    var counter;
-    var maxElements;
-    var tmp = [];
+(function () {
+    "use strict";
 
-    elements = $(".list-group-item");
-    maxElements = elements.length;
-
-    var form = document.createElement("form");
-    form.setAttribute("method", "post");
-    form.setAttribute("action", path);
-    // form.setAttribute("csrf_token", );
-
-    for (counter = 0;counter < maxElements;counter++) {
-        tmp[counter] = elements[counter].getAttribute("id");
-        var hiddenField = document.createElement("input");
-        hiddenField.setAttribute("type", "hidden");
-        hiddenField.setAttribute("name", elements[counter].getAttribute("id"));
-        hiddenField.setAttribute("value", String(counter + 1));
-        form.appendChild(hiddenField);
+    var grid = document.getElementById("reorder-grid");
+    if (!grid || typeof Sortable === "undefined") {
+        return;
     }
-    $("<input type='hidden'/>")
-     .attr("name", "csrf_token").val($("input[name='csrf_token']").val())
-     .appendTo(form);
+    var statusEl = document.getElementById("reorder-status");
+    var saveUrl = grid.getAttribute("data-save-url");
+    var saveTimer = null;
+    var ITEM_SELECTOR = ".reorder-item";
 
-    document.body.appendChild(form);
-    form.submit();
-}
+    function text(name) {
+        return statusEl ? (statusEl.getAttribute("data-" + name + "-text") || "") : "";
+    }
+
+    function getCsrfToken() {
+        var el = document.querySelector("input[name='csrf_token']");
+        return el ? el.value : "";
+    }
+
+    function currentOrder() {
+        var ids = [];
+        var items = grid.querySelectorAll(ITEM_SELECTOR);
+        for (var i = 0; i < items.length; i++) {
+            ids.push(parseInt(items[i].getAttribute("data-book-id"), 10));
+        }
+        return ids;
+    }
+
+    function setStatus(message, isError) {
+        if (!statusEl) {
+            return;
+        }
+        statusEl.textContent = message || " ";
+        statusEl.classList.toggle("reorder-error", !!isError);
+    }
+
+    function persist() {
+        setStatus(text("saving"), false);
+        fetch(saveUrl, {
+            method: "POST",
+            credentials: "same-origin",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRFToken": getCsrfToken()
+            },
+            body: JSON.stringify({order: currentOrder()})
+        }).then(function (response) {
+            if (!response.ok) {
+                throw new Error("HTTP " + response.status);
+            }
+            return response.json();
+        }).then(function () {
+            setStatus(text("saved"), false);
+        }).catch(function () {
+            // The status line doubles as the retry control while in error.
+            setStatus(text("error"), true);
+        });
+    }
+
+    function schedulePersist() {
+        if (saveTimer) {
+            window.clearTimeout(saveTimer);
+        }
+        saveTimer = window.setTimeout(persist, 400);
+    }
+
+    if (statusEl) {
+        statusEl.addEventListener("click", function () {
+            if (statusEl.classList.contains("reorder-error")) {
+                persist();
+            }
+        });
+    }
+
+    Sortable.create(grid, {
+        animation: 150,
+        draggable: ITEM_SELECTOR,
+        // Long-press to lift on touch devices so a plain swipe scrolls the
+        // page instead of grabbing a cover; immediate on mouse.
+        delay: 150,
+        delayOnTouchOnly: true,
+        touchStartThreshold: 4,
+        ghostClass: "reorder-ghost",
+        chosenClass: "reorder-chosen",
+        onEnd: schedulePersist
+    });
+
+    function announceMove(card) {
+        var items = Array.prototype.slice.call(grid.querySelectorAll(ITEM_SELECTOR));
+        var pos = items.indexOf(card) + 1;
+        var template = text("moved");
+        setStatus(template.replace("__POS__", String(pos)).replace("__TOTAL__", String(items.length)), false);
+    }
+
+    grid.addEventListener("keydown", function (event) {
+        var card = event.target.closest ? event.target.closest(ITEM_SELECTOR) : null;
+        if (!card) {
+            return;
+        }
+        var key = event.key;
+        if (key === "ArrowLeft" || key === "ArrowUp") {
+            var prev = card.previousElementSibling;
+            if (prev) {
+                grid.insertBefore(card, prev);
+            }
+        } else if (key === "ArrowRight" || key === "ArrowDown") {
+            var next = card.nextElementSibling;
+            if (next) {
+                grid.insertBefore(next, card);
+            }
+        } else {
+            return;
+        }
+        event.preventDefault();
+        card.focus();
+        announceMove(card);
+        schedulePersist();
+    });
+})();

--- a/cps/templates/shelf_order.html
+++ b/cps/templates/shelf_order.html
@@ -1,7 +1,14 @@
 {% import 'image.html' as image %}
 {% extends "layout.html" %}
 {% block body %}
-  <div class="discover">
+  {# Deliberately NOT the discover wrapper class: main.js runs isotope on
+     every `.discover .row` that contains .book cards. Isotope absolutely-
+     positions cards from its own item-order model, which goes stale the
+     moment Sortable moves a DOM node — any relayout (viewport resize, font
+     load) snaps the covers back to the pre-drag picture while the DB
+     already holds the new order. This page owns its layout: plain
+     responsive flow, Sortable moves real nodes. #}
+  <div class="reorder-page">
     <h2>{{title}}</h2>
     {# fork #320 (@SpookyUSAF): the reorder screen is the same responsive
        cover grid as the regular shelf view — drag a cover where it belongs,

--- a/cps/templates/shelf_order.html
+++ b/cps/templates/shelf_order.html
@@ -1,46 +1,60 @@
+{% import 'image.html' as image %}
 {% extends "layout.html" %}
 {% block body %}
-  <div class="col-sm-8 col-lg-8 col-xs-12">
+  <div class="discover">
     <h2>{{title}}</h2>
-    <div>{{_('Drag to Rearrange Order')}}</div>
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <div id="sortTrue" class="list-group">
-        {% for entry in entries %}
-          <div id="{{entry['Books']['id']}}" class="list-group-item">
-            <div class="row">
-              <div class="col-lg-2 col-sm-4 hidden-xs">
-                {% if entry['visible'] %}
-                  <img title="{{entry['Books']['title']}}" class="cover-height" src="{{ url_for('web.get_cover', book_id=entry['Books']['id']) }}">
-                {% else %}
-                  <img title="{{entry['Books']['title']}}" class="cover-height" src="{{ url_for('static', filename='generic_cover.svg') }}">
-                {% endif %}
-              </div>
-              <div class="col-lg-10 col-sm-8 col-xs-12">
-              {% if entry['visible'] %}
-                  {{entry['Books']['title']}}
-                  {% if entry['Books']['series']|length > 0 %}
-                    <br>
-                    {{entry['Books']['series_index']|formatfloat(2)}} - {{entry['Books']['series'][0].name}}
-                  {% endif %}
-                  <br>
-                  {% for author in entry['Books']['author'] %}
-                    {{author.name.replace('|',',')}}
-                    {% if not loop.last %}
-                      &amp;
-                    {% endif %}
-                  {% endfor %}
-              {% else %}
-                  {{_('Hidden Book')}}
-                  <br>
-              {% endif %}
-              </div>
-            </div>
+    {# fork #320 (@SpookyUSAF): the reorder screen is the same responsive
+       cover grid as the regular shelf view — drag a cover where it belongs,
+       or focus a cover and use the arrow keys. Order saves on every change;
+       there is no Save button to forget. #}
+    <p>
+      {{_('Drag a cover to its new spot — the order saves automatically.')}}
+      <span class="hidden-xs">{{_('Keyboard: focus a cover with Tab, then move it with the arrow keys.')}}</span>
+    </p>
+    <p id="reorder-status" class="text-muted" role="status" aria-live="polite"
+       data-saving-text="{{_('Saving…')}}"
+       data-saved-text="{{_('Order saved')}}"
+       data-error-text="{{_('Could not save the order — click here to retry')}}"
+       data-moved-text="{{_('Moved to position %(num)s of %(total)s', num='__POS__', total='__TOTAL__')}}">&nbsp;</p>
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div id="reorder-grid" class="row display-flex"
+         role="list" aria-label="{{_('Shelf order')}}"
+         data-save-url="{{ url_for('shelf.order_shelf', shelf_id=shelf.id) }}">
+      {% for entry in entries %}
+        <div class="col-sm-3 col-lg-2 col-xs-6 book reorder-item" role="listitem" tabindex="0"
+             data-book-id="{{entry['Books']['id']}}"
+             aria-label="{{entry['Books']['title'] if entry['visible'] else _('Hidden Book')}}">
+          <div class="cover">
+            {% if entry['visible'] %}
+              {{ image.book_cover(entry['Books']) }}
+            {% else %}
+              <img title="{{_('Hidden Book')}}" src="{{ url_for('static', filename='generic_cover.svg') }}" alt="">
+            {% endif %}
           </div>
-        {% endfor %}
-      </div>
-        <button onclick="sendData('{{ url_for('shelf.order_shelf', shelf_id=shelf.id) }}')" class="btn btn-default" id="ChangeOrder">{{_('Save')}}</button>
-        <a href="{{ url_for('shelf.show_shelf', shelf_id=shelf.id) }}" id="shelf_back" class="btn btn-default">{{_('Back')}}</a>
+          <div class="meta">
+            {% if entry['visible'] %}
+              <p class="title" title="{{entry['Books']['title']}}">{{entry['Books']['title']|shortentitle}}</p>
+              {% if entry['Books']['series']|length > 0 %}
+                <p class="series">{{entry['Books']['series'][0].name|shortentitle(30)}} ({{entry['Books']['series_index']|formatfloat(2)}})</p>
+              {% endif %}
+            {% else %}
+              <p class="title">{{_('Hidden Book')}}</p>
+            {% endif %}
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+    <a href="{{ url_for('shelf.show_shelf', shelf_id=shelf.id) }}" id="shelf_back" class="btn btn-default">{{_('Back')}}</a>
   </div>
+  <style>
+    /* Reorder affordances: grab cursor, drop ghost, keyboard focus ring. */
+    #reorder-grid .reorder-item { cursor: grab; user-select: none; -webkit-user-select: none; }
+    #reorder-grid .reorder-item:active { cursor: grabbing; }
+    #reorder-grid .reorder-item:focus { outline: 2px solid #45b29d; outline-offset: 2px; }
+    #reorder-grid .reorder-ghost { opacity: 0.4; }
+    #reorder-grid .reorder-chosen { transform: scale(1.03); }
+    #reorder-status.reorder-error { color: #d9534f; cursor: pointer; font-weight: bold; }
+  </style>
 {% endblock %}
 
 {% block js %}

--- a/tests/unit/test_320_shelf_reorder_grid.py
+++ b/tests/unit/test_320_shelf_reorder_grid.py
@@ -1,0 +1,197 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Fork #320 (@SpookyUSAF, design seconded by @droM4X): the shelf reorder
+screen is a responsive cover grid with save-on-drop — no more vertical list
+at 10% browser zoom, no Save button to forget.
+
+Design decisions pinned here:
+- The reorder stays on its own page rather than live-dragging in the shelf
+  view: the shelf grid's existing cover-drag is the destructive book MERGE,
+  and disambiguating drop-on (merge) from drop-between (reorder) by pixels
+  would put a data-destroying action one mis-drop away — worst on touch.
+- Touch uses long-press-to-lift (Sortable delayOnTouchOnly) so plain swipes
+  scroll the page.
+- Keyboard: covers are focusable; arrow keys move them; an aria-live status
+  line announces positions and doubles as the error/retry control.
+- POST accepts JSON {"order": [...]} normalized via normalize_shelf_order —
+  unknown ids dropped, duplicates collapsed, missing books keep their
+  relative order at the end. The legacy form shape (which raised KeyError →
+  500 on a stale page) is still accepted, tolerantly.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHELF_PY = (REPO_ROOT / "cps" / "shelf.py").read_text()
+ORDER_HTML = (REPO_ROOT / "cps" / "templates" / "shelf_order.html").read_text()
+ORDER_JS = (REPO_ROOT / "cps" / "static" / "js" / "shelforder.js").read_text()
+
+
+def _isolated(*func_names):
+    """Exec the named module-level functions from shelf.py in isolation
+    (the cps import chain isn't needed for pure helpers)."""
+    ns: dict = {}
+    for name in func_names:
+        match = re.search(
+            r"(def %s\(.*?)(?=\ndef |\n@|\nclass )" % re.escape(name),
+            SHELF_PY, re.DOTALL,
+        )
+        assert match, f"{name} not found in cps/shelf.py"
+        exec(match.group(1), ns)  # noqa: S102 - fixture source, not user input
+    return ns
+
+
+# --------------------------------------------------- position computation
+
+class TestComputeShelfPositions:
+    def _fn(self):
+        return _isolated("normalize_shelf_order", "compute_shelf_positions")[
+            "compute_shelf_positions"]
+
+    def test_full_permutation(self):
+        fn = self._fn()
+        assert fn([30, 10, 20], [10, 20, 30]) == {30: 1, 10: 2, 20: 3}
+
+    def test_stale_payload_missing_books_keep_relative_order_at_end(self):
+        """A book added to the shelf after page load must keep a position
+        (the legacy handler 500'd here)."""
+        fn = self._fn()
+        assert fn([20, 10], [10, 20, 30, 40]) == {20: 1, 10: 2, 30: 3, 40: 4}
+
+    def test_unknown_ids_dropped_duplicates_collapse(self):
+        fn = self._fn()
+        assert fn([99, 20, 20, "junk", 10], [10, 20]) == {20: 1, 10: 2}
+
+    def test_string_ids_coerced(self):
+        fn = self._fn()
+        assert fn(["2", "1"], [1, 2]) == {2: 1, 1: 2}
+
+    def test_empty_payload_keeps_current_order(self):
+        fn = self._fn()
+        assert fn([], [5, 6, 7]) == {5: 1, 6: 2, 7: 3}
+
+
+# ----------------------------------------------- behavioral: apply + save
+
+class TestReorderPersistence:
+    @pytest.fixture
+    def ub_session(self):
+        from cps import ub
+        engine = create_engine("sqlite:///:memory:", future=True)
+        ub.Base.metadata.create_all(engine)
+        s = sessionmaker(bind=engine, future=True)()
+        original = ub.session
+        ub.session = s
+        try:
+            yield s
+        finally:
+            ub.session = original
+            s.close()
+
+    def test_route_apply_block_renumbers_sequentially(self, ub_session):
+        """Replicates the route's apply block against a real session: the
+        JSON order [30, 10, 20] must persist as orders 1..3."""
+        from cps import ub
+        from sqlalchemy import func  # noqa: F401  (parity with route imports)
+        shelf = ub.Shelf(name="R", is_public=0, user_id=1)
+        shelf.id = 9
+        ub_session.add(shelf)
+        for bid, order in ((10, 1), (20, 2), (30, 3)):
+            shelf.books.append(ub.BookShelf(shelf=9, book_id=bid, order=order))
+        ub_session.commit()
+
+        fns = _isolated("normalize_shelf_order", "compute_shelf_positions")
+        books_in_shelf = (ub_session.query(ub.BookShelf)
+                          .filter(ub.BookShelf.shelf == 9)
+                          .order_by(ub.BookShelf.order.asc()).all())
+        available = [e.book_id for e in books_in_shelf]
+        positions = fns["compute_shelf_positions"]([30, 10, 20], available)
+        for entry in books_in_shelf:
+            entry.order = positions[entry.book_id]
+        ub_session.commit()
+
+        rows = (ub_session.query(ub.BookShelf).filter(ub.BookShelf.shelf == 9)
+                .order_by(ub.BookShelf.order).all())
+        assert [(r.book_id, r.order) for r in rows] == [(30, 1), (10, 2), (20, 3)]
+
+
+# ------------------------------------------------------------ source pins
+
+class TestRouteContract:
+    def _body(self):
+        return SHELF_PY.split("def order_shelf", 1)[1].split("\n@shelf.route", 1)[0]
+
+    def test_json_payload_accepted_and_normalized(self):
+        body = self._body()
+        assert "request.is_json" in body
+        assert "get_json(silent=True)" in body, "malformed JSON must not 500"
+        assert "compute_shelf_positions" in body
+
+    def test_legacy_form_path_is_tolerant(self):
+        """The old handler did to_save[str(book.book_id)] — KeyError → 500
+        when the shelf changed between page load and save."""
+        body = self._body()
+        assert "to_save[str(" not in body, "raw dict indexing of form keys is the 500 bug"
+        assert "to_save.get(" in body
+
+    def test_edit_permission_denial_returns_403_json_for_fetch(self):
+        body = self._body()
+        assert "403" in body, "the grid's fetch needs a JSON 403, not a redirect"
+
+
+class TestTemplateContract:
+    def test_grid_uses_responsive_book_card_classes(self):
+        assert 'id="reorder-grid"' in ORDER_HTML
+        assert "col-xs-6" in ORDER_HTML, (
+            "cards must use the responsive column classes of the regular "
+            "cover grid — the vertical list at 10%% zoom was the complaint"
+        )
+        assert "display-flex" in ORDER_HTML
+
+    def test_no_save_button(self):
+        assert 'id="ChangeOrder"' not in ORDER_HTML, (
+            "saving is automatic on every change; a Save button reintroduces "
+            "the forget-to-save failure mode"
+        )
+        assert "sendData(" not in ORDER_HTML
+
+    def test_accessibility_wiring(self):
+        assert 'aria-live="polite"' in ORDER_HTML
+        assert 'tabindex="0"' in ORDER_HTML
+        assert 'role="list"' in ORDER_HTML
+
+    def test_status_line_carries_translated_strings(self):
+        for attr in ("data-saving-text", "data-saved-text", "data-error-text",
+                     "data-moved-text"):
+            assert attr in ORDER_HTML, f"status line must carry {attr}"
+
+
+class TestJsContract:
+    def test_touch_uses_long_press(self):
+        assert "delayOnTouchOnly: true" in ORDER_JS, (
+            "without delayOnTouchOnly a plain swipe grabs a cover instead of "
+            "scrolling the page"
+        )
+
+    def test_keyboard_handler_moves_cards(self):
+        assert "ArrowLeft" in ORDER_JS and "ArrowRight" in ORDER_JS
+        assert "insertBefore" in ORDER_JS
+
+    def test_persist_is_json_with_csrf(self):
+        assert "X-CSRFToken" in ORDER_JS
+        assert "JSON.stringify({order: currentOrder()})" in ORDER_JS
+
+    def test_failure_surfaces_with_retry(self):
+        assert "reorder-error" in ORDER_JS
+        assert "catch" in ORDER_JS

--- a/tests/unit/test_320_shelf_reorder_grid.py
+++ b/tests/unit/test_320_shelf_reorder_grid.py
@@ -171,6 +171,17 @@ class TestTemplateContract:
         assert 'tabindex="0"' in ORDER_HTML
         assert 'role="list"' in ORDER_HTML
 
+    def test_grid_not_wrapped_in_discover_isotope_selector(self):
+        """main.js initializes isotope on every `.discover .row` containing
+        .book cards. Isotope absolutely-positions cards from its own item
+        model, which desyncs from Sortable's DOM moves — a resize or font
+        load snaps covers back to the pre-drag picture while the DB holds
+        the new order. The reorder page must NOT match that selector."""
+        assert 'class="discover"' not in ORDER_HTML, (
+            "shelf_order.html must not use class=discover — isotope would "
+            "capture the reorder grid and fight Sortable"
+        )
+
     def test_status_line_carries_translated_strings(self):
         for attr in ("data-saving-text", "data-saved-text", "data-error-text",
                      "data-moved-text"):


### PR DESCRIPTION
Addresses #320 — requested by @SpookyUSAF, save-on-drop design by @droM4X.

## The problem

The manual sort screen was a top-down list that used space so poorly the reporter zoomed his browser to 10% to drag books around. His ask, verbatim: make the ordering screen look like the regular view of covers in rows, drag a cover between two books.

## Design decision (and why not in-place drag in the shelf view)

@droM4X suggested dragging directly in the shelf view. Evaluated and amended: the shelf grid's existing cover-drag is the **destructive book merge** — disambiguating drop-*on* (merge) from drop-*between* (reorder) by pixel position puts a data-destroying action one mis-drop away, worst on touch. The dedicated page instead becomes the exact same responsive cover grid, with @droM4X's save-on-drop adopted wholesale: no Save button, every change persists automatically.

## Input modalities (each deliberate)

| Modality | Behavior |
|---|---|
| Mouse | Drag a cover between two others (Sortable.js grid mode, insertion animation) |
| Touch | Long-press 150ms to lift (`delayOnTouchOnly`) — a plain swipe scrolls the page |
| Keyboard | Tab focuses a cover; arrow keys move it; aria-live line announces "Moved to position N of M" |
| Failure | Status line shows the error and becomes click-to-retry |

## Server

`POST /shelf/order/<id>` accepts JSON `{order: [...]}` normalized via `normalize_shelf_order`: unknown ids dropped, duplicates collapsed, books missing from a stale payload keep their relative order at the end. The legacy handler did `to_save[str(book_id)]` and **500'd with KeyError** whenever the shelf changed between page load and save — the form shape is still accepted (one release of tolerance), parsed defensively. Edit-permission denial returns JSON 403 for the fetch path.

## Caught live during verification

`main.js` runs **isotope** on every `.discover .row` with `.book` cards — it absolutely-positions cards from its own item model, which desyncs from Sortable's DOM moves: a resize snapped covers back to the pre-drag picture while the DB held the new order. The page now uses its own wrapper class; regression-pinned. Side win: mobile renders the true 2-up grid (isotope had forced a centered single column).

## Verification (cwn-local from this branch)

- Desktop drag → "Order saved" → DB rows match, exactly
- Keyboard ArrowLeft → moved, focus retained, announced, saved → DB match
- Mobile 375px: true 2-up grid; drag works and persists
- **Resize stability** (the isotope regression): visual == DOM == DB after 375→1280px resize following both drag and keyboard moves
- Hostile payloads: `[3, 3, 99, "junk"]` → junk dropped, missing books keep relative order; malformed JSON → no-op, no 500
- AuthZ: JSON 403 observed with the edit-public-shelves role bit cleared (and the apparent bypass was the test user legitimately holding the role)
- 18 unit tests; full suite 1496 passed (2 pre-existing macOS env failures)
- JPEGs: `notes/feat-320-*.jpeg` (desktop grid, post-keyboard, mobile 2-up, post-resize stability)