### PR TITLE
fix(mobile): tapping outside the sidebar closes it; toggle stays tappable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ is for things you can see or feel when running the app.
   sort still sticks for next time.
 
 ### Fixed
+- On phones, opening the sidebar no longer dead-ends the page: tapping
+  anywhere outside the menu now closes it (it used to do nothing, and the
+  menu button itself became untappable behind the overlay — the page was
+  stuck until a reload).
 - Adding a single book to a Kobo-synced shelf without JavaScript now syncs it
   to Hardcover the same way the normal button does.
 - Bulk shelf adds no longer claim books were added when a database error

--- a/cps/static/css/caliBlur_override.css
+++ b/cps/static/css/caliBlur_override.css
@@ -225,3 +225,15 @@ a#advanced_search > span.hidden-sm {
     margin-bottom: 2rem;
     padding-left: 2rem;
 }
+/* Fork mobile-sidebar fix: keep the drawer toggle (the round profile-head
+   button, which IS the menu button in this theme) tappable while the drawer
+   is open. The full-screen .sidebar-backdrop is a later sibling inside the
+   same .navbar stacking context with z-index 9 — without a higher z-index on
+   .navbar-header, the open drawer's backdrop covered the toggle and (with no
+   tap-to-close on the backdrop either) every tap on the page went dead. */
+@media screen and (max-width: 768px) {
+    .navbar > .container-fluid > .navbar-header {
+        position: relative;
+        z-index: 10;
+    }
+}

--- a/cps/static/js/caliBlur.js
+++ b/cps/static/js/caliBlur.js
@@ -725,6 +725,16 @@ if ($(".order-shelf-btn").length > 1) {
 $("#top_user > span.hidden-sm").clone().insertBefore(".profileDropli");
 $(".navbar-collapse.collapse.in").before('<div class="sidebar-backdrop"></div>');
 
+// Fork mobile-sidebar fix: the backdrop never had a close handler, so on
+// phones the natural tap-outside gesture did nothing — and with the open
+// drawer's full-screen backdrop sitting above the navbar, the toggle
+// itself became untappable. One accidental open bricked the page until a
+// reload ("can't access the sidebar anymore"). Delegated handler because
+// mobileSupport() recreates the backdrop on resize.
+$(document).on("click", ".sidebar-backdrop", function () {
+    $(".navbar-collapse.collapse.in").collapse("hide");
+});
+
 // Get rid of leading white space
 recentlyAdded = $("#nav_new a:contains('Recently')").text().trim();
 $("#nav_new a:contains('Recently')").contents().filter(function () {

--- a/tests/unit/test_mobile_sidebar_backdrop_close.py
+++ b/tests/unit/test_mobile_sidebar_backdrop_close.py
@@ -1,0 +1,78 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Mobile sidebar drawer: tap-outside closes, toggle stays reachable.
+
+The caliBlur theme renders the mobile nav as an off-canvas drawer with a
+full-screen ``.sidebar-backdrop`` (z-index 9) while open. Two inherited
+gaps bricked phones: the backdrop had NO close handler (the natural
+tap-outside gesture did nothing), and the backdrop covered the navbar's
+toggle button (the round profile-head icon — the theme's menu button), so
+once opened the page was dead until a reload. Operator report: "on mobile
+I can't access the sidebar anymore."
+
+Fix: a delegated click handler on the backdrop collapses the drawer, and
+``.navbar-header`` gets z-index 10 inside the navbar's stacking context so
+the toggle outranks the z-9 backdrop. Verified live with hit-tested taps
+(elementFromPoint, not synthetic .click()) at 375px: open → tap-outside
+closes; open → toggle visible/tappable → closes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CALIBLUR_JS = (REPO_ROOT / "cps" / "static" / "js" / "caliBlur.js").read_text()
+OVERRIDE_CSS = (REPO_ROOT / "cps" / "static" / "css" / "caliBlur_override.css").read_text()
+
+
+class TestBackdropCloseHandler:
+    def test_delegated_click_handler_exists(self):
+        """Delegated (document-level) because mobileSupport() recreates the
+        backdrop on every crossing of the 768px boundary."""
+        m = re.search(
+            r'\$\(document\)\.on\("click",\s*"\.sidebar-backdrop",',
+            CALIBLUR_JS,
+        )
+        assert m, (
+            "caliBlur.js must register a delegated click handler on "
+            ".sidebar-backdrop — without it, tap-outside does nothing and "
+            "the open drawer bricks the page on phones"
+        )
+
+    def test_handler_collapses_the_open_drawer(self):
+        handler_zone = CALIBLUR_JS.split('"click", ".sidebar-backdrop"', 1)[1][:200]
+        assert '.collapse("hide")' in handler_zone, (
+            "the backdrop handler must hide the open .navbar-collapse"
+        )
+        assert ".navbar-collapse.collapse.in" in handler_zone, (
+            "the handler must target the OPEN collapse only"
+        )
+
+
+class TestToggleAboveBackdrop:
+    def test_navbar_header_outranks_backdrop_z9(self):
+        """The backdrop (z-index 9, same .navbar stacking context) must not
+        cover the toggle — .navbar-header needs position + higher z-index."""
+        m = re.search(
+            r"\.navbar\s*>\s*\.container-fluid\s*>\s*\.navbar-header\s*\{[^}]*z-index:\s*(\d+)",
+            OVERRIDE_CSS,
+        )
+        assert m, "caliBlur_override.css must raise .navbar-header above the backdrop"
+        assert int(m.group(1)) > 9, (
+            f"z-index {m.group(1)} does not outrank the backdrop's 9"
+        )
+        block = re.search(
+            r"\.navbar\s*>\s*\.container-fluid\s*>\s*\.navbar-header\s*\{[^}]*\}",
+            OVERRIDE_CSS,
+        ).group(0)
+        assert "position" in block, (
+            "z-index needs a positioned element to take effect"
+        )


### PR DESCRIPTION
Operator report from a phone: **"on mobile I can't access the sidebar anymore."**

## Root cause (reproduced with hit-tested taps, not synthetic clicks)

The caliBlur off-canvas drawer inserts a full-screen `.sidebar-backdrop` (z-index 9, inside `.navbar`) while open. Two inherited gaps (upstream caliBlur, 2024):

1. **The backdrop never had a close handler** — the natural tap-outside gesture did nothing.
2. **The backdrop covered the navbar toggle** (the round profile-head button — this theme's menu button), so the toggle couldn't close it either.

Net effect on a phone: open the drawer once → every tap lands on the inert backdrop → page bricked until reload. Automation masked this for months because `element.click()` bypasses hit-testing; `elementFromPoint` probes exposed it immediately.

## Fix

- Delegated click handler on `.sidebar-backdrop` collapses the open drawer (delegated because `mobileSupport()` recreates the backdrop on resize).
- `.navbar-header` gets `position:relative; z-index:10` (mobile media query) so the toggle outranks the z-9 backdrop and remains a second close path.

## Verification (cwn-local @ 375×812, honest tap cycle)

| Step | Before | After |
|---|---|---|
| Tap outside open drawer | hits backdrop, no-op | hits backdrop → **closes** |
| Toggle reachable while open | **false** (covered) | true |
| Toggle tap while open | blocked | closes |

JPEGs + probes in `notes/`; 3 regression pins; full suite 1499 passed (2 pre-existing macOS env failures).

## Mobile design pass (operator-directed)

Surveyed home, book detail, shelf, series, search at 375px: no horizontal overflow or offscreen controls anywhere. Polish-tier findings queued in `notes/mobile-design-pass-2026-06-07.md`: duplicate-scan toast geometry on phones, two undersized close targets, and the head-icon-as-menu-button affordance question (theme design decision for the operator).