### PR TITLE
fix(mobile): menu button is now a recognizable hamburger, not a profile-head glyph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ is for things you can see or feel when running the app.
 - Series pages now list books in series order by default (1, 2, 3…) instead of
   newest-first — matching what the OPDS feed always did. Choosing a different
   sort still sticks for next time.
+- On phones, the menu button now looks like one: a standard hamburger icon
+  replaces the round profile-head glyph, which nobody recognized as the way
+  to open the sidebar. Same spot (top right), same tap target; your profile
+  options are inside the menu it opens, where they always were.
 
 ### Fixed
 - On phones, opening the sidebar no longer dead-ends the page: tapping

--- a/cps/static/css/caliBlur_override.css
+++ b/cps/static/css/caliBlur_override.css
@@ -237,3 +237,16 @@ a#advanced_search > span.hidden-sm {
         z-index: 10;
     }
 }
+/* Fork mobile-menu affordance: caliBlur paints a profile-head glyph over
+   Bootstrap's hamburger button, so nothing on a phone reads as "menu" —
+   users (including the operator) look for a hamburger and conclude the
+   sidebar is gone. Repaint the same button with a standard three-bar
+   hamburger; geometry, position, and tap target are unchanged, and profile
+   access still lives inside the drawer the button opens. Breakpoint matches
+   the theme's own mobile block (767px), where the toggle is visible. */
+@media only screen and (max-width: 767px) {
+    .navbar > .container-fluid > .navbar-header > button.navbar-toggle:before {
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' viewBox='0 0 22 22'%3E%3Cg fill='%23F5F5F5'%3E%3Crect y='3' width='22' height='2.5' rx='1.25'/%3E%3Crect y='9.75' width='22' height='2.5' rx='1.25'/%3E%3Crect y='16.5' width='22' height='2.5' rx='1.25'/%3E%3C/g%3E%3C/svg%3E");
+        border-radius: 0;
+    }
+}

--- a/tests/unit/test_mobile_sidebar_backdrop_close.py
+++ b/tests/unit/test_mobile_sidebar_backdrop_close.py
@@ -57,6 +57,34 @@ class TestBackdropCloseHandler:
         )
 
 
+class TestToggleLooksLikeAMenuButton:
+    def test_mobile_toggle_repainted_as_hamburger(self):
+        """caliBlur paints a profile-head glyph over Bootstrap's hamburger
+        button; nothing on a phone reads as "menu" (operator: "there is no
+        hamburger visible"). The override must repaint the toggle's :before
+        with a three-bar glyph and drop the theme's circular clip."""
+        m = re.search(
+            r"button\.navbar-toggle:before\s*\{([^}]*)\}",
+            OVERRIDE_CSS,
+        )
+        assert m, (
+            "caliBlur_override.css must override the toggle's :before glyph — "
+            "the theme's profile-head fails the menu-affordance test"
+        )
+        block = m.group(1)
+        assert "background-image" in block, (
+            "the override must replace the profile-head background-image"
+        )
+        # Three bars = the recognizable hamburger (rects in the inline SVG).
+        assert block.count("rect") == 3, (
+            "the replacement glyph must be a standard three-bar hamburger"
+        )
+        assert "border-radius: 0" in block, (
+            "the theme's 50% border-radius clips the bar corners — "
+            "the override must unclip it"
+        )
+
+
 class TestToggleAboveBackdrop:
     def test_navbar_header_outranks_backdrop_z9(self):
         """The backdrop (z-index 9, same .navbar stacking context) must not

--- a/tests/unit/test_mobile_sidebar_backdrop_close.py
+++ b/tests/unit/test_mobile_sidebar_backdrop_close.py
@@ -62,14 +62,27 @@ class TestToggleLooksLikeAMenuButton:
         """caliBlur paints a profile-head glyph over Bootstrap's hamburger
         button; nothing on a phone reads as "menu" (operator: "there is no
         hamburger visible"). The override must repaint the toggle's :before
-        with a three-bar glyph and drop the theme's circular clip."""
-        m = re.search(
-            r"button\.navbar-toggle:before\s*\{([^}]*)\}",
-            OVERRIDE_CSS,
+        with a three-bar glyph and drop the theme's circular clip — and the
+        rule must live INSIDE the theme's mobile media block (767px, where
+        the toggle is visible), not at top level (Greptile P2)."""
+        mobile_chunks = [
+            chunk
+            for chunk in OVERRIDE_CSS.split("@media")
+            if chunk.lstrip().startswith("only screen and (max-width: 767px)")
+        ]
+        assert mobile_chunks, (
+            "the hamburger override must be wrapped in the theme's own "
+            "mobile media query — @media only screen and (max-width: 767px)"
         )
+        m = None
+        for chunk in mobile_chunks:
+            m = re.search(r"button\.navbar-toggle:before\s*\{([^}]*)\}", chunk)
+            if m:
+                break
         assert m, (
-            "caliBlur_override.css must override the toggle's :before glyph — "
-            "the theme's profile-head fails the menu-affordance test"
+            "caliBlur_override.css must override the toggle's :before glyph "
+            "inside the 767px media block — the theme's profile-head fails "
+            "the menu-affordance test"
         )
         block = m.group(1)
         assert "background-image" in block, (


### PR DESCRIPTION
## Symptom

Shown the #382-fixed build on a phone, the operator's immediate reaction: **"there is no hamburger visible in my screenshot."** The product owner could not find the menu — the strongest possible failure of the affordance test for the single most important mobile control.

## Root cause

caliBlur hides Bootstrap's real hamburger (`.navbar-toggle > span { opacity: 0 }`) and paints a **profile-head SVG** over the button via `:before`. On a phone, the only navigation control reads as "account," not "menu."

## Fix

Theme-scoped override in `caliBlur_override.css` (loads only for caliBlur, after the theme CSS): repaint the same `:before` with a standard three-bar hamburger SVG and drop the theme's `border-radius: 50%` clip. **Geometry, position, and the 40×40 tap target are unchanged**; profile options live inside the drawer the button opens, as before. Stock Bootstrap theme keeps its native hamburger — untouched. Breakpoint matches the theme's own mobile block (767px).

## Verification (live, hit-tested — elementFromPoint, not synthetic .click())

| Viewport | Result |
|---|---|
| 375×812 | Hamburger renders top-right; tap opens drawer; toggle stays reachable while open (#382 z-index holds); outside tap lands on `.sidebar-backdrop` → closes |
| 320×568 | Visible, hamburger glyph computed, hit-testable, inside viewport |
| 1280×800 | Override media-scoped — cannot apply; desktop navbar visually unchanged |

1 regression pin (red on `main`, green here) in the #382 pin file.

Skipped rows: stress/concurrency, DB, i18n — pure-CSS glyph swap, no server code, no strings, no state.

Follow-up to #382; part of the operator-directed mobile design pass.