### PR TITLE
fix(shelf): reorder covers stay thumbnail-sized; Back button aligned + spaced (#320 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+- The shelf reorder screen now shows covers at the normal thumbnail size
+  instead of blown-up "large icon" size, and the Back button lines up under
+  the covers with proper spacing above it. (#320 follow-up, reported by
+  @droM4X and @SpookyUSAF)
+
 ## [v4.0.157] – 2026-06-07
 
 ### Added

--- a/cps/templates/shelf_order.html
+++ b/cps/templates/shelf_order.html
@@ -51,7 +51,15 @@
         </div>
       {% endfor %}
     </div>
-    <a href="{{ url_for('shelf.show_shelf', shelf_id=shelf.id) }}" id="shelf_back" class="btn btn-default">{{_('Back')}}</a>
+    {# Back button in its own grid row so it inherits the same left gutter as
+       the cover columns on every theme — caliBlur and the default theme resolve
+       the row's negative margin differently, so a bare sibling lands 15px left
+       of the covers on one and flush on the other (fork #320 @droM4X). #}
+    <div class="row reorder-back-row">
+      <div class="col-xs-12">
+        <a href="{{ url_for('shelf.show_shelf', shelf_id=shelf.id) }}" id="shelf_back" class="btn btn-default">{{_('Back')}}</a>
+      </div>
+    </div>
   </div>
   <style>
     /* Reorder affordances: grab cursor, drop ghost, keyboard focus ring. */
@@ -61,6 +69,18 @@
     #reorder-grid .reorder-ghost { opacity: 0.4; }
     #reorder-grid .reorder-chosen { transform: scale(1.03); }
     #reorder-status.reorder-error { color: #d9534f; cursor: pointer; font-weight: bold; }
+    /* fork #320 follow-up (@droM4X + @SpookyUSAF on v4.0.157): cap cover height
+       to the normal book-grid box (225px), independent of theme. Normal grids
+       constrain covers via `.container-fluid .book .cover { height: 225px }`
+       (default theme) or `.cover img { width: 150px }` (caliBlur); on this
+       fork-new page some configurations leave the default-theme box uncapped,
+       so covers render near-natural size ("large icon style ... not needed
+       here"). An id-scoped cap on the image itself is theme-independent, beats
+       the responsive max-width cascade, is a no-op where covers are already
+       correct, and doesn't distort caliBlur (already 225px tall). */
+    #reorder-grid .reorder-item .cover img { max-height: 225px !important; }
+    /* Clear separation between the cover grid and the Back button below it. */
+    .reorder-back-row { margin-top: 1.5em; }
   </style>
 {% endblock %}
 

--- a/tests/unit/test_320_shelf_reorder_grid.py
+++ b/tests/unit/test_320_shelf_reorder_grid.py
@@ -200,13 +200,15 @@ class TestDisplayFollowup320:
 
     def test_cover_height_capped_independent_of_theme(self):
         m = re.search(
-            r"#reorder-grid\s+\.reorder-item\s+\.cover\s+img\s*\{[^}]*max-height:\s*225px",
+            r"#reorder-grid\s+\.reorder-item\s+\.cover\s+img\s*\{"
+            r"[^}]*max-height:\s*225px[^}]*!important",
             ORDER_HTML,
         )
         assert m, (
             "shelf_order.html must cap reorder cover height to the normal "
-            "book-grid box (225px) with an id-scoped rule on the image — "
-            "without it, default-theme covers render near-natural size "
+            "book-grid box (225px !important) with an id-scoped rule on the "
+            "image — the !important is deliberate: it caps covers even on the "
+            "reporters' instances where the global .cover box renders uncapped "
             "(#320 follow-up, @droM4X)"
         )
 

--- a/tests/unit/test_320_shelf_reorder_grid.py
+++ b/tests/unit/test_320_shelf_reorder_grid.py
@@ -188,6 +188,45 @@ class TestTemplateContract:
             assert attr in ORDER_HTML, f"status line must carry {attr}"
 
 
+class TestDisplayFollowup320:
+    """v4.0.157 follow-up: @droM4X + @SpookyUSAF confirmed the reorder feature
+    works but reported two display defects on the default theme — covers render
+    near-natural size ("large icon style ... not needed here") and the Back
+    button sits too far left with no spacing above it. The default theme caps
+    covers only via `.container-fluid .book .cover { height: 225px }`; on this
+    fork-new page that box can render uncapped, so covers blow past the normal
+    grid size. Both fixes are theme-independent and live in the template's own
+    scoped <style> + markup."""
+
+    def test_cover_height_capped_independent_of_theme(self):
+        m = re.search(
+            r"#reorder-grid\s+\.reorder-item\s+\.cover\s+img\s*\{[^}]*max-height:\s*225px",
+            ORDER_HTML,
+        )
+        assert m, (
+            "shelf_order.html must cap reorder cover height to the normal "
+            "book-grid box (225px) with an id-scoped rule on the image — "
+            "without it, default-theme covers render near-natural size "
+            "(#320 follow-up, @droM4X)"
+        )
+
+    def test_back_button_has_gutter_and_spacing(self):
+        # Back button must sit inside a grid column so it inherits the same
+        # left gutter as the cover columns on every theme (a bare sibling
+        # lands 15px off on caliBlur), and the wrapper must carry top spacing.
+        back_idx = ORDER_HTML.find('id="shelf_back"')
+        assert back_idx != -1, "shelf_order.html must keep the Back button"
+        wrapper = ORDER_HTML[max(0, back_idx - 250):back_idx]
+        assert "reorder-back-row" in wrapper and "col-" in wrapper, (
+            "the Back button must be wrapped in a grid row/column so it aligns "
+            "under the first cover on both themes (#320 follow-up, @droM4X)"
+        )
+        assert re.search(r"\.reorder-back-row\s*\{[^}]*margin-top", ORDER_HTML), (
+            "the Back button row must carry top margin so it doesn't butt "
+            "against the cover grid above it"
+        )
+
+
 class TestJsContract:
     def test_touch_uses_long_press(self):
         assert "delayOnTouchOnly: true" in ORDER_JS, (


### PR DESCRIPTION
## Symptom

@droM4X and @SpookyUSAF confirmed the v4.0.157 shelf-reorder grid **works**, but flagged two display defects (default/light theme): covers render at near-natural **"large icon" size** ("used in Ratings and Languages, but not needed here"), and the **Back button** sits too far left with no spacing above it.

![droM4X report](https://github.com/user-attachments/assets/9c62115b-ceda-4d9b-84d1-2cab480a20bb)

## Root cause (traced live on both themes)

The reorder page is fork-new and reuses the responsive `.book` card, but on the **default theme** covers are sized *only* by the global `.container-fluid .book .cover { height: 225px }` box + `.container-fluid img { max-height: 100% }`. On the reporters' instances that box renders **uncapped** for this page → covers fall back to near-natural size. **caliBlur was unaffected** (it sizes the image directly via `.cover img { width: 150px }`) — which is exactly why an early caliBlur-only repro showed correct 150×225 covers and *masked* the bug. The Back button (a bare sibling of the grid) inherits the row's negative margin **differently per theme**: flush on default, 15px left on caliBlur.

## Fix (template-scoped, theme-independent)

- **Cover height cap:** id-scoped `#reorder-grid .reorder-item .cover img { max-height: 225px !important }` — matches the normal grid's box, beats the responsive `max-width` cascade, is a no-op where covers are already correct, and doesn't touch caliBlur's `width:150`.
- **Back button:** wrapped in a grid row/column so it inherits the same left gutter as the cover columns on every theme, plus a top margin.

## Verification (live, Playwright, hit-tested — both themes + mobile)

| State | Covers | Back button |
|---|---|---|
| default theme | 131×225 | aligned (0px), 21px gap above |
| default, **global box cap removed to mirror reporters' uncapped state** | **rule still caps → 131×225 (the fix)** | — |
| caliBlur | 150×225 (no regression) | alignment **improved** −15px → 0px |
| 375px mobile | 2-up grid, 150×225, no overflow | in viewport |

Reorder mechanics intact: ArrowRight moved book 2 → autosave POST to `/shelf/order/3` → **DB persisted**. 2 regression pins (red on main, green here). Screenshots in notes/.

Skipped rows: stress/concurrency, i18n — pure template/CSS, no server code or strings.

Addresses #320.