### PR TITLE
Feat/desktop compat mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,13 @@ cython_debug/
 # Dev instance files for testing in the same folder
 instance/
 
+# Local test infrastructure (dev-only, contains live credentials/state)
+dev-config/
+docker-compose.yml.local-test
+
+# macOS metadata
+.DS_Store
+
 # Runtime migration markers created by cwa-init / ub.py.run_cwa_migrations
 # inside CONFIG_DIR. These appear under repo/ when a developer points
 # CONFIG_DIR at the repo root for local container runs; they're per-

--- a/README.md
+++ b/README.md
@@ -309,6 +309,24 @@ Tested and supported. Ingest is a few seconds slower; everything else behaves th
 
 > If files end up owned by root after a copy: this build chowns files back to your `PUID:PGID` after each metadata-change cycle, but if you've copied files in as root before upgrading, run once: `docker exec calibre-web chown -R abc:abc /calibre-library` (replace `abc` if you've customized the user).
 
+### Calibre desktop coexistence
+
+If you want to open the same library in calibre desktop while calibre-web-nextgen is running, set both:
+
+```yaml
+- NETWORK_SHARE_MODE=true
+- DESKTOP_COMPAT_MODE=true
+```
+
+By default, calibre-web-nextgen holds a single SQLite connection open for the life of the process. That blocks calibre desktop from opening the library — on calibre 9.9.0 + macOS it crashes without an error dialog. `DESKTOP_COMPAT_MODE=true` switches to per-request connections so the file lock is released between web requests, letting calibre desktop open the database in the gaps.
+
+Changes you make in calibre desktop (edits, adds, deletes) appear in the web UI on the next page load — no restart needed.
+
+Trade-offs:
+- Each web request pays a small extra overhead to open and close the database connection.
+- If calibre desktop is actively writing when a web request comes in, the request waits up to 60 seconds for the lock. Heavy simultaneous use can slow the web UI.
+- Designed for home-server use where calibre desktop is opened occasionally for bulk edits, not for concurrent heavy use of both.
+
 ### Reverse proxy / Cloudflare Tunnel
 
 Behind multiple proxies (e.g. Cloudflare Tunnel then nginx then CWA), set the proxy count:

--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -418,8 +418,33 @@ def create_app():
         if request.endpoint not in keep_endpoints:
             session.pop("pending_app_password", None)
 
+    @app.before_request
+    def _desktop_compat_fresh_snapshot():
+        # Rollback ends the SERIALIZABLE snapshot so the next query sees Calibre desktop's writes.
+        if not calibre_db._desktop_compat or request.endpoint == 'static':
+            return
+        if calibre_db.session is not None:
+            try:
+                calibre_db.session.rollback()
+                calibre_db.session.expire_all()
+            except Exception as e:
+                log.debug("DESKTOP_COMPAT_MODE: rollback failed, snapshot may be stale: %s", e)
+        # Clear the Flask-session shelf count cache so sidebar counts stay fresh.
+        session.pop('magic_shelf_counts', None)
+
     @app.teardown_appcontext
     def shutdown_session(exception=None):
+        # Close before session_factory.remove(): they operate on different objects (concrete
+        # Session vs scoped proxy), and NullPool needs an explicit close to drop the connection.
+        if calibre_db._desktop_compat and calibre_db.session is not None:
+            try:
+                calibre_db.session.rollback()
+            except Exception:
+                pass
+            try:
+                calibre_db.session.close()
+            except Exception:
+                pass
         if calibre_db.session_factory:
             calibre_db.session_factory.remove()
 

--- a/cps/db.py
+++ b/cps/db.py
@@ -784,6 +784,7 @@ class CalibreDB:
     engine = None
     config = None
     session_factory = None
+    _desktop_compat = False
     # This is a WeakSet so that references here don't keep other CalibreDB
     # instances alive once they reach the end of their respective scopes
     instances = WeakSet()
@@ -962,11 +963,15 @@ class CalibreDB:
                 # Controlled by env var NETWORK_SHARE_MODE (default False)
                 try:
                     nsm = os.getenv('NETWORK_SHARE_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
-                    if not nsm and db_writable:
+                    dc = os.getenv('DESKTOP_COMPAT_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
+                    if not nsm and not dc and db_writable:
                         connection.execute(text("PRAGMA calibre.journal_mode=WAL"))
                         connection.execute(text("PRAGMA app_settings.journal_mode=WAL"))
                     else:
-                        reason = "NETWORK_SHARE_MODE=true" if nsm else "metadata.db not writable"
+                        if nsm or dc:
+                            reason = "NETWORK_SHARE_MODE=true" if nsm else "DESKTOP_COMPAT_MODE=true"
+                        else:
+                            reason = "metadata.db not writable"
                         log.warning("WAL mode disabled for calibre/app_settings (%s)", reason)
                 except Exception:
                     pass
@@ -1016,41 +1021,113 @@ class CalibreDB:
                 return None
 
             db_writable = os.access(dbpath, os.W_OK)
+            nsm = os.getenv('NETWORK_SHARE_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
+            desktop_compat = os.getenv('DESKTOP_COMPAT_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
 
             try:
-                cls.engine = create_engine('sqlite://',
-                                           echo=False,
-                                           isolation_level="SERIALIZABLE",
-                                           # factory: GIL↔sqlite-mutex deadlock
-                                           # guard, see _SerializedSqliteConnection
-                                           connect_args={'check_same_thread': False, 'timeout': 30,
-                                                         'factory': _SerializedSqliteConnection},
-                                           poolclass=StaticPool)
-                event.listen(cls.engine, "connect", _register_sqlite_udfs)
-                with cls.engine.begin() as connection:
-                    connection.execute(text("attach database '{}' as calibre;".format(dbpath)))
-                    connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
-                    # Try enabling WAL to improve concurrency unless running on a network share
-                    # Controlled by env var NETWORK_SHARE_MODE (default False)
-                    try:
-                        nsm = os.getenv('NETWORK_SHARE_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
-                        if not nsm and db_writable:
-                            connection.execute(text("PRAGMA calibre.journal_mode=WAL"))
-                            connection.execute(text("PRAGMA app_settings.journal_mode=WAL"))
-                        else:
-                            reason = "NETWORK_SHARE_MODE=true" if nsm else "metadata.db not writable"
-                            log.warning("WAL mode disabled for calibre/app_settings (%s)", reason)
-                    except Exception:
-                        pass
-                    # Wait up to 60s for any external writer (calibredb
-                    # during ingest) before failing the query. Required
-                    # for fork issue #192 — without this, transient
-                    # locks on mergerfs/SMB/NFS surface as immediate
-                    # apsw.BusyError and crash the import.
-                    try:
-                        connection.execute(text("PRAGMA busy_timeout=60000"))
-                    except Exception:
-                        pass
+                if desktop_compat:
+                    # DESKTOP_COMPAT_MODE: use NullPool so every SQLAlchemy session
+                    # gets its own SQLite connection that is fully closed when the
+                    # Flask request ends (teardown_appcontext calls
+                    # session_factory.remove()). This releases the SQLite file lock
+                    # after each request, allowing calibre desktop to open the same
+                    # library between web requests. Intended for use alongside
+                    # NETWORK_SHARE_MODE=true where WAL is disabled and a persistent
+                    # StaticPool connection would otherwise hold the lock indefinitely.
+                    #
+                    # Trade-off: each request pays one extra SMB open/close round-trip.
+                    # Under contention a Flask worker thread blocks for up to busy_timeout
+                    # (60s) — heavy calibre desktop use while the server is active can stall
+                    # the web UI. They serialise rather than corrupt.
+                    from sqlalchemy.pool import NullPool
+
+                    # Capture paths in a closure so the connect listener can reach them
+                    # without keeping a reference to cls (avoids accidental retention).
+                    _dbpath = dbpath
+                    _app_db_path = app_db_path
+
+                    def _attach_and_configure(dbapi_connection, connection_record):
+                        _register_sqlite_udfs(dbapi_connection, connection_record)
+                        cur = dbapi_connection.cursor()
+                        try:
+                            cur.execute("ATTACH DATABASE ? AS calibre", (_dbpath,))
+                            cur.execute("ATTACH DATABASE ? AS app_settings", (_app_db_path,))
+                            cur.execute("PRAGMA busy_timeout=60000")
+                        finally:
+                            cur.close()
+
+                    # One-time startup only: per-connection mode switches checkpoint the WAL
+                    # and destroy any frames Calibre desktop wrote, corrupting its transactions.
+                    if nsm and db_writable:
+                        import sqlite3 as _sqlite3
+                        import time as _time
+                        for _dbfile in (dbpath, app_db_path):
+                            for attempt in range(10):
+                                try:
+                                    _startup_conn = _sqlite3.connect(_dbfile, timeout=6)
+                                    mode = _startup_conn.execute("PRAGMA journal_mode=DELETE").fetchone()[0]
+                                    _startup_conn.close()
+                                    if mode == 'delete':
+                                        break
+                                    # Mode didn't switch (another connection holds WAL); retry.
+                                except Exception:
+                                    pass
+                                _time.sleep(1)
+                            else:
+                                log.warning("DESKTOP_COMPAT_MODE: could not convert %s to DELETE "
+                                            "journal mode after 10 attempts; WAL may still be active.", _dbfile)
+
+                    cls.engine = create_engine(
+                        'sqlite://',
+                        echo=False,
+                        isolation_level="SERIALIZABLE",
+                        connect_args={'check_same_thread': False, 'timeout': 30,
+                                      'factory': _SerializedSqliteConnection},
+                        poolclass=NullPool)
+                    event.listen(cls.engine, "connect", _attach_and_configure)
+                    cls._desktop_compat = True
+                    log.warning(
+                        "DESKTOP_COMPAT_MODE=true: using per-request SQLite connections. "
+                        "calibre desktop can access the library between web requests. "
+                        "WAL mode remains disabled (NETWORK_SHARE_MODE behaviour).")
+                    if not nsm:
+                        log.warning(
+                            "DESKTOP_COMPAT_MODE=true without NETWORK_SHARE_MODE=true: "
+                            "behaviour is technically valid on a local library but untested.")
+                else:
+                    cls._desktop_compat = False
+                    cls.engine = create_engine('sqlite://',
+                                               echo=False,
+                                               isolation_level="SERIALIZABLE",
+                                               # factory: GIL↔sqlite-mutex deadlock
+                                               # guard, see _SerializedSqliteConnection
+                                               connect_args={'check_same_thread': False, 'timeout': 30,
+                                                             'factory': _SerializedSqliteConnection},
+                                               poolclass=StaticPool)
+                    event.listen(cls.engine, "connect", _register_sqlite_udfs)
+                    with cls.engine.begin() as connection:
+                        connection.execute(text("attach database '{}' as calibre;".format(dbpath)))
+                        connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
+                        # Try enabling WAL to improve concurrency unless running on a network share
+                        # Controlled by env var NETWORK_SHARE_MODE (default False)
+                        try:
+                            if not nsm and db_writable:
+                                connection.execute(text("PRAGMA calibre.journal_mode=WAL"))
+                                connection.execute(text("PRAGMA app_settings.journal_mode=WAL"))
+                            else:
+                                reason = "NETWORK_SHARE_MODE=true" if nsm else "metadata.db not writable"
+                                log.warning("WAL mode disabled for calibre/app_settings (%s)", reason)
+                        except Exception:
+                            pass
+                        # Wait up to 60s for any external writer (calibredb
+                        # during ingest) before failing the query. Required
+                        # for fork issue #192 — without this, transient
+                        # locks on mergerfs/SMB/NFS surface as immediate
+                        # apsw.BusyError and crash the import.
+                        try:
+                            connection.execute(text("PRAGMA busy_timeout=60000"))
+                        except Exception:
+                            pass
 
                 conn = cls.engine.connect()
                 # conn.text_factory = lambda b: b.decode(errors = 'ignore') possible fix for #1302
@@ -1096,9 +1173,19 @@ class CalibreDB:
             from .progress_syncing.models import ensure_calibre_db_tables
             if (
                 db_writable
-                and os.getenv('NETWORK_SHARE_MODE', 'False').lower() not in ('1', 'true', 'yes', 'on')
+                and not nsm
+                and not desktop_compat
             ):
                 ensure_calibre_db_tables(conn)
+
+            # With NullPool (DESKTOP_COMPAT_MODE) the setup connection is not the
+            # shared persistent connection — close it so the file lock is released
+            # before normal request handling begins.
+            if desktop_compat:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
 
             cls._init = True
         # End of with cls._reconnect_lock

--- a/cps/db.py
+++ b/cps/db.py
@@ -1065,8 +1065,10 @@ class CalibreDB:
                             for attempt in range(10):
                                 try:
                                     _startup_conn = _sqlite3.connect(_dbfile, timeout=6)
-                                    mode = _startup_conn.execute("PRAGMA journal_mode=DELETE").fetchone()[0]
-                                    _startup_conn.close()
+                                    try:
+                                        mode = _startup_conn.execute("PRAGMA journal_mode=DELETE").fetchone()[0]
+                                    finally:
+                                        _startup_conn.close()
                                     if mode == 'delete':
                                         break
                                     # Mode didn't switch (another connection holds WAL); retry.

--- a/cps/db.py
+++ b/cps/db.py
@@ -914,6 +914,9 @@ class CalibreDB:
                     ccdict['value'] = Column(String)
                 if row.datatype in ['float', 'int', 'bool', 'datetime', 'comments']:
                     ccdict['book'] = Column(Integer, ForeignKey('books.id'))
+                if row.datatype in ['text', 'enumeration']:
+                    ccdict['name'] = property(lambda self: self.value)
+                    ccdict['sort'] = None
                 cc_classes[row.id] = type(str('custom_column_' + str(row.id)), (Base,), ccdict)
 
         for cc_id in cc_ids:
@@ -1079,13 +1082,12 @@ class CalibreDB:
                                 log.warning("DESKTOP_COMPAT_MODE: could not convert %s to DELETE "
                                             "journal mode after 10 attempts; WAL may still be active.", _dbfile)
 
-                    cls.engine = create_engine(
-                        'sqlite://',
-                        echo=False,
-                        isolation_level="SERIALIZABLE",
-                        connect_args={'check_same_thread': False, 'timeout': 30,
-                                      'factory': _SerializedSqliteConnection},
-                        poolclass=NullPool)
+                    cls.engine = create_engine('sqlite://',
+                                               echo=False,
+                                               isolation_level="SERIALIZABLE",
+                                               connect_args={'check_same_thread': False, 'timeout': 30,
+                                                             'factory': _SerializedSqliteConnection},
+                                               poolclass=NullPool)
                     event.listen(cls.engine, "connect", _attach_and_configure)
                     cls._desktop_compat = True
                     log.warning(

--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -544,6 +544,9 @@ def build_query_from_rules(rules_json, user_id=None):
 def get_book_ids_for_magic_shelf(shelf_id, sort_order=None, sort_param='stored', bypass_cache=False):
     """Return ordered book IDs for a magic shelf without loading book objects."""
     try:
+        from . import calibre_db
+        if calibre_db._desktop_compat:
+            bypass_cache = True
         if not bypass_cache and current_user.is_authenticated:
             cache = ub.session.query(ub.MagicShelfCache).filter_by(
                 shelf_id=shelf_id,
@@ -566,7 +569,7 @@ def get_book_ids_for_magic_shelf(shelf_id, sort_order=None, sort_param='stored',
         all_ids = [book_id for (book_id,) in query.with_entities(db.Books.id).all()]
         total_count = len(all_ids)
 
-        if current_user.is_authenticated:
+        if current_user.is_authenticated and not bypass_cache:
             ub.session.query(ub.MagicShelfCache).filter_by(
                 shelf_id=shelf_id,
                 user_id=current_user.id,

--- a/tests/unit/test_desktop_compat_mode.py
+++ b/tests/unit/test_desktop_compat_mode.py
@@ -1,0 +1,419 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Tests for DESKTOP_COMPAT_MODE — the NullPool connection strategy that
+releases the SQLite file lock after every request so calibre desktop can open
+the same library between web requests.
+
+Coverage:
+  - Source pins: DESKTOP_COMPAT_MODE branch exists; NullPool is used; connect
+    listener performs ATTACH for both databases; setup conn is closed at end.
+  - Behavioural: NullPool engine with the ATTACH closure actually serves
+    queries against an attached calibre database.
+  - Behavioural: session.remove() fully releases the connection (the core
+    property that makes calibre desktop coexistence possible).
+  - Behavioural: busy_timeout is set on each new connection.
+"""
+
+import ast
+import re
+import sqlite3
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker, scoped_session
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _minimal_calibre_db(path: Path) -> None:
+    """Write the bare minimum calibre schema into a SQLite file so ATTACH +
+    SELECT queries work in tests without a full calibre installation."""
+    con = sqlite3.connect(str(path))
+    con.executescript("""
+        CREATE TABLE IF NOT EXISTS books (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL DEFAULT 'Unknown',
+            sort TEXT,
+            author_sort TEXT,
+            timestamp TIMESTAMP,
+            pubdate TIMESTAMP,
+            series_index TEXT NOT NULL DEFAULT '1.0',
+            last_modified TIMESTAMP,
+            path TEXT NOT NULL DEFAULT '',
+            has_cover INTEGER DEFAULT 0,
+            uuid TEXT
+        );
+        CREATE TABLE IF NOT EXISTS library_id (
+            id  INTEGER PRIMARY KEY,
+            uuid TEXT NOT NULL
+        );
+        INSERT OR IGNORE INTO library_id VALUES (1, 'test-library-uuid');
+        CREATE TABLE IF NOT EXISTS custom_columns (
+            id INTEGER PRIMARY KEY,
+            label TEXT,
+            name TEXT,
+            datatype TEXT,
+            mark_for_delete INTEGER,
+            editable INTEGER,
+            display TEXT,
+            is_multiple INTEGER,
+            normalized INTEGER
+        );
+    """)
+    con.commit()
+    con.close()
+
+
+def _minimal_app_db(path: Path) -> None:
+    """Write a minimal app_settings (calibre-web user) schema."""
+    con = sqlite3.connect(str(path))
+    con.executescript("""
+        CREATE TABLE IF NOT EXISTS user (
+            id INTEGER PRIMARY KEY,
+            nickname TEXT
+        );
+    """)
+    con.commit()
+    con.close()
+
+
+def _build_nullpool_engine(dbpath: str, app_db_path: str):
+    """Replicate what setup_db does in DESKTOP_COMPAT_MODE.
+
+    Uses plain sqlite3 (no cps imports) so the test is self-contained and
+    doesn't require the full Flask/SQLAlchemy stack to be installed locally.
+    The UDF and _SerializedSqliteConnection aspects are covered by the
+    existing test_sqlite_udf_registration_listener.py suite.
+
+    Returns the engine. Caller is responsible for disposing.
+    """
+    from sqlalchemy.pool import NullPool
+
+    _dbpath = dbpath
+    _app_db_path = app_db_path
+
+    def _attach_and_configure(dbapi_connection, _connection_record):
+        cur = dbapi_connection.cursor()
+        try:
+            cur.execute("ATTACH DATABASE ? AS calibre", (_dbpath,))
+            cur.execute("ATTACH DATABASE ? AS app_settings", (_app_db_path,))
+            cur.execute("PRAGMA busy_timeout=60000")
+        finally:
+            cur.close()
+
+    engine = sa.create_engine(
+        "sqlite://",
+        echo=False,
+        isolation_level="SERIALIZABLE",
+        connect_args={"check_same_thread": False, "timeout": 30},
+        poolclass=NullPool,
+    )
+    sa.event.listen(engine, "connect", _attach_and_configure)
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# Source-level pins
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestSourcePinDesktopCompatMode:
+    """Pin the structural invariants of the DESKTOP_COMPAT_MODE branch in
+    setup_db so a future refactor can't quietly remove the behaviour without
+    a test failure.
+    """
+
+    def test_env_var_check_exists_in_setup_db(self):
+        """setup_db must read DESKTOP_COMPAT_MODE from the environment."""
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        assert "DESKTOP_COMPAT_MODE" in src, (
+            "DESKTOP_COMPAT_MODE env var check not found in cps/db.py"
+        )
+
+    def test_nullpool_imported_and_used_in_setup_db(self):
+        """The desktop_compat branch must import NullPool and pass it as
+        poolclass — that's the mechanism that releases the lock after each
+        request.
+        """
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        assert "NullPool" in src, "NullPool must be referenced in cps/db.py"
+        assert "poolclass=NullPool" in src, (
+            "poolclass=NullPool must be set in the DESKTOP_COMPAT_MODE branch"
+        )
+
+    def test_connect_listener_attaches_calibre_database(self):
+        """The per-connection listener in the desktop_compat branch must
+        ATTACH the calibre database — without this, every request-level
+        connection would be a bare in-memory DB with no tables.
+        """
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        # The ATTACH must reference 'calibre' as the schema name (same as
+        # StaticPool branch) so all existing ORM queries keep working.
+        assert re.search(r"ATTACH DATABASE.+AS calibre", src), (
+            "The desktop_compat connect listener must ATTACH the calibre database"
+        )
+
+    def test_connect_listener_attaches_app_settings_database(self):
+        """app_settings must also be ATTACHed per-connection — user data
+        (ReadBook, ArchivedBook, etc.) lives there.
+        """
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        assert re.search(r"ATTACH DATABASE.+AS app_settings", src), (
+            "The desktop_compat connect listener must ATTACH app_settings"
+        )
+
+    def test_setup_conn_is_closed_in_desktop_compat_branch(self):
+        """With NullPool the setup conn is not the shared persistent
+        connection. It must be explicitly closed so the file lock is released
+        before normal request handling begins.
+        """
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        # Look for conn.close() inside a desktop_compat guard block.
+        # We accept any of: conn.close() / try: conn.close() etc.
+        assert "conn.close()" in src, (
+            "setup_db must call conn.close() to release the NullPool setup "
+            "connection before request handling begins (DESKTOP_COMPAT_MODE)"
+        )
+
+    def test_desktop_compat_busy_timeout_set_per_connection(self):
+        """busy_timeout must be set in the per-connection listener so every
+        request connection inherits it, not just the one-time setup conn.
+        """
+        src = _read(REPO_ROOT / "cps" / "db.py")
+        # The busy_timeout PRAGMA must appear inside the _attach_and_configure
+        # closure (i.e. after the desktop_compat check and before the else
+        # block for StaticPool). We verify it's present at all — the
+        # behavioural test confirms it fires on each new connection.
+        assert src.count("PRAGMA busy_timeout=60000") >= 2, (
+            "busy_timeout=60000 must be set both in the StaticPool branch and "
+            "inside the NullPool connect listener"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavioural tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestDesktopCompatModeConnectListener:
+    """Verify the NullPool + ATTACH closure pattern actually works end-to-end
+    against a real (minimal) calibre database file.
+    """
+
+    def test_calibre_tables_accessible_via_attached_schema(self, tmp_path):
+        """Queries against calibre.books work when ATTACH fires on connect."""
+        dbpath = tmp_path / "metadata.db"
+        app_db_path = tmp_path / "app_settings.db"
+        _minimal_calibre_db(dbpath)
+        _minimal_app_db(app_db_path)
+
+        engine = _build_nullpool_engine(str(dbpath), str(app_db_path))
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    sa.text("SELECT id FROM calibre.books")
+                ).fetchall()
+            # Empty is fine — we just need no OperationalError.
+            assert isinstance(rows, list)
+        finally:
+            engine.dispose()
+
+    def test_app_settings_tables_accessible_via_attached_schema(self, tmp_path):
+        """Queries against app_settings.user work when ATTACH fires on connect."""
+        dbpath = tmp_path / "metadata.db"
+        app_db_path = tmp_path / "app_settings.db"
+        _minimal_calibre_db(dbpath)
+        _minimal_app_db(app_db_path)
+
+        engine = _build_nullpool_engine(str(dbpath), str(app_db_path))
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    sa.text("SELECT id FROM app_settings.user")
+                ).fetchall()
+            assert isinstance(rows, list)
+        finally:
+            engine.dispose()
+
+    def test_lower_udf_available_on_nullpool_connection(self, tmp_path):
+        """UDFs registered by _register_sqlite_udfs (called from the closure)
+        must be available on each NullPool connection.
+        """
+        dbpath = tmp_path / "metadata.db"
+        app_db_path = tmp_path / "app_settings.db"
+        _minimal_calibre_db(dbpath)
+        _minimal_app_db(app_db_path)
+
+        engine = _build_nullpool_engine(str(dbpath), str(app_db_path))
+        try:
+            with engine.connect() as conn:
+                result = conn.execute(
+                    sa.text("SELECT lower('DESKTOP') AS r")
+                ).scalar()
+            assert result == "desktop"
+        finally:
+            engine.dispose()
+
+    def test_busy_timeout_set_on_each_new_connection(self, tmp_path):
+        """Each NullPool connection must have busy_timeout set — verify by
+        reading the PRAGMA value back from two successive connections.
+        """
+        dbpath = tmp_path / "metadata.db"
+        app_db_path = tmp_path / "app_settings.db"
+        _minimal_calibre_db(dbpath)
+        _minimal_app_db(app_db_path)
+
+        engine = _build_nullpool_engine(str(dbpath), str(app_db_path))
+        try:
+            for _ in range(2):
+                with engine.connect() as conn:
+                    timeout = conn.execute(
+                        sa.text("PRAGMA busy_timeout")
+                    ).scalar()
+                assert timeout == 60000, (
+                    f"Expected busy_timeout=60000, got {timeout!r}"
+                )
+        finally:
+            engine.dispose()
+
+
+@pytest.mark.unit
+class TestDesktopCompatModeLockRelease:
+    """The whole point of DESKTOP_COMPAT_MODE: the SQLite file lock is released
+    after session.remove() so an external process (calibre desktop) can open
+    the database between web requests.
+    """
+
+    def test_session_remove_releases_file_lock(self, tmp_path):
+        """After scoped_session.remove(), a separate sqlite3 connection must
+        be able to open the database in exclusive mode — proof that NullPool
+        actually closed the connection and released the lock.
+        """
+        dbpath = tmp_path / "metadata.db"
+        app_db_path = tmp_path / "app_settings.db"
+        _minimal_calibre_db(dbpath)
+        _minimal_app_db(app_db_path)
+
+        engine = _build_nullpool_engine(str(dbpath), str(app_db_path))
+        try:
+            session_factory = scoped_session(
+                sessionmaker(autocommit=False, autoflush=True, bind=engine, future=True)
+            )
+
+            # Open a session and run a query (this acquires a connection).
+            session = session_factory()
+            session.execute(sa.text("SELECT 1"))
+
+            # Connection is held — calibre desktop can't get in yet.
+            # (We don't assert this half; the important half is after remove().)
+
+            # Simulate Flask's teardown_appcontext: session_factory.remove()
+            session_factory.remove()
+
+            # With NullPool the connection is now fully closed. A new sqlite3
+            # connection in exclusive mode must succeed immediately.
+            probe = sqlite3.connect(str(dbpath), timeout=0.5)
+            try:
+                probe.execute("BEGIN EXCLUSIVE")
+                probe.execute("COMMIT")
+            finally:
+                probe.close()
+
+            # If we reach here, the lock was released — calibre desktop can
+            # open the library between requests.
+        finally:
+            engine.dispose()
+
+    def test_multiple_request_cycles_each_release_lock(self, tmp_path):
+        """Simulate several request/teardown cycles — each must release the
+        lock, not accumulate held connections.
+        """
+        dbpath = tmp_path / "metadata.db"
+        app_db_path = tmp_path / "app_settings.db"
+        _minimal_calibre_db(dbpath)
+        _minimal_app_db(app_db_path)
+
+        engine = _build_nullpool_engine(str(dbpath), str(app_db_path))
+        try:
+            session_factory = scoped_session(
+                sessionmaker(autocommit=False, autoflush=True, bind=engine, future=True)
+            )
+
+            for i in range(5):
+                # Simulate a request.
+                session = session_factory()
+                session.execute(sa.text("SELECT 1"))
+                # Simulate teardown_appcontext.
+                session_factory.remove()
+
+                # Verify lock is free after every cycle.
+                probe = sqlite3.connect(str(dbpath), timeout=0.5)
+                try:
+                    probe.execute("BEGIN EXCLUSIVE")
+                    probe.execute("COMMIT")
+                finally:
+                    probe.close()
+        finally:
+            engine.dispose()
+
+    def test_concurrent_requests_do_not_leave_stale_connections(self, tmp_path):
+        """Multiple threads each run a request cycle and call remove(). After
+        all threads finish, the database must be unlocked.
+        """
+        dbpath = tmp_path / "metadata.db"
+        app_db_path = tmp_path / "app_settings.db"
+        _minimal_calibre_db(dbpath)
+        _minimal_app_db(app_db_path)
+
+        engine = _build_nullpool_engine(str(dbpath), str(app_db_path))
+        errors = []
+
+        try:
+            session_factory = scoped_session(
+                sessionmaker(autocommit=False, autoflush=True, bind=engine, future=True)
+            )
+
+            barrier = threading.Barrier(8)
+
+            def request_cycle():
+                try:
+                    barrier.wait(timeout=5)
+                    session = session_factory()
+                    session.execute(sa.text("SELECT 1"))
+                    session_factory.remove()
+                except Exception as e:
+                    errors.append(e)
+
+            threads = [threading.Thread(target=request_cycle) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=15)
+
+            assert not errors, f"Thread errors during request cycles: {errors}"
+
+            # All threads done — database must be fully unlocked.
+            probe = sqlite3.connect(str(dbpath), timeout=0.5)
+            try:
+                probe.execute("BEGIN EXCLUSIVE")
+                probe.execute("COMMIT")
+            finally:
+                probe.close()
+        finally:
+            engine.dispose()

--- a/tests/unit/test_desktop_compat_mode.py
+++ b/tests/unit/test_desktop_compat_mode.py
@@ -251,9 +251,12 @@ class TestDesktopCompatModeConnectListener:
         finally:
             engine.dispose()
 
-    def test_lower_udf_available_on_nullpool_connection(self, tmp_path):
-        """UDFs registered by _register_sqlite_udfs (called from the closure)
-        must be available on each NullPool connection.
+    def test_sql_scalar_functions_available_on_nullpool_connection(self, tmp_path):
+        """SQL scalar functions work on each NullPool connection.
+
+        _build_nullpool_engine omits _register_sqlite_udfs to stay self-contained,
+        so this exercises SQLite's built-in lower() rather than the custom UDF.
+        Custom UDF registration is covered by test_sqlite_udf_registration_listener.py.
         """
         dbpath = tmp_path / "metadata.db"
         app_db_path = tmp_path / "app_settings.db"

--- a/tests/unit/test_udf_gil_deadlock_serialized_connection.py
+++ b/tests/unit/test_udf_gil_deadlock_serialized_connection.py
@@ -173,8 +173,9 @@ class TestFactoryWiredIntoProductionEngines:
         connect_args dicts carrying the guard factory — both must be 2."""
         src = (REPO_ROOT / "cps" / "db.py").read_text(encoding="utf-8")
         engine_sites = re.findall(r"create_engine\('sqlite://'", src)
-        assert len(engine_sites) == 2, (
-            f"expected exactly 2 in-memory calibre engines in cps/db.py, "
+        assert len(engine_sites) == 3, (
+            f"expected exactly 3 in-memory calibre engines in cps/db.py "
+            f"(StaticPool, NullPool/DESKTOP_COMPAT_MODE, and app-settings), "
             f"found {len(engine_sites)} — update this pin if the architecture "
             f"changed"
         )
@@ -182,8 +183,8 @@ class TestFactoryWiredIntoProductionEngines:
             r"connect_args=\{[^}]*'factory':\s*_SerializedSqliteConnection",
             src,
         )
-        assert len(guarded_connect_args) == 2, (
-            f"expected the deadlock-guard factory in both calibre engines' "
+        assert len(guarded_connect_args) == 3, (
+            f"expected the deadlock-guard factory in all calibre engines' "
             f"connect_args, found {len(guarded_connect_args)} — a calibre "
             f"engine without _SerializedSqliteConnection reopens the "
             f"GIL↔sqlite-mutex freeze"


### PR DESCRIPTION
DESKTOP_COMPAT_MODE=true lets calibre desktop and calibre-web-nextgen share the same library on a network share without crashing.

**Problem**

With NETWORK_SHARE_MODE=true, WAL is disabled and SQLAlchemy uses StaticPool: one connection, held open for the life of the process. That's the right call for NFS/SMB durability, but it means calibre desktop can't open the same database. It hits the lock, and on calibre 9.9.0 + macOS 26, it crashes hard — no error dialog, just an abort in sqlite3_load_extension.

This setup is common: calibre-web on a NAS or Docker host, calibre desktop opened occasionally for bulk edits. It used to work because older calibre-web released connections between operations. calibre-web-nextgen holds them.

**Solution**

DESKTOP_COMPAT_MODE=true switches the pool from StaticPool to NullPool. Each web request gets its own SQLite connection. Flask's teardown_appcontext calls session_factory.remove(), which with NullPool fully closes the con lock between requests.
                                                                                                                                                                 The ATTACH DATABASE calls move from a one-time engine.begin() blocvent listener, so every per-request connection still gets bothschemas (calibre + app_settings) attached automatically. Bound parameters (?) are used in ATTACH so library paths with apostrophes don't break it.               
A before_request hook rolls back the SQLAlchemy session's SERIALIZABLE snapshot before each request so the page sees changes calibre desktop committed since the last page load. Static file requests skip this to avoid unnecessar

Both the magic shelf ID-list cache and the Flask-session shelf cou mode so sidebar counts and book lists can't go stale.

At startup, metadata.db and app.db are converted to DELETE journaln — a per-connection mode switch checkpoints the WAL and destroysany frames calibre desktop wrote mid-transaction). check_valid_db is gated to prevent an admin config-save from re-enabling WAL and undoing this.

Contention is handled by busy_timeout=60000. If calibre desktop holds the DB open mid-edit and a web request comes in, the Flask worker blocks for up to 60
seconds. They serialize rather than corrupt — but heavy calibre de active can exhaust the worker pool and stall the whole UI, not just one request.

**Trade-offs**

- Each request pays an extra SMB open/close round-trip. Fine for a home server.
- ensure_calibre_db_tables is skipped, same as under NETWORK_SHAREldn't run on network shares anyway.
- Meant to be used with NETWORK_SHARE_MODE=true. Using it without logs a warning. It technically works on a local library but hasn't been tested that way.

**Usage**

environment:
  - NETWORK_SHARE_MODE=true
  - DESKTOP_COMPAT_MODE=true

**Tests**

13 unit tests in tests/unit/test_desktop_compat_mode.py:
- Source pins: env var parsing, NullPool import, bound-param ATTACetup
- Behavioural: ATTACH works per-connection, busy_timeout set, session.remove() releases the file lock (verified via exclusive-mode probe connection)
- Concurrent: 8 threads run request cycles; database is unlocked a