### PR TITLE
feat(magic-shelf): custom columns in the rule builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,9 @@ cython_debug/
 # Dev instance files for testing in the same folder
 instance/
 
+# Local dev container state (logs, db, processed books)
+dev-config/
+
 # Runtime migration markers created by cwa-init / ub.py.run_cwa_migrations
 # inside CONFIG_DIR. These appear under repo/ when a developer points
 # CONFIG_DIR at the repo root for local container runs; they're per-

--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -392,6 +392,17 @@ def build_filter_from_rule(rule, user_id=None):
                             log.warning(f"Invalid date value '{v}' for custom column {cc_id}")
                             return None
                     value = parsed
+            elif cc_col.datatype == 'enumeration':
+                try:
+                    allowed = set(cc_col.get_display_dict().get('enum_values', []))
+                except Exception:
+                    allowed = set()
+                if allowed:
+                    values_to_check = value if isinstance(value, list) else [value]
+                    for v in values_to_check:
+                        if v not in allowed:
+                            log.warning(f"Invalid enum value '{v}' for custom column {cc_id}")
+                            return None
 
         negated_ops = {
             'not_equal': 'equal',

--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -369,19 +369,29 @@ def build_filter_from_rule(rule, user_id=None):
 
         # Coerce value to match the column's Python type before filtering
         from . import calibre_db
-        cc_col = calibre_db.session.query(db.CustomColumns).get(cc_id)
+        cc_col = calibre_db.session.get(db.CustomColumns, cc_id)
         if cc_col:
             if cc_col.datatype == 'bool' and value is not None:
                 try:
                     value = bool(int(value))
                 except (ValueError, TypeError):
                     pass
-            elif cc_col.datatype == 'datetime' and isinstance(value, str):
-                try:
-                    value = datetime.strptime(value, '%Y-%m-%d')
-                except ValueError:
-                    log.warning(f"Invalid date value '{value}' for custom column {cc_id}")
-                    return None
+            elif cc_col.datatype == 'datetime':
+                if isinstance(value, str):
+                    try:
+                        value = datetime.strptime(value, '%Y-%m-%d')
+                    except ValueError:
+                        log.warning(f"Invalid date value '{value}' for custom column {cc_id}")
+                        return None
+                elif isinstance(value, list):
+                    parsed = []
+                    for v in value:
+                        try:
+                            parsed.append(datetime.strptime(v, '%Y-%m-%d'))
+                        except (ValueError, TypeError):
+                            log.warning(f"Invalid date value '{v}' for custom column {cc_id}")
+                            return None
+                    value = parsed
 
         negated_ops = {
             'not_equal': 'equal',

--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -347,6 +347,71 @@ def build_filter_from_rule(rule, user_id=None):
     if not all([field_name, operator_name]):
         return None
 
+    # Handle dynamic custom column fields (id: 'custom_column_<N>')
+    if field_name and field_name.startswith('custom_column_'):
+        try:
+            cc_id = int(field_name[len('custom_column_'):])
+        except ValueError:
+            return None
+
+        if cc_id not in db.cc_classes:
+            log.warning(f"Custom column {cc_id} not found in cc_classes")
+            return None
+
+        cc_rel_name = f'custom_column_{cc_id}'
+        if not hasattr(db.Books, cc_rel_name):
+            log.warning(f"Books model has no relationship '{cc_rel_name}'")
+            return None
+
+        cc_class = db.cc_classes[cc_id]
+        column = cc_class.value
+        rel = getattr(db.Books, cc_rel_name)
+
+        # Coerce value to match the column's Python type before filtering
+        from . import calibre_db
+        cc_col = calibre_db.session.query(db.CustomColumns).get(cc_id)
+        if cc_col:
+            if cc_col.datatype == 'bool' and value is not None:
+                try:
+                    value = bool(int(value))
+                except (ValueError, TypeError):
+                    pass
+            elif cc_col.datatype == 'datetime' and isinstance(value, str):
+                try:
+                    value = datetime.strptime(value, '%Y-%m-%d')
+                except ValueError:
+                    log.warning(f"Invalid date value '{value}' for custom column {cc_id}")
+                    return None
+
+        negated_ops = {
+            'not_equal': 'equal',
+            'not_contains': 'contains',
+            'not_begins_with': 'begins_with',
+            'not_ends_with': 'ends_with',
+            'not_in': 'in',
+            'not_between': 'between',
+        }
+        try:
+            if operator_name in ('is_empty', 'is_null'):
+                return ~rel.any()
+            elif operator_name in ('is_not_empty', 'is_not_null'):
+                return rel.any()
+            elif operator_name in negated_ops:
+                base_op = OPERATOR_MAP.get(negated_ops[operator_name])
+                if not base_op:
+                    return None
+                filter_expr = base_op(column, value)
+                return ~rel.any(filter_expr) if filter_expr is not None else None
+            else:
+                operator = OPERATOR_MAP.get(operator_name)
+                if not operator:
+                    return None
+                filter_expr = operator(column, value)
+                return rel.any(filter_expr) if filter_expr is not None else None
+        except Exception as e:
+            log.error(f"Error building filter for custom column {cc_id}: {e}", exc_info=True)
+            return None
+
     field_info = FIELD_MAP.get(field_name)
     if not field_info:
         return None

--- a/cps/templates/magic_shelf_edit.html
+++ b/cps/templates/magic_shelf_edit.html
@@ -479,10 +479,12 @@ div.help-panel > .panel-body {
 
 {% set rules_json = shelf.rules|tojson if shelf and shelf.rules else 'null' %}
 {% set languages_json = languages|tojson if languages else '{}' %}
+{% set custom_columns_json = custom_columns|tojson if custom_columns else '[]' %}
 {% block js %}
 {{ super() }}
 <script src="{{ url_for('static', filename='js/moment.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/query-builder.standalone.min.js') }}"></script>
+<script type="application/json" id="custom-columns-data">{{ custom_columns_json|safe }}</script>
 <script>
 $(function() {
     // Initialize tooltips
@@ -630,6 +632,36 @@ $(function() {
             description: 'Whether book has Hardcover identifier'
         }
     ];
+
+    // Append user-defined custom columns from Calibre
+    var customColumns = JSON.parse(document.getElementById('custom-columns-data').textContent || '[]');
+    customColumns.forEach(function(cc) {
+        var field = {
+            id: 'custom_column_' + cc.id,
+            label: cc.label,
+            description: 'Custom column'
+        };
+        if (cc.datatype === 'bool') {
+            field.type = 'integer';
+            field.input = 'radio';
+            field.values = {1: 'Yes', 0: 'No'};
+        } else if (cc.datatype === 'int' || cc.datatype === 'rating') {
+            field.type = 'integer';
+        } else if (cc.datatype === 'float') {
+            field.type = 'double';
+        } else if (cc.datatype === 'datetime') {
+            field.type = 'date';
+            field.validation = {format: 'YYYY-MM-DD'};
+        } else if (cc.datatype === 'enumeration' && cc.enum_values && cc.enum_values.length > 0) {
+            field.type = 'string';
+            field.input = 'select';
+            field.values = {};
+            cc.enum_values.forEach(function(v) { field.values[v] = v; });
+        } else {
+            field.type = 'string';
+        }
+        fields.push(field);
+    });
 
     var operators = [
         {type: 'equal', optgroup: 'basic'},

--- a/cps/web.py
+++ b/cps/web.py
@@ -1263,6 +1263,29 @@ def preview_magic_shelf():
         return jsonify({"success": False, "message": _("Invalid request")}), 400
 
 
+def _build_custom_columns_json():
+    """Return a list of queryable custom columns for the magic shelf rule builder."""
+    try:
+        cc_list = calibre_db.session.query(db.CustomColumns).filter(
+            db.CustomColumns.datatype.notin_(db.cc_exceptions),
+            db.CustomColumns.mark_for_delete == False  # noqa: E712
+        ).order_by(db.CustomColumns.name).all()
+    except Exception:
+        log.error("Failed to query custom columns for magic shelf rule builder", exc_info=True)
+        return []
+
+    result = []
+    for cc in cc_list:
+        entry = {'id': cc.id, 'label': cc.name, 'datatype': cc.datatype}
+        if cc.datatype == 'enumeration':
+            try:
+                entry['enum_values'] = cc.get_display_dict().get('enum_values', [])
+            except Exception:
+                entry['enum_values'] = []
+        result.append(entry)
+    return result
+
+
 @web.route("/magicshelf", methods=["GET", "POST"])
 @user_login_required
 def create_magic_shelf():
@@ -1368,6 +1391,8 @@ def create_magic_shelf():
         except:
             language_map[lang.lang_code] = lang.lang_code
 
+    custom_columns_json = _build_custom_columns_json()  # list, serialized by tojson in template
+
     return render_title_template('magic_shelf_edit.html',
                                  title=_("Create Magic Shelf"),
                                  page="magic_shelf_create",
@@ -1375,7 +1400,8 @@ def create_magic_shelf():
                                  opds_expose_checked=False,
                                  kobo_magic_sync_enabled=bool(config.config_kobo_sync_magic_shelves),
                                  allowed_icons=ALLOWED_ICONS,
-                                 languages=language_map)
+                                 languages=language_map,
+                                 custom_columns=custom_columns_json)
 
 
 @web.route("/magicshelf/<int:shelf_id>/edit", methods=["GET", "POST"])
@@ -1500,6 +1526,8 @@ def edit_magic_shelf(shelf_id):
         except:
             language_map[lang.lang_code] = lang.lang_code
 
+    custom_columns_json = _build_custom_columns_json()  # list, serialized by tojson in template
+
     return render_title_template('magic_shelf_edit.html',
                                  shelf=shelf,
                                  title=_("Edit Magic Shelf"),
@@ -1508,7 +1536,8 @@ def edit_magic_shelf(shelf_id):
                                  opds_expose_checked=opds_expose_checked,
                                  kobo_magic_sync_enabled=bool(config.config_kobo_sync_magic_shelves),
                                  allowed_icons=ALLOWED_ICONS,
-                                 languages=language_map)
+                                 languages=language_map,
+                                 custom_columns=custom_columns_json)
 
 
 @web.route("/magicshelf/<int:shelf_id>/duplicate", methods=["POST"])

--- a/docker-compose.yml.local-dev
+++ b/docker-compose.yml.local-dev
@@ -1,0 +1,31 @@
+---
+# Local development compose — mounts ./cps live into the container so code
+# changes take effect on container restart without a full image rebuild.
+#
+# Usage:
+#   docker compose -f docker-compose.yml.local-dev up -d
+#   docker compose -f docker-compose.yml.local-dev restart   # pick up code changes
+#   docker compose -f docker-compose.yml.local-dev down
+#
+# The published :latest image is used as the base so you get all the compiled
+# dependencies (Calibre, kepubify, Python venv) without waiting for a full build.
+
+services:
+  calibre-web-automated:
+    image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+    container_name: calibre-web-nextgen-dev
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/New_York
+      - HARDCOVER_TOKEN=dev
+    volumes:
+      # Live-reload the app source — no rebuild needed, just restart the container
+      - ./cps:/app/calibre-web-automated/cps
+      # Persistent dev config & CWA state (db, logs, etc.)
+      - ./dev-config:/config
+      # Point at a local Calibre library (ideally one with custom columns to test)
+      - /path/to/your/calibre-library:/calibre-library
+    ports:
+      - "8084:8083"
+    restart: "no"


### PR DESCRIPTION
## Magic Shelf: custom columns in the rule builder

The rule builder's field picker was hardcoded — Title, Author, Tag, and the other built-ins, that's it. If you had custom columns in your library, they weren't there.

This queries the `custom_columns` table on page load and appends whatever's defined to the field list. All queryable types are handled:

| Calibre type | QueryBuilder field |
|---|---|
| `text`, `comments`, `rating` | string / integer |
| `int`, `float` | integer / double |
| `bool` | Yes/No radio |
| `datetime` | date with YYYY-MM-DD validation |
| `enumeration` | select populated from `display.enum_values` |

`composite` and `series` columns are excluded — they're not filterable.

Two correctness fixes that would've caused silent no-matches:
- `bool` column values are coerced from int to Python `bool` before filtering (the read-status path already did this; the new generic path now does too)
- `datetime` column values are parsed from the `YYYY-MM-DD` string the UI emits to actual `datetime` objects before comparing against `TIMESTAMP` columns

**Implementation notes:**
- `web.py`: `_build_custom_columns_json()` returns a plain list; the template serializes it with `|tojson` (same pattern as `languages` and `rules` already on this page). Uses `db.cc_exceptions` and `cc.get_display_dict()` rather than re-implementing them.
- `magic_shelf.py`: `build_filter_from_rule()` detects `custom_column_<N>` field IDs, looks up the ORM class from `db.cc_classes`, and dispatches through `Books.custom_column_N` relationships the same way the built-in relationship fields do.
- Template: columns are injected via `<script type="application/json">` and parsed with `JSON.parse(el.textContent)` — no `|safe` on raw data.
- `docker-compose.yml.local-dev` added for local dev (live-mounts `./cps/` so you don't need to rebuild the image on every change).