### PR TITLE
fix(mobile): right-align organizer buttons so the settings menu stays on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- On phones, the select and settings buttons above a book list now sit on the
+  right (matching the desktop layout), so tapping the gear opens its menu on
+  screen instead of off the left edge where it was getting cut off.
 - Pages no longer occasionally fall back to the old, deprecated light theme —
   including error pages. That fallback could happen when a request hit a snag
   while loading, and it was the underlying cause of display glitches like the

--- a/cps/static/css/book_organizer.css
+++ b/cps/static/css/book_organizer.css
@@ -141,9 +141,13 @@
     flex: 1 1 100%;
     width: 100%;
   }
+  /* Keep the multi-select + settings buttons right-aligned when the bar wraps
+     to its own row on mobile — matches desktop (space-between pushes them
+     right) and, critically, keeps the settings dropdown-menu-right popover on
+     screen: a left-aligned button made it open off the left edge. */
   .book-organizer-bar-right {
     gap: 6px;
-    justify-content: flex-start;
+    justify-content: flex-end;
   }
   /* Sort dropdown sized to its parent (now full width of the bar row). */
   .book-organizer-sort,

--- a/tests/unit/test_mobile_organizer_buttons_right.py
+++ b/tests/unit/test_mobile_organizer_buttons_right.py
@@ -1,0 +1,64 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Mobile book-organizer bar: the multi-select + settings buttons stay right-aligned.
+
+On the book-listing pages the organizer bar shows a sort dropdown (left) and a
+multi-select toggle + a settings gear (right). The settings menu uses Bootstrap's
+``dropdown-menu-right``, so it opens *leftward* from its button.
+
+On phones the bar wraps (``@media (max-width: 480px)``): the sort dropdown takes
+the full first row and the button group wraps to its own row. The group was
+``justify-content: flex-start`` — so the gear sat near the LEFT edge and its
+left-opening menu ran off the left side of the screen (reported: the "Hide shelf
+badges on covers" popover was clipped). Right-aligning the group keeps the menu
+on screen and matches desktop (where ``space-between`` already pushes the group
+right). Verified live at 390px: the open settings menu sits fully within the
+viewport (left=123, right=350 on a 390px screen, 0px clipped).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CSS = (REPO_ROOT / "cps" / "static" / "css" / "book_organizer.css").read_text()
+
+
+def _mobile_media_block() -> str:
+    """Return the body of the ``@media (max-width: 480px)`` block via brace
+    counting (robust to nested rule braces)."""
+    start = CSS.find("@media (max-width: 480px)")
+    assert start != -1, "no @media (max-width: 480px) block in book_organizer.css"
+    open_brace = CSS.find("{", start)
+    depth = 0
+    for i in range(open_brace, len(CSS)):
+        if CSS[i] == "{":
+            depth += 1
+        elif CSS[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return CSS[open_brace + 1 : i]
+    raise AssertionError("unbalanced braces in @media (max-width: 480px) block")
+
+
+class TestMobileOrganizerButtonsRightAligned:
+    def test_right_group_is_flex_end_on_mobile(self):
+        # The only justify-content in the mobile media block is on the
+        # .book-organizer-bar-right button group; it must right-align (flex-end),
+        # never left-align (flex-start, which clipped the settings dropdown).
+        block = _mobile_media_block()
+        assert "justify-content: flex-end" in block, (
+            "the multi-select + settings group must be right-aligned (flex-end) "
+            "when the bar wraps on mobile, so the settings dropdown-menu-right "
+            "stays on screen and the layout matches desktop"
+        )
+        assert "justify-content: flex-start" not in block, (
+            "left-aligning the mobile button group (flex-start) made the settings "
+            "dropdown open off the left edge of the viewport"
+        )


### PR DESCRIPTION
## Problem (mobile)

On phones, the **select** and **settings** buttons above a book list sat on the *left*. The settings menu uses Bootstrap's `dropdown-menu-right` (it opens leftward from its button), so a left-positioned gear made the "Cover Settings / Hide shelf badges on covers" popover open **off the left edge of the screen** — it got cut off (reported with a screenshot).

## Root cause

`book_organizer.css` `@media (max-width: 480px)`: when the bar wraps, the sort dropdown takes the full first row and the `.book-organizer-bar-right` group (multi-select + settings) wraps to its own row with `justify-content: flex-start` — pinning the buttons to the left. On desktop `space-between` already pushes that group to the right, so this only affected mobile.

## Fix

Right-align the group (`justify-content: flex-end`) when it wraps on mobile. This both keeps the dropdown on screen and makes mobile match desktop's buttons-on-the-right layout.

## Verification

- **Live (Playwright, caliBlur, 390px):** before — buttons left, settings menu clipped off the left edge. After — gear right edge at x=350; the open menu spans x=123→350, **fully within the 390px viewport, 0px clipped**. Screenshots in `notes/`.
- The change is inside the `max-width: 480px` media query, so desktop is untouched; `book_organizer.css` is theme-independent, so the fix applies on both themes.
- 1 CSS source-pin (`test_mobile_organizer_buttons_right.py`).

Addresses the mobile organizer-button placement report.
