### PR TITLE
fix(mobile): move the hamburger menu to the left to match the left-sliding drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- On phones, the menu (hamburger) button is now on the **left**, the same side
+  the navigation drawer slides out from — so the button and the menu it opens
+  line up. Tapping it opens the menu; tapping outside still closes it.
 - On phones, the select and settings buttons above a book list now sit on the
   right (matching the desktop layout), so tapping the gear opens its menu on
   screen instead of off the left edge where it was getting cut off.

--- a/cps/static/css/caliBlur_override.css
+++ b/cps/static/css/caliBlur_override.css
@@ -250,3 +250,29 @@ a#advanced_search > span.hidden-sm {
         border-radius: 0;
     }
 }
+/* Fork: hamburger on the LEFT on phones. The off-canvas sidebar slides in from
+   the LEFT, so the menu toggle belongs on the left to match — caliBlur floats it
+   to the right (position:relative; right:50px), which reads as disconnected from
+   where the drawer appears. Re-anchor the toggle to the left and reflow the brand
+   to its right. On this breakpoint the home/back buttons are display:none and the
+   search form is absolute at right:10px, so only the toggle + brand reserve change.
+   Centre the hamburger glyph in its now left-anchored 40px button. */
+@media only screen and (max-width: 767px) {
+    .navbar > .container-fluid > .navbar-header > button.navbar-toggle {
+        float: left;
+        right: auto;
+        left: auto;
+        margin-left: 6px;
+    }
+    .navbar > .container-fluid > .navbar-header > button.navbar-toggle:before {
+        left: 9px;
+        right: auto;
+    }
+    /* Brand reserved 138px on the right for the old right-side toggle + search.
+       With the toggle now on the left, reserve room for the toggle (left) +
+       search (right) and let the brand text sit between them. */
+    body > div.navbar.navbar-default.navbar-static-top > div > div.navbar-header > a {
+        width: calc(100vw - 116px);
+        padding-left: 10px;
+    }
+}

--- a/tests/unit/test_mobile_hamburger_left.py
+++ b/tests/unit/test_mobile_hamburger_left.py
@@ -1,0 +1,61 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Mobile caliBlur navbar: the hamburger toggle sits on the LEFT.
+
+The off-canvas navigation drawer slides in from the **left**, but caliBlur floats
+the menu toggle to the right (``position: relative; right: 50px`` in
+``caliBlur.css``), so on a phone the only menu control was on the opposite side
+from where the drawer appears — disconnected. The fork override re-anchors the
+toggle to the left (``float: left; right: auto``) and reflows the brand to its
+right; the drawer then opens from under the hamburger and the existing
+tap-outside-to-close path (fork #382) closes it.
+
+Verified live (caliBlur, 320px + 390px): toggle at the far-left (x=6), brand
+reflowed beside it with no overlap of the right-anchored search, drawer slides
+from the left, and a tap on the visible scrim closes it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OVERRIDE_CSS = (REPO_ROOT / "cps" / "static" / "css" / "caliBlur_override.css").read_text()
+
+# `.navbar-toggle {` matches the positioning rules but NOT `.navbar-toggle:before {`
+# (the ':before' glyph repaint), because ':' is neither whitespace nor '{'.
+_TOGGLE_RULES = re.findall(r"\.navbar-toggle\s*\{([^}]*)\}", OVERRIDE_CSS)
+
+
+class TestMobileHamburgerLeftPlacement:
+    def test_mobile_toggle_floats_left(self):
+        float_left_rules = [r for r in _TOGGLE_RULES if "float: left" in r]
+        assert float_left_rules, (
+            "caliBlur_override.css must float the mobile .navbar-toggle left so the "
+            "hamburger sits on the same side as the left-sliding off-canvas drawer"
+        )
+        assert any("right: auto" in r for r in float_left_rules), (
+            "the left-floated toggle must reset caliBlur's right:50px (right: auto) "
+            "so it anchors to the left edge, not the right"
+        )
+
+    def test_left_placement_is_mobile_scoped(self):
+        # The float:left override must live under a max-width:767px media query so
+        # the expanded desktop navbar is untouched. Check the float:left toggle
+        # rule is preceded by a 767px media open with no intervening close-at-col-0.
+        idx = OVERRIDE_CSS.find("float: left")
+        assert idx != -1
+        head = OVERRIDE_CSS[:idx]
+        media_open = head.rfind("max-width: 767px")
+        assert media_open != -1, "the hamburger-left override must be inside a max-width:767px media query"
+        # no media block closed (newline + '}' at column 0) between the media open and the rule
+        assert not re.search(r"\n\}", head[media_open:]), (
+            "the float:left toggle rule escaped its mobile media block"
+        )


### PR DESCRIPTION
## Problem (mobile)

The hamburger menu button was on the top-**right**, but caliBlur's navigation drawer slides in from the **left**. So on a phone the only menu control sat on the opposite side from where the menu actually appears — the button and the panel it opens were visually disconnected (reported with a screenshot).

## Root cause

caliBlur (`caliBlur.css`, inside `@media (max-width: 767px)`) floats `.navbar-toggle` to the right and nudges it with `position: relative; right: 50px`. The brand reserves `width: calc(100vw - 138px)` on the right for that toggle + the search box.

## Fix

In `caliBlur_override.css` (the same file as the #382/#383 navbar fixes), within caliBlur's 767px mobile block:
- Float the toggle **left** (`float: left; right: auto; margin-left: 6px`) so it anchors to the left edge.
- Reflow the brand beside it (recompute the width reserve, add left padding).
- Centre the hamburger glyph in the now left-anchored button.
- The right-anchored search and the `display:none` home/back buttons are untouched.

## Verification (live, caliBlur, Playwright)

- **320px + 390px:** toggle at x=6 (far left); brand reflowed beside it (46→320) with **no overlap** of the right-anchored search (340→380).
- **Drawer:** opens from the left (left edge ~0); **tap-outside closes it** (`tap_outside_closes: true`) — the fork #382 backdrop-close path is intact and **not regressed**. The drawer correctly covers the now-left hamburger (standard left-drawer pattern); raising the toggle above the drawer would obscure the drawer's profile icon, so tap-outside is the correct close path.
- Scoped to `max-width: 767px`, so the expanded desktop navbar is unchanged. 2 CSS source-pins.

Addresses the mobile hamburger-placement report.
