### PR TITLE
feat(shelf): add books to a shelf from the shelf page (searchable picker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+- You can now add books to a shelf right from the shelf page. A new **Add Books**
+  button opens a searchable picker — type to find books in your library, tick the
+  ones you want, and add them all at once. Books already on the shelf show as
+  "Already on this shelf" so you can't add duplicates, and it works on phone and
+  desktop. Especially handy for filling a brand-new empty shelf.
+
 ### Fixed
 - On phones, the menu (hamburger) button is now on the **left**, the same side
   the navigation drawer slides out from — so the button and the menu it opens

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -737,6 +737,58 @@ def add_selected_to_shelf():
         }), 200
 
 
+@shelf.route("/shelf/<int:shelf_id>/available_books", methods=["GET"])
+@user_login_required
+def shelf_available_books(shelf_id):
+    """JSON book picker for the shelf-page "Add books" modal.
+
+    Returns up to 30 library books matching ``query`` (or the most recent books
+    when the query is empty), each flagged with whether it is already on this
+    shelf so the picker can disable it. Reuses ``calibre_db.get_search_results``
+    so the same visibility filters (archived / hidden / language) that apply to
+    normal browsing apply here too; ``add_selected_to_shelf`` remains the single
+    (deduping, permission-checked) write path.
+    """
+    shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.id == shelf_id).first()
+    if shelf is None:
+        return jsonify({'status': 'error', 'message': 'Shelf not found'}), 404
+    if not check_shelf_edit_permissions(shelf):
+        return jsonify({'status': 'error',
+                        'message': 'You are not allowed to add books to this shelf'}), 403
+
+    query = (request.args.get('query') or '').strip()
+    limit = 30
+    in_shelf = {row.book_id for row in
+                ub.session.query(ub.BookShelf.book_id).filter(ub.BookShelf.shelf == shelf_id).all()}
+
+    if query:
+        # get_search_results returns author-ordered rows that wrap the book in a
+        # `.Books` attribute (the shape the list/search templates consume).
+        entries, __, ___ = calibre_db.get_search_results(query, config, 0, None, limit)
+    else:
+        # A plain Books query returns Books instances directly (no `.Books`).
+        entries = (calibre_db.session.query(db.Books)
+                   .filter(calibre_db.common_filters())
+                   .order_by(db.Books.timestamp.desc())
+                   .limit(limit).all())
+
+    # Normalise the two shapes: search rows expose the book at `.Books`; the plain
+    # query yields the book itself.
+    books = []
+    for entry in entries:
+        book = getattr(entry, 'Books', entry)
+        books.append({
+            'id': book.id,
+            'title': book.title,
+            'authors': ' & '.join(author.name for author in book.authors) if book.authors else '',
+            'cover': url_for('web.get_cover', book_id=book.id, resolution='sm'),
+            'in_shelf': book.id in in_shelf,
+        })
+
+    return jsonify({'status': 'ok', 'shelf_id': shelf_id,
+                    'shelf_name': shelf.name, 'books': books})
+
+
 # ---------------------------------------------------------------------------
 # Fork #237 (@new-usemame): drag-to-reorder regular shelves in the sidebar.
 #

--- a/cps/static/css/shelf_add_books.css
+++ b/cps/static/css/shelf_add_books.css
@@ -1,0 +1,134 @@
+/* "Add books" picker modal for the shelf page. Theme-independent (works in both
+   the default theme and caliBlur); the rows are a simple cover + title/author
+   list with a clear selected state. */
+
+.add-books-search-wrap {
+  position: relative;
+}
+.add-books-search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0.5;
+  pointer-events: none;
+}
+.add-books-search.form-control {
+  padding-left: 34px;
+}
+
+.add-books-results {
+  max-height: 50vh;
+  overflow-y: auto;
+  margin: 0 -4px;
+}
+
+.add-books-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  text-align: left;
+  padding: 8px 10px;
+  border: 0;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  color: inherit;
+}
+.add-books-row + .add-books-row {
+  margin-top: 2px;
+}
+.add-books-row:hover:not(:disabled),
+.add-books-row:focus-visible {
+  background: rgba(127, 127, 127, 0.12);
+  outline: none;
+}
+.add-books-row.is-selected {
+  background: rgba(74, 144, 226, 0.18);
+}
+
+.add-books-cover {
+  width: 38px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: 3px;
+  flex: 0 0 auto;
+  background: rgba(127, 127, 127, 0.15);
+}
+.add-books-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.add-books-title {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.add-books-author {
+  font-size: 0.85em;
+  opacity: 0.7;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.add-books-check {
+  flex: 0 0 auto;
+  width: 22px;
+  text-align: center;
+  opacity: 0.35;
+}
+.add-books-check:before {
+  content: "\002b"; /* plus */
+}
+.add-books-row.is-selected .add-books-check {
+  opacity: 1;
+  color: #4a90e2;
+}
+.add-books-row.is-selected .add-books-check:before,
+.add-books-row.is-in-shelf .add-books-check:before {
+  content: "\e013"; /* glyphicon-ok */
+}
+.add-books-row.is-in-shelf {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.add-books-empty {
+  text-align: center;
+  padding: 24px 0;
+}
+
+.add-books-footer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.add-books-count {
+  margin-right: auto;
+}
+
+/* Phones: full-screen sheet so the picker is comfortable to use one-handed. */
+@media (max-width: 767px) {
+  .add-books-modal .modal-dialog {
+    margin: 0;
+    width: 100%;
+    min-height: 100%;
+  }
+  .add-books-modal .modal-content {
+    min-height: 100vh;
+    border-radius: 0;
+    border: 0;
+  }
+  .add-books-results {
+    max-height: calc(100vh - 230px);
+  }
+  .add-books-cover {
+    width: 34px;
+    height: 50px;
+  }
+}

--- a/cps/static/css/shelf_add_books.css
+++ b/cps/static/css/shelf_add_books.css
@@ -111,6 +111,14 @@
 .add-books-count {
   margin-right: auto;
 }
+.add-books-error {
+  margin-right: auto;
+  font-size: 0.9em;
+}
+/* When an error is shown it takes the count's left slot. */
+.add-books-error:not([hidden]) + .add-books-count {
+  display: none;
+}
 
 /* Phones: full-screen sheet so the picker is comfortable to use one-handed. */
 @media (max-width: 767px) {

--- a/cps/static/js/shelf_add_books.js
+++ b/cps/static/js/shelf_add_books.js
@@ -1,0 +1,220 @@
+/* Calibre-Web-NextGen — "Add books" picker for the shelf page.
+ *
+ * Opens a modal from the shelf's "Add Books" button, live-searches the library
+ * via GET /shelf/<id>/available_books (books already on the shelf come back
+ * flagged and are shown disabled), lets the user multi-select, and POSTs the
+ * chosen ids to /shelf/add_selected_to_shelf — the one server-side write path,
+ * which validates + dedupes. i18n strings come from data-* on the modal so the
+ * script needs no build-time translation.
+ */
+(function () {
+  "use strict";
+
+  var btn = document.getElementById("add_books_to_shelf");
+  var modal = document.getElementById("addBooksModal");
+  if (!btn || !modal) {
+    return;
+  }
+
+  var searchInput = document.getElementById("addBooksSearch");
+  var resultsEl = document.getElementById("addBooksResults");
+  var emptyEl = document.getElementById("addBooksEmpty");
+  var countEl = document.getElementById("addBooksCount");
+  var submitBtn = document.getElementById("addBooksSubmit");
+  var shelfNameEl = document.getElementById("addBooksShelfName");
+
+  var shelfId = Number(btn.getAttribute("data-shelf-id"));
+  var availableUrl = btn.getAttribute("data-available-url");
+  var addUrl = btn.getAttribute("data-add-url");
+
+  var i18n = {
+    selected: modal.getAttribute("data-i18n-selected") || "{count} selected",
+    add: modal.getAttribute("data-i18n-add") || "Add",
+    addN: modal.getAttribute("data-i18n-add-n") || "Add {count}",
+    empty: modal.getAttribute("data-i18n-empty") || "No books found.",
+    added: modal.getAttribute("data-i18n-added") || "Already on this shelf"
+  };
+
+  var selected = new Set();
+  var debounceTimer = null;
+  var requestSeq = 0;
+
+  function fmt(template, count) {
+    return String(template).replace("{count}", count);
+  }
+
+  function csrfToken() {
+    var input = document.querySelector('input[name="csrf_token"]');
+    return input ? input.value : "";
+  }
+
+  function updateFooter() {
+    var n = selected.size;
+    countEl.textContent = fmt(i18n.selected, n);
+    submitBtn.disabled = n === 0;
+    submitBtn.textContent = n > 0 ? fmt(i18n.addN, n) : i18n.add;
+  }
+
+  function makeRow(book) {
+    var row = document.createElement("button");
+    row.type = "button";
+    row.className = "add-books-row" + (book.in_shelf ? " is-in-shelf" : "");
+    row.setAttribute("data-book-id", book.id);
+    row.setAttribute("role", "option");
+    if (book.in_shelf) {
+      row.disabled = true;
+      row.setAttribute("aria-disabled", "true");
+    }
+    if (selected.has(book.id)) {
+      row.classList.add("is-selected");
+    }
+    row.setAttribute("aria-selected", selected.has(book.id) ? "true" : "false");
+
+    var img = document.createElement("img");
+    img.className = "add-books-cover";
+    img.src = book.cover;
+    img.alt = "";
+    img.loading = "lazy";
+
+    var meta = document.createElement("span");
+    meta.className = "add-books-meta";
+    var title = document.createElement("span");
+    title.className = "add-books-title";
+    title.textContent = book.title;
+    var author = document.createElement("span");
+    author.className = "add-books-author";
+    author.textContent = book.in_shelf ? i18n.added : book.authors;
+    meta.appendChild(title);
+    meta.appendChild(author);
+
+    var check = document.createElement("span");
+    check.className = "add-books-check glyphicon";
+
+    row.appendChild(img);
+    row.appendChild(meta);
+    row.appendChild(check);
+
+    if (!book.in_shelf) {
+      row.addEventListener("click", function () {
+        toggle(book.id, row);
+      });
+    }
+    return row;
+  }
+
+  function toggle(bookId, row) {
+    if (selected.has(bookId)) {
+      selected.delete(bookId);
+      row.classList.remove("is-selected");
+      row.setAttribute("aria-selected", "false");
+    } else {
+      selected.add(bookId);
+      row.classList.add("is-selected");
+      row.setAttribute("aria-selected", "true");
+    }
+    updateFooter();
+  }
+
+  function render(books) {
+    resultsEl.innerHTML = "";
+    if (!books.length) {
+      emptyEl.hidden = false;
+      return;
+    }
+    emptyEl.hidden = true;
+    var frag = document.createDocumentFragment();
+    books.forEach(function (book) {
+      frag.appendChild(makeRow(book));
+    });
+    resultsEl.appendChild(frag);
+  }
+
+  function search(query) {
+    var seq = ++requestSeq;
+    resultsEl.setAttribute("aria-busy", "true");
+    fetch(availableUrl + "?query=" + encodeURIComponent(query), {
+      headers: { "Accept": "application/json" },
+      credentials: "same-origin"
+    })
+      .then(function (r) {
+        return r.ok ? r.json() : Promise.reject(r.status);
+      })
+      .then(function (data) {
+        if (seq !== requestSeq) {
+          return; // a newer search superseded this one
+        }
+        render((data && data.books) || []);
+      })
+      .catch(function () {
+        if (seq === requestSeq) {
+          render([]);
+        }
+      })
+      .then(function () {
+        resultsEl.removeAttribute("aria-busy");
+      });
+  }
+
+  function openModal() {
+    selected.clear();
+    updateFooter();
+    shelfNameEl.textContent = btn.getAttribute("data-shelf-name") || "";
+    searchInput.value = "";
+    resultsEl.innerHTML = "";
+    emptyEl.hidden = true;
+    search("");
+    if (window.jQuery && window.jQuery(modal).modal) {
+      window.jQuery(modal).modal("show");
+    } else {
+      modal.classList.add("in");
+      modal.style.display = "block";
+    }
+    setTimeout(function () {
+      searchInput.focus();
+    }, 250);
+  }
+
+  function closeModal() {
+    if (window.jQuery && window.jQuery(modal).modal) {
+      window.jQuery(modal).modal("hide");
+    } else {
+      modal.classList.remove("in");
+      modal.style.display = "none";
+    }
+  }
+
+  function submit() {
+    if (!selected.size) {
+      return;
+    }
+    submitBtn.disabled = true;
+    fetch(addUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-CSRFToken": csrfToken() },
+      credentials: "same-origin",
+      body: JSON.stringify({ shelf_id: shelfId, book_ids: Array.from(selected) })
+    })
+      .then(function (r) {
+        return r.json().then(function (d) {
+          return { status: r.status, data: d };
+        });
+      })
+      .then(function () {
+        closeModal();
+        window.location.reload();
+      })
+      .catch(function () {
+        submitBtn.disabled = false;
+      });
+  }
+
+  btn.addEventListener("click", openModal);
+  submitBtn.addEventListener("click", submit);
+  searchInput.addEventListener("input", function () {
+    clearTimeout(debounceTimer);
+    var q = searchInput.value.trim();
+    debounceTimer = setTimeout(function () {
+      search(q);
+    }, 250);
+  });
+})();

--- a/cps/static/js/shelf_add_books.js
+++ b/cps/static/js/shelf_add_books.js
@@ -22,6 +22,7 @@
   var countEl = document.getElementById("addBooksCount");
   var submitBtn = document.getElementById("addBooksSubmit");
   var shelfNameEl = document.getElementById("addBooksShelfName");
+  var errorEl = document.getElementById("addBooksError");
 
   var shelfId = Number(btn.getAttribute("data-shelf-id"));
   var availableUrl = btn.getAttribute("data-available-url");
@@ -32,7 +33,8 @@
     add: modal.getAttribute("data-i18n-add") || "Add",
     addN: modal.getAttribute("data-i18n-add-n") || "Add {count}",
     empty: modal.getAttribute("data-i18n-empty") || "No books found.",
-    added: modal.getAttribute("data-i18n-added") || "Already on this shelf"
+    added: modal.getAttribute("data-i18n-added") || "Already on this shelf",
+    error: modal.getAttribute("data-i18n-error") || "Could not add the books. Please try again."
   };
 
   var selected = new Set();
@@ -53,6 +55,14 @@
     countEl.textContent = fmt(i18n.selected, n);
     submitBtn.disabled = n === 0;
     submitBtn.textContent = n > 0 ? fmt(i18n.addN, n) : i18n.add;
+  }
+
+  function setError(message) {
+    if (!errorEl) {
+      return;
+    }
+    errorEl.textContent = message || "";
+    errorEl.hidden = !message;
   }
 
   function makeRow(book) {
@@ -157,6 +167,7 @@
 
   function openModal() {
     selected.clear();
+    setError("");
     updateFooter();
     shelfNameEl.textContent = btn.getAttribute("data-shelf-name") || "";
     searchInput.value = "";
@@ -188,6 +199,7 @@
       return;
     }
     submitBtn.disabled = true;
+    setError("");
     fetch(addUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json", "X-CSRFToken": csrfToken() },
@@ -195,16 +207,28 @@
       body: JSON.stringify({ shelf_id: shelfId, book_ids: Array.from(selected) })
     })
       .then(function (r) {
-        return r.json().then(function (d) {
-          return { status: r.status, data: d };
-        });
+        return r.json().then(
+          function (d) { return { status: r.status, data: d }; },
+          function () { return { status: r.status, data: {} }; }
+        );
       })
-      .then(function () {
-        closeModal();
-        window.location.reload();
+      .then(function (res) {
+        if (res.status >= 200 && res.status < 300) {
+          // 200 success or 207 partial — the added books appear on the reloaded
+          // shelf; any already-present ones were skipped server-side.
+          closeModal();
+          window.location.reload();
+        } else {
+          // 400 / 403 / 500 (e.g. a session that expired while the picker was
+          // open): keep the picker open and surface the failure instead of
+          // silently closing + reloading with nothing added.
+          setError((res.data && res.data.message) || i18n.error);
+          submitBtn.disabled = selected.size === 0;
+        }
       })
       .catch(function () {
-        submitBtn.disabled = false;
+        setError(i18n.error);
+        submitBtn.disabled = selected.size === 0;
       });
   }
 

--- a/cps/templates/shelf.html
+++ b/cps/templates/shelf.html
@@ -102,7 +102,8 @@
      data-i18n-add="{{ _('Add') }}"
      data-i18n-add-n="{{ _('Add %(count)s', count='{count}') }}"
      data-i18n-empty="{{ _('No books found.') }}"
-     data-i18n-added="{{ _('Already on this shelf') }}">
+     data-i18n-added="{{ _('Already on this shelf') }}"
+     data-i18n-error="{{ _('Could not add the books. Please try again.') }}">
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -119,6 +120,7 @@
         <p id="addBooksEmpty" class="text-muted add-books-empty" hidden>{{ _('No books found.') }}</p>
       </div>
       <div class="modal-footer add-books-footer">
+        <span id="addBooksError" class="add-books-error text-danger" role="alert" hidden></span>
         <span id="addBooksCount" class="add-books-count text-muted">{{ _('%(count)s selected', count=0) }}</span>
         <button type="button" class="btn btn-default" data-dismiss="modal">{{ _('Cancel') }}</button>
         <button type="button" class="btn btn-primary" id="addBooksSubmit" disabled>{{ _('Add') }}</button>

--- a/cps/templates/shelf.html
+++ b/cps/templates/shelf.html
@@ -14,6 +14,13 @@
         <div class="btn btn-danger" data-action="{{url_for('shelf.delete_shelf', shelf_id=shelf.id)}}" id="delete_shelf" data-value="{{ shelf.id }}">{{ _('Delete this Shelf') }}</div>
       <a id="edit_shelf" href="{{ url_for('shelf.edit_shelf', shelf_id=shelf.id) }}" class="btn btn-primary">{{ _('Edit Shelf Properties') }} </a>
       </form>
+      <button type="button" id="add_books_to_shelf" class="btn btn-primary"
+              data-shelf-id="{{ shelf.id }}"
+              data-shelf-name="{{ shelf.name }}"
+              data-available-url="{{ url_for('shelf.shelf_available_books', shelf_id=shelf.id) }}"
+              data-add-url="{{ url_for('shelf.add_selected_to_shelf') }}">
+        <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {{ _('Add Books') }}
+      </button>
       {% if entries.__len__() %}
       <a id="order_shelf" href="{{ url_for('shelf.order_shelf', shelf_id=shelf.id) }}" class="btn btn-primary">{{ _('Arrange books manually') }} </a>
       <button id="toggle_order_shelf" data-alt-text="{% if status == "on" %}{{_('Disable Change order')}}{% else %}{{_('Enable Change order')}}{% endif %}" data-view="shelf" class="btn btn-primary{% if status == 'on' %} dummy">{{ _('Enable Change order') }}{% else%}">{{ _('Disable Change order') }}{% endif %}</button>
@@ -89,4 +96,38 @@
 {% endblock %}
 {% block modal %}
 {{ delete_confirm_modal() }}
+<div class="modal fade add-books-modal" id="addBooksModal" tabindex="-1" role="dialog"
+     aria-labelledby="addBooksModalLabel"
+     data-i18n-selected="{{ _('%(count)s selected', count='{count}') }}"
+     data-i18n-add="{{ _('Add') }}"
+     data-i18n-add-n="{{ _('Add %(count)s', count='{count}') }}"
+     data-i18n-empty="{{ _('No books found.') }}"
+     data-i18n-added="{{ _('Already on this shelf') }}">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="addBooksModalLabel">{{ _('Add books to') }} <span id="addBooksShelfName"></span></h4>
+      </div>
+      <div class="modal-body">
+        <div class="form-group add-books-search-wrap">
+          <span class="glyphicon glyphicon-search add-books-search-icon" aria-hidden="true"></span>
+          <input type="text" class="form-control add-books-search" id="addBooksSearch"
+                 placeholder="{{ _('Search your library…') }}" autocomplete="off" aria-label="{{ _('Search your library') }}">
+        </div>
+        <div id="addBooksResults" class="add-books-results" role="listbox" aria-label="{{ _('Search results') }}"></div>
+        <p id="addBooksEmpty" class="text-muted add-books-empty" hidden>{{ _('No books found.') }}</p>
+      </div>
+      <div class="modal-footer add-books-footer">
+        <span id="addBooksCount" class="add-books-count text-muted">{{ _('%(count)s selected', count=0) }}</span>
+        <button type="button" class="btn btn-default" data-dismiss="modal">{{ _('Cancel') }}</button>
+        <button type="button" class="btn btn-primary" id="addBooksSubmit" disabled>{{ _('Add') }}</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block js %}
+<link href="{{ url_for('static', filename='css/shelf_add_books.css') }}" rel="stylesheet">
+<script src="{{ url_for('static', filename='js/shelf_add_books.js') }}"></script>
 {% endblock %}

--- a/tests/unit/test_shelf_add_books_picker.py
+++ b/tests/unit/test_shelf_add_books_picker.py
@@ -81,6 +81,15 @@ class TestPickerJsSafety:
         # JS reads the add URL from the button rather than hardcoding it
         assert "data-add-url" in PICKER_JS or "getAttribute(\"data-add-url\")" in PICKER_JS
 
+    def test_submit_checks_status_before_reload(self):
+        # submit() must not blindly close + reload on any JSON response — a 4xx/5xx
+        # (e.g. a session that expired while the picker was open) must surface an
+        # error instead of silently closing with nothing added (Greptile finding).
+        assert "res.status >= 200 && res.status < 300" in PICKER_JS, (
+            "submit() must gate close+reload on a 2xx status"
+        )
+        assert "setError(" in PICKER_JS, "submit() must surface failures to the user"
+
     def test_book_text_set_via_textcontent_not_innerhtml(self):
         # titles/authors come from the library — they must be assigned with
         # textContent, never interpolated into innerHTML (XSS).

--- a/tests/unit/test_shelf_add_books_picker.py
+++ b/tests/unit/test_shelf_add_books_picker.py
@@ -1,0 +1,93 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Shelf-page "Add books" picker — endpoint + wiring invariants.
+
+A shelf page now has an "Add Books" button that opens a modal book-picker. The
+picker reads ``GET /shelf/<id>/available_books`` (library search, each book
+flagged ``in_shelf``) and submits the chosen ids to the existing, deduping
+``/shelf/add_selected_to_shelf`` write path. The full open→search→select→add→
+dedup flow is verified live with Playwright (desktop + mobile); these pins guard
+the structural invariants so a refactor can't silently break them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHELF_PY = (REPO_ROOT / "cps" / "shelf.py").read_text()
+SHELF_HTML = (REPO_ROOT / "cps" / "templates" / "shelf.html").read_text()
+PICKER_JS = (REPO_ROOT / "cps" / "static" / "js" / "shelf_add_books.js").read_text()
+
+
+class TestAvailableBooksEndpoint:
+    def test_route_defined(self):
+        assert re.search(
+            r'@shelf\.route\(\s*["\']/shelf/<int:shelf_id>/available_books["\']',
+            SHELF_PY,
+        ), "the picker endpoint /shelf/<id>/available_books must exist"
+
+    def test_endpoint_checks_edit_permission(self):
+        # the function body must gate on check_shelf_edit_permissions and 403
+        m = re.search(r"def shelf_available_books\(shelf_id\):(.*?)\n@", SHELF_PY, re.S)
+        assert m, "shelf_available_books function not found"
+        body = m.group(1)
+        assert "check_shelf_edit_permissions" in body, "endpoint must check edit permission"
+        assert "403" in body, "endpoint must 403 when the user can't edit the shelf"
+        assert "404" in body, "endpoint must 404 on an unknown shelf"
+
+    def test_endpoint_normalises_search_and_plain_book_shapes(self):
+        # get_search_results returns rows wrapping the book in `.Books`; the plain
+        # recent query returns Books directly — the endpoint must handle both.
+        m = re.search(r"def shelf_available_books\(shelf_id\):(.*?)\n@", SHELF_PY, re.S)
+        body = m.group(1)
+        assert "getattr(entry, 'Books', entry)" in body, (
+            "must normalise the two book shapes (search rows expose .Books; the "
+            "plain query yields the book) — otherwise the search path 500s on book.id"
+        )
+        assert "in_shelf" in body, "each book must be flagged with in_shelf"
+
+
+class TestShelfPageWiring:
+    def test_add_books_button_present_and_edit_gated(self):
+        assert 'id="add_books_to_shelf"' in SHELF_HTML, "Add Books button must exist"
+        # the button must carry the endpoint + add URLs for the JS
+        assert "shelf.shelf_available_books" in SHELF_HTML
+        assert "shelf.add_selected_to_shelf" in SHELF_HTML
+        # it must sit before the `entries.__len__()` guard so empty shelves show it
+        btn_idx = SHELF_HTML.find('id="add_books_to_shelf"')
+        entries_guard_idx = SHELF_HTML.find("entries.__len__()")
+        assert btn_idx != -1 and entries_guard_idx != -1 and btn_idx < entries_guard_idx, (
+            "the Add Books button must render before the non-empty-entries guard so "
+            "it appears on empty shelves (the main use case)"
+        )
+
+    def test_modal_and_assets_included(self):
+        assert 'id="addBooksModal"' in SHELF_HTML, "picker modal must exist"
+        assert "js/shelf_add_books.js" in SHELF_HTML, "picker JS must be loaded"
+        assert "css/shelf_add_books.css" in SHELF_HTML, "picker CSS must be loaded"
+
+
+class TestPickerJsSafety:
+    def test_posts_to_dedup_write_path(self):
+        assert "add_selected_to_shelf" not in PICKER_JS or "data-add-url" in SHELF_HTML
+        # JS reads the add URL from the button rather than hardcoding it
+        assert "data-add-url" in PICKER_JS or "getAttribute(\"data-add-url\")" in PICKER_JS
+
+    def test_book_text_set_via_textcontent_not_innerhtml(self):
+        # titles/authors come from the library — they must be assigned with
+        # textContent, never interpolated into innerHTML (XSS).
+        assert ".textContent = book.title" in PICKER_JS
+        # the only innerHTML use is clearing the container
+        innerhtml_assigns = re.findall(r"\.innerHTML\s*=\s*([^;]+);", PICKER_JS)
+        for rhs in innerhtml_assigns:
+            assert rhs.strip() in ('""', "''"), (
+                f"innerHTML must only be used to clear (= \"\"), got: {rhs.strip()}"
+            )


### PR DESCRIPTION
## What

Adds an **Add Books** button + searchable picker to the shelf page, so you can fill a shelf without visiting each book individually. Especially useful for a brand-new empty shelf (which previously showed only Download/Delete/Edit).

![desktop picker](notes/add-books-modal-desktop.jpeg)

## Why

The only way to add a book to a shelf was from the book's own page ("Add to Shelf"). For a new/empty shelf that means hunting down each book one at a time — the operator hit exactly this on an empty "test" shelf.

## How (maximal reuse — minimal new surface)

- **Reuses** the existing, robust `POST /shelf/add_selected_to_shelf` as the single write path — it already validates, **dedupes** (skips books already on the shelf), and reports per-book results.
- **One new endpoint:** `GET /shelf/<id>/available_books?query=` — library search via `calibre_db.get_search_results` (so normal visibility filters apply), returns `{id, title, authors, cover, in_shelf}`; `check_shelf_edit_permissions` → 403, unknown shelf → 404.
  - **Root-caused bug fixed during the build:** `get_search_results` returns rows that wrap the book in `.Books` (the list/search shape), while the empty-query recent list returns `Books` directly — the missing normalisation 500'd on `book.id`. Fixed with `getattr(entry, 'Books', entry)`.
- **Frontend:** edit-gated button (rendered before the non-empty guard so empty shelves show it) + a Bootstrap/caliBlur modal + vanilla `shelf_add_books.js` (debounced search, multi-select, race-guarded requests, CSRF via the app's global fetch patch) + `shelf_add_books.css` (cover + title/author rows, selected state, **mobile full-height sheet**). i18n strings passed via `data-*`; book text set with `textContent` (no `innerHTML` injection).

## Verification (live, cwn-local, Playwright)

As the shelf owner, desktop (1280) + mobile (390):
- Open → 19 library books listed; search `orwell` / `crime` filters correctly.
- Select 2 → footer "2 selected" / "Add 2" → **Add** → persisted to `app.db` with correct order (`20, 17`).
- Re-open → both show **"Already on this shelf"**, disabled, can't re-add (dedup UX); the backend dedupe is the safety net.
- 403 for a non-owner (admin on a private shelf), 404 for a bad shelf, empty-query recent list — all confirmed.
- 7 source-pin tests guard the endpoint + wiring invariants.

No new dependencies.
