### PR TITLE
fix(shelf): externalise reorder cover CSS + self-contained sizing (#320 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ is for things you can see or feel when running the app.
   desktop. Especially handy for filling a brand-new empty shelf.
 
 ### Fixed
+- The shelf reorder screen's cover-size fix now reaches more setups: the covers
+  were still showing oversized for some users on v4.0.158 (e.g. behind certain
+  reverse proxies). The styling moved out of the page into a regular stylesheet
+  and now sizes covers on its own, so they stay at the normal thumbnail size
+  regardless of theme or proxy. (#320 follow-up, reported by @SpookyUSAF)
 - On phones, the menu (hamburger) button is now on the **left**, the same side
   the navigation drawer slides out from — so the button and the menu it opens
   line up. Tapping it opens the menu; tapping outside still closes it.

--- a/cps/static/css/shelf_reorder.css
+++ b/cps/static/css/shelf_reorder.css
@@ -1,0 +1,32 @@
+/* Shelf reorder grid ("Change order of Shelf") — drag/keyboard reorder
+   affordances + cover sizing. Externalised from an inline <style> so it is
+   CSP-robust and cacheable: an inline block can be stripped by a strict
+   reverse-proxy Content-Security-Policy, which would leave the cover sizing
+   below unapplied and covers oversized (fork #320, @SpookyUSAF on v4.0.158). */
+
+/* Reorder affordances: grab cursor, drop ghost, keyboard focus ring. */
+#reorder-grid .reorder-item { cursor: grab; user-select: none; -webkit-user-select: none; }
+#reorder-grid .reorder-item:active { cursor: grabbing; }
+#reorder-grid .reorder-item:focus { outline: 2px solid #45b29d; outline-offset: 2px; }
+#reorder-grid .reorder-ghost { opacity: 0.4; }
+#reorder-grid .reorder-chosen { transform: scale(1.03); }
+#reorder-status.reorder-error { color: #d9534f; cursor: pointer; font-weight: bold; }
+
+/* fork #320 follow-up (@droM4X + @SpookyUSAF): keep reorder covers at the normal
+   thumbnail size on EVERY theme and configuration. This page is fork-new and
+   deliberately avoids the .discover / isotope wrappers, so it must NOT rely on
+   either theme's cover sizing (the default theme's
+   `.container-fluid .book .cover { height: 225px }` box, or caliBlur's
+   `.cover img { width: 150px }`) — those don't always reach this grid. Size the
+   image itself, fully self-contained: fit it inside a 150x225 thumbnail box with
+   aspect ratio preserved, regardless of theme, cover orientation, or whether any
+   theme rule applies. The id scope beats the responsive max-width cascade. */
+#reorder-grid .reorder-item .cover img {
+  max-width: 150px !important;
+  max-height: 225px !important;
+  width: auto !important;
+  height: auto !important;
+}
+
+/* Clear separation between the cover grid and the Back button below it. */
+.reorder-back-row { margin-top: 1.5em; }

--- a/cps/templates/shelf_order.html
+++ b/cps/templates/shelf_order.html
@@ -61,27 +61,10 @@
       </div>
     </div>
   </div>
-  <style>
-    /* Reorder affordances: grab cursor, drop ghost, keyboard focus ring. */
-    #reorder-grid .reorder-item { cursor: grab; user-select: none; -webkit-user-select: none; }
-    #reorder-grid .reorder-item:active { cursor: grabbing; }
-    #reorder-grid .reorder-item:focus { outline: 2px solid #45b29d; outline-offset: 2px; }
-    #reorder-grid .reorder-ghost { opacity: 0.4; }
-    #reorder-grid .reorder-chosen { transform: scale(1.03); }
-    #reorder-status.reorder-error { color: #d9534f; cursor: pointer; font-weight: bold; }
-    /* fork #320 follow-up (@droM4X + @SpookyUSAF on v4.0.157): cap cover height
-       to the normal book-grid box (225px), independent of theme. Normal grids
-       constrain covers via `.container-fluid .book .cover { height: 225px }`
-       (default theme) or `.cover img { width: 150px }` (caliBlur); on this
-       fork-new page some configurations leave the default-theme box uncapped,
-       so covers render near-natural size ("large icon style ... not needed
-       here"). An id-scoped cap on the image itself is theme-independent, beats
-       the responsive max-width cascade, is a no-op where covers are already
-       correct, and doesn't distort caliBlur (already 225px tall). */
-    #reorder-grid .reorder-item .cover img { max-height: 225px !important; }
-    /* Clear separation between the cover grid and the Back button below it. */
-    .reorder-back-row { margin-top: 1.5em; }
-  </style>
+  {# Reorder grid styles live in an external stylesheet (not an inline <style>):
+     inline blocks can be stripped by a strict reverse-proxy CSP, which would
+     leave the cover sizing unapplied and covers oversized (fork #320). #}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/shelf_reorder.css') }}">
 {% endblock %}
 
 {% block js %}

--- a/tests/unit/test_320_shelf_reorder_grid.py
+++ b/tests/unit/test_320_shelf_reorder_grid.py
@@ -35,6 +35,7 @@ pytestmark = pytest.mark.unit
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SHELF_PY = (REPO_ROOT / "cps" / "shelf.py").read_text()
 ORDER_HTML = (REPO_ROOT / "cps" / "templates" / "shelf_order.html").read_text()
+REORDER_CSS = (REPO_ROOT / "cps" / "static" / "css" / "shelf_reorder.css").read_text()
 ORDER_JS = (REPO_ROOT / "cps" / "static" / "js" / "shelforder.js").read_text()
 
 
@@ -198,19 +199,34 @@ class TestDisplayFollowup320:
     grid size. Both fixes are theme-independent and live in the template's own
     scoped <style> + markup."""
 
-    def test_cover_height_capped_independent_of_theme(self):
+    def test_cover_sizing_externalised_and_self_contained(self):
+        # The reorder styles must be an EXTERNAL stylesheet, not an inline
+        # <style>: a strict reverse-proxy CSP can strip inline blocks, leaving
+        # the cover cap unapplied and covers oversized. @SpookyUSAF still saw
+        # oversized covers on v4.0.158 even though the inline rule was in the
+        # release — the inline block wasn't reaching their render.
+        assert "css/shelf_reorder.css" in ORDER_HTML, (
+            "shelf_order.html must link the external shelf_reorder.css"
+        )
+        _html_no_comments = re.sub(r"\{#.*?#\}", "", ORDER_HTML, flags=re.S)
+        assert "<style" not in _html_no_comments, (
+            "reorder styles must not live in an inline <style> (CSP-fragile, #320)"
+        )
+        # The cover sizing must be SELF-CONTAINED — fit inside a 150x225 box
+        # regardless of theme or cover orientation, not reliant on caliBlur's
+        # width:150 or the default theme's box (which don't always reach this
+        # fork-new grid that deliberately avoids .discover/isotope).
         m = re.search(
-            r"#reorder-grid\s+\.reorder-item\s+\.cover\s+img\s*\{"
-            r"[^}]*max-height:\s*225px[^}]*!important",
-            ORDER_HTML,
+            r"#reorder-grid\s+\.reorder-item\s+\.cover\s+img\s*\{([^}]*)\}",
+            REORDER_CSS,
         )
-        assert m, (
-            "shelf_order.html must cap reorder cover height to the normal "
-            "book-grid box (225px !important) with an id-scoped rule on the "
-            "image — the !important is deliberate: it caps covers even on the "
-            "reporters' instances where the global .cover box renders uncapped "
-            "(#320 follow-up, @droM4X)"
+        assert m, "shelf_reorder.css must size the reorder cover image"
+        rule = m.group(1)
+        assert "max-width: 150px" in rule and "!important" in rule, (
+            "cover must be width-capped to 150px (self-contained), so it stays a "
+            "thumbnail even where no theme width rule applies (#320, @SpookyUSAF)"
         )
+        assert "max-height: 225px" in rule, "cover must be height-capped to 225px"
 
     def test_back_button_has_gutter_and_spacing(self):
         # Back button must sit inside a grid column so it inherits the same
@@ -223,9 +239,9 @@ class TestDisplayFollowup320:
             "the Back button must be wrapped in a grid row/column so it aligns "
             "under the first cover on both themes (#320 follow-up, @droM4X)"
         )
-        assert re.search(r"\.reorder-back-row\s*\{[^}]*margin-top", ORDER_HTML), (
-            "the Back button row must carry top margin so it doesn't butt "
-            "against the cover grid above it"
+        assert re.search(r"\.reorder-back-row\s*\{[^}]*margin-top", REORDER_CSS), (
+            "the Back button row must carry top margin (in shelf_reorder.css) so "
+            "it doesn't butt against the cover grid above it"
         )
 
 


### PR DESCRIPTION
## Problem

@SpookyUSAF reported on #320 that reorder-screen covers are **still oversized on caliBlur after updating to v4.0.158**, even though the cover-cap fix (#385) shipped in that release. On a fresh v4.0.158 instance the covers render correctly (verified caliBlur desktop, 150×225), so the fix wasn't *reaching* their render.

## Root cause

The fix lived in an **inline `<style>` block** in `shelf_order.html`. A strict reverse-proxy Content-Security-Policy can strip inline style blocks before they reach the browser (the app's own CSP allows them via `style-src-elem 'unsafe-inline'`, but a fronting proxy can override that). With the inline block stripped, the cover cap never applied → covers fell back to near-natural size. The height-only cap was also implicitly leaning on the 2:3 cover aspect ratio + the theme's width rule.

## Fix (root-cause, theme/proxy-independent)

- **Externalise** all reorder-grid styles from the inline `<style>` into a real stylesheet, `cps/static/css/shelf_reorder.css` — CSP-robust and cacheable.
- Make cover sizing **self-contained**: fit the image inside a 150×225 box (`max-width` + `max-height` + `width/height: auto`), aspect-preserved — so it stays a thumbnail regardless of theme, cover orientation, or whether any theme width rule reaches this fork-new grid (it deliberately avoids `.discover`/isotope).

## Verification (live, cwn-local, caliBlur desktop)

- Inline `<style>` gone; external CSS linked + served (200); all 8 covers within 150×225 (computed `max-width:150px` / `max-height:225px`).
- Simulation confirmed the height cap alone already yields 150×225 for 2:3 covers, so the new `max-width` belt additionally covers non-portrait covers + the no-theme-rule case.
- #320 regression test updated (external + self-contained pins); 20 pass.

Follow-up to #385 / #320, reported by @SpookyUSAF. No new dependencies.
