### PR TITLE
fix(duplicates): don't close the shared DB session in auto_resolve_duplicates (D1, data-safety)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ is for things you can see or feel when running the app.
   desktop. Especially handy for filling a brand-new empty shelf.
 
 ### Fixed
+- Resolving duplicate books is more reliable: the resolver no longer closes a
+  shared database connection mid-operation, which could cause errors or a
+  half-finished cleanup when the library was being used at the same time.
 - The shelf reorder screen's cover-size fix now reaches more setups: the covers
   were still showing oversized for some users on v4.0.158 (e.g. behind certain
   reverse proxies). The styling moved out of the page into a regular stylesheet

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -1871,12 +1871,15 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
         return result
         
     finally:
-        # Always cleanup sessions
-        try:
-            if calibre_db.session is not None:
-                calibre_db.session.close()
-        except Exception:
-            pass
+        # Do NOT close calibre_db.session here (data-safety, D1). It is a shared
+        # module-level (scoped) session used by BOTH the HTTP worker and the
+        # TaskDuplicateScan thread. Closing it from this utility — which runs from
+        # request contexts (preview/execute-resolution) AND the background scan —
+        # detaches objects mid-operation for any concurrent context
+        # (DetachedInstanceError) and can abort a delete partway through a group.
+        # The session lifecycle is owned by the Flask request teardown and by
+        # TaskDuplicateScan.run()'s own finally — not by this function.
+        pass
 
 
 def merge_duplicate_group(book_to_keep, books_to_merge):

--- a/tests/unit/test_duplicate_resolution_safety.py
+++ b/tests/unit/test_duplicate_resolution_safety.py
@@ -1,0 +1,52 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Duplicate-resolution data-safety regression pins.
+
+The duplicate resolve/merge path is destructive (it deletes books). These pins
+guard the data-safety invariants found in the 2026-06 audit
+(notes/duplicate-detection-fix-plan.md). Behavioural reproduction of the live
+flows runs on cwn-local against the real same-title pairs; these source-pins
+lock the structural invariants so a refactor can't silently reintroduce a bug.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DUP_SRC = (REPO_ROOT / "cps" / "duplicates.py").read_text()
+
+
+def _func_src(name: str) -> str:
+    """Slice a top-level function's source out of duplicates.py by text."""
+    lines = DUP_SRC.splitlines()
+    start = next((i for i, l in enumerate(lines) if l.startswith(f"def {name}(")), None)
+    assert start is not None, f"def {name}( not found in duplicates.py"
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if re.match(r"^(def |class |@)", lines[j]):
+            end = j
+            break
+    return "\n".join(lines[start:end])
+
+
+class TestD1SharedSessionNotClosed:
+    def test_auto_resolve_does_not_close_shared_session(self):
+        # D1: auto_resolve_duplicates runs from request contexts (preview /
+        # execute-resolution) AND the background TaskDuplicateScan thread. It must
+        # NOT close the shared module-level calibre_db.session in a finally —
+        # doing so detaches objects mid-operation for any concurrent context
+        # (DetachedInstanceError) and can abort a delete partway through a group.
+        src = _func_src("auto_resolve_duplicates")
+        assert "calibre_db.session.close()" not in src, (
+            "auto_resolve_duplicates must not close the shared scoped "
+            "calibre_db.session — its lifecycle is owned by the Flask request "
+            "teardown and by TaskDuplicateScan.run() (D1 data-safety)"
+        )


### PR DESCRIPTION
First fix of the **duplicate-detection data-safety series** (full audit: a 6-facet investigation that found 11 critical/high data-safety bugs in the resolve/merge path — plan in `notes/duplicate-detection-fix-plan.md`).

## D1 — `auto_resolve_duplicates` closes the shared DB session mid-operation

**Severity:** critical · data-safety.

`auto_resolve_duplicates` had a `finally` block that called `calibre_db.session.close()`. That session is a **shared module-level (scoped) session** used by *both* the HTTP worker and the `TaskDuplicateScan` thread. The function runs from request contexts (`preview_resolution`, `execute_resolution`) **and** the background scan — so closing the shared session from here detaches objects mid-operation for any concurrent context (`DetachedInstanceError`) and can **abort a delete partway through a duplicate group**, leaving an inconsistent result.

**Fix (root cause):** removed the `close()`. Session lifecycle is owned by the Flask request teardown and by `TaskDuplicateScan.run()`'s own `finally` — a utility called from two contexts must not own the shared session's lifecycle.

## Verification
- `duplicates.py` compiles; 1 source pin (the resolver must not close the shared session) — RED on current `main`, GREEN here.
- Behavioural verification (concurrent resolution doesn't abort) rides the **D2** live cwn-local repro using the real "Crime and Punishment" pair.

No new dependencies. Small, isolated, unblocks safe concurrent testing of the rest of the series.
