### PR TITLE
fix(duplicates): incomplete-metadata books are not grouped as duplicates (D7, data-safety)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ is for things you can see or feel when running the app.
   desktop. Especially handy for filling a brand-new empty shelf.
 
 ### Fixed
+- Duplicate detection no longer treats books that are *missing* a title or
+  author as duplicates of each other. Two unrelated books that both happen to
+  have no title (or no author) used to collapse together as a "duplicate" — and
+  could then be offered up for deletion. They're now kept separate; only books
+  with real matching metadata are grouped.
 - Resolving duplicate books is more reliable: the resolver no longer closes a
   shared database connection mid-operation, which could cause errors or a
   half-finished cleanup when the library was being used at the same time.

--- a/cps/duplicate_index.py
+++ b/cps/duplicate_index.py
@@ -165,6 +165,19 @@ def _enabled_key_values(parts: BookKeyParts, settings):
 
 
 def build_duplicate_key(book, settings):
+    # D7 (data-safety): a book must have the REAL metadata for every enabled
+    # criterion to be a duplicate candidate. build_book_key_parts substitutes
+    # sentinels ("untitled" / "unknown") for missing fields, so two distinct
+    # books that both lack a title (or both lack an author) would otherwise
+    # collapse to the same key and auto-resolve could DELETE one. Give such
+    # incomplete-metadata books a per-book-unique key so they are "duplicates of
+    # only themselves" — never grouped, never auto-deleted. (Sentinels remain
+    # fine for display; they just must not be dedup keys.)
+    criteria = get_effective_duplicate_criteria(settings)
+    if criteria.get("title") and not getattr(book, "title", None):
+        return _hash_json([("incomplete-no-title", str(getattr(book, "id", id(book))))])
+    if criteria.get("author") and not _primary_author(book):
+        return _hash_json([("incomplete-no-author", str(getattr(book, "id", id(book))))])
     return _hash_json(_enabled_key_values(build_book_key_parts(book, settings), settings))
 
 

--- a/tests/unit/test_duplicate_resolution_safety.py
+++ b/tests/unit/test_duplicate_resolution_safety.py
@@ -22,6 +22,7 @@ pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DUP_SRC = (REPO_ROOT / "cps" / "duplicates.py").read_text()
+DUP_INDEX_SRC = (REPO_ROOT / "cps" / "duplicate_index.py").read_text()
 
 
 def _func_src(name: str) -> str:
@@ -49,4 +50,28 @@ class TestD1SharedSessionNotClosed:
             "auto_resolve_duplicates must not close the shared scoped "
             "calibre_db.session — its lifecycle is owned by the Flask request "
             "teardown and by TaskDuplicateScan.run() (D1 data-safety)"
+        )
+
+
+class TestD7IncompleteMetadataNotGrouped:
+    def test_build_duplicate_key_guards_missing_required_fields(self):
+        # D7: build_book_key_parts substitutes "untitled"/"unknown" sentinels for
+        # missing fields, so two distinct books that both lack a title (or author)
+        # would collapse to the same duplicate_key and auto-resolve could DELETE
+        # one. build_duplicate_key must give such incomplete-metadata books a
+        # per-book-unique key instead (keyed on book id), so they never group.
+        m = re.search(
+            r"def build_duplicate_key\(book, settings\):(.*?)\ndef ",
+            DUP_INDEX_SRC,
+            re.S,
+        )
+        assert m, "build_duplicate_key not found in duplicate_index.py"
+        body = m.group(1)
+        assert "incomplete-no-title" in body and "incomplete-no-author" in body, (
+            "build_duplicate_key must give a book missing a required enabled "
+            "criterion a unique key (D7) so metadata-less books aren't grouped + "
+            "auto-deleted"
+        )
+        assert "book" in body and "id" in body, (
+            "the incomplete-book key must incorporate the book id to be unique"
         )


### PR DESCRIPTION
Second fix of the duplicate-detection data-safety series (audit: `notes/duplicate-detection-fix-plan.md`).

## D7 — incomplete-metadata books grouped as duplicates → auto-deletable

**Severity:** high · data-safety · directly the "accidental duplications" concern.

`build_book_key_parts` (duplicate_index.py) substitutes sentinels (`"untitled"` / `"unknown"`) for a missing title or author. So in the **production index path**, two genuinely-distinct books that both lack a title (or both lack an author) collapse to the **same `duplicate_key`** → they're grouped as duplicates → `auto_resolve_duplicates` can **delete one of them**.

## Fix (root cause)

`build_duplicate_key` now checks: if a criterion is enabled (e.g. title) and the book is missing that real field, it returns a **per-book-unique key** (keyed on the book id) — the book becomes a "duplicate of only itself", never grouped, never auto-deleted. Sentinels stay fine for *display*; they just can't be *dedup keys*.

## Why it's safe to ship now

This fix is **purely preventive** — it only ever *removes* books from the delete population, never adds. Worst case if mis-scoped: a metadata-less book that should dedup doesn't (conservative). It cannot cause a deletion.

## Verification
- 1 source pin (RED on `main` → GREEN) — `build_duplicate_key` must guard missing required fields with a per-book key; `duplicate_index.py` compiles.
- Behavioural reproduction (two title-`None` books → different keys → not grouped) runs in CI (the module imports `calibre_db`/`db`, unavailable in the local sandbox).

No new dependencies.
