### PR TITLE
fix(duplicates): put the D7 guard on the actual write path + fix the author check

### DIFF
--- a/cps/duplicate_index.py
+++ b/cps/duplicate_index.py
@@ -164,7 +164,7 @@ def _enabled_key_values(parts: BookKeyParts, settings):
     return values
 
 
-def build_duplicate_key(book, settings):
+def build_duplicate_key(book, settings, parts=None):
     # D7 (data-safety): a book must have the REAL metadata for every enabled
     # criterion to be a duplicate candidate. build_book_key_parts substitutes
     # sentinels ("untitled" / "unknown") for missing fields, so two distinct
@@ -172,13 +172,22 @@ def build_duplicate_key(book, settings):
     # collapse to the same key and auto-resolve could DELETE one. Give such
     # incomplete-metadata books a per-book-unique key so they are "duplicates of
     # only themselves" — never grouped, never auto-deleted. (Sentinels remain
-    # fine for display; they just must not be dedup keys.)
+    # fine for display; they just must not be dedup keys.) This is the SINGLE
+    # key-computation entry point: the index writers (upsert_book_keys /
+    # rebuild_duplicate_index) call it, so the guard is on the actual write path.
     criteria = get_effective_duplicate_criteria(settings)
     if criteria.get("title") and not getattr(book, "title", None):
         return _hash_json([("incomplete-no-title", str(getattr(book, "id", id(book))))])
-    if criteria.get("author") and not _primary_author(book):
+    # _primary_author returns the literal "unknown" sentinel (never falsy) when
+    # the book has no authors or a nameless first author — detect THAT, not the
+    # truthiness of the return value.
+    if criteria.get("author") and (
+        not getattr(book, "authors", None) or _primary_author(book) == "unknown"
+    ):
         return _hash_json([("incomplete-no-author", str(getattr(book, "id", id(book))))])
-    return _hash_json(_enabled_key_values(build_book_key_parts(book, settings), settings))
+    if parts is None:
+        parts = build_book_key_parts(book, settings)
+    return _hash_json(_enabled_key_values(parts, settings))
 
 
 def _book_query(book_ids=None):
@@ -246,7 +255,7 @@ def upsert_book_keys(book_ids: Iterable[int], settings):
     updated = 0
     for book in books:
         parts = build_book_key_parts(book, settings)
-        duplicate_key = _hash_json(_enabled_key_values(parts, settings))
+        duplicate_key = build_duplicate_key(book, settings, parts)
         cwa_db.cur.execute(
             """
             INSERT INTO cwa_duplicate_book_keys (
@@ -301,7 +310,7 @@ def rebuild_duplicate_index(settings, progress_callback=None):
             if book is None:
                 continue
             parts = build_book_key_parts(book, settings)
-            duplicate_key = _hash_json(_enabled_key_values(parts, settings))
+            duplicate_key = build_duplicate_key(book, settings, parts)
             key_rows.append(
                 (book.id, *parts.as_db_tuple(), duplicate_key, fingerprint)
             )

--- a/tests/unit/test_duplicate_resolution_safety.py
+++ b/tests/unit/test_duplicate_resolution_safety.py
@@ -61,7 +61,7 @@ class TestD7IncompleteMetadataNotGrouped:
         # one. build_duplicate_key must give such incomplete-metadata books a
         # per-book-unique key instead (keyed on book id), so they never group.
         m = re.search(
-            r"def build_duplicate_key\(book, settings\):(.*?)\ndef ",
+            r"def build_duplicate_key\(book, settings(?:, parts=None)?\):(.*?)\ndef ",
             DUP_INDEX_SRC,
             re.S,
         )
@@ -75,3 +75,69 @@ class TestD7IncompleteMetadataNotGrouped:
         assert "book" in body and "id" in body, (
             "the incomplete-book key must incorporate the book id to be unique"
         )
+
+    def test_author_guard_detects_the_unknown_sentinel(self):
+        # The guard must not be `not _primary_author(book)`: _primary_author
+        # returns the literal "unknown" sentinel (never falsy), so that condition
+        # can never fire. Detect the empty-authors case or the sentinel directly.
+        m = re.search(
+            r"def build_duplicate_key\(book, settings(?:, parts=None)?\):(.*?)\ndef ",
+            DUP_INDEX_SRC,
+            re.S,
+        )
+        body = m.group(1)
+        assert "not _primary_author(book)" not in body, (
+            "author guard must not key off `not _primary_author(book)` — it "
+            "returns 'unknown' (truthy) and so never fires"
+        )
+        assert 'getattr(book, "authors"' in body or '== "unknown"' in body, (
+            "author guard must detect empty authors / the 'unknown' sentinel"
+        )
+
+    def test_index_writers_use_the_guarded_key_function(self):
+        # CRITICAL: the guard only matters if the index WRITERS use it. Both
+        # upsert_book_keys and rebuild_duplicate_index must compute duplicate_key
+        # via build_duplicate_key, not the raw _hash_json(_enabled_key_values(...)).
+        for writer in ("upsert_book_keys", "rebuild_duplicate_index"):
+            m = re.search(rf"def {writer}\([^)]*\):(.*?)\n(?:def |\Z)", DUP_INDEX_SRC, re.S)
+            assert m, f"{writer} not found"
+            wbody = m.group(1)
+            assert "build_duplicate_key(book, settings" in wbody, (
+                f"{writer} must compute duplicate_key via build_duplicate_key so "
+                f"the D7 incomplete-metadata guard is on the actual write path"
+            )
+            assert "duplicate_key = _hash_json(_enabled_key_values(parts" not in wbody, (
+                f"{writer} must not bypass build_duplicate_key with a raw key compute"
+            )
+
+
+class TestD7BehaviouralDistinctKeys:
+    """Behavioural proof (runs in CI; skipped locally where `cps` can't import).
+
+    Directly addresses the security-review request: two distinct books that both
+    lack a title (or both lack an author) must get DIFFERENT duplicate_keys so
+    they never group + get auto-deleted.
+    """
+
+    def test_incomplete_books_get_distinct_unique_keys(self):
+        di = pytest.importorskip("cps.duplicate_index")
+        from unittest import mock
+
+        class StubBook:
+            def __init__(self, id, title=None, authors=None):
+                self.id = id
+                self.title = title
+                self.authors = authors if authors is not None else []
+
+        crit = {
+            "title": True, "author": True, "language": False,
+            "series": False, "publisher": False, "format": False,
+        }
+        with mock.patch.object(di, "get_effective_duplicate_criteria", return_value=crit):
+            # two distinct title-less books -> distinct keys (not grouped)
+            assert di.build_duplicate_key(StubBook(1, title=None), settings=None) \
+                != di.build_duplicate_key(StubBook(2, title=None), settings=None)
+            # two distinct author-less books -> distinct keys (the guard that the
+            # broken version could never reach)
+            assert di.build_duplicate_key(StubBook(3, title="X", authors=[]), settings=None) \
+                != di.build_duplicate_key(StubBook(4, title="X", authors=[]), settings=None)


### PR DESCRIPTION
Forward-fix to #395 (D7). The **automated commit security review** correctly caught that D7 as merged was a **no-op** — addressing both findings here.

## What was wrong (both real)

1. **[CRITICAL] Guard not on the write path.** The D7 guard lived in `build_duplicate_key`, but the index *writers* — `upsert_book_keys` and `rebuild_duplicate_index` — computed `duplicate_key` directly via `_hash_json(_enabled_key_values(parts, settings))`, **bypassing the guard**. So the persisted index still collapsed metadata-less books together; D7 did nothing in production.
2. **[HIGH] Author guard could never fire.** It was `not _primary_author(book)`, but `_primary_author` returns the literal `"unknown"` sentinel (never falsy) — so the condition was always False.

## Fix

- Both writers now compute the key via `build_duplicate_key(book, settings, parts)` — it's the **single key-computation entry point**, so the guard is on the actual write path. (Takes the already-computed `parts` to avoid recomputing.)
- The author guard now detects the real condition: `not getattr(book, "authors", None) or _primary_author(book) == "unknown"`.

## Verification

- **Write-path pin:** both writers must use `build_duplicate_key` (not the raw compute) — RED on the merged code, GREEN here.
- **Author-sentinel pin:** the guard must not key off `not _primary_author(book)`.
- **Behavioural test (CI):** two title-less books → distinct keys; two author-less books → distinct keys (the path the broken guard could never reach). Skips locally where `cps` can't import; runs in CI.

Process note: I should have run `/security-review` before merging #395 — the automated commit review was the backstop that caught it. Lesson logged.
