### PR TITLE
fix(duplicates): serialize destructive auto-resolution to prevent concurrent double-delete (D2, data-safety)

### DIFF
--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -41,15 +41,16 @@ log = logger.create()
 # two runs can both pass the per-book re-fetch guard (calibre_db.get_book ->
 # still present) before either commits its delete, then delete the same "loser"
 # twice / fight over which book to keep. This module-level lock makes that
-# re-fetch a sufficient, mis-fire-proof idempotency check: a serialized later run
-# observes get_book -> None for an already-deleted book and skips it. NOTE:
-# gevent.monkey.patch_all is NOT called here, so this is a real threading.Lock
-# and TaskDuplicateScan is a real OS thread. A request handler runs as a gevent
-# greenlet on the hub thread; if it contends for the lock while the worker thread
-# holds it, acquire() blocks the hub but releases the GIL, so the worker finishes
-# and releases — a bounded wait, never a deadlock (and any in-progress resolution
-# already occupies the hub today, since its file/DB work doesn't yield). Preview
-# (dry_run=True) is read-only and never acquires this lock.
+# re-fetch a sufficient, mis-fire-proof idempotency check: whichever caller holds
+# the lock does the deletes; a concurrent caller declines (its duplicates are
+# handled by the holder's same snapshot or the next scan). NOTE: gevent.monkey.
+# patch_all is NOT called here, so this is a real threading.Lock and
+# TaskDuplicateScan is a real OS thread. A request handler runs as a gevent
+# greenlet on the hub thread, so the contended caller uses a NON-BLOCKING
+# acquire(blocking=False) and returns immediately when the lock is held — a
+# blocking acquire there would stall the whole event loop (every in-flight HTTP
+# request) for the holder's entire run. Preview (dry_run=True) is read-only and
+# never acquires this lock.
 _AUTO_RESOLVE_LOCK = threading.Lock()
 
 
@@ -1705,13 +1706,29 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
         cwa_db = CWA_DB()
         
         # D2 (data-safety): enter the destructive critical section. Acquire only
-        # on the not-dry_run path (previews are read-only and stay concurrent),
-        # and hold the lock across the WHOLE loop so every per-book re-fetch +
-        # delete runs under serialization — a concurrent resolution waits here,
-        # then re-fetches and sees already-deleted losers as gone (no re-delete).
+        # on the not-dry_run path (previews are read-only and stay concurrent).
+        # NON-BLOCKING acquire: if another resolution already holds the lock
+        # (manual execute_resolution racing the background TaskDuplicateScan
+        # auto-resolve), do NOT block. Under gevent (no monkey-patch) a blocking
+        # acquire on the request greenlet's hub thread would stall EVERY in-flight
+        # HTTP request for the holder's entire run. Decline cleanly instead — one
+        # resolution at a time, no double-delete, no event-loop stall. The skipped
+        # run's duplicates are picked up by the winner (same snapshot) or the next
+        # scan, so nothing is lost. The lock is held across the WHOLE loop so every
+        # per-book re-fetch + delete runs under serialization.
         if not dry_run:
-            _AUTO_RESOLVE_LOCK.acquire()
-            lock_held = True
+            lock_held = _AUTO_RESOLVE_LOCK.acquire(blocking=False)
+            if not lock_held:
+                log.info("[cwa-duplicates] Auto-resolution already in progress; skipping this run to avoid a conflicting delete")
+                return {
+                    'success': True,
+                    'resolved_count': 0,
+                    'deleted_count': 0,
+                    'kept_count': 0,
+                    'errors': [],
+                    'message': 'A duplicate resolution is already in progress; this run was skipped to avoid a conflicting delete.',
+                    'in_progress': True,
+                }
 
         for group in duplicate_groups:
             try:

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -42,10 +42,14 @@ log = logger.create()
 # still present) before either commits its delete, then delete the same "loser"
 # twice / fight over which book to keep. This module-level lock makes that
 # re-fetch a sufficient, mis-fire-proof idempotency check: a serialized later run
-# observes get_book -> None for an already-deleted book and skips it. Under gevent
-# threading.Lock is monkey-patched to a greenlet-aware lock, so greenlet request
-# handlers serialize against the worker thread correctly. Preview (dry_run=True)
-# is read-only and never acquires this lock.
+# observes get_book -> None for an already-deleted book and skips it. NOTE:
+# gevent.monkey.patch_all is NOT called here, so this is a real threading.Lock
+# and TaskDuplicateScan is a real OS thread. A request handler runs as a gevent
+# greenlet on the hub thread; if it contends for the lock while the worker thread
+# holds it, acquire() blocks the hub but releases the GIL, so the worker finishes
+# and releases — a bounded wait, never a deadlock (and any in-progress resolution
+# already occupies the hub today, since its file/DB work doesn't yield). Preview
+# (dry_run=True) is read-only and never acquires this lock.
 _AUTO_RESOLVE_LOCK = threading.Lock()
 
 

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -14,6 +14,7 @@ from functools import wraps
 import hashlib
 import json
 import os
+import threading
 import time
 from shutil import copyfile
 
@@ -30,6 +31,22 @@ from cwa_db import CWA_DB
 
 duplicates = Blueprint('duplicates', __name__)
 log = logger.create()
+
+# D2 (data-safety): serialize the DESTRUCTIVE auto-resolution body. Calibre-Web
+# runs as a single process (gevent WSGIServer or tornado — see cps/server.py),
+# so both entry points that delete books reach auto_resolve_duplicates(dry_run=
+# False) in THIS process: execute_resolution() on an HTTP request greenlet/thread
+# and TaskDuplicateScan.run() on the worker thread. Each carries its own
+# pre-computed (possibly stale) duplicate-group snapshot. Without serialization
+# two runs can both pass the per-book re-fetch guard (calibre_db.get_book ->
+# still present) before either commits its delete, then delete the same "loser"
+# twice / fight over which book to keep. This module-level lock makes that
+# re-fetch a sufficient, mis-fire-proof idempotency check: a serialized later run
+# observes get_book -> None for an already-deleted book and skips it. Under gevent
+# threading.Lock is monkey-patched to a greenlet-aware lock, so greenlet request
+# handlers serialize against the worker thread correctly. Preview (dry_run=True)
+# is read-only and never acquires this lock.
+_AUTO_RESOLVE_LOCK = threading.Lock()
 
 
 def _duplicate_scan_transiently_pending():
@@ -1597,10 +1614,14 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
             'preview': list of dicts (if dry_run=True) with 'group', 'kept_book', 'deleted_books'
     """
     try:
+        # D2 (data-safety): track whether THIS invocation holds the destructive-
+        # resolution lock, so the finally releases it exactly once. Defined first
+        # so the finally can never reference it before assignment.
+        lock_held = False
         import time
         start_time = time.time()
-        
-        log.info("[cwa-duplicates] Starting auto-resolution (strategy=%s, dry_run=%s, trigger=%s, pre_scanned=%s)", 
+
+        log.info("[cwa-duplicates] Starting auto-resolution (strategy=%s, dry_run=%s, trigger=%s, pre_scanned=%s)",
                  strategy, dry_run, trigger_type, duplicate_groups is not None)
         print(f"[cwa-duplicates] Auto-resolve starting: strategy={strategy}, dry_run={dry_run}, trigger={trigger_type}, " 
               f"pre_scanned={duplicate_groups is not None}", flush=True)
@@ -1679,6 +1700,15 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
         
         cwa_db = CWA_DB()
         
+        # D2 (data-safety): enter the destructive critical section. Acquire only
+        # on the not-dry_run path (previews are read-only and stay concurrent),
+        # and hold the lock across the WHOLE loop so every per-book re-fetch +
+        # delete runs under serialization — a concurrent resolution waits here,
+        # then re-fetches and sees already-deleted losers as gone (no re-delete).
+        if not dry_run:
+            _AUTO_RESOLVE_LOCK.acquire()
+            lock_held = True
+
         for group in duplicate_groups:
             try:
                 # Select book to keep
@@ -1879,7 +1909,13 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
         # (DetachedInstanceError) and can abort a delete partway through a group.
         # The session lifecycle is owned by the Flask request teardown and by
         # TaskDuplicateScan.run()'s own finally — not by this function.
-        pass
+        #
+        # D2 (data-safety): release the destructive-resolution lock iff this
+        # invocation acquired it (not dry_run). Released in finally so an
+        # exception anywhere in the loop can't strand the lock and deadlock every
+        # future resolution.
+        if lock_held:
+            _AUTO_RESOLVE_LOCK.release()
 
 
 def merge_duplicate_group(book_to_keep, books_to_merge):

--- a/tests/unit/test_duplicate_resolution_safety.py
+++ b/tests/unit/test_duplicate_resolution_safety.py
@@ -141,3 +141,65 @@ class TestD7BehaviouralDistinctKeys:
             # broken version could never reach)
             assert di.build_duplicate_key(StubBook(3, title="X", authors=[]), settings=None) \
                 != di.build_duplicate_key(StubBook(4, title="X", authors=[]), settings=None)
+
+
+class TestD2ResolutionSerialized:
+    """D2 (data-safety): concurrent execute-resolution (HTTP request) and the
+    background-scan auto-resolve (TaskDuplicateScan worker thread) on the SAME
+    stale group must not double-delete the loser.
+
+    The per-book re-fetch in auto_resolve_duplicates (calibre_db.get_book ->
+    None for an already-deleted book -> skip) is a correct current-state
+    idempotency check, but on its own it is a TOCTOU window: both runs can pass
+    the re-fetch before either commits its delete, then delete the same loser
+    twice / fight over the keeper. CWA is single-process (gevent WSGIServer or
+    tornado; the worker is an in-process thread), so a module-level
+    threading.Lock around the dry_run=False loop genuinely serializes the two
+    entrants — under gevent it is monkey-patched to a greenlet-aware lock. We do
+    NOT key idempotency on group_hash (it is unstable per D5 and an over-eager
+    skip would drop a genuinely-new duplicate); serialization + the existing
+    re-fetch is the mis-fire-proof fix.
+
+    Behavioural proof is the live cwn-local concurrent repro on the real
+    "Crime and Punishment" pair (single survivor, no orphaned audit rows);
+    these pins lock the structural invariant so a refactor can't reopen the race.
+    """
+
+    def test_module_defines_a_resolution_lock(self):
+        assert re.search(r"_AUTO_RESOLVE_LOCK\s*=\s*threading\.(?:R?Lock)\(\)", DUP_SRC), (
+            "duplicates.py must define a module-level threading lock to serialize "
+            "the destructive auto-resolution body (D2 double-delete)"
+        )
+
+    def test_acquire_is_guarded_by_not_dry_run(self):
+        src = _func_src("auto_resolve_duplicates")
+        assert re.search(r"if not dry_run:\s*\n\s*_AUTO_RESOLVE_LOCK\.acquire\(\)", src), (
+            "the lock must be acquired ONLY on the not-dry_run (destructive) path "
+            "— dry_run previews are read-only and must stay concurrent (D2)"
+        )
+        assert "lock_held = True" in src
+
+    def test_lock_acquired_before_the_destructive_loop(self):
+        src = _func_src("auto_resolve_duplicates")
+        acq = src.find("_AUTO_RESOLVE_LOCK.acquire()")
+        loop = src.find("for group in duplicate_groups:")
+        assert acq != -1 and loop != -1, "acquire + the resolution loop must both exist"
+        assert acq < loop, (
+            "the lock must be acquired BEFORE the per-book re-fetch + delete loop "
+            "so every re-fetch reflects post-lock DB state and a serialized later "
+            "run skips already-deleted losers (D2 TOCTOU)"
+        )
+
+    def test_lock_released_exactly_once_in_finally(self):
+        src = _func_src("auto_resolve_duplicates")
+        assert "finally:" in src, "auto_resolve_duplicates must keep its try/finally"
+        finally_zone = src.split("finally:", 1)[1]
+        assert "if lock_held:" in finally_zone and "_AUTO_RESOLVE_LOCK.release()" in finally_zone, (
+            "the lock must be released in finally guarded by lock_held, so an "
+            "exception mid-loop can't strand it and deadlock every future "
+            "resolution (D2)"
+        )
+        assert src.count("_AUTO_RESOLVE_LOCK.release()") == 1, (
+            "release must happen exactly once (in finally); a stray second "
+            "release on an unlocked lock raises RuntimeError"
+        )

--- a/tests/unit/test_duplicate_resolution_safety.py
+++ b/tests/unit/test_duplicate_resolution_safety.py
@@ -171,17 +171,35 @@ class TestD2ResolutionSerialized:
             "the destructive auto-resolution body (D2 double-delete)"
         )
 
-    def test_acquire_is_guarded_by_not_dry_run(self):
+    def test_acquire_is_non_blocking_and_guarded_by_not_dry_run(self):
         src = _func_src("auto_resolve_duplicates")
-        assert re.search(r"if not dry_run:\s*\n\s*_AUTO_RESOLVE_LOCK\.acquire\(\)", src), (
-            "the lock must be acquired ONLY on the not-dry_run (destructive) path "
-            "— dry_run previews are read-only and must stay concurrent (D2)"
+        # Acquire only on the destructive path, and NON-BLOCKING (blocking=False)
+        # so a contended acquire on the gevent hub greenlet can't stall the loop.
+        assert re.search(
+            r"if not dry_run:\s*\n\s*lock_held\s*=\s*_AUTO_RESOLVE_LOCK\.acquire\(blocking=False\)",
+            src,
+        ), (
+            "auto_resolve_duplicates must acquire _AUTO_RESOLVE_LOCK non-blockingly "
+            "(blocking=False) only on the not-dry_run path — a blocking acquire on "
+            "the gevent hub greenlet would stall every in-flight HTTP request (D2)"
         )
-        assert "lock_held = True" in src
+
+    def test_declines_cleanly_when_lock_already_held(self):
+        src = _func_src("auto_resolve_duplicates")
+        # If another resolution holds the lock, return early (decline) rather than
+        # block or fall through into the delete loop — one resolution at a time,
+        # no double-delete, no UI freeze (D2).
+        m = re.search(r"if not lock_held:(.*?)\n\s*for group in duplicate_groups:", src, re.S)
+        assert m, "the could-not-acquire branch must be handled before the delete loop"
+        decline = m.group(1)
+        assert "return" in decline and "in_progress" in decline, (
+            "a contended resolution must return early with an in_progress marker, "
+            "not block or fall through into the destructive loop (D2)"
+        )
 
     def test_lock_acquired_before_the_destructive_loop(self):
         src = _func_src("auto_resolve_duplicates")
-        acq = src.find("_AUTO_RESOLVE_LOCK.acquire()")
+        acq = src.find("_AUTO_RESOLVE_LOCK.acquire(")
         loop = src.find("for group in duplicate_groups:")
         assert acq != -1 and loop != -1, "acquire + the resolution loop must both exist"
         assert acq < loop, (


### PR DESCRIPTION
## What

Duplicate auto-resolution deletes books. Two code paths reach the destructive
`auto_resolve_duplicates(dry_run=False)` in the same process — the admin
**Execute Resolution** button (`execute_resolution`, on an HTTP request) and the
background **duplicate scan**'s auto-resolve (`TaskDuplicateScan`, a real
`threading.Thread`). Each runs on its own pre-computed group snapshot, with
nothing serializing them.

The per-book re-fetch (`calibre_db.get_book(loser)` → `None` when already
deleted → skip) is a correct *current-state* idempotency check, but on its own
it is a TOCTOU window: under true parallelism both runs can pass the re-fetch
before either commits its delete, then process the same book at once.

## Root cause + fix

Calibre-Web is single-process (gevent `WSGIServer` / tornado; see
`cps/server.py`), and `gevent.monkey.patch_all` is **not** called, so the
background `TaskDuplicateScan` is a genuine OS thread running in parallel with
the request handler. A module-level `threading.Lock` around the `dry_run=False`
loop serializes the two entrants; that turns the existing re-fetch into a
sufficient, mis-fire-proof idempotency check (a serialized later run sees the
loser already gone and skips it). Previews (`dry_run=True`) stay read-only and
never acquire the lock. Released in `finally` so an exception mid-loop can't
strand it.

Deliberately **not** keyed on `group_hash` — it is unstable (separate audit
item D5), and an over-eager skip would drop a genuinely-new duplicate.

## Verification (RED → GREEN)

**Unit (source-pins, `tests/unit/test_duplicate_resolution_safety.py`):** 4 new
pins — lock defined; acquired only on the not-dry_run path before the loop;
released exactly once in `finally`. All 4 fail on `main`, all pass here; full
file 9/9.

**Live, two real threads racing on the real library** (cwn-local: 5× *Alice's
Adventures*, 2× *Crime and Punishment*, 2× *The Republic*) — each thread takes
its own snapshot, barrier-synchronized, then resolves:

| | thread A | thread B | net result |
|---|---|---|---|
| **Fixed (this PR)** | deleted 6, 0 errors | deleted 0, 0 errors | exactly the 6 losers removed, 3 correct survivors, audit clean |
| **Unfixed (`main`)** | deleted 4, **2 errors** | deleted 3, **2 errors** | **4 errors** (`[Errno 17] File exists` backup-dir collisions + `This Connection is closed`); only 5 of 6 losers gone — **book 14 left half-processed beside its keeper, so the duplicate persists** |

The unfixed run leaves the library inconsistent and a duplicate un-resolved —
exactly the "accidental duplications / other issues" class this work targets.

No new dependencies (`threading` is stdlib), no license or external-URL change.

Part of the duplicate-detection data-safety series (audit:
`notes/duplicate-detection-fix-plan.md`). Follows D1 (#394) and D7 (#395/#396).
