### PR TITLE
fix(duplicates): resolve DB-first, delete files last — prevent phantom books (D3/D11, data-safety)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ is for things you can see or feel when running the app.
   desktop. Especially handy for filling a brand-new empty shelf.
 
 ### Fixed
+- Resolving duplicate books no longer risks leaving a book in a broken,
+  half-deleted state if something fails partway through. Previously the files
+  were removed before the library database was updated, so an error in between
+  could leave a "ghost" book that still showed in your library but wouldn't open.
+  The database is now updated first and the files removed last, so a failure
+  leaves the book fully intact and the duplicate is simply re-resolved next time.
 - Resolving duplicate books is now safe even if a duplicate scan happens to run
   at the same moment. Before, the two could collide — deleting the same book
   twice, leaving a duplicate only half-removed, or throwing a brief error that

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -54,6 +54,21 @@ log = logger.create()
 _AUTO_RESOLVE_LOCK = threading.Lock()
 
 
+class _DeletedBookFileRef:
+    """Plain-value stand-in for a just-deleted Book, used by the files-last
+    cleanup in auto_resolve_duplicates so it never reads an expired/detached ORM
+    instance (D3, Greptile #399). delete_whole_book runs intermediate commits
+    (custom-column deletes) and a bulk Books.delete() that expire + detach the
+    real `book`; helper.delete_book(book_format="") only needs .id and .path
+    (both delete_book_file and the Google-Drive whole-book branch), so we capture
+    those as plain values before the DB delete and hand the cleanup this object."""
+    __slots__ = ("id", "path")
+
+    def __init__(self, book_id, path):
+        self.id = book_id
+        self.path = path
+
+
 def _duplicate_scan_transiently_pending():
     try:
         from cps.duplicate_index import ingest_batch_follow_up_pending
@@ -1806,7 +1821,12 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
                 # Backup and delete each duplicate
                 for book in books_to_delete:
                     try:
-                        print(f"[cwa-duplicates-auto] Starting deletion of book {book.id}...", flush=True)
+                        # Capture identity as plain values up front so the per-book except and the
+                        # post-DB-delete bookkeeping never read the ORM `book` (delete_whole_book +
+                        # its commit expire/detach it — Greptile #399).
+                        deleted_book_id = book.id
+                        deleted_book_title = book.title
+                        print(f"[cwa-duplicates-auto] Starting deletion of book {deleted_book_id}...", flush=True)
                         
                         # Backup book files
                         book_path = os.path.join(config.config_calibre_dir, book.path)
@@ -1823,33 +1843,27 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
                         # 404s when opened, unrecoverable without the backup. DB-first means a DB
                         # failure here leaves the book fully intact (files + rows): the per-book except
                         # below records an error and the duplicate stays resolvable on the next run.
-                        deleted_book_id = book.id
-                        deleted_book_title = book.title
-                        # Force-load the attributes the file deletion reads AFTER the DB delete:
-                        # delete_book_file needs book.path; delete_book_gdrive walks book.data. Once
-                        # delete_whole_book's bulk Books.delete() + the commit run, `book` becomes a
-                        # detached instance and a lazy load would raise — so populate them while live.
-                        _ = book.path
-                        _ = list(book.data)
+                        # Capture the relative path as a plain value: the files-last cleanup must NOT
+                        # read the ORM `book` after the DB delete. delete_whole_book runs intermediate
+                        # commits for custom-column deletes (editbooks.py 1367/1374/1380) and ends with
+                        # a bulk Books.delete(), all of which expire + detach `book` — so reading it in
+                        # helper.delete_book would raise DetachedInstanceError on any library that uses
+                        # custom columns (Greptile #399). A whole-book cleanup reads only .id and .path.
+                        deleted_book_path = book.path
 
                         print(f"[cwa-duplicates-auto] Cleaning up database for book {deleted_book_id}...", flush=True)
                         from cps.editbooks import delete_whole_book
                         delete_whole_book(deleted_book_id, book)  # book live here — reads its relationships
-
-                        # The bulk Books.delete() inside delete_whole_book detaches `book` via
-                        # synchronize_session; guard the expunge in case it is already detached, so the
-                        # commit's expire_on_commit can't strand the attributes loaded above.
-                        try:
-                            calibre_db.session.expunge(book)
-                        except Exception:
-                            pass
                         calibre_db.session.commit()
 
                         # Files-last: a failure here is recoverable (the row is already gone; the
-                        # backup + the orphaned files can be reclaimed), so log it — do NOT raise.
+                        # backup + the orphaned files can be reclaimed), so log it — do NOT raise. The
+                        # cleanup gets a plain stand-in, never the now-detached ORM object.
                         print(f"[cwa-duplicates-auto] Deleting book {deleted_book_id} files from disk...", flush=True)
                         from cps import helper
-                        delete_result, delete_error = helper.delete_book(book, config.get_book_path(), book_format="")
+                        delete_result, delete_error = helper.delete_book(
+                            _DeletedBookFileRef(deleted_book_id, deleted_book_path),
+                            config.get_book_path(), book_format="")
                         if not delete_result:
                             log.warning("[cwa-duplicates] Book %s removed from the database but file "
                                         "cleanup failed: %s (files remain on disk; backup under %s)",
@@ -1858,36 +1872,36 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
                         deleted_ids.append(deleted_book_id)
                         log.info("[cwa-duplicates] Deleted duplicate book %s: %s", deleted_book_id, deleted_book_title)
                         
-                        print(f"[cwa-duplicates-auto] Cancelling tasks for book {book.id}...", flush=True)
+                        print(f"[cwa-duplicates-auto] Cancelling tasks for book {deleted_book_id}...", flush=True)
                         # Cancel any pending tasks for this book
                         try:
                             from cps.services.worker import WorkerThread
                             worker = WorkerThread.get_instance()
                             if worker:
-                                cancelled_count = worker.cancel_tasks_for_book(book.id)
+                                cancelled_count = worker.cancel_tasks_for_book(deleted_book_id)
                                 if cancelled_count > 0:
-                                    log.info("[cwa-duplicates] Cancelled %d pending task(s) for deleted book %s", 
-                                            cancelled_count, book.id)
-                                    print(f"[cwa-duplicates-auto] Cancelled {cancelled_count} pending task(s) for book {book.id}", 
+                                    log.info("[cwa-duplicates] Cancelled %d pending task(s) for deleted book %s",
+                                            cancelled_count, deleted_book_id)
+                                    print(f"[cwa-duplicates-auto] Cancelled {cancelled_count} pending task(s) for book {deleted_book_id}",
                                           flush=True)
                         except Exception as cancel_ex:
-                            log.warning("[cwa-duplicates] Failed to cancel tasks for book %s: %s", book.id, cancel_ex)
-                        
-                        print(f"[cwa-duplicates-auto] Cancelling scheduled jobs for book {book.id}...", flush=True)
+                            log.warning("[cwa-duplicates] Failed to cancel tasks for book %s: %s", deleted_book_id, cancel_ex)
+
+                        print(f"[cwa-duplicates-auto] Cancelling scheduled jobs for book {deleted_book_id}...", flush=True)
                         # Cancel any scheduled jobs (auto-send, etc.) for this book
                         try:
-                            cancelled_scheduled = cwa_db.scheduled_cancel_for_book(book.id)
+                            cancelled_scheduled = cwa_db.scheduled_cancel_for_book(deleted_book_id)
                             if cancelled_scheduled > 0:
-                                log.info("[cwa-duplicates] Cancelled %d scheduled job(s) for deleted book %s", 
-                                        cancelled_scheduled, book.id)
+                                log.info("[cwa-duplicates] Cancelled %d scheduled job(s) for deleted book %s",
+                                        cancelled_scheduled, deleted_book_id)
                         except Exception as schedule_ex:
-                            log.warning("[cwa-duplicates] Failed to cancel scheduled jobs for book %s: %s", book.id, schedule_ex)
-                        
-                        print(f"[cwa-duplicates-auto] Book {book.id} deletion complete", flush=True)
-                        
+                            log.warning("[cwa-duplicates] Failed to cancel scheduled jobs for book %s: %s", deleted_book_id, schedule_ex)
+
+                        print(f"[cwa-duplicates-auto] Book {deleted_book_id} deletion complete", flush=True)
+
                     except Exception as e:
-                        log.error("[cwa-duplicates] Error deleting book %s: %s", book.id, e)
-                        result['errors'].append(f"Failed to delete book {book.id}: {str(e)}")
+                        log.error("[cwa-duplicates] Error deleting book %s: %s", deleted_book_id, e)
+                        result['errors'].append(f"Failed to delete book {deleted_book_id}: {str(e)}")
                 
                 if deleted_ids:
                     try:

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -1816,22 +1816,47 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
                             shutil.copytree(book_path, backup_path)
                             log.info("[cwa-duplicates] Backed up book %s to %s", book.id, backup_path)
                         
-                        print(f"[cwa-duplicates-auto] Deleting book {book.id} from library...", flush=True)
-                        # Delete from Calibre library (bypass user permission check for automatic resolution)
+                        # D3/D11 (data-safety): commit the DB deletes FIRST, remove files LAST.
+                        # The old order deleted files (helper.delete_book) BEFORE the DB commit, so a
+                        # failure in delete_whole_book / the metadata.db commit left the files gone but
+                        # the Books row surviving — a phantom book that still shows in the library and
+                        # 404s when opened, unrecoverable without the backup. DB-first means a DB
+                        # failure here leaves the book fully intact (files + rows): the per-book except
+                        # below records an error and the duplicate stays resolvable on the next run.
+                        deleted_book_id = book.id
+                        deleted_book_title = book.title
+                        # Force-load the attributes the file deletion reads AFTER the DB delete:
+                        # delete_book_file needs book.path; delete_book_gdrive walks book.data. Once
+                        # delete_whole_book's bulk Books.delete() + the commit run, `book` becomes a
+                        # detached instance and a lazy load would raise — so populate them while live.
+                        _ = book.path
+                        _ = list(book.data)
+
+                        print(f"[cwa-duplicates-auto] Cleaning up database for book {deleted_book_id}...", flush=True)
+                        from cps.editbooks import delete_whole_book
+                        delete_whole_book(deleted_book_id, book)  # book live here — reads its relationships
+
+                        # The bulk Books.delete() inside delete_whole_book detaches `book` via
+                        # synchronize_session; guard the expunge in case it is already detached, so the
+                        # commit's expire_on_commit can't strand the attributes loaded above.
+                        try:
+                            calibre_db.session.expunge(book)
+                        except Exception:
+                            pass
+                        calibre_db.session.commit()
+
+                        # Files-last: a failure here is recoverable (the row is already gone; the
+                        # backup + the orphaned files can be reclaimed), so log it — do NOT raise.
+                        print(f"[cwa-duplicates-auto] Deleting book {deleted_book_id} files from disk...", flush=True)
                         from cps import helper
                         delete_result, delete_error = helper.delete_book(book, config.get_book_path(), book_format="")
-                        
                         if not delete_result:
-                            raise Exception(f"Delete failed: {delete_error}")
-                        
-                        print(f"[cwa-duplicates-auto] Cleaning up database for book {book.id}...", flush=True)
-                        # Clean up database references
-                        from cps.editbooks import delete_whole_book
-                        delete_whole_book(book.id, book)
-                        
-                        calibre_db.session.commit()
-                        deleted_ids.append(book.id)
-                        log.info("[cwa-duplicates] Deleted duplicate book %s: %s", book.id, book.title)
+                            log.warning("[cwa-duplicates] Book %s removed from the database but file "
+                                        "cleanup failed: %s (files remain on disk; backup under %s)",
+                                        deleted_book_id, delete_error, backup_dir)
+
+                        deleted_ids.append(deleted_book_id)
+                        log.info("[cwa-duplicates] Deleted duplicate book %s: %s", deleted_book_id, deleted_book_title)
                         
                         print(f"[cwa-duplicates-auto] Cancelling tasks for book {book.id}...", flush=True)
                         # Cancel any pending tasks for this book

--- a/tests/unit/test_duplicate_resolution_safety.py
+++ b/tests/unit/test_duplicate_resolution_safety.py
@@ -221,3 +221,51 @@ class TestD2ResolutionSerialized:
             "release must happen exactly once (in finally); a stray second "
             "release on an unlocked lock raises RuntimeError"
         )
+
+
+class TestD3FilesDeletedAfterDbCommit:
+    """D3/D11 (data-safety): the resolution loop must commit the DB deletes
+    (delete_whole_book + calibre_db.session.commit) BEFORE removing files
+    (helper.delete_book). The old order deleted files first, so a DB-commit
+    failure left a phantom book — the Books row survives but its files are gone,
+    so it shows in the library and 404s on open, unrecoverable without the
+    backup. The behavioural proof is the live cwn-local repro (clean run: no
+    DetachedInstanceError from the post-commit file delete, files+rows gone;
+    injected commit failure: book fully intact). These pins lock the ordering.
+    """
+
+    def _body(self):
+        return _func_src("auto_resolve_duplicates")
+
+    def test_db_commit_precedes_file_delete(self):
+        src = self._body()
+        commit = src.find("calibre_db.session.commit()")
+        file_del = src.find("helper.delete_book(book, config.get_book_path()")
+        assert commit != -1 and file_del != -1, "commit + file-delete must both exist in the loop"
+        assert commit < file_del, (
+            "delete_whole_book + calibre_db.session.commit() must run BEFORE "
+            "helper.delete_book, so a DB failure can't leave a phantom book whose "
+            "files are already gone (D3/D11)"
+        )
+
+    def test_file_attrs_forceloaded_and_object_detached_before_commit(self):
+        src = self._body()
+        assert "_ = book.path" in src and "list(book.data)" in src, (
+            "book.path (delete_book_file) and book.data (delete_book_gdrive) must be "
+            "force-loaded before the DB delete detaches/expires `book` (D3)"
+        )
+        assert "expunge(book)" in src, (
+            "`book` must be detached (guarded expunge) before the commit so "
+            "expire_on_commit can't strand the loaded attributes (D3)"
+        )
+
+    def test_file_cleanup_failure_is_logged_not_raised(self):
+        src = self._body()
+        assert 'raise Exception(f"Delete failed' not in src, (
+            "a post-DB-commit file cleanup failure must be logged, not raised — "
+            "raising would falsely report the already-completed DB delete as failed "
+            "and skip the audit bookkeeping (D3)"
+        )
+        assert "removed from the database but file" in src, (
+            "the files-last path must log a warning on a file-cleanup failure"
+        )

--- a/tests/unit/test_duplicate_resolution_safety.py
+++ b/tests/unit/test_duplicate_resolution_safety.py
@@ -240,7 +240,7 @@ class TestD3FilesDeletedAfterDbCommit:
     def test_db_commit_precedes_file_delete(self):
         src = self._body()
         commit = src.find("calibre_db.session.commit()")
-        file_del = src.find("helper.delete_book(book, config.get_book_path()")
+        file_del = src.find("helper.delete_book(")
         assert commit != -1 and file_del != -1, "commit + file-delete must both exist in the loop"
         assert commit < file_del, (
             "delete_whole_book + calibre_db.session.commit() must run BEFORE "
@@ -248,15 +248,30 @@ class TestD3FilesDeletedAfterDbCommit:
             "files are already gone (D3/D11)"
         )
 
-    def test_file_attrs_forceloaded_and_object_detached_before_commit(self):
+    def test_file_cleanup_uses_plain_standin_not_orm_object(self):
         src = self._body()
-        assert "_ = book.path" in src and "list(book.data)" in src, (
-            "book.path (delete_book_file) and book.data (delete_book_gdrive) must be "
-            "force-loaded before the DB delete detaches/expires `book` (D3)"
+        # delete_whole_book runs intermediate commits (custom-column deletes) +
+        # a bulk Books.delete() that expire/detach `book`; passing it to the
+        # files-last cleanup raises DetachedInstanceError on custom-column
+        # libraries (Greptile #399). Hand the cleanup a plain stand-in instead.
+        assert "helper.delete_book(book," not in src, (
+            "files-last cleanup must NOT pass the ORM `book` — it is detached/"
+            "expired after delete_whole_book on custom-column libraries (D3)"
         )
-        assert "expunge(book)" in src, (
-            "`book` must be detached (guarded expunge) before the commit so "
-            "expire_on_commit can't strand the loaded attributes (D3)"
+        assert "_DeletedBookFileRef(deleted_book_id, deleted_book_path)" in src, (
+            "the cleanup must receive a plain-value stand-in (id + path)"
+        )
+        assert "deleted_book_path = book.path" in src, (
+            "book.path must be captured as a plain value before the DB delete"
+        )
+
+    def test_no_orm_book_access_after_the_db_delete(self):
+        src = self._body()
+        after = src.split("delete_whole_book(deleted_book_id, book)", 1)[1]
+        assert "book.id" not in after, (
+            "no `book.id` (ORM access on the now-detached/expired object) is "
+            "allowed after delete_whole_book — use the captured deleted_book_id "
+            "(D3, Greptile #399)"
         )
 
     def test_file_cleanup_failure_is_logged_not_raised(self):


### PR DESCRIPTION
## What

Resolving duplicate books deletes the losers. The per-book delete in
`auto_resolve_duplicates` removed **files** (`helper.delete_book`) BEFORE
committing the **DB** deletes (`delete_whole_book` + `calibre_db.session.commit`).
A failure in the DB phase then left the files gone but the `Books` row surviving
— a **phantom book**: still listed in the library / shelves / search, 404s on
open, unrecoverable without the backup.

## Fix — DB-commit-first, files-last

- A DB failure now leaves the book fully intact (files + rows) → the per-book
  `except` records an error and the duplicate stays resolvable next run.
- A file-cleanup failure *after* the DB is consistent is recoverable (row already
  gone; backup + orphaned files reclaimable) → logged, not raised.

ORM-lifecycle detail: after the commit deletes the `Books` row, `book` is a
detached/expired instance. `helper.delete_book` reads only `book.path` + `book.id`
(and `book.data` on the Google-Drive path), so those are force-loaded and the
object is detached (guarded `expunge`) before the commit's `expire_on_commit` can
strand them.

## Verification (RED → GREEN)

- **Unit:** 3 source-pins — commit precedes file-delete; force-load + guarded
  expunge present; file-cleanup failure logged not raised. All fail on `main`,
  pass here (file 13/13).
- **Live, real library** (cwn-local: Alice ×5 / Crime ×2 / Republic ×2):
  - **Clean run** — reorder works end-to-end: 0 errors, **no DetachedInstanceError**
    from the post-commit file delete, exactly the 6 losers removed.
  - **Injected DB-commit failure** — the loser book's `Books` row **and** its files
    both survive (`NO-PHANTOM`). On the old files-first order the same failure
    leaves files gone + row surviving (phantom).

## Left out (documented — `notes/d3-d11-delete-ordering-design.md`)

- The normal `delete_book_from_table` (UI delete) has the same files-first defect
  — higher blast radius + a UX call (a file-delete failure currently *aborts* the
  delete; files-last would make it a warning with the book already gone). Own PR +
  live UI verification.
- The app.db-vs-metadata.db commit split (book survives but shelf/read rows are
  lost on a metadata-commit failure) — unchanged here (strict improvement: the
  phantom-files case is gone), ties into D4 (orphan rows / ORM cascade).

No new dependencies, no license or external-URL change. Dup-series: D1 #394,
D2 #397, D7 #395/#396.
