### PR TITLE
fix(shelf): load reorder cover-sizing stylesheet from <head>, not <body> (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- Shelf reorder covers: the stylesheet that keeps the covers at the normal
+  thumbnail size now loads from the page head, alongside every other stylesheet,
+  instead of from the page body. A body-loaded stylesheet link can be dropped by
+  some reverse proxies, which left the covers oversized on an otherwise-correct
+  page — the case @SpookyUSAF kept hitting on caliBlur even after v4.0.158/159.
+  (#320 follow-up, reported by @SpookyUSAF)
 - Automatic metadata fetch (the admin "auto metadata fetch" option, off by
   default) no longer overwrites a book's correct author, ISBN, series,
   publication date or rating with a wrong match's. Previously, with auto-fetch

--- a/cps/templates/shelf_order.html
+++ b/cps/templates/shelf_order.html
@@ -1,5 +1,16 @@
 {% import 'image.html' as image %}
 {% extends "layout.html" %}
+{# Load the reorder grid styles from the document HEAD (fork #320, @SpookyUSAF):
+   the cover-sizing rule MUST reach the browser, and the only difference between
+   the core stylesheets (which always apply for this reporter) and this page's
+   sheet was that this one's <link> sat in the <body>. A body-placed stylesheet
+   link is valid HTML but some reverse proxies / security middleware strip or
+   ignore <link> elements found in the body as "injected", which left the covers
+   unsized and oversized on an otherwise-styled (caliBlur) page. Loading it here,
+   in the same <head> block as cwa.css/caliBlur.css, removes that difference. #}
+{% block header %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/shelf_reorder.css') }}">
+{% endblock %}
 {% block body %}
   {# Deliberately NOT the discover wrapper class: main.js runs isotope on
      every `.discover .row` that contains .book cards. Isotope absolutely-
@@ -61,10 +72,6 @@
       </div>
     </div>
   </div>
-  {# Reorder grid styles live in an external stylesheet (not an inline <style>):
-     inline blocks can be stripped by a strict reverse-proxy CSP, which would
-     leave the cover sizing unapplied and covers oversized (fork #320). #}
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/shelf_reorder.css') }}">
 {% endblock %}
 
 {% block js %}

--- a/tests/unit/test_320_reorder_css_head_load.py
+++ b/tests/unit/test_320_reorder_css_head_load.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""fork #320 (@SpookyUSAF): the shelf-reorder cover-sizing stylesheet must load
+from the document HEAD, not the body.
+
+The reorder grid's cover sizing lives in cps/static/css/shelf_reorder.css. It was
+linked via a <link> placed inside the page's {% block body %}. A body-placed
+stylesheet link is valid HTML and works in a plain browser, but the only difference
+between it and the core stylesheets (cwa.css / caliBlur.css, which always applied for
+the reporter) was head-vs-body placement — and some reverse proxies / security
+middleware strip or ignore <link> elements found in the body as "injected", leaving
+the covers unsized (oversized "large icon" style) on an otherwise-styled page. The
+reporter saw oversized covers across v4.0.158 and v4.0.159 on caliBlur even though a
+fresh local instance rendered them at the normal 150x225 thumbnail size — the tell
+that the page-specific sheet wasn't reaching their browser.
+
+This pins the fix: the link is declared in a {% block header %} (which layout.html
+renders inside <head>) and NOT in the body, so it loads the same way as every other
+stylesheet. See notes/fix-320-reproduction-attempts.md.
+"""
+
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+TEMPLATE = REPO / "cps" / "templates" / "shelf_order.html"
+
+
+def _src():
+    return TEMPLATE.read_text(encoding="utf-8")
+
+
+def test_reorder_stylesheet_linked_in_header_block():
+    src = _src()
+    assert "{% block header %}" in src, "shelf_order.html must define a header block"
+    header = src.split("{% block header %}", 1)[1].split("{% endblock %}", 1)[0]
+    assert "shelf_reorder.css" in header, (
+        "the shelf_reorder.css <link> must live in the {% block header %} so it loads "
+        "from the document <head> (fork #320 — a body-placed link got stripped by some "
+        "reverse proxies, leaving reorder covers oversized)"
+    )
+
+
+def test_reorder_stylesheet_not_in_body_block():
+    src = _src()
+    body = src.split("{% block body %}", 1)[1]
+    assert "shelf_reorder.css" not in body, (
+        "the shelf_reorder.css <link> must NOT be in {% block body %} — a body-placed "
+        "stylesheet link can be dropped by reverse proxies / security middleware (#320)"
+    )
+
+
+def test_reorder_stylesheet_file_exists():
+    css = REPO / "cps" / "static" / "css" / "shelf_reorder.css"
+    assert css.is_file(), "shelf_reorder.css must exist"
+    body = css.read_text(encoding="utf-8")
+    assert "#reorder-grid .reorder-item .cover img" in body and "max-width" in body, (
+        "shelf_reorder.css must still cap the reorder cover image width"
+    )


### PR DESCRIPTION
Addresses #320 (follow-up; reported by @SpookyUSAF).

## Symptom
@SpookyUSAF sees oversized "large icon" covers on the reorder shelf view (`/shelf/order/<id>`) on **caliBlur**, persisting across v4.0.157 → v4.0.158 (#385) → v4.0.159 (#393/#389), through fresh container rebuilds + hard refreshes. Mechanics work; only cover size is wrong.

## Could not reproduce locally
cwn-local runs code byte-identical to v4.0.159 for this page. Measured with Playwright on caliBlur at 1200px and 988px (the reporter's width): covers are **150×225 in every combination** — caliBlur alone, shelf_reorder.css alone, or both. The only way to get oversized covers is if **neither** sizing rule applies, leaving the img to fill its ~200px column cell. Full matrix in `notes/fix-320-reproduction-attempts.md`.

## Root cause (the one actionable difference)
The reporter's page is styled (caliBlur loads), so the core stylesheets reach them. Those are all `<link>`-ed in `layout.html`'s `<head>`. `shelf_reorder.css` was the **only** stylesheet linked from inside `{% block body %}`. A body-placed `<link rel=stylesheet>` is valid HTML and works in a plain browser, but some reverse proxies / security middleware strip or ignore body `<link>` elements as "injected" — leaving the cover-sizing rule unapplied. Head-vs-body is the single difference between the sheets that always reach this reporter and the one that doesn't.

## Fix
Move the `<link>` into `{% block header %}` → renders in `<head>` with every other stylesheet. **Verified live** (cwn-local): link now in `<head>`, covers 150×225, `max-width:150px` applied. 3 source-pins (`tests/unit/test_320_reorder_css_head_load.py`).

## Honest status
Not confirmed against the reporter's exact case (couldn't reproduce). Removes the one identified difference; low-risk template change. The issue reply asks for the decisive DevTools reading if it's still off.