### PR TITLE
fix(editbooks): delete books DB-first, files-last — no phantom on failure (D3-sibling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- Deleting a book no longer risks leaving a broken "ghost" entry if something
+  fails partway through. Previously the book's files were removed before the
+  library database was updated, so an error in between could leave an entry that
+  still shows in your library but won't open. The database is now updated first
+  and the files removed last, so a failure leaves the book fully intact. (Mirrors
+  the same data-safety fix already made for duplicate resolution.)
 - Shelf reorder covers: the stylesheet that keeps the covers at the normal
   thumbnail size now loads from the page head, alongside every other stylesheet,
   instead of from the page body. A body-loaded stylesheet link can be dropped by

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -1321,6 +1321,20 @@ def move_coverfile(meta, db_book):
               category="error")
 
 
+class _DeletedBookFileRef:
+    """Plain-value stand-in for a just-deleted Book, used by the files-last cleanup
+    in delete_book_from_table so it never reads an expired/detached ORM instance
+    (data-safety, D3-sibling). delete_whole_book runs intermediate commits that
+    expire + detach the real ``book``; a whole-book helper.delete_book reads only
+    ``.id`` and ``.path``, so we capture those as plain values before the DB delete
+    and hand the cleanup this object."""
+    __slots__ = ("id", "path")
+
+    def __init__(self, book_id, path):
+        self.id = book_id
+        self.path = path
+
+
 def delete_whole_book(book_id, book):
     # Capture a tombstone for every Kobo-synced user BEFORE we touch
     # any of the metadata.db / app.db rows. The Kobo protocol needs the
@@ -1411,32 +1425,64 @@ def delete_book_from_table(book_id, book_format, json_response, location="", ski
         book = calibre_db.get_book(book_id)
         if book:
             try:
-                result, error = helper.delete_book(book, config.get_book_path(), book_format=book_format.upper())
-                if not result:
-                    if json_response:
-                        return json.dumps([{"location": url_for("edit-book.show_edit_book", book_id=book_id),
-                                            "type": "danger",
-                                            "format": "",
-                                            "message": error}])
-                    else:
-                        flash(error, category="error")
-                        return redirect(url_for('edit-book.show_edit_book', book_id=book_id))
-                if error:
-                    if json_response:
-                        warning = {"location": url_for("edit-book.show_edit_book", book_id=book_id),
-                                   "type": "warning",
-                                   "format": "",
-                                   "message": error}
-                    else:
-                        flash(error, category="warning")
                 if not book_format:
-                    delete_whole_book(book_id, book)
+                    # Whole-book delete — data-safety (D3-sibling): commit the DB deletes
+                    # FIRST, remove files LAST. The old order deleted the files
+                    # (helper.delete_book) before delete_whole_book + commit, so a DB failure
+                    # left the files gone but the Books row surviving — a phantom book that
+                    # still shows in the library and 404s when opened, unrecoverable. DB-first
+                    # leaves the book fully intact on a DB failure (the except below rolls back);
+                    # a file-cleanup failure after the DB is consistent is recoverable (rows
+                    # already gone, orphaned files reclaimable) and is logged + warned, not raised.
+                    deleted_book_id = book.id
+                    deleted_book_path = book.path
+                    delete_whole_book(deleted_book_id, book)
+                    calibre_db.session.commit()
+                    # Files last: a plain stand-in, never the now-detached ORM book
+                    # (delete_whole_book's intermediate commits expire/detach it; a whole-book
+                    # cleanup reads only .id and .path).
+                    result, error = helper.delete_book(
+                        _DeletedBookFileRef(deleted_book_id, deleted_book_path),
+                        config.get_book_path(), book_format="")
+                    if not result:
+                        log.warning("[delete-book] Book %s removed from the database but file "
+                                    "cleanup failed: %s (files remain on disk)", deleted_book_id, error)
+                    if error:
+                        if json_response:
+                            warning = {"location": url_for("edit-book.show_edit_book", book_id=book_id),
+                                       "type": "warning",
+                                       "format": "",
+                                       "message": error}
+                        else:
+                            flash(error, category="warning")
                 else:
+                    # Single-format delete: remove the format file, then its Data row. Kept
+                    # files-first — a failure here orphans at most one format's row (not the
+                    # whole book), and the format's on-disk path is resolved from that Data row,
+                    # which a files-last order would have already removed.
+                    result, error = helper.delete_book(book, config.get_book_path(), book_format=book_format.upper())
+                    if not result:
+                        if json_response:
+                            return json.dumps([{"location": url_for("edit-book.show_edit_book", book_id=book_id),
+                                                "type": "danger",
+                                                "format": "",
+                                                "message": error}])
+                        else:
+                            flash(error, category="error")
+                            return redirect(url_for('edit-book.show_edit_book', book_id=book_id))
+                    if error:
+                        if json_response:
+                            warning = {"location": url_for("edit-book.show_edit_book", book_id=book_id),
+                                       "type": "warning",
+                                       "format": "",
+                                       "message": error}
+                        else:
+                            flash(error, category="warning")
                     calibre_db.session.query(db.Data).filter(db.Data.book == book.id).\
                         filter(db.Data.format == book_format).delete()
                     if book_format.upper() in ['KEPUB', 'EPUB', 'EPUB3']:
                         kobo_sync_status.remove_synced_book(book.id, True)
-                calibre_db.session.commit()
+                    calibre_db.session.commit()
 
                 refreshed_duplicate_cache = False
                 if not book_format:

--- a/tests/unit/test_delete_book_files_last.py
+++ b/tests/unit/test_delete_book_files_last.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Whole-book delete is DB-commit-first, files-last (data-safety, D3-sibling).
+
+`delete_book_from_table` (the normal delete path — the edit-book "Delete" button,
+batch delete, ingest auto-merge) used to remove a book's files (`helper.delete_book`)
+BEFORE committing the DB deletes (`delete_whole_book` + `calibre_db.session.commit`).
+A failure in the DB phase then left the files gone but the `Books` row surviving — a
+phantom book that still shows in the library and 404s when opened, unrecoverable
+without the backup. This is the exact defect fixed in the duplicate-resolution path
+(D3, #399); this pins the same fix for the normal delete path.
+
+The whole-book branch now: commit the DB deletes first, then remove files last via a
+plain-value stand-in (`_DeletedBookFileRef`) — never the now-detached ORM `book`
+(`delete_whole_book`'s intermediate commits expire/detach it). A post-commit file
+cleanup failure is logged + surfaced as a warning, not raised (the row is already
+gone; orphaned files are reclaimable). The single-format branch is intentionally left
+files-first (a failure orphans at most one format's row, and the format's on-disk path
+is resolved from that Data row) — see notes/delete-ordering-d4-findings.md.
+
+The behavioural proof is the live cwn-local repro (injected delete_whole_book failure ->
+book row + files both survive). These source-pins lock the ordering.
+"""
+
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+EDITBOOKS = REPO / "cps" / "editbooks.py"
+
+
+def _func_src():
+    src = EDITBOOKS.read_text(encoding="utf-8")
+    body = src.split("def delete_book_from_table", 1)[1]
+    return body.split("\ndef ", 1)[0]
+
+
+def test_whole_book_db_commit_precedes_file_delete():
+    body = _func_src()
+    db_delete = body.find("delete_whole_book(deleted_book_id, book)")
+    file_ref = body.find("_DeletedBookFileRef(deleted_book_id, deleted_book_path)")
+    assert db_delete != -1, "whole-book branch must call delete_whole_book(deleted_book_id, book)"
+    assert file_ref != -1, "whole-book file cleanup must use the _DeletedBookFileRef stand-in"
+    commit = body.find("calibre_db.session.commit()", db_delete)
+    assert db_delete < commit < file_ref, (
+        "whole-book delete must commit the DB deletes (delete_whole_book + "
+        "calibre_db.session.commit()) BEFORE removing files, so a DB failure can't "
+        "leave a phantom book whose files are already gone (D3-sibling)"
+    )
+
+
+def test_whole_book_file_cleanup_uses_standin_not_orm_book():
+    body = _func_src()
+    # the whole-book files-last call must hand helper.delete_book the plain stand-in,
+    # not the ORM `book` (detached/expired after delete_whole_book).
+    assert "_DeletedBookFileRef(deleted_book_id, deleted_book_path)" in body
+    assert "deleted_book_path = book.path" in body, (
+        "book.path must be captured as a plain value before the DB delete"
+    )
+
+
+def test_whole_book_file_failure_is_logged_not_returned():
+    body = _func_src()
+    ref = body.find("_DeletedBookFileRef(deleted_book_id, deleted_book_path)")
+    after = body[ref:]
+    # after the DB is committed, a file-cleanup failure must be logged/warned, not
+    # returned as a hard "danger" (that would falsely report the completed DB delete
+    # as failed). The else: starts the single-format branch.
+    whole_book_tail = after.split("\n                else:", 1)[0]
+    assert "removed from the database but file" in whole_book_tail, (
+        "whole-book file-cleanup failure must log a warning"
+    )
+    assert "return json.dumps" not in whole_book_tail, (
+        "whole-book file-cleanup failure must NOT return a danger response — the DB "
+        "delete already succeeded (D3-sibling)"
+    )
+
+
+def test_standin_class_defined():
+    src = EDITBOOKS.read_text(encoding="utf-8")
+    assert "class _DeletedBookFileRef:" in src
+    assert '__slots__ = ("id", "path")' in src


### PR DESCRIPTION
## The bug
`delete_book_from_table` — the **normal** delete path (edit-book Delete button, batch delete, and the duplicate auto-merge loser deletion at editbooks.py:783) — removed a book's files (`helper.delete_book`) **before** committing the DB deletes (`delete_whole_book` + `calibre_db.session.commit`). A failure in the DB phase left the files gone but the `Books` row surviving — a phantom book that still shows in the library and 404s on open, unrecoverable. This is the exact defect fixed for the duplicate-**resolution** path in D3 (#399); it was still present in the normal delete path (documented as a D3 follow-up in `notes/delete-ordering-d4-findings.md`).

## The fix
Whole-book branch reordered to **DB-commit-first, files-last**: capture id + path as plain values, `delete_whole_book` + commit, then `helper.delete_book` on a plain stand-in (`_DeletedBookFileRef` — `delete_whole_book`'s intermediate commits expire/detach the ORM book; a whole-book cleanup reads only `.id`/`.path`). A post-commit file-cleanup failure is logged + warned, not raised (row already gone, orphaned files reclaimable). The `except` still rolls back a DB-phase failure so the book stays fully intact.

**Single-format branch left files-first** (intentional): a failure there orphans at most one format's Data row, not the whole book, and the format's on-disk path is resolved from that Data row — documented follow-up.

## Verification
- **4 source-pins** (`tests/unit/test_delete_book_files_last.py`) RED on main (tokens absent) / GREEN on branch.
- **Live cwn-local** (restart clean-boot, no import break): injected `delete_whole_book` failure → book row + files **both survive** (NO_PHANTOM=True); happy-path delete → row + files **both removed**. Direct `delete_book_from_table` harness against the real DB + files.

Addresses the D3-sibling data-safety follow-up.