### PR TITLE
Duplicate resolution keeps your highlights, progress and shelves (D4: single enumerator for per-user-book data)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- Resolving duplicate books no longer loses your highlights, notes, reading
+  progress, or shelf placement. When duplicates were merged or resolved, only
+  the book files moved to the kept copy — anything you'd done on the removed
+  copy (annotations, read status, Kobo reading position, shelf membership)
+  silently disappeared. All of it now follows the kept book, whichever
+  resolve strategy you use. Deleting a book and deleting a user also clean up
+  everything that belongs to them now (deleted accounts previously left their
+  annotations and annotation-backup files behind).
 - Deleting a book no longer risks leaving a broken "ghost" entry if something
   fails partway through. Previously the book's files were removed before the
   library database was updated, so an error in between could leave an entry that

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -33,6 +33,7 @@ from sqlalchemy.exc import IntegrityError, OperationalError, InvalidRequestError
 from sqlalchemy.sql.expression import func, or_, text
 
 from . import constants, logger, helper, services, cli_param, apply_https_runtime_config
+from . import user_book_data
 from . import db, calibre_db, ub, web_server, config, updater_thread, gdriveutils, \
     kobo_sync_status, schedule
 from .helper import check_valid_domain, send_test_mail, reset_password, generate_password_hash, check_email, \
@@ -2343,14 +2344,11 @@ def _db_configuration_update_helper():
         # if db changed -> delete shelfs, delete download books, delete read books, kobo sync...
         if db_change:
             log.info("Calibre Database changed, all Calibre-Web NextGen info related to old Database gets deleted")
-            ub.session.query(ub.Downloads).delete()
-            ub.session.query(ub.ArchivedBook).delete()
-            ub.session.query(ub.ReadBook).delete()
-            ub.session.query(ub.BookShelf).delete()
-            ub.session.query(ub.Bookmark).delete()
-            ub.session.query(ub.KoboReadingState).delete()
-            ub.session.query(ub.KoboStatistics).delete()
-            ub.session.query(ub.KoboSyncedBooks).delete()
+            # The old hand-written delete list here missed annotations and
+            # half the Kobo state children; the single enumerator gets all
+            # of it (D4). Book ids from the old library mean nothing in the
+            # new one, so the backup snapshots go too.
+            user_book_data.purge_user_book_data()
             helper.delete_thumbnail_cache()
             ub.session_commit()
             # deleted visibilities based on custom column and tags
@@ -2678,23 +2676,19 @@ def _delete_user(content):
     if ub.session.query(ub.User).filter(ub.User.role.op('&')(constants.ROLE_ADMIN) == constants.ROLE_ADMIN,
                                         ub.User.id != content.id).count():
         if content.name != "Guest":
-            # Delete all books in shelfs belonging to user, all shelfs of user, downloadstat of user, read status
-            # and user itself
-            ub.session.query(ub.ReadBook).filter(content.id == ub.ReadBook.user_id).delete()
-            ub.session.query(ub.Downloads).filter(content.id == ub.Downloads.user_id).delete()
+            # Per-user-book rows (read status, downloads, bookmarks,
+            # annotations + their on-disk backup files, Kobo state…) go
+            # through the single enumerator (D4). The old hand-written list
+            # here left the user's annotation rows and backup gzips behind
+            # (PII surviving the account deletion).
+            user_book_data.purge_user_book_data(user_id=content.id)
+            # User-scoped (not per-book) rows + the user itself stay here.
             for us in ub.session.query(ub.Shelf).filter(content.id == ub.Shelf.user_id):
                 ub.session.query(ub.BookShelf).filter(us.id == ub.BookShelf.shelf).delete()
             ub.session.query(ub.Shelf).filter(content.id == ub.Shelf.user_id).delete()
-            ub.session.query(ub.Bookmark).filter(content.id == ub.Bookmark.user_id).delete()
             ub.session.query(ub.User).filter(ub.User.id == content.id).delete()
-            ub.session.query(ub.ArchivedBook).filter(ub.ArchivedBook.user_id == content.id).delete()
             ub.session.query(ub.RemoteAuthToken).filter(ub.RemoteAuthToken.user_id == content.id).delete()
             ub.session.query(ub.User_Sessions).filter(ub.User_Sessions.user_id == content.id).delete()
-            ub.session.query(ub.KoboSyncedBooks).filter(ub.KoboSyncedBooks.user_id == content.id).delete()
-            # delete KoboReadingState and all it's children
-            kobo_entries = ub.session.query(ub.KoboReadingState).filter(ub.KoboReadingState.user_id == content.id).all()
-            for kobo_entry in kobo_entries:
-                ub.session.delete(kobo_entry)
             ub.session_commit()
             log.info("User {} deleted".format(content.name))
             return _("User '%(nick)s' deleted", nick=content.name)

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -18,7 +18,7 @@ import threading
 import time
 from shutil import copyfile
 
-from . import db, calibre_db, logger, ub, csrf, config, helper
+from . import db, calibre_db, logger, ub, csrf, config, helper, user_book_data
 from .services.worker import WorkerThread, STAT_FINISH_SUCCESS, STAT_FAIL, STAT_ENDED, STAT_CANCELLED
 from .admin import admin_required  
 from .usermanagement import login_required_if_no_ano
@@ -1851,6 +1851,14 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
                         # custom columns (Greptile #399). A whole-book cleanup reads only .id and .path.
                         deleted_book_path = book.path
 
+                        # D4: move the user's data on this loser (annotations,
+                        # reading progress, Kobo state, shelf membership…) to
+                        # the kept book BEFORE deleting — for every strategy,
+                        # not just 'merge'. A keep-newest resolution otherwise
+                        # silently deletes highlights made on the older copy.
+                        user_book_data.migrate_user_book_data(deleted_book_id, book_to_keep_id)
+                        ub.session_commit()
+
                         print(f"[cwa-duplicates-auto] Cleaning up database for book {deleted_book_id}...", flush=True)
                         from cps.editbooks import delete_whole_book
                         delete_whole_book(deleted_book_id, book)  # book live here — reads its relationships
@@ -1979,7 +1987,13 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
 
 
 def merge_duplicate_group(book_to_keep, books_to_merge):
-    """Merge formats from duplicate books into the target book."""
+    """Merge file formats from duplicate books into the target book.
+
+    Per-user data (annotations, reading progress, Kobo state, shelf
+    membership…) is migrated separately in the resolution deletion loop —
+    for EVERY strategy, not just 'merge' — via
+    user_book_data.migrate_user_book_data (D4).
+    """
     if not book_to_keep or not books_to_merge:
         return
 

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm.exc import StaleDataError
 from sqlalchemy.sql.expression import func
 
 from . import constants, logger, isoLanguages, gdriveutils, uploader, helper, kobo_sync_status
+from . import user_book_data
 from .clean_html import clean_string
 from . import config, ub, db, calibre_db
 from .services.worker import WorkerThread
@@ -1351,12 +1352,12 @@ def delete_whole_book(book_id, book):
         # the orphan (same as pre-fix behavior), no data loss.
         log.warning("Could not record kobo deletion tombstone for book %s: %s", book_id, e)
 
-    # delete book from shelves, Downloads, Read list
-    ub.session.query(ub.BookShelf).filter(ub.BookShelf.book_id == book_id).delete()
-    ub.session.query(ub.ReadBook).filter(ub.ReadBook.book_id == book_id).delete()
-    ub.session.query(ub.ArchivedBook).filter(ub.ArchivedBook.book_id == book_id).delete()
+    # Delete every per-user-book row (shelves, read status, annotations,
+    # Kobo state, downloads…) through the single enumerator (D4). The
+    # annotation-backup snapshots are deliberately retained — they're the
+    # recovery path for an accidental delete; retention keeps managing them.
+    user_book_data.purge_user_book_data(book_id=book_id, remove_backup_files=False)
     ub.session.query(ub.BookOriginalFilename).filter(ub.BookOriginalFilename.book_id == book_id).delete()
-    ub.delete_download(book_id)
     ub.session_commit()
 
     # check if only this book links to:

--- a/cps/user_book_data.py
+++ b/cps/user_book_data.py
@@ -1,0 +1,267 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Single source of truth for per-user-book rows in app.db.
+
+Several places need to enumerate "every app.db row that ties a user to a
+book": deleting a book, merging a duplicate into the kept copy, switching
+the Calibre database, deleting a user. Historically each site kept its own
+hand-written list and the lists disagreed — the duplicate merge moved only
+file formats (orphaning the user's annotations, reading progress and shelf
+membership), the database-change wipe missed annotations entirely, and the
+per-user delete left the user's annotation rows and on-disk backup files
+behind.
+
+These two functions are the ONLY place that set is enumerated:
+
+* :func:`migrate_user_book_data` — re-point/merge everything from a book
+  that is about to be deleted (a duplicate-merge loser) onto the kept book.
+* :func:`purge_user_book_data` — delete everything for a book and/or user.
+
+Neither commits; the caller owns the transaction. When adding a new
+per-user-book model to ``cps/ub.py``, add it here (the test suite pins the
+enumeration against the model registry).
+"""
+
+import os
+
+from . import logger, ub
+
+log = logger.create()
+
+
+def _newer(a, b):
+    """True if datetime ``a`` is strictly newer than ``b``. Tolerates None and
+    the naive/aware mix SQLite round-trips produce (columns are stored
+    naive; fresh ORM defaults are timezone-aware)."""
+    if a is None:
+        return False
+    if b is None:
+        return True
+    if (a.tzinfo is None) != (b.tzinfo is None):
+        a = a.replace(tzinfo=None)
+        b = b.replace(tzinfo=None)
+    return a > b
+
+# Models keyed (user_id, book_id) handled by this module, with merge
+# semantics for migrate. BookShelf has no user_id (shelf-scoped) and
+# KoboBookmark/KoboStatistics/AnnotationSyncTarget are children reached
+# through their parents; all are still handled below.
+PER_USER_BOOK_MODELS = (
+    "Annotation",            # + AnnotationSyncTarget children
+    "Bookmark",
+    "ReadBook",
+    "KoboReadingState",      # + KoboBookmark/KoboStatistics children
+    "KoboAnnotationBackup",  # + on-disk .json.gz snapshots
+    "Downloads",
+    "ArchivedBook",
+    "BookShelf",             # shelf-scoped, no user_id column
+    "KoboSyncedBooks",
+    "UserHiddenBook",
+    "BookCoverPreview",
+)
+
+
+def migrate_user_book_data(from_book_id, to_book_id, session=None):
+    """Move all per-user-book rows from ``from_book_id`` to ``to_book_id``.
+
+    Used by the duplicate merge before the losing book is deleted, so the
+    user's annotations, reading progress, shelf membership etc. survive on
+    the kept copy. Where the kept book already has a row for the same user
+    (UNIQUE constraints on most of these tables), the two are merged rather
+    than blindly re-pointed. Does not commit.
+    """
+    session = session if session is not None else ub.session
+    if from_book_id == to_book_id:
+        return
+
+    # Annotations: re-point, but a user may already have the same
+    # annotation_id on the kept book (e.g. the device synced both copies) —
+    # there only the loser row is dropped (ORM delete so sync-target
+    # children go with it).
+    for ann in session.query(ub.Annotation).filter(
+            ub.Annotation.book_id == from_book_id).all():
+        clash = session.query(ub.Annotation).filter(
+            ub.Annotation.user_id == ann.user_id,
+            ub.Annotation.annotation_id == ann.annotation_id,
+            ub.Annotation.book_id == to_book_id).first()
+        if clash is not None:
+            # sync_targets declares passive_deletes=True (expects DB-level
+            # ON DELETE CASCADE), but SQLite FK enforcement is off — delete
+            # the children explicitly.
+            session.query(ub.AnnotationSyncTarget).filter(
+                ub.AnnotationSyncTarget.annotation_id == ann.id).delete(
+                synchronize_session=False)
+            session.delete(ann)
+        else:
+            ann.book_id = to_book_id
+    session.flush()
+
+    # Kobo reading state: UNIQUE(user_id, book_id). If both books have a
+    # state for the same user, the most recently modified one wins; ORM
+    # deletes so the bookmark/statistics children follow.
+    for state in session.query(ub.KoboReadingState).filter(
+            ub.KoboReadingState.book_id == from_book_id).all():
+        existing = session.query(ub.KoboReadingState).filter(
+            ub.KoboReadingState.user_id == state.user_id,
+            ub.KoboReadingState.book_id == to_book_id).first()
+        if existing is None:
+            state.book_id = to_book_id
+        elif _newer(state.last_modified, existing.last_modified):
+            session.delete(existing)
+            session.flush()  # clear the UNIQUE slot before re-pointing
+            state.book_id = to_book_id
+        else:
+            session.delete(state)
+    session.flush()
+
+    # ReadBook: UNIQUE(user_id, book_id); merge keeps the further-along
+    # read status. Bulk delete (no ORM cascade) — the loser's
+    # KoboReadingState was already merged above.
+    _READ_RANK = {ub.ReadBook.STATUS_UNREAD: 0,
+                  ub.ReadBook.STATUS_IN_PROGRESS: 1,
+                  ub.ReadBook.STATUS_FINISHED: 2}
+    for rb in session.query(ub.ReadBook).filter(
+            ub.ReadBook.book_id == from_book_id).all():
+        existing = session.query(ub.ReadBook).filter(
+            ub.ReadBook.user_id == rb.user_id,
+            ub.ReadBook.book_id == to_book_id).first()
+        if existing is None:
+            session.query(ub.ReadBook).filter(ub.ReadBook.id == rb.id).update(
+                {ub.ReadBook.book_id: to_book_id}, synchronize_session=False)
+        else:
+            if _READ_RANK.get(rb.read_status, 0) > _READ_RANK.get(existing.read_status, 0):
+                existing.read_status = rb.read_status
+            existing.times_started_reading = \
+                (existing.times_started_reading or 0) + (rb.times_started_reading or 0)
+            if _newer(rb.last_time_started_reading, existing.last_time_started_reading):
+                existing.last_time_started_reading = rb.last_time_started_reading
+            session.query(ub.ReadBook).filter(ub.ReadBook.id == rb.id).delete(
+                synchronize_session=False)
+    session.flush()
+
+    # Bookmark (reader position, per user+format): keep the kept book's own
+    # position where one exists.
+    for bm in session.query(ub.Bookmark).filter(
+            ub.Bookmark.book_id == from_book_id).all():
+        clash = session.query(ub.Bookmark).filter(
+            ub.Bookmark.user_id == bm.user_id,
+            ub.Bookmark.book_id == to_book_id,
+            ub.Bookmark.format == bm.format).first()
+        if clash is not None:
+            session.delete(bm)
+        else:
+            bm.book_id = to_book_id
+
+    # Shelf membership: re-point unless the kept book is already on that
+    # shelf (keeps the existing position there).
+    for link in session.query(ub.BookShelf).filter(
+            ub.BookShelf.book_id == from_book_id).all():
+        clash = session.query(ub.BookShelf).filter(
+            ub.BookShelf.book_id == to_book_id,
+            ub.BookShelf.shelf == link.shelf).first()
+        if clash is not None:
+            session.delete(link)
+        else:
+            link.book_id = to_book_id
+
+    # Simple UNIQUE(user, book) flags: keep the kept book's row on clash.
+    for model in (ub.ArchivedBook, ub.Downloads, ub.UserHiddenBook,
+                  ub.BookCoverPreview):
+        for row in session.query(model).filter(model.book_id == from_book_id).all():
+            clash = session.query(model).filter(
+                model.user_id == row.user_id,
+                model.book_id == to_book_id).first()
+            if clash is not None:
+                session.delete(row)
+            else:
+                row.book_id = to_book_id
+    session.flush()
+
+    # Annotation backup snapshots index: re-point so retention keeps
+    # managing them; the gzip files referenced by file_path stay valid.
+    session.query(ub.KoboAnnotationBackup).filter(
+        ub.KoboAnnotationBackup.book_id == from_book_id).update(
+        {ub.KoboAnnotationBackup.book_id: to_book_id}, synchronize_session=False)
+
+    # KoboSyncedBooks marks "this book's file already delivered to this
+    # device". The kept book's file is a different file, so the marker must
+    # NOT migrate — drop it and let the next sync deliver the kept copy.
+    session.query(ub.KoboSyncedBooks).filter(
+        ub.KoboSyncedBooks.book_id == from_book_id).delete(synchronize_session=False)
+
+    session.flush()
+    log.info("[user-book-data] migrated per-user data from book %s to book %s",
+             from_book_id, to_book_id)
+
+
+def purge_user_book_data(book_id=None, user_id=None, session=None,
+                         remove_backup_files=True):
+    """Delete every per-user-book row matching ``book_id`` and/or ``user_id``.
+
+    With only ``book_id``: a book is being deleted (every user's rows go).
+    With only ``user_id``: a user is being deleted (their rows for every
+    book go, including on-disk annotation-backup files — PII).
+    With neither: the Calibre database was swapped out; everything goes.
+
+    ``remove_backup_files=False`` leaves the annotation-backup index rows
+    and their gzip snapshots in place (the recovery path for an accidental
+    book delete — retention keeps managing them). Does not commit.
+    """
+    session = session if session is not None else ub.session
+
+    def _scoped(query, model):
+        if book_id is not None:
+            query = query.filter(model.book_id == book_id)
+        if user_id is not None:
+            query = query.filter(model.user_id == user_id)
+        return query
+
+    # Annotations: delete sync-target children first (bulk deletes bypass
+    # ORM cascade, and SQLite FK enforcement can't be relied on).
+    ann_ids = _scoped(session.query(ub.Annotation.id), ub.Annotation)
+    session.query(ub.AnnotationSyncTarget).filter(
+        ub.AnnotationSyncTarget.annotation_id.in_(
+            ann_ids.scalar_subquery())).delete(synchronize_session=False)
+    _scoped(session.query(ub.Annotation), ub.Annotation).delete(
+        synchronize_session=False)
+
+    # Kobo reading state + children.
+    krs_ids = _scoped(session.query(ub.KoboReadingState.id), ub.KoboReadingState)
+    for child in (ub.KoboBookmark, ub.KoboStatistics):
+        session.query(child).filter(
+            child.kobo_reading_state_id.in_(
+                krs_ids.scalar_subquery())).delete(synchronize_session=False)
+    _scoped(session.query(ub.KoboReadingState), ub.KoboReadingState).delete(
+        synchronize_session=False)
+
+    for model in (ub.Bookmark, ub.ReadBook, ub.ArchivedBook, ub.Downloads,
+                  ub.KoboSyncedBooks, ub.UserHiddenBook, ub.BookCoverPreview):
+        _scoped(session.query(model), model).delete(synchronize_session=False)
+
+    # BookShelf has no user_id — shelf membership is shelf-scoped, and the
+    # user-delete path removes the user's shelves (with their links)
+    # separately. Only book-scoped (and full) purges touch it.
+    if user_id is None:
+        query = session.query(ub.BookShelf)
+        if book_id is not None:
+            query = query.filter(ub.BookShelf.book_id == book_id)
+        query.delete(synchronize_session=False)
+
+    if remove_backup_files:
+        backups = _scoped(session.query(ub.KoboAnnotationBackup),
+                          ub.KoboAnnotationBackup).all()
+        for row in backups:
+            try:
+                if row.file_path and os.path.isfile(row.file_path):
+                    os.remove(row.file_path)
+            except OSError as e:
+                log.warning("[user-book-data] could not remove annotation "
+                            "backup %s: %s", row.file_path, e)
+            session.delete(row)
+
+    session.flush()
+    log.info("[user-book-data] purged per-user data (book_id=%s, user_id=%s)",
+             book_id, user_id)

--- a/tests/unit/test_duplicate_delete_index_maintenance.py
+++ b/tests/unit/test_duplicate_delete_index_maintenance.py
@@ -180,6 +180,11 @@ def _load_editbooks_module(delete_key_calls):
 
     _install_stub("cps.ub")
     _install_stub(
+        "cps.user_book_data",
+        {"migrate_user_book_data": lambda *a, **k: None,
+         "purge_user_book_data": lambda *a, **k: None},
+    )
+    _install_stub(
         "cps.kobo_sync_status",
         {
             "remove_synced_book": lambda *args, **kwargs: calls.append("kobo"),
@@ -274,7 +279,13 @@ def _load_duplicates_module(delete_key_calls):
     cps.config = config
     cps.db = db
 
-    _install_stub("cps.ub", {"init_db_thread": lambda: calls.append("init-db-thread")})
+    _install_stub("cps.ub", {"init_db_thread": lambda: calls.append("init-db-thread"),
+                             "session_commit": lambda *a, **k: None})
+    _install_stub(
+        "cps.user_book_data",
+        {"migrate_user_book_data": lambda *a, **k: None,
+         "purge_user_book_data": lambda *a, **k: None},
+    )
     _install_stub("cps.csrf", {"exempt": _decorator})
     _install_stub("cps.admin", {"admin_required": _decorator})
     _install_stub("cps.usermanagement", {"login_required_if_no_ano": _decorator})

--- a/tests/unit/test_duplicate_scan_index_rewire.py
+++ b/tests/unit/test_duplicate_scan_index_rewire.py
@@ -515,7 +515,7 @@ def _load_duplicates_route_module(
     _clear_modules()
     _RouteCwaDB.cache_data = {"scan_pending": not baseline_valid, "duplicate_groups": [], "last_scanned_book_id": 55 if baseline_valid else 0}
     cps = _install_stub("cps")
-    for name in ("db", "calibre_db", "ub", "config", "helper"):
+    for name in ("db", "calibre_db", "ub", "config", "helper", "user_book_data"):
         module = _install_stub(f"cps.{name}")
         setattr(cps, name, module)
     logger = _install_stub("cps.logger", {"create": lambda: _Logger()})

--- a/tests/unit/test_user_book_data_d4.py
+++ b/tests/unit/test_user_book_data_d4.py
@@ -1,0 +1,358 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""D4: per-user-book data has ONE enumerator (cps/user_book_data.py).
+
+Merging a duplicate used to copy only file formats — the losing book was
+then deleted and the user's annotations, reading progress, Kobo state and
+shelf membership on it were orphaned (annotations: silent data loss). The
+admin database-change wipe and the per-user delete each kept their own
+disagreeing hand-list, both missing annotations (per-user delete also left
+on-disk annotation-backup gzips behind — PII surviving account deletion).
+
+migrate_user_book_data / purge_user_book_data are now the only places that
+enumerate the per-user-book model set; behavioural tests run against a real
+in-memory app.db; source-pins lock the four call sites onto the helpers.
+"""
+
+import pathlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+WINNER = 101
+LOSER = 202
+USER = 7
+
+
+@pytest.fixture
+def session(monkeypatch):
+    import sys
+    # some suites stub cps.*, flask, sqlalchemy… into sys.modules and don't
+    # restore — evict the whole affected families so we import the real ones.
+    if "cps.ub" in sys.modules and not hasattr(sys.modules["cps.ub"], "Base"):
+        stubbed = {"cps", "cwa_db", "flask", "flask_babel", "flask_dance",
+                   "sqlalchemy", "werkzeug"}
+        for name in [m for m in list(sys.modules) if m.split(".")[0] in stubbed]:
+            sys.modules.pop(name, None)
+    from cps import ub
+    from cps.services import annotation_backup
+    annotation_backup.reset_for_tests()
+    monkeypatch.setattr(annotation_backup, "WORKER_AUTOSTART", False)
+    engine = create_engine("sqlite:///:memory:", future=True)
+    ub.Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine, future=True)()
+    # the BookShelf before_flush listener walks link.ub_shelf — give the
+    # shelves used in these tests real rows.
+    s.add_all([ub.Shelf(id=1, name="one", user_id=USER),
+               ub.Shelf(id=2, name="two", user_id=USER)])
+    s.commit()
+    yield s
+    s.close()
+
+
+def _set_state_timestamps(session, ub, book_to_ts):
+    # the ub before_flush listener stamps KoboReadingState.last_modified to
+    # now() whenever its bookmark child flushes, clobbering explicit values —
+    # set them afterwards with a bulk UPDATE (which the listener ignores).
+    for book_id, ts in book_to_ts.items():
+        session.query(ub.KoboReadingState).filter(
+            ub.KoboReadingState.book_id == book_id).update(
+            {ub.KoboReadingState.last_modified: ts}, synchronize_session=False)
+    session.commit()
+    session.expire_all()
+
+
+def _shelf_link(session, ub, book_id, shelf_id, order):
+    # production creates links through the Shelf.books relationship, which
+    # populates the ub_shelf backref the before_flush listener relies on.
+    shelf = session.get(ub.Shelf, shelf_id)
+    link = ub.BookShelf(book_id=book_id, order=order, ub_shelf=shelf)
+    session.add(link)
+    return link
+
+
+def _annotation(ub, book_id, annotation_id="ann-1", user_id=USER, **kw):
+    return ub.Annotation(user_id=user_id, annotation_id=annotation_id,
+                         book_id=book_id, highlighted_text=kw.pop("text", "hl"),
+                         source="webreader", **kw)
+
+
+@pytest.mark.unit
+class TestMigrate:
+    def test_annotation_moves_to_winner_with_sync_targets(self, session):
+        from cps import ub
+        from cps.user_book_data import migrate_user_book_data
+        ann = _annotation(ub, LOSER)
+        ann.sync_targets.append(ub.AnnotationSyncTarget(target="hardcover", status="synced"))
+        session.add(ann)
+        session.commit()
+
+        migrate_user_book_data(LOSER, WINNER, session=session)
+        session.commit()
+
+        moved = session.query(ub.Annotation).one()
+        assert moved.book_id == WINNER
+        assert moved.highlighted_text == "hl"
+        assert session.query(ub.AnnotationSyncTarget).count() == 1
+
+    def test_annotation_clash_keeps_winner_row(self, session):
+        from cps import ub
+        from cps.user_book_data import migrate_user_book_data
+        keep = _annotation(ub, WINNER, text="winner-copy")
+        lose = _annotation(ub, LOSER, text="loser-copy")
+        lose.sync_targets.append(ub.AnnotationSyncTarget(target="hardcover", status="pending"))
+        session.add_all([keep, lose])
+        session.commit()
+
+        migrate_user_book_data(LOSER, WINNER, session=session)
+        session.commit()
+
+        rows = session.query(ub.Annotation).all()
+        assert len(rows) == 1 and rows[0].highlighted_text == "winner-copy"
+        # the dropped loser row's sync-target child went with it
+        assert session.query(ub.AnnotationSyncTarget).count() == 0
+
+    def test_kobo_reading_state_newer_loser_wins(self, session):
+        from cps import ub
+        from cps.user_book_data import migrate_user_book_data
+        now = datetime.now(timezone.utc)
+        old = ub.KoboReadingState(user_id=USER, book_id=WINNER)
+        new = ub.KoboReadingState(user_id=USER, book_id=LOSER)
+        new.current_bookmark = ub.KoboBookmark(progress_percent=42.0)
+        session.add_all([old, new])
+        session.commit()
+        _set_state_timestamps(session, ub, {WINNER: now - timedelta(days=2), LOSER: now})
+
+        migrate_user_book_data(LOSER, WINNER, session=session)
+        session.commit()
+
+        state = session.query(ub.KoboReadingState).one()
+        assert state.book_id == WINNER
+        assert state.current_bookmark.progress_percent == 42.0
+
+    def test_kobo_reading_state_older_loser_dropped(self, session):
+        from cps import ub
+        from cps.user_book_data import migrate_user_book_data
+        now = datetime.now(timezone.utc)
+        keep = ub.KoboReadingState(user_id=USER, book_id=WINNER)
+        keep.current_bookmark = ub.KoboBookmark(progress_percent=80.0)
+        stale = ub.KoboReadingState(user_id=USER, book_id=LOSER)
+        stale.current_bookmark = ub.KoboBookmark(progress_percent=10.0)
+        session.add_all([keep, stale])
+        session.commit()
+        _set_state_timestamps(session, ub, {WINNER: now, LOSER: now - timedelta(days=2)})
+
+        migrate_user_book_data(LOSER, WINNER, session=session)
+        session.commit()
+
+        state = session.query(ub.KoboReadingState).one()
+        assert state.book_id == WINNER
+        assert state.current_bookmark.progress_percent == 80.0
+        assert session.query(ub.KoboBookmark).count() == 1
+
+    def test_read_book_merge_keeps_furthest_status(self, session):
+        from cps import ub
+        from cps.user_book_data import migrate_user_book_data
+        session.add_all([
+            ub.ReadBook(user_id=USER, book_id=WINNER,
+                        read_status=ub.ReadBook.STATUS_IN_PROGRESS, times_started_reading=1),
+            ub.ReadBook(user_id=USER, book_id=LOSER,
+                        read_status=ub.ReadBook.STATUS_FINISHED, times_started_reading=3),
+        ])
+        session.commit()
+
+        migrate_user_book_data(LOSER, WINNER, session=session)
+        session.commit()
+
+        rb = session.query(ub.ReadBook).one()
+        assert rb.book_id == WINNER
+        assert rb.read_status == ub.ReadBook.STATUS_FINISHED
+        assert rb.times_started_reading == 4
+
+    def test_shelf_membership_repointed_unless_already_on_shelf(self, session):
+        from cps import ub
+        from cps.user_book_data import migrate_user_book_data
+        _shelf_link(session, ub, LOSER, 1, 5)      # winner not on shelf 1
+        _shelf_link(session, ub, LOSER, 2, 1)      # clash on shelf 2
+        _shelf_link(session, ub, WINNER, 2, 9)
+        session.commit()
+
+        migrate_user_book_data(LOSER, WINNER, session=session)
+        session.commit()
+
+        links = session.query(ub.BookShelf).order_by(ub.BookShelf.shelf).all()
+        assert [(l.shelf, l.book_id, l.order) for l in links] == [(1, WINNER, 5), (2, WINNER, 9)]
+
+    def test_kobo_synced_marker_dropped_not_migrated(self, session):
+        from cps import ub
+        from cps.user_book_data import migrate_user_book_data
+        session.add(ub.KoboSyncedBooks(user_id=USER, book_id=LOSER))
+        session.commit()
+
+        migrate_user_book_data(LOSER, WINNER, session=session)
+        session.commit()
+
+        # the marker means "this file was delivered" — the kept book is a
+        # different file, so it must sync fresh, not inherit the marker.
+        assert session.query(ub.KoboSyncedBooks).count() == 0
+
+    def test_simple_flags_migrate_and_dedupe(self, session):
+        from cps import ub
+        from cps.user_book_data import migrate_user_book_data
+        session.add_all([
+            ub.ArchivedBook(user_id=USER, book_id=LOSER, is_archived=True),
+            ub.Downloads(user_id=USER, book_id=LOSER),
+            ub.Downloads(user_id=USER, book_id=WINNER),  # clash → loser row dropped
+        ])
+        session.commit()
+
+        migrate_user_book_data(LOSER, WINNER, session=session)
+        session.commit()
+
+        assert session.query(ub.ArchivedBook).one().book_id == WINNER
+        downloads = session.query(ub.Downloads).all()
+        assert len(downloads) == 1 and downloads[0].book_id == WINNER
+
+
+@pytest.mark.unit
+class TestPurge:
+    def _populate(self, session, ub):
+        ann = _annotation(ub, LOSER)
+        ann.sync_targets.append(ub.AnnotationSyncTarget(target="hardcover", status="synced"))
+        state = ub.KoboReadingState(user_id=USER, book_id=LOSER)
+        state.current_bookmark = ub.KoboBookmark(progress_percent=10.0)
+        state.statistics = ub.KoboStatistics(spent_reading_minutes=5)
+        session.add_all([
+            ann, state,
+            ub.ReadBook(user_id=USER, book_id=LOSER, read_status=1),
+            ub.Bookmark(user_id=USER, book_id=LOSER, format="EPUB", bookmark_key="k"),
+            ub.ArchivedBook(user_id=USER, book_id=LOSER, is_archived=False),
+            ub.Downloads(user_id=USER, book_id=LOSER),
+            ub.KoboSyncedBooks(user_id=USER, book_id=LOSER),
+        ])
+        _shelf_link(session, ub, LOSER, 1, 1)
+        session.commit()
+
+    def test_purge_by_book_removes_everything_for_all_users(self, session):
+        from cps import ub
+        from cps.user_book_data import purge_user_book_data
+        self._populate(session, ub)
+
+        purge_user_book_data(book_id=LOSER, session=session, remove_backup_files=False)
+        session.commit()
+
+        for model in (ub.Annotation, ub.AnnotationSyncTarget, ub.KoboReadingState,
+                      ub.KoboBookmark, ub.KoboStatistics, ub.ReadBook, ub.Bookmark,
+                      ub.ArchivedBook, ub.Downloads, ub.BookShelf, ub.KoboSyncedBooks):
+            assert session.query(model).count() == 0, model.__name__
+
+    def test_purge_by_book_leaves_other_books_alone(self, session):
+        from cps import ub
+        from cps.user_book_data import purge_user_book_data
+        self._populate(session, ub)
+        session.add(_annotation(ub, WINNER, annotation_id="ann-other"))
+        session.commit()
+
+        purge_user_book_data(book_id=LOSER, session=session, remove_backup_files=False)
+        session.commit()
+
+        assert session.query(ub.Annotation).one().book_id == WINNER
+
+    def test_purge_by_user_removes_backup_files_on_disk(self, session, tmp_path):
+        from cps import ub
+        from cps.user_book_data import purge_user_book_data
+        gz = tmp_path / "snapshot.json.gz"
+        gz.write_bytes(b"x")
+        session.add_all([
+            _annotation(ub, LOSER),
+            ub.KoboAnnotationBackup(user_id=USER, book_id=LOSER, content_hash="h",
+                                    file_path=str(gz), size_bytes=1, annotation_count=1),
+            _annotation(ub, LOSER, annotation_id="ann-keep", user_id=USER + 1),
+        ])
+        session.commit()
+
+        purge_user_book_data(user_id=USER, session=session)
+        session.commit()
+
+        assert not gz.exists(), "backup gzip (PII) must be removed with the user"
+        assert session.query(ub.KoboAnnotationBackup).count() == 0
+        remaining = session.query(ub.Annotation).one()
+        assert remaining.user_id == USER + 1, "other users' annotations untouched"
+
+    def test_purge_by_user_does_not_touch_shelf_links(self, session):
+        from cps import ub
+        from cps.user_book_data import purge_user_book_data
+        # BookShelf has no user column — shelf membership belongs to the
+        # shelf (handled by the user-delete path via the user's shelves).
+        _shelf_link(session, ub, LOSER, 1, 1)
+        session.commit()
+
+        purge_user_book_data(user_id=USER, session=session)
+        session.commit()
+
+        assert session.query(ub.BookShelf).count() == 1
+
+    def test_book_purge_can_retain_backup_snapshots(self, session, tmp_path):
+        from cps import ub
+        from cps.user_book_data import purge_user_book_data
+        gz = tmp_path / "snapshot.json.gz"
+        gz.write_bytes(b"x")
+        session.add(ub.KoboAnnotationBackup(user_id=USER, book_id=LOSER, content_hash="h",
+                                            file_path=str(gz), size_bytes=1, annotation_count=1))
+        session.commit()
+
+        purge_user_book_data(book_id=LOSER, session=session, remove_backup_files=False)
+        session.commit()
+
+        assert gz.exists()
+        assert session.query(ub.KoboAnnotationBackup).count() == 1, (
+            "remove_backup_files=False keeps the recovery snapshots indexed"
+        )
+
+
+@pytest.mark.unit
+class TestCallSitesPinned:
+    """The four enumeration sites must go through the helpers — RED on main."""
+
+    def test_resolution_loop_migrates_user_data_before_delete(self):
+        src = (REPO / "cps" / "duplicates.py").read_text(encoding="utf-8")
+        body = src.split("def auto_resolve_duplicates", 1)[1].split("\ndef ", 1)[0]
+        migrate = body.find("migrate_user_book_data(deleted_book_id, book_to_keep_id)")
+        delete = body.find("delete_whole_book(deleted_book_id, book)")
+        assert migrate != -1, (
+            "resolving a duplicate must migrate per-user data (annotations, "
+            "progress, shelves) to the kept book for EVERY strategy — D4 data loss"
+        )
+        assert delete != -1 and migrate < delete, (
+            "migration must happen BEFORE the loser is deleted"
+        )
+
+    def test_delete_whole_book_purges_via_helper(self):
+        src = (REPO / "cps" / "editbooks.py").read_text(encoding="utf-8")
+        body = src.split("def delete_whole_book", 1)[1].split("\ndef ", 1)[0]
+        assert "purge_user_book_data(book_id=book_id" in body
+        for stale in ("ub.session.query(ub.BookShelf)", "ub.session.query(ub.ReadBook)",
+                      "ub.session.query(ub.ArchivedBook)", "ub.delete_download("):
+            assert stale not in body, f"hand-list remnant in delete_whole_book: {stale}"
+
+    def test_admin_db_change_wipe_purges_via_helper(self):
+        src = (REPO / "cps" / "admin.py").read_text(encoding="utf-8")
+        idx = src.find("Calibre Database changed")
+        block = src[idx:idx + 800]
+        assert "purge_user_book_data()" in block
+        assert "ub.session.query(ub.Downloads).delete()" not in block
+
+    def test_admin_user_delete_purges_via_helper(self):
+        src = (REPO / "cps" / "admin.py").read_text(encoding="utf-8")
+        body = src.split("def _delete_user", 1)[1].split("\ndef ", 1)[0]
+        assert "purge_user_book_data(user_id=content.id)" in body
+        for stale in ("ub.ReadBook.user_id", "ub.Bookmark.user_id",
+                      "ub.KoboSyncedBooks.user_id", "ub.KoboReadingState.user_id"):
+            assert stale not in body, f"hand-list remnant in _delete_user: {stale}"


### PR DESCRIPTION
## Symptom

Resolving duplicate books loses user data. Whatever you'd done on the removed copies — highlights/notes, read status, Kobo reading position, shelf placement — silently disappeared. `merge_duplicate_group` moved only file formats; keep-newest/oldest moved nothing at all.

## Root cause

Four sites each kept a hand-written list of "every per-user-book table", and the lists disagreed:

| Site | What it missed |
|---|---|
| duplicate resolution loop | everything per-user (only formats merged, and only for strategy=merge) |
| `delete_whole_book` | Annotation(+sync targets), Bookmark, KoboReadingState(+children), KoboSyncedBooks, hidden flags |
| admin DB-change wipe | annotations, KoboBookmark, hidden flags, cover previews, backup index |
| admin per-user delete | the user's Annotation rows + on-disk annotation-backup gzips (**PII surviving account deletion**) |

## Fix

New `cps/user_book_data.py` is the **only** enumerator of the per-user-book model set:

- `migrate_user_book_data(from, to)` — re-points/merges everything onto the kept book. UNIQUE(user,book) tables merge instead of blind re-point: KoboReadingState keeps the newest `last_modified` (children follow), ReadBook keeps the furthest read status and sums started-counts, Annotation dedupes on `(user_id, annotation_id)` with sync-target children deleted explicitly (`passive_deletes` can't rely on SQLite FK enforcement). KoboSyncedBooks markers are deliberately dropped — the kept book is a different file and must sync fresh.
- `purge_user_book_data(book_id/user_id)` — routed from `delete_whole_book` (annotation-backup snapshots deliberately retained as the accidental-delete recovery path), the DB-change wipe, and the per-user delete (backup gzips removed — PII).

The resolution loop migrates before each loser is deleted, **for every strategy**.

## Verification

- 17 unit tests in `tests/unit/test_user_book_data_d4.py`: behavioural (real in-memory app.db ORM) + call-site source pins. Pins are RED on main (verified by stash-run).
- Live cwn-local: seeded annotations on all 5 copies of a duplicate group + read status + shelf membership, ran a real keep-newest resolution across 3 groups → all 5 annotations, the FINISHED status, and the shelf link migrated to the kept book; 0 errors; no orphaned rows; clean log scan.
- CI-style run (`-m 'smoke or unit' -n auto --dist=loadfile`): same single pre-existing flaky failure as main, +17 passing.
- Deliberately not exercised live: the admin per-user-delete HTTP flow (unit-covered; only HTTP wiring differs) and Google-Drive mode.

Part of the duplicate-detection data-safety series (D1 #394, D2 #397, D3/D11 #399, #409). Also fixes the reader-program blocker: annotations now survive duplicate merges.