### PR TITLE
fix(shelf): drop the legacy shelforder body class from the reorder grid page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- Shelf reorder: the giant white sort icon (a down arrow with lines) that sat on
+  top of the first covers on wide screens is gone. It was a leftover decoration
+  from the old list-style reorder page — the theme drew it in what used to be
+  empty space, and the new cover grid now fills that space. The wider your
+  browser window, the bigger the icon got. (#320, reported with screenshots by
+  @SpookyUSAF — the covers themselves were already the right size; this was the
+  last piece.)
 - Resolving duplicate books no longer loses your highlights, notes, reading
   progress, or shelf placement. When duplicates were merged or resolved, only
   the book files moved to the kept copy — anything you'd done on the removed

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -442,7 +442,7 @@ def order_shelf(shelf_id):
                 .filter(ub.BookShelf.shelf == shelf_id).order_by(ub.BookShelf.order.asc()).all()
         return render_title_template('shelf_order.html', entries=result,
                                      title=_("Change order of Shelf: '%(name)s'", name=shelf.name),
-                                     shelf=shelf, page="shelforder")
+                                     shelf=shelf, page="shelfreorder")
     else:
         abort(404)
 

--- a/cps/static/js/caliBlur.js
+++ b/cps/static/js/caliBlur.js
@@ -747,8 +747,8 @@ $("#nav_new a:contains('Recently')").contents().filter(function () {
 shelfText = $(".shelf .discover h2:first").text().replace(":", " —").replace(/\'/g, "");
 $(".shelf .discover h2:first").text(shelfText);
 
-shelfText = $(".shelforder .col-sm-10 .col-sm-6.col-lg-6.col-xs-6 h2:first").text().replace(':', ' —').replace(/\'/g, "");
-$(".shelforder .col-sm-10 .col-sm-6.col-lg-6.col-xs-6 h2:first").text(shelfText);
+shelfText = $(".shelfreorder .col-sm-10 .col-sm-6.col-lg-6.col-xs-6 h2:first").text().replace(':', ' —').replace(/\'/g, "");
+$(".shelfreorder .col-sm-10 .col-sm-6.col-lg-6.col-xs-6 h2:first").text(shelfText);
 
 
 function mobileSupport() {

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -117,7 +117,7 @@ $(_kobo_padding_color_sync);
 
 // Syntax has to be bind not on, otherwise problems with firefox
 $(".container-fluid").bind("dragenter dragover", function () {
-    if($("#btn-upload").length && !$('body').hasClass('shelforder')) {
+    if($("#btn-upload").length && !$('body').hasClass('shelfreorder')) {
         $(this).css('background', '#e6e6e6');
     }
     return false;
@@ -125,7 +125,7 @@ $(".container-fluid").bind("dragenter dragover", function () {
 
 // Syntax has to be bind not on, otherwise problems with firefox
 $(".container-fluid").bind("dragleave", function () {
-    if($("#btn-upload").length && !$('body').hasClass('shelforder')) {
+    if($("#btn-upload").length && !$('body').hasClass('shelfreorder')) {
         $(this).css('background', '');
     }
     return false;

--- a/tests/unit/test_320_reorder_legacy_glyph.py
+++ b/tests/unit/test_320_reorder_legacy_glyph.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""fork #320 (@SpookyUSAF): the redesigned shelf-reorder page must not wear the
+legacy ``shelforder`` body class.
+
+caliBlur.css carries a block of rules for the OLD list-based reorder page, keyed
+on ``body.shelforder``. One of them paints a decorative sort glyph as a
+fixed-position pseudo-element on the layout wrapper itself::
+
+    body.shelforder > div.container-fluid > div.row-fluid > div.col-sm-10:before {
+        content: "\\e155";            /* glyphicon sort-by-attributes */
+        font-size: 6vw;
+        position: fixed; left: 240px; top: 180px;
+    }
+
+On the old page the content sat 20% from the left, so the glyph decorated the
+empty gutter. The redesigned cover grid fills the full width, so the glyph — a
+giant white "down arrow + lines" icon, 117px at a 1955px viewport — renders on
+top of the first covers. (The reporter's screenshots: covers correctly 150x225,
+shelf_reorder.css loading 200, and still a huge icon over the grid.)
+
+The fix gives the redesigned page its own body class, ``shelfreorder``, so the
+whole legacy caliBlur block is inert for it. These tests pin that:
+
+* shelf.py renders the reorder page with ``page="shelfreorder"`` (layout.html
+  emits ``page`` as the body class) and never with the legacy name;
+* main.js's drag-upload background gates follow the rename (they suppress the
+  upload drop-zone flash while dragging covers on this page);
+* the legacy glyph rule still targets only ``body.shelforder`` — if a future
+  caliBlur sync rewrites it to a selector the new page matches, this fails.
+"""
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _read(*parts):
+    return REPO.joinpath(*parts).read_text(encoding="utf-8")
+
+
+def test_reorder_route_uses_new_body_class():
+    src = _read("cps", "shelf.py")
+    assert 'page="shelfreorder"' in src, (
+        "the reorder route must render with page=\"shelfreorder\" — the legacy "
+        "\"shelforder\" class pulls in caliBlur's old-page rules, including the "
+        "fixed 6vw sort glyph that covers the grid (#320)"
+    )
+    assert 'page="shelforder"' not in src, (
+        "no route may use the legacy \"shelforder\" page class (#320)"
+    )
+
+
+def test_mainjs_upload_gates_follow_rename():
+    src = _read("cps", "static", "js", "main.js")
+    assert "hasClass('shelfreorder')" in src, (
+        "main.js must gate the drag-upload background flash on the new "
+        "'shelfreorder' body class (dragging covers is the page's own interaction)"
+    )
+    assert "hasClass('shelforder')" not in src, (
+        "stale 'shelforder' gate in main.js — the body class was renamed (#320)"
+    )
+
+
+def test_legacy_glyph_rule_stays_scoped_to_old_class():
+    css = _read("cps", "static", "css", "caliBlur.css")
+    # Find every rule block whose declarations include the \e155 glyph.
+    for match in re.finditer(r"([^{}]+)\{([^{}]*\\e155[^{}]*)\}", css):
+        selector = match.group(1).strip().splitlines()[-1].strip()
+        assert "shelforder" in selector and "shelfreorder" not in selector, (
+            "the caliBlur \\e155 sort-glyph rule must stay keyed to the legacy "
+            "body.shelforder class only — the redesigned grid page "
+            "(body.shelfreorder) must never match it (#320): %r" % selector
+        )


### PR DESCRIPTION
## Symptom (#320, @SpookyUSAF)

A giant white sort icon (down arrow + lines) renders on top of the first covers of the shelf-reorder grid on wide screens — covers themselves are correctly sized (150x225) and `shelf_reorder.css` loads with 200. The reporter's screenshots finally pinned the real element: it was never the covers.

## Root cause

The redesigned grid page kept the old list page's `shelforder` body class. `caliBlur.css:468` paints a decorative glyph (`\e155`, sort-by-attributes) as a **fixed-position `::before` on the layout wrapper** at `font-size: 6vw` — on the old page the content sat 20% from the left, so the glyph decorated the empty gutter; the new grid fills the full width, so the glyph lands on the covers, growing with the viewport (117px at the reporter's 1955px window). A mobile media query shrinks it to a corner badge, which is why phone-width verification passed.

## Fix

The redesigned page gets its own body class: `page="shelfreorder"` (cps/shelf.py), making the entire legacy caliBlur `shelforder` block inert. main.js's drag-upload background gates follow the rename; the dead caliBlur.js title-transform selector renamed for consistency. No CSS changes — the legacy rules stay for nothing else matches them.

## Verification

- **RED (live, OBSERVED)**: cwn-local caliBlur @ 1955x1124 reproduced the reporter's exact symptom — `::before` computed `fixed, left 240px, top 180px, 117.3px Glyphicons Halflings` (/tmp/320-red-desktop-1955.jpg matches the reporter's screenshot).
- **GREEN (live, OBSERVED)**: after the rename, `content: none / position: static` at 1955, 1280, and 390 widths; grid renders identically, drag order intact (book-id walk via DOM).
- **Tests**: `tests/unit/test_320_reorder_legacy_glyph.py` — 2 source pins RED on pre-fix code, plus a guard that the \e155 rule stays scoped to the legacy class; 45 total green across the 4 shelf-reorder test files.
- Deliberately not exercised: non-caliBlur default theme (the glyph rule is caliBlur-only), Google-Drive mode (no interaction).

Greptile at monthly cap. Security review not run — CSS/body-class rename, no auth/route/file-path surface (per review policy).