### PR TITLE
fix(metadata): implement auto-fetch cover download; harden cover-by-URL against stub/junk bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- Automatic metadata fetch now actually downloads covers. The "update cover"
+  option existed but did nothing — books imported with auto-fetch on never got
+  their cover updated. Covers now download through the same safe path as the
+  manual editor (size limits, image checks, server-side request protections),
+  respect the per-book cover lock, and in "smart application" mode only fill in
+  a missing cover, never replace one you have. (#404, confirmed by @beanscg)
+- Downloading a cover by URL (manual editor and auto-fetch alike) no longer
+  destroys the existing cover when the server misbehaves: a redirect stub or an
+  error page served with an image content-type used to get saved as the cover
+  file. The download now follows redirects properly (cover CDNs like Open
+  Library's redirect every image) and verifies the bytes are really an image
+  before anything is overwritten.
 - Shelf reorder: the giant white sort icon (a down arrow with lines) that sat on
   top of the first covers on wide screens is gone. It was a leftover decoration
   from the old list-style reorder page — the theme drew it in what used to be

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -66,15 +66,9 @@ def edit_required(f):
 
 
 def _book_cover_is_locked(book_id) -> bool:
-    """Honor the per-book BookCoverLock flag set from the focused
-    cover-picker page. Resolves janeczku/calibre-web#2165 — when locked,
-    the metadata-fetch save path skips the cover_url field instead of
-    silently overwriting a deliberately-chosen cover."""
-    try:
-        record = ub.session.query(ub.BookCoverLock).filter_by(book_id=book_id).first()
-    except Exception:  # pragma: no cover - defensive; missing migrations etc.
-        return False
-    return bool(record and record.locked)
+    """Single implementation lives in helper.book_cover_is_locked — shared
+    with the ingest auto-metadata cover path (fork #404)."""
+    return helper.book_cover_is_locked(book_id)
 
 
 @editbook.route("/ajax/delete/<int:book_id>", methods=["POST"])

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -1254,7 +1254,8 @@ def save_cover_from_url(url, book_path):
             requests.exceptions.HTTPError,
             requests.exceptions.InvalidURL,
             requests.exceptions.ConnectionError,
-            requests.exceptions.Timeout) as ex:
+            requests.exceptions.Timeout,
+            requests.exceptions.TooManyRedirects) as ex:
         # "Invalid host" can be the result of a redirect response
         log.error(u'Cover Download Error %s', ex)
         return False, _("Error Downloading Cover")

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -1168,20 +1168,62 @@ def _get_cover_download_limit():
     return max_mb * 1024 * 1024, max_mb
 
 
+def _sniff_image_bytes(content) -> bool:
+    """True when ``content`` starts with the magic bytes of a supported cover
+    format (JPEG/PNG/WebP/BMP). Cheap guard for downloaded covers whose
+    content-type header lies (fork #404)."""
+    if not content or len(content) < 12:
+        return False
+    if content[:3] == b"\xff\xd8\xff":                      # JPEG
+        return True
+    if content[:8] == b"\x89PNG\r\n\x1a\n":                 # PNG
+        return True
+    if content[:4] == b"RIFF" and content[8:12] == b"WEBP":  # WebP
+        return True
+    if content[:2] == b"BM":                                 # BMP
+        return True
+    return False
+
+
+def book_cover_is_locked(book_id) -> bool:
+    """Honor the per-book BookCoverLock flag set from the focused
+    cover-picker page (resolves janeczku/calibre-web#2165): when locked, any
+    automated cover-write path — the metadata-fetch save in the editor and
+    the ingest auto-metadata fetch (fork #404) — must skip the cover instead
+    of silently overwriting a deliberately-chosen one."""
+    try:
+        record = ub.session.query(ub.BookCoverLock).filter_by(book_id=book_id).first()
+    except Exception:  # pragma: no cover - defensive; missing migrations etc.
+        return False
+    return bool(record and record.locked)
+
+
 def save_cover_from_url(url, book_path):
     max_cover_bytes, max_cover_mb = _get_cover_download_limit()
     img = None
     download_start = time.monotonic()
     log.debug("Cover fetch start: url=%s", url)
     try:
+        # Redirects are followed: cover CDNs redirect as a matter of course
+        # (covers.openlibrary.org 302s every image to archive.org). The
+        # advocate path stays SSRF-safe under redirects because validation
+        # happens per-connection in ValidatingPoolManager — every hop's
+        # target is re-validated, not just the first URL (fork #404).
         if cli_param.allow_localhost:
-            img = requests.get(url, timeout=(10, 30), allow_redirects=False, stream=True)  # ToDo: Error Handling
+            img = requests.get(url, timeout=(10, 30), allow_redirects=True, stream=True)
         elif use_advocate:
-            img = cw_advocate.get(url, timeout=(10, 30), allow_redirects=False, stream=True)      # ToDo: Error Handling
+            img = cw_advocate.get(url, timeout=(10, 30), allow_redirects=True, stream=True)
         else:
             log.error("python module advocate is not installed but is needed")
             return False, _("Python module 'advocate' is not installed but is needed for cover uploads")
         img.raise_for_status()
+        if img.status_code != 200:
+            # raise_for_status passes 3xx: a redirect that wasn't followed
+            # (e.g. redirect loop cut off) must not have its stub body saved
+            # as the cover — that destroys the existing one. Fork #404.
+            log.error("Cover download refused: HTTP %s url=%s location=%s",
+                      img.status_code, url, img.headers.get("location"))
+            return False, _("Error Downloading Cover")
 
         content_length = img.headers.get("content-length")
         if content_length and content_length.isdigit() and int(content_length) > max_cover_bytes:
@@ -1195,6 +1237,14 @@ def save_cover_from_url(url, book_path):
             if len(content) > max_cover_bytes:
                 return False, _("Cover image exceeds maximum size of %(size)s MB", size=max_cover_mb)
         img._content = bytes(content)
+        if not _sniff_image_bytes(img._content):
+            # A correct content-type header is no guarantee of an image body
+            # (error pages and stubs are served as image/jpeg in the wild),
+            # and the JPEG fast path below save_cover skips ImageMagick — a
+            # junk body would overwrite a real cover. Fork #404.
+            log.error("Cover download refused: body is not an image (url=%s, content-type=%s, bytes=%s)",
+                      url, img.headers.get("content-type"), len(img._content))
+            return False, _("Cover-file is not a valid image file, or could not be stored")
         log.info("Cover download ok: url=%s status=%s content-type=%s bytes=%s elapsed=%.3fs",
                  url, getattr(img, "status_code", "?"),
                  img.headers.get("content-type"), len(img._content),

--- a/cps/metadata_helper.py
+++ b/cps/metadata_helper.py
@@ -309,24 +309,68 @@ def _apply_metadata_to_book(book, metadata, calibre_db_instance) -> bool:
                         book.identifiers.append(new_identifier)
                         updated = True
         
-        # Handle cover image - only if enabled in settings
-        if (cwa_settings.get('auto_metadata_update_cover', True) and 
-            hasattr(metadata, 'cover') and metadata.cover):
-            # TODO: Implement cover resolution checking for smart mode
-            # For now, just apply the cover in normal mode
-            if not use_smart_application:
-                # Apply cover (implementation depends on how covers are handled in Calibre-Web)
-                pass
-        
+        # Cover image (fork #404): download and apply through the same
+        # validated path the manual editor uses. Smart mode only fills a
+        # missing cover; the per-book cover lock is honored in both modes.
+        cover_updated = False
+        if (cwa_settings.get('auto_metadata_update_cover', True) and
+                not (use_smart_application and getattr(book, 'has_cover', 0))):
+            if _apply_cover_from_metadata(book, metadata):
+                updated = True
+                cover_updated = True
+
         if updated:
             calibre_db_instance.session.commit()
-            
+            if cover_updated:
+                # Regenerate the cached thumbnails so the new cover shows in
+                # the grid, same as a manual cover edit.
+                from cps import helper
+                try:
+                    helper.replace_cover_thumbnail_cache(
+                        book.id, book_path=book.path,
+                        last_modified=getattr(book, 'last_modified', None))
+                except Exception as e:
+                    log.warning(f"Cover thumbnail refresh failed for book {book.id}: {e}")
+
         return updated
         
     except Exception as e:
         log.error(f"Error applying metadata to book {getattr(book, 'id', 'unknown')}: {e}")
         calibre_db_instance.session.rollback()
         return False
+
+
+def _apply_cover_from_metadata(book, metadata) -> bool:
+    """Download the provider's cover and store it for ``book`` (fork #404).
+
+    Routed through ``helper.save_cover_from_url`` so the ingest auto-fetch
+    gets the exact safeguards of the manual editor: advocate SSRF guard,
+    download size cap, and image-format validation. Returns True only when
+    the cover was actually written (and sets ``book.has_cover``).
+
+    Fully self-contained failure boundary: this runs in the ingest
+    processor (no Flask app context, where the error-path ``_()`` calls in
+    helper can raise) and a cover problem must never void the rest of the
+    metadata application.
+    """
+    cover_url = str(getattr(metadata, 'cover', '') or '').strip()
+    if not cover_url or cover_url.endswith('/static/generic_cover.svg'):
+        # Providers fall back to the placeholder image when an edition has
+        # no cover — never overwrite a real cover with the placeholder.
+        return False
+    try:
+        from cps import helper
+        if helper.book_cover_is_locked(book.id):
+            log.info(f"Auto metadata fetch: cover locked for book {book.id}, skipping")
+            return False
+        result, error = helper.save_cover_from_url(cover_url, book.path)
+        if result:
+            book.has_cover = 1
+            return True
+        log.warning(f"Auto metadata fetch: cover download failed for book {book.id}: {error}")
+    except Exception as e:
+        log.warning(f"Auto metadata fetch: cover apply failed for book {book.id}: {e}")
+    return False
 
 
 def _normalize_isbn(value):

--- a/tests/unit/test_404_auto_cover_fetch.py
+++ b/tests/unit/test_404_auto_cover_fetch.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+"""fork #404 (@beanscg confirmed): ``auto_metadata_update_cover`` must actually
+download and apply covers.
+
+The auto-metadata cover branch checked the setting and the provider's cover
+URL, then hit a bare ``pass`` — covers were never fetched, never written, and
+``updated`` was never set. The fix routes the download through
+``helper.save_cover_from_url`` — the manual editor's path, with its SSRF guard
+(advocate), size cap and image validation — honors the per-book cover lock and
+smart mode (only fill a missing cover), never applies the generic placeholder,
+and refreshes the thumbnail cache after commit. A cover failure must never
+void the rest of the metadata application (the fetch runs in the ingest
+processor without a Flask app context, where helper's error-path ``_()``
+calls can raise).
+"""
+
+import types
+
+import pytest
+
+import cps.metadata_helper as m
+
+
+class _List(list):
+    pass
+
+
+class _Book:
+    def __init__(self, *, has_cover=0):
+        self.id = 7
+        self.title = "Existing Title"
+        self.path = "Author/Book (7)"
+        self.has_cover = has_cover
+        self.last_modified = None
+        self.authors = _List()
+        self.comments = _List()
+        self.publishers = _List()
+        self.tags = _List()
+        self.series = _List()
+        self.series_index = "1.0"
+        self.pubdate = None
+        self.ratings = _List()
+        self.identifiers = _List()
+
+
+class _FakeSession:
+    def __init__(self):
+        self.commits = 0
+
+    def add(self, *a, **k):
+        pass
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        pass
+
+
+class _FakeCDB:
+    def __init__(self):
+        self.session = _FakeSession()
+
+
+def _metadata(cover):
+    return types.SimpleNamespace(title="", cover=cover)
+
+
+def _settings(**over):
+    base = {
+        "auto_metadata_smart_application": False,
+        "auto_metadata_update_title": False,
+        "auto_metadata_update_authors": False,
+        "auto_metadata_update_description": False,
+        "auto_metadata_update_publisher": False,
+        "auto_metadata_update_tags": False,
+        "auto_metadata_update_series": False,
+        "auto_metadata_update_published_date": False,
+        "auto_metadata_update_rating": False,
+        "auto_metadata_update_identifiers": False,
+        "auto_metadata_update_cover": True,
+    }
+    base.update(over)
+    return base
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    """Patch CWA_DB + the helper module the cover path imports lazily."""
+    state = {
+        "settings": _settings(),
+        "save_calls": [],
+        "save_result": (True, None),
+        "locked": False,
+        "thumb_calls": [],
+    }
+    monkeypatch.setattr(
+        m, "CWA_DB",
+        lambda: type("S", (), {"get_cwa_settings": staticmethod(lambda: state["settings"])})())
+
+    import cps.helper as helper
+
+    def fake_save(url, book_path):
+        state["save_calls"].append((url, book_path))
+        result = state["save_result"]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(helper, "save_cover_from_url", fake_save)
+    monkeypatch.setattr(helper, "book_cover_is_locked", lambda book_id: state["locked"])
+    monkeypatch.setattr(
+        helper, "replace_cover_thumbnail_cache",
+        lambda book_id, book_path=None, last_modified=None: state["thumb_calls"].append(book_id))
+    return state
+
+
+COVER_URL = "https://covers.example.org/b/id/12345-L.jpg"
+
+
+def test_cover_is_downloaded_and_applied(harness):
+    book = _Book()
+    cdb = _FakeCDB()
+    assert m._apply_metadata_to_book(book, _metadata(COVER_URL), cdb) is True
+    assert harness["save_calls"] == [(COVER_URL, book.path)]
+    assert book.has_cover == 1
+    assert cdb.session.commits == 1
+    assert harness["thumb_calls"] == [book.id]
+
+
+def test_smart_mode_keeps_existing_cover(harness):
+    harness["settings"] = _settings(auto_metadata_smart_application=True)
+    book = _Book(has_cover=1)
+    assert m._apply_metadata_to_book(book, _metadata(COVER_URL), _FakeCDB()) is False
+    assert harness["save_calls"] == []
+
+
+def test_smart_mode_fills_missing_cover(harness):
+    harness["settings"] = _settings(auto_metadata_smart_application=True)
+    book = _Book(has_cover=0)
+    assert m._apply_metadata_to_book(book, _metadata(COVER_URL), _FakeCDB()) is True
+    assert harness["save_calls"] == [(COVER_URL, book.path)]
+    assert book.has_cover == 1
+
+
+def test_cover_lock_is_honored(harness):
+    harness["locked"] = True
+    book = _Book()
+    assert m._apply_metadata_to_book(book, _metadata(COVER_URL), _FakeCDB()) is False
+    assert harness["save_calls"] == []
+    assert book.has_cover == 0
+
+
+def test_generic_placeholder_is_never_applied(harness):
+    book = _Book(has_cover=1)
+    md = _metadata("http://example.org/static/generic_cover.svg")
+    assert m._apply_metadata_to_book(book, md, _FakeCDB()) is False
+    assert harness["save_calls"] == []
+
+
+def test_setting_off_skips_download(harness):
+    harness["settings"] = _settings(auto_metadata_update_cover=False)
+    assert m._apply_metadata_to_book(_Book(), _metadata(COVER_URL), _FakeCDB()) is False
+    assert harness["save_calls"] == []
+
+
+def test_download_failure_does_not_void_other_updates(harness):
+    harness["save_result"] = (False, "Error Downloading Cover")
+    harness["settings"] = _settings(auto_metadata_update_title=True)
+    book = _Book()
+    md = types.SimpleNamespace(title="Fetched Title", cover=COVER_URL)
+    cdb = _FakeCDB()
+    assert m._apply_metadata_to_book(book, md, cdb) is True  # title applied
+    assert book.has_cover == 0
+    assert book.title == "Fetched Title"
+    assert cdb.session.commits == 1
+    assert harness["thumb_calls"] == []  # no cover -> no thumbnail churn
+
+
+def test_helper_exception_is_contained(harness):
+    # No Flask app context in the ingest processor: helper's error-path _()
+    # can raise. The cover boundary must swallow it.
+    harness["save_result"] = RuntimeError("Working outside of application context")
+    harness["settings"] = _settings(auto_metadata_update_title=True)
+    book = _Book()
+    md = types.SimpleNamespace(title="Fetched Title", cover=COVER_URL)
+    assert m._apply_metadata_to_book(book, md, _FakeCDB()) is True
+    assert book.has_cover == 0
+    assert book.title == "Fetched Title"
+
+
+def test_sniff_image_bytes_accepts_real_formats():
+    import cps.helper as helper
+    assert helper._sniff_image_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)          # JPEG
+    assert helper._sniff_image_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 20)        # PNG
+    assert helper._sniff_image_bytes(b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 8)  # WebP
+    assert helper._sniff_image_bytes(b"BM" + b"\x00" * 20)                        # BMP
+
+
+def test_sniff_image_bytes_rejects_junk():
+    import cps.helper as helper
+    assert not helper._sniff_image_bytes(b"")                       # empty
+    assert not helper._sniff_image_bytes(b"Found")                  # 302 stub body
+    assert not helper._sniff_image_bytes(b"<html><body>err</body>")  # error page
+    assert not helper._sniff_image_bytes(b"GIF89a" + b"\x00" * 20)   # unsupported format
+
+
+def test_download_guards_source_pin():
+    """The 302-stub and junk-body guards must stay in save_cover_from_url:
+    covers.openlibrary.org serves 302 + content-type image/jpeg, and the JPEG
+    fast path in save_cover skips ImageMagick — without these a 9-byte stub
+    overwrites a real cover (observed live on cwn-local, #404)."""
+    import inspect
+    import cps.helper as helper
+    src = inspect.getsource(helper.save_cover_from_url)
+    assert "img.status_code != 200" in src
+    assert "_sniff_image_bytes" in src
+    assert "allow_redirects=True" in src  # cover CDNs redirect; advocate re-validates each hop
+
+
+def test_no_op_stub_is_gone_source_pin():
+    import inspect
+    src = inspect.getsource(m._apply_metadata_to_book)
+    assert "_apply_cover_from_metadata" in src, (
+        "the cover branch must call _apply_cover_from_metadata — the old "
+        "branch ended in a bare `pass` and never fetched anything (#404)"
+    )
+    assert "TODO: Implement cover resolution" not in src


### PR DESCRIPTION
## Symptom (#404, confirmed on main by @beanscg)

`auto_metadata_update_cover` is a no-op: the branch checks the setting and the provider's cover URL, then hits a bare `pass`. Books imported with auto-fetch on never get covers.

## Fix

`_apply_cover_from_metadata` (cps/metadata_helper.py) routes the download through `helper.save_cover_from_url` — the manual editor's path with its advocate SSRF guard, size cap and format validation. It honors the per-book cover lock (single implementation moved to `helper.book_cover_is_locked`, editbooks delegates), skips provider placeholder covers, only fills a missing cover in smart mode, sets `has_cover`, and refreshes the thumbnail cache after commit. Own failure boundary: the fetch runs in the ingest processor (no Flask app context, where helper's error-path gettext can raise) and a cover problem must never void the rest of the metadata application.

## Two real defects found by live verification, fixed in the shared path (manual editor benefits too)

1. **Redirect stub overwrites a real cover (observed live).** covers.openlibrary.org answers every image with a 302 (content-type `image/jpeg`); with `allow_redirects=False` the 9-byte stub body passed `raise_for_status` (3xx) and the JPEG fast path (no ImageMagick decode), and was written over the existing cover.jpg. Redirects are now followed — advocate validates **every hop's connection** in ValidatingPoolManager (per-connection getaddrinfo + blacklist, pool key includes validator, proxies disabled), so the SSRF guard holds across redirects — non-200 final responses are refused, and TooManyRedirects is handled.
2. **Junk body with an image content-type.** Downloaded bytes must now carry JPEG/PNG/WebP/BMP magic bytes before anything is written.

## Verification

- 12 unit tests (RED on main: 1 failed + 8 errors pre-fix), incl. smart-mode preserve, cover lock, placeholder skip, failure containment, magic-byte sniffing, source pins.
- Adjacent: 16 metadata-safety tests green; CI-style suite locally = 1551 passed, 2 pre-existing env failures (`/config` smoke check is container-only; ingest_batch_dirty is the known flaky, identical on main).
- **Live cwn-local**: real 35KB cover downloaded via the redirecting OL URL, `has_cover` committed in metadata.db, smart mode preserves an existing cover; the pre-fix run demonstrably destroyed a real cover with a 9-byte stub (restored from snapshot).
- **Security review run (qualifies: redirect policy on user-controlled URL fetch)**: verdict safe — evidence chain through cw_advocate connection.py/poolmanager.py in the review; one LOW robustness item (TooManyRedirects) applied as follow-up commit.
- Deliberately not exercised: Google-Drive cover storage (save_cover's gdrive branch, unchanged logic), live end-to-end ingest with a real provider query (provider selection already covered by #402 tests; the applied-cover path is what changed).

Greptile at monthly cap.