### PR TITLE
fix(kosync): mirror KOReader read-status to the configured Calibre custom read column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- Finishing a book in KOReader now marks it read on the website when you use a
+  custom "read" column. If your admin set a Calibre custom column as the read
+  marker (a stock option under Feature Configuration), KOReader completions
+  only wrote the built-in read list, so the book page checkmark stayed empty.
+  The sync now also sets the custom column — and only ever sets it: re-opening
+  a finished book never silently un-reads it.
 - Automatic metadata fetch now actually downloads covers. The "update cover"
   option existed but did nothing — books imported with auto-fetch on never got
   their cover updated. Covers now download through the same safe path as the

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -47,7 +47,7 @@ from flask import Blueprint, request, jsonify
 from flask_babel import gettext as _
 from werkzeug.security import check_password_hash
 from sqlalchemy import func, desc
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import SQLAlchemyError, OperationalError, InvalidRequestError
 
 from ... import logger, ub, csrf, config, constants, services, usermanagement
 from ...render_template import render_title_template
@@ -461,6 +461,48 @@ def update_book_read_status(user, book_id: int, percentage: float) -> None:
 
     # Merge the record (caller commits)
     ub.session.merge(book_read)
+
+    # Mirror the web read-status path (helper.edit_book_read_status): when an admin has
+    # designated a Calibre custom column as the read marker, the book detail page reads
+    # read-status from THAT column, not ub.ReadBook. The ReadBook write above stays intact
+    # (Kobo cross-sync and the default UI read from it), but for custom-column users a
+    # KOReader completion never reached the column, so the checkmark stayed empty (#312,
+    # custom-column subset). Sticky semantics: we only SET the marker on FINISHED and never
+    # clear it from a sync, so re-opening a finished book in KOReader can't silently un-read
+    # it — un-marking stays a manual web toggle, matching "mark as read" intent.
+    if config.config_read_column and new_status == ub.ReadBook.STATUS_FINISHED:
+        _mark_custom_read_column(book_id)
+
+
+def _mark_custom_read_column(book_id: int) -> None:
+    """Set the configured Calibre custom read-column for ``book_id`` to truthy.
+
+    Mirrors the custom-column branch of ``helper.edit_book_read_status`` for the
+    kosync path, which has no Flask ``current_user``. Calibre custom read-columns
+    are book-level (not per-user), so no user scoping is needed — same as the web
+    path, which writes the column without a user filter.
+
+    Best-effort: a missing column or a metadata.db error is logged, never raised,
+    so a custom-column hiccup can't break progress sync (the ReadBook write has
+    already happened and the caller still commits app.db).
+    """
+    from ... import calibre_db, db  # lazy: calibre_db instance + reflected cc_classes
+    cfg = config.config_read_column
+    try:
+        book = calibre_db.get_filtered_book(book_id, True)
+        read_status = getattr(book, 'custom_column_' + str(cfg))
+        if len(read_status):
+            read_status[0].value = True
+        else:
+            cc_class = db.cc_classes[cfg]
+            calibre_db.session.add(cc_class(value=1, book=book_id))
+        calibre_db.session.commit()
+        log.info("kosync read-status: marked book %s read via custom column No.%s", book_id, cfg)
+    except (KeyError, AttributeError, IndexError):
+        log.error("kosync read-status: custom column No.%s does not exist in calibre database", cfg)
+    except (OperationalError, InvalidRequestError) as ex:
+        calibre_db.session.rollback()
+        log.error("kosync read-status: custom column write failed: %s", ex)
 
 
 def get_progress_record(user_id, document_checksum, book_id) -> KOSyncProgress:

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -489,7 +489,15 @@ def _mark_custom_read_column(book_id: int) -> None:
     from ... import calibre_db, db  # lazy: calibre_db instance + reflected cc_classes
     cfg = config.config_read_column
     try:
-        book = calibre_db.get_filtered_book(book_id, True)
+        # get_book, not get_filtered_book: kosync auths via headers, so flask-login's
+        # current_user is the ANONYMOUS user here — get_filtered_book would apply the
+        # anonymous content/language/tag restrictions (and the restricted-column error
+        # path even calls flash()), silently filtering the book to None and dropping
+        # the marker. The syncing user's access was already established by the sync flow.
+        book = calibre_db.get_book(book_id)
+        if book is None:
+            log.error("kosync read-status: book %s not found in calibre database", book_id)
+            return
         read_status = getattr(book, 'custom_column_' + str(cfg))
         if len(read_status):
             read_status[0].value = True

--- a/tests/unit/test_kosync_custom_read_column.py
+++ b/tests/unit/test_kosync_custom_read_column.py
@@ -1,0 +1,116 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for fork #312 (custom-column subset) — the KOReader sync
+read-status write must honor ``config.config_read_column``, mirroring the web
+path ``helper.edit_book_read_status``.
+
+Before the fix, ``update_book_read_status`` wrote only ``ub.ReadBook``. A user
+who configured a Calibre custom column as their read marker (a stock
+Calibre-Web option) got KOReader completions written to a ``ReadBook`` row their
+detail page never reads, so the "read" checkmark stayed empty — the exact #312
+symptom, re-introduced for the custom-column subset of users.
+
+The behavioral red/green lives in the docker-integration suite (the custom-column
+write needs real Calibre ``cc_classes`` reflection + metadata.db). These are
+source pins: cheap CI-runnable invariants that fail RED if the mirror is dropped
+or its sticky/guard semantics drift, so a future refactor can't silently undo
+the fix while the slow integration test is path-skipped.
+"""
+
+import inspect
+import sys
+
+import pytest
+
+
+def _kosync_module():
+    """Return the kosync *module* (not the re-exported Blueprint).
+
+    ``cps.progress_syncing.protocols.__init__`` does ``from .kosync import
+    kosync``, binding the Blueprint object as ``protocols.kosync`` and shadowing
+    the submodule attribute. The module itself stays in ``sys.modules``.
+    """
+    import cps.progress_syncing.protocols.kosync  # noqa: F401 — populate sys.modules
+    return sys.modules["cps.progress_syncing.protocols.kosync"]
+
+
+@pytest.fixture(scope="module")
+def kosync():
+    return _kosync_module()
+
+
+class TestCustomReadColumnMirrorExists:
+    def test_mark_custom_read_column_helper_defined(self, kosync):
+        """A dedicated single-concern helper writes the custom read column."""
+        assert hasattr(kosync, "_mark_custom_read_column"), (
+            "kosync must define _mark_custom_read_column to mirror the web "
+            "path's config_read_column branch for the KOReader sync path (#312)"
+        )
+        assert callable(kosync._mark_custom_read_column)
+
+    def test_update_status_gates_mirror_on_read_column_and_finished(self, kosync):
+        """update_book_read_status routes FINISHED completions to the column
+        ONLY when config_read_column is set (default ReadBook path untouched),
+        and only on FINISHED (sticky — a sync never clears the marker)."""
+        src = inspect.getsource(kosync.update_book_read_status)
+        assert "config.config_read_column" in src, (
+            "update_book_read_status must branch on config.config_read_column; "
+            "without it KOReader completions never reach a custom read column (#312)"
+        )
+        assert "_mark_custom_read_column" in src, (
+            "update_book_read_status must call _mark_custom_read_column"
+        )
+        # Sticky semantics: the mirror is gated on FINISHED, so re-opening a
+        # finished book in KOReader (a later <99% sync) cannot un-read it.
+        assert "STATUS_FINISHED" in src
+        gate = src[src.index("config.config_read_column"):]
+        assert "STATUS_FINISHED" in gate, (
+            "the custom-column mirror must be gated on STATUS_FINISHED (sticky "
+            "mark-as-read), not fired on every status"
+        )
+
+
+class TestCustomReadColumnMirrorMatchesWebPath:
+    """The mirror must use the same Calibre custom-column write idiom as
+    helper.edit_book_read_status, so both surfaces stay consistent."""
+
+    def test_uses_calibre_db_and_cc_classes(self, kosync):
+        src = inspect.getsource(kosync._mark_custom_read_column)
+        assert "calibre_db.get_filtered_book" in src, (
+            "must read the book via calibre_db.get_filtered_book like the web path"
+        )
+        assert "custom_column_" in src, (
+            "must address the custom column via getattr(book, 'custom_column_'+id)"
+        )
+        assert "cc_classes" in src, (
+            "must create a missing column row via db.cc_classes[...] like the web path"
+        )
+        assert "calibre_db.session.commit" in src, (
+            "must commit the metadata.db (calibre_db) session for the column write"
+        )
+
+    def test_guards_missing_column_and_db_errors(self, kosync):
+        """Best-effort: a missing column / metadata.db error is logged, never
+        raised, so a custom-column hiccup can't break progress sync."""
+        src = inspect.getsource(kosync._mark_custom_read_column)
+        for exc in ("KeyError", "AttributeError", "IndexError"):
+            assert exc in src, f"missing-column guard must catch {exc}"
+        for exc in ("OperationalError", "InvalidRequestError"):
+            assert exc in src, f"metadata.db write guard must catch {exc}"
+        assert "rollback" in src, (
+            "must roll back calibre_db.session on a write error (mirror web path)"
+        )
+
+    def test_book_level_not_user_scoped(self, kosync):
+        """Calibre custom read-columns are book-level, not per-user — the helper
+        takes a book_id and no user, matching the web path which writes the
+        column without a user filter."""
+        sig = inspect.signature(kosync._mark_custom_read_column)
+        params = list(sig.parameters)
+        assert params == ["book_id"], (
+            f"_mark_custom_read_column should take only book_id, got {params}"
+        )

--- a/tests/unit/test_kosync_custom_read_column.py
+++ b/tests/unit/test_kosync_custom_read_column.py
@@ -80,8 +80,14 @@ class TestCustomReadColumnMirrorMatchesWebPath:
 
     def test_uses_calibre_db_and_cc_classes(self, kosync):
         src = inspect.getsource(kosync._mark_custom_read_column)
-        assert "calibre_db.get_filtered_book" in src, (
-            "must read the book via calibre_db.get_filtered_book like the web path"
+        assert "calibre_db.get_book" in src, (
+            "must read the book via the unfiltered calibre_db.get_book"
+        )
+        assert "calibre_db.get_filtered_book(" not in src, (
+            "must NOT use get_filtered_book: kosync requests carry no flask-login "
+            "user, so current_user is the ANONYMOUS user and get_filtered_book "
+            "would apply anonymous content/language restrictions — filtering the "
+            "book to None and silently dropping the read marker"
         )
         assert "custom_column_" in src, (
             "must address the custom column via getattr(book, 'custom_column_'+id)"


### PR DESCRIPTION
## Why
Addresses #312 (custom-column subset). Users who configure a Calibre custom column as their read marker (Admin → Feature Configuration → read-status column) never see the "read" checkmark after finishing a book in KOReader: the kosync path wrote only `ub.ReadBook`, while the book detail page reads from the custom column.

## Root cause
`update_book_read_status` in `cps/progress_syncing/protocols/kosync.py` mirrored only the default `ReadBook` path of `helper.edit_book_read_status`, not its custom-column branch.

## Fix
New `_mark_custom_read_column(book_id)` mirrors the web path's custom-column write (book-level, no user scoping — same as web). Gated on `config.config_read_column` and STATUS_FINISHED only; sticky (never un-reads on sync); best-effort with rollback so a metadata.db hiccup can't break progress sync.

## Hardening on top of the original commit
`_mark_custom_read_column` initially read the book via `calibre_db.get_filtered_book`. kosync authenticates via Basic-auth headers, not flask-login, so `current_user` inside the request is the **anonymous** user — `get_filtered_book` would apply the anonymous profile's language/tag/restricted-column filters and could silently filter the book to `None`, dropping the marker with a misleading "column does not exist" log (the restricted-column error path even calls `flash()`). Switched to the unfiltered `calibre_db.get_book` (the syncing user's access to the book is already established by the sync flow) with an explicit `None` guard for deleted books. Test pin updated to forbid `get_filtered_book` here.

## Validation
- `tests/unit/test_kosync_custom_read_column.py` — 5 source-pin tests, FAIL on main, PASS on branch (red/green).
- **Live container e2e (cwn-local, real flow end-to-end):**
  - Setup: `calibredb add_custom_column` → bool column id 1; `config_read_column=1`; KOReader sync enabled; app restarted (cc_classes reflected).
  - **RED on main:** real `PUT /kosync/syncs/progress` (Basic auth, partialMD5 of book 2's EPUB, percentage 1.0) → 200, book matched (`calibre_book_id: 2`), `book_read_link` row written FINISHED — but `custom_column_1` stayed **empty** (the reporter's symptom).
  - **GREEN on branch:** same PUT → `custom_column_1` row `(book 2, value 1)` + log `kosync read-status: marked book 2 read via custom column No.1`.
  - **User-visible:** `/book/2` renders the read checkbox `checked`; control book 3 unchecked.
  - **Sticky:** follow-up PUT at 50% (re-opened book) leaves the column at 1 — no silent un-read.
  - No ERROR/Traceback in container logs across the runs.

## Tier
Autonomous-merge gate: CI green required; red/green tests ✔; live e2e ✔; no new deps ✔; Greptile at monthly review cap (noted, no findings to disposition); no auth/session/CSRF/subprocess/file-path/new-route surface → conditional security review not required.

Release target: next daily train.
