### PR TITLE
fix(duplicates): key dismissals on the stable duplicate_key — dismissed groups no longer resurface (D5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- Dismissed duplicate groups stay dismissed. Adding another copy of a book or
+  editing its title changed the group's internal label, so groups you had
+  dismissed popped back onto the Duplicates page (and could re-enter
+  auto-resolve). Dismissals are now tied to the group's stable identity and
+  survive new ingests and metadata edits; existing dismissals are upgraded
+  automatically the first time they match. Two different groups that happened
+  to share a display title also no longer share one dismissal.
 - Merging duplicate books can no longer overwrite one of the kept book's
   files. If a file with the merge target's name was already on disk (from an
   earlier partial failure or a manual edit), the merge silently copied over

--- a/cps/duplicate_index.py
+++ b/cps/duplicate_index.py
@@ -410,7 +410,7 @@ def _decorate_books_for_group(books):
         book.cover_url = f"/cover/{book.id}" if getattr(book, "has_cover", None) else "/static/generic_cover.svg"
 
 
-def _group_from_books(books):
+def _group_from_books(books, duplicate_key=None):
     books.sort(key=lambda book: _timestamp_or_default(book.timestamp, _AWARE_MIN), reverse=True)
     _decorate_books_for_group(books)
     display_title = books[0].title if books[0].title else "Untitled"
@@ -422,18 +422,22 @@ def _group_from_books(books):
         "author": display_author,
         "count": len(books),
         "books": books,
+        # group_hash derives from DISPLAY data and drifts when an ingest or a
+        # metadata edit changes books[0] — kept for the UI routes only.
+        # duplicate_key is the stable identity dismissals match on (D5).
         "group_hash": generate_group_hash(display_title, display_author),
+        "duplicate_key": duplicate_key,
     }
 
 
 def get_duplicate_groups_from_index(settings, include_dismissed=False, user_id=None, candidate_book_ids=None):
     duplicate_groups = []
-    for _duplicate_key, book_ids_str, _count in _duplicate_key_rows(settings, candidate_book_ids=candidate_book_ids):
+    for duplicate_key, book_ids_str, _count in _duplicate_key_rows(settings, candidate_book_ids=candidate_book_ids):
         book_ids = [int(book_id) for book_id in book_ids_str.split(",") if book_id]
         books = _load_books_by_ids(book_ids, user_id=user_id)
         if len(books) < 2:
             continue
-        duplicate_groups.append(_group_from_books(books))
+        duplicate_groups.append(_group_from_books(books, duplicate_key=duplicate_key))
 
     duplicate_groups.sort(key=lambda group: (group["title"].lower(), group["author"].lower()))
     if not include_dismissed:

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -6,7 +6,7 @@
 
 from flask import Blueprint, jsonify, request, abort
 from flask_babel import gettext as _
-from sqlalchemy import func, and_, case
+from sqlalchemy import func, and_, case, or_
 from sqlalchemy.sql.expression import true, false
 from sqlalchemy.orm import joinedload
 from datetime import datetime, timezone
@@ -314,6 +314,22 @@ def get_unresolved_duplicate_count(user_id=None):
         return 0
 
 
+def _stable_group_key(books):
+    """Best-effort stable duplicate_key for a legacy-path group (D5).
+
+    The index path carries the key straight from cwa_duplicate_book_keys; the
+    legacy SQL/Python fallback paths recompute it from the group's first book
+    through the same single key-computation entry point so dismissals keyed on
+    duplicate_key apply regardless of which scan path produced the group.
+    """
+    try:
+        from cps.duplicate_index import build_duplicate_key
+        return build_duplicate_key(books[0], CWA_DB().cwa_settings)
+    except Exception as e:
+        log.warning("[cwa-duplicates] Could not compute stable group key: %s", e)
+        return None
+
+
 def filter_dismissed_groups(duplicate_groups, user_id=None):
     """Filter dismissed duplicate groups for a given user."""
     if not duplicate_groups:
@@ -327,13 +343,41 @@ def filter_dismissed_groups(duplicate_groups, user_id=None):
         return duplicate_groups
 
     try:
-        dismissed_groups = ub.session.query(ub.DismissedDuplicateGroup.group_hash)\
+        dismissed_rows = ub.session.query(ub.DismissedDuplicateGroup)\
             .filter(ub.DismissedDuplicateGroup.user_id == user_id)\
             .all()
-        dismissed_hashes = {row[0] for row in dismissed_groups}
-        if not dismissed_hashes:
+        if not dismissed_rows:
             return duplicate_groups
-        return [group for group in duplicate_groups if group.get('group_hash') not in dismissed_hashes]
+        # D5: duplicate_key (stable SHA-256 grouping identity) is the match of
+        # record. group_hash derives from display title/author of whichever
+        # book sorts first, so a new ingest or metadata edit changed it and
+        # dismissed groups resurfaced — it remains only for rows written
+        # before the migration (NULL duplicate_key).
+        dismissed_keys = {row.duplicate_key for row in dismissed_rows if row.duplicate_key}
+        legacy_rows = [row for row in dismissed_rows if not row.duplicate_key]
+        legacy_hashes = {row.group_hash for row in legacy_rows}
+
+        # Lazy backfill: a pre-migration row whose hash still matches a live
+        # group learns that group's duplicate_key, surviving future drift.
+        if legacy_hashes:
+            backfilled = False
+            by_hash = {g.get('group_hash'): g.get('duplicate_key')
+                       for g in duplicate_groups if g.get('duplicate_key')}
+            for row in legacy_rows:
+                key = by_hash.get(row.group_hash)
+                if key:
+                    row.duplicate_key = key
+                    dismissed_keys.add(key)
+                    backfilled = True
+            if backfilled:
+                try:
+                    ub.session.commit()
+                except Exception:
+                    ub.session.rollback()
+
+        return [group for group in duplicate_groups
+                if not ((group.get('duplicate_key') and group.get('duplicate_key') in dismissed_keys)
+                        or group.get('group_hash') in legacy_hashes)]
     except Exception as e:
         log.error("[cwa-duplicates] Error filtering dismissed groups: %s", str(e))
         return duplicate_groups
@@ -803,39 +847,25 @@ def find_duplicate_books_sql(use_title, use_author, use_language, use_series, us
             'author': display_author,
             'count': len(books),
             'books': books,
-            'group_hash': group_hash
+            'group_hash': group_hash,
+            'duplicate_key': _stable_group_key(books)
         })
         
         print(f"[cwa-duplicates] Found duplicate group: '{display_title}' by {display_author} ({len(books)} copies) - IDs: {book_ids}", flush=True)
         log.info("[cwa-duplicates] Found duplicate group: '%s' by %s (%s copies) - IDs: %s", 
                 display_title, display_author, len(books), book_ids)
     
-    # Filter out dismissed groups if requested
+    # Filter out dismissed groups if requested — single implementation (D5):
+    # filter_dismissed_groups matches on the stable duplicate_key with a
+    # group_hash fallback for pre-migration rows.
     if not include_dismissed and user_id:
-        try:
-            dismissed_hashes = set()
-            dismissed_groups = ub.session.query(ub.DismissedDuplicateGroup.group_hash)\
-                .filter(ub.DismissedDuplicateGroup.user_id == user_id)\
-                .all()
-            dismissed_hashes = {row[0] for row in dismissed_groups}
-            
-            if dismissed_hashes:
-                original_count = len(duplicate_groups)
-                duplicate_groups = [group for group in duplicate_groups 
-                                  if group['group_hash'] not in dismissed_hashes]
-                filtered_count = original_count - len(duplicate_groups)
-                if filtered_count > 0:
-                    print(f"[cwa-duplicates] Filtered out {filtered_count} dismissed groups for user {user_id}", flush=True)
-                    log.info("[cwa-duplicates] Filtered out %s dismissed groups for user %s", 
-                            filtered_count, user_id)
-        except Exception as e:
-            log.error("[cwa-duplicates] Error filtering dismissed groups: %s", str(e))
-    
+        duplicate_groups = filter_dismissed_groups(duplicate_groups, user_id=user_id)
+
     # Sort by title, then author for consistent display
     duplicate_groups.sort(key=lambda x: (x['title'].lower(), x['author'].lower()))
-    
+
     print(f"[cwa-duplicates] Found {len(duplicate_groups)} duplicate groups total", flush=True)
-    
+
     return duplicate_groups
 
 
@@ -1015,7 +1045,8 @@ def find_duplicate_books_python(use_title, use_author, use_language, use_series,
                 'author': display_author,
                 'count': len(books),
                 'books': books,
-                'group_hash': group_hash
+                'group_hash': group_hash,
+                'duplicate_key': _stable_group_key(books)
             })
             
             book_ids = [book.id for book in books]
@@ -1023,32 +1054,17 @@ def find_duplicate_books_python(use_title, use_author, use_language, use_series,
             log.info("[cwa-duplicates] Found duplicate group: '%s' by %s (%s copies) - IDs: %s", 
                     display_title, display_author, len(books), book_ids)
     
-    # Filter out dismissed groups if requested
+    # Filter out dismissed groups if requested — single implementation (D5):
+    # filter_dismissed_groups matches on the stable duplicate_key with a
+    # group_hash fallback for pre-migration rows.
     if not include_dismissed and user_id:
-        try:
-            dismissed_hashes = set()
-            dismissed_groups = ub.session.query(ub.DismissedDuplicateGroup.group_hash)\
-                .filter(ub.DismissedDuplicateGroup.user_id == user_id)\
-                .all()
-            dismissed_hashes = {row[0] for row in dismissed_groups}
-            
-            if dismissed_hashes:
-                original_count = len(duplicate_groups)
-                duplicate_groups = [group for group in duplicate_groups 
-                                  if group['group_hash'] not in dismissed_hashes]
-                filtered_count = original_count - len(duplicate_groups)
-                if filtered_count > 0:
-                    print(f"[cwa-duplicates] Filtered out {filtered_count} dismissed groups for user {user_id}", flush=True)
-                    log.info("[cwa-duplicates] Filtered out %s dismissed groups for user %s", 
-                            filtered_count, user_id)
-        except Exception as e:
-            log.error("[cwa-duplicates] Error filtering dismissed groups: %s", str(e))
-    
+        duplicate_groups = filter_dismissed_groups(duplicate_groups, user_id=user_id)
+
     # Sort by title, then author for consistent display
     duplicate_groups.sort(key=lambda x: (x['title'].lower(), x['author'].lower()))
-    
+
     print(f"[cwa-duplicates] Found {len(duplicate_groups)} duplicate groups total", flush=True)
-    
+
     return duplicate_groups
 
 
@@ -1255,6 +1271,27 @@ def dismiss_duplicate_scan_setup_notice():
         return jsonify({"success": False, "error": str(e)}), 500
 
 
+def _resolve_duplicate_key_for_hash(group_hash, user_id):
+    """Map a UI group_hash to the group's stable duplicate_key (D5).
+
+    The dismiss/undismiss routes are addressed by group_hash (what the page's
+    buttons carry), but the dismissal of record is keyed on duplicate_key so
+    it survives display-data drift. Resolve against the current groups,
+    dismissed included (undismiss targets a dismissed group).
+    """
+    try:
+        from cps.duplicate_index import get_duplicate_groups_from_index
+        groups = get_duplicate_groups_from_index(
+            CWA_DB().cwa_settings, include_dismissed=True, user_id=user_id)
+        for group in groups:
+            if group.get('group_hash') == group_hash:
+                return group.get('duplicate_key')
+    except Exception as e:
+        log.warning("[cwa-duplicates] Could not resolve duplicate_key for hash %s: %s",
+                    group_hash, e)
+    return None
+
+
 @duplicates.route("/duplicates/dismiss/<group_hash>", methods=['POST'])
 @login_required_if_no_ano
 @admin_or_edit_required
@@ -1268,23 +1305,37 @@ def dismiss_duplicate_group(group_hash):
         JSON response with success status and new count
     """
     try:
-        # Check if already dismissed
-        existing = ub.session.query(ub.DismissedDuplicateGroup)\
-            .filter(ub.DismissedDuplicateGroup.user_id == current_user.id)\
-            .filter(ub.DismissedDuplicateGroup.group_hash == group_hash)\
-            .first()
-        
+        duplicate_key = _resolve_duplicate_key_for_hash(group_hash, current_user.id)
+
+        # Check if already dismissed — by stable key first (D5), then by the
+        # transitional hash for pre-migration rows.
+        query = ub.session.query(ub.DismissedDuplicateGroup)\
+            .filter(ub.DismissedDuplicateGroup.user_id == current_user.id)
+        existing = None
+        if duplicate_key:
+            existing = query.filter(
+                ub.DismissedDuplicateGroup.duplicate_key == duplicate_key).first()
+        if not existing:
+            existing = query.filter(
+                ub.DismissedDuplicateGroup.group_hash == group_hash).first()
+
         if existing:
+            # Backfill the stable key onto a pre-migration row.
+            if duplicate_key and not existing.duplicate_key:
+                existing.duplicate_key = duplicate_key
+                ub.session.commit()
             return jsonify({
                 'success': True,
                 'message': _('Duplicate group already dismissed'),
                 'count': get_unresolved_duplicate_count()
             })
-        
-        # Create dismissal record
+
+        # Create dismissal record keyed on the stable duplicate_key (D5);
+        # group_hash is kept for the UI routes and pre-migration matching.
         dismissal = ub.DismissedDuplicateGroup(
             user_id=current_user.id,
-            group_hash=group_hash
+            group_hash=group_hash,
+            duplicate_key=duplicate_key
         )
         ub.session.add(dismissal)
         ub.session.commit()
@@ -1323,12 +1374,18 @@ def undismiss_duplicate_group(group_hash):
         JSON response with success status and new count
     """
     try:
-        # Find and delete dismissal record
+        # Find and delete the dismissal record — match the stable key when the
+        # group resolves to one (D5), plus the hash for pre-migration rows or
+        # groups whose display data has since drifted.
+        duplicate_key = _resolve_duplicate_key_for_hash(group_hash, current_user.id)
+        conditions = [ub.DismissedDuplicateGroup.group_hash == group_hash]
+        if duplicate_key:
+            conditions.append(ub.DismissedDuplicateGroup.duplicate_key == duplicate_key)
         deleted = ub.session.query(ub.DismissedDuplicateGroup)\
             .filter(ub.DismissedDuplicateGroup.user_id == current_user.id)\
-            .filter(ub.DismissedDuplicateGroup.group_hash == group_hash)\
-            .delete()
-        
+            .filter(or_(*conditions))\
+            .delete(synchronize_session=False)
+
         ub.session.commit()
         
         if deleted:

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -551,7 +551,15 @@ class DismissedDuplicateGroup(Base):
 
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey('user.id'), nullable=False)
-    group_hash = Column(String(32), nullable=False)  # MD5 hash of title+author combo
+    group_hash = Column(String(32), nullable=False)  # MD5 hash of title+author combo (display data; transitional)
+    # D5: the stable identity of the group — the SHA-256 duplicate_key from
+    # cwa_duplicate_book_keys. group_hash is derived from the DISPLAY
+    # title/author of whichever book happens to sort first, so a new ingest or
+    # a metadata edit changed it and dismissed groups resurfaced (and two
+    # groups sharing a raw display title collided into one dismissal).
+    # Dismissals match on duplicate_key when present; group_hash remains for
+    # rows written before the migration and for the UI routes.
+    duplicate_key = Column(String, nullable=True)
     dismissed_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     __table_args__ = (
@@ -2017,6 +2025,31 @@ def migrate_user_view_settings_null(engine, _session):
         log.error("[view-settings-null-migration] failed: %s", ex)
 
 
+def migrate_dismissed_duplicate_groups_table(engine, _session):
+    """Add the D5 ``duplicate_key`` column to dismissed_duplicate_groups.
+
+    Introspects the live schema and adds only what's missing, so the
+    migration is idempotent and repairs partial states (same pattern as
+    migrate_oauth_provider_table, fork #354). Existing rows keep a NULL
+    duplicate_key and are lazily backfilled by filter_dismissed_groups when
+    their group_hash next matches a live group.
+    """
+    from sqlalchemy import inspect as sa_inspect
+    try:
+        inspector = sa_inspect(engine)
+        if "dismissed_duplicate_groups" not in inspector.get_table_names():
+            return  # created fresh from the model with every column present
+        existing = {col["name"] for col in inspector.get_columns("dismissed_duplicate_groups")}
+        if "duplicate_key" not in existing:
+            _run_ddl_with_retry(
+                engine,
+                "ALTER TABLE dismissed_duplicate_groups ADD COLUMN duplicate_key TEXT",
+            )
+            print("[dup-dismiss-migration] Added duplicate_key column to dismissed_duplicate_groups", flush=True)
+    except Exception as e:
+        print(f"[dup-dismiss-migration] Failed to add duplicate_key column: {e}", flush=True)
+
+
 def migrate_book_cover_preview_table(engine, _session):
     """Create the book_cover_preview table if it doesn't exist.
     Idempotent — `BookCoverPreview.__table__.create(engine, checkfirst=True)`
@@ -2414,6 +2447,7 @@ def migrate_Database(_session):
     migrate_annotation_polymorphic_position(engine, _session)
     migrate_annotation_device_origin(engine, _session)
     migrate_book_cover_preview_table(engine, _session)
+    migrate_dismissed_duplicate_groups_table(engine, _session)
 
     # Ensure progress syncing tables in app.db (user-related tables).
     # Schema invariant — must not be gated on KOReader sync being enabled.

--- a/tests/unit/test_duplicate_delete_index_maintenance.py
+++ b/tests/unit/test_duplicate_delete_index_maintenance.py
@@ -317,6 +317,7 @@ def _load_duplicates_module(delete_key_calls):
         {
             "func": SimpleNamespace(),
             "and_": lambda *args: args,
+            "or_": lambda *args: args,
             "case": lambda *args, **kwargs: ("case", args, kwargs),
         },
     )

--- a/tests/unit/test_duplicate_dismiss_stable_key.py
+++ b/tests/unit/test_duplicate_dismiss_stable_key.py
@@ -1,0 +1,196 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""D5 regression tests — dismissals keyed on the stable duplicate_key.
+
+From the 2026-06 duplicate audit (notes/duplicate-detection-fix-plan.md §D5):
+group_hash is an MD5 of the DISPLAY title/author of whichever book sorts
+first in the group. A new ingest, a metadata edit, or a criteria change moved
+that hash, so a prior dismissal stopped matching and the group resurfaced —
+re-entering the destructive auto-resolve population. Two normalized groups
+sharing a raw display title collided into one dismissal.
+
+The fix keys dismissals on the SHA-256 ``duplicate_key`` the index already
+groups by (carried through every scan path), keeps ``group_hash`` only for
+the UI routes and pre-migration rows, and lazily backfills old rows.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_HERE = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = _HERE.parents[1]
+DUP_SRC = (REPO_ROOT / "cps" / "duplicates.py").read_text()
+UB_SRC = (REPO_ROOT / "cps" / "ub.py").read_text()
+IDX_SRC = (REPO_ROOT / "cps" / "duplicate_index.py").read_text()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sys_modules():
+    """Restore sys.modules after the stub harness (see D8 test for why)."""
+    saved = sys.modules.copy()
+    yield
+    for name in list(sys.modules):
+        if name not in saved:
+            del sys.modules[name]
+    for name, module in saved.items():
+        if sys.modules.get(name) is not module:
+            sys.modules[name] = module
+
+
+def _harness():
+    path = _HERE / "test_duplicate_delete_index_maintenance.py"
+    spec = importlib.util.spec_from_file_location("_dup_stub_harness", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Field:
+    def __eq__(self, other):  # SQLAlchemy-style column comparison stub
+        return ("eq", other)
+
+
+class _DismissQuery:
+    def __init__(self, rows, calls):
+        self._rows = rows
+        self._calls = calls
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+def _world_with_dismissals(rows):
+    """Stubbed cps.duplicates with ub.session.query returning `rows`."""
+    harness = _harness()
+    module, _books, calls = harness._load_duplicates_module([])
+    ub_stub = sys.modules["cps.ub"]
+    ub_stub.DismissedDuplicateGroup = type(
+        "DismissedDuplicateGroup", (),
+        {"user_id": _Field(), "group_hash": _Field(), "duplicate_key": _Field()},
+    )
+    ub_stub.session = SimpleNamespace(
+        query=lambda *a, **k: _DismissQuery(rows, calls),
+        commit=lambda: calls.append("ub-commit"),
+        rollback=lambda: calls.append("ub-rollback"),
+    )
+    return module, calls
+
+
+def _group(title, group_hash, duplicate_key):
+    return {"title": title, "author": "A", "count": 2, "books": [],
+            "group_hash": group_hash, "duplicate_key": duplicate_key}
+
+
+class TestD5DismissalSurvivesDisplayDrift:
+    def test_key_match_filters_group_even_when_hash_drifted(self):
+        # Dismissed when the group's display hash was OLDHASH; a new ingest
+        # changed books[0] so the rebuilt group hashes to NEWHASH. The stable
+        # duplicate_key is unchanged — the dismissal must still apply.
+        row = SimpleNamespace(group_hash="OLDHASH", duplicate_key="KEY-1")
+        module, _calls = _world_with_dismissals([row])
+        groups = [_group("The Republic", "NEWHASH", "KEY-1")]
+        out = module.filter_dismissed_groups(groups, user_id=7)
+        assert out == [], (
+            "a dismissed group resurfaced after display-data drift — the "
+            "dismissal must match on duplicate_key, not the display hash (D5)"
+        )
+
+
+class TestD5NoCrossContamination:
+    def test_same_display_hash_different_keys_do_not_collide(self):
+        # Two distinct normalized groups whose newest books share a raw
+        # display title produce the same MD5 hash. Dismissing one (keyed on
+        # its duplicate_key) must NOT hide the other.
+        row = SimpleNamespace(group_hash="SAMEHASH", duplicate_key="KEY-A")
+        module, _calls = _world_with_dismissals([row])
+        groups = [
+            _group("Café", "SAMEHASH", "KEY-A"),
+            _group("Café", "SAMEHASH", "KEY-B"),
+        ]
+        out = module.filter_dismissed_groups(groups, user_id=7)
+        assert [g["duplicate_key"] for g in out] == ["KEY-B"], (
+            "dismissing one group hid another group that shares its display "
+            "hash — dismissals must be keyed on duplicate_key (D5)"
+        )
+
+
+class TestD5LegacyRowsBackfillAndStillMatch:
+    def test_premigration_row_matches_by_hash_and_learns_the_key(self):
+        # A row written before the migration has only group_hash. It must
+        # still filter the matching group (transitional behavior) AND learn
+        # that group's duplicate_key so future drift can't resurface it.
+        row = SimpleNamespace(group_hash="H1", duplicate_key=None)
+        module, calls = _world_with_dismissals([row])
+        groups = [_group("Old Book", "H1", "KEY-9")]
+        out = module.filter_dismissed_groups(groups, user_id=7)
+        assert out == []
+        assert row.duplicate_key == "KEY-9", (
+            "pre-migration dismissal rows must be backfilled with the "
+            "matching group's duplicate_key (D5 lazy backfill)"
+        )
+        assert "ub-commit" in calls, "the backfill must be persisted"
+
+
+class TestD5SourcePins:
+    def test_dismiss_route_stores_duplicate_key(self):
+        m = re.search(r"def dismiss_duplicate_group\(group_hash\):(.*?)\n@", DUP_SRC, re.S)
+        assert m, "dismiss_duplicate_group not found"
+        body = m.group(0)
+        assert "_resolve_duplicate_key_for_hash" in body
+        assert "duplicate_key=duplicate_key" in body, (
+            "dismiss must store the stable duplicate_key on the row (D5)"
+        )
+
+    def test_undismiss_deletes_by_key_or_hash(self):
+        m = re.search(r"def undismiss_duplicate_group\(group_hash\):(.*?)\n@", DUP_SRC, re.S)
+        assert m, "undismiss_duplicate_group not found"
+        body = m.group(0)
+        assert "or_(" in body and "duplicate_key" in body, (
+            "undismiss must delete by duplicate_key OR group_hash so drifted "
+            "and pre-migration rows are both removable (D5)"
+        )
+
+    def test_index_group_carries_duplicate_key(self):
+        m = re.search(r"def _group_from_books\(books, duplicate_key=None\):(.*?)\ndef ", IDX_SRC, re.S)
+        assert m, "_group_from_books must accept duplicate_key (D5)"
+        assert '"duplicate_key": duplicate_key' in m.group(1)
+        assert "_group_from_books(books, duplicate_key=duplicate_key)" in IDX_SRC, (
+            "get_duplicate_groups_from_index must pass the key it grouped by"
+        )
+
+    def test_legacy_paths_attach_stable_key(self):
+        assert DUP_SRC.count("'duplicate_key': _stable_group_key(books)") >= 2, (
+            "both legacy scan paths (SQL + Python) must attach the stable "
+            "duplicate_key to their groups (D5)"
+        )
+
+    def test_model_and_migration(self):
+        assert re.search(r"class DismissedDuplicateGroup\(Base\):.*?duplicate_key = Column", UB_SRC, re.S), (
+            "DismissedDuplicateGroup must have a duplicate_key column (D5)"
+        )
+        assert "def migrate_dismissed_duplicate_groups_table" in UB_SRC
+        assert "migrate_dismissed_duplicate_groups_table(engine, _session)" in UB_SRC, (
+            "the migration must be registered in migrate_Database"
+        )
+
+    def test_single_dismiss_filter_implementation(self):
+        # The two legacy inline copies of the dismissed-filter were divergence
+        # bait — both paths must route through filter_dismissed_groups.
+        assert DUP_SRC.count("DismissedDuplicateGroup.group_hash)\\") == 0, (
+            "inline dismissed-hash queries must not reappear outside "
+            "filter_dismissed_groups (single source of truth, D5)"
+        )


### PR DESCRIPTION
## Why
D5 from the duplicate-detection audit (notes/duplicate-detection-fix-plan.md). `group_hash` — the dismiss table's only identity — is an MD5 of the **display** title/author of whichever book sorts first in the group. A new ingest changing `books[0]`, a metadata edit, or a criteria change moved the hash, so prior dismissals stopped matching and dismissed groups resurfaced (re-entering the destructive auto-resolve population). Two normalized groups sharing a raw display title collided into one dismissal.

## Fix
Dismissals are keyed on the SHA-256 `duplicate_key` the index already groups by:
- `dismissed_duplicate_groups` gains a nullable `duplicate_key` column via an idempotent introspection migration; pre-migration rows are lazily backfilled when their hash next matches a live group.
- The index path carries the key it grouped by into each group dict; the legacy SQL/Python fallback paths recompute it through the same single key-computation entry point.
- `filter_dismissed_groups` matches on `duplicate_key` (hash fallback for pre-migration rows) and is now the **single** dismissed-filter implementation — the two inline legacy copies are gone.
- Dismiss stores both identifiers; undismiss deletes by key OR hash. UI routes stay hash-addressed — no template/JS changes.

## Validation
- `tests/unit/test_duplicate_dismiss_stable_key.py` — 9 tests, all RED on main: drift survival, no cross-contamination, lazy backfill (behavioral via the shared stub harness), plus source pins (routes, index/legacy key carriage, model+migration, single filter implementation).
- **Live cwn-local e2e (real admin flow):**
  - Boot on branch: migration added the column (`[dup-dismiss-migration]` log line, PRAGMA confirms).
  - Dismissed the 'The Republic' pair via `POST /duplicates/dismiss/<hash>` → row stored **with** the stable key.
  - Ingested a third copy titled 'Plato, The Republic' (normalizes to the same key; display hash drifted `cf391cf0…→cf1fc145…`) → rescan → **group stayed dismissed** (page renders only the other two groups). On main this resurfaces.
  - Simulated a pre-migration row (key=NULL, current hash) → still filtered AND backfilled with the key on first page load.
  - `POST /duplicates/undismiss/<drifted-hash>` → row deleted, group visible again.
  - Zero ERROR/Traceback across the runs; library + app.db snapshot-restored after.
- CI-equivalent suite locally: 1565 passed (2 standing env failures only).

## Notes
The page-bootstrap preview/count (`window.cwaDuplicateBootstrap`) reads the global unfiltered cache and can disagree with the per-user filtered list — pre-existing behavior, untouched here; candidate for a follow-up.

## Tier
Autonomous-merge gate candidate: schema migration is additive + idempotent; no new deps; no auth/route-surface changes → conditional security review not required.