### PR TITLE
fix(duplicates): NFC + whitespace normalization on every keying surface; index v2 (D6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- Duplicate detection now catches copies whose titles differ only in unicode
+  form or spacing. A "Café" imported from a Mac (decomposed accents) and a
+  "Café" typed by hand, or "The  Book" with a double space, counted as
+  different books and never showed up as duplicates. All duplicate matching
+  now normalizes accents and whitespace first; the duplicate index rebuilds
+  itself on first scan after the update, and your existing dismissals carry
+  over automatically.
 - Dismissed duplicate groups stay dismissed. Adding another copy of a book or
   editing its title changed the group's internal label, so groups you had
   dismissed popped back onto the Duplicates page (and could re-enter

--- a/cps/duplicate_index.py
+++ b/cps/duplicate_index.py
@@ -23,6 +23,7 @@ from .duplicates import (
     generate_group_hash,
     get_common_filters,
     normalize_title_for_duplicates,
+    normalize_text_for_duplicates,
 )
 
 sys.path.insert(1, "/app/calibre-web-automated/scripts/")
@@ -31,7 +32,7 @@ from cwa_db import CWA_DB
 
 log = logger.create()
 
-NORMALIZATION_VERSION = "duplicate-index-v1"
+NORMALIZATION_VERSION = "duplicate-index-v2"  # v2: NFC + whitespace-collapse normalization (D6)
 MAX_INCREMENTAL_BOOK_IDS = 1000
 DUPLICATE_INDEX_REBUILD_BATCH_SIZE = 250
 INGEST_BATCH_DIRTY_FILE = "/config/cwa_ingest_batch_dirty"
@@ -138,10 +139,10 @@ def build_book_key_parts(book, settings):
     # leading primary-author prefix, unlike the old Python fallback's no-author mode.
     return BookKeyParts(
         normalized_title=normalize_title_for_duplicates(title, primary_author),
-        normalized_author=primary_author.lower().strip() if primary_author else "unknown",
-        normalized_language=language.lower().strip(),
-        normalized_series=series.lower().strip(),
-        normalized_publisher=publisher.lower().strip(),
+        normalized_author=normalize_text_for_duplicates(primary_author, default="unknown"),
+        normalized_language=normalize_text_for_duplicates(language, default="unknown"),
+        normalized_series=normalize_text_for_duplicates(series, default="no_series"),
+        normalized_publisher=normalize_text_for_duplicates(publisher, default="unknown_publisher"),
         format_signature=format_signature,
     )
 

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -13,6 +13,8 @@ from datetime import datetime, timezone
 from functools import wraps
 import hashlib
 import json
+import re
+import unicodedata
 import os
 import threading
 import time
@@ -126,23 +128,38 @@ def admin_or_edit_required(f):
     return decorated_function
 
 
+def normalize_text_for_duplicates(value, default=""):
+    """Shared text normalization for every duplicate-keying surface (D6).
+
+    Unicode NFC first (an NFD 'Café' from macOS filenames or some metadata
+    sources hashed differently from the NFC 'Café' a user typed — real
+    duplicates were invisible), then collapse internal whitespace ('The  Book'
+    vs 'The Book'), then lowercase + strip. generate_group_hash,
+    normalize_title_for_duplicates, and duplicate_index.build_book_key_parts
+    all route through here so the three keying surfaces can never drift.
+    """
+    text = value if value is not None and str(value) else default
+    text = unicodedata.normalize('NFC', str(text))
+    text = re.sub(r'\s+', ' ', text)
+    return text.lower().strip()
+
+
 def generate_group_hash(title, author):
     """Generate MD5 hash for a duplicate group based on title and author
-    
+
     Args:
         title: Book title (will be normalized)
         author: Primary author name (will be normalized)
-        
+
     Returns:
         32-character MD5 hash string
     """
-    # Normalize inputs - lowercase, strip whitespace
-    normalized_title = (title or "untitled").lower().strip()
-    normalized_author = (author or "unknown").lower().strip()
-    
+    normalized_title = normalize_text_for_duplicates(title, default="untitled")
+    normalized_author = normalize_text_for_duplicates(author, default="unknown")
+
     # Create composite key
     composite = f"{normalized_title}|{normalized_author}"
-    
+
     # Generate MD5 hash
     return hashlib.md5(composite.encode('utf-8')).hexdigest()
 
@@ -153,9 +170,9 @@ def normalize_title_for_duplicates(title, primary_author=None):
     If the title starts with the primary author (e.g., "Homer, the Iliad"),
     strip the leading author prefix to avoid false negatives.
     """
-    normalized = (title or "untitled").lower().strip()
+    normalized = normalize_text_for_duplicates(title, default="untitled")
     if primary_author:
-        author_norm = str(primary_author).lower().strip()
+        author_norm = normalize_text_for_duplicates(primary_author)
         author_prefix = f"{author_norm}, "
         if normalized.startswith(author_prefix):
             normalized = normalized[len(author_prefix):].strip()
@@ -353,8 +370,14 @@ def filter_dismissed_groups(duplicate_groups, user_id=None):
         # book sorts first, so a new ingest or metadata edit changed it and
         # dismissed groups resurfaced — it remains only for rows written
         # before the migration (NULL duplicate_key).
+        live_keys = {g.get('duplicate_key') for g in duplicate_groups if g.get('duplicate_key')}
         dismissed_keys = {row.duplicate_key for row in dismissed_rows if row.duplicate_key}
-        legacy_rows = [row for row in dismissed_rows if not row.duplicate_key]
+        # Rows needing (re-)keying: pre-migration rows (no key) AND rows whose
+        # stored key matches no live group — a NORMALIZATION_VERSION bump
+        # rotates every duplicate_key (v1→v2, D6), and without re-keying those
+        # dismissals would silently stop matching after the index rebuilds.
+        legacy_rows = [row for row in dismissed_rows
+                       if not row.duplicate_key or row.duplicate_key not in live_keys]
         legacy_hashes = {row.group_hash for row in legacy_rows}
 
         # Lazy backfill: a pre-migration row whose hash still matches a live
@@ -365,7 +388,7 @@ def filter_dismissed_groups(duplicate_groups, user_id=None):
                        for g in duplicate_groups if g.get('duplicate_key')}
             for row in legacy_rows:
                 key = by_hash.get(row.group_hash)
-                if key:
+                if key and key != row.duplicate_key:
                     row.duplicate_key = key
                     dismissed_keys.add(key)
                     backfilled = True

--- a/tests/unit/test_duplicate_dismiss_stable_key.py
+++ b/tests/unit/test_duplicate_dismiss_stable_key.py
@@ -145,6 +145,24 @@ class TestD5LegacyRowsBackfillAndStillMatch:
         assert "ub-commit" in calls, "the backfill must be persisted"
 
 
+class TestD5KeyRotationRekeys:
+    def test_normalization_bump_rekeys_dismissal_via_hash(self):
+        # A NORMALIZATION_VERSION bump (D6) rotates every duplicate_key. A row
+        # holding a stale v1 key must still match its group via the hash
+        # fallback AND be re-keyed to the group's current key, so the
+        # dismissal survives the index rebuild.
+        row = SimpleNamespace(group_hash="H1", duplicate_key="V1-KEY")
+        module, calls = _world_with_dismissals([row])
+        groups = [_group("Old Book", "H1", "V2-KEY")]
+        out = module.filter_dismissed_groups(groups, user_id=7)
+        assert out == [], (
+            "a dismissal stopped matching after the normalization-version "
+            "rebuild rotated its duplicate_key (D5/D6 interaction)"
+        )
+        assert row.duplicate_key == "V2-KEY", "stale keys must be re-keyed"
+        assert "ub-commit" in calls
+
+
 class TestD5SourcePins:
     def test_dismiss_route_stores_duplicate_key(self):
         m = re.search(r"def dismiss_duplicate_group\(group_hash\):(.*?)\n@", DUP_SRC, re.S)

--- a/tests/unit/test_duplicate_unicode_normalization.py
+++ b/tests/unit/test_duplicate_unicode_normalization.py
@@ -1,0 +1,126 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""D6 regression tests — unicode + whitespace normalization in duplicate keys.
+
+From the 2026-06 duplicate audit (notes/duplicate-detection-fix-plan.md §D6):
+every keying surface normalized with only ``.lower().strip()``. An NFD 'Café'
+(macOS filenames, some metadata sources) hashed differently from the NFC
+'Café' a user typed, and 'The  Book' differed from 'The Book' — so genuine
+duplicates were silently invisible to the scanner. NFC + internal-whitespace
+collapse now applies on all three surfaces via one shared normalizer, and
+NORMALIZATION_VERSION is bumped so the criteria fingerprint changes and the
+index rebuilds (stale v1 keys would otherwise persist).
+
+These run against the real functions (no stub world needed for the
+normalizers themselves) by importing duplicates.py through the shared stub
+harness, since cps imports Flask at package level.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+import sys
+import unicodedata
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_HERE = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = _HERE.parents[1]
+IDX_SRC = (REPO_ROOT / "cps" / "duplicate_index.py").read_text()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sys_modules():
+    """Restore sys.modules after the stub harness (see D8 test for why)."""
+    saved = sys.modules.copy()
+    yield
+    for name in list(sys.modules):
+        if name not in saved:
+            del sys.modules[name]
+    for name, module in saved.items():
+        if sys.modules.get(name) is not module:
+            sys.modules[name] = module
+
+
+@pytest.fixture()
+def dup():
+    path = _HERE / "test_duplicate_delete_index_maintenance.py"
+    spec = importlib.util.spec_from_file_location("_dup_stub_harness", path)
+    harness = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(harness)
+    module, _books, _calls = harness._load_duplicates_module([])
+    return module
+
+
+NFC = unicodedata.normalize("NFC", "Café")
+NFD = unicodedata.normalize("NFD", "Café")
+
+
+class TestD6GroupHash:
+    def test_nfd_and_nfc_hash_identically(self, dup):
+        assert dup.generate_group_hash(NFD, "x") == dup.generate_group_hash(NFC, "x"), (
+            "NFD and NFC forms of the same title must produce the same group "
+            "hash — otherwise real duplicates are invisible (D6)"
+        )
+
+    def test_internal_whitespace_collapses(self, dup):
+        assert dup.generate_group_hash("The  Book", "x") == dup.generate_group_hash("The Book", "x")
+        assert dup.generate_group_hash("The\tBook", "x") == dup.generate_group_hash("The Book", "x")
+
+    def test_author_side_normalizes_too(self, dup):
+        assert dup.generate_group_hash("t", NFD) == dup.generate_group_hash("t", NFC)
+
+
+class TestD6TitleNormalization:
+    def test_nfd_title_normalizes_to_nfc_form(self, dup):
+        assert dup.normalize_title_for_duplicates(NFD) == dup.normalize_title_for_duplicates(NFC)
+
+    def test_author_prefix_strip_survives_mixed_forms(self, dup):
+        # Title carries an NFD author prefix, author arrives NFC — the strip
+        # must still fire because both sides share the normalizer.
+        title = unicodedata.normalize("NFD", "Café, the book")
+        author = unicodedata.normalize("NFC", "Café")
+        assert dup.normalize_title_for_duplicates(title, author) == "the book"
+
+    def test_whitespace_collapse_in_title(self, dup):
+        assert dup.normalize_title_for_duplicates("The   Republic") == "the republic"
+
+
+class TestD6SharedNormalizer:
+    def test_single_normalizer_exists(self, dup):
+        assert hasattr(dup, "normalize_text_for_duplicates")
+        assert dup.normalize_text_for_duplicates(" Á  B ") == \
+            dup.normalize_text_for_duplicates(unicodedata.normalize("NFC", " Á  B "))
+
+    def test_empty_values_fall_back_to_default(self, dup):
+        assert dup.normalize_text_for_duplicates(None, default="untitled") == "untitled"
+        assert dup.normalize_text_for_duplicates("", default="unknown") == "unknown"
+
+
+class TestD6IndexSurface:
+    def test_normalization_version_bumped(self):
+        m = re.search(r'NORMALIZATION_VERSION = "([^"]+)"', IDX_SRC)
+        assert m and m.group(1) != "duplicate-index-v1", (
+            "NORMALIZATION_VERSION must be bumped with the normalization "
+            "change so the criteria fingerprint rotates and the index "
+            "rebuilds — stale v1 keys would otherwise persist (D6)"
+        )
+
+    def test_key_parts_route_through_shared_normalizer(self):
+        m = re.search(r"def build_book_key_parts\(book, settings\):(.*?)\ndef ", IDX_SRC, re.S)
+        assert m, "build_book_key_parts not found"
+        body = m.group(1)
+        assert body.count("normalize_text_for_duplicates(") >= 4, (
+            "author/language/series/publisher key parts must use the shared "
+            "normalizer so all keying surfaces agree (D6)"
+        )
+        assert ".lower().strip()" not in body, (
+            "raw .lower().strip() must not survive in build_book_key_parts"
+        )


### PR DESCRIPTION
## Why
D6 from the duplicate-detection audit. Every keying surface normalized with only `.lower().strip()` — an NFD 'Café' (macOS, some metadata sources) hashed differently from the NFC 'Café' a user typed, and 'The  Book' ≠ 'The Book'. Genuine duplicates were silently invisible.

## Fix
- One shared normalizer (`normalize_text_for_duplicates`: NFC → collapse internal whitespace → lower → strip) feeds `generate_group_hash`, `normalize_title_for_duplicates`, and every `build_book_key_parts` field — the three keying surfaces can't drift.
- `NORMALIZATION_VERSION` → `duplicate-index-v2`: the criteria fingerprint rotates and the index rebuilds on the next scan (stale v1 keys would otherwise persist).
- **D5 interaction:** the version bump rotates every `duplicate_key`, which would orphan stored dismissal keys. `filter_dismissed_groups` now re-keys rows whose key matches no live group via the hash fallback — dismissals survive normalization rebuilds.

## Validation
- `tests/unit/test_duplicate_unicode_normalization.py` — 10 tests, all RED on main (NFD==NFC hashes both sides, whitespace/tab collapse, mixed-form author-prefix strip, version-bump pin, key-parts routing through the shared normalizer with no raw `.lower().strip()` left).
- Rotation re-key test added to the D5 suite (stale v1 key + matching hash → still filtered + re-keyed + committed).
- **Live cwn-local:** added NFD (`65CC81`) and NFC (`C3A9`) 'Café' copies → v2 scan groups them (count 2; both books share ONE `duplicate_key` under the v2 fingerprint `bd719aa5…`), `/duplicates` renders the group; zero tracebacks. Library snapshot-restored.
- CI-equivalent suite locally: 1576 passed (2 standing env failures only).

## Tier
Autonomous-merge gate candidate: no schema change (index rebuild is data-only), no new deps, no auth/route surface → conditional security review not required.