### PR TITLE
fix(duplicates): exclude user-hidden books from the duplicate scan (D10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- Books you've hidden no longer show up in your duplicate scan. The Duplicates
+  page respected your language, tag, and archive filters but not your hidden
+  list, so hidden books reappeared there and could even be swept into
+  duplicate auto-resolution.
 - Duplicate detection now catches copies whose titles differ only in unicode
   form or spacing. A "Café" imported from a Mac (decomposed accents) and a
   "Café" typed by hand, or "The  Book" with a double space, counted as

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -1091,7 +1091,8 @@ def find_duplicate_books_python(use_title, use_author, use_language, use_series,
     return duplicate_groups
 
 
-def get_common_filters(user_id=None, allow_show_archived=False, return_all_languages=False):
+def get_common_filters(user_id=None, allow_show_archived=False, return_all_languages=False,
+                       allow_show_hidden=False):
     """Build common filters using either current_user or a specific user_id.
 
     Falls back to no-op filters if user context is unavailable.
@@ -1099,7 +1100,8 @@ def get_common_filters(user_id=None, allow_show_archived=False, return_all_langu
     try:
         if user_id is None:
             return calibre_db.common_filters(allow_show_archived=allow_show_archived,
-                                             return_all_languages=return_all_languages)
+                                             return_all_languages=return_all_languages,
+                                             allow_show_hidden=allow_show_hidden)
     except Exception:
         # No request context; fall back to permissive filter
         return true()
@@ -1118,6 +1120,18 @@ def get_common_filters(user_id=None, allow_show_archived=False, return_all_langu
             archived_filter = db.Books.id.notin_(archived_book_ids)
         else:
             archived_filter = true()
+
+        # D10: mirror calibre_db.common_filters' UserHiddenBook exclusion. The
+        # user explicitly hid these books; without this they reappeared in
+        # their duplicate scan and could be fed to destructive auto-resolve.
+        if not allow_show_hidden:
+            hidden_books = (ub.session.query(ub.UserHiddenBook)
+                            .filter(ub.UserHiddenBook.user_id == int(user.id))
+                            .all())
+            hidden_book_ids = [hidden.book_id for hidden in hidden_books]
+            hidden_filter = db.Books.id.notin_(hidden_book_ids)
+        else:
+            hidden_filter = true()
 
         if user.filter_language() == "all" or return_all_languages:
             lang_filter = true()
@@ -1147,7 +1161,8 @@ def get_common_filters(user_id=None, allow_show_archived=False, return_all_langu
             neg_content_cc_filter = false()
 
         return and_(lang_filter, pos_content_tags_filter, ~neg_content_tags_filter,
-                    pos_content_cc_filter, ~neg_content_cc_filter, archived_filter)
+                    pos_content_cc_filter, ~neg_content_cc_filter, archived_filter,
+                    hidden_filter)
     except Exception:
         return true()
 

--- a/tests/unit/test_duplicate_resolution_safety.py
+++ b/tests/unit/test_duplicate_resolution_safety.py
@@ -284,3 +284,30 @@ class TestD3FilesDeletedAfterDbCommit:
         assert "removed from the database but file" in src, (
             "the files-last path must log a warning on a file-cleanup failure"
         )
+
+
+class TestD10HiddenBooksExcludedFromScan:
+    def test_get_common_filters_excludes_user_hidden_books(self):
+        # D10: the local re-implementation of common_filters for explicit
+        # user_id scans omitted the UserHiddenBook exclusion — books the user
+        # explicitly hid reappeared in their duplicate scan and could be fed
+        # to destructive auto-resolve.
+        src = _func_src("get_common_filters")
+        assert "UserHiddenBook" in src, (
+            "get_common_filters must exclude UserHiddenBook rows like "
+            "calibre_db.common_filters does (D10 data-safety)"
+        )
+        assert "hidden_filter" in src and "hidden_filter)" in src, (
+            "the hidden filter must be part of the returned and_() filter set"
+        )
+
+    def test_get_common_filters_has_allow_show_hidden_parity(self):
+        src = _func_src("get_common_filters")
+        assert "allow_show_hidden" in src.splitlines()[0] + src.splitlines()[1], (
+            "get_common_filters must take allow_show_hidden for parity with "
+            "calibre_db.common_filters (D10)"
+        )
+        assert "allow_show_hidden=allow_show_hidden" in src, (
+            "the user_id=None branch must forward allow_show_hidden to "
+            "calibre_db.common_filters"
+        )


### PR DESCRIPTION
## Why
D10 from the duplicate-detection audit. `get_common_filters` re-implements `calibre_db.common_filters` for explicit-`user_id` scans (background scan, status counts, index loads) but omitted the `UserHiddenBook` exclusion — books the user explicitly hid reappeared in their duplicate scan and could be swept into destructive auto-resolution.

## Fix
Mirror the `UserHiddenBook` exclusion from `common_filters`, and add an `allow_show_hidden` parameter for full parity (forwarded in the no-`user_id` branch). The durable theme per the audit: reduce divergence between this re-implementation and the canonical filter.

## Validation
- 2 source pins in `test_duplicate_resolution_safety.py` — RED on main (verified: `UserHiddenBook`/`allow_show_hidden` absent from main's `get_common_filters`).
- **Live cwn-local:** enabled `config_user_hide_enabled`, hid book 10 (half of the 'The Republic' duplicate pair) via the real `POST /ajax/togglehidden/10` → `/duplicates` dropped the group (2 groups rendered, zero Republic matches); all 3 groups rendered before the hide. app.db snapshot-restored.
- Live RED (main-code page render with a hidden book) not separately run — the mechanism is the missing filter term, proven by the source diff; stated per verification standard.
- CI-equivalent suite locally: passes with only the 2 standing env failures.

## Tier
Autonomous-merge gate candidate: filter-only change, no schema, no deps, no auth/route surface → conditional security review not required.