### PR TITLE
fix(shelf): sync bulk shelf adds to Hardcover via a background task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- Adding several books at once to a Kobo-synced shelf now syncs them to
+  Hardcover, just like adding one book does. Before, only single adds reached
+  Hardcover — "add all" from search results, multi-select adds, and
+  add-series-to-shelf silently skipped it. The sync now runs as a background
+  task (visible under Tasks, cancellable), so adding a long series doesn't
+  hold the page open on an external service — and single adds respond faster
+  for the same reason.
 - The experimental "SQL" duplicate-scan mode no longer produces different (and
   sometimes wrong) results than the default mode. It grouped co-authored books
   into multiple duplicate groups at once and skipped a title normalization the

--- a/cps/services/hardcover.py
+++ b/cps/services/hardcover.py
@@ -16,14 +16,16 @@ This module provides a client for interacting with Hardcover's GraphQL API to:
 """
 
 from datetime import datetime
+from os import getenv
 import requests
 
 from .. import logger
 
 log = logger.create()
 
-# API Configuration
-GRAPHQL_ENDPOINT = "https://api.hardcover.app/v1/graphql"
+# API Configuration. The env override exists for integration testing against
+# a local mock; production deployments leave it unset.
+GRAPHQL_ENDPOINT = getenv("HARDCOVER_API_ENDPOINT", "https://api.hardcover.app/v1/graphql")
 REQUEST_TIMEOUT = 10  # seconds
 
 # Book Status Constants (Hardcover status IDs)

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -18,9 +18,32 @@ from . import calibre_db, config, db, logger, ub
 from .render_template import render_title_template
 from .usermanagement import login_required_if_no_ano, user_login_required
 from .services import hardcover
+from .services.worker import WorkerThread
+from .tasks.hardcover_sync import TaskHardcoverBulkSync
 log = logger.create()
 
 shelf = Blueprint('shelf', __name__)
+
+
+def queue_hardcover_sync(shelf_obj, book_ids):
+    """Queue the background Hardcover get-or-add for books just added to a
+    Kobo-synced shelf (fork #381). Single source of truth for the gate the
+    inline single-add sync used to apply: every add path — single, search
+    mass-add, multi-select, add-series — calls this after its commit, so the
+    button used no longer changes whether Hardcover hears about the book.
+    The token is captured here because the worker thread has no request
+    context."""
+    if not (shelf_obj.kobo_sync and config.config_hardcover_sync and bool(hardcover)):
+        return
+    if not book_ids:
+        return
+    token = current_user.hardcover_token
+    if not token:
+        log.info("User %s has no Hardcover token, cannot sync shelf %s to Hardcover",
+                 current_user.name, shelf_obj.name)
+        return
+    WorkerThread.add(current_user.name,
+                     TaskHardcoverBulkSync(token, list(book_ids), shelf_obj.name))
 
 
 @shelf.route("/shelf/add/<int:shelf_id>/<int:book_id>", methods=["POST"])
@@ -98,20 +121,10 @@ def add_to_shelf(shelf_id, book_id):
     # Hardcover sync runs for BOTH response flavors — it used to sit after
     # the non-XHR early-return below, so plain form adds (no JS) silently
     # skipped Hardcover while XHR adds synced. Same book, same shelf, same
-    # user intent — the transport must not change the outcome.
-    if shelf.kobo_sync and config.config_hardcover_sync and bool(hardcover):
-        try:
-            hardcoverClient = hardcover.HardcoverClient(current_user.hardcover_token)
-            # Will add the book to Hardcover if it doesn't exist,
-            # and leave it alone otherwise
-            # (updating status is handled in update_reading_progress
-            # and the book may be blacklisted from syncing)
-            if not hardcoverClient.get_user_book(book.identifiers):
-                hardcoverClient.add_book(book.identifiers)
-        except hardcover.MissingHardcoverToken:
-            log.info(f"User {current_user.name} has no Hardcover token, cannot add to Hardcover")
-        except Exception as e:
-            log.debug(f"Failed to create Hardcover client for {current_user.name}: {e}")
+    # user intent — the transport must not change the outcome. The get-or-add
+    # itself runs as a background task now: inline it blocked the response on
+    # up to two external API calls (fork #381).
+    queue_hardcover_sync(shelf, [book_id])
 
     if not xhr:
         log.debug("Book has been added to shelf: {}".format(shelf.name))
@@ -165,6 +178,7 @@ def search_to_shelf(shelf_id):
         try:
             ub.session.merge(shelf)
             ub.session.commit()
+            queue_hardcover_sync(shelf, books_for_shelf)
             flash(_("Books have been added to shelf: %(sname)s", sname=shelf.name), category="success")
         except (OperationalError, InvalidRequestError) as e:
             ub.session.rollback()
@@ -185,10 +199,9 @@ def add_series_to_shelf(shelf_id, series_id):
     plumbing as the search page's "add all" dropdown): flash + redirect back.
     Books land in ``series_index`` order so the shelf reads 1, 2, 3…; books
     already on the shelf are skipped. ``common_filters()`` applies, so a
-    user can only bulk-add books they are allowed to see. Hardcover sync is
-    deliberately not attempted inline — both existing bulk paths skip it
-    too, and a per-book external API loop doesn't belong in a request
-    handler (tracked as the bulk-shelf Hardcover parity follow-up).
+    user can only bulk-add books they are allowed to see. Hardcover sync
+    runs as a queued background task (fork #381) — a per-book external API
+    loop doesn't belong in a request handler.
     """
     def _back():
         if "HTTP_REFERER" in request.environ:
@@ -244,6 +257,7 @@ def add_series_to_shelf(shelf_id, series_id):
         flash(_("Oops! Database Error: %(error)s.", error=getattr(e, 'orig', e)), category="error")
         return _back()
 
+    queue_hardcover_sync(shelf, [book.id for book in to_add])
     log.debug("Series %s (%d books) added to shelf: %s", series.name, len(to_add), shelf.name)
     flash(_("%(count)d books of series '%(name)s' added to shelf: %(sname)s",
             count=len(to_add), name=series.name, sname=shelf.name), category="success")
@@ -669,6 +683,7 @@ def add_selected_to_shelf():
         return jsonify({'status': 'error', 'message': 'You are not allowed to add books to this shelf'}), 403
 
     success_count = 0
+    added_ids = []
     errors = []
 
     if not book_ids:
@@ -697,6 +712,7 @@ def add_selected_to_shelf():
         maxOrder += 1
         new_entry = ub.BookShelf(shelf=shelf.id, book_id=book_id, order=maxOrder)
         shelf.books.append(new_entry)
+        added_ids.append(book_id)
         success_count += 1
 
     if success_count > 0:
@@ -704,6 +720,7 @@ def add_selected_to_shelf():
         try:
             ub.session.merge(shelf)
             ub.session.commit()
+            queue_hardcover_sync(shelf, added_ids)
             log.info(f"Successfully added {success_count} books to shelf: {shelf.name}")
         except (OperationalError, InvalidRequestError) as e:
             ub.session.rollback()

--- a/cps/tasks/hardcover_sync.py
+++ b/cps/tasks/hardcover_sync.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Background Hardcover get-or-add sync for shelf additions (fork #381).
+
+Adding a book to a Kobo-synced shelf mirrors it to the user's Hardcover
+library ("Want to Read"). The single-add route used to do this inline —
+blocking the HTTP response on up to two external API calls — and all three
+bulk-add routes skipped it entirely, so the same user intent produced a
+different outcome depending on which button was pressed.
+
+Every add path now queues this task instead. It runs on the WorkerThread,
+shows up in the Tasks list, tolerates per-book failures, and is cancellable
+between books. The token and book ids are captured at enqueue time because
+the worker thread has no request context (no ``current_user``).
+"""
+
+import time
+
+from cps import db, logger
+from cps.services import hardcover
+from cps.services.worker import CalibreTask, STAT_CANCELLED, STAT_ENDED
+from flask_babel import lazy_gettext as N_
+
+# Pause between books so a big series add doesn't burst-hammer the API.
+INTER_BOOK_DELAY = 0.2
+
+
+class TaskHardcoverBulkSync(CalibreTask):
+    """Get-or-add each book on Hardcover, mirroring the single-add semantics:
+    a book already in the user's Hardcover library is left alone (status
+    updates belong to update_reading_progress); otherwise it is added.
+    Books without ``hardcover-*`` identifiers are skipped without an API
+    call — Hardcover can't match them and would just log two warnings."""
+
+    def __init__(self, token, book_ids, shelf_name,
+                 task_message=N_('Syncing shelf additions to Hardcover')):
+        super(TaskHardcoverBulkSync, self).__init__(task_message)
+        self.log = logger.create()
+        self.token = token
+        self.book_ids = list(book_ids or [])
+        self.shelf_name = shelf_name
+        self.synced = 0
+        self.already_synced = 0
+        self.skipped_no_identifiers = 0
+        self.errors = 0
+
+    def _cancelled(self):
+        return self.stat in (STAT_CANCELLED, STAT_ENDED)
+
+    def run(self, worker_thread):
+        if hardcover is None:
+            self._handleError("Hardcover service is not available")
+            return
+        if not self.book_ids:
+            self._handleSuccess()
+            return
+        try:
+            client = hardcover.HardcoverClient(self.token)
+        except hardcover.MissingHardcoverToken:
+            self._handleError("No valid Hardcover token configured for this user")
+            return
+        except Exception as ex:
+            self._handleError("Could not connect to Hardcover: {}".format(ex))
+            return
+
+        calibre_db = db.CalibreDB(expire_on_commit=False, init=True)
+        try:
+            total = len(self.book_ids)
+            for position, book_id in enumerate(self.book_ids):
+                if self._cancelled():
+                    self.log.info("Hardcover shelf sync cancelled by user")
+                    return
+                try:
+                    book = calibre_db.session.query(db.Books).filter(
+                        db.Books.id == book_id).one_or_none()
+                    if book is None:
+                        # Deleted between enqueue and run — nothing to sync.
+                        self.skipped_no_identifiers += 1
+                        continue
+                    identifiers = {ident.type: ident.val for ident in book.identifiers
+                                   if "hardcover" in ident.type}
+                    if not identifiers:
+                        self.skipped_no_identifiers += 1
+                        continue
+                    if client.get_user_book(identifiers):
+                        self.already_synced += 1
+                    else:
+                        client.add_book(identifiers)
+                        self.synced += 1
+                except Exception as ex:
+                    # One bad book must not strand the rest of the batch.
+                    self.errors += 1
+                    self.log.error("Hardcover sync failed for book %s: %s", book_id, ex)
+                finally:
+                    self.progress = (position + 1) / total
+                if position + 1 < total and INTER_BOOK_DELAY:
+                    time.sleep(INTER_BOOK_DELAY)
+
+            summary = ("Hardcover sync for shelf '{}': {} added, {} already synced, "
+                       "{} without Hardcover identifiers, {} errors").format(
+                self.shelf_name, self.synced, self.already_synced,
+                self.skipped_no_identifiers, self.errors)
+            self.log.info(summary)
+            if self.errors and not (self.synced or self.already_synced):
+                self._handleError(summary)
+            else:
+                self.message = summary
+                self._handleSuccess()
+        finally:
+            calibre_db.session.close()
+
+    @property
+    def name(self):
+        return N_("Hardcover Sync")
+
+    def __str__(self):
+        return "Hardcover sync for shelf '{}' ({} books)".format(
+            self.shelf_name, len(self.book_ids))
+
+    @property
+    def is_cancellable(self):
+        return True

--- a/tests/unit/test_hardcover_bulk_sync.py
+++ b/tests/unit/test_hardcover_bulk_sync.py
@@ -1,0 +1,370 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Fork #381 regression tests — bulk shelf adds sync to Hardcover.
+
+Adding a single book to a Kobo-synced shelf synced it to Hardcover inline;
+all three bulk paths (search mass-add, multi-select, add-series) skipped
+Hardcover entirely. Same user intent, different outcome per button.
+
+The fix queues TaskHardcoverBulkSync (cps/tasks/hardcover_sync.py) on the
+WorkerThread from every add path via one gate helper in cps/shelf.py
+(queue_hardcover_sync). The single path stops blocking the HTTP response on
+external API calls; the bulk paths gain the sync.
+
+Behavioural tests load the task module standalone through a stub world
+(cps imports Flask at package level); source pins hold the call sites.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+import sys
+import types
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_HERE = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = _HERE.parents[1]
+SHELF_SRC = (REPO_ROOT / "cps" / "shelf.py").read_text()
+TASK_SRC = (REPO_ROOT / "cps" / "tasks" / "hardcover_sync.py").read_text()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sys_modules():
+    """Restore sys.modules after the stub harness (see D8 test for why)."""
+    saved = sys.modules.copy()
+    yield
+    for name in list(sys.modules):
+        if name not in saved:
+            del sys.modules[name]
+    for name, module in saved.items():
+        if sys.modules.get(name) is not module:
+            sys.modules[name] = module
+
+
+# --- stub world -------------------------------------------------------------
+
+class _StubLogger:
+    def __getattr__(self, _name):
+        return lambda *a, **k: None
+
+
+class _BooksIdColumn:
+    def __eq__(self, other):  # `db.Books.id == book_id` -> the id itself
+        return other
+
+    def __hash__(self):
+        return id(self)
+
+
+class _Identifier:
+    def __init__(self, id_type, val):
+        self.type = id_type
+        self.val = val
+
+
+class _Book:
+    def __init__(self, book_id, identifiers):
+        self.id = book_id
+        self.identifiers = [_Identifier(t, v) for t, v in identifiers]
+
+
+class _Query:
+    def __init__(self, books_by_id):
+        self._books_by_id = books_by_id
+        self._wanted = None
+
+    def filter(self, arg):
+        self._wanted = arg
+        return self
+
+    def one_or_none(self):
+        return self._books_by_id.get(self._wanted)
+
+
+class _Session:
+    def __init__(self, books_by_id):
+        self._books_by_id = books_by_id
+        self.closed = False
+
+    def query(self, _model):
+        return _Query(self._books_by_id)
+
+    def close(self):
+        self.closed = True
+
+
+class _RecordingClient:
+    """get_user_book returns truthy for ids in `existing`; add_book records."""
+
+    instances = []
+
+    def __init__(self, token):
+        self.token = token
+        self.get_calls = []
+        self.add_calls = []
+        _RecordingClient.instances.append(self)
+
+    def get_user_book(self, identifiers):
+        self.get_calls.append(dict(identifiers))
+        return {"id": 1} if identifiers.get("hardcover-id") in self.existing else None
+
+    def add_book(self, identifiers):
+        self.add_calls.append(dict(identifiers))
+        return {"id": 2}
+
+    existing = set()
+
+
+def _load_task_module(books_by_id, client_cls=_RecordingClient):
+    """Load cps/tasks/hardcover_sync.py against a stubbed cps world."""
+    cps_pkg = types.ModuleType("cps")
+    cps_pkg.__path__ = []
+
+    logger_mod = types.ModuleType("cps.logger")
+    logger_mod.create = lambda: _StubLogger()
+
+    db_mod = types.ModuleType("cps.db")
+    session = _Session(books_by_id)
+
+    class _CalibreDB:
+        last = None
+
+        def __init__(self, **_kwargs):
+            self.session = session
+            _CalibreDB.last = self
+
+    class _Books:
+        id = _BooksIdColumn()
+
+    db_mod.CalibreDB = _CalibreDB
+    db_mod.Books = _Books
+
+    services_pkg = types.ModuleType("cps.services")
+    services_pkg.__path__ = []
+    hardcover_mod = types.ModuleType("cps.services.hardcover")
+
+    class MissingHardcoverToken(Exception):
+        pass
+
+    hardcover_mod.MissingHardcoverToken = MissingHardcoverToken
+    hardcover_mod.HardcoverClient = client_cls
+    services_pkg.hardcover = hardcover_mod
+
+    worker_mod = types.ModuleType("cps.services.worker")
+    worker_mod.STAT_WAITING = 0
+    worker_mod.STAT_FAIL = 1
+    worker_mod.STAT_FINISH_SUCCESS = 3
+    worker_mod.STAT_ENDED = 4
+    worker_mod.STAT_CANCELLED = 5
+
+    class CalibreTask:
+        def __init__(self, message):
+            self.message = message
+            self.stat = worker_mod.STAT_WAITING
+            self.error = None
+            self.progress = 0
+
+        def _handleError(self, error_message):
+            self.stat = worker_mod.STAT_FAIL
+            self.error = error_message
+            self.progress = 1
+
+        def _handleSuccess(self):
+            self.stat = worker_mod.STAT_FINISH_SUCCESS
+            self.progress = 1
+
+    worker_mod.CalibreTask = CalibreTask
+
+    babel_mod = types.ModuleType("flask_babel")
+    babel_mod.lazy_gettext = lambda text: text
+
+    cps_pkg.db = db_mod
+    cps_pkg.logger = logger_mod
+    cps_pkg.services = services_pkg
+
+    sys.modules["cps"] = cps_pkg
+    sys.modules["cps.db"] = db_mod
+    sys.modules["cps.logger"] = logger_mod
+    sys.modules["cps.services"] = services_pkg
+    sys.modules["cps.services.hardcover"] = hardcover_mod
+    sys.modules["cps.services.worker"] = worker_mod
+    sys.modules["flask_babel"] = babel_mod
+
+    spec = importlib.util.spec_from_file_location(
+        "_hardcover_sync_under_test", REPO_ROOT / "cps" / "tasks" / "hardcover_sync.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.INTER_BOOK_DELAY = 0  # keep tests instant
+    return module, session
+
+
+def _books(*specs):
+    """specs: (book_id, [(type, val), ...])"""
+    return {book_id: _Book(book_id, idents) for book_id, idents in specs}
+
+
+class TestBulkSyncBehaviour:
+    def test_get_or_add_per_book_mirrors_single_semantics(self):
+        _RecordingClient.instances = []
+        _RecordingClient.existing = {"77"}
+        books = _books((1, [("hardcover-id", "42")]),
+                       (2, [("hardcover-id", "77")]),   # already on Hardcover
+                       (3, [("hardcover-id", "99")]))
+        module, session = _load_task_module(books)
+        task = module.TaskHardcoverBulkSync("tok", [1, 2, 3], "My Shelf")
+        task.run(None)
+        client = _RecordingClient.instances[-1]
+        assert [c["hardcover-id"] for c in client.get_calls] == ["42", "77", "99"]
+        assert [c["hardcover-id"] for c in client.add_calls] == ["42", "99"], (
+            "a book already in the user's Hardcover library must be left "
+            "alone; the others must be added (single-add semantics, #381)"
+        )
+        assert (task.synced, task.already_synced) == (2, 1)
+        assert task.stat == 3 and task.progress == 1
+        assert session.closed, "the task must close its thread-local session"
+
+    def test_books_without_hardcover_identifiers_skip_api(self):
+        _RecordingClient.instances = []
+        _RecordingClient.existing = set()
+        books = _books((1, [("isbn", "9780000000001")]),
+                       (2, [("hardcover-id", "42")]))
+        module, _session = _load_task_module(books)
+        task = module.TaskHardcoverBulkSync("tok", [1, 2], "S")
+        task.run(None)
+        client = _RecordingClient.instances[-1]
+        assert len(client.get_calls) == 1, (
+            "books with no hardcover-* identifiers must not cost API calls"
+        )
+        assert task.skipped_no_identifiers == 1 and task.synced == 1
+
+    def test_one_failing_book_does_not_strand_the_batch(self):
+        _RecordingClient.instances = []
+        _RecordingClient.existing = set()
+
+        class _FlakyClient(_RecordingClient):
+            def get_user_book(self, identifiers):
+                if identifiers.get("hardcover-id") == "boom":
+                    raise RuntimeError("API exploded")
+                return super().get_user_book(identifiers)
+
+        books = _books((1, [("hardcover-id", "42")]),
+                       (2, [("hardcover-id", "boom")]),
+                       (3, [("hardcover-id", "99")]))
+        module, _session = _load_task_module(books, client_cls=_FlakyClient)
+        task = module.TaskHardcoverBulkSync("tok", [1, 2, 3], "S")
+        task.run(None)
+        assert task.synced == 2 and task.errors == 1
+        assert task.stat == 3, (
+            "per-book error tolerance: partial success is still success (#381)"
+        )
+
+    def test_all_errors_fail_the_task(self):
+        _RecordingClient.instances = []
+
+        class _DeadClient(_RecordingClient):
+            def get_user_book(self, identifiers):
+                raise RuntimeError("down")
+
+        books = _books((1, [("hardcover-id", "42")]))
+        module, _session = _load_task_module(books, client_cls=_DeadClient)
+        task = module.TaskHardcoverBulkSync("tok", [1], "S")
+        task.run(None)
+        assert task.stat == 1 and task.errors == 1
+
+    def test_missing_token_errors_without_touching_calibre(self):
+        class _StrictClient:
+            def __init__(self, token):
+                raise sys.modules["cps.services.hardcover"].MissingHardcoverToken()
+
+        module, session = _load_task_module({}, client_cls=_StrictClient)
+        task = module.TaskHardcoverBulkSync(None, [1], "S")
+        task.run(None)
+        assert task.stat == 1
+        assert not session.closed, "no calibre session should have been opened"
+
+    def test_deleted_book_is_skipped(self):
+        _RecordingClient.instances = []
+        _RecordingClient.existing = set()
+        module, _session = _load_task_module(_books((1, [("hardcover-id", "42")])))
+        task = module.TaskHardcoverBulkSync("tok", [1, 999], "S")
+        task.run(None)
+        assert task.synced == 1 and task.skipped_no_identifiers == 1
+        assert task.stat == 3
+
+    def test_cancellation_stops_between_books(self):
+        _RecordingClient.instances = []
+        _RecordingClient.existing = set()
+
+        class _CancellingClient(_RecordingClient):
+            task = None
+
+            def get_user_book(self, identifiers):
+                result = super().get_user_book(identifiers)
+                _CancellingClient.task.stat = 5  # STAT_CANCELLED
+                return result
+
+        books = _books((1, [("hardcover-id", "42")]),
+                       (2, [("hardcover-id", "99")]))
+        module, _session = _load_task_module(books, client_cls=_CancellingClient)
+        task = module.TaskHardcoverBulkSync("tok", [1, 2], "S")
+        _CancellingClient.task = task
+        task.run(None)
+        client = _RecordingClient.instances[-1]
+        assert len(client.get_calls) == 1, "cancellation must stop the loop"
+
+    def test_task_is_cancellable(self):
+        module, _session = _load_task_module({})
+        assert module.TaskHardcoverBulkSync("tok", [], "S").is_cancellable is True
+
+
+class TestShelfCallSitePins:
+    """Every add path must route through the single gate helper (#381)."""
+
+    def test_helper_exists_with_full_gate(self):
+        m = re.search(r"def queue_hardcover_sync\(shelf_obj, book_ids\):(.*?)\n@shelf", SHELF_SRC, re.S)
+        assert m, "queue_hardcover_sync helper not found in cps/shelf.py"
+        body = m.group(1)
+        for fragment in ("kobo_sync", "config.config_hardcover_sync",
+                         "hardcover_token", "WorkerThread.add",
+                         "TaskHardcoverBulkSync"):
+            assert fragment in body, f"gate helper must contain {fragment}"
+
+    def test_single_add_uses_helper(self):
+        m = re.search(r"def add_to_shelf\(shelf_id, book_id\):(.*?)\n@shelf", SHELF_SRC, re.S)
+        assert m and "queue_hardcover_sync(shelf, [book_id])" in m.group(1)
+
+    def test_search_massadd_syncs(self):
+        m = re.search(r"def search_to_shelf\(shelf_id\):(.*?)\n@shelf", SHELF_SRC, re.S)
+        assert m and "queue_hardcover_sync(shelf, books_for_shelf)" in m.group(1), (
+            "search mass-add must queue Hardcover sync for the added books (#381)"
+        )
+
+    def test_add_series_syncs(self):
+        m = re.search(r"def add_series_to_shelf\(shelf_id, series_id\):(.*?)\n@shelf", SHELF_SRC, re.S)
+        assert m and "queue_hardcover_sync(shelf, [book.id for book in to_add])" in m.group(1), (
+            "add-series must queue Hardcover sync for the added books (#381)"
+        )
+
+    def test_multi_select_syncs(self):
+        m = re.search(r"def add_selected_to_shelf\(\):(.*?)\n@shelf", SHELF_SRC, re.S)
+        assert m and "queue_hardcover_sync(shelf, added_ids)" in m.group(1), (
+            "multi-select add must queue Hardcover sync for the added books (#381)"
+        )
+
+    def test_no_inline_client_left_in_routes(self):
+        assert "HardcoverClient(" not in SHELF_SRC, (
+            "shelf routes must not construct HardcoverClient inline — the "
+            "request must not block on external API calls (#381)"
+        )
+
+    def test_task_creates_one_client_for_the_batch(self):
+        assert TASK_SRC.count("hardcover.HardcoverClient(") == 1, (
+            "the task must create one client per batch, not per book"
+        )

--- a/tests/unit/test_shelf_add_series_334.py
+++ b/tests/unit/test_shelf_add_series_334.py
@@ -285,7 +285,9 @@ class TestHardcoverTransportParity:
         """In add_to_shelf, the Hardcover sync must run before the xhr/non-xhr
         response branches — both transports get the same outcome."""
         body = SHELF_PY.split("def add_to_shelf", 1)[1].split("\n@shelf.route", 1)[0]
-        hardcover_pos = body.find("config.config_hardcover_sync")
+        # Since fork #381 the sync is a queued task; the enqueue call is the
+        # transport-parity point and must still precede the response split.
+        hardcover_pos = body.find("queue_hardcover_sync(shelf, [book_id])")
         response_split_pos = body.find('flash(_("Book has been added to shelf')
         assert hardcover_pos != -1 and response_split_pos != -1
         assert hardcover_pos < response_split_pos, (


### PR DESCRIPTION
Addresses #381.

## Symptom

Adding a single book to a Kobo-synced shelf synced it to the user's Hardcover library. All three bulk paths — "add all" from search results, multi-select add, and add-series-to-shelf — skipped Hardcover entirely. Same user intent, different outcome depending on which button you used.

## Fix

- New `cps/tasks/hardcover_sync.py` (`TaskHardcoverBulkSync`): background get-or-add on the WorkerThread. Mirrors the single-add semantics per book (a book already in the user's Hardcover library is left alone — status changes belong to `update_reading_progress`). One client per batch, books without `hardcover-*` identifiers skipped without API calls, per-book error tolerance, cancellable, progress + summary in the Tasks list. Token and book ids are captured at enqueue time (the worker thread has no request context).
- `cps/shelf.py`: one gate helper `queue_hardcover_sync` (kobo_sync shelf + `config_hardcover_sync` + user token) called from **all four** add paths. The single-add route stops blocking its HTTP response on up to two external API calls (10 s timeout each); the bulk paths gain the sync.
- `cps/services/hardcover.py`: `GRAPHQL_ENDPOINT` is now overridable via `HARDCOVER_API_ENDPOINT` (default unchanged) so integration tests can point at a local mock. No new dependencies or external URLs.

## Verification

- **Tests**: `tests/unit/test_hardcover_bulk_sync.py` — 8 behavioural tests of the task through a stub world (get-or-add semantics, identifier-less skip, per-book error tolerance, all-error failure, missing token, deleted book, cancellation) + 7 call-site/source pins. RED on main (module absent; pins fail). One superseded #334 pin updated (the transport-parity point is now the enqueue call, still ahead of the response split). Full unit+smoke suite: 1595 passed, 2 standing env failures only.
- **Live (cwn-local, image rebuilt from this branch)**: mock Hardcover GraphQL server inside the container via `HARDCOVER_API_ENDPOINT`; `config_hardcover_sync` + kobo-synced shelf + admin token configured. Drove the real routes session-authed: single add (`/shelf/add`), multi-select (`/shelf/add_selected_to_shelf`), add-series (`/shelf/add_series`). OBSERVED in the mock's request log: per-book `get_user_book` + `insert_user_book` with the right ids for every path; already-on-Hardcover book got `get_user_book` only; identifier-less book got zero API calls. Task summaries OBSERVED in the Tasks UI (`/ajax/emailstat`): "1 added / 0 already synced…", "2 added…", "1 added, 1 without Hardcover identifiers", "0 added, 1 already synced".
- **Resilience**: with the mock down, the add still returns 204 and the task fails cleanly ("Failed" in Tasks, no traceback). Log scan over the test window: no new ERROR/Traceback.
- Skipped: stress/concurrency row (WorkerThread serializes tasks; no shared mutable state beyond the task's own counters), i18n row (task name/messages use lazy_gettext for the task title; summary strings are log/status text).

Mass-add (`search_to_shelf`) was verified by pin + shared helper (it requires live search-session state; the helper call is identical to the three live-driven paths).