### PR TITLE
fix(security): parse comic-reader bookmark as int instead of eval() (XSS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Security
+- Closed a cross-site scripting hole in the comic (CBR/CBZ) reader. The reader
+  ran your saved page bookmark through JavaScript's `eval()`, so a bookmark
+  value that contained code — which any logged-in account could store for a
+  comic — would execute when the reader page opened. Bookmarks are now read
+  strictly as a page number.
+
 ### Fixed
 - Adding several books at once to a Kobo-synced shelf now syncs them to
   Hardcover, just like adding one book does. Before, only single adds reached

--- a/cps/templates/readcbr.html
+++ b/cps/templates/readcbr.html
@@ -194,8 +194,8 @@
     document.onreadystatechange = function () {
       if (document.readyState == "complete") {
           if (calibre.useBookmarks) {
-              currentImage = eval(calibre.bookmark);
-              if (typeof currentImage !== 'number') {
+              currentImage = parseInt(calibre.bookmark, 10);
+              if (!Number.isInteger(currentImage) || currentImage < 0) {
                   currentImage = 0;
               }
           }

--- a/tests/unit/test_readcbr_no_eval_xss.py
+++ b/tests/unit/test_readcbr_no_eval_xss.py
@@ -1,0 +1,35 @@
+"""Regression: the comic (CBR/CBZ) reader must not eval() the stored bookmark.
+
+`bookmark_key` is user-writable — any authenticated user can POST an arbitrary
+string to /ajax/bookmark/<comic_id>/CBR and it is rendered verbatim into
+window.calibre.bookmark. The old code ran `currentImage = eval(calibre.bookmark)`
+on page load, so a stored payload like `alert(document.cookie)` executed in the
+reader page (stored-XSS-equivalent / self-XSS escalation). The bookmark is only
+ever a page index, so it must be parsed as an integer, never eval'd.
+"""
+import os
+import re
+
+HERE = os.path.dirname(__file__)
+READCBR = os.path.normpath(
+    os.path.join(HERE, "..", "..", "cps", "templates", "readcbr.html")
+)
+
+
+def _src():
+    with open(READCBR, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_readcbr_does_not_eval_bookmark():
+    src = _src()
+    # No eval of the templated bookmark value anywhere in the comic reader.
+    assert "eval(calibre.bookmark)" not in src
+    assert not re.search(r"\beval\s*\(", src), "readcbr.html must not call eval()"
+
+
+def test_readcbr_parses_bookmark_as_int():
+    src = _src()
+    assert "parseInt(calibre.bookmark, 10)" in src
+    # And guards against NaN / negative so garbage falls back to page 0.
+    assert "Number.isInteger(currentImage)" in src


### PR DESCRIPTION
## Symptom

Opening a comic (CBR/CBZ) in the web reader could run arbitrary JavaScript. The reader executed your saved page bookmark with `eval()`:

```js
currentImage = eval(calibre.bookmark);
```

`calibre.bookmark` comes from `bookmark.bookmark_key`, which is user-writable — any logged-in account can POST an arbitrary string to `/ajax/bookmark/<comic_id>/CBR` and it is rendered verbatim into `window.calibre.bookmark`. A stored payload like `alert(document.cookie)//` then executes when the comic reader page opens (stored-XSS / self-XSS escalation; the bookmark is per-user-scoped, so the practical vector is self-XSS or a tricked-into-storing flow, but `eval` of user data is unacceptable regardless).

## Fix

The bookmark is only ever a page index. Parse it with `parseInt(.., 10)` and fall back to page 0 on any non-integer or negative value. No execution sink remains.

## Verification

- **RED/GREEN:** `tests/unit/test_readcbr_no_eval_xss.py` (source-pin: no `eval(`, parseInt present + bounds guard) — fails on `main`, passes here.
- **Live (cwn-local, rebuilt off this branch):** stored the payload `alert(document.cookie)//` as the bookmark for comic id 19. Pre-fix image: rendered page showed `eval(calibre.bookmark)` and the stored alert payload. Post-fix image: rendered page shows `parseInt(calibre.bookmark, 10)`; Playwright load of `/read/19/cbr` fired **no** dialog and `currentImage === 0` (payload parsed to NaN → safe fallback). Comic opened normally.
- **/security-review:** clean — removes the eval sink; the remaining `bookmark: "{{...}}"` interpolation is unchanged and safe in `<script>` raw-text context under Jinja autoescaping (`<`/`"` escaped, cannot break out).

Addresses the P0 finding from the web-reader program audit (`notes/web-reader-DESIGN.md` §4).