### PR TITLE
fix(metadata): order search modal by configured provider hierarchy (#405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ is for things you can see or feel when running the app.
   strictly as a page number.
 
 ### Fixed
+- The metadata search dialog now lists providers in the order you set under
+  Settings, instead of alphabetically. Whatever provider order you configure
+  for automatic metadata fetching is now also the order the search popup shows
+  and ranks results in, so your preferred source appears first.
 - Adding several books at once to a Kobo-synced shelf now syncs them to
   Hardcover, just like adding one book does. Before, only single adds reached
   Hardcover — "add all" from search results, multi-select adds, and

--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -105,6 +105,43 @@ def _get_global_provider_enabled_map() -> dict:
         return {}
     # Remove redundant return
 
+
+# Helper to load the configured provider hierarchy from CWA settings (fork #405).
+# The interactive search modal must present providers in the order the user
+# configured — the same order the ingest auto-fetch in cps/metadata_helper.py
+# obeys — falling back to alphabetical only for providers not named in the
+# hierarchy. Returns the ordered list of provider ids.
+def _get_provider_hierarchy() -> list:
+    from .metadata_constants import (
+        DEFAULT_METADATA_PROVIDER_HIERARCHY,
+        DEFAULT_METADATA_PROVIDER_HIERARCHY_JSON,
+    )
+    try:
+        sys.path.insert(1, '/app/calibre-web-automated/scripts/')
+        from cwa_db import CWA_DB  # type: ignore
+        settings = CWA_DB().get_cwa_settings() or {}
+        hierarchy = json.loads(
+            settings.get('metadata_provider_hierarchy', DEFAULT_METADATA_PROVIDER_HIERARCHY_JSON)
+        )
+        if not isinstance(hierarchy, list):
+            raise ValueError("metadata_provider_hierarchy must be a list")
+        return [p for p in hierarchy if isinstance(p, str)]
+    except Exception as e:
+        log.warning(f"Error loading provider hierarchy, using default: {e}")
+        return list(DEFAULT_METADATA_PROVIDER_HIERARCHY)
+
+
+def _hierarchy_sort_key(hierarchy: list):
+    """Sort key: configured-hierarchy index first (providers not listed sort
+    after all listed ones), then alphabetical by provider id for stability."""
+    order = {pid: idx for idx, pid in enumerate(hierarchy)}
+    big = len(order)
+
+    def key(provider_id: str, name: str = ""):
+        return (order.get(provider_id, big), (name or provider_id).lower())
+
+    return key
+
 # Providers that take a single API token / key plus the config column that
 # stores it and a public signup URL. Used by the metadata-search modal's
 # 🔑 Keys panel so users don't have to leave the modal to plug in a key.
@@ -386,9 +423,17 @@ def metadata_search():
                 "message": message,
                 "duration_ms": elapsed_ms,
             })
-    # Stable sort so rendering is deterministic even though futures complete
-    # out of order.
-    provider_status.sort(key=lambda p: p["name"].lower())
+    # Order provider rows by the configured hierarchy (fork #405) so the modal
+    # presents providers in the order the user set — the same order the ingest
+    # auto-fetch obeys — with alphabetical fallback for providers not listed.
+    _hierarchy = _get_provider_hierarchy()
+    _hkey = _hierarchy_sort_key(_hierarchy)
+    provider_status.sort(key=lambda p: _hkey(p["id"], p["name"]))
+    # Same ordering for the flattened results so the preferred provider's
+    # matches lead; stable sort preserves each provider's internal order.
+    _rank = {pid: idx for idx, pid in enumerate(_hierarchy)}
+    _big = len(_rank)
+    results.sort(key=lambda r: _rank.get((r.get("source") or {}).get("id"), _big))
 
     # Upgrade thumbnail-sized covers to high-DPI variants (Kobo Libra Color
     # etc.) by ISBN/title lookup against iTunes Search API. No-op when the

--- a/tests/unit/test_metadata_search_hierarchy_order_405.py
+++ b/tests/unit/test_metadata_search_hierarchy_order_405.py
@@ -1,0 +1,92 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Fork #405 — the interactive metadata-search modal must present providers
+in the user-configured hierarchy order, not alphabetically by class name.
+
+Before this fix ``cps/search_metadata.py::metadata_search`` ended with
+``provider_status.sort(key=lambda p: p["name"].lower())`` — alphabetical,
+ignoring ``metadata_provider_hierarchy`` that the ingest auto-fetch in
+``cps/metadata_helper.py`` obeys. A user who set a preferred order in
+settings did not get that order in the search dialog.
+
+``cps/search_metadata.py`` cannot be imported in the unit env (it pulls
+``cwa_db`` which only exists in the container), so the ordering function is
+extracted from source and exercised directly; the integration points are
+source-pinned.
+"""
+from __future__ import annotations
+
+import ast
+import os
+
+HERE = os.path.dirname(__file__)
+SEARCH_META = os.path.normpath(
+    os.path.join(HERE, "..", "..", "cps", "search_metadata.py")
+)
+
+
+def _src():
+    with open(SEARCH_META, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _load_func(name):
+    """Extract a top-level function from search_metadata.py and exec it in an
+    isolated namespace (the helpers under test depend only on stdlib)."""
+    tree = ast.parse(_src())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            module = ast.Module(body=[node], type_ignores=[])
+            ns: dict = {}
+            exec(compile(module, SEARCH_META, "exec"), ns)
+            return ns[name]
+    raise AssertionError(f"{name} not found in search_metadata.py")
+
+
+def test_hierarchy_sort_key_orders_by_configured_then_alpha():
+    key = _load_func("_hierarchy_sort_key")(["google", "openlibrary", "ibdb"])
+    rows = [
+        {"id": "douban", "name": "Douban"},
+        {"id": "google", "name": "Google"},
+        {"id": "amazon", "name": "Amazon"},
+        {"id": "ibdb", "name": "iBDB"},
+        {"id": "openlibrary", "name": "Open Library"},
+    ]
+    rows.sort(key=lambda p: key(p["id"], p["name"]))
+    ids = [r["id"] for r in rows]
+    # Configured providers in configured order first...
+    assert ids[:3] == ["google", "openlibrary", "ibdb"]
+    # ...then the unlisted ones, alphabetical by name (Amazon before Douban).
+    assert ids[3:] == ["amazon", "douban"]
+
+
+def test_hierarchy_sort_key_empty_hierarchy_is_alphabetical():
+    key = _load_func("_hierarchy_sort_key")([])
+    rows = [{"id": "zzz", "name": "Zed"}, {"id": "aaa", "name": "Alpha"}]
+    rows.sort(key=lambda p: key(p["id"], p["name"]))
+    assert [r["id"] for r in rows] == ["aaa", "zzz"]
+
+
+def test_metadata_search_orders_provider_status_by_hierarchy():
+    src = _src()
+    # The old alphabetical-only sort must be gone.
+    assert 'provider_status.sort(key=lambda p: p["name"].lower())' not in src
+    # provider_status is ordered through the hierarchy key helper.
+    assert "_hierarchy_sort_key(" in src
+    assert "provider_status.sort(key=lambda p: _hkey(" in src
+
+
+def test_metadata_search_orders_results_by_hierarchy():
+    src = _src()
+    # The flattened results are also reordered by provider hierarchy.
+    assert "results.sort(key=lambda r:" in src
+    assert '(r.get("source") or {}).get("id")' in src
+
+
+def test_get_provider_hierarchy_helper_exists():
+    src = _src()
+    assert "def _get_provider_hierarchy(" in src
+    # Falls back to the single-source-of-truth default constant on any error.
+    assert "DEFAULT_METADATA_PROVIDER_HIERARCHY" in src


### PR DESCRIPTION
## Symptom

The interactive metadata-search dialog listed providers alphabetically by class name, ignoring the `metadata_provider_hierarchy` you configure in Settings — the same order the ingest auto-fetch obeys. A user who set a preferred provider order didn't get it in the search popup.

## Root cause

`cps/search_metadata.py::metadata_search` ended with `provider_status.sort(key=lambda p: p["name"].lower())` (alphabetical), and the flattened results came back in future-completion order. Neither consulted the configured hierarchy.

## Fix

- `_get_provider_hierarchy()` loads the configured order from CWA settings, falling back to the single-source-of-truth `DEFAULT_METADATA_PROVIDER_HIERARCHY` constant on any error.
- `_hierarchy_sort_key()` orders configured providers first (in configured order), then unlisted providers alphabetically.
- Both the provider rows and the flattened results are ordered by it, so your preferred provider leads.

This closes the **last open sub-issue of #405** — the three divergent defaults, the dead `cps/auto_metadata.py` duplicate fetcher, and the missing `openlibrary` default were already resolved (`cps/metadata_constants.py` is now the single source).

## Verification

- **RED/GREEN:** `tests/unit/test_metadata_search_hierarchy_order_405.py` — behavioural test of the sort key (extracted from source; the module pulls container-only `cwa_db`) + source-pins of both ordering points. Fails on `main`, passes here. Full metadata suite (27 tests) green.
- **Live (cwn-local, rebuilt off branch):** set hierarchy to `["douban","ibdb","google","openlibrary"]`, POSTed `/metadata/search` session-authed. Provider order returned `douban, ibdb, google, openlibrary, amazon, amazonjp, applebooks, comicvine, dnb, …` — configured order first, unlisted alphabetical. Results led with `ibdb` (first configured provider returning matches). No new errors in logs.

Addresses #405.