### PR TITLE
docs: CHANGELOG train v4.0.160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+## [v4.0.160] - 2026-06-10
+
 ### Security
 - Closed a cross-site scripting hole in the comic (CBR/CBZ) reader. The reader
   ran your saved page bookmark through JavaScript's `eval()`, so a bookmark


### PR DESCRIPTION
Cut v4.0.160 from the `[Unreleased]` train — 1 Security + 13 Fixed, all post-v4.0.159 and `:dev`-soaked on the teenyverse canary. Docs-only (`safe-tier-1`); release tag + notes follow once merged.