### PR TITLE
i18n(fr): translate Calibre-database-unavailable admin message

### DIFF
--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -43,7 +43,7 @@ msgstr "Statistiques"
 
 #: cps/admin.py:139
 msgid "Calibre database unavailable. Please reconfigure the library path."
-msgstr ""
+msgstr "Base de données Calibre indisponible. Veuillez reconfigurer le chemin de la bibliothèque."
 "Base de données de Calibre indisponible. Veuillez reconfigurer le chemin de "
 "la bibliothèque."
 


### PR DESCRIPTION
## Why
Upstream CWA PR crocodilestick/Calibre-Web-Automated#1370 (@martinlehanneur) fills three empty French msgstrs. Two of the three are already translated on our fork with better wording, so a straight cherry-pick would downgrade them. This takes only the genuinely missing one.

## Change
One msgstr in `cps/translations/fr/LC_MESSAGES/messages.po`: the admin "Calibre database unavailable. Please reconfigure the library path." message. Wording corrected from the upstream PR (chemin, bibliothèque, base de données).

## Validation
`msgfmt -c` passes on the updated `fr.po`. `tests/unit/test_translations_compile.py` covers compile in CI.

## Tier
safe-tier-1 (single .po file, no code).

Credit: @martinlehanneur for the original translation upstream.