### PR TITLE
Fix Calibre config dir in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -295,7 +295,7 @@ RUN \
 COPY --from=unrar /usr/bin/unrar-ubuntu /usr/bin/unrar
 
 # Set calibre environment variable
-ENV CALIBRE_CONFIG_DIR=/config/.config/calibre
+ENV CALIBRE_CONFIG_DIRECTORY=/config/.config/calibre
 
 # Ports and volumes
 WORKDIR /config


### PR DESCRIPTION
The Docker container configures `CALIBRE_CONFIG_DIR`; as far as I can tell, that's a typo for `CALIBRE_CONFIG_DIRECTORY`, which is the only one of the two mentioned by Calibre docs.

This causes Calibre to fall back to the default directory, `$HOME/.config/...`, which doesn't exist, breaking book ingestion that relies on plugins. The path described in the Calibre Web docs, `/config/.config/calibre`, works after this update.

Fixes crocodilestick/Calibre-Web-Automated#1372