### PR TITLE
docs: CHANGELOG train v4.0.161

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+## [v4.0.161] - 2026-06-12
+
 ### Fixed
 - Hardcover progress sync no longer dies on books without a chosen edition.
   Reading on a KOReader/Kobo device synced progress to the library fine, but


### PR DESCRIPTION
Stamps the [Unreleased] train as v4.0.161 (2026-06-12). Docs-only.

Carries (all already merged to main and soaked on `:dev`):
- Hardcover progress sync nullable-GraphQL fix — PR #435, ships fix for #433
- Mobile search tap fix — PR #427, ships fix for #425 (reporter-confirmed on `:dev`)
- Mobile detail cover sizing — PR #423, addresses #288

Train was eligible 07:09Z Jun 11 and missed a day due to the autopilot LLM-timeout outage (resolved 22:09Z Jun 11). Tag + release follow merge.