### PR TITLE
fix(calibre): set CALIBRE_CONFIG_DIRECTORY per-subprocess; drop misspelled global ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+- Calibre plugin and configuration loading is now reliable when you opt in
+  with `CWA_CALIBRE_USER_PLUGINS=true`. The image used to set a misspelled
+  environment variable (`CALIBRE_CONFIG_DIR`) that Calibre simply ignores, so
+  Calibre invocations could fall back to a nonexistent home directory and
+  miss plugins installed under `/config/.config/calibre/plugins`. The opt-in
+  now sets Calibre's documented `CALIBRE_CONFIG_DIRECTORY` on every Calibre
+  subprocess it covers (ingest, conversion, cover enforcement, metadata
+  embed). Plugin loading stays off unless you opt in. (Diagnosed by
+  @jasonobrien in #434)
+
 ## [v4.0.161] - 2026-06-12
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -294,8 +294,12 @@ RUN \
 # Add unrar from unrar stage
 COPY --from=unrar /usr/bin/unrar-ubuntu /usr/bin/unrar
 
-# Set calibre environment variable
-ENV CALIBRE_CONFIG_DIR=/config/.config/calibre
+# Deliberately NO global CALIBRE_CONFIG_DIRECTORY here. (A misspelled
+# CALIBRE_CONFIG_DIR lived here for a while -- Calibre ignores that name,
+# and setting the real one globally would force user-plugin loading on for
+# every Calibre subprocess. Plugin loading is opt-in via
+# CWA_CALIBRE_USER_PLUGINS; cps/services/calibre_user_plugins.py sets
+# CALIBRE_CONFIG_DIRECTORY per-subprocess when the operator enables it.)
 
 # Ports and volumes
 WORKDIR /config

--- a/cps/services/calibre_user_plugins.py
+++ b/cps/services/calibre_user_plugins.py
@@ -8,10 +8,21 @@
 
 When ``CWA_CALIBRE_USER_PLUGINS`` is set to a truthy value (``1`` /
 ``true`` / ``yes`` / ``on``), Calibre subprocess invocations launched by
-the ingest pipeline run with ``HOME=/config`` so that the embedded
-Calibre process loads any plugins the operator has placed under
+the ingest pipeline run with ``HOME=/config`` and
+``CALIBRE_CONFIG_DIRECTORY=/config/.config/calibre`` so that the
+embedded Calibre process loads any plugins the operator has placed under
 ``/config/.config/calibre/plugins/``. The plugins directory is created
 on first use if missing.
+
+``CALIBRE_CONFIG_DIRECTORY`` is Calibre's documented configuration
+variable and is authoritative; ``HOME`` is kept alongside it for any
+Calibre code path that derives dotfile locations from the home
+directory. (The image used to set a misspelled ``CALIBRE_CONFIG_DIR``
+globally in the Dockerfile — Calibre ignores that name, which is why
+plugin loading historically only worked through the HOME override.
+Diagnosed by @jasonobrien in fork PR #434. A global
+``CALIBRE_CONFIG_DIRECTORY`` would defeat this module's off-state, so
+the variable is set here, per-subprocess, gated on the opt-in.)
 
 The default is **off**. Plugin loading is the operator's explicit
 choice — it activates third-party Python code from a user-controlled
@@ -54,8 +65,10 @@ def is_enabled() -> bool:
 
 
 def apply_to_env(env: dict[str, str]) -> dict[str, str]:
-    """If enabled, set ``HOME=/config`` on the given env mapping in
-    place and return it. If disabled, return the env unchanged.
+    """If enabled, set ``HOME=/config`` and
+    ``CALIBRE_CONFIG_DIRECTORY=/config/.config/calibre`` on the given
+    env mapping in place and return it. If disabled, return the env
+    unchanged.
 
     Designed to be called right before ``subprocess.run(..., env=env)``:
 
@@ -70,7 +83,15 @@ def apply_to_env(env: dict[str, str]) -> dict[str, str]:
     """
     if is_enabled():
         env["HOME"] = _HOME
+        env["CALIBRE_CONFIG_DIRECTORY"] = str(config_dir())
     return env
+
+
+def config_dir() -> Path:
+    """Absolute path to the Calibre configuration directory the opt-in
+    points subprocesses at (``/config/.config/calibre``). The plugins
+    directory lives directly beneath it."""
+    return Path(_HOME) / _PLUGINS_SUBPATH.rsplit("/", 1)[0]
 
 
 def plugins_dir() -> Path:

--- a/tests/unit/test_calibre_user_plugins.py
+++ b/tests/unit/test_calibre_user_plugins.py
@@ -84,6 +84,18 @@ class TestCalibreUserPluginsHelper:
         assert result is env, "must mutate in place + return the same dict"
         assert env["PATH"] == "/usr/bin", "must not touch other env vars"
 
+    def test_apply_to_env_when_enabled_sets_calibre_config_directory(self, clean_env):
+        # CALIBRE_CONFIG_DIRECTORY is Calibre's documented config variable
+        # and the authoritative way to point subprocesses at
+        # /config/.config/calibre — HOME alone only works for code paths
+        # that derive config from the home dir. (Fork PR #434 diagnosis:
+        # the image's old global CALIBRE_CONFIG_DIR was a misspelling
+        # Calibre ignores.)
+        clean_env.setenv("CWA_CALIBRE_USER_PLUGINS", "true")
+        env = {"PATH": "/usr/bin"}
+        result = calibre_user_plugins.apply_to_env(env)
+        assert result["CALIBRE_CONFIG_DIRECTORY"] == "/config/.config/calibre"
+
     def test_apply_to_env_when_disabled_leaves_HOME_alone(self, clean_env):
         # No env var set
         env = {"PATH": "/usr/bin", "HOME": "/home/abc"}
@@ -101,6 +113,34 @@ class TestCalibreUserPluginsHelper:
         assert "HOME" not in result, (
             "off-state must not silently introduce HOME — it would be "
             "indistinguishable from on-state at runtime"
+        )
+        assert "CALIBRE_CONFIG_DIRECTORY" not in result, (
+            "off-state must not set CALIBRE_CONFIG_DIRECTORY either — "
+            "that variable alone is enough for Calibre to load plugins"
+        )
+
+    def test_config_dir_path(self, clean_env):
+        assert (
+            str(calibre_user_plugins.config_dir()) == "/config/.config/calibre"
+        ), "must match Calibre's expectation AND contain plugins_dir"
+        assert calibre_user_plugins.plugins_dir().parent == (
+            calibre_user_plugins.config_dir()
+        )
+
+    def test_dockerfile_has_no_global_calibre_config_env(self):
+        # Regression vector for fork PR #434: a global CALIBRE_CONFIG_DIR
+        # (misspelled, ignored) or CALIBRE_CONFIG_DIRECTORY (correct, but
+        # would force the plugin opt-in permanently ON) must not reappear
+        # in the image. The per-subprocess opt-in in this module is the
+        # only sanctioned way to point Calibre at /config.
+        dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+        env_lines = [
+            line for line in dockerfile.splitlines()
+            if re.match(r"^\s*ENV\s+CALIBRE_CONFIG", line)
+        ]
+        assert env_lines == [], (
+            f"Dockerfile must not set a global Calibre config variable; "
+            f"found: {env_lines}"
         )
 
     def test_plugins_dir_path(self, clean_env):


### PR DESCRIPTION
Supersedes #434 with an opt-in-preserving variant; diagnosis credit @jasonobrien.

## What
- `Dockerfile`: remove `ENV CALIBRE_CONFIG_DIR=...` — a misspelling of Calibre's `CALIBRE_CONFIG_DIRECTORY` that Calibre ignores (dead line since Aug 2025).
- `cps/services/calibre_user_plugins.py`: `apply_to_env()` now sets `CALIBRE_CONFIG_DIRECTORY=/config/.config/calibre` alongside `HOME=/config` when `CWA_CALIBRE_USER_PLUGINS` is enabled. New `config_dir()` helper.

## Why not just fix the spelling globally (the #434 approach)
A global `CALIBRE_CONFIG_DIRECTORY` would force plugin loading ON for every Calibre subprocess, defeating the documented off-state of the opt-in shipped in #122/#123 (plugins execute third-party code at ingest time; the off-default is deliberate). Setting the variable per-subprocess, gated on the opt-in, fixes the reporter's symptom (plugins not honored) without changing the trust model.

## Evidence
- OBSERVED (cwn-local): `CALIBRE_CONFIG_DIR` typo → calibre config_dir = `/root/.config/calibre` (bug); `CALIBRE_CONFIG_DIRECTORY` → `/config/.config/calibre` (fix).
- OBSERVED (cwn-local): `apply_to_env()`'d environment steers real `calibre-debug` to `/config/.config/calibre`.
- Red/green: 3 new tests fail on main, pass here; full `test_calibre_user_plugins.py` 46/46.
- Source-pin added: Dockerfile may never reintroduce a global `ENV CALIBRE_CONFIG*`.

Review gate: Greptile unavailable (trial ended). /security-review not run — no new subprocess, no user-controlled input (env value is a constant path), no auth/route/crypto surface.

Addresses #434.