### PR TITLE
i18n(fr): keep Hardcover service name untranslated in integration labels (CWA #1202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- French (`fr`): the Hardcover integration labels no longer translate the service name "Hardcover" as "livres reliés" (hardback books). "Run Hardcover Auto-Fetch", "Hardcover Token Required" and "Enable Hardcover Auto-Fetch" now keep the Hardcover name so the buttons match the feature. Thanks to @Korri.
 - Spanish (`es`): the "Invalid request" error now reads "Petición inválida" instead of the incorrect "Rol inválido" (Invalid role), and punctuation is tidied across 36 shared interface strings to match the source text. Thanks to @pablo-alcaniz.
 - German (`de`): fixed 11 interface strings that showed the wrong text — the cover-size limit read "5-120 Minuten" (minutes) instead of "1–200 MB", "Failed to update shelves" showed the tags message, and "KOReader Sync is disabled" showed the default-login message. OIDC, logfile, email and Magic Shelves labels are corrected too. Thanks to @futurelook.
 

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -3500,7 +3500,7 @@ msgstr ""
 
 #: cps/templates/admin.html:222
 msgid "Run Hardcover Auto-Fetch"
-msgstr "Exécuter la récupération automatique des livres reliés"
+msgstr "Exécuter la récupération automatique des IDs Hardcover"
 
 #: cps/templates/admin.html:227
 msgid "Administration&nbsp;&nbsp;🚀"
@@ -5859,7 +5859,7 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:557
 msgid "Hardcover Token Required"
-msgstr "Jeton relié requis"
+msgstr "Jeton Hardcover requis"
 
 #: cps/templates/cwa_settings.html:558
 msgid ""
@@ -5874,7 +5874,7 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:569
 msgid "Enable Hardcover Auto-Fetch"
-msgstr "Activer la récupération automatique des livres reliés"
+msgstr "Activer la récupération automatique Hardcover"
 
 #: cps/templates/cwa_settings.html:571
 msgid ""


### PR DESCRIPTION
## Why
French users see the Hardcover integration buttons labelled with "livres reliés" (hardback books) — a literal translation of the **Hardcover** service name, which should stay as the brand name. Reported and fixed upstream by @Korri in [crocodilestick/Calibre-Web-Automated#1202](https://github.com/crocodilestick/Calibre-Web-Automated/pull/1202).

## Root cause
Our `fr` translation rendered the product name "Hardcover" as "livres reliés" / "relié" in three admin/settings labels. Hardcover is the name of the reading-progress service, not a book binding, so the labels read wrong against the feature they trigger.

## Fix
Curated from upstream #1202 by `(msgid, msgctxt)`-keyed delta (reflow-resistant; see `notes/i18n-drainage-technique.md`). Applies only the **3 strings** where our `fr` value matched the PR base (clean improvement):

- `Run Hardcover Auto-Fetch`: "…des livres reliés" → "…des IDs Hardcover"
- `Hardcover Token Required`: "Jeton relié requis" → "Jeton Hardcover requis"
- `Enable Hardcover Auto-Fetch`: "…des livres reliés" → "…Hardcover"

Deliberately **skips** `Hardcover Sync Blacklist` — our fork already has a correct translation there ("Liste noire de synchronisation avec Hardcover"), so upstream's variant is not clobbered. The PR's 4th changed string exists only as an obsolete entry in our tree (no active msgid) and is not touched.

## Validation
- `msgfmt -c` clean; compiled `.mo` resolves all three corrected strings.
- msgid set unchanged (none added/dropped), header/metadata identical, exactly 3 active `msgstr` changed.
- `tests/unit/test_translations_compile.py` — 30/30 pass.

## Tier / release
`safe-tier-1` (single `.po` + CHANGELOG). Target: v4.0.163 train.

Credit: @Korri (upstream CWA #1202).