### PR TITLE
fix(detail): reclaim oversized book-detail margins; side-by-side from 1024px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Changed
+- The **book details page** is easier to read, especially on phones. The big
+  empty margins that boxed in the cover and info are gone — you get noticeably
+  more width for the title, tags and description — and the page is tidier
+  overall. The star rating now shows clean stars instead of a stray white box.
+  On wider screens the cover and details sit side-by-side from 1024px up
+  (previously only above 1400px), so desktops and landscape tablets use the
+  width instead of stranding the cover alone in the middle.
+
 ## [v4.0.165] - 2026-06-16
 
 ### Fixed

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -17,25 +17,29 @@
         .book-detail-page {
             display: flex;
             justify-content: center;
-            margin-top: 2rem;
-            margin-left: 1rem;
+            margin-top: 1.5rem;
         }
 
         .book-detail-card {
             width: min(1500px, 100%);
-            background: rgba(0, 0, 0, 0.20);
+            background-color: rgba(0, 0, 0, 0.20);
+            background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0) 140px);
             border: 1px solid rgba(255, 255, 255, 0.08);
             border-radius: 18px;
-            padding: 4rem;
+            padding: 2rem;                         /* fallback: no clamp() (old e-reader browsers) */
+            padding: clamp(1.4rem, 3.2vw, 3rem);   /* fluid: ~14px phone -> 30px desktop (was 40px flat) */
             display: flex;
             flex-direction: column;
-            gap: 4rem;
+            gap: 2.5rem;
+            gap: clamp(2rem, 3.4vw, 3rem);
             backdrop-filter: blur(6px);
+            box-shadow: 0 18px 50px -20px rgba(0, 0, 0, 0.55);
         }
 
         .book-detail-main {
             display: flex;
-            gap: 6rem;
+            gap: 3rem;
+            gap: clamp(2rem, 3vw, 3.5rem);
             align-items: flex-start;
         }
 
@@ -77,14 +81,18 @@
         }
 
         .book-detail-meta h2#title {
-            margin: 0;
-            font-size: 3rem;
-            margin-bottom: 1rem;
+            margin: 0 0 0.6rem;
+            font-size: 2.4rem;
+            font-size: clamp(2.1rem, 1.4rem + 1.8vw, 2.9rem);
+            line-height: 1.15;
+            letter-spacing: -0.015em;
+            font-weight: 700;
         }
 
         .book-detail-meta .author {
             margin: 0;
-            opacity: 0.85;
+            font-size: 1.6rem;
+            opacity: 0.78;
         }
 
         .book-metadata {
@@ -96,13 +104,14 @@
         .meta-chip {
             display: flex;
             align-items: center;
-            padding: 1rem 1.5rem;
+            padding: 0.7rem 1.1rem;
             background: rgba(0, 0, 0, 0.2);
             border: 1px solid rgba(255, 255, 255, 0.08);
             border-radius: 10px;
             flex-wrap: wrap;
             width: fit-content;
             gap: 10px;
+            font-size: 1.4rem;
         }
 
         .meta-label {
@@ -246,13 +255,16 @@
         }
 
         .book-detail-description {
-            padding-top: 4rem;
+            padding-top: 2.5rem;
+            padding-top: clamp(2rem, 3.4vw, 3rem);
             border-top: 1px solid rgba(255, 255, 255, 0.08);
         }
 
         .book-detail-description h3 {
             margin-top: 0;
-            margin-bottom: 3rem;
+            margin-bottom: 1.4rem;
+            font-size: 1.9rem;
+            letter-spacing: -0.01em;
         }
 
         .book-detail-card .hr {
@@ -272,6 +284,24 @@
 
         .rating .glyphicon-star-empty {
             color: #ffffff82;
+        }
+
+        /* Theme the raw numeric rating input so the pre-init / no-JS fallback
+           isn't a full-width white slab (the "white 0 box" on the detail page).
+           When bootstrap-rating-input initialises it hides this input and shows
+           the star glyphs; this only styles the fallback state. */
+        .rating input.rating,
+        #detail-rating {
+            width: auto;
+            max-width: 7rem;
+            height: auto;
+            padding: 0.3rem 0.7rem;
+            background: rgba(0, 0, 0, 0.25);
+            color: #fff;
+            border: 1px solid rgba(255, 255, 255, 0.14);
+            border-radius: 8px;
+            font-size: 1.6rem;
+            text-align: center;
         }
 
         .rating .rating-input {
@@ -331,9 +361,9 @@
         .book-action-bar .action-icon-btn {
             position: static;
             align-content: center;
-            height: 60px;
+            height: 46px;
+            width: 46px;
             border: none !important;
-            width: 50px;
         }
 
         .action-icon-btn {
@@ -399,7 +429,10 @@
             }
         }
 
-        @media (max-width: 1400px) {
+        /* Cover + meta stay side-by-side down to 1024px (landscape tablets and
+           desktops); below that they stack. Was 1400px — which left most desktop
+           widths showing a lone centred cover with big empty sides. */
+        @media (max-width: 1024px) {
             .book-detail-main {
                 flex-direction: column;
                 align-items: center;

--- a/tests/unit/test_detail_spacing.py
+++ b/tests/unit/test_detail_spacing.py
@@ -1,0 +1,46 @@
+"""Regression: the book-detail page keeps its reclaimed spacing + lowered
+stack breakpoint.
+
+The detail-page layout is styled inline in cps/templates/detail.html, so these
+are source-pins. They are RED on main (which ships a flat ``padding: 4rem`` card
+and a 1400px stack breakpoint) and GREEN on this branch. Paired with live
+multi-viewport verification on the running container; this guards against a
+future refactor silently reverting the reclaimed gutters.
+"""
+import os
+
+HERE = os.path.dirname(__file__)
+DETAIL = os.path.normpath(
+    os.path.join(HERE, "..", "..", "cps", "templates", "detail.html")
+)
+
+
+def _src():
+    with open(DETAIL, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_card_padding_is_fluid_and_reclaimed():
+    src = _src()
+    # Card padding reclaimed from a flat 4rem (40px every side, never reduced on
+    # phones) to a fluid clamp with a ~14px phone floor.
+    assert "clamp(1.4rem, 3.2vw, 3rem)" in src
+    # The old flat 40px card padding is gone.
+    assert "padding: 4rem;" not in src
+
+
+def test_stack_breakpoint_lowered_to_1024():
+    src = _src()
+    # Cover + metadata sit side-by-side down to 1024px now (was only >1400px).
+    assert "max-width: 1024px" in src
+    assert "max-width: 1400px" not in src
+
+
+def test_title_is_fluid():
+    assert "clamp(2.1rem, 1.4rem + 1.8vw, 2.9rem)" in _src()
+
+
+def test_rating_input_has_themed_fallback():
+    # The raw numeric rating input is themed so the pre-init / no-JS fallback is
+    # not a full-width white slab (the "white 0 box").
+    assert "#detail-rating" in _src()


### PR DESCRIPTION
## What
A natural iteration of the existing caliBlur book-detail card, not a redesign.

- Card padding: flat `4rem` (40px, never reduced on phones) → fluid `clamp(1.4rem, 3.2vw, 3rem)` (~14px phone → 30px desktop), each fluid value preceded by a static fallback so clamp-less e-reader browsers degrade cleanly instead of collapsing to 0 padding.
- Cover/meta gap `6rem` → `clamp(2rem, 3vw, 3.5rem)`; section gaps & description top `4rem` → fluid; tighter fluid title; lighter meta-chip padding; uniform 46×46 action icons (were an uneven 50×60).
- Themed the raw numeric rating input so its pre-init / no-JS fallback isn't a white slab (the "white 0 box").
- Dropped the cover/meta side-by-side breakpoint `1400px → 1024px` so desktops and landscape tablets use the width instead of stranding the cover centred.

## Why
Reported: margins pushing content in too far on the detail page, especially mobile. The flat 40px card padding ate ~40% of phone width; the 1400px breakpoint left most desktops with a lone centred cover.

## Verification
- **Regression test** `tests/unit/test_detail_spacing.py` source-pins the reclaimed padding, lowered breakpoint, fluid title and themed rating. RED on main (`padding: 4rem` / `max-width: 1400px` present, clamps absent), GREEN here.
- **Live** on the container at **390 / 768 / 1100 / 1280**: mobile content noticeably wider, no overflow/clipping, rating shows clean stars, desktop now side-by-side. No console errors.

## Scope
Detail page only. List/grid/shelf pages don't share the excessive side-margin (their `.discover` gutters are modest, and the grid's top margin is what clears the fixed filter bar — cutting it blind would overlap), so broader per-page polish continues separately rather than as a risky global tweak.

No new dependencies, license changes, or external URLs — CSS/template + test only.
