### PR TITLE
feat(detail): full-width Read button under the cover; drop read icon from action row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ is for things you can see or feel when running the app.
   On wider screens the cover and details sit side-by-side from 1024px up
   (previously only above 1400px), so desktops and landscape tablets use the
   width instead of stranding the cover alone in the middle.
+- The book details page now has a clear **Read** button right under the cover —
+  the full width of the cover — as the obvious way to start reading in your
+  browser. The small "read" icon was removed from the row of action buttons so
+  that row is less cluttered.
 
 ## [v4.0.165] - 2026-06-16
 

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -43,9 +43,60 @@
             align-items: flex-start;
         }
 
-        .book-detail-cover {
+        /* The cover and the primary Read CTA share one fixed-width column so the
+           Read button is always exactly the cover's width ("the width of the
+           book's icon", operator #28). The column owns the width; the cover and
+           the button each fill it at 100%. */
+        .book-cover-column {
             flex: 0 0 240px;
             max-width: 240px;
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        .book-detail-cover {
+            width: 100%;
+        }
+
+        .book-read-cta {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
+            width: 100%;
+            padding: 12px 16px;
+            border-radius: 12px;
+            color: #fff;
+            font-size: 1.6rem;
+            font-weight: 700;
+            letter-spacing: 0.01em;
+            text-decoration: none;
+            background-color: #161f27;                 /* fallback: flat color (old e-reader browsers) */
+            background-color: rgba(22, 31, 39, 0.92);
+            background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.10), rgba(255, 255, 255, 0));
+            border: 1px solid rgba(255, 255, 255, 0.22);
+            box-shadow: 0 8px 24px -10px rgba(0, 0, 0, 0.6);
+            -webkit-transition: background-color .15s ease, border-color .15s ease;
+            transition: background-color .15s ease, border-color .15s ease, transform .05s ease;
+            cursor: pointer;
+        }
+
+        .book-read-cta:hover,
+        .book-read-cta:focus {
+            background-color: #1d2a36;
+            border-color: rgba(255, 255, 255, 0.42);
+            color: #fff;
+            text-decoration: none;
+        }
+
+        .book-read-cta:active {
+            transform: translateY(1px);
+        }
+
+        .book-read-cta .glyphicon {
+            font-size: 16px;
+            top: 2px;
         }
 
         .book-detail-cover img {
@@ -447,7 +498,8 @@
                 justify-content: center;
             }
 
-            .book-detail-cover {
+            .book-cover-column {
+                flex: 0 0 auto;   /* parent is column flex now; don't impose a 240px height basis */
                 width: 240px;
                 max-width: 60%;
             }
@@ -458,7 +510,7 @@
         }
 
         @media (max-width: 600px) {
-            .book-detail-cover {
+            .book-cover-column {
                 width: 200px;
                 max-width: 70%;
             }
@@ -558,6 +610,7 @@
     <div class="book-detail-page">
         <div class="book-detail-card">
             <div class="book-detail-main">
+                <div class="book-cover-column">
                 <div class="book-detail-cover cover{% if current_user.role_edit() %} cover-editable{% endif %}">
                 <img id="detailcover" title="{{ entry.title }}"
                      src="{{ url_for('web.get_cover', book_id=entry.id, resolution='og', c=entry|last_modified) }}"/>
@@ -574,6 +627,14 @@
                 </a>
                 {% endif %}
             </div>
+                {% if entry.reader_list and current_user.role_viewer() %}
+                <a class="book-read-cta" target="_blank"
+                   href="{{ url_for('web.read_book', book_id=entry.id, book_format=entry.reader_list[0]) }}">
+                    <span class="glyphicon glyphicon-book" aria-hidden="true"></span>
+                    <span>{{ _('Read') }}</span>
+                </a>
+                {% endif %}
+                </div>
                     <div class="book-detail-meta">
                         <div class="book-detail-actions">
                             <div class="book-action-bar" role="toolbar">
@@ -615,15 +676,6 @@
                                         {% endif %}
                                     {% endif %}
                                     {% endif %}
-                                    {% if entry.reader_list and current_user.role_viewer() %}
-                                        <a target="_blank"
-                                           href="{{ url_for('web.read_book', book_id=entry.id, book_format=entry.reader_list[0]) }}"
-                                           class="btn btn-primary action-icon-btn" role="button"
-                                           title="{{ _('Read in Browser') }}" aria-label="{{ _('Read in Browser') }}">
-                                            <span class="glyphicon glyphicon-book"></span>
-                                        </a>
-                                    {% endif %}
-
                                     {% if not current_user.is_anonymous %}
                                         {# Read-status icon uses the glyphicon-check / glyphicon-unchecked matched
                                            pair per fork #319 @droM4X (#2 + #3 of the 2026-05-28 four-item list).

--- a/tests/unit/test_detail_read_cta.py
+++ b/tests/unit/test_detail_read_cta.py
@@ -1,0 +1,64 @@
+"""Regression: the book-detail page exposes a single prominent "Read" CTA the
+full width of the cover, and no longer carries a separate read icon in the
+action row.
+
+Operator ask #28: "in the detail view put a 'Read' button under the book that's
+the width of the book's icon and serves as the entry for the book reader view.
+remove the existing entry in the detail view to declutter that section."
+
+The detail-page layout is styled + structured inline in cps/templates/detail.html,
+so these are source-pins. They are RED on main (which ships the read action as a
+small `Read in Browser` icon inside `.book-action-bar`, and has no
+`.book-cover-column` / `.book-read-cta`) and GREEN on this branch. Paired with
+live multi-viewport Playwright verification on the running container.
+"""
+import os
+
+HERE = os.path.dirname(__file__)
+DETAIL = os.path.normpath(
+    os.path.join(HERE, "..", "..", "cps", "templates", "detail.html")
+)
+
+
+def _src():
+    with open(DETAIL, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_read_cta_and_cover_column_exist():
+    src = _src()
+    # The new full-width primary Read CTA and the fixed-width cover column wrapper.
+    assert 'class="book-read-cta"' in src
+    assert 'class="book-cover-column"' in src
+
+
+def test_read_cta_sits_inside_cover_column_under_the_cover():
+    src = _src()
+    col = src.index('class="book-cover-column"')
+    cta = src.index('class="book-read-cta"')
+    meta = src.index('class="book-detail-meta"')
+    # CTA is rendered inside the cover column (so it stacks under the cover at the
+    # cover's width), strictly before the metadata column begins.
+    assert col < cta < meta, "Read CTA must live in the cover column, before the meta block"
+
+
+def test_read_cta_targets_the_in_browser_reader():
+    src = _src()
+    cta = src.index('class="book-read-cta"')
+    block = src[cta:src.index("</a>", cta)]
+    # Same navigation semantics as the old icon: first readable format -> reader view.
+    assert "url_for('web.read_book'" in block
+    assert "reader_list[0]" in block
+
+
+def test_read_cta_is_full_cover_width():
+    src = _src()
+    css = src.index(".book-read-cta {")
+    block = src[css:src.index("}", css)]
+    assert "width: 100%" in block, "Read CTA must fill the cover column (= cover width)"
+
+
+def test_old_read_icon_removed_from_action_row():
+    src = _src()
+    # The only user of the `Read in Browser` label was the action-row icon we removed.
+    assert "Read in Browser" not in src


### PR DESCRIPTION
## What

Adds a prominent **Read** button directly under the book cover on the detail page — the full width of the cover — as the primary entry to the in-browser reader. Removes the small read-in-browser icon from the action-icon row so that row is less cluttered.

The cover and the button share a new fixed-width `.book-cover-column`, so the button always matches the cover's width across breakpoints. Navigation is unchanged: opens the first readable format (`entry.reader_list[0]`) in a new tab, exactly like the old icon. `Read` is an existing translated msgid, so no new strings.

## Why

The read action was a small icon mixed in with edit/download/delete, where it was easy to miss. A full-width Read CTA under the cover is the obvious "start reading" affordance and reuses the dark glassy detail-page styling, so it reads as a natural part of the page rather than a bolt-on.

## Verification

- **Regression test** `tests/unit/test_detail_read_cta.py` (source-pins): RED on main, GREEN here. Asserts the CTA and cover column exist, the CTA sits inside the cover column before the meta block, targets `web.read_book` via `reader_list[0]`, is full-width, and the old `Read in Browser` icon is gone.
- **Live** (cwn-local): detail renders 200; rendered CTA href `/read/2/epub`; reader route 200; no read icon left in the action row; no error/traceback markers in logs.
- **Playwright** at 390 / 768 / 1280: the Read button sits under the cover at cover width; the action row is decluttered; layout stacks at ≤1024px and is side-by-side at ≥1024px.

Detail-page template only — no auth, route, or dependency changes.
