### PR TITLE
fix(mobile): stop iOS Safari zooming the page when the search field is focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ is for things you can see or feel when running the app.
   browser. The small "read" icon was removed from the row of action buttons so
   that row is less cluttered.
 
+### Fixed
+- On a phone, tapping the **Search** box (or other text fields) no longer zooms
+  the page in. iOS Safari zooms toward any field whose text is smaller than 16px;
+  the inputs are now sized so that doesn't happen, while pinch-to-zoom still works
+  normally.
+
 ## [v4.0.165] - 2026-06-16
 
 ### Fixed

--- a/cps/static/css/mobile-input-zoom.css
+++ b/cps/static/css/mobile-input-zoom.css
@@ -1,0 +1,35 @@
+/* Fork #25 (operator): stop iOS Safari from auto-zooming the whole page when a
+   form field is tapped on a phone — most visibly the navbar Search box, which on
+   mobile is a collapsed icon that expands into a text input on tap.
+
+   iOS Safari zooms in on focus whenever the focused control's font-size is below
+   16px. caliBlur.css pins every `.form-control` to `font-size: 13px !important`
+   (caliBlur.css "#.form-control { font-size: 13px !important }"), so focusing the
+   search field — or any input — fired the zoom. Because caliBlur uses
+   `!important`, the override must also use `!important`; `#query` is listed
+   explicitly so the navbar search wins on ID specificity regardless of any
+   later-loading stylesheet. This file is linked AFTER caliBlur.css in layout.html.
+
+   Deliberately NOT a `maximum-scale=1` / `user-scalable=no` viewport hack — that
+   disables pinch-to-zoom, an accessibility regression. Phone-only (<= 767px);
+   tablet/desktop keep caliBlur's existing 13px sizing. */
+@media (max-width: 767px) {
+  input[type="text"],
+  input[type="search"],
+  input[type="email"],
+  input[type="password"],
+  input[type="number"],
+  input[type="url"],
+  input[type="tel"],
+  input[type="date"],
+  input[type="datetime-local"],
+  input:not([type]),
+  textarea,
+  select,
+  .form-control,
+  .input-group-sm > .form-control,
+  .input-sm,
+  #query {
+    font-size: 16px !important;
+  }
+}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -35,6 +35,9 @@
     {# Fork #288 mobile sweep: book card titles + authors wrap to 2 lines on
        mobile instead of single-line ellipsis. #}
     <link href="{{ url_for('static', filename='css/fork-mobile-cards.css') }}" rel="stylesheet" media="screen">
+    {# Fork #25: pin form inputs to 16px on phones so iOS Safari doesn't auto-zoom
+       on focus (e.g. tapping the navbar search). Must load after caliBlur.css. #}
+    <link href="{{ url_for('static', filename='css/mobile-input-zoom.css') }}" rel="stylesheet" media="screen">
     <link href="{{ url_for('static', filename='css/cwa.css') }}" rel="stylesheet" media="screen">
     <link href="{{ url_for('static', filename='css/book_organizer.css') }}" rel="stylesheet" media="screen">
     {% if current_user.is_authenticated and (current_user.role_admin() or current_user.role_edit()) %}

--- a/tests/unit/test_mobile_input_zoom.py
+++ b/tests/unit/test_mobile_input_zoom.py
@@ -1,0 +1,43 @@
+"""Regression: form inputs are pinned to 16px on phones so iOS Safari does not
+auto-zoom the page when an input is focused (operator #25 — the navbar Search
+box was the most visible offender).
+
+iOS Safari zooms in on focus whenever the focused control's font-size is below
+16px. caliBlur.css ships `.form-control { font-size: 13px !important }`, which is
+under that threshold, so tapping Search zoomed the layout. `mobile-input-zoom.css`
+overrides inputs to 16px on phones (<=767px) and MUST be linked after caliBlur.css
+in layout.html so the override wins the cascade; `#query` is pinned by ID so the
+navbar search wins regardless of later stylesheets.
+
+Source-pins: RED on main (CSS file + link absent), GREEN on this branch.
+"""
+import os
+
+HERE = os.path.dirname(__file__)
+CSS = os.path.normpath(
+    os.path.join(HERE, "..", "..", "cps", "static", "css", "mobile-input-zoom.css")
+)
+LAYOUT = os.path.normpath(
+    os.path.join(HERE, "..", "..", "cps", "templates", "layout.html")
+)
+
+
+def test_css_pins_phone_inputs_to_16px():
+    with open(CSS, encoding="utf-8") as fh:
+        src = fh.read()
+    assert "@media (max-width: 767px)" in src, "must be phone-only"
+    # !important is required to beat caliBlur's `.form-control { font-size: 13px !important }`.
+    assert "font-size: 16px !important" in src
+    # The navbar search must be pinned by ID so it wins on specificity.
+    assert "#query" in src
+    # And cover the generic input surface, not just #query.
+    assert ".form-control" in src
+
+
+def test_layout_links_css_after_caliblur():
+    with open(LAYOUT, encoding="utf-8") as fh:
+        src = fh.read()
+    assert "mobile-input-zoom.css" in src, "stylesheet must be linked in the base template"
+    cb = src.index("caliBlur.css")
+    miz = src.index("mobile-input-zoom.css")
+    assert cb < miz, "mobile-input-zoom.css must load AFTER caliBlur.css to win the cascade"


### PR DESCRIPTION
## What

Stops iOS Safari from auto-zooming the page when a form field is focused on a phone — most visibly the navbar **Search** box.

Adds `cps/static/css/mobile-input-zoom.css` (linked after caliBlur.css in `layout.html`) that pins inputs to `16px !important` at `<=767px`, including `#query` by ID.

## Why / root cause

iOS Safari zooms toward any focused control whose font-size is below 16px. caliBlur.css sets `.form-control { font-size: 13px !important }`, and on mobile the navbar search is a collapsed icon that expands into that 13px input on tap — so tapping Search zoomed the layout. The override needs `!important` (to beat caliBlur's) and `#query` (ID specificity). No `maximum-scale` / `user-scalable=no` hack, so pinch-to-zoom still works (accessibility).

## Verification

- **Regression test** `tests/unit/test_mobile_input_zoom.py`: RED on main, GREEN here. Pins the 16px-`!important` rule + `#query` + that the stylesheet loads after caliBlur.css.
- **Live** (cwn-local, 390px): `#query` computed font-size **13px before → 16px after** (measured with a cache-busted fresh load to defeat the test browser's HTTP cache); CSS served 200; link present in rendered HTML after caliBlur; search field renders normally at 390px.

Note: the final "no visible zoom" confirmation is an iOS-Safari runtime behaviour best confirmed on a real iPhone — the verifiable trigger (a sub-16px focused input) is removed.

CSS + one base-template `<link>` only; no auth, route, or dependency changes.
