### PR TITLE
fix(nav): cover editor returns to where you came from; Back-to-book on edit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ is for things you can see or feel when running the app.
   the page in. iOS Safari zooms toward any field whose text is smaller than 16px;
   the inputs are now sized so that doesn't happen, while pinch-to-zoom still works
   normally.
+- The cover editor's **Back** link now returns you to wherever you opened it from —
+  the book's page when you tapped its cover, or the edit screen when you came from
+  there — instead of always jumping to the edit screen. The **Edit metadata** screen
+  also gained a clear **Back to book** link at the top, and on a phone its form is no
+  longer pushed off-screen.
 
 ## [v4.0.165] - 2026-06-16
 

--- a/cps/cover_picker.py
+++ b/cps/cover_picker.py
@@ -99,14 +99,28 @@ def _is_provider_enabled_for_user(provider) -> bool:
 def cover_picker_page(book_id):
     """Render the picker page. Candidates are loaded asynchronously so
     the page itself returns instantly; the JS hits the candidates
-    endpoint immediately on load."""
+    endpoint immediately on load.
+
+    The back link returns the user to wherever they opened the picker from:
+    the edit-metadata page when they came from there (``?origin=edit``), and
+    the book detail page otherwise — which is both the usual entry point (the
+    cover on the detail page) and the safe default for a direct/bookmarked hit
+    (fork #26)."""
     book = _load_book(book_id)
     locked = _get_lock_state(book_id)
+    if request.args.get("origin") == "edit":
+        back_url = url_for("edit-book.show_edit_book", book_id=book_id)
+        back_label = _(u"Back to edit metadata")
+    else:
+        back_url = url_for("web.show_book", book_id=book_id)
+        back_label = _(u"Back to book")
     return render_title_template(
         "cover_picker.html",
         book=book,
         cover_locked=locked,
         config=config,
+        back_url=back_url,
+        back_label=back_label,
         title=_(u"Change cover — %(title)s", title=book.title),
         page="coverpicker",
     )

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -1,6 +1,22 @@
 {% extends "layout.html" %}
 {% block body %}
+<style>
+  /* The edit form column carries an inline `margin-left: 40rem` to clear the cover
+     column on desktop; on phones that inline offset pushed the whole form (title,
+     authors, tags, and the Back-to-book link) off-screen. Drop the offset on phones
+     so the form stacks under the cover column and is usable (fork #26 audit). */
+  @media (max-width: 767px) {
+    #book_edit_frm > .col-sm-9 {
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+      padding: 1.5rem !important;
+    }
+  }
+</style>
 {% if book %}
+  <a href="{{ url_for('web.show_book', book_id=book.id) }}" class="cwa-edit-back" style="display:block; clear:both; margin:0.5rem 0 1rem; color:hsla(0,0%,100%,.82); text-decoration:none; font-weight:600;">
+    <span class="glyphicon glyphicon-chevron-left"></span> {{ _('Back to book') }}
+  </a>
   <div class="editbook-cover-section col-sm-3 col-lg-3 col-xs-12">
     {# No clickable cover overlay here (unlike the detail page): this page hosts
        the metadata edit form, and a large cover-sized navigation target would
@@ -150,7 +166,7 @@
     {# Decouple cover changes from global uploads: allow users with edit rights to change covers #}
     {% if current_user.role_edit() %}
     <div class="form-group">
-      <a class="btn btn-default cwa-cover-picker__entry" href="{{ url_for('cover_picker.cover_picker_page', book_id=book.id) }}">
+      <a class="btn btn-default cwa-cover-picker__entry" href="{{ url_for('cover_picker.cover_picker_page', book_id=book.id, origin='edit') }}">
         <span class="glyphicon glyphicon-picture"></span> {{ _('Change cover') }}
       </a>
       <p class="text-muted" style="font-size: 12px; margin: 4px 0 0 0;">

--- a/cps/templates/cover_picker.html
+++ b/cps/templates/cover_picker.html
@@ -6,8 +6,8 @@
 
   <div class="row cwa-cover-picker__header">
     <div class="col-sm-12">
-      <a href="{{ url_for('edit-book.show_edit_book', book_id=book.id) }}" class="cwa-cover-picker__back">
-        <span class="glyphicon glyphicon-chevron-left"></span> {{ _('Back to edit metadata') }}
+      <a href="{{ back_url }}" class="cwa-cover-picker__back">
+        <span class="glyphicon glyphicon-chevron-left"></span> {{ back_label }}
       </a>
       <h2 class="cwa-cover-picker__title">{{ _('Change cover') }}</h2>
       <p class="cwa-cover-picker__subtitle text-muted">

--- a/tests/unit/test_edit_back_nav.py
+++ b/tests/unit/test_edit_back_nav.py
@@ -1,0 +1,62 @@
+"""Regression: cover-editor + edit-metadata back navigation (operator #26).
+
+- The cover picker's back link returns to the book DETAIL page by default, and to
+  the edit-metadata page only when the picker was opened from there
+  (``?origin=edit``). Previously it always hardcoded edit-metadata, so opening the
+  picker from the detail page (clicking the cover) and pressing back wrongly landed
+  on edit-metadata.
+- The edit-metadata page now has an explicit "Back to book" link to the detail
+  page (it previously only had a bottom "Cancel" button).
+
+Source-pins on the templates + route (the source of truth). RED on main, GREEN here.
+"""
+import os
+
+HERE = os.path.dirname(__file__)
+COVER_PY = os.path.normpath(os.path.join(HERE, "..", "..", "cps", "cover_picker.py"))
+COVER_HTML = os.path.normpath(os.path.join(HERE, "..", "..", "cps", "templates", "cover_picker.html"))
+EDIT_HTML = os.path.normpath(os.path.join(HERE, "..", "..", "cps", "templates", "book_edit.html"))
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_cover_picker_route_is_origin_aware():
+    s = _read(COVER_PY)
+    assert 'request.args.get("origin")' in s
+    assert 'url_for("web.show_book"' in s             # default destination -> book detail
+    assert 'url_for("edit-book.show_edit_book"' in s  # origin=edit -> edit metadata
+    assert "back_url=back_url" in s
+    assert "back_label=back_label" in s
+
+
+def test_cover_picker_template_uses_dynamic_back():
+    s = _read(COVER_HTML)
+    assert "{{ back_url }}" in s
+    assert "{{ back_label }}" in s
+    # The old hardcoded "always go to edit metadata" link must be gone.
+    assert "url_for('edit-book.show_edit_book'" not in s
+
+
+def test_edit_page_opens_cover_picker_with_origin():
+    s = _read(EDIT_HTML)
+    assert "cover_picker.cover_picker_page" in s
+    assert "origin='edit'" in s
+
+
+def test_edit_page_has_back_to_book_link():
+    s = _read(EDIT_HTML)
+    assert "cwa-edit-back" in s
+    assert "Back to book" in s
+    assert "url_for('web.show_book'" in s
+
+
+def test_edit_form_usable_on_phone():
+    # The desktop `margin-left: 40rem` offset is dropped on phones so the form
+    # (and the back link) are no longer pushed off-screen on mobile.
+    s = _read(EDIT_HTML)
+    assert "@media (max-width: 767px)" in s
+    assert "#book_edit_frm > .col-sm-9" in s
+    assert "margin-left: 0 !important" in s


### PR DESCRIPTION
## What
The cover editor's back link is now origin-aware, and the Edit Metadata page has an explicit "Back to book" link.

- **Cover editor**: the back link returns to the **book detail page** when you opened the picker from there (tapping the cover — the common path), and to **edit-metadata** only when you came from edit (`?origin=edit`). Previously it always went to edit-metadata, so the common path landed in the wrong place.
- **Edit Metadata page**: new "Back to book" link at the top (it previously only had a bottom "Cancel"). Placed above the offset form column so it's visible on phones too.
- **Adjacent fix**: the edit form's inline `margin-left: 40rem` (a desktop offset to clear the cover column) pushed the whole form off-screen on phones. A `<=767px` override drops it so the form is reachable on mobile.

## Why / root cause
The picker is reachable from two places (the detail-page cover and the edit page's "Change cover" button) but hardcoded its back to edit-metadata. Detail.html callers default correctly to detail; only the edit-page link passes `origin=edit`.

## Verification
- **Regression test** `tests/unit/test_edit_back_nav.py` (source-pins): RED on main, GREEN here.
- **Live** (cwn-local): `/book/2/cover` back → `/book/2` ("Back to book"); `?origin=edit` back → `/admin/book/2` ("Back to edit metadata"); edit page has top "Back to book" → `/book/2`; no errors in logs.
- **Playwright** 390 / 1280: back link visible on mobile + desktop; edit form reachable on mobile after the offset fix.

Note: on mobile the edit page still shows the cover/convert column before the metadata form (DOM order); the form is reachable by scrolling. A fuller mobile reorder of the edit page is tracked separately.

The route reads a query param only to choose between two fixed internal endpoints (no open redirect); no auth/CSRF/dependency changes.
