### PR TITLE
feat(library): star/favorite books — toggle, Favorites view, cover badge (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+- You can now **star your favorite books**. Tap the star on a book's page to
+  favorite it (a gold star also appears on its cover while you browse), then use
+  the new **Favorites** entry in the sidebar to see just your starred books.
+  Favorites are private to your own account.
+
 ### Changed
 - The **book details page** is easier to read, especially on phones. The big
   empty margins that boxed in the cover and info are gone — you get noticeably

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -89,6 +89,7 @@ SIDEBAR_ARCHIVED        = 1 << 15
 SIDEBAR_DOWNLOAD        = 1 << 16
 SIDEBAR_LIST            = 1 << 17
 SIDEBAR_DUPLICATES      = 1 << 18
+SIDEBAR_FAVORITES       = 1 << 19
 
 sidebar_settings = {
                 "detail_random": DETAIL_RANDOM,
@@ -108,11 +109,12 @@ sidebar_settings = {
                 "sidebar_download": SIDEBAR_DOWNLOAD,
                 "sidebar_list": SIDEBAR_LIST,
                 "sidebar_duplicates": SIDEBAR_DUPLICATES,
+                "sidebar_favorites": SIDEBAR_FAVORITES,
             }
 
 
 ADMIN_USER_ROLES        = sum(r for r in ALL_ROLES.values()) & ~ROLE_ANONYMOUS
-ADMIN_USER_SIDEBAR      = (SIDEBAR_DUPLICATES << 1) - 1
+ADMIN_USER_SIDEBAR      = (SIDEBAR_FAVORITES << 1) - 1
 
 UPDATE_STABLE       = 0 << 0
 AUTO_UPDATE_STABLE  = 1 << 0

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -128,6 +128,10 @@ def get_sidebar_config(kwargs=None):
         {"glyph": "glyphicon-trash", "text": _('Archived Books'), "link": 'web.books_list', "id": "archived",
          "visibility": constants.SIDEBAR_ARCHIVED, 'public': (not current_user.is_anonymous), "page": "archived",
          "show_text": _('Show Archived Books'), "config_show": content})
+    sidebar.append(
+        {"glyph": "glyphicon-star", "text": _('Favorites'), "link": 'web.books_list', "id": "favorites",
+         "visibility": constants.SIDEBAR_FAVORITES, 'public': (not current_user.is_anonymous), "page": "favorites",
+         "show_text": _('Show Favorites'), "config_show": content})
     if not simple:
         sidebar.append(
             {"glyph": "glyphicon-th-list", "text": _('Books List'), "link": 'web.books_table', "id": "list",
@@ -161,6 +165,16 @@ def get_sidebar_config(kwargs=None):
         g.book_shelves_map = book_shelves
     else:
         g.book_shelves_map = {}
+
+    # Per-user favorited book ids for the cover star badge — fork #27. One query
+    # per render; the cover_badges macro does an O(1) membership check.
+    if not current_user.is_anonymous:
+        g.favorite_book_ids = {
+            row.book_id for row in ub.session.query(ub.FavoriteBook.book_id)
+            .filter(ub.FavoriteBook.user_id == int(current_user.id)).all()
+        }
+    else:
+        g.favorite_book_ids = set()
 
     return sidebar, simple
 

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -695,6 +695,17 @@
                                                 data-toast-off="{{ _('Marked as unread') }}">
                                             <span id="read-icon" class="glyphicon {{ entry.read_status and 'glyphicon-unchecked' or 'glyphicon-check' }}"></span>
                                         </button>
+                                        {# Favorite / star toggle — fork #27. Always available to signed-in
+                                           users (favorites are per-user); flips in place via the form below. #}
+                                        <button type="button" class="btn btn-default action-icon-btn" id="toggle-favorite-btn"
+                                                title="{{ is_favorited and _('Remove from favorites') or _('Add to favorites') }}"
+                                                aria-label="{{ is_favorited and _('Remove from favorites') or _('Add to favorites') }}"
+                                                data-on-title="{{ _('Remove from favorites') }}"
+                                                data-off-title="{{ _('Add to favorites') }}"
+                                                data-toast-on="{{ _('Added to favorites') }}"
+                                                data-toast-off="{{ _('Removed from favorites') }}">
+                                            <span id="favorite-icon" class="glyphicon {{ is_favorited and 'glyphicon-star' or 'glyphicon-star-empty' }}"{% if is_favorited %} style="color:#f5c518"{% endif %}></span>
+                                        </button>
                                         {% if current_user.check_visibility(32768) %}
                                             <button type="button" class="btn btn-default action-icon-btn" id="toggle-archive-btn"
                                                     title="{{ entry.is_archived and _('Restore from archive') or _('Add to archive') }}"
@@ -1048,6 +1059,10 @@
                                            data-unchecked="{{ _('Mark As Read') }}" type="checkbox"
                                            {% if entry.read_status %}checked{% endif %}>
                                 </form>
+                                <form id="favorite_form" action="{{ url_for('web.toggle_favorite', book_id=entry.id) }}" method="POST">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <input id="favorite_cb" type="checkbox" {% if is_favorited %}checked{% endif %}>
+                                </form>
                                 {% if current_user.check_visibility(32768) %}
                                     <form id="archived_form" action="{{ url_for('web.toggle_archived', book_id=entry.id) }}" method="POST">
                                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -1270,6 +1285,39 @@
                     var $btn = $("#toggle-archive-btn");
                     var toastMsg = isArchived ? $btn.data("toast-on") : $btn.data("toast-off");
                     showActionToast(toastMsg, $btn[0]);
+                },
+                error: function () {
+                    $cb.prop("checked", !nextChecked);
+                }
+            });
+        });
+
+        $("#toggle-favorite-btn").on("click", function () {
+            var $cb = $("#favorite_cb");
+            var $form = $("#favorite_form");
+            if (!$cb.length || !$form.length) {
+                return;
+            }
+            var nextChecked = !$cb.prop("checked");
+            $cb.prop("checked", nextChecked);
+            $.ajax({
+                url: $form[0].action,
+                method: "post",
+                data: $form.serialize(),
+                success: function (data) {
+                    if (typeof handleResponse === "function") {
+                        handleResponse(data);
+                    }
+                    var isFavorite = $cb.prop("checked");
+                    // Filled gold star when favorited, empty star when not.
+                    $("#favorite-icon")
+                        .toggleClass("glyphicon-star", isFavorite)
+                        .toggleClass("glyphicon-star-empty", !isFavorite)
+                        .css("color", isFavorite ? "#f5c518" : "");
+                    var $btn = $("#toggle-favorite-btn");
+                    var title = isFavorite ? $btn.data("on-title") : $btn.data("off-title");
+                    $btn.attr("title", title).attr("aria-label", title);
+                    showActionToast(isFavorite ? $btn.data("toast-on") : $btn.data("toast-off"), $btn[0]);
                 },
                 error: function () {
                     $cb.prop("checked", !nextChecked);

--- a/cps/templates/image.html
+++ b/cps/templates/image.html
@@ -12,8 +12,10 @@
 
 {% macro cover_badges(book, is_read=false) -%}
 {% set shelves_here = g.book_shelves_map.get(book.id, []) if g.book_shelves_map is defined else [] %}
-{% if is_read or shelves_here %}
+{% set is_favorited = (g.favorite_book_ids is defined and book.id in g.favorite_book_ids) %}
+{% if is_read or shelves_here or is_favorited %}
 <div class="cover-badges">
+  {% if is_favorited %}<span class="cover-badge cover-badge-favorite" title="{{ _('Favorite') }}"><span class="glyphicon glyphicon-star" style="color:#f5c518" aria-hidden="true"></span></span>{% endif %}
   {% if is_read %}<span class="cover-badge cover-badge-read" title="{{ _('Read') }}"><span class="glyphicon glyphicon-check" aria-hidden="true"></span><span class="cover-badge-read-label">{{ _('Read') }}</span></span>{% endif %}
   {% set max_shown = 3 %}
   {% set extra = shelves_here|length - max_shown %}

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -721,6 +721,28 @@ class UserHiddenBook(Base):
     )
 
 
+class FavoriteBook(Base):
+    """Per-user favorited / starred books — fork #27.
+
+    Presence-based (a row exists iff the user has starred that book), mirroring
+    UserHiddenBook rather than ArchivedBook's boolean column: un-starring deletes
+    the row. Starred books get a dedicated /favorites listing and a star badge on
+    their cover. The per-(user, book) unique constraint keeps a fast double-tap
+    from creating duplicate rows.
+    """
+    __tablename__ = 'favorite_book'
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('user.id', ondelete='CASCADE'),
+                     nullable=False, index=True)
+    book_id = Column(Integer, nullable=False, index=True)
+    favorited_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        UniqueConstraint('user_id', 'book_id', name='uq_favorite_book'),
+    )
+
+
 class KoboSyncedBooks(Base):
     __tablename__ = 'kobo_synced_books'
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -1242,6 +1264,8 @@ def add_missing_tables(engine, _session):
         HiddenMagicShelfTemplate.__table__.create(bind=engine, checkfirst=True)
     if not engine.dialect.has_table(engine.connect(), "kobo_annotation_backup"):
         KoboAnnotationBackup.__table__.create(bind=engine, checkfirst=True)
+    if not engine.dialect.has_table(engine.connect(), "favorite_book"):
+        FavoriteBook.__table__.create(bind=engine, checkfirst=True)
 
 
 # migrate all settings missing in registration table
@@ -1377,6 +1401,34 @@ def migrate_user_table(engine, _session):
                 )
     except Exception as e:
         print(f"[Migration] Warning: Could not update duplicates sidebar setting: {e}")
+
+    # Migration to enable favorites sidebar for existing users (one-time) — fork #27
+    try:
+        from . import constants
+        SIDEBAR_FAVORITES = constants.SIDEBAR_FAVORITES
+
+        migration_dir = os.path.join(constants.CONFIG_DIR, ".cwa_migrations")
+        migration_marker = os.path.join(migration_dir, "favorites_sidebar_v1")
+
+        if not os.path.isfile(migration_marker):
+            # Favorites is a general per-user feature, so enable it for every
+            # existing user (not just admins) — otherwise the new sidebar bit
+            # would be off for accounts created before this release.
+            for user in _session.query(User).all():
+                if not (user.sidebar_view & SIDEBAR_FAVORITES):
+                    user.sidebar_view |= SIDEBAR_FAVORITES
+            _session.commit()
+            try:
+                os.makedirs(migration_dir, exist_ok=True)
+                with open(migration_marker, "w", encoding="utf-8") as marker:
+                    marker.write(datetime.now(timezone.utc).isoformat())
+            except Exception as marker_error:
+                print(
+                    f"[Migration] Warning: Could not persist favorites sidebar migration marker: {marker_error}",
+                    flush=True,
+                )
+    except Exception as e:
+        print(f"[Migration] Warning: Could not update favorites sidebar setting: {e}")
         _session.rollback()
 
     # Migration for cover-preview per-user preference columns (Phase 2 of

--- a/cps/web.py
+++ b/cps/web.py
@@ -223,6 +223,25 @@ def toggle_archived(book_id):
     return ""
 
 
+# Per-user favorite / starred books — fork #27. Presence-based toggle: a row in
+# favorite_book exists iff the calling user has starred the book. Returns the
+# resulting state as JSON so the UI can flip the star in place without a reload.
+@web.route("/ajax/togglefavorite/<int:book_id>", methods=['POST'])
+@user_login_required
+def toggle_favorite(book_id):
+    favorite = ub.session.query(ub.FavoriteBook).filter(
+        and_(ub.FavoriteBook.user_id == int(current_user.id),
+             ub.FavoriteBook.book_id == book_id)).first()
+    if favorite:
+        ub.session.delete(favorite)
+        favorited = False
+    else:
+        ub.session.add(ub.FavoriteBook(user_id=int(current_user.id), book_id=book_id))
+        favorited = True
+    ub.session_commit("Book {} favorite bit toggled".format(book_id))
+    return json.dumps({"favorited": favorited})
+
+
 # Per-user hidden books — fork issue #64. Hide removes the book from index
 # pages, search, OPDS feeds, and shelf listings for the calling user only;
 # /hidden lists hidden books with an unhide button. Distinct from archive
@@ -513,6 +532,8 @@ def render_books_list(data, sort_param, book_id, page):
         return render_language_books(page, book_id, order)
     elif data == "archived":
         return render_archived_books(page, order)
+    elif data == "favorites":
+        return render_favorite_books(page, order)
     elif data in ("hidden", "hidden_books"):
         # The 'hidden_books' alias exists because render_hidden_books sets
         # the body CSS class to 'hidden_books' (not 'hidden' — Bootstrap's
@@ -955,6 +976,31 @@ def render_archived_books(page, sort_param):
 
     name = _('Archived Books') + ' (' + str(len(archived_book_ids)) + ')'
     page_name = "archived"
+    return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
+                                 title=name, page=page_name, order=sort_param[1])
+
+
+def render_favorite_books(page, sort_param):
+    """List the current user's favorited / starred books — fork #27. Mirrors
+    render_archived_books: pull the starred book_ids from app.db (ub), then
+    filter the metadata.db listing to those ids."""
+    order = sort_param[0] or []
+    favorite_books = (ub.session.query(ub.FavoriteBook)
+                      .filter(ub.FavoriteBook.user_id == int(current_user.id))
+                      .all())
+    favorite_book_ids = [fav.book_id for fav in favorite_books]
+
+    favorite_filter = db.Books.id.in_(favorite_book_ids)
+
+    entries, random, pagination = calibre_db.fill_indexpage_with_archived_books(page, db.Books,
+                                                                                0,
+                                                                                favorite_filter,
+                                                                                order,
+                                                                                True,
+                                                                                True, config.config_read_column)
+
+    name = _('Favorite Books') + ' (' + str(len(favorite_book_ids)) + ')'
+    page_name = "favorites"
     return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
                                  title=name, page=page_name, order=sort_param[1])
 
@@ -3432,6 +3478,14 @@ def show_book(book_id):
                 ub.UserHiddenBook.book_id == int(book_id),
             ).first() is not None
 
+        # Per-user favorite / starred state — fork #27.
+        is_favorited = False
+        if not current_user.is_anonymous:
+            is_favorited = ub.session.query(ub.FavoriteBook).filter(
+                ub.FavoriteBook.user_id == int(current_user.id),
+                ub.FavoriteBook.book_id == int(book_id),
+            ).first() is not None
+
         # Fork #276 (@magdalar): admin checkboxes for sending to OTHER
         # users' kindle_mail addresses (family eReader management). Only
         # admins see other users' emails — those are PII otherwise.
@@ -3460,6 +3514,7 @@ def show_book(book_id):
                                      kosync_progress=kosync_progress,
                                      kosync_progress_timestamp=kosync_progress_timestamp,
                                      is_hidden=is_hidden,
+                                     is_favorited=is_favorited,
                                      other_users_with_kindle=other_users_with_kindle,
                                      page="book")
     else:

--- a/tests/unit/test_favorite_books.py
+++ b/tests/unit/test_favorite_books.py
@@ -1,0 +1,78 @@
+"""Regression: per-user favorite / starred books — fork #27.
+
+Users can star a book (toggle), see a dedicated Favorites listing (filter), and a
+gold star badge on starred covers. Built mirroring the existing per-user archived
+/ hidden book features.
+
+Source-pins across the layers (models, constants, routes, sidebar, templates).
+RED on main (none of this exists), GREEN on this branch. Paired with live
+verification on the running container (toggle insert/delete + per-user scoping,
+Favorites view, grid badge, cold-boot migration idempotency, end-to-end click).
+"""
+import os
+
+HERE = os.path.dirname(__file__)
+ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
+
+
+def _read(*parts):
+    with open(os.path.join(ROOT, *parts), encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_favoritebook_model_and_migration():
+    src = _read("cps", "ub.py")
+    assert "class FavoriteBook(Base):" in src
+    assert "__tablename__ = 'favorite_book'" in src
+    assert "uq_favorite_book" in src
+    # New table is auto-created on startup (idempotent), like the sibling tables.
+    assert 'has_table(engine.connect(), "favorite_book")' in src
+    assert "FavoriteBook.__table__.create(bind=engine, checkfirst=True)" in src
+    # Existing users get the new sidebar bit OR'd in (one-time, marker-guarded).
+    assert "favorites_sidebar_v1" in src
+
+
+def test_constants_favorites_sidebar_bit():
+    src = _read("cps", "constants.py")
+    assert "SIDEBAR_FAVORITES       = 1 << 19" in src
+    assert '"sidebar_favorites": SIDEBAR_FAVORITES,' in src
+    # The default sidebar mask must extend to include the new bit, else the entry
+    # is off by default for new users.
+    assert "ADMIN_USER_SIDEBAR      = (SIDEBAR_FAVORITES << 1) - 1" in src
+
+
+def test_web_toggle_endpoint_and_render():
+    src = _read("cps", "web.py")
+    assert '@web.route("/ajax/togglefavorite/<int:book_id>", methods=[\'POST\'])' in src
+    assert "def toggle_favorite(book_id):" in src
+    # Presence-based toggle: delete the row to un-favorite, insert to favorite.
+    assert "ub.session.delete(favorite)" in src
+    assert "ub.FavoriteBook(user_id=int(current_user.id), book_id=book_id)" in src
+    # Dedicated listing + dispatch.
+    assert "def render_favorite_books(page, sort_param):" in src
+    assert 'elif data == "favorites":' in src
+    assert "return render_favorite_books(page, order)" in src
+
+
+def test_sidebar_entry_and_grid_set():
+    src = _read("cps", "render_template.py")
+    assert '"id": "favorites"' in src
+    assert "constants.SIDEBAR_FAVORITES" in src
+    # Per-request favorited-id set powers the cover badge (O(1) lookup in the macro).
+    assert "g.favorite_book_ids" in src
+
+
+def test_detail_page_star_toggle():
+    src = _read("cps", "templates", "detail.html")
+    assert 'id="toggle-favorite-btn"' in src
+    assert 'id="favorite_form"' in src
+    assert "web.toggle_favorite" in src
+    # JS handler flips the star icon in place.
+    assert '$("#toggle-favorite-btn").on("click"' in src
+    assert "glyphicon-star" in src
+
+
+def test_cover_badge_star():
+    src = _read("cps", "templates", "image.html")
+    assert "cover-badge-favorite" in src
+    assert "g.favorite_book_ids" in src


### PR DESCRIPTION
## What

A per-user **favorite / star** for books (fork #27):

- **Star toggle** on the book-detail action row (gold filled star ↔ empty star), backed by a new `/ajax/togglefavorite/<id>` POST.
- **Favorites listing** in the sidebar (gold star entry) at `/favorites/<sort>` — your starred books in one place. Mirrors the existing Archived/Hidden listings.
- **Gold star badge** on starred covers while browsing the grid.
- New presence-based `favorite_book` table (mirrors `UserHiddenBook`); a row exists iff the user starred that book. Auto-created on boot; existing users get the new sidebar bit via a one-time marker-guarded migration.

Favorites are strictly per-user (every query is scoped to `current_user.id`).

## Design notes / what's deliberately scoped out
- The grid cover star is a **read-only indicator** in this PR (starring is from the detail page). Interactive star-from-grid-card is a fast-follow.
- "Float starred books to the top of the **main paginated list**" is **not** in this PR: favorites live in `app.db` while Books live in `metadata.db` (separate SQLite files), so cross-DB ordering can't be expressed cleanly in the paginated query without fragile custom pagination. The dedicated **Favorites** view is the robust grouping. Tracked as a follow-up.
- To avoid a wide blast radius, the grid badge uses a per-request `g.favorite_book_ids` set (like the existing `g.book_shelves_map`) rather than adding a column to `db.py`'s shared query tuple.

## Verification
- **Regression test** `tests/unit/test_favorite_books.py` (source-pins across model/constants/routes/sidebar/templates): RED on main, GREEN here.
- **Live** (cwn-local): `favorite_book` auto-created on boot; toggle inserts/deletes a per-user row (`1|2`); CSRF enforced on the new POST (same as sibling toggles); `/favorites/stored/` → "Favorite Books (1)" with the book; gold star badge on a favorited grid cover; **cold-boot restart keeps favorites, no errors** (idempotent migration); Playwright click-toggle flips the star end-to-end.

New route added (`/ajax/togglefavorite`) — security-reviewed (auth-gated, int-bound id, CSRF-protected, user-scoped writes, parameterized queries).
