### PR TITLE
feat(grid): star a book directly from its cover in the grid (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Added
-- You can now **star your favorite books**. Tap the star on a book's page to
-  favorite it (a gold star also appears on its cover while you browse), then use
-  the new **Favorites** entry in the sidebar to see just your starred books.
-  Favorites are private to your own account.
+- You can now **star your favorite books**. Tap the star on a book's page — or
+  the star on its cover anywhere in the grid — to favorite it; favorited books
+  show a gold star on the cover. Use the new **Favorites** entry in the sidebar
+  to see just your starred books. Favorites are private to your own account.
 - The **Published Date** field now accepts just a **year**. When you edit a
   book you can type `2020` (or `2020-05`) instead of clicking through the date
   picker for the full day — the missing month and day default to January 1st.

--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -8754,6 +8754,45 @@ button.close {
     margin-bottom: -2px;
 }
 
+/* Favorite / star toggle on covers — fork #33. Top-right corner (the read/edit/
+   send quick-actions line the bottom edge). Gold when favorited. Revealed on
+   cover hover on desktop; kept visible + tappable on touch devices. */
+.favorite-toggle-btn {
+    background: rgb(19 28 36 / 71%);
+    border-radius: 50%;
+    width: 35px;
+    height: 35px;
+    line-height: 35px;
+    text-align: center;
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    opacity: 0;
+    z-index: 9;
+    color: #fff;
+    transition: all 0.2s ease;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+}
+.favorite-toggle-btn .glyphicon { font-size: 14px; color: #fff; }
+.favorite-toggle-btn.is-favorited .glyphicon { color: #f5c518; }
+.cover:hover .favorite-toggle-btn { opacity: 1; pointer-events: auto; }
+.favorite-toggle-btn:hover { background: rgba(200, 152, 94, 0.9); transform: scale(1.1); }
+.favorite-toggle-btn.loading { opacity: 1; pointer-events: auto; }
+/* The static cover_badges favorite marker is superseded by this interactive
+   toggle (same state, plus it toggles); hide it so there's no duplicate star.
+   It stays in the DOM as the initial-state source the JS reads. */
+.cover-badge-favorite { display: none !important; }
+/* No hover (touch devices) OR a narrow viewport (phones): the cover never gets a
+   hover state, so keep the star visible + tappable. Width is included so this also
+   holds on hybrid touch+mouse devices that report `hover: hover`. */
+@media (hover: none), (max-width: 767px) {
+    .favorite-toggle-btn { opacity: 0.85; pointer-events: auto; }
+}
+
 /* Show additional elements on cover hover - buttons are now inside the link */
 #books > .cover > a:hover .read-toggle-btn,
 #books > .cover > a:hover .edit-metadata-btn,

--- a/cps/static/js/caliBlur.js
+++ b/cps/static/js/caliBlur.js
@@ -831,8 +831,29 @@ $(function() {
     function initDirectReadingHandler() {
         // Remove any existing handlers first
         $('.book-cover-link').off('click.directReading mousemove.directReading mouseleave.directReading');
-        $('.read-toggle-btn, .edit-metadata-btn, .send-ereader-btn').off('click.quickActions');
+        $('.read-toggle-btn, .edit-metadata-btn, .send-ereader-btn, .favorite-toggle-btn').off('click.quickActions');
         
+        // Favorite/star toggle (fork #33) — injected on ALL devices (mobile tap +
+        // desktop hover), unlike the read/edit/send quick-actions below which are
+        // desktop-hover-only. CSS reveals it on cover hover (desktop) and keeps it
+        // visible + tappable on touch devices.
+        $('.book-cover-link').each(function() {
+            var $favLink = $(this);
+            if ($favLink.find('.favorite-toggle-btn').length === 0) {
+                var favIsOn = $favLink.find('.cover-badge-favorite').length > 0;
+                var $favToggle = $('<div class="favorite-toggle-btn"><span class="glyphicon"></span></div>')
+                    .attr('title', favIsOn ? 'Remove from favorites' : 'Add to favorites');
+                $favToggle.find('.glyphicon').addClass(favIsOn ? 'glyphicon-star' : 'glyphicon-star-empty');
+                if (favIsOn) { $favToggle.addClass('is-favorited'); }
+                $favLink.append($favToggle);
+            }
+        });
+        $('.favorite-toggle-btn').on('click.quickActions', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            handleFavoriteToggle($(this).closest('.book-cover-link'));
+        });
+
         // Check if device supports hover (not a touch device)
         var supportsHover = window.matchMedia('(hover: hover)').matches;
         var isDesktop = $(window).width() >= 768;
@@ -1158,6 +1179,33 @@ $(function() {
         });
     }
     
+    function handleFavoriteToggle($link) {
+        var bookId = $link.data('book-id');
+        if (!bookId) { console.error('Book ID not found'); return; }
+        var $btn = $link.find('.favorite-toggle-btn');
+        var wasFav = $btn.hasClass('is-favorited');
+        $btn.addClass('loading');
+        $btn.find('.glyphicon').removeClass().addClass('glyphicon glyphicon-refresh');
+        $.ajax({
+            url: window.scriptRoot + '/ajax/togglefavorite/' + bookId,
+            type: 'POST',
+            data: { csrf_token: $("input[name='csrf_token']").val() },
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            success: function(response) {
+                var nowFav = !wasFav;
+                try { nowFav = JSON.parse(response).favorited; } catch (e) { /* keep optimistic toggle */ }
+                $btn.removeClass('loading').toggleClass('is-favorited', nowFav)
+                    .attr('title', nowFav ? 'Remove from favorites' : 'Add to favorites');
+                $btn.find('.glyphicon').removeClass().addClass('glyphicon ' + (nowFav ? 'glyphicon-star' : 'glyphicon-star-empty'));
+            },
+            error: function() {
+                $btn.removeClass('loading').toggleClass('is-favorited', wasFav)
+                    .attr('title', wasFav ? 'Remove from favorites' : 'Add to favorites');
+                $btn.find('.glyphicon').removeClass().addClass('glyphicon ' + (wasFav ? 'glyphicon-star' : 'glyphicon-star-empty'));
+            }
+        });
+    }
+
     function handleSendToEReader($link) {
         var bookId = $link.data('book-id');
         var formatsStr = $link.data('book-formats');

--- a/tests/unit/test_grid_favorite_toggle.py
+++ b/tests/unit/test_grid_favorite_toggle.py
@@ -1,0 +1,41 @@
+"""Regression: interactive favorite/star toggle on grid covers — fork #33.
+
+Builds on #27 (per-user favorites). Each book cover gets a top-right star button
+(mirroring the existing read/edit/send cover quick-actions in caliBlur.js) that
+POSTs to /ajax/togglefavorite/<id> and flips in place — so a book can be starred
+directly from the main books page without opening its detail page. Injected on ALL
+devices (the read/edit/send quick-actions are desktop-hover-only), so it's tappable
+on phones too.
+
+Source-pins on caliBlur.js + caliBlur.css. RED on main, GREEN here. Paired with
+live Playwright verification (hover→appear→click→toggle without navigating; mobile
+tappable).
+"""
+import os
+
+HERE = os.path.dirname(__file__)
+ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
+
+
+def _read(*parts):
+    with open(os.path.join(ROOT, *parts), encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_caliblur_js_injects_and_handles_favorite_toggle():
+    js = _read("cps", "static", "js", "caliBlur.js")
+    assert "favorite-toggle-btn" in js
+    assert "function handleFavoriteToggle" in js
+    assert "/ajax/togglefavorite/" in js
+    # Must be in the click-handler teardown so re-init (resize) doesn't double-bind.
+    assert ".send-ereader-btn, .favorite-toggle-btn').off('click.quickActions')" in js
+
+
+def test_caliblur_css_styles_favorite_toggle_and_hides_static_badge():
+    css = _read("cps", "static", "css", "caliBlur.css")
+    assert ".favorite-toggle-btn {" in css
+    assert ".favorite-toggle-btn.is-favorited" in css
+    # The static cover_badges marker is superseded by the interactive toggle.
+    assert ".cover-badge-favorite { display: none !important; }" in css
+    # Tappable on touch devices (the read/edit/send actions are desktop-only).
+    assert "@media (hover: none)" in css


### PR DESCRIPTION
## What
Extends #27 (per-user favorites) so you can **star a book directly from its cover in the grid** — no need to open the detail page.

Each cover gets a top-right star button (mirroring the existing read/edit/send cover quick-actions in `caliBlur.js`): click/tap to favorite; it flips in place (gold filled ↔ outline) **without navigating**. Favorited covers show a gold star.

## Notes
- Injected on **all devices**. The existing read/edit/send quick-actions are desktop-hover-only; the favorite star is added in a separate pass before that gate, and a `(hover: none), (max-width: 767px)` rule keeps it visible + tappable on phones — so "star from the main books page" works on mobile (the part of #27 deferred to this follow-up).
- The static `cover_badges` favorite marker (from #27) is now hidden (`display:none`) and superseded by this interactive star; it stays in the DOM as the JS's initial-favorited-state source.
- Minor known gap: the optional "discover"/random featured strip (`#books_rand`) doesn't render the `cover_badges` marker, so its stars start as outline regardless of state (toggling still works + persists). The main grid reflects state correctly.

## Verification
- **Regression test** `tests/unit/test_grid_favorite_toggle.py` (source-pins on caliBlur.js + caliBlur.css): RED on main, GREEN here.
- **Live** (cwn-local, Playwright): star injects on every cover; desktop hover-reveals it, clicking toggles ON (0→1 gold) **without navigating** (path stays `/`); favorited state persists across reload; mobile 390px shows the star at opacity 0.85 on all covers (gold on favorited, outline otherwise).

`caliBlur.js` / `caliBlur.css` only (the only live theme); uses the existing `/ajax/togglefavorite` endpoint from #27 — no new route, no backend change.
