### PR TITLE
fix(editbook): mobile form-first + flexbox two-column layout (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ is for things you can see or feel when running the app.
   there — instead of always jumping to the edit screen. The **Edit metadata** screen
   also gained a clear **Back to book** link at the top, and on a phone its form is no
   longer pushed off-screen.
+- On a phone, the **Edit Metadata** page now shows the book's details form first —
+  you can edit the title, author and tags straight away instead of scrolling past
+  the cover. On wider screens the cover and form still sit side-by-side. (Builds on
+  the earlier off-screen-form fix; replaces a brittle fixed-offset layout.)
 
 ## [v4.0.165] - 2026-06-16
 

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -12,11 +12,33 @@
       padding: 1.5rem !important;
     }
   }
+  /* Proper responsive two-column layout for the edit page (fork #32), replacing
+     the fragile inline `margin-left: 40rem` float offset that coupled the desktop
+     and mobile layouts. Desktop: cover column + form sit side-by-side via flexbox.
+     Phone: they stack with the metadata form FIRST, so you can edit title/author
+     straight away instead of scrolling past the cover (#26 follow-up). */
+  .cwa-editbook-layout { display: flex; flex-wrap: wrap; align-items: flex-start; gap: 2rem; }
+  .cwa-editbook-layout > .editbook-cover-section { flex: 0 0 260px; max-width: 260px; width: auto; float: none; }
+  .cwa-editbook-layout > #book_edit_frm { flex: 1 1 320px; min-width: 0; }
+  /* Neutralize the legacy Bootstrap float + inline 40rem offset on the form's
+     inner column so it fills the flex track instead of floating with a huge gap. */
+  .cwa-editbook-layout > #book_edit_frm > .col-sm-9 {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    width: auto !important;
+    float: none !important;
+  }
+  @media (max-width: 767px) {
+    .cwa-editbook-layout { flex-direction: column; gap: 0; }
+    .cwa-editbook-layout > .editbook-cover-section { flex: none; max-width: 100%; }
+    .cwa-editbook-layout > #book_edit_frm { order: -1; flex: none; }
+  }
 </style>
 {% if book %}
   <a href="{{ url_for('web.show_book', book_id=book.id) }}" class="cwa-edit-back" style="display:block; clear:both; margin:0.5rem 0 1rem; color:hsla(0,0%,100%,.82); text-decoration:none; font-weight:600;">
     <span class="glyphicon glyphicon-chevron-left"></span> {{ _('Back to book') }}
   </a>
+  <div class="cwa-editbook-layout">
   <div class="editbook-cover-section col-sm-3 col-lg-3 col-xs-12">
     {# No clickable cover overlay here (unlike the detail page): this page hosts
        the metadata edit form, and a large cover-sized navigation target would
@@ -293,6 +315,7 @@
     </div>
   </div>
 </form>
+  </div>
 
 {% endif %}
 {% endblock %}

--- a/tests/unit/test_edit_mobile_reorder.py
+++ b/tests/unit/test_edit_mobile_reorder.py
@@ -1,0 +1,51 @@
+"""Regression: the Edit Metadata page puts the form first on phones — fork #32
+(follow-up to #26).
+
+The page is a two-column layout: a cover/convert/upload column (col-sm-3) and the
+metadata form (col-sm-9, offset right on desktop via an inline margin-left). In DOM
+order the cover column comes first, so on phones — where the columns stack — you had
+to scroll past the cover to reach the title/author fields.
+
+The two columns are now wrapped in `.cwa-editbook-layout`:
+  - desktop: `display: flow-root` (contains the floated columns; no collapse, layout
+    unchanged);
+  - phones (<=767px): a flex column with the form pulled first (`order: -1`).
+
+Source-pins. RED on main, GREEN here. Paired with live Playwright verification
+(desktop layout unchanged; mobile form-first).
+"""
+import os
+
+HERE = os.path.dirname(__file__)
+EDIT = os.path.normpath(os.path.join(HERE, "..", "..", "cps", "templates", "book_edit.html"))
+
+
+def _src():
+    with open(EDIT, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_layout_wrapper_present():
+    src = _src()
+    assert 'class="cwa-editbook-layout"' in src
+    # Proper flexbox two-column layout, replacing the fragile margin-left: 40rem hack.
+    assert ".cwa-editbook-layout { display: flex;" in src
+    # The legacy Bootstrap float on the form's inner column is neutralized.
+    assert "float: none !important;" in src
+
+
+def test_form_pulled_first_on_phones():
+    src = _src()
+    assert "@media (max-width: 767px)" in src
+    # On phones the form is pulled above the cover column.
+    assert "order: -1;" in src
+
+
+def test_wrapper_encloses_both_columns():
+    src = _src()
+    wrap = src.index('class="cwa-editbook-layout"')
+    cover = src.index('class="editbook-cover-section')
+    form = src.index('id="book_edit_frm"')
+    # Wrapper opens before the cover column; DOM order is still cover-then-form
+    # (the reorder is CSS-only), so the visual flip is purely the media query.
+    assert wrap < cover < form


### PR DESCRIPTION
## What
Replaces the Edit Metadata page's fragile inline `margin-left: 40rem` float offset with a proper flexbox two-column layout, and makes the page **form-first on phones**.

- **Desktop**: cover/convert column + metadata form sit side-by-side via flexbox (cover ~260px, form fills the rest). No more 40rem hack.
- **Phones (≤767px)**: the columns stack and the **form comes first** (`order: -1`) — you can edit title/author/tags immediately instead of scrolling past the cover. Completes the #26 fix (which only stopped the form being pushed off-screen).

The two columns are wrapped in `.cwa-editbook-layout`; the legacy Bootstrap float + inline 40rem offset on the form's inner column are neutralized so it fills the flex track.

## Verification
- **Regression test** `tests/unit/test_edit_mobile_reorder.py` (source-pins): RED on main, GREEN here.
- **Live** (cwn-local, Playwright):
  - Desktop 1280px: Book Title + Author + all fields visible **to the right of the cover** (two-column intact, nothing overlapping/cut off). Title at y≈243 (was below the fold with the old offset).
  - Mobile 390px: form **first** (Book Title at y≈193), cover/convert pushed below.

Template + CSS only — no route or backend change.
