### PR TITLE
feat(reader): tap left/right page-turn zones + swipe threshold + selection guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Added
+- **Tap the left or right side of the page to turn pages in the web reader.**
+  The page is split down the middle — tap (or click) the right half to go
+  forward, the left half to go back. Swiping left/right still works. Two
+  annoyances are fixed along the way: a stray finger-wobble no longer flips the
+  page, and selecting text to highlight no longer turns the page out from under
+  you.
 - You can now **star your favorite books**. Tap the star on a book's page — or
   the star on its cover anywhere in the grid — to favorite it; favorited books
   show a gold star on the cover. Use the new **Favorites** entry in the sidebar

--- a/cps/static/js/reading/epub.js
+++ b/cps/static/js/reading/epub.js
@@ -56,32 +56,81 @@ var reader;
         $("#bookmark, #show-Bookmarks").remove();
     }
 
-    // Enable swipe support
-    // I have no idea why swiperRight/swiperLeft from plugins is not working, events just don't get fired
-    var touchStart = 0;
-    var touchEnd = 0;
+    // Page navigation by touch: tap the left or right half of the screen to
+    // turn pages (split down the centre), or swipe left/right. A movement
+    // threshold separates a tap from a swipe, so a stray jitter no longer turns
+    // the page, and an active text selection (the highlight gesture) never
+    // turns the page. Desktop arrow buttons + keyboard nav are handled by the
+    // reader library; this layer adds the touch affordances.
+    var TAP_SLOP_PX = 10;     // movement at or under this counts as a tap
+    var SWIPE_MIN_PX = 40;    // horizontal travel over this counts as a swipe
+    var TAP_MAX_MS = 300;     // a longer press is a long-press/selection, not a tap
+    var touchStartX = 0, touchStartY = 0, touchStartT = 0;
+
+    // True when the rendered content holds a non-empty selection — used to
+    // suppress page turns while the reader is selecting text to highlight.
+    function readerHasSelection() {
+        try {
+            var contents = reader.rendition.getContents() || [];
+            for (var i = 0; i < contents.length; i++) {
+                var win = contents[i] && contents[i].window;
+                var sel = win && win.getSelection && win.getSelection();
+                if (sel && String(sel).length > 0) {
+                    return true;
+                }
+            }
+        } catch (e) { /* contents unavailable mid-transition — treat as no selection */ }
+        return false;
+    }
+
+    function readerIsRtl() {
+        try {
+            return reader.book.package.metadata.direction === "rtl";
+        } catch (e) {
+            return false;
+        }
+    }
 
     if (reader && reader.rendition) {
         reader.rendition.on('touchstart', function(event) {
-            touchStart = event.changedTouches[0].screenX;
+            var t = event.changedTouches[0];
+            touchStartX = t.screenX;
+            touchStartY = t.screenY;
+            touchStartT = Date.now();
         });
         reader.rendition.on('touchend', function(event) {
-          touchEnd = event.changedTouches[0].screenX;
-            if (touchStart < touchEnd) {
-                if(reader.book.package.metadata.direction === "rtl") {
-					reader.rendition.next();
-				} else {
-					reader.rendition.prev();
-				}
-                // Swiped Right
+            var t = event.changedTouches[0];
+            var dx = t.screenX - touchStartX;
+            var dy = t.screenY - touchStartY;
+            var adx = Math.abs(dx), ady = Math.abs(dy);
+            var dt = Date.now() - touchStartT;
+            var rtl = readerIsRtl();
+
+            // Never turn the page while text is selected (highlight gesture).
+            if (readerHasSelection()) {
+                return;
             }
-            if (touchStart > touchEnd) {
-                if(reader.book.package.metadata.direction === "rtl") {
-					reader.rendition.prev();
-				} else {
-                    reader.rendition.next();
-				}
-                // Swiped Left
+
+            // Swipe: dominant horizontal movement past the threshold.
+            if (adx > SWIPE_MIN_PX && adx > ady) {
+                if (dx > 0) {                       // swiped right
+                    rtl ? reader.rendition.next() : reader.rendition.prev();
+                } else {                            // swiped left
+                    rtl ? reader.rendition.prev() : reader.rendition.next();
+                }
+                return;
+            }
+
+            // Tap: little movement, short press → turn by which half was tapped,
+            // split down the centre of the viewport.
+            if (adx <= TAP_SLOP_PX && ady <= TAP_SLOP_PX && dt <= TAP_MAX_MS) {
+                var viewportWidth = window.innerWidth || document.documentElement.clientWidth || 1;
+                var tappedLeftHalf = t.screenX < (viewportWidth / 2);
+                if (tappedLeftHalf) {
+                    rtl ? reader.rendition.next() : reader.rendition.prev();
+                } else {
+                    rtl ? reader.rendition.prev() : reader.rendition.next();
+                }
             }
         });
     }
@@ -99,7 +148,7 @@ var reader;
                 this.removeBookmark(bookmark);
             }.bind(this));
         }
-        
+
         var csrftoken = $("input[name='csrf_token']").val();
 
         // Save to database
@@ -111,7 +160,7 @@ var reader;
             alert(error);
         });
     }
-    
+
     // Restore all settings after DOM and reader are ready
     document.addEventListener("DOMContentLoaded", function() {
         // Declare reflowBox once and reuse

--- a/tests/unit/test_reader_tap_zones.py
+++ b/tests/unit/test_reader_tap_zones.py
@@ -1,0 +1,68 @@
+"""Source-pin: the web reader turns pages by tapping the left/right half of the
+viewport (split down the centre), keeps swipe behind a movement threshold, and
+never turns the page while text is selected (the highlight gesture). Task #29.
+
+This is client-side behaviour with no Python entry point, so — like
+test_pubdate_datepicker_js_472.py — we pin the shipped JS source. RED on main
+(the old handler turned the page on ANY touchend movement: no tap zones, no
+threshold, no selection guard); GREEN once the tap-zone handler ships.
+"""
+import re
+from pathlib import Path
+
+EPUB_JS = (
+    Path(__file__).resolve().parents[2]
+    / "cps" / "static" / "js" / "reading" / "epub.js"
+)
+
+
+def _src():
+    return EPUB_JS.read_text(encoding="utf-8")
+
+
+def test_epub_js_exists():
+    assert EPUB_JS.is_file(), f"missing {EPUB_JS}"
+
+
+def test_tap_zone_splits_viewport_down_the_centre():
+    src = _src()
+    # A tap maps to a page turn based on which half of the viewport width was hit.
+    assert "tappedLeftHalf" in src, "no left/right tap-half decision"
+    assert re.search(r"viewportWidth\s*/\s*2", src), "tap zone not split on viewport centre"
+
+
+def test_swipe_has_a_movement_threshold():
+    src = _src()
+    assert "SWIPE_MIN_PX" in src, "swipe threshold constant missing"
+    # The swipe branch must be gated by the threshold (not fire on any movement).
+    assert re.search(r"adx\s*>\s*SWIPE_MIN_PX", src), "swipe not gated by a movement threshold"
+
+
+def test_tap_is_distinguished_from_swipe_and_long_press():
+    src = _src()
+    assert "TAP_SLOP_PX" in src, "tap movement-slop constant missing"
+    assert "TAP_MAX_MS" in src, "tap duration limit missing (long-press == selection, not a tap)"
+
+
+def test_selection_suppresses_page_turn():
+    src = _src()
+    assert "readerHasSelection" in src, "no selection-guard helper"
+    # The guard must short-circuit the touchend handler before any page turn.
+    assert re.search(r"if\s*\(\s*readerHasSelection\(\)\s*\)\s*\{\s*return", src), \
+        "touchend does not return early while a selection is active"
+
+
+def test_old_thresholdless_swipe_is_gone():
+    src = _src()
+    # The previous handler compared raw screenX with no threshold; that exact
+    # shape must be gone so a jitter or a selection drag no longer turns the page.
+    assert "if (touchStart < touchEnd)" not in src, "old thresholdless swipe still present"
+    assert "if (touchStart > touchEnd)" not in src, "old thresholdless swipe still present"
+
+
+def test_rtl_books_still_reverse_direction():
+    src = _src()
+    # Page-turn direction must still honour right-to-left books in both the tap
+    # and swipe branches (regression: the original swipe respected rtl).
+    assert "readerIsRtl" in src, "rtl handling dropped"
+    assert src.count("rtl ? reader.rendition") >= 3, "rtl branch missing from tap and/or swipe paths"


### PR DESCRIPTION
## What users get

Tap the **left or right half of the page** to turn pages in the web reader — split down the middle (right → forward, left → back). Swiping still works. Two annoyances are fixed: a stray finger-wobble no longer flips the page, and selecting text to highlight no longer turns the page out from under you.

## Why

The reader only navigated by swipe, and the swipe handler turned the page on *any* `touchend` movement (even 1px) — so jitter flipped pages and a text-selection drag (the highlight gesture) turned the page. The on-screen ‹ › arrows were visual-only on touch. Desktop mouse-click on the arrows + keyboard arrows are handled by `reader.min.js` and already worked.

## How

All in `cps/static/js/reading/epub.js` (the `touchstart`/`touchend` listeners on the epub.js rendition); `reader.min.js` untouched:
- **Tap zones** — a tap (small movement, under 300ms) turns the page by which half of the viewport width was hit, split at the centre, RTL-aware.
- **Swipe threshold** — a swipe now needs >40px of dominant-horizontal movement, so a tap stays a tap.
- **Selection guard** — if the rendered content holds a non-empty selection at `touchend`, no page turn (highlighting no longer flips the page).

## Verification

- `tests/unit/test_reader_tap_zones.py` source-pins the behaviour: **RED (6 fail) → GREEN (7 pass)** in container Python; `node --check` clean.
- Live Playwright on the real reader (book 5), synthetic touch through the actual handler:
  - **Desktop 1280px — 8/8**: 4 forward taps (incl. a chapter-boundary cross `/6/6`→`/6/8`), 3 back taps (crossing back), tap with a 302-char active selection → **no page turn**.
  - **Mobile 390px — 6/6**: tap both halves, swipe both directions, selection guard.
  - No console errors.

No new dependencies, routes, auth/CSRF, or external URLs.