### PR TITLE
feat(reader): per-user reader settings (cross-device) + text-margin + settings redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ is for things you can see or feel when running the app.
   annoyances are fixed along the way: a stray finger-wobble no longer flips the
   page, and selecting text to highlight no longer turns the page out from under
   you.
+- **Your reader display settings now follow you across devices.** Theme, font,
+  font size, page layout and the new text-margin setting are saved to your
+  account, so a book you open on your phone looks the way you set it on your
+  laptop — previously these lived only in one browser and didn't travel.
+- **Adjustable text margins in the reader.** A new slider in the reader's
+  Settings trims the side whitespace to fit more text per line, or widens it —
+  whatever's comfortable to read.
 - You can now **star your favorite books**. Tap the star on a book's page — or
   the star on its cover anywhere in the grid — to favorite it; favorited books
   show a gold star on the cover. Use the new **Favorites** entry in the sidebar
@@ -34,6 +41,9 @@ is for things you can see or feel when running the app.
   @huperaisan for the suggestion.
 
 ### Changed
+- The **reader's Settings panel** has a cleaner layout — clearly labelled
+  sections, live value readouts on the font-size and margin sliders, and bigger
+  touch targets that fit comfortably on a phone.
 - The **book details page** is easier to read, especially on phones. The big
   empty margins that boxed in the cover and info are gone — you get noticeably
   more width for the title, tags and description — and the page is tidier

--- a/cps/static/js/reading/epub.js
+++ b/cps/static/js/reading/epub.js
@@ -91,6 +91,22 @@ var reader;
         }
     }
 
+    // Adjustable text margin: set the epub content's side padding via the
+    // rendition theme (re-applied on every section), so the reader can cut or
+    // widen the side whitespace. 0 = full-width text. Exposed on window so the
+    // settings-modal slider in read.html can call it.
+    window.applyReaderMargin = function (px) {
+        if (!reader || !reader.rendition || !reader.rendition.themes) {
+            return;
+        }
+        var val = parseInt(px, 10);
+        if (isNaN(val)) { return; }
+        try {
+            reader.rendition.themes.override('padding-left', val + 'px', true);
+            reader.rendition.themes.override('padding-right', val + 'px', true);
+        } catch (e) { /* themes not ready yet */ }
+    };
+
     if (reader && reader.rendition) {
         reader.rendition.on('touchstart', function(event) {
             var t = event.changedTouches[0];
@@ -193,11 +209,11 @@ var reader;
             }
         }, 0);
         // Theme
-        const theme = localStorage.getItem("calibre.reader.theme") ?? "lightTheme";
+        const theme = ReaderSettings.get("theme", "lightTheme");
         if (typeof selectTheme === 'function') selectTheme(theme);
 
         // Font size
-        let savedFontSize = localStorage.getItem("calibre.reader.fontSize");
+        let savedFontSize = ReaderSettings.get("fontSize", null);
         let fontSizeFader = document.getElementById('fontSizeFader');
         if (savedFontSize && fontSizeFader && reader && reader.rendition && reader.rendition.themes) {
             fontSizeFader.value = savedFontSize;
@@ -212,7 +228,7 @@ var reader;
             'KaiTi': 'KaiTi, serif',
             'Arial': 'Arial, Helvetica, sans-serif'
         };
-        let savedFont = localStorage.getItem("calibre.reader.font");
+        let savedFont = ReaderSettings.get("font", null);
         if (savedFont && typeof selectFont === 'function') {
             selectFont(savedFont);
             let fontValue = fontMap[savedFont] || '';
@@ -222,14 +238,22 @@ var reader;
         }
 
         // Spread
-        let savedSpread = localStorage.getItem("calibre.reader.spread");
+        let savedSpread = ReaderSettings.get("spread", null);
         if (savedSpread && typeof spread === 'function') {
             spread(savedSpread);
         }
 
+        // Text margin (side whitespace) — applied as content padding via the
+        // rendition theme so it survives chapter changes and is independent of
+        // the viewer container CSS.
+        let savedMargin = ReaderSettings.get("margin", null);
+        if (savedMargin !== null && typeof window.applyReaderMargin === 'function') {
+            window.applyReaderMargin(savedMargin);
+        }
+
         // Reflow
         // Use the reflowBox declared earlier in this handler
-        var savedReflow = localStorage.getItem("calibre.reader.reflow");
+        var savedReflow = ReaderSettings.get("reflow", null);
         function applyReflow(enabled) {
             if (reader && reader.rendition && typeof reader.rendition.reflow === 'function') {
                 reader.rendition.reflow(enabled);
@@ -239,11 +263,11 @@ var reader;
         }
         if (reflowBox) {
             if (savedReflow !== null) {
-                reflowBox.checked = savedReflow === 'true';
+                reflowBox.checked = savedReflow === true || savedReflow === 'true';
                 applyReflow(reflowBox.checked);
             }
             reflowBox.addEventListener("change", function() {
-                localStorage.setItem("calibre.reader.reflow", this.checked);
+                ReaderSettings.set("reflow", this.checked);
                 applyReflow(this.checked);
             });
         }

--- a/cps/static/js/reading/reader-settings.js
+++ b/cps/static/js/reading/reader-settings.js
@@ -1,0 +1,93 @@
+/* global $, calibre */
+// Per-user web-reader display settings.
+//
+// Settings (theme, font, fontSize, spread, reflow, margin) used to live only
+// in this browser's localStorage, so they didn't follow the reader to a phone
+// or another browser. This module makes the server the source of truth for
+// signed-in users: the page is rendered with the saved settings in
+// window.calibre.readerSettings, and every change is persisted to BOTH
+// localStorage (instant, offline, anonymous fallback) AND the server
+// (debounced POST to /ajax/readersettings, signed-in only). See web.py
+// save_reader_settings() + view_settings['reader'].
+//
+// Exposes window.ReaderSettings.{get,set,isAuthenticated}. Loaded before
+// epub.js so the reader restore + the settings-modal handlers can use it.
+(function () {
+    "use strict";
+
+    var LS_PREFIX = "calibre.reader.";
+    var INT_KEYS = { fontSize: true, margin: true };
+    var BOOL_KEYS = { reflow: true };
+
+    var server = (typeof calibre === "object" && calibre && calibre.readerSettings) ? calibre.readerSettings : {};
+    // useBookmarks mirrors current_user.is_authenticated (tojson'd to "true"/"false").
+    var authenticated = !!(typeof calibre === "object" && calibre && String(calibre.useBookmarks) === "true");
+
+    var pending = {};
+    var saveTimer = null;
+
+    function lsGet(key) {
+        try { return localStorage.getItem(LS_PREFIX + key); } catch (e) { return null; }
+    }
+    function lsSet(key, value) {
+        try { localStorage.setItem(LS_PREFIX + key, value); } catch (e) { /* private mode / quota */ }
+    }
+
+    // Normalise a raw value (server-typed, or a localStorage string) to the
+    // canonical type for its key so consumers don't each re-parse.
+    function coerce(key, raw, dflt) {
+        if (raw === undefined || raw === null || raw === "") { return dflt; }
+        if (INT_KEYS[key]) {
+            var n = parseInt(raw, 10);
+            return isNaN(n) ? dflt : n;
+        }
+        if (BOOL_KEYS[key]) {
+            return raw === true || raw === "true";
+        }
+        return raw;
+    }
+
+    function flush() {
+        saveTimer = null;
+        if (!authenticated) { return; }
+        var csrf = $("input[name='csrf_token']").val();
+        var body = pending;
+        pending = {};
+        $.ajax("/ajax/readersettings", {
+            method: "post",
+            contentType: "application/json",
+            data: JSON.stringify(body),
+            headers: { "X-CSRFToken": csrf }
+        }).fail(function () {
+            // Server save failed — localStorage already holds the change, so the
+            // setting still survives a reload on this device; just re-queue it.
+            Object.keys(body).forEach(function (k) {
+                if (!(k in pending)) { pending[k] = body[k]; }
+            });
+        });
+    }
+
+    window.ReaderSettings = {
+        // Signed-in: the server snapshot wins (cross-device). Otherwise
+        // localStorage. Falls back to dflt when neither has the key.
+        get: function (key, dflt) {
+            if (authenticated && server && Object.prototype.hasOwnProperty.call(server, key)) {
+                return coerce(key, server[key], dflt);
+            }
+            return coerce(key, lsGet(key), dflt);
+        },
+        set: function (key, value) {
+            lsSet(key, value);
+            var prev = server[key];
+            server[key] = value;          // keep the in-memory snapshot current
+            // Skip the server round-trip when nothing actually changed — the
+            // restore-on-load path re-applies saved values (theme/font/spread)
+            // and shouldn't fire a POST each time the reader opens.
+            if (prev === value) { return; }
+            pending[key] = value;
+            if (saveTimer) { clearTimeout(saveTimer); }
+            saveTimer = setTimeout(flush, 400);   // debounce slider drags into one POST
+        },
+        isAuthenticated: function () { return authenticated; }
+    };
+})();

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -73,47 +73,83 @@
 	    <div id="progress">0%</div>
 	    <div id="loader"><div class="css-spinner" role="status" aria-label="{{ _('Loading') }}"></div></div>
 	</div>
+    <style>
+        /* Reader settings modal — clearer sections, labelled sliders with live
+           value readouts, touch-friendly controls, and a layout that fits small
+           screens. Scoped to #settings-modal so the rest of the reader chrome
+           is untouched. */
+        #settings-modal .md-content { max-width: 440px; }
+        #settings-modal h3 { margin: 0 0 0.8em; }
+        #settings-modal .rs-section { padding: 0.8em 0; border-top: 1px solid rgba(127,127,127,0.22); }
+        #settings-modal .rs-section:first-of-type { border-top: 0; padding-top: 0; }
+        #settings-modal .rs-label { display: block; font-weight: 600; margin-bottom: 0.55em; font-size: 0.95em; }
+        #settings-modal .rs-buttons { display: flex; flex-wrap: wrap; gap: 8px; }
+        #settings-modal .rs-buttons button { flex: 1 1 auto; min-height: 40px; min-width: 66px; cursor: pointer; }
+        #settings-modal .rs-slider-row { display: flex; align-items: center; gap: 12px; }
+        #settings-modal .rs-slider-row input[type="range"] { flex: 1; min-height: 28px; }
+        #settings-modal .rs-value { min-width: 3.4em; text-align: right; font-variant-numeric: tabular-nums; opacity: 0.85; }
+        #settings-modal .rs-check { display: flex; align-items: flex-start; gap: 8px; cursor: pointer; margin: 0; }
+        #settings-modal .rs-check input { width: 18px; height: 18px; margin-top: 1px; flex: none; }
+        @media (max-width: 600px) {
+            #settings-modal .md-content { max-width: 92vw; max-height: 86vh; overflow-y: auto; }
+        }
+    </style>
     <div class="modal md-effect-1" id="settings-modal">
         <div class="md-content">
             <h3>{{_('Settings')}}</h3>
-            <div class="form-group themes" id="themes">
-                Choose a theme below: <br />
 
-                <!-- Hardcoded a tick in the light theme button because it is the "default" theme. Need to find a way to do this dynamically on startup-->
-                <button type="button" id="lightTheme" class="lightTheme" onclick="selectTheme(this.id)"><span
-                        id="lightSelected">✓</span>{{_('Light')}}</button>
-                <button type="button" id="darkTheme" class="darkTheme" onclick="selectTheme(this.id)"><span
-                        id="darkSelected"> </span>{{_('Dark')}}</button>
-                <button type="button" id="sepiaTheme" class="sepiaTheme" onclick="selectTheme(this.id)"><span
-                        id="sepiaSelected"> </span>{{_('Sepia')}}</button>
-                <button type="button" id="blackTheme" class="blackTheme" onclick="selectTheme(this.id)"><span
-                        id="blackSelected"> </span>{{_('Black')}}</button>
+            <div class="rs-section themes" id="themes">
+                <label class="rs-label">{{_('Theme')}}</label>
+                <div class="rs-buttons">
+                    <button type="button" id="lightTheme" class="lightTheme" onclick="selectTheme(this.id)"><span id="lightSelected">✓</span>{{_('Light')}}</button>
+                    <button type="button" id="darkTheme" class="darkTheme" onclick="selectTheme(this.id)"><span id="darkSelected"> </span>{{_('Dark')}}</button>
+                    <button type="button" id="sepiaTheme" class="sepiaTheme" onclick="selectTheme(this.id)"><span id="sepiaSelected"> </span>{{_('Sepia')}}</button>
+                    <button type="button" id="blackTheme" class="blackTheme" onclick="selectTheme(this.id)"><span id="blackSelected"> </span>{{_('Black')}}</button>
+                </div>
             </div>
-            <div class="form-group">
-                <p>
-                    <input type="checkbox" id="sidebarReflow"
-                        name="sidebarReflow">{{_('Reflow text when sidebars are open.')}}
-                </p>
-            </div>
-            <div class="form-group fontSizeWrapper">
-                <div class="slider">
-                    <label for="fader">{{ _('Font Sizes') }}</label>
+
+            <div class="rs-section">
+                <label class="rs-label" for="fontSizeFader">{{ _('Font Sizes') }}</label>
+                <div class="rs-slider-row">
                     <input type="range" min="75" max="200" value="100" id="fontSizeFader" step="25">
-                </div>            
+                    <span class="rs-value" id="fontSizeValue">100%</span>
+                </div>
             </div>
-              <div class="font" id="font">
-                <label class="item">{{_('Font')}}:</label>
-                <button type="button" id="default" onclick="selectFont(this.id)"><span>✓</span>{{_('Default')}}</button> 
-                <button type="button" id="Yahei" onclick="selectFont(this.id)"><span></span>{{_('Yahei')}}</button>
-                <button type="button" id="SimSun" onclick="selectFont(this.id)"><span></span>{{_('SimSun')}}</button>
-                <button type="button" id="KaiTi" onclick="selectFont(this.id)"><span></span>{{_('KaiTi')}}</button>
-                <button type="button" id="Arial" onclick="selectFont(this.id)"><span></span>{{_('Arial')}}</button>
-              </div>
-              <div class="layou" id="layout">
-                <label class="item">{{ _('Spread') }}:</label>
-                <button type="button" id="spread" onclick="spread(this.id)"><span>✓</span>{{_('Two columns')}}</button>
-                <button type="button" id="nonespread" onclick="spread(this.id)"><span></span>{{_('One column')}}</button>
-              </div>            
+
+            <div class="rs-section">
+                <label class="rs-label" for="marginFader">{{ _('Text margin') }}</label>
+                <div class="rs-slider-row">
+                    <input type="range" min="0" max="80" value="0" id="marginFader" step="8">
+                    <span class="rs-value" id="marginValue">0px</span>
+                </div>
+            </div>
+
+            <div class="rs-section font" id="font">
+                <label class="rs-label">{{_('Font')}}</label>
+                <div class="rs-buttons">
+                    <button type="button" id="default" onclick="selectFont(this.id)"><span>✓</span>{{_('Default')}}</button>
+                    <button type="button" id="Yahei" onclick="selectFont(this.id)"><span></span>{{_('Yahei')}}</button>
+                    <button type="button" id="SimSun" onclick="selectFont(this.id)"><span></span>{{_('SimSun')}}</button>
+                    <button type="button" id="KaiTi" onclick="selectFont(this.id)"><span></span>{{_('KaiTi')}}</button>
+                    <button type="button" id="Arial" onclick="selectFont(this.id)"><span></span>{{_('Arial')}}</button>
+                </div>
+            </div>
+
+            <div class="rs-section layou" id="layout">
+                <label class="rs-label">{{ _('Spread') }}</label>
+                <div class="rs-buttons">
+                    <button type="button" id="spread" onclick="spread(this.id)"><span>✓</span>{{_('Two columns')}}</button>
+                    <button type="button" id="nonespread" onclick="spread(this.id)"><span></span>{{_('One column')}}</button>
+                </div>
+            </div>
+
+            <div class="rs-section">
+                <label class="rs-check">
+                    <input type="checkbox" id="sidebarReflow" name="sidebarReflow">
+                    <span>{{_('Reflow text when sidebars are open.')}}</span>
+                </label>
+            </div>
+
             <div class="closer icon-cancel-circled"></div>
         </div>
     </div>
@@ -130,6 +166,7 @@
             bookUrl: "{{ url_for('web.serve_book', book_id=bookid, book_format=book_format, anyname='file.epub') }}",
             bookmark: "{{ bookmark.bookmark_key if bookmark != None }}",
             useBookmarks: "{{ current_user.is_authenticated | tojson }}",
+            readerSettings: {{ reader_settings | default('{}') | safe }},
             kosyncPercent: {{ kosync_progress | tojson if kosync_progress is not none else 'null' }},
             annotationsApiBase: "{{ url_for('annotations.annotations_view', book_id=bookid).rstrip('/') }}",
             annotationsI18n: {
@@ -181,7 +218,7 @@
             // Add tick mark to the button corresponding to the currently selected theme
             document.getElementById(id).querySelector("span").textContent = "✓";
             // Saving theme to local storage
-            localStorage.setItem("calibre.reader.theme", id);
+            ReaderSettings.set("theme", id);
             // Apply theme to epubjs iframe
             reader.rendition.themes.select(id);
             // Apply theme to rest of the page. 
@@ -202,7 +239,7 @@
             spans[i].textContent = "";
           }
           document.getElementById(id).querySelector("span").textContent = "✓";
-          localStorage.setItem("calibre.reader.font", id);
+          ReaderSettings.set("font", id);
           if (id == 'default' && defaultFont) {
             reader.rendition.themes.font(defaultFont);
             return;
@@ -216,7 +253,7 @@
             spans[i].textContent = "";
           }
           document.getElementById(id).querySelector("span").textContent = "✓";
-          localStorage.setItem("calibre.reader.spread", id);
+          ReaderSettings.set("spread", id);
           reader.rendition.spread(id==='spread'?true:'none');
         }
 
@@ -224,13 +261,13 @@
         document.addEventListener("DOMContentLoaded", function() {
           let fontSizeFader = document.getElementById('fontSizeFader');
           if (fontSizeFader) {
-            let savedFontSize = localStorage.getItem("calibre.reader.fontSize");
+            let savedFontSize = ReaderSettings.get("fontSize", null);
             if (savedFontSize) {
               fontSizeFader.value = savedFontSize;
             }
             fontSizeFader.addEventListener("change", function () {
               reader.rendition.themes.fontSize(`${this.value}%`);
-              localStorage.setItem("calibre.reader.fontSize", this.value);
+              ReaderSettings.set("fontSize", parseInt(this.value, 10));
             });
           }
         });
@@ -239,18 +276,45 @@
         document.addEventListener("DOMContentLoaded", function() {
           let reflowBox = document.getElementById('sidebarReflow');
           if (reflowBox) {
-            let savedReflow = localStorage.getItem("calibre.reader.reflow");
+            let savedReflow = ReaderSettings.get("reflow", null);
             if (savedReflow !== null) {
-              reflowBox.checked = savedReflow === 'true';
+              reflowBox.checked = savedReflow === true || savedReflow === 'true';
             }
             reflowBox.addEventListener("change", function() {
-              localStorage.setItem("calibre.reader.reflow", this.checked);
+              ReaderSettings.set("reflow", this.checked);
+            });
+          }
+        });
+
+        // Text-margin slider + live value readouts (font size + margin).
+        document.addEventListener("DOMContentLoaded", function() {
+          var fsFader = document.getElementById('fontSizeFader');
+          var fsValue = document.getElementById('fontSizeValue');
+          if (fsFader && fsValue) {
+            var fsUpdate = function () { fsValue.textContent = fsFader.value + '%'; };
+            fsUpdate();
+            fsFader.addEventListener("input", fsUpdate);
+            fsFader.addEventListener("change", fsUpdate);
+          }
+          var marginFader = document.getElementById('marginFader');
+          var marginValue = document.getElementById('marginValue');
+          if (marginFader) {
+            var savedMargin = ReaderSettings.get("margin", null);
+            if (savedMargin !== null) { marginFader.value = savedMargin; }
+            if (marginValue) { marginValue.textContent = marginFader.value + 'px'; }
+            marginFader.addEventListener("input", function () {
+              if (marginValue) { marginValue.textContent = this.value + 'px'; }
+            });
+            marginFader.addEventListener("change", function () {
+              if (window.applyReaderMargin) { window.applyReaderMargin(this.value); }
+              ReaderSettings.set("margin", parseInt(this.value, 10));
             });
           }
         });
       </script>
       <script src="{{ url_for('static', filename='js/libs/screenfull.min.js') }}"></script>
       <script src="{{ url_for('static', filename='js/libs/reader.min.js') }}"></script>
+      <script src="{{ url_for('static', filename='js/reading/reader-settings.js') }}"></script>
       <script src="{{ url_for('static', filename='js/reading/epub.js') }}"></script>
       <script src="{{ url_for('static', filename='js/reading/epub-progress.js') }}"></script>
       <script src="{{ url_for('static', filename='js/reading/annotations.js') }}"></script>

--- a/cps/web.py
+++ b/cps/web.py
@@ -242,6 +242,82 @@ def toggle_favorite(book_id):
     return json.dumps({"favorited": favorited})
 
 
+# --- Web-reader per-user display settings -----------------------------------
+# The epub reader's theme / font / font-size / column-spread / reflow / text
+# margin used to live only in the one browser's localStorage, so they never
+# followed a user to their phone or another browser. We persist them under
+# view_settings['reader'] (same JSON column + flag_modified pattern as the
+# books-list view settings) so they sync per-user across devices. Anonymous
+# sessions never reach the save route (@user_login_required) and keep using
+# localStorage as before.
+_READER_THEMES = {"lightTheme", "darkTheme", "sepiaTheme", "blackTheme"}
+_READER_FONTS = {"default", "Yahei", "SimSun", "KaiTi", "Arial"}
+_READER_SPREADS = {"spread", "nonespread"}
+
+
+def _reader_setting_int(value, lo, hi):
+    """Coerce a slider value to an int clamped to [lo, hi]; None if not numeric.
+    Booleans are rejected first (isinstance(True, int) is True) so a JSON
+    ``true`` can't slip through as 1."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return max(lo, min(hi, int(value)))
+    if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+        return max(lo, min(hi, int(value.strip())))
+    return None
+
+
+def sanitize_reader_settings(payload):
+    """Reduce an arbitrary POST body to the known reader settings with safe
+    values, so a crafted payload can never store junk on the user row. Unknown
+    keys and out-of-range / ill-typed values are dropped."""
+    if not isinstance(payload, dict):
+        return {}
+    out = {}
+    if payload.get("theme") in _READER_THEMES:
+        out["theme"] = payload["theme"]
+    if payload.get("font") in _READER_FONTS:
+        out["font"] = payload["font"]
+    if payload.get("spread") in _READER_SPREADS:
+        out["spread"] = payload["spread"]
+    font_size = _reader_setting_int(payload.get("fontSize"), 75, 200)
+    if font_size is not None:
+        out["fontSize"] = font_size
+    margin = _reader_setting_int(payload.get("margin"), 0, 80)
+    if margin is not None:
+        out["margin"] = margin
+    reflow = payload.get("reflow")
+    if isinstance(reflow, bool):
+        out["reflow"] = reflow
+    elif isinstance(reflow, str):
+        out["reflow"] = reflow.strip().lower() == "true"
+    return out
+
+
+@web.route("/ajax/readersettings", methods=['POST'])
+@user_login_required
+def save_reader_settings():
+    """Persist the web reader's per-user display settings so they follow the
+    user across devices instead of living only in one browser's localStorage."""
+    try:
+        payload = json.loads(request.data or b"{}")
+    except (ValueError, TypeError):
+        return json.dumps({"saved": False}), 400, {"Content-Type": "application/json"}
+    cleaned = sanitize_reader_settings(payload)
+    if current_user.view_settings is None:
+        current_user.view_settings = {}
+    current_user.view_settings["reader"] = cleaned
+    try:
+        flag_modified(current_user, "view_settings")
+        ub.session.commit()
+    except Exception as exc:
+        ub.session.rollback()
+        log.error("Could not save reader settings for user %s: %s", current_user.id, exc)
+        return json.dumps({"saved": False}), 500, {"Content-Type": "application/json"}
+    return json.dumps({"saved": True, "reader": cleaned})
+
+
 # Per-user hidden books — fork issue #64. Hide removes the book from index
 # pages, search, OPDS feeds, and shelf listings for the calling user only;
 # /hidden lists hidden books with an unhide button. Distinct from archive
@@ -3356,8 +3432,16 @@ def read_book(book_id, book_format):
 
     if book_format.lower() in ("epub", "kepub"):
         log.debug("Start epub reader for %d (%s)", book_id, book_format.lower())
+        # Per-user reader display settings (theme/font/size/spread/reflow/margin)
+        # so the reader boots with the user's saved choices instead of waiting
+        # for a localStorage read. Anonymous users get {} and fall back to
+        # localStorage. See save_reader_settings() + reader-settings.js.
+        reader_settings = {}
+        if current_user.is_authenticated:
+            reader_settings = (getattr(current_user, "view_settings", None) or {}).get("reader", {}) or {}
         return render_title_template('read.html', bookid=book_id, title=book.title,
                                      bookmark=bookmark, kosync_progress=kosync_progress,
+                                     reader_settings=json.dumps(reader_settings),
                                      book_format=book_format.lower())
     elif book_format.lower() == "pdf":
         log.debug("Start pdf reader for %d", book_id)

--- a/cps/web.py
+++ b/cps/web.py
@@ -271,7 +271,13 @@ def _reader_setting_int(value, lo, hi):
 def sanitize_reader_settings(payload):
     """Reduce an arbitrary POST body to the known reader settings with safe
     values, so a crafted payload can never store junk on the user row. Unknown
-    keys and out-of-range / ill-typed values are dropped."""
+    keys and out-of-range / ill-typed values are dropped.
+
+    SECURITY: read_book() injects this dict verbatim into a <script> via Jinja's
+    ``| safe`` (no HTML escaping). Every value stored here MUST stay a closed
+    enum, a clamped int, or a bool — never store free text, or that inject
+    becomes a stored-XSS sink.
+    """
     if not isinstance(payload, dict):
         return {}
     out = {}

--- a/tests/unit/test_reader_settings_persist.py
+++ b/tests/unit/test_reader_settings_persist.py
@@ -1,0 +1,67 @@
+"""Per-user web-reader display settings (task #31).
+
+Reader settings (theme/font/fontSize/spread/reflow/margin) are persisted under
+view_settings['reader'] so they follow a user across devices. sanitize_reader_settings()
+is the gate that keeps a crafted POST from storing junk on the user row — pin
+its whitelist + clamping. RED on main (the function doesn't exist there); GREEN
+on the branch.
+"""
+import pytest
+
+from cps.web import sanitize_reader_settings, _reader_setting_int
+
+
+def test_keeps_each_valid_field():
+    out = sanitize_reader_settings({
+        "theme": "darkTheme", "font": "Arial", "spread": "nonespread",
+        "fontSize": 150, "margin": 40, "reflow": True,
+    })
+    assert out == {
+        "theme": "darkTheme", "font": "Arial", "spread": "nonespread",
+        "fontSize": 150, "margin": 40, "reflow": True,
+    }
+
+
+def test_drops_unknown_keys_and_bad_enum_values():
+    out = sanitize_reader_settings({
+        "theme": "neonTheme", "font": "ComicSans", "spread": "triple",
+        "evil": "<script>alert(1)</script>", "fontSize": 100,
+    })
+    # Only the valid fontSize survives; bad enums + unknown keys are dropped.
+    assert out == {"fontSize": 100}
+
+
+def test_clamps_numeric_ranges():
+    assert sanitize_reader_settings({"fontSize": 9999})["fontSize"] == 200
+    assert sanitize_reader_settings({"fontSize": 10})["fontSize"] == 75
+    assert sanitize_reader_settings({"margin": -10})["margin"] == 0
+    assert sanitize_reader_settings({"margin": 999})["margin"] == 80
+
+
+def test_numeric_strings_accepted_booleans_rejected():
+    assert sanitize_reader_settings({"fontSize": "125"})["fontSize"] == 125
+    # A JSON `true` must not be coerced into fontSize=1 / margin=1.
+    assert "fontSize" not in sanitize_reader_settings({"fontSize": True})
+    assert "margin" not in sanitize_reader_settings({"margin": False})
+
+
+def test_reflow_coercion():
+    assert sanitize_reader_settings({"reflow": True})["reflow"] is True
+    assert sanitize_reader_settings({"reflow": "true"})["reflow"] is True
+    assert sanitize_reader_settings({"reflow": "false"})["reflow"] is False
+    assert "reflow" not in sanitize_reader_settings({"reflow": 5})
+
+
+def test_non_dict_payload_is_empty():
+    assert sanitize_reader_settings("nope") == {}
+    assert sanitize_reader_settings(None) == {}
+    assert sanitize_reader_settings([1, 2]) == {}
+
+
+def test_reader_setting_int_helper():
+    assert _reader_setting_int(50, 75, 200) == 75      # clamp up to lo
+    assert _reader_setting_int(300, 75, 200) == 200    # clamp down to hi
+    assert _reader_setting_int(True, 0, 80) is None     # bool rejected
+    assert _reader_setting_int("abc", 0, 80) is None
+    assert _reader_setting_int(None, 0, 80) is None
+    assert _reader_setting_int("40", 0, 80) == 40


### PR DESCRIPTION
## What users get
- **Reader settings now follow you across devices.** Theme, font, font size, page layout and a new text-margin setting are saved to your account — open a book on your phone and it looks the way you set it on your laptop. (They were browser-local before.)
- **Adjustable text margins** — a slider in the reader's Settings trims the side whitespace to fit more text per line, or widens it.
- **The Settings panel got a cleaner layout** — labelled sections, live readouts on the sliders, bigger touch targets, mobile-fit.

## How
- **Backend** (`web.py`): new `POST /ajax/readersettings` (`@user_login_required`, CSRF via the global Flask-WTF middleware). `sanitize_reader_settings()` whitelists keys (`theme`/`font`/`spread` from fixed sets) and clamps `fontSize` 75–200 / `margin` 0–80, dropping anything else. `read_book()` injects the saved settings into `window.calibre.readerSettings`. Stored under `view_settings['reader']` — the existing JSON column + `flag_modified` pattern, namespaced so it doesn't touch `useredit`/`opds`.
- **Frontend**: `reader-settings.js` exposes `ReaderSettings.get/set` — server snapshot wins for signed-in users, localStorage is the instant + anonymous fallback, saves are debounced into one POST and skipped when unchanged. The existing settings handlers + the reader's restore-on-load now route through it. A text-margin slider applies content side-padding via the rendition theme. The settings modal is redesigned.

## Security (new route)
Auth-gated + CSRF-protected; writes only to the calling user's own `view_settings`; the sanitizer means stored values are always enum/int/bool, so the `json.dumps(...) | safe` inject into the `<script>` carries no user-controlled free text.

## Verification
- `tests/unit/test_reader_settings_persist.py` — 7 tests pinning the sanitizer: **RED → GREEN** in container Python.
- Live `cwn-local` (Playwright, signed-in user): change theme/font-size/margin → **persisted to `view_settings['reader']` in `app.db`** (direct query; bogus key dropped); **reload** restores from the server inject; **clear localStorage + reload** still restores (cross-device proof, not browser-local); margin visibly shifts content; **0 console errors**; redesigned modal verified **desktop 1280 + mobile 390**.

No new dependencies or external URLs.