### PR TITLE
feat(reader): suppress native context menu so the highlight popup is the affordance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ is for things you can see or feel when running the app.
   @huperaisan for the suggestion.
 
 ### Changed
+- In the **web reader**, long-pressing or right-clicking text no longer pops up
+  the browser's own menu competing with the highlight popup — the in-app
+  highlight menu is the one that shows. (On iOS Safari, Apple's built-in
+  text-selection menu still appears alongside it; that one can't be switched off
+  from a web page.)
 - The **reader's Settings panel** has a cleaner layout — clearly labelled
   sections, live value readouts on the font-size and margin sliders, and bigger
   touch targets that fit comfortably on a phone.

--- a/cps/static/js/reading/epub.js
+++ b/cps/static/js/reading/epub.js
@@ -107,6 +107,34 @@ var reader;
         } catch (e) { /* themes not ready yet */ }
     };
 
+    // Suppress the native long-press / right-click context menu inside the
+    // reader so the in-app highlight popup is the affordance. Text stays
+    // selectable (highlighting needs it); we only swallow `contextmenu` and the
+    // iOS long-press callout. NOTE: iOS Safari's text-selection edit menu
+    // (Copy / Look Up / Share, shown AFTER a selection) cannot be suppressed via
+    // web APIs without disabling selection, so the custom popup coexists with it
+    // there. See notes/2026-06-17-reader-native-menu-DESIGN.md.
+    function suppressMenuOnContents(contents) {
+        var doc = contents && contents.document;
+        if (!doc || doc.__cwaMenuSuppressed) { return; }
+        doc.__cwaMenuSuppressed = true;
+        doc.addEventListener('contextmenu', function (ev) { ev.preventDefault(); }, false);
+    }
+    window.suppressReaderNativeMenu = function () {
+        if (!reader || !reader.rendition) { return; }
+        try {
+            // Kill the iOS long-press callout for links/images across all sections.
+            reader.rendition.themes.override('-webkit-touch-callout', 'none', true);
+        } catch (e) { /* themes not ready yet */ }
+        var list = [];
+        try { list = reader.rendition.getContents() || []; } catch (e) { list = []; }
+        list.forEach(suppressMenuOnContents);
+    };
+    if (reader && reader.rendition && typeof reader.rendition.on === 'function') {
+        // Re-apply on every section render (epub.js swaps the iframe document).
+        reader.rendition.on('rendered', function () { window.suppressReaderNativeMenu(); });
+    }
+
     if (reader && reader.rendition) {
         reader.rendition.on('touchstart', function(event) {
             var t = event.changedTouches[0];

--- a/notes/2026-06-17-reader-native-menu-DESIGN.md
+++ b/notes/2026-06-17-reader-native-menu-DESIGN.md
@@ -1,0 +1,49 @@
+# Reader native-menu suppression — design + platform reality (task #30)
+
+**Goal:** in the web reader, suppress the browser's native long-press / right-click
+menu so the in-app highlight popup (shipped in #349) is the affordance for
+selecting text to highlight.
+
+## What ships
+
+In `cps/static/js/reading/epub.js` — `suppressReaderNativeMenu()`, re-applied on
+every section render (epub.js swaps the iframe document per spine item):
+
+- `-webkit-touch-callout: none` injected into the epub content via the rendition
+  theme override — kills the iOS long-press **callout** (for links/images).
+- a `contextmenu` → `preventDefault` listener on each rendered section's document
+  — swallows the right-click (desktop) and long-press context menu (Android) so
+  the custom popup is the only menu that shows.
+
+Text stays selectable (`user-select` is **not** disabled) because the highlight
+feature needs a real selection. The custom popup is untouched — it fires on
+epub.js's `selected` event, independent of `contextmenu`. Keyboard copy (Ctrl/⌘-C)
+still works.
+
+## The iOS limitation (honest scope)
+
+iOS Safari shows a **text-selection edit menu** (Copy / Look Up / Translate /
+Share) *after* a selection is made. That is native UI, not a DOM `contextmenu`
+event, and **cannot be suppressed from a web context** without setting
+`user-select: none` — which would disable the very selection highlighting needs.
+So on iOS Safari the native edit menu **coexists** with the custom popup.
+
+Options considered and rejected for iOS:
+- `user-select: none` + reimplement selection by hand (long-press → manual range):
+  fragile across iOS versions, breaks VoiceOver/accessibility, large surface area.
+  Not worth it for a reader.
+- Overlay tricks to cover the native menu: it renders above page content and
+  can't be reliably covered.
+
+Conclusion: the web-suppressible parts (callout + contextmenu) ship and help
+Android + desktop; the iOS text-selection edit menu is a documented platform
+constraint. Removing it would require a native app shell — out of scope.
+
+## Verification
+
+- contextmenu suppression: dispatch a `contextmenu` event in the rendered content
+  iframe and assert `defaultPrevented` (Playwright, desktop) — OBSERVED.
+- callout CSS applied to content; text still selectable; custom popup still
+  appears on selection — OBSERVED.
+- iOS edit-menu coexistence: needs a real iPhone (operator / household device) —
+  ASSUMED to behave as analysed above; it is expected behaviour, not a regression.

--- a/tests/unit/test_reader_native_menu.py
+++ b/tests/unit/test_reader_native_menu.py
@@ -1,0 +1,46 @@
+"""Source-pin: the web reader suppresses the native context menu (right-click /
+long-press) inside the content so the in-app highlight popup is the affordance,
+WITHOUT disabling text selection (highlighting needs a live selection). Task #30.
+
+Client-side behaviour with no Python entry point — pinned on the shipped source
+like the other reader JS tests. RED on main (no suppression); GREEN on branch.
+The iOS text-selection edit menu is a documented platform limit
+(notes/2026-06-17-reader-native-menu-DESIGN.md) and is intentionally not asserted.
+"""
+import re
+from pathlib import Path
+
+EPUB_JS = (
+    Path(__file__).resolve().parents[2]
+    / "cps" / "static" / "js" / "reading" / "epub.js"
+)
+
+
+def _src():
+    return EPUB_JS.read_text(encoding="utf-8")
+
+
+def test_has_suppress_helper():
+    assert "suppressReaderNativeMenu" in _src()
+
+
+def test_contextmenu_is_prevented():
+    src = _src()
+    assert re.search(r"addEventListener\(\s*['\"]contextmenu['\"]", src), "no contextmenu listener"
+    assert "preventDefault" in src
+
+
+def test_ios_long_press_callout_suppressed():
+    assert "-webkit-touch-callout" in _src()
+
+
+def test_reapplied_on_each_section_render():
+    # epub.js swaps the iframe document per spine item — suppression must re-run.
+    assert re.search(r"on\(\s*['\"]rendered['\"][\s\S]{0,120}suppressReaderNativeMenu", _src()), \
+        "suppression not re-applied on 'rendered'"
+
+
+def test_does_not_disable_text_selection():
+    # The fix must NOT kill selection to remove the menu — highlighting needs it.
+    # Guards against a future "iOS fix" that sets user-select:none on content.
+    assert "user-select" not in _src(), "epub.js must not disable user-select (breaks highlighting)"


### PR DESCRIPTION
## What users get
Long-pressing or right-clicking text in the web reader no longer pops the browser's own menu fighting the in-app highlight popup — the highlight menu is the one that shows.

**Honest scope:** on **iOS Safari**, Apple's text-selection edit menu (Copy / Look Up / Share) still appears alongside the custom popup. That's native UI shown *after* a selection — not a `contextmenu` event — and can't be suppressed from a web page without disabling text selection (which highlighting needs). So this PR removes the **context menu** (right-click / long-press) and the iOS long-press **callout**; the custom popup coexists with the iOS edit menu. Full iOS suppression would need a native app shell. See `notes/2026-06-17-reader-native-menu-DESIGN.md`.

## How
`cps/static/js/reading/epub.js` — `suppressReaderNativeMenu()`, re-applied on every section render (epub.js swaps the iframe document per spine item): injects `-webkit-touch-callout: none` via the rendition theme + a `contextmenu` `preventDefault` listener on each content document. `user-select` is left untouched so selection (and highlighting) keep working.

## Verification
- `tests/unit/test_reader_native_menu.py` — source-pins the suppression + that selection is NOT disabled: **RED (4) → GREEN (5)** in container Python.
- Live `cwn-local`: `contextmenu` in rendered content → **`defaultPrevented: true`**; text still selectable (`selectionLen 705`, `user-select: auto`); **0 console errors**; renders normally.
- `-webkit-touch-callout` is Safari-only (not exposed by Chromium), so verifiable only on a real iOS device — flagged for household-device confirmation.

No new dependencies, routes, or external URLs.