### PR TITLE
feat(magic-shelf): recover rule-builder width on mobile + fix filter-select width typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ is for things you can see or feel when running the app.
   @huperaisan for the suggestion.
 
 ### Changed
+- The **Magic Shelf editor** is easier to use on a phone. The rule builder and
+  the Kobo-sync / OPDS / public option cards were being squeezed into a narrow
+  strip with big wasted margins; they now use much more of the screen width, and
+  each rule's field/operator/value controls stack full-width instead of
+  clustering. A typo that mis-sized the rule's field dropdown is fixed too
+  (helps desktop).
 - In the **web reader**, long-pressing or right-clicking text no longer pops up
   the browser's own menu competing with the highlight popup — the in-app
   highlight menu is the one that shows. (On iOS Safari, Apple's built-in

--- a/cps/static/css/query_builder.css
+++ b/cps/static/css/query_builder.css
@@ -54,7 +54,7 @@
     text-align: center;
     padding: 0.3rem;
     border-radius: 6px;
-    width: --webkit-fill-available;
+    width: 100%;
 }
 .rules-list > .rule-container > .rule-operator-container > select {
     background-color: rgb(187 187 187 / 34%);

--- a/cps/templates/magic_shelf_edit.html
+++ b/cps/templates/magic_shelf_edit.html
@@ -277,6 +277,50 @@ div.help-panel > .panel-body {
     border: 1px solid #3e444c;
 }
 
+/* Shelf-option cards (Kobo sync / OPDS / public) — extracted from three
+   repeated inline styles so they can be made responsive. */
+.shelf-option-card {
+    background: #21252b;
+    padding: 2rem;
+    padding-inline: 4rem;
+    border-radius: 4px;
+}
+
+/* Mobile width recovery. The editor's generous desktop paddings (4rem option
+   cards, 2rem rule-group + value containers, 4rem help) starve the rule
+   builder of width on phones, pushing rule controls into a narrow, off-centre
+   strip (~226px in a 390px viewport). Tighten them on small screens so every
+   section and rule control uses the available width. Placed last + !important
+   so it wins over the desktop rules above (including the value container's own
+   !important). */
+@media (max-width: 767px) {
+    .shelf-option-card {
+        padding: 1rem !important;
+        padding-inline: 1rem !important;
+    }
+    .query-builder .rules-group-container {
+        padding: 0.6rem !important;
+    }
+    .rule-value-container {
+        padding: 0.6rem !important;
+        padding-inline: 0.6rem !important;
+        gap: 0.75rem;
+    }
+    .help-content {
+        padding: 1rem !important;
+    }
+    /* Recover more rule-builder width: tighten the panel body + the nested
+       rule/group left-indent on phones (this <style> is page-scoped to the
+       editor, so it doesn't affect panels elsewhere). */
+    .panel.panel-default > .panel-body {
+        padding: 0.6rem !important;
+    }
+    .query-builder .rule-container,
+    .query-builder .rule-group-container {
+        padding-left: 6px !important;
+    }
+}
+
 </style>
 {% endblock %}
 
@@ -383,7 +427,7 @@ div.help-panel > .panel-body {
                     </div>
 
                     <!-- Kobo Sync Checkbox -->
-                    <div class="form-group" style="background: #21252b; padding: 2rem; padding-inline: 4rem; border-radius: 4px;">
+                    <div class="form-group shelf-option-card">
                         <label>
                             <input style="margin-right: 2rem !important;" type="checkbox" id="shelf-kobo-sync" {{ 'checked' if shelf and shelf.kobo_sync else '' }} {{ 'disabled' if not kobo_magic_sync_enabled else '' }}>
                             Enable Kobo sync (shelf appears on Kobo devices)
@@ -396,7 +440,7 @@ div.help-panel > .panel-body {
                     </div>
 
                     {% if opds_expose_enabled %}
-                    <div class="form-group" style="background: #21252b; padding: 2rem; padding-inline: 4rem; border-radius: 4px;">
+                    <div class="form-group shelf-option-card">
                         <label>
                             <input style="margin-right: 2rem !important;" type="checkbox" id="shelf-opds-expose" {{ 'checked' if opds_expose_checked else '' }}>
                             Expose this magic shelf in my OPDS feed
@@ -407,7 +451,7 @@ div.help-panel > .panel-body {
 
                     <!-- Public Shelf Checkbox (only for custom shelves with permission) -->
                     {% if current_user.role_edit_shelfs() and not (shelf and shelf.is_system) %}
-                    <div class="form-group" style="background: #21252b; padding: 2rem; padding-inline: 4rem; border-radius: 4px;">
+                    <div class="form-group shelf-option-card">
                         <label>
                             <input style="margin-right: 2rem !important;" type="checkbox" id="shelf-is-public" {{ 'checked' if shelf and shelf.is_public == 1 else '' }}>
                             {{_('Share with Everyone (Public)')}}

--- a/notes/2026-06-17-magic-shelf-editor-rework-DESIGN.md
+++ b/notes/2026-06-17-magic-shelf-editor-rework-DESIGN.md
@@ -1,0 +1,87 @@
+# Magic Shelf editor rework (task #22) — research + plan
+
+Status: **research complete, implementation not started.** Written after the
+reader program (#29/#30/#31) shipped; parked at a clean point so the rework
+starts fresh rather than on depleted context. This note is the entry point.
+
+## What a Magic Shelf is
+
+A dynamic/smart shelf defined by a rule tree (like a smart playlist). Books are
+matched by query, not added by hand.
+
+- **Model:** `MagicShelf` — `cps/ub.py:462-483`. `rules` is a JSON column in
+  jQuery-QueryBuilder shape: `{condition: "AND"|"OR", rules: [{id, field, type,
+  operator, value}, ...]}`, nestable (a rule entry that itself has `condition`
+  is a group). `HiddenMagicShelfTemplate` (`ub.py:526-544`) lets a user hide a
+  system/public shelf without deleting it. `MagicShelfCache` (`ub.py:485-499`)
+  caches matched book ids for 30 min.
+- **Rule engine:** `cps/magic_shelf.py` — `FIELD_MAP` (281-296: title, author,
+  tag, series, publisher, rating, language, pubdate, timestamp, has_cover,
+  series_index, comments, read_status, hardcover_id, custom_column_*),
+  `OPERATOR_MAP` (299-327: equal/contains/begins_with/between/is_empty/… +
+  negations), `build_query_from_rules()` (601-632, recursive AND/OR).
+- **System templates:** `magic_shelf.py:154-260` (recently_added, highly_rated,
+  currently_reading, yet_to_read, recent_publications, …).
+- **Routes** (`cps/web.py`): `GET/POST /magicshelf` create (1335-1450),
+  `GET/POST /magicshelf/<id>/edit` (1453-1588), `POST /magicshelf/preview`
+  (1268-1309 → count + sample), `POST /magicshelf/<id>/delete` (1641-1684),
+  `POST /magicshelf/<id>/duplicate` (1589-1639), `GET /magicshelf/<id>` list.
+  Save payload: `{name, icon, rules, kobo_sync, is_public, opds_expose}`.
+
+## The editor today
+
+`cps/templates/magic_shelf_edit.html` — **937 lines**, all-in-one: inline
+`<style>` (7-279), the form (name + char counter, emoji icon picker, kobo/opds/
+public checkboxes, the `#builder` QueryBuilder mount, preview box, action
+buttons), and inline JS (488-935: fields array 536-634, operators 666-687,
+`queryBuilder()` init 689, preview 771-819, save 822-879, delete/duplicate
+882-933). The rule UI is **jQuery QueryBuilder 3.0.0** (vendored minified +
+`cps/static/css/query_builder.css` overrides). Editor is a full page, not a modal.
+
+## Concrete mobile/desktop pain points (from the audit)
+
+P1 — small, high-value, low-risk (CSS, fixes real breakage):
+1. `query_builder.css:57` `width: --webkit-fill-available` is a webkit-only
+   typo → should be `width: 100%` (field/operator/value selects don't fill).
+2. `.form-group` uses `padding-inline: 4rem` (template ~386/410) with **no
+   mobile override** → inputs/text clip below ~375px. Add `@media (max-width:
+   480px)` reducing to ~1rem.
+3. Preview results list has no `word-wrap` → long titles overflow horizontally.
+4. Action buttons (`.btn-group` wrap) stack into 3–4 rows on mobile; give
+   Save/Cancel/Preview a sensible `min-width` / 2-up layout.
+5. Help panel (`.help-content { padding: 4rem }`, ~203) has no mobile styles.
+
+P2 — moderate UX:
+6. Icon picker grid is tight on small phones; collapse to an accordion/“pick
+   icon” disclosure under ~600px.
+7. QueryBuilder rule rows are inherently row-based (`inline-block`); the
+   `@media` flex-column override (query_builder.css:121-172) helps but rows
+   still cluster. Tighten the mobile stacking (one control per line, full-width,
+   clear rule-card boundaries + delete affordance).
+8. Native `<select>` for field/operator is acceptable on mobile (iOS full-screen
+   picker) — leave unless P3 replaces the lib.
+
+P3 — large (separate, deliberate decision):
+9. Replace jQuery QueryBuilder with a mobile-first rule builder (custom, or a
+   maintained lib). Biggest UX win on mobile but high blast radius (touches the
+   rules round-trip + every system template's JSON must still load/save). Only
+   if P1+P2 prove insufficient.
+10. Optional: a step flow on mobile (name → icon → rules → preview/save).
+
+## Recommended first PR (when picked up)
+
+Ship **P1 (1–5)** as one CSS-focused PR — it removes the actual mobile breakage
+(clipping, overflow, the width typo) and brings the editor to a usable mobile
+standard without touching the rules round-trip. Then evaluate P2 as a second
+pass. Hold P3 (library replacement) for an explicit operator decision — it's a
+rework of the rule UI's core, not a polish.
+
+**Verification plan:** rebuild cwn-local; create/edit a Magic Shelf with several
+rules + a nested group; Playwright at 390×844 and 1280 — assert no horizontal
+overflow, selects fill width, buttons reachable, preview wraps, save round-trips
+the rules JSON unchanged (load an existing shelf, save, diff the `rules`). Source-
+pin the `width:100%` fix + the mobile `@media` in a JS/CSS test.
+
+## Open decision for the operator
+- **Fix-in-place (P1+P2) or replace QueryBuilder (P3)?** P1+P2 is the low-risk,
+  high-value path and what this note recommends first. P3 is a larger commitment.

--- a/tests/unit/test_magic_shelf_editor_mobile.py
+++ b/tests/unit/test_magic_shelf_editor_mobile.py
@@ -1,0 +1,34 @@
+"""Source-pin: the Magic Shelf editor uses the available width on mobile. Task #22.
+
+The rule builder was starved of width on phones by generous desktop paddings
+(4rem option cards / 2rem rule-group + value containers / 4rem help) with no
+mobile override, plus a `width: --webkit-fill-available` typo on the filter
+select. Pin the fixes. RED on main; GREEN on branch. (The visual width recovery
+itself is verified live with Playwright.)
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+QB_CSS = ROOT / "cps" / "static" / "css" / "query_builder.css"
+EDITOR = ROOT / "cps" / "templates" / "magic_shelf_edit.html"
+
+
+def test_filter_select_width_typo_fixed():
+    css = QB_CSS.read_text(encoding="utf-8")
+    assert "--webkit-fill-available" not in css, "broken `width: --webkit-fill-available` still present"
+
+
+def test_option_cards_extracted_from_inline_padding():
+    html = EDITOR.read_text(encoding="utf-8")
+    # The three repeated inline 4rem-padding styles were extracted to a class.
+    assert 'padding-inline: 4rem; border-radius: 4px;"' not in html, \
+        "inline 4rem option-card style still present (should be a class)"
+    assert "shelf-option-card" in html, "extracted .shelf-option-card class missing"
+
+
+def test_mobile_media_tightens_editor_paddings():
+    html = EDITOR.read_text(encoding="utf-8")
+    assert "max-width: 767px" in html, "no mobile media query"
+    assert "Mobile width recovery" in html, "mobile width-recovery block missing"
+    # the rule-group + value containers get tight mobile padding so rules fill width
+    assert "0.6rem !important" in html, "mobile rule-group/value padding not tightened"


### PR DESCRIPTION
## What users get
The **Magic Shelf editor** is much more usable on a phone. The rule builder and the option cards (Kobo sync / OPDS / public) were squeezed into a narrow strip with big wasted margins; now they use most of the screen width, and each rule's field/operator/value controls stack full-width instead of clustering. A typo that mis-sized the rule's field dropdown is fixed too (helps desktop).

## How
- `query_builder.css`: `width: --webkit-fill-available` (invalid typo) → `width: 100%` on the rule filter select.
- `magic_shelf_edit.html`: extracted the 3 repeated inline `padding-inline: 4rem` option-card styles into a documented `.shelf-option-card` class; added one consolidated mobile `@media` (placed last so it wins) tightening the option-card / rule-group / value-container / help paddings + the panel body + nested rule indent. The `<style>` is page-scoped, so other pages' panels are untouched.

## Verification
- `tests/unit/test_magic_shelf_editor_mobile.py` — pins the typo fix, the inline→class extraction, and the mobile-tightening block: **RED (3) → GREEN (3)** in container Python.
- Live `cwn-local` measurements (Playwright):
  - **390px**: rule container **226px → 272px** (58% → **70%** of viewport), left indent 93 → 64px; field/operator/value controls fill + stack; **no overflow**; builder still functional (picking a field renders operator + value).
  - **1280px**: 668px container, controls inline, no overflow.
  - 0 editor console errors; app boots clean with the template.

**Scope (honest):** mobile-usability + typo + structural cleanup pass. The remaining ~30% mobile margin is the global page-content padding (out of scope — it'd affect every page). Replacing the jQuery QueryBuilder library with a mobile-first rule builder is captured in `notes/2026-06-17-magic-shelf-editor-rework-DESIGN.md` for a separate, explicit decision.

No new dependencies, routes, or external URLs.