### PR TITLE
feat(duplicates): accent + punctuation normalization (precision-preserving) + first algorithm tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ is for things you can see or feel when running the app.
   @huperaisan for the suggestion.
 
 ### Changed
+- **Duplicate detection catches more real duplicates.** Books that differ only
+  by accents (Café vs Cafe) or punctuation (The Book! vs The Book) are now
+  recognized as the same. It stays deliberately careful not to merge genuinely
+  different books — "Dune" vs "Dune: Messiah" and "Volume 1" vs "Volume 2" stay
+  separate — so nothing distinct gets wrongly flagged for removal.
 - The **Magic Shelf editor** is easier to use on a phone. The rule builder and
   the Kobo-sync / OPDS / public option cards were being squeezed into a narrow
   strip with big wasted margins; they now use much more of the screen width, and

--- a/cps/duplicate_index.py
+++ b/cps/duplicate_index.py
@@ -32,7 +32,7 @@ from cwa_db import CWA_DB
 
 log = logger.create()
 
-NORMALIZATION_VERSION = "duplicate-index-v2"  # v2: NFC + whitespace-collapse normalization (D6)
+NORMALIZATION_VERSION = "duplicate-index-v3"  # v3: + accent-fold (NFKD) + punctuation-to-space, precision-preserving (D6)
 MAX_INCREMENTAL_BOOK_IDS = 1000
 DUPLICATE_INDEX_REBUILD_BATCH_SIZE = 250
 INGEST_BATCH_DIRTY_FILE = "/config/cwa_ingest_batch_dirty"

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -131,17 +131,38 @@ def admin_or_edit_required(f):
 def normalize_text_for_duplicates(value, default=""):
     """Shared text normalization for every duplicate-keying surface (D6).
 
-    Unicode NFC first (an NFD 'Café' from macOS filenames or some metadata
-    sources hashed differently from the NFC 'Café' a user typed — real
-    duplicates were invisible), then collapse internal whitespace ('The  Book'
-    vs 'The Book'), then lowercase + strip. generate_group_hash,
-    normalize_title_for_duplicates, and duplicate_index.build_book_key_parts
-    all route through here so the three keying surfaces can never drift.
+    generate_group_hash, normalize_title_for_duplicates, and
+    duplicate_index.build_book_key_parts all route through here so the keying
+    surfaces can never drift. Steps:
+
+      1. NFC, then fold accents (NFKD + drop combining marks) so 'Café' == 'Cafe'
+         and 'naïve' == 'naive' — metadata sources disagree on accents and real
+         duplicates were invisible across that difference.
+      2. lowercase.
+      3. punctuation -> space, so 'The Book!', 'The--Book' and 'The Book' all
+         collapse to the same key.
+      4. collapse whitespace + strip.
+
+    PRECISION (data-safety): these steps only remove accents and punctuation —
+    every word and number survives. So genuinely distinct titles ('Dune' vs
+    'Dune: Messiah', 'Volume 1' vs 'Volume 2') keep their distinguishing tokens,
+    hash apart, and are never grouped or auto-deleted. Changing these steps
+    REQUIRES bumping duplicate_index.NORMALIZATION_VERSION so the on-disk index
+    rebuilds with the new keys instead of mixing old and new.
     """
     text = value if value is not None and str(value) else default
     text = unicodedata.normalize('NFC', str(text))
+    # Fold accents: decompose and drop combining marks (Café -> Cafe).
+    text = ''.join(
+        ch for ch in unicodedata.normalize('NFKD', text)
+        if not unicodedata.combining(ch)
+    )
+    text = text.lower()
+    # Punctuation -> space so punctuation-only variants collapse, while every
+    # word and number is preserved (this is what keeps distinct titles distinct).
+    text = re.sub(r'[^\w\s]', ' ', text, flags=re.UNICODE)
     text = re.sub(r'\s+', ' ', text)
-    return text.lower().strip()
+    return text.strip()
 
 
 def generate_group_hash(title, author):
@@ -167,16 +188,25 @@ def generate_group_hash(title, author):
 def normalize_title_for_duplicates(title, primary_author=None):
     """Normalize title for duplicate detection.
 
-    If the title starts with the primary author (e.g., "Homer, the Iliad"),
-    strip the leading author prefix to avoid false negatives.
+    If the title is stored as "Author, Title" (a metadata quirk), strip the
+    leading author prefix so it still matches the plain "Title". The prefix is
+    detected on a comma-preserving form BEFORE the shared normalizer folds the
+    comma to a space, and it REQUIRES the literal comma — so a title that merely
+    starts with the author's name (e.g. "Homer's World" by Homer) is left
+    intact rather than mangled.
     """
-    normalized = normalize_text_for_duplicates(title, default="untitled")
+    text = title if title is not None and str(title) else "untitled"
     if primary_author:
         author_norm = normalize_text_for_duplicates(primary_author)
+        # Comma-preserving normalization (deaccent + lowercase + whitespace),
+        # used only to detect the leading "Author, " prefix.
+        cmp = unicodedata.normalize('NFKD', unicodedata.normalize('NFC', str(text)))
+        cmp = ''.join(c for c in cmp if not unicodedata.combining(c)).lower()
+        cmp = re.sub(r'\s+', ' ', cmp).strip()
         author_prefix = f"{author_norm}, "
-        if normalized.startswith(author_prefix):
-            normalized = normalized[len(author_prefix):].strip()
-    return normalized
+        if cmp.startswith(author_prefix):
+            text = cmp[len(author_prefix):]
+    return normalize_text_for_duplicates(text, default="untitled")
 
 
 def validate_resolution_strategy(strategy):

--- a/notes/2026-06-17-duplicate-detection-DESIGN.md
+++ b/notes/2026-06-17-duplicate-detection-DESIGN.md
@@ -1,0 +1,63 @@
+# Duplicate detection — robustness + test strategy (task #24)
+
+The duplicate subsystem is already mature (`cps/duplicates.py`,
+`cps/duplicate_index.py`, `cps/tasks/duplicate_scan.py`, `duplicates.html`,
+notifier) with real data-safety scaffolding (D2–D11: serialize lock, per-book
+re-fetch, user-data migration, DB-delete-before-file-delete, backup-before-
+delete, audit log, index cleanup). The gaps were a **weak normalizer** and
+**almost no tests** (1 auth test; zero for the algorithm or the delete paths).
+
+## Shipped in this increment
+
+**Safe, precision-preserving normalizer robustness** (`normalize_text_for_duplicates`):
+- accent folding (NFKD + drop combining marks): `Café` == `Cafe`, `naïve` == `naive`;
+- punctuation → space: `The Book!` == `The--Book` == `The Book`.
+- Only accents + punctuation are removed; every word and number survives, so
+  distinct titles (`Dune` vs `Dune: Messiah`, `Volume 1` vs `Volume 2`) still
+  hash apart. This is the key data-safety property — a normalizer that
+  over-collapsed would let auto-resolve DELETE genuinely different books.
+- `normalize_title_for_duplicates` rewritten so the `"Author, "` prefix strip
+  runs on a comma-preserving form *before* punctuation folding (otherwise it
+  broke, and over-stripped any title starting with the author's name — caught
+  by a test).
+- `duplicate_index.NORMALIZATION_VERSION` bumped v2 → v3 so the fingerprint
+  changes and the on-disk index rebuilds with the new keys (queries filter
+  `WHERE criteria_fingerprint = ?`, so old rows are ignored, not mixed in).
+
+**First real test coverage** (`tests/unit/test_duplicate_detection_normalize.py`):
+recall (accent/punct variants collapse), **precision** (distinct titles/numbers
+never collapse), the **D7 guard** (a title-less book is a duplicate of only
+itself — never grouped/auto-deleted), the version bump, and select_book_to_keep
+newest/oldest.
+
+## Deferred — and WHY (each raises false-positive → data-loss risk)
+
+These improve recall but risk grouping *distinct* books, which auto-resolve
+could then delete. They need precision-first design + their own tests before
+shipping, and several need an integration harness with a real Calibre DB:
+
+1. **Author-format folding** (`Smith, John` ↔ `John Smith` ↔ `J. Smith`):
+   valuable, but initials/suffixes/co-author-order make it easy to over-merge.
+2. **ISBN / identifier cross-edition matching:** two editions share work-level
+   identity but are legitimately different files; merging them is a *choice*,
+   not obviously correct — must be opt-in.
+3. **Fuzzy title matching** (edit distance): inherently precision-risky; only
+   safe as a *review-suggestion*, never an auto-delete input.
+4. **Subtitle/edition stripping** (`Dune` vs `Dune: Part One`): would merge a
+   book with its sequel/companion — do NOT add to the auto-delete key.
+5. **Format-subset grouping** ([EPUB] vs [EPUB,PDF]): interacts with the merge
+   strategy; design alongside merge, not detection.
+
+## Deferred — delete-orchestration tests (highest follow-up value)
+
+`auto_resolve_duplicates()` (the code that actually DELETES books) is untested.
+Needs an integration harness (real Calibre DB fixture) characterizing:
+- the D2 lock serializes concurrent resolutions (no double-delete);
+- DB row is deleted before files (D3) — on DB error, files survive;
+- user data (annotations/progress/shelves) migrates to the kept book (D4);
+- a backup folder is written before delete (D11);
+- the dry-run preview matches the executed result;
+- rollback/leftover behavior on mid-loop failure.
+
+This is the single most valuable next increment for a feature that deletes user
+data — pin the safety scaffolding with tests before any further algorithm change.

--- a/tests/unit/test_duplicate_detection_normalize.py
+++ b/tests/unit/test_duplicate_detection_normalize.py
@@ -1,0 +1,102 @@
+"""Duplicate-detection normalization + data-safety invariants (task #24).
+
+The duplicate-detection keying surface (which decides what auto-resolve may
+DELETE) had no test coverage. These pin:
+  - RECALL: accent + punctuation variants of the same title/author collapse so
+    real duplicates are found;
+  - PRECISION (data-safety core): distinct titles/numbers NEVER collapse — a
+    false merge would let auto-resolve delete a genuinely different book;
+  - the D7 guard: an incomplete-metadata (title-less) book is a "duplicate of
+    only itself" — never grouped, never auto-deleted;
+  - the index NORMALIZATION_VERSION bump (so changing the normalizer rebuilds
+    the on-disk index instead of mixing old + new keys);
+  - select_book_to_keep newest/oldest.
+
+RED on main (old normalizer didn't deaccent or strip punctuation; version v2);
+GREEN on branch.
+"""
+from datetime import datetime, timezone
+
+from cps.duplicates import (
+    normalize_text_for_duplicates,
+    normalize_title_for_duplicates,
+    generate_group_hash,
+    select_book_to_keep,
+)
+from cps import duplicate_index
+
+
+# --- normalizer RECALL: genuine variants collapse -------------------------
+
+def test_accents_are_folded():
+    assert normalize_text_for_duplicates("Café Society") == normalize_text_for_duplicates("Cafe Society")
+    assert normalize_text_for_duplicates("naïve") == "naive"
+    assert normalize_text_for_duplicates("Jürgen") == normalize_text_for_duplicates("Jurgen")
+
+
+def test_punctuation_is_collapsed():
+    base = normalize_text_for_duplicates("The Book")
+    assert normalize_text_for_duplicates("The Book!") == base
+    assert normalize_text_for_duplicates("The--Book") == base
+    assert normalize_text_for_duplicates("The, Book.") == base
+
+
+def test_whitespace_case_collapse():
+    assert normalize_text_for_duplicates("  The   BOOK ") == "the book"
+
+
+def test_default_sentinel_for_empty():
+    assert normalize_text_for_duplicates("", default="untitled") == "untitled"
+    assert normalize_text_for_duplicates(None, default="untitled") == "untitled"
+
+
+# --- normalizer PRECISION: distinct stay distinct (data-safety) -----------
+
+def test_distinct_titles_do_not_collapse():
+    assert normalize_text_for_duplicates("Dune") != normalize_text_for_duplicates("Dune: Messiah")
+    assert normalize_text_for_duplicates("Volume 1") != normalize_text_for_duplicates("Volume 2")
+    assert normalize_text_for_duplicates("Book One") != normalize_text_for_duplicates("Book Two")
+    # numbers (edition/volume) must survive so they keep books apart
+    assert "1" in normalize_text_for_duplicates("Vol. 1")
+    assert normalize_text_for_duplicates("Harry Potter 1") != normalize_text_for_duplicates("Harry Potter 2")
+
+
+def test_group_hash_matches_variants_not_distinct():
+    assert generate_group_hash("Café", "José Saramago") == generate_group_hash("Cafe!", "Jose Saramago")
+    assert generate_group_hash("Dune", "Herbert") != generate_group_hash("Dune Messiah", "Herbert")
+
+
+def test_title_author_prefix_and_normalization():
+    assert normalize_title_for_duplicates("Homer, The Iliad", "Homer") == "the iliad"
+    assert normalize_title_for_duplicates("Café!") == "cafe"
+
+
+# --- D7 data-safety guard: incomplete metadata never groups ----------------
+
+class _FakeBook:
+    def __init__(self, **kw):
+        self.title = kw.get("title")
+        self.authors = kw.get("authors")
+        self.id = kw.get("id")
+        self.timestamp = kw.get("timestamp")
+
+
+def test_titleless_books_never_share_a_key():
+    settings = {}  # defaults -> title + author criteria enabled
+    k1 = duplicate_index.build_duplicate_key(_FakeBook(title=None, id=1), settings)
+    k2 = duplicate_index.build_duplicate_key(_FakeBook(title=None, id=2), settings)
+    assert k1 != k2, "two title-less books must NOT group together (auto-resolve could delete one)"
+
+
+def test_index_normalization_version_bumped():
+    # changing the normalizer must change the fingerprint so the index rebuilds
+    assert duplicate_index.NORMALIZATION_VERSION == "duplicate-index-v3"
+
+
+# --- selection strategy: which copy is kept --------------------------------
+
+def test_select_newest_and_oldest():
+    old = _FakeBook(id=1, timestamp=datetime(2020, 1, 1, tzinfo=timezone.utc))
+    new = _FakeBook(id=2, timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc))
+    assert select_book_to_keep([old, new], "newest").id == 2
+    assert select_book_to_keep([old, new], "oldest").id == 1


### PR DESCRIPTION
## What users get
Duplicate detection now catches more genuine duplicates — books that differ only by **accents** (Café vs Cafe) or **punctuation** (The Book! vs The Book) are recognized as the same. It stays **deliberately careful**: genuinely different books ("Dune" vs "Dune: Messiah", "Volume 1" vs "Volume 2") are kept apart, so nothing distinct gets wrongly flagged for removal.

## Why precision-first
The normalizer feeds the grouping that auto-resolve can act on (it **deletes** books). A normalizer that over-collapsed would risk deleting a genuinely different book. So this PR adds only **safe, precision-preserving** transforms (accent-fold + punctuation→space — every word/number survives) and explicitly defers the riskier ideas (fuzzy / ISBN / subtitle-strip / author-format), each because it raises false-positive → data-loss risk.

## How
- `normalize_text_for_duplicates`: NFKD accent-fold (drop combining marks) + punctuation→space, then the existing lowercase/whitespace.
- `normalize_title_for_duplicates`: the `"Author, "` prefix-strip now runs on a comma-preserving form *before* punctuation folds the comma away (a test caught that the naïve change broke it and over-stripped titles starting with the author's name).
- `duplicate_index.NORMALIZATION_VERSION` v2→v3 → fingerprint changes → the on-disk key index rebuilds with the new normalization (queries filter `WHERE criteria_fingerprint = ?`, so old keys are ignored, never mixed).

## Verification
- **First real tests for the detection layer** — `tests/unit/test_duplicate_detection_normalize.py` (10): recall (variants collapse), **precision** (distinct never collapse), the **D7 safety guard** (a title-less book is a duplicate of only itself — never grouped/auto-deleted), the version bump, select newest/oldest. **RED (5) → GREEN (10)** in container Python (RED caught a real author-prefix regression, now fixed).
- Live `cwn-local` (deployed v3 module): `VERSION: duplicate-index-v3`, recall + precision confirmed on the real module, clean boot.

## Scope (honest)
Normalizer-robustness + first-tests increment. Deferred to `notes/2026-06-17-duplicate-detection-DESIGN.md`: author-format folding, ISBN cross-edition, fuzzy, subtitle-strip, format-subset (all false-positive-risky), and **characterization tests for the delete-orchestration** (`auto_resolve_duplicates` — the code that deletes books — is still untested; the highest-value follow-up).

No new dependencies, routes, or external URLs.