### PR TITLE
feat(books): float starred books to the top of the main library list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ is for things you can see or feel when running the app.
   @huperaisan for the suggestion.
 
 ### Changed
+- On the **main books list**, your **starred books now float to the top**, so
+  your favorites are the first thing you see in the full library (the Favorites
+  sidebar entry still shows them on their own). Within the starred group your
+  chosen sort order still applies. Only the main list is affected — author,
+  series, category and search views keep their usual order.
 - **Duplicate detection catches more real duplicates.** Books that differ only
   by accents (Café vs Cafe) or punctuation (The Book! vs The Book) are now
   recognized as the same. It stays deliberately careful not to merge genuinely

--- a/cps/web.py
+++ b/cps/web.py
@@ -24,7 +24,7 @@ from .cw_login import login_user, logout_user, current_user
 from flask_limiter import RateLimitExceeded
 from flask_limiter.util import get_remote_address
 from sqlalchemy.exc import IntegrityError, InvalidRequestError, OperationalError
-from sqlalchemy.sql.expression import text, func, false, not_, and_, or_
+from sqlalchemy.sql.expression import text, func, false, not_, and_, or_, case
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.sql.functions import coalesce
 from werkzeug.datastructures import Headers
@@ -584,6 +584,27 @@ def cwa_get_num_books_in_library() -> int:
         return 0
 
 
+def _favorites_first_order():
+    """ORDER-BY term that floats the calling user's starred books to the top,
+    or None when there's nothing to float (anonymous, or no favorites). Used
+    only by the main library list below — the Favorites sidebar view shows
+    starred books alone; this surfaces them within the *full* list. It is NOT
+    applied to the author / series / category / search / shelf views, which keep
+    their own ordering. Favorites live in app.db and books in metadata.db (they
+    can't be JOINed), so we fetch the favorite ids first and feed them to a CASE
+    on the metadata.db query."""
+    if not current_user.is_authenticated:
+        return None
+    rows = ub.session.query(ub.FavoriteBook.book_id).filter(
+        ub.FavoriteBook.user_id == int(current_user.id)).all()
+    fav_ids = [row[0] for row in rows]
+    if not fav_ids:
+        return None
+    # 0 sorts before 1 -> favorites first; the user's chosen sort then orders
+    # within each group.
+    return case((db.Books.id.in_(fav_ids), 0), else_=1)
+
+
 def render_books_list(data, sort_param, book_id, page):
     order = get_sort_function(sort_param, data)
     if data == "rated":
@@ -638,7 +659,14 @@ def render_books_list(data, sort_param, book_id, page):
         return render_magic_shelf(book_id, sort_param, page)
     else:
         website = data or "newest"
-        entries, random, pagination = calibre_db.fill_indexpage(page, 0, db.Books, True, order[0],
+        # #34: float the user's starred books to the top of the main library
+        # list. Scoped to this branch only — the other views above keep their
+        # own ordering untouched.
+        book_order = list(order[0])
+        favorites_first = _favorites_first_order()
+        if favorites_first is not None:
+            book_order = [favorites_first] + book_order
+        entries, random, pagination = calibre_db.fill_indexpage(page, 0, db.Books, True, book_order,
                                                                 True, config.config_read_column,
                                                                 db.books_series_link,
                                                                 db.Books.id == db.books_series_link.c.book,

--- a/tests/unit/test_favorites_first_main_list.py
+++ b/tests/unit/test_favorites_first_main_list.py
@@ -1,0 +1,27 @@
+"""The main library list floats the user's starred books to the top (#34).
+
+Favorites (app.db) and books (metadata.db) can't be JOINed, so the main-list
+ordering fetches favorite ids and prepends a CASE. Pin that the helper exists,
+is anonymous-safe, and that ONLY the main-list branch prepends it (other views
+keep their own ordering). The live float-to-top behaviour is verified with
+Playwright. RED on main; GREEN on branch.
+"""
+import inspect
+import re
+
+from cps import web
+
+
+def test_favorites_first_helper_exists():
+    src = inspect.getsource(web._favorites_first_order)
+    assert "FavoriteBook" in src, "helper must read the FavoriteBook table"
+    assert "case(" in src, "helper must build a CASE ordering"
+    assert "is_authenticated" in src, "anonymous users must be a no-op (return None)"
+
+
+def test_main_list_prepends_favorites_first():
+    src = inspect.getsource(web.render_books_list)
+    assert "_favorites_first_order()" in src, "main list must call the helper"
+    # favorites prepended -> they sort first, then the user's chosen order
+    assert re.search(r"\[\s*favorites_first\s*\]\s*\+\s*book_order", src), \
+        "favorites_first must be PREPENDED to the order (top of the list)"


### PR DESCRIPTION
## What users get
On the **main books list**, your **starred books float to the top** — your favorites are the first thing you see in the full library, without leaving it. (The Favorites sidebar entry still shows them on their own.) Your chosen sort still orders books within the starred group, and only the main list is affected — author / series / category / search keep their usual order.

## How
Favorites live in `app.db` and books in `metadata.db` — they can't be JOINed. `_favorites_first_order()` fetches the calling user's favorite ids and returns a `case(Books.id.in_(fav_ids), 0, else_=1)` ORDER-BY term (0 sorts before 1 → favorites first; the chosen sort applies within each group). It's prepended **only in the main-list branch** of `render_books_list`; every other view keeps its own ordering. Anonymous users and users with no favorites are a no-op.

## Verification
- `tests/unit/test_favorites_first_main_list.py` — pins the helper (reads FavoriteBook, builds a CASE, anonymous-safe) and that the main-list branch *prepends* it: **RED (2) → GREEN (2)** in container Python.
- Live `cwn-local` (user with favorites {2, 18, 20}): main list = `[20, 18, 2, 19]` = favorites `[20, 18, 2]` (timestamp-desc within the group) then non-favorite `[19]` — **exactly the computed expected order**. Favoriting a previously-last book moved it into the favorites group; `/author/1` was unaffected. Clean boot.

No new dependencies, routes, or external URLs.