### PR TITLE
chore(funding): point donations at the project's own Ko-fi

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-ko_fi: crocodilestick
+ko_fi: newusemame

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+- You can now **support Calibre-Web NextGen's development** directly — the
+  project has its own [Ko-fi](https://ko-fi.com/newusemame), linked from the
+  README and the GitHub "Sponsor" button. (The upstream project it builds on is
+  still credited and linked too.)
+
 ### Fixed
 - **Hardcover metadata search no longer fails when one of your saved API tokens
   is stale.** If you have both a per-account token and a global one, search used

--- a/README.md
+++ b/README.md
@@ -572,7 +572,9 @@ Built on:
 - **Calibre-Web** ([@janeczku](https://github.com/janeczku) and contributors) — the web UI underneath CWA.
 - **Calibre** ([@kovidgoyal](https://github.com/kovidgoyal)) — the library underneath all of it.
 
-Every backported patch is credited to its original author by GitHub handle in the commit message and in [`CHANGES-vs-upstream.md`](CHANGES-vs-upstream.md). To support upstream's continued development, [@crocodilestick has a Ko-fi](https://ko-fi.com/crocodilestick).
+Every backported patch is credited to its original author by GitHub handle in the commit message and in [`CHANGES-vs-upstream.md`](CHANGES-vs-upstream.md).
+
+If this build is useful to you, you can support its development on [Ko-fi](https://ko-fi.com/newusemame). To support the upstream project it builds on, [@crocodilestick has a Ko-fi](https://ko-fi.com/crocodilestick) too.
 
 ---
 

--- a/root/donate.txt
+++ b/root/donate.txt
@@ -1,1 +1,2 @@
-Calibre-Web Automated: https://ko-fi.com/crocodilestick/tip
+Calibre-Web NextGen: https://ko-fi.com/newusemame
+Built on Calibre-Web Automated by crocodilestick: https://ko-fi.com/crocodilestick/tip


### PR DESCRIPTION
## What

The GitHub **Sponsor** button (`.github/FUNDING.yml`) and the container boot banner (`root/donate.txt`) pointed only at upstream's Ko-fi. This adds the project's **own** Ko-fi — [ko-fi.com/newusemame](https://ko-fi.com/newusemame) — as the primary donation target across `FUNDING.yml`, `donate.txt` and the README, while keeping a credit + link to upstream's Ko-fi.

## State of the Ko-fi page

- Page is **live and branded** (bio + logo) at `ko-fi.com/newusemame` (the handle has no hyphen — Ko-fi strips it).
- **Payout not yet connected**, so Ko-fi hides the tip button until a Stripe/PayPal method is linked. The links here are forward-compatible: the tip button appears automatically once payout is connected, with no further repo change.

## Why no tests

Docs/config only — no code paths changed. `donate.txt` is consumed verbatim by the base image's boot banner; `FUNDING.yml` drives GitHub's Sponsor button.
