### PR TITLE
chore(funding): point Ko-fi at ko-fi.com/calibrewebnextgen

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-ko_fi: newusemame
+ko_fi: calibrewebnextgen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ is for things you can see or feel when running the app.
 
 ### Added
 - You can now **support Calibre-Web NextGen's development** directly — the
-  project has its own [Ko-fi](https://ko-fi.com/newusemame), linked from the
+  project has its own [Ko-fi](https://ko-fi.com/calibrewebnextgen), linked from the
   README and the GitHub "Sponsor" button. (The upstream project it builds on is
   still credited and linked too.)
 

--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ Built on:
 
 Every backported patch is credited to its original author by GitHub handle in the commit message and in [`CHANGES-vs-upstream.md`](CHANGES-vs-upstream.md).
 
-If this build is useful to you, you can support its development on [Ko-fi](https://ko-fi.com/newusemame). To support the upstream project it builds on, [@crocodilestick has a Ko-fi](https://ko-fi.com/crocodilestick) too.
+If this build is useful to you, you can support its development on [Ko-fi](https://ko-fi.com/calibrewebnextgen). To support the upstream project it builds on, [@crocodilestick has a Ko-fi](https://ko-fi.com/crocodilestick) too.
 
 ---
 

--- a/root/donate.txt
+++ b/root/donate.txt
@@ -1,2 +1,2 @@
-Calibre-Web NextGen: https://ko-fi.com/newusemame
+Calibre-Web NextGen: https://ko-fi.com/calibrewebnextgen
 Built on Calibre-Web Automated by crocodilestick: https://ko-fi.com/crocodilestick/tip


### PR DESCRIPTION
Repoints the donation links from `ko-fi.com/newusemame` (older, inaccessible account) to the active, branded page **ko-fi.com/calibrewebnextgen** — across `.github/FUNDING.yml`, the boot-banner `root/donate.txt`, the README, and the `[Unreleased]` changelog entry. Docs/config only; no code paths changed. Payout (PayPal/Stripe) is being connected separately.