### PR TITLE
fix(build): bump py7zr to 1.x for Python 3.13 (pyppmd cp313 wheel)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ html2text>=2020.1.16,<2025.2.26
 python-dateutil>=2.1,<2.10.0
 beautifulsoup4>=4.0.1,<4.14.0
 faust-cchardet>=2.1.18,<2.1.20
-py7zr>=0.15.0,<0.21.0
+py7zr>=1.0.0,<2.0.0  # 1.x pulls pyppmd>=1.3.1 which ships cp313 wheels; the old <0.21 cap forced pyppmd 1.1.1 (no cp313 wheel) -> sdist build fail on the Py3.13 base image
 mutagen>=1.40.0,<1.50.0
 
 # Comics


### PR DESCRIPTION
**Unblocks the v4.0.169 release image build.**

The base image now ships **Python 3.13**. `py7zr>=0.15,<0.21` transitively pins `pyppmd<1.2.0`, and **pyppmd 1.1.1 has no cp313 wheel** → the release build's cold pip layer built it from sdist and `setuptools-scm` failed (`:dev` only survived on a warm cache). py7zr 1.x requires `pyppmd>=1.3.1`, which ships cp313/cp314 wheels.

Usage is API-stable across the bump — `cps/comic.py` only calls `SevenZipFile`/`getnames`/`read`/`Bad7zFile` for optional CB7 cover extraction (graceful ImportError fallback). py7zr 1.1.3 requires Python ≥3.10 (we run 3.13). Validation: dev image build re-runs pip (requirements changed = cache miss) and resolves pyppmd 1.3.1 cp313 wheel.

Analysis: `notes/dep-review-pyppmd-cp313-2026-06-22.md`.