### PR TITLE
fix(reader): inset epub Settings panel body content (fork #503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+- **The epub reader's Settings panel no longer sits flush against its edges.**
+  After the recent settings redesign, the option labels were pressed against the
+  left edge and the slider readouts ("150%", "0px") were clipped at the right.
+  The panel now insets its content again, and the "Settings" title keeps its
+  full-width bar across the top. Reported by @sambong.
+
 ## [v4.0.169] - 2026-06-22
 
 ### Changed

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -78,8 +78,12 @@
            value readouts, touch-friendly controls, and a layout that fits small
            screens. Scoped to #settings-modal so the rest of the reader chrome
            is untouched. */
-        #settings-modal .md-content { max-width: 440px; max-height: 86vh; overflow-y: auto; }
-        #settings-modal h3 { margin: 0 0 0.8em; }
+        /* Inset the body content; the #484 redesign moved sections to direct
+           children of .md-content, which the base `.md-content > div` padding
+           no longer reaches, leaving content flush against both edges (#503). */
+        #settings-modal .md-content { max-width: 440px; max-height: 86vh; overflow-y: auto; padding: 0 22px 22px; box-sizing: border-box; }
+        /* Title keeps its full-width bar look — bleed back out past the padding. */
+        #settings-modal h3 { margin: 0 -22px 0.8em; }
         #settings-modal .rs-section { padding: 0.8em 0; border-top: 1px solid rgba(127,127,127,0.22); }
         #settings-modal .rs-section:first-of-type { border-top: 0; padding-top: 0; }
         #settings-modal .rs-label { display: block; font-weight: 600; margin-bottom: 0.55em; font-size: 0.95em; }

--- a/tests/unit/test_503_reader_settings_modal_padding.py
+++ b/tests/unit/test_503_reader_settings_modal_padding.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+"""fork #503 (@sambong): the epub reader Settings modal must inset its body
+content horizontally.
+
+The #484 settings redesign moved every `.rs-section` to be a *direct child* of
+`.md-content`. The base modal padding comes from `.md-content > div { padding:
+15px 40px 30px; }` (main.css) — written for the old single-wrapper structure —
+and is overridden for the redesigned sections by the higher-specificity scoped
+rule `#settings-modal .rs-section { padding: 0.8em 0; }`. The net effect: zero
+horizontal padding, so the section labels sat flush against the left edge and
+the slider value readouts ("150%", "0px") were clipped at the right edge. The
+reporter (on a short-but-wide NAS admin tab) saw this after the v4.0.169 scroll
+fix made all the options reachable.
+
+The fix restores a horizontal inset on `#settings-modal .md-content` itself and
+bleeds the `<h3>` title bar back out past that padding so it keeps hugging the
+modal's top corners. This pins both halves so a future template edit can't
+silently drop the inset and reintroduce the flush-edge layout.
+
+Verified live on cwn-local at 1100x560 (reporter's window shape) and 390x740
+(mobile): section left/right insets non-zero and symmetric, value readouts no
+longer clipped, title bar full-bleed.
+"""
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+TEMPLATE = REPO / "cps" / "templates" / "read.html"
+
+
+def _src():
+    return TEMPLATE.read_text(encoding="utf-8")
+
+
+def _rule_body(src, selector):
+    """Return the declaration block for the first `selector { ... }` rule."""
+    idx = src.find(selector)
+    assert idx != -1, f"expected a CSS rule for `{selector}` in read.html"
+    open_brace = src.index("{", idx)
+    close_brace = src.index("}", open_brace)
+    return src[open_brace + 1 : close_brace]
+
+
+def _horizontal_padding_present(decl):
+    """True if a `padding:` declaration in `decl` carries a non-zero left/right
+    value (shorthand 1-4 values; vertical-only `0.8em 0` does NOT count)."""
+    m = re.search(r"padding\s*:\s*([^;]+);", decl)
+    if not m:
+        return False
+    parts = m.group(1).split()
+    if len(parts) == 1:  # all sides
+        horiz = parts[0]
+    elif len(parts) == 2:  # vertical | horizontal
+        horiz = parts[1]
+    elif len(parts) == 3:  # top | horizontal | bottom
+        horiz = parts[1]
+    else:  # top right bottom left
+        horiz = parts[1]
+    return not re.fullmatch(r"0(px|em|rem|%)?", horiz)
+
+
+def test_settings_modal_content_has_horizontal_padding():
+    decl = _rule_body(_src(), "#settings-modal .md-content")
+    assert _horizontal_padding_present(decl), (
+        "#settings-modal .md-content must declare non-zero horizontal padding so "
+        "the redesigned sections are inset from the modal edge (#503 — the base "
+        "`.md-content > div` padding no longer reaches direct-child sections)"
+    )
+
+
+def test_settings_modal_title_bleeds_full_width():
+    decl = _rule_body(_src(), "#settings-modal h3")
+    m = re.search(r"margin\s*:\s*([^;]+);", decl)
+    assert m, "#settings-modal h3 must declare a margin"
+    parts = m.group(1).split()
+    # Need a negative horizontal margin to pull the title bar back out past the
+    # .md-content padding so it keeps hugging the top corners.
+    horiz = parts[1] if len(parts) >= 2 else parts[0]
+    assert horiz.startswith("-"), (
+        "#settings-modal h3 must use a negative horizontal margin so its "
+        "background title bar spans the full modal width despite the body inset "
+        "(#503)"
+    )
+
+
+def test_settings_sections_still_present():
+    # Guard the structural assumption the fix relies on: sections are direct
+    # children of .md-content (so the inset must come from .md-content itself).
+    src = _src()
+    assert 'class="rs-section' in src, "reader settings sections must exist"
+    assert "#settings-modal .rs-section { padding: 0.8em 0" in src, (
+        "the scoped .rs-section rule that zeroes section horizontal padding is "
+        "the reason the inset must live on .md-content — if this changes, revisit "
+        "the #503 fix"
+    )

--- a/tests/unit/test_503_reader_settings_modal_padding.py
+++ b/tests/unit/test_503_reader_settings_modal_padding.py
@@ -46,22 +46,34 @@ def _rule_body(src, selector):
     return src[open_brace + 1 : close_brace]
 
 
+def _is_zero(value):
+    return re.fullmatch(r"-?0(px|em|rem|%)?", value) is not None
+
+
+def _horizontal_values(shorthand):
+    """Return the (right, left) values of a CSS box shorthand (padding/margin),
+    handling all four shorthand arities. The right value is mapped to the left
+    when the shorthand doesn't list a distinct left."""
+    parts = shorthand.split()
+    if len(parts) == 1:  # all sides
+        return parts[0], parts[0]
+    if len(parts) == 2:  # vertical | horizontal
+        return parts[1], parts[1]
+    if len(parts) == 3:  # top | horizontal | bottom
+        return parts[1], parts[1]
+    # top | right | bottom | left
+    return parts[1], parts[3]
+
+
 def _horizontal_padding_present(decl):
-    """True if a `padding:` declaration in `decl` carries a non-zero left/right
-    value (shorthand 1-4 values; vertical-only `0.8em 0` does NOT count)."""
+    """True if a `padding:` declaration in `decl` insets BOTH horizontal edges
+    (shorthand 1-4 values; vertical-only `0.8em 0` does NOT count, and an
+    asymmetric `0 0 0 22px` that leaves one edge flush does NOT count)."""
     m = re.search(r"padding\s*:\s*([^;]+);", decl)
     if not m:
         return False
-    parts = m.group(1).split()
-    if len(parts) == 1:  # all sides
-        horiz = parts[0]
-    elif len(parts) == 2:  # vertical | horizontal
-        horiz = parts[1]
-    elif len(parts) == 3:  # top | horizontal | bottom
-        horiz = parts[1]
-    else:  # top right bottom left
-        horiz = parts[1]
-    return not re.fullmatch(r"0(px|em|rem|%)?", horiz)
+    right, left = _horizontal_values(m.group(1))
+    return not _is_zero(right) and not _is_zero(left)
 
 
 def test_settings_modal_content_has_horizontal_padding():
@@ -77,11 +89,10 @@ def test_settings_modal_title_bleeds_full_width():
     decl = _rule_body(_src(), "#settings-modal h3")
     m = re.search(r"margin\s*:\s*([^;]+);", decl)
     assert m, "#settings-modal h3 must declare a margin"
-    parts = m.group(1).split()
     # Need a negative horizontal margin to pull the title bar back out past the
     # .md-content padding so it keeps hugging the top corners.
-    horiz = parts[1] if len(parts) >= 2 else parts[0]
-    assert horiz.startswith("-"), (
+    right, left = _horizontal_values(m.group(1))
+    assert right.startswith("-") or left.startswith("-"), (
         "#settings-modal h3 must use a negative horizontal margin so its "
         "background title bar spans the full modal width despite the body inset "
         "(#503)"


### PR DESCRIPTION
## Why
Fork issue #503 (@sambong). After the v4.0.169 scroll fix made every option in the epub reader's Settings panel reachable, the reporter confirmed the functional bug is gone but flagged that the panel "still looks a little strange" — content pressed flush against both edges.

## Root cause
The #484 settings redesign moved each `.rs-section` to be a **direct child** of `.md-content`. The base modal padding lives on `.md-content > div { padding: 15px 40px 30px; }` (main.css) — written for the old single-wrapper structure — and is overridden for the redesigned sections by the higher-specificity scoped rule `#settings-modal .rs-section { padding: 0.8em 0; }`. Net effect: zero horizontal padding, so section labels sat flush against the left edge and the slider readouts ("150%", "0px") were clipped at the right.

## Fix
Restore a horizontal inset on `#settings-modal .md-content` itself, and give the `<h3>` a negative horizontal margin so the title keeps its full-width bar across the top corners while the body content is inset. Scoped entirely to `#settings-modal`; the v4.0.169 scroll cap is untouched.

## Verification
Live on `cwn-local` (reader page, real template via `docker cp`, no injected CSS):
- **1100×560** (reporter's short-wide NAS-admin-tab shape): section left/right insets symmetric and non-zero, "150%"/"80px" readouts no longer clipped, title bar full-bleed.
- **390×740** (mobile, 92vw modal): same — content stays within the viewport, insets hold.

Regression test `tests/unit/test_503_reader_settings_modal_padding.py` (source-pin on read.html): **fails** on the pre-fix template (no horizontal padding, no title bleed), **passes** on the fix. Adjacent reader tests (settings-persist, native-menu, tap-zones) all green.

## Tier
needs-review — fork-original CSS change in the flagship web reader.

## Release target
Next train (groups with the [Unreleased] entry).