### PR TITLE
Add "Update now" button + autoupdate guidance (banner, admin, settings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+- **Update from a button instead of hunting for the right Docker command.** When
+  a new version is available, the update banner and the Admin page now show an
+  **Update now** button that gives you the exact one-line command for your setup
+  — Docker Compose, `docker run`, Unraid, or Portainer/Synology — with one-click
+  copy. A new **Automatic updates** section under Admin → NextGen Settings walks
+  you through turning on truly hands-off updates with Watchtower, so new versions
+  install themselves. (Admin only.) The README gains a matching "Updating" guide,
+  including how to run NextGen under Podman.
+
 ## [v4.0.169] - 2026-06-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -216,6 +216,54 @@ The Admin → Settings panel has many optional toggles (auto-convert formats, au
 
 ---
 
+## Updating
+
+Calibre-Web NextGen ships new versions regularly — often weekly. Updating means pulling the new image and recreating the container; your library, settings and reading progress live in the mounted volumes, so they're left untouched.
+
+**Update once, by hand:**
+
+```bash
+docker compose pull calibre-web && docker compose up -d calibre-web
+```
+
+(Use your own service name if it isn't `calibre-web`.)
+
+**Update automatically** with [Watchtower](https://github.com/nicholas-fedor/watchtower) (the maintained fork). Add it alongside CWA and label the CWA service so Watchtower only ever touches this one container — your other containers are left alone:
+
+```yaml
+services:
+  calibre-web:
+    image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+    labels: ["com.centurylinklabs.watchtower.enable=true"]
+    # ...rest of your config
+
+  watchtower:
+    image: nickfedor/watchtower
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+    command: --label-enable --cleanup --interval 86400   # check daily, remove old images
+    restart: unless-stopped
+```
+
+The in-app **Admin → NextGen Settings → Automatic updates** panel shows these same steps, and the "Update available" banner has an **Update now** button that gives the right command for your setup (Compose, `docker run`, Unraid, Portainer/Synology).
+
+### Running with Podman
+
+Calibre-Web NextGen is a standard OCI image, so it runs under Podman too — same image, no separate build:
+
+```bash
+podman run -d --name calibre-web \
+  -e PUID=1000 -e PGID=1000 -e TZ=America/New_York \
+  -p 8083:8083 \
+  -v /path/to/config:/config \
+  -v /path/to/library:/calibre-library \
+  -v /path/to/ingest:/cwa-book-ingest \
+  ghcr.io/new-usemame/calibre-web-nextgen:latest
+```
+
+Rootless Podman remaps user IDs, so if the container can't write to your volumes, add `--userns=keep-id` (or run it rootful). Podman also has native automatic updates (`podman auto-update`) with rollback — a step-by-step guide is coming once we've verified it against this image.
+
+---
+
 ## Migrating
 
 ### From upstream CWA

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -231,6 +231,17 @@ def get_cwa_last_notification() -> str:
             last_notification = f.read()
     return last_notification
 
+def _format_update_banner_message(current_version: str, latest_version: str) -> str:
+    # Build from a STATIC msgid with named placeholders so pybabel can extract
+    # it and translators can localize it. Interpolating the versions *before*
+    # gettext (the old ``_(f"...")``) made the translation key the runtime
+    # string, so every non-English locale silently fell back to English.
+    return _("Calibre-Web NextGen %(latest)s is available — you're on %(current)s.") % {
+        "latest": latest_version,
+        "current": current_version,
+    }
+
+
 # Displays a notification to the user that an update for CWA is available, no matter which page they're on
 # Currently set to only display once per calender day
 def cwa_update_notification() -> None:
@@ -244,8 +255,8 @@ def cwa_update_notification() -> None:
 
         update_available, current_version, tag_name = cwa_update_available()
         if update_available:
-            message = _(f"⚡🚨 Calibre-Web NextGen UPDATE AVAILABLE! 🚨⚡ Current - {current_version} | Newest - {tag_name} | To update, just re-pull the image! This message will only display once per day |")
-            flash(_(message), category="cwa_update")
+            message = _format_update_banner_message(current_version, tag_name)
+            flash(message, category="cwa_update")
             print(f"[cwa-update-notification-service] {message}", flush=True)
 
         with open('/app/cwa_update_notice', 'w') as f:

--- a/cps/static/js/update_now.js
+++ b/cps/static/js/update_now.js
@@ -1,0 +1,85 @@
+/* Update Now modal: setup selector + copy-to-clipboard.
+ *
+ * No server interaction — a container cannot recreate itself, so the update
+ * runs in the user's own container runtime. This only switches which set of
+ * instructions is shown and copies a command to the clipboard.
+ * See notes/easy-update-autoupdate-design.md.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+(function () {
+  "use strict";
+
+  function activatePane(setup) {
+    var selector = document.getElementById("update-setup-selector");
+    if (!selector) { return; }
+    var buttons = selector.querySelectorAll("[data-update-setup]");
+    for (var i = 0; i < buttons.length; i++) {
+      if (buttons[i].getAttribute("data-update-setup") === setup) {
+        buttons[i].classList.add("active");
+      } else {
+        buttons[i].classList.remove("active");
+      }
+    }
+    var panes = document.querySelectorAll("[data-update-pane]");
+    for (var j = 0; j < panes.length; j++) {
+      panes[j].style.display =
+        (panes[j].getAttribute("data-update-pane") === setup) ? "" : "none";
+    }
+  }
+
+  function legacyCopy(text) {
+    var ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "absolute";
+    ta.style.left = "-9999px";
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand("copy"); } catch (e) { /* no-op */ }
+    document.body.removeChild(ta);
+  }
+
+  function flashCopied(btn) {
+    if (!btn) { return; }
+    if (!btn.getAttribute("data-orig")) {
+      btn.setAttribute("data-orig", btn.textContent);
+    }
+    btn.textContent = btn.getAttribute("data-copied-label") || "Copied!";
+    setTimeout(function () {
+      btn.textContent = btn.getAttribute("data-orig");
+    }, 1500);
+  }
+
+  function copyText(text, btn) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(
+        function () { flashCopied(btn); },
+        function () { legacyCopy(text); flashCopied(btn); }
+      );
+    } else {
+      legacyCopy(text);
+      flashCopied(btn);
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var selector = document.getElementById("update-setup-selector");
+    if (selector) {
+      selector.addEventListener("click", function (e) {
+        var btn = e.target.closest ? e.target.closest("[data-update-setup]") : null;
+        if (!btn) { return; }
+        activatePane(btn.getAttribute("data-update-setup"));
+      });
+    }
+    var copyBtns = document.querySelectorAll(".update-copy-btn");
+    for (var i = 0; i < copyBtns.length; i++) {
+      copyBtns[i].addEventListener("click", function (e) {
+        var trigger = e.currentTarget;
+        var wrap = trigger.closest ? trigger.closest(".update-cmd") : null;
+        var code = wrap ? wrap.querySelector("code") : null;
+        if (code) { copyText(code.textContent.trim(), trigger); }
+      });
+    }
+  });
+})();

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -258,7 +258,8 @@
             <td>{{cwa_version}} </td>
             <td>
               {% if cwa_is_outdated and cwa_latest_tag %}
-                <i style="color:#cc7b19;">{{_('Update available')}}: <strong>{{cwa_latest_tag}}</strong> — <code>docker pull ghcr.io/new-usemame/calibre-web-nextgen:latest</code></i>
+                <i style="color:#cc7b19;">{{_('Update available')}}: <strong>{{cwa_latest_tag}}</strong></i>
+                <button type="button" class="btn btn-primary btn-xs" data-toggle="modal" data-target="#updateNowDialog" style="margin-left: 8px;">{{ _('Update now') }}</button>
               {% else %}
                 <i>{{_('Current Version')}}</i>
               {% endif %}

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -747,6 +747,36 @@
         {{_('When active, you will receive notifications in the Web UI when a new version of NextGen is released')}}
       </p>
 
+      <div id="cwa-autoupdate" style="margin-top: 16px; padding-top: 14px; border-top: 1px solid rgba(128,128,128,0.25);">
+        <strong style="display:block; margin-bottom: 6px;">{{_('Automatic updates')}}</strong>
+        <p class="cwa-settings-tooltip">
+          {{_('New versions ship regularly — often weekly. Calibre-Web NextGen cannot update itself from inside its container (nothing running inside a container can), so a small companion called Watchtower does it for you: it watches for a new image and swaps NextGen in safely, leaving your other containers alone.')}}
+        </p>
+        <p class="cwa-settings-tooltip">
+          {{_('Add these two services to your docker-compose file and run "docker compose up -d". After that you stay up to date automatically — no button to press.')}}
+        </p>
+        <div class="update-cmd">
+          <pre><code>services:
+  calibre-web-nextgen:
+    image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+    labels: ["com.centurylinklabs.watchtower.enable=true"]
+    # ...your existing config
+
+  watchtower:
+    image: nickfedor/watchtower
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+    command: --label-enable --cleanup --interval 86400
+    restart: unless-stopped</code></pre>
+          <button type="button" class="btn btn-primary btn-sm update-copy-btn" data-copied-label="{{ _('Copied!') }}">{{ _('Copy') }}</button>
+        </div>
+        <p class="cwa-settings-tooltip">
+          {{_('The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 interval checks once a day; "cleanup" removes the old image after each update.')}}
+        </p>
+        <p class="cwa-settings-tooltip">
+          {{_('Running under Podman instead? Native "podman auto-update" works too — a setup guide is coming once we have verified it against this image.')}}
+        </p>
+      </div>
+
       {% if cwa_settings['contribute_translations_notifications'] %}
       <input type="checkbox" id="contribute_translations_notifications" name="contribute_translations_notifications" value="True" checked style="accent-color: var(--color-secondary);" data-toggle="tooltip" data-placement="right" title="Does NOT require restart for changes to take effect">
       {% else %}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -528,7 +528,9 @@
     <script src="{{ url_for('static', filename='js/libs/jquery.form.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/uploadprogress.js') }}"> </script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+    {% if current_user.is_authenticated and current_user.role_admin() %}
     <script src="{{ url_for('static', filename='js/update_now.js') }}"></script>
+    {% endif %}
     {% if g.current_theme == 1 %}
       <script src="{{ url_for('static', filename='js/libs/jquery.visible.min.js') }}"></script>
       <script src="{{ url_for('static', filename='js/libs/compromise.min.js') }}"></script>

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -258,7 +258,9 @@
       {%if message[0] == "cwa_update" %}
       <div class="row-fluid text-center">
         <div id="flash_info" class="alert alert-info alert-cwa">
-          {{ message[1] }} <a href="https://github.com/new-usemame/Calibre-Web-NextGen/releases">{{ _('See Changelog') }}</a>
+          {{ message[1] }}
+          <button type="button" class="btn btn-primary btn-xs update-now-banner-btn" data-toggle="modal" data-target="#updateNowDialog">{{ _('Update now') }}</button>
+          <a href="https://github.com/new-usemame/Calibre-Web-NextGen/releases">{{ _('See Changelog') }}</a>
           <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
@@ -508,6 +510,9 @@
         </div>
       </div>
     </div>
+    {% if current_user.is_authenticated and current_user.role_admin() %}
+      {% include "update_now_modal.html" %}
+    {% endif %}
     {% block modal %}{% endblock %}
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="{{ url_for('static', filename='js/libs/jquery.min.js') }}"></script>
@@ -523,6 +528,7 @@
     <script src="{{ url_for('static', filename='js/libs/jquery.form.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/uploadprogress.js') }}"> </script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/update_now.js') }}"></script>
     {% if g.current_theme == 1 %}
       <script src="{{ url_for('static', filename='js/libs/jquery.visible.min.js') }}"></script>
       <script src="{{ url_for('static', filename='js/libs/compromise.min.js') }}"></script>

--- a/cps/templates/update_now_modal.html
+++ b/cps/templates/update_now_modal.html
@@ -1,0 +1,65 @@
+{# Update Now modal — guided, setup-aware update instructions.
+   Admin-only (included gated in layout.html). There is NO server action here:
+   a container cannot recreate itself, so the update is run by the user's own
+   container runtime. We show the right command/steps for their setup and let
+   them run one line. See notes/easy-update-autoupdate-design.md. #}
+<div id="updateNowDialog" class="modal fade" role="dialog" aria-labelledby="updateNowTitle">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="updateNowTitle">{{ _('Update Calibre-Web NextGen') }}</h4>
+      </div>
+      <div class="modal-body">
+        <p>{{ _('Updating pulls the new image and recreates the container. It is quick, and your library, settings and reading progress are safe — they live in your mounted volumes, not in the container.') }}</p>
+
+        <p><strong>{{ _('How do you run Calibre-Web NextGen?') }}</strong></p>
+        <div class="btn-group" role="group" aria-label="{{ _('Setup type') }}" id="update-setup-selector">
+          <button type="button" class="btn btn-default active" data-update-setup="compose">{{ _('Docker Compose') }}</button>
+          <button type="button" class="btn btn-default" data-update-setup="run">{{ _('docker run') }}</button>
+          <button type="button" class="btn btn-default" data-update-setup="unraid">{{ _('Unraid') }}</button>
+          <button type="button" class="btn btn-default" data-update-setup="gui">{{ _('Portainer / Synology') }}</button>
+        </div>
+
+        <div class="update-setup-pane" data-update-pane="compose" style="margin-top: 14px;">
+          <p>{{ _('Run this from the folder that holds your compose file:') }}</p>
+          <div class="update-cmd">
+            <pre><code>docker compose pull calibre-web-nextgen &amp;&amp; docker compose up -d calibre-web-nextgen</code></pre>
+            <button type="button" class="btn btn-primary btn-sm update-copy-btn" data-copied-label="{{ _('Copied!') }}">{{ _('Copy') }}</button>
+          </div>
+          <p class="text-muted">{{ _('Replace calibre-web-nextgen with your service name if it differs.') }}</p>
+        </div>
+
+        <div class="update-setup-pane" data-update-pane="run" style="margin-top: 14px; display:none;">
+          <p>{{ _('Pull the new image, then recreate your container with the same options you started it with:') }}</p>
+          <div class="update-cmd">
+            <pre><code>docker pull ghcr.io/new-usemame/calibre-web-nextgen:latest</code></pre>
+            <button type="button" class="btn btn-primary btn-sm update-copy-btn" data-copied-label="{{ _('Copied!') }}">{{ _('Copy') }}</button>
+          </div>
+          <p class="text-muted">{{ _('Then stop and remove the old container and start a new one with your usual docker run command. Your mounted volumes keep all data.') }}</p>
+        </div>
+
+        <div class="update-setup-pane" data-update-pane="unraid" style="margin-top: 14px; display:none;">
+          <ol>
+            <li>{{ _('Open the Docker tab in the Unraid web UI.') }}</li>
+            <li>{{ _('Click the Calibre-Web NextGen container icon and choose Force update (check for updates first if you want to see what changed).') }}</li>
+          </ol>
+          <p class="text-muted">{{ _('For hands-off updates, install the "CA Auto Update Applications" plugin from Community Applications.') }}</p>
+        </div>
+
+        <div class="update-setup-pane" data-update-pane="gui" style="margin-top: 14px; display:none;">
+          <p><strong>{{ _('Portainer:') }}</strong> {{ _('Images → pull the image below, then Containers → select Calibre-Web NextGen → Recreate with "Re-pull image" enabled.') }}</p>
+          <p><strong>{{ _('Synology Container Manager:') }}</strong> {{ _('Registry → download the image below (tag: latest), then stop the container → Action → Reset to recreate it.') }}</p>
+          <div class="update-cmd">
+            <pre><code>ghcr.io/new-usemame/calibre-web-nextgen:latest</code></pre>
+            <button type="button" class="btn btn-primary btn-sm update-copy-btn" data-copied-label="{{ _('Copied!') }}">{{ _('Copy') }}</button>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <a class="btn btn-link pull-left" href="{{ url_for('cwa_settings.set_cwa_settings') }}#cwa-autoupdate">{{ _('Set up automatic updates') }}</a>
+        <button type="button" class="btn btn-default" data-dismiss="modal">{{ _('Close') }}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/cps/translations/ar/LC_MESSAGES/messages.po
+++ b/cps/translations/ar/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2025-06-07 14:44+0300\n"
 "Last-Translator: UsamaFoad <usamafoad@gmail.com>\n"
 "Language-Team: \n"
@@ -1915,7 +1915,7 @@ msgstr "الكتب مرتبة حسب الفئة"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1951,7 +1951,7 @@ msgstr "تنسيقات الملفات"
 msgid "Books ordered by file formats"
 msgstr "الكتب مرتبة حسب تنسيقات الملفات"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "الأرفف"
@@ -2101,6 +2101,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "عرض الكتب الأعلى تقييمًا"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2286,7 +2291,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "استبعاد الرفوف"
@@ -2503,7 +2508,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "خطأ في حذف الرف"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "إنشاء رف"
@@ -3004,7 +3009,7 @@ msgstr "إضافة إلى الرف"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3417,40 +3422,45 @@ msgstr "التفاصيل"
 msgid "Update available"
 msgstr "فشل التحديث:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "قناة التحديث"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "الإصدار الحالي"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "التحقق من التحديث"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "إجراء التحديث"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "هل أنت متأكد أنك تريد إعادة التشغيل؟"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "جاري التحميل..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "موافق"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3461,8 +3471,8 @@ msgstr "موافق"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3472,11 +3482,11 @@ msgstr "موافق"
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "هل أنت متأكد أنك تريد إيقاف التشغيل؟"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "جاري التحديث، يرجى عدم إعادة تحميل هذه الصفحة"
 
@@ -3529,7 +3539,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "جاري التحميل..."
 
@@ -3564,8 +3574,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3636,9 +3646,10 @@ msgstr "تحويل الكتاب"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "إغلاق"
 
@@ -3665,7 +3676,7 @@ msgid "Imported as"
 msgstr "فشل التحديث:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "المؤلف"
 
@@ -3683,13 +3694,13 @@ msgstr "تاريخ النشر"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "الناشر"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "اللغة"
@@ -3898,7 +3909,7 @@ msgstr "أدخل العنوان"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "العنوان"
@@ -5695,78 +5706,122 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "إعدادات OAuth"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "مزامنة الرفوف المختارة مع Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "إعدادات OAuth"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5774,44 +5829,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "اختر سمة أدناه:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5819,322 +5874,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "تمكين التسجيل العام"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "إعدادات OAuth"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "تحميل التنسيق"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "تمكين التسجيل العام"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "تمكين التسجيل العام"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "حذف التنسيقات:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "جلب البيانات الوصفية"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "التقييم"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6524,7 +6579,7 @@ msgstr "دمج الكتب المختارة"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6582,7 +6637,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "سيتم مسح هذا الكتاب بشكل دائم من قاعدة البيانات"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "الكتب غير المقروءة"
@@ -6689,8 +6744,8 @@ msgstr "أدخل اسم النطاق"
 msgid "Denied Domains (Blacklist)"
 msgstr "النطاقات المرفوضة (القائمة السوداء)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "التالي"
 
@@ -6974,165 +7029,165 @@ msgstr "الإعدادات"
 msgid "Refresh Library"
 msgstr "البحث في المكتبة"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "حذف الكتاب"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "يرجى عدم تحديث الصفحة"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "تصفح"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "إنشاء رف"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "حول"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "السابق"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "تفاصيل الكتاب"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "هل أنت متأكد أنك تريد إيقاف التشغيل؟"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "حذف هذا الرف"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "تحميل التنسيق"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "حذف التنسيقات:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "حذف الكتاب"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "حذف الكتاب"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "لم يتم العثور على نتائج"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "مقياس إلى الأفضل"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "إلى:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "التهيئة"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "إضافة إلى الرف"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "وضع علامة كـ غير مقروء"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "وضع علامة كـ غير مقروء"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "حذف الكتاب"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "حذف الكتاب"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "إنشاء رف"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "خطأ في الاتصال"
@@ -7920,6 +7975,102 @@ msgstr "تم حذف {} مستخدم(ين) بنجاح"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "كتالوج الكتب الإلكترونية Calibre-Web"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8224,14 +8375,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/cs/LC_MESSAGES/messages.po
+++ b/cps/translations/cs/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2020-06-09 21:11+0100\n"
 "Last-Translator: Lukas Heroudek <lukas.heroudek@gmail.com>\n"
 "Language-Team: \n"
@@ -1915,7 +1915,7 @@ msgstr "Knihy seřazené podle kategorie"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1951,7 +1951,7 @@ msgstr "Formáty souborů"
 msgid "Books ordered by file formats"
 msgstr "Knihy seřazené podle souboru formátů"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Police"
@@ -2110,6 +2110,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Zobrazit nejlépe hodnocené knihy"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2298,7 +2303,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Vynechat série"
@@ -2518,7 +2523,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Chyba stahování obalu"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Vytvořit polici"
@@ -3032,7 +3037,7 @@ msgstr "Přidat do police"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3449,40 +3454,45 @@ msgstr "Detaily"
 msgid "Update available"
 msgstr "Aktualizace selhala:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Aktualizační kanál"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Současná verze"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Zkontrolovat aktualizace"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Provést aktualizaci"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Opravdu chcete restartovat?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Načítání..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3493,8 +3503,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3504,11 +3514,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Opravdu chcete vypnout?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Probíhá aktualizace, prosím nenačítejte stránku znovu"
 
@@ -3561,7 +3571,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Nahrávání..."
 
@@ -3596,8 +3606,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3669,9 +3679,10 @@ msgstr "Převést knihu"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Zavřít"
 
@@ -3698,7 +3709,7 @@ msgid "Imported as"
 msgstr "Aktualizace selhala:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Autor"
 
@@ -3716,13 +3727,13 @@ msgstr "Datum vydání"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Vydavatel"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Jazyk"
@@ -3933,7 +3944,7 @@ msgstr "Zkušební e-mail"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Název"
@@ -5753,77 +5764,121 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Nastavení OAuth"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Nastavení OAuth"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5831,44 +5886,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Převést formát knihy:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5876,322 +5931,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Povolit veřejnou registraci"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Nastavení OAuth"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Nahrát formát"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Povolit veřejnou registraci"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Povolit veřejnou registraci"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Smazat formáty:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Získat metadata"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Hodnocení"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6580,7 +6635,7 @@ msgstr "Smazat knihu"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6638,7 +6693,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Tato kniha bude trvale odstraněna z databáze"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Nepřečtené knihy"
@@ -6750,8 +6805,8 @@ msgstr "Zadejte jméno domény"
 msgid "Denied Domains (Blacklist)"
 msgstr "Zakázané domény pro registraci"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Další"
 
@@ -7036,164 +7091,164 @@ msgstr "Nastavení"
 msgid "Refresh Library"
 msgstr "Hledat v knihovně"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Prosím neobnovujte stránku"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Procházet"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Vytvořit polici"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "O knihovně"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Předchozí"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Podrobnosti o knize"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Opravdu chcete vypnout?"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Nahrát formát"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Smazat formáty:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Smazat knihu"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Smazat knihu"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nenalezeny žádné výsledky"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Změnit měřítko na nejlepší"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfigurace"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Přidat do police"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Označit jako nepřečtené"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Označit jako nepřečtené"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Smazat knihu"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Vytvořit polici"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Chyba připojení"
@@ -8010,6 +8065,102 @@ msgstr ""
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web katalog eknih"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8312,14 +8463,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2026-04-06 17:03+0000\n"
 "Last-Translator: Manuel Drescher\n"
 "Language-Team: German\n"
@@ -1988,7 +1988,7 @@ msgstr ""
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -2025,7 +2025,7 @@ msgstr "Dateiformate"
 msgid "Books ordered by file formats"
 msgstr ""
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Regale"
@@ -2173,6 +2173,11 @@ msgstr "Duplikate"
 #: cps/render_template.py:144
 msgid "Show Duplicate Books"
 msgstr "Zeige Bücherduplikate"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr "Reihenfolge konnte nicht gespeichert werden"
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 msgid "Reorder Shelves"
 msgstr "Regale neu anordnen"
 
@@ -2585,7 +2590,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Fehler beim Erstellen des Regals"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 msgid "Create Magic Shelf"
 msgstr "Neues magisches Regal"
 
@@ -3087,7 +3092,7 @@ msgstr "Zu Regal hinzufügen"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3493,40 +3498,45 @@ msgstr "Details"
 msgid "Update available"
 msgstr "Aktualisierung fehlgeschlagen:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Aktualisierungskanal"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Aktuelle Version"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Nach Update suchen"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Aktualisierung durchführen"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Calibre-Web wirklich neustarten?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Lade..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3537,8 +3547,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3548,11 +3558,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Calibre-Web wirklich anhalten?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Aktualisierungsvorgang, bitte diese Seite nicht neu laden"
 
@@ -3606,7 +3616,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Lädt hoch..."
 
@@ -3641,8 +3651,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr "Hinweis:"
 
@@ -3713,9 +3723,10 @@ msgstr "Buch konvertieren"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Schließen"
 
@@ -3742,7 +3753,7 @@ msgid "Imported as"
 msgstr "Wichtig:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Autor"
 
@@ -3760,13 +3771,13 @@ msgstr "Herausgabedatum"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Verleger"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Sprache"
@@ -3972,7 +3983,7 @@ msgstr "Titel eingeben"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Titel"
@@ -5893,11 +5904,56 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Einstellungen für automatische Backups"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+#, fuzzy
+msgid "Copy"
+msgstr "UUID kopieren"
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "Aktiviere Benachrichtigungen zur Übersetzungsbeitragung"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -5907,11 +5963,11 @@ msgstr ""
 "mehr erhalten, wenn du eine andere Sprache als Englisch nutzt und es "
 "fehlende Übersetzungen gibt."
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Magische Regale mit Kobo synchronisieren"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -5920,11 +5976,11 @@ msgstr ""
 "Gerät synchronisiert. Hinweis: Sie müssen zusätzlich die Kobo-"
 "Synchronisierung in der Grundkonfiguration aktivieren."
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Aktiviere unscharfe Hintergründe auf dem Handy (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5933,15 +5989,15 @@ msgstr ""
 "auf kleinen Bildschirm dargestellt. Deaktiviere es, wenn du beim Scrollen "
 "oder bei Animationen Stocken siehst."
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 msgid "Automatic Backup Settings"
 msgstr "Einstellungen für automatische Backups"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -5949,11 +6005,11 @@ msgstr ""
 "Wenn es aktiviert ist, wird eine Kopie aller importierten Dateien unter <i>/"
 "config/processed_books/imported</i> gespeichert"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -5961,21 +6017,21 @@ msgstr ""
 "Wenn es aktiviert ist, werden die Orignale der ingestierten Dateien, die "
 "konvertiert wurden, gespeichert unter /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5988,11 +6044,11 @@ msgstr ""
 "Unterverzeichnisse von /config/processed_books übersichtlich zu halten und "
 "die Festplattennutzung zu minimieren."
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -6002,32 +6058,32 @@ msgstr ""
 "ingestierten Bücher automatisch in das hier ausgewählte Format konvertiert "
 "(außer der gewählten Formate in der Liste mit ignorierten Formaten von unten)"
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 msgid "Choose a target format:"
 msgstr "Wähle ein Zielformat:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -6035,20 +6091,20 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre kann doppelte Buchtitel beim Import erkennen und abhängig von dem"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "automatisches Zusammenführen"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -6056,35 +6112,35 @@ msgstr ""
 "Einstellung. Es kann gesetzt werden, eine Kopie des Bücherduplikats zu "
 "löschen oder beide zu behalten (Standard)."
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Verwirft duplizierte Importe, behält die Kopie in der Bibliothek"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 "Überschreibt die Kopie in der Bibliothek mit der neu importierten Datei"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Erstellt einen doppelten Eintrag, wobei beide Kopien behalten werden"
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -6093,31 +6149,31 @@ msgstr ""
 "deaktiviert, wird kein Scan nach Dubletten ausgeführt und es werden keine "
 "Benachrichtigungen angezeigt."
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 msgid "Enable Duplicate Detection"
 msgstr "Duplikaterkennung aktivieren"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr "Methode zur Dublettenerkennung"
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Hybrid (SQL-Vorfilter + Python-Validierung)"
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr "Nur Python (am langsamsten, am robustesten)"
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr "Nur Legacy-SQL (experimentell)"
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -6126,11 +6182,11 @@ msgstr ""
 "Kandidaten einzugrenzen, und wendet dann die robuste Python-Logik für die "
 "Endergebnisse an."
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 msgid "Automatic Duplicate Scanning"
 msgstr "Automatischer Duplikat-Scan"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -6138,27 +6194,27 @@ msgstr ""
 "Konfigurieren Sie Dubletten-Scans im Hintergrund. Diese werden automatisch "
 "ausgeführt, ohne die Benutzeroberfläche zu blockieren."
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr "Automatische Dubletten-Scans aktivieren"
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr "Scans nach dem Import"
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr "Nach jedem Import ausführen (mit Verzögerung)"
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr "Nur manuell"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr "Wartezeit nach Import (Sekunden)"
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -6166,15 +6222,15 @@ msgstr ""
 "Wartet diese Anzahl an Sekunden nach dem letzten Import ab, bevor ein "
 "Hintergrund-Scan gestartet wird."
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr "Geplante Scans (Cron-Ausdruck)"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "Leer lassen, um geplante Scans zu deaktivieren. Beispiel:"
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -6183,15 +6239,15 @@ msgstr ""
 "ausgeführt werden. Wählen Sie „Nur manuell“, um Scans nach dem Import zu "
 "deaktivieren, während Cron-Zeitpläne beibehalten werden."
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr "Nächster geplanter Scan:"
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -6201,35 +6257,35 @@ msgstr ""
 "ob Bücher Dubletten sind. Bücher müssen ALLE ausgewählten Kriterien "
 "erfüllen, um als Dubletten eingestuft zu werden."
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr "Buchtitel bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr "Buchautoren bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr "Buchsprache bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr "Buchreihen bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Buchverlag bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 msgid "Format"
 msgstr "Zielformat"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr "Dateiformat bei der Dublettenerkennung berücksichtigen"
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -6237,11 +6293,11 @@ msgstr ""
 "Es muss mindestens ein Kriterium ausgewählt werden. Titel und Autor werden "
 "als Kernkriterien empfohlen."
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr "Prioritätsrangfolge für Dubletten-Formate"
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -6252,11 +6308,11 @@ msgstr ""
 "Verschieben Sie die Formate per Drag-and-Drop, um die Priorität festzulegen "
 "(höher = besser)."
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr "Tipp:"
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -6266,11 +6322,11 @@ msgstr ""
 "werden Bücher mit höher eingestuften Formaten beibehalten. Formate mit "
 "niedrigerer Priorität werden gelöscht."
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Dubletten-Benachrichtigungen & automatische Lösung"
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -6278,11 +6334,11 @@ msgstr ""
 "Konfigurieren Sie, wie Sie über Buchdubletten benachrichtigt werden, und "
 "aktivieren Sie optional die automatische Auflösung."
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 msgid "Enable Duplicate Notifications"
 msgstr "Duplikatbenachrichtigungen aktivieren"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -6293,15 +6349,15 @@ msgstr ""
 "Schaltfläche „Dubletten“ in der Seitenleiste sowie ein Benachrichtigungs-"
 "Popup beim Login."
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Automatische Duplikatbehandlung aktivieren"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr "Warnung:"
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -6309,75 +6365,75 @@ msgstr ""
 "Dies wird automatisch Bücher basierend auf der untenstehenden Strategie "
 "löschen. Originaldateien werden gesichert unter"
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr "Strategie zur automatischen Auflösung"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr "Neueste behalten"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr "Ältere Kopien löschen, das zuletzt hinzugefügte Buch behalten"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr "Älteste behalten"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr "Neuere Kopien löschen, das zuerst hinzugefügte Buch behalten"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge Formats"
 msgstr "Formate zusammenführen"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "Formate im neuesten Buch zusammenführen, den Rest löschen"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr "Format mit höchster Qualität behalten"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 "Bevorzugt Formate basierend auf Ihrer Prioritätsrangfolge für Dubletten-"
 "Formate"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep Most Metadata"
 msgstr "Eintrag mit den meisten Metadaten behalten"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr "Buch mit den vollständigsten Informationen behalten"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr "Größte Dateigröße behalten"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr "Das Buch mit der größten Gesamtdateigröße behalten"
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Auswählen, welches Buch behalten werden soll, wenn Dubletten automatisch "
 "aufgelöst werden."
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 msgid "Rate Limiting"
 msgstr "Anzahl der Anfragen begrenzen"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr "Abkühlzeit (Minuten)"
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -6385,7 +6441,7 @@ msgstr ""
 "Mindestzeit zwischen automatischen Auflösungen (0 zum Deaktivieren). "
 "Verhindert schlagartige Löschungen während Massenimporten."
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6775,7 +6831,7 @@ msgstr "Ausgewählte zusammenführen"
 msgid "Dismiss this duplicate group"
 msgstr "Diese Dubletten-Gruppe ignorieren"
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr "Schließen"
 
@@ -6833,7 +6889,7 @@ msgstr "Diese Aktion kann nicht rückgängig gemacht werden!"
 msgid "The following books will be permanently deleted:"
 msgstr "Die folgenden Bücher werden permanent gelöscht:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 msgid "Merge Books"
 msgstr "Bücher zusammenführen"
 
@@ -6939,8 +6995,8 @@ msgstr "Domainnamen eingeben"
 msgid "Denied Domains (Blacklist)"
 msgstr "Verbotene Domains für eine Registrierung"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Nächste"
 
@@ -7226,149 +7282,149 @@ msgstr "Einstellungen"
 msgid "Refresh Library"
 msgstr "Bibliothek aktualisieren"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "Siehe Änderungsprotokoll"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Duplikate"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "Hier mitmachen!"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Bitte diese Seite nicht neu laden"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 msgid "Create Shelf"
 msgstr "Neues Regal"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr "Magische Regale ✨"
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Über"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Vorheriger Eintrag"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Buchdetails"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Diese Aktion kann nicht rückgängig gemacht werden!"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Ausgewählte löschen"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Zielformat"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Lösche Formate:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:644
+#: cps/templates/layout.html:650
 msgid "Duplicate Books Detected"
 msgstr "Bücherduplikate erkannt"
 
-#: cps/templates/layout.html:645
+#: cps/templates/layout.html:651
 msgid "You have unresolved duplicate books in your library"
 msgstr "Nicht aufgelöste Buch-Dubletten in der Bibliothek"
 
-#: cps/templates/layout.html:650
+#: cps/templates/layout.html:656
 msgid "Duplicate Groups Found"
 msgstr "Duplikatgruppen gefunden"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr "Später erinnern"
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr "Duplikate anzeigen & bereinigen"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Optimale Skalierung"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Tipp"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Zu Regal hinzufügen"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Als gelesen markiert"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Als ungelesen markiert"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Buch löschen"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Buch löschen"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7376,12 +7432,12 @@ msgid ""
 msgstr ""
 "Dies wird Bücher dauerhaft löschen. Originaldateien werden gesichert unter"
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Bitte zuerst ein Buch auswählen"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Wiederherstellung fehlgeschlagen: %(err)s"
@@ -8192,6 +8248,104 @@ msgstr "Geplanter Task erfolgreich abgebrochen"
 msgid "Error cancelling scheduled item"
 msgstr "Fehler beim Abbrechen des geplanten Elements"
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web Automated E-Book-Katalog"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+#, fuzzy
+msgid "Portainer:"
+msgstr "Wichtig:"
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+#, fuzzy
+msgid "Set up automatic updates"
+msgstr "Automatische Dubletten-Scans aktivieren"
+
 #: cps/templates/user_edit.html:173
 msgid "Your Profile"
 msgstr "Dein Profil"
@@ -8509,15 +8663,6 @@ msgstr ""
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-#, fuzzy
-msgid "Copy"
-msgstr "UUID kopieren"
-
 #: cps/templates/user_edit.html:625
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
@@ -8801,9 +8946,9 @@ msgstr "Zeige Gelesen/Ungelesen-Abschnitt"
 #~ "        <a href=\"https://github.com/crocodilestick/Calibre-Web-Automated/"
 #~ "wiki/Configuration#database-configuration\">see here</a>!"
 #~ msgstr ""
-#~ "CWA ist so konfiguriert, dass es deine Calibre-Datenbank (<code>metadata."
-#~ "db</code>-Datei) irgendwo in dem Pfad <code>/calibre-library</code> "
-#~ "sucht.\n"
+#~ "CWA ist so konfiguriert, dass es deine Calibre-Datenbank "
+#~ "(<code>metadata.db</code>-Datei) irgendwo in dem Pfad <code>/calibre-"
+#~ "library</code> sucht.\n"
 #~ "        CWA durchsucht automatisch das Verzeichnis, das du auf <code>/"
 #~ "calibre-library</code> in der docker-compose-Datei verbunden hast, um "
 #~ "eine existierende Calibre-\n"

--- a/cps/translations/el/LC_MESSAGES/messages.po
+++ b/cps/translations/el/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2025-09-03 14:59+0200\n"
 "Last-Translator: Depountis Georgios\n"
 "Language-Team: \n"
@@ -1956,7 +1956,7 @@ msgstr "Τα βιβλία ταξινομήθηκαν ανά κατηγορία"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1992,7 +1992,7 @@ msgstr "Μορφές αρχείου"
 msgid "Books ordered by file formats"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά μορφές αρχείου"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Ράφια"
@@ -2152,6 +2152,11 @@ msgstr ""
 msgid "Show Duplicate Books"
 msgstr "Προβολή Βιβλίων με Κορυφαία Αξιολόγηση"
 
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
+
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
 #: cps/templates/index.xml:12 cps/templates/layout.html:167
@@ -2271,8 +2276,8 @@ msgstr "Δημιούργησε ένα Ράφι"
 #, fuzzy
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr ""
-"Συγγνώμη αλλά δεν σου επιτρέπεται η αφαίρεση ενός βιβλίου από αυτό το ράφι: "
-"%(sname)s"
+"Συγγνώμη αλλά δεν σου επιτρέπεται η αφαίρεση ενός βιβλίου από αυτό το ράφι: %"
+"(sname)s"
 
 #: cps/shelf.py:356
 msgid "Edit a shelf"
@@ -2343,7 +2348,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Εξαίρεση Σειρών"
@@ -2566,7 +2571,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Σφάλμα Κατεβάσματος Φόντου"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Δημιούργησε ένα Ράφι"
@@ -3093,7 +3098,7 @@ msgstr "Προσθήκη στο ράφι"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3509,40 +3514,45 @@ msgstr "Λεπτομέρειες"
 msgid "Update available"
 msgstr "Η ενημέρωση απέτυχε:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Ενημέρωση Καναλιού"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Τρέχουσα έκδοση"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Έλεγχος για Ενημέρωση"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Πραγματοποίηση Ενημέρωσης"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Είσαι σίγουρος/η πως θέλεις να κάνεις επανεκκίνηση"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Φόρτωση..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3553,8 +3563,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3564,11 +3574,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Είσαι σίγουρος/η πως θέλεις να κάνεις κλείσιμο;"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Γίνεται ενημέρωση, παρακαλούμε μη φορτώσεις ξανά αυτή τη σελίδα"
 
@@ -3621,7 +3631,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Φόρτωση..."
 
@@ -3656,8 +3666,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3729,9 +3739,10 @@ msgstr "Μετατροπή βιβλίου"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Κλείσιμο"
 
@@ -3758,7 +3769,7 @@ msgid "Imported as"
 msgstr "Η ενημέρωση απέτυχε:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Συγγραφέας"
 
@@ -3776,13 +3787,13 @@ msgstr "Ημερομηνία Έκδοσης"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Εκδότης"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Γλώσσα"
@@ -3994,7 +4005,7 @@ msgstr "Εισαγωγή Τίτλου"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Τίτλος"
@@ -5815,77 +5826,121 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "OAuth Ρυθμίσεις"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5893,44 +5948,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Μετατροπή μορφής βιβλίου:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5938,322 +5993,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Ενεργοποίηση Δημόσιας Εγγραφής"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth Ρυθμίσεις"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Μορφή Ανεβάσματος"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Ενεργοποίηση Δημόσιας Εγγραφής"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Ενεργοποίηση Δημόσιας Εγγραφής"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Διαγραφή μορφών:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Συγκέντρωση Μεταδεδομένων"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Αξιολόγηση"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6642,7 +6697,7 @@ msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6700,7 +6755,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Αυτό το βιβλίο θα διαγραφεί για πάντα από τη βάση δεδομένων"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Βιβλία που δεν Διαβάστηκαν"
@@ -6812,8 +6867,8 @@ msgstr "Όνομα domain"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domains που Απορρίφθηκαν (Μαύρη λίστα)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Επόμενο"
 
@@ -7100,164 +7155,164 @@ msgstr "Ρυθμίσεις"
 msgid "Refresh Library"
 msgstr "Αναζήτηση Βιβλιοθήκης"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Παρακαλούμε μην ανανεώσεις τη σελίδα"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Περιήγηση"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Σχετικά"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Προηγούμενο"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Λεπτομέρειες Βιβλίου"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Είσαι σίγουρος/η πως θέλεις να κάνεις κλείσιμο;"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Μορφή Ανεβάσματος"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Διαγραφή μορφών:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Διαγραφή Βιβλίου"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Διαγραφή Βιβλίου"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Δεν Βρέθηκαν Αποτελέσματα"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Κλιμάκωση στο Καλυτερο"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Διαμόρφωση"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Προσθήκη στο ράφι"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Συγχώνευση επιλεγμένων βιβλίων"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Σήμανση ως Αδιάβαστο"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Διαγραφή Βιβλίου"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Δημιούργησε ένα Ράφι"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Σφάλμα σύνδεσης"
@@ -8075,6 +8130,102 @@ msgstr ""
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web Κατάλογος eBook"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8377,14 +8528,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/es/LC_MESSAGES/messages.po
+++ b/cps/translations/es/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2025-11-17 12:21-0300\n"
 "Last-Translator: minakmostoles <xxx@xxx.com>\n"
 "Language-Team: es <LL@li.org>\n"
@@ -1780,13 +1780,18 @@ msgstr ""
 msgid ""
 "Login failed: Could not connect to the OAuth provider's user info endpoint. "
 "Please try again or contact your administrator."
-msgstr "Inicio de sesión fallido: No se pudo conectar al endpoint de información del usuario del proveedor OAuth. Inténtalo de nuevo o contacta con el administrador."
+msgstr ""
+"Inicio de sesión fallido: No se pudo conectar al endpoint de información del "
+"usuario del proveedor OAuth. Inténtalo de nuevo o contacta con el "
+"administrador."
 
 #: cps/oauth_bb.py:268
 msgid ""
 "Login failed: The OAuth provider returned invalid user profile data. Please "
 "contact your administrator."
-msgstr "Inicio de sesión fallido: El proveedor OAuth devolvió datos de perfil de usuario no válidos. Contacta con el administrador."
+msgstr ""
+"Inicio de sesión fallido: El proveedor OAuth devolvió datos de perfil de "
+"usuario no válidos. Contacta con el administrador."
 
 #: cps/oauth_bb.py:290
 #, python-format
@@ -2010,7 +2015,7 @@ msgstr "Libros ordenados por categorías"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -2046,7 +2051,7 @@ msgstr "Formatos de archivo"
 msgid "Books ordered by file formats"
 msgstr "Libros ordenados por formato de archivo"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Estanterías"
@@ -2194,6 +2199,11 @@ msgstr "Duplicados"
 #: cps/render_template.py:144
 msgid "Show Duplicate Books"
 msgstr "Mostrar Libros Duplicados"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2384,7 +2394,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Excluir Estanterías"
@@ -2610,7 +2620,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Error al crear la estantería"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 msgid "Create Magic Shelf"
 msgstr "Crear una Magic Shelf"
 
@@ -2718,7 +2728,8 @@ msgstr "Correos electrónicos adicionales están desactivados para tu cuenta."
 
 #: cps/web.py:2506
 msgid "Success! Book queued for sending to the selected address(es)!"
-msgstr "¡Éxito! Libro en cola para enviar a la(s) dirección(es) seleccionada(s)."
+msgstr ""
+"¡Éxito! Libro en cola para enviar a la(s) dirección(es) seleccionada(s)."
 
 #: cps/web.py:2525
 msgid "Please wait one minute to register next user"
@@ -2766,7 +2777,9 @@ msgstr ""
 msgid ""
 "OAuth authentication is not properly configured. Please contact "
 "administrator."
-msgstr "La autenticación OAuth no está configurada correctamente. Contacta con el administrador."
+msgstr ""
+"La autenticación OAuth no está configurada correctamente. Contacta con el "
+"administrador."
 
 #: cps/web.py:2673 cps/web.py:2700
 msgid "Cannot activate LDAP authentication"
@@ -2794,13 +2807,17 @@ msgstr "has iniciado sesión como : '%(nickname)s'"
 msgid ""
 "Welcome! Your account has been automatically created. You are now logged in "
 "as: '%(nickname)s'"
-msgstr "¡Bienvenido! Tu cuenta se ha creado automáticamente. Has iniciado sesión como: '%(nickname)s'"
+msgstr ""
+"¡Bienvenido! Tu cuenta se ha creado automáticamente. Has iniciado sesión "
+"como: '%(nickname)s'"
 
 #: cps/web.py:2744 cps/web.py:2747
 msgid ""
 "Authentication successful, but account creation failed. Please contact your "
 "administrator."
-msgstr "Autenticación correcta, pero ha fallado la creación de la cuenta. Por favor, contacta con tu administrador."
+msgstr ""
+"Autenticación correcta, pero ha fallado la creación de la cuenta. Por favor, "
+"contacta con tu administrador."
 
 #: cps/web.py:2751
 msgid ""
@@ -3110,7 +3127,7 @@ msgstr "Agregar a la estantería"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3518,40 +3535,45 @@ msgstr "Detalles"
 msgid "Update available"
 msgstr "Falló la actualización:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Canal de Actualización"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Versión actual"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Comprobar actualizaciones"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Realizar actualización"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "¿Realmente quieres reiniciar?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Cargando..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3562,8 +3584,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3573,11 +3595,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "¿Estás seguro de que deseas apagar?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Actualizando. Por favor, no recargue la página"
 
@@ -3631,7 +3653,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Cargando..."
 
@@ -3666,8 +3688,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr "Nota:"
 
@@ -3738,9 +3760,10 @@ msgstr "Convertir libro"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Cerrar"
 
@@ -3767,7 +3790,7 @@ msgid "Imported as"
 msgstr "Importante:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Autor"
 
@@ -3785,13 +3808,13 @@ msgstr "Fecha de Publicación"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Editor"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Idioma"
@@ -3998,7 +4021,7 @@ msgstr "Introduce título"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Título"
@@ -4408,7 +4431,9 @@ msgstr ""
 
 #: cps/templates/config_edit.html:225
 msgid "Sync Kobo annotations to Hardcover (Requires API key per user)"
-msgstr "Sincronizar anotaciones de Kobo con Hardcover (requiere una clave API por usuario)"
+msgstr ""
+"Sincronizar anotaciones de Kobo con Hardcover (requiere una clave API por "
+"usuario)"
 
 #: cps/templates/config_edit.html:230
 msgid "Pad book covers to Kobo screen aspect ratio"
@@ -5933,11 +5958,56 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Configuración de Copias de Seguridad Automáticas"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+#, fuzzy
+msgid "Copy"
+msgstr "Copiar UUID"
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "Habilitar notificaciones de contribuciones a traducciones"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -5947,12 +6017,12 @@ msgstr ""
 "usuario web cuando utilice un idioma distinto del inglés si las traducciones "
 "para el idioma elegido no están completas."
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Sincronizar estanterías seleccionadas con Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -5961,11 +6031,11 @@ msgstr ""
 "dispositivo Kobo como colecciones. Nota: también debes activar Kobo Sync en "
 "Configuración básica."
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Habilitar fondos difuminados en dispositivos móviles (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5974,15 +6044,15 @@ msgstr ""
 "reproduce en pantallas pequeñas. Desactívalo si notas retrasos en el "
 "desplazamiento o la animación."
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 msgid "Automatic Backup Settings"
 msgstr "Configuración de Copias de Seguridad Automáticas"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -5990,11 +6060,11 @@ msgstr ""
 "Cuando esté activo, se almacenará una copia de todos los archivos importados "
 "en <i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -6002,21 +6072,21 @@ msgstr ""
 "Cuando esté activo, los originales de los archivos importados que se sometan "
 "a conversión se almacenarán en /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -6029,11 +6099,11 @@ msgstr ""
 "mantener organizados los subdirectorios de /config/processed_books y "
 "minimizar el uso del espacio en disco."
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -6044,32 +6114,32 @@ msgstr ""
 "los formatos seleccionados en la lista de ignorados que aparece a "
 "continuación)."
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 msgid "Choose a target format:"
 msgstr "Elija un formato de destino:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -6077,21 +6147,21 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre puede detectar títulos de libros duplicados durante la importación y "
 "dependiendo de la configuración de la"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "fusión automatica"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -6099,34 +6169,34 @@ msgstr ""
 ". Se puede configurar para eliminar cualquiera de las instancias de un libro "
 "duplicado o conservar ambas (por defecto)."
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Descarta importación duplicada, conserva la copia de la biblioteca"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr "Sobrescribe la copia de la biblioteca con el archivo recién importado"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Crea un registro duplicado, conservando ambas copias"
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -6134,32 +6204,32 @@ msgstr ""
 "Activa o desactiva el sistema de detección de duplicados. Si se desactiva, "
 "no se ejecutará el escaneo de duplicados y no se mostrarán notificaciones."
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Habilitar detección de duplicados"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr "Método de detección de duplicados"
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Híbrido (prefiltro SQL + validación en Python)"
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr "Solo Python (más lento, más robusto)"
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr "Solo SQL heredado (experimental)"
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -6167,12 +6237,12 @@ msgstr ""
 "El modo híbrido usa un prefiltro SQL rápido para reducir candidatos y luego "
 "aplica la lógica robusta en Python para obtener el resultado final."
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Escaneo automático de duplicados"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -6180,28 +6250,28 @@ msgstr ""
 "Configura los escaneos de duplicados en segundo plano. Se ejecutan "
 "automáticamente sin bloquear la interfaz."
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr "Habilitar escaneos automáticos de duplicados"
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr "Escaneos tras la importación"
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr "Ejecutar tras cada importación (con retardo)"
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 #, fuzzy
 msgid "Manual only"
 msgstr "Solo manual"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr "Retardo tras la importación (segundos)"
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -6209,15 +6279,15 @@ msgstr ""
 "Espera estos segundos después de la última importación antes de iniciar un "
 "escaneo en segundo plano."
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr "Escaneos programados (expresión cron)"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "Déjalo en blanco para desactivar los escaneos programados. Ejemplo:"
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -6226,15 +6296,15 @@ msgstr ""
 "como los escaneos por cron. Usa “Solo manual” para desactivar los escaneos "
 "tras la importación y mantener la programación por cron."
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr "Próximo escaneo programado:"
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -6244,36 +6314,36 @@ msgstr ""
 "duplicados. Para considerarse duplicados, deben coincidir TODOS los "
 "criterios seleccionados."
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr "Considerar títulos al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr "Considerar autores al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr "Considerar idioma al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr "Considerar series al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Considerar editorial al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Formato"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr "Considerar el formato de archivo al detectar duplicados"
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -6281,11 +6351,11 @@ msgstr ""
 "Debe seleccionarse al menos un criterio. Se recomiendan Título y Autor como "
 "criterios principales."
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr "Orden de prioridad de formatos para duplicados"
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -6295,11 +6365,11 @@ msgstr ""
 "resolución automática \"Formato de mayor calidad\". Arrastra y suelta para "
 "reordenar los formatos por prioridad (más alto = mejor)."
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr "Consejo:"
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -6309,11 +6379,11 @@ msgstr ""
 "conservarán los libros con formatos mejor clasificados. Los formatos con "
 "menor prioridad se eliminarán."
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Notificaciones de duplicados y resolución automática"
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -6321,12 +6391,12 @@ msgstr ""
 "Configura cómo se te notifican los libros duplicados y, opcionalmente, "
 "activa la resolución automática."
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Habilitar notificaciones de duplicados"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -6337,16 +6407,16 @@ msgstr ""
 "un indicador en el botón \"Duplicados\" de la barra lateral y una "
 "notificación emergente al iniciar sesión."
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Habilitar resolución automática de duplicados"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr "Advertencia:"
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -6354,77 +6424,77 @@ msgstr ""
 "Esto eliminará automáticamente libros según la estrategia indicada abajo. "
 "Los archivos originales se guardarán como copia de seguridad en"
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr "Estrategia de resolución automática"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr "Conservar el más reciente"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 "Eliminar copias más antiguas y conservar el libro añadido más recientemente"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr "Conservar el más antiguo"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr "Eliminar copias más recientes y conservar el primero que se añadió"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Fusionar formatos"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "Fusionar los formatos en el libro más reciente y eliminar el resto"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr "Conservar el formato de mayor calidad"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 "Preferir formatos según tu orden de prioridad de formatos para duplicados"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Probar Metadatos"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr "Conservar el libro con la información más completa"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr "Conservar el tamaño de archivo más grande"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr "Conservar el libro con el mayor tamaño total de archivos"
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Elige qué libro conservar cuando los duplicados se resuelven automáticamente."
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Limitación de tasa"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr "Periodo de enfriamiento (minutos)"
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -6432,7 +6502,7 @@ msgstr ""
 "Tiempo mínimo entre resoluciones automáticas (0 para desactivar). Evita "
 "eliminaciones en ráfaga durante importaciones por lotes."
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6690,7 +6760,9 @@ msgstr ""
 msgid ""
 "Books with matching titles, authors, and languages. Books in different "
 "languages are not considered duplicates."
-msgstr "Libros con títulos, autores e idiomas coincidentes. Los libros en idiomas distintos no se consideran duplicados."
+msgstr ""
+"Libros con títulos, autores e idiomas coincidentes. Los libros en idiomas "
+"distintos no se consideran duplicados."
 
 #: cps/templates/duplicates.html:507
 #, fuzzy
@@ -6823,7 +6895,7 @@ msgstr "Fusionar seleccionados"
 msgid "Dismiss this duplicate group"
 msgstr "Descartar este grupo de duplicados"
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr "Descartar"
 
@@ -6880,7 +6952,7 @@ msgstr "¡Esta acción no se puede deshacer!"
 msgid "The following books will be permanently deleted:"
 msgstr "Los siguientes libros se eliminarán de forma permanente:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 msgid "Merge Books"
 msgstr "Fusionar libros"
 
@@ -6986,8 +7058,8 @@ msgstr "Introducir nombre de dominio"
 msgid "Denied Domains (Blacklist)"
 msgstr "Dominios Prohibidos (Lista Negra)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Siguiente"
 
@@ -7123,7 +7195,9 @@ msgstr "No se pudo aplicar la coincidencia"
 msgid ""
 "Are you sure you want to reject all matches for this book? This cannot be "
 "undone."
-msgstr "¿Seguro que quieres rechazar todas las coincidencias de este libro? Esto no se puede deshacer."
+msgstr ""
+"¿Seguro que quieres rechazar todas las coincidencias de este libro? Esto no "
+"se puede deshacer."
 
 #: cps/templates/hardcover_review_matches.html:324
 #: cps/templates/hardcover_review_matches.html:333
@@ -7137,7 +7211,9 @@ msgstr "No se pudo rechazar la coincidencia"
 #: cps/templates/hardcover_review_matches.html:342
 msgid ""
 "Are you sure you want to reject all pending matches? This cannot be undone."
-msgstr "¿Seguro que quieres rechazar todas las coincidencias pendientes? Esto no se puede deshacer."
+msgstr ""
+"¿Seguro que quieres rechazar todas las coincidencias pendientes? Esto no se "
+"puede deshacer."
 
 #: cps/templates/hardcover_review_matches.html:361
 #: cps/templates/hardcover_review_matches.html:370
@@ -7270,153 +7346,153 @@ msgstr "Ajustes"
 msgid "Refresh Library"
 msgstr "Actualizar Biblioteca"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "Ver registro de cambios"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Duplicados"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "¡Colabora aquí!"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Por favor, no actualice la página"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Navegar"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Crear una Estantería"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr "Estanterías mágicas ✨"
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Acerca de"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Anterior"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Detalles del libro"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "¡Esta acción no se puede deshacer!"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Eliminar Seleccionados"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Formato"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Borrar formatos:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:644
+#: cps/templates/layout.html:650
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Se han detectado libros duplicados"
 
-#: cps/templates/layout.html:645
+#: cps/templates/layout.html:651
 msgid "You have unresolved duplicate books in your library"
 msgstr "Tienes libros duplicados sin resolver en tu biblioteca"
 
-#: cps/templates/layout.html:650
+#: cps/templates/layout.html:656
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Se han encontrado grupos de duplicados"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr "Recordármelo más tarde"
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Seleccionar duplicados"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Escala al máximo"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Tip"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Agregar a la estantería"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Fusionar libros seleccionados"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marcar como no leído"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Borrar Libro"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Borrar Libro"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7425,12 +7501,12 @@ msgstr ""
 "Esto eliminará libros de forma permanente. Los archivos originales se "
 "guardarán como copia de seguridad en"
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Selecciona una Estantería"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Error de conexión"
@@ -8239,6 +8315,104 @@ msgstr "Elemento programado cancelado correctamente"
 msgid "Error cancelling scheduled item"
 msgstr "Error cancelling scheduled item"
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Catálogo de eBooks de Calibre-Web"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+#, fuzzy
+msgid "Portainer:"
+msgstr "Importante:"
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+#, fuzzy
+msgid "Set up automatic updates"
+msgstr "Habilitar escaneos automáticos de duplicados"
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8573,15 +8747,6 @@ msgstr ""
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
 msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-#, fuzzy
-msgid "Copy"
-msgstr "Copiar UUID"
 
 #: cps/templates/user_edit.html:625
 msgid "e.g. Kobo Forma, KOReader iPad"

--- a/cps/translations/fi/LC_MESSAGES/messages.po
+++ b/cps/translations/fi/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2020-01-12 13:56+0100\n"
 "Last-Translator: Samuli Valavuo <svalavuo@gmail.com>\n"
 "Language-Team: \n"
@@ -1906,7 +1906,7 @@ msgstr "Kirjat kategorioittain"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1945,7 +1945,7 @@ msgstr "Tiedotomuodot"
 msgid "Books ordered by file formats"
 msgstr "Kirjat sarjoittain"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 #, fuzzy
 msgid "Shelves"
@@ -2106,6 +2106,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Näytä parhaiten arvioidut kirjat"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2296,7 +2301,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Poissulje sarja"
@@ -2514,7 +2519,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "luo hylly"
@@ -3019,7 +3024,7 @@ msgstr "Lisää hyllyyn"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3439,40 +3444,45 @@ msgstr "Yksityiskohdat"
 msgid "Update available"
 msgstr "Päivitys epäonnistui:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Päivityskanava"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Nykyinen versio"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Tarkista päivitykset"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Päivitä"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Haluatko varmasti uudelleenkäynnistää Calibre-Webin?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Ladataan..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3483,8 +3493,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3494,11 +3504,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Haluatko varmasti pysäyttää Calibre-Webin?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Päivitetään, älä päivitä sivua"
 
@@ -3551,7 +3561,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Ladataan..."
 
@@ -3586,8 +3596,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3659,9 +3669,10 @@ msgstr "Muunna kirja"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Sulje"
 
@@ -3688,7 +3699,7 @@ msgid "Imported as"
 msgstr "Päivitys epäonnistui:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Kirjailija"
 
@@ -3707,13 +3718,13 @@ msgstr "Julkaisupäivä"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Julkaisija"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Kieli"
@@ -3923,7 +3934,7 @@ msgstr "Testi sähköposti"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Otsikko"
@@ -5743,77 +5754,121 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "OAuth asetukset"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth asetukset"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5821,44 +5876,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Muunna kirjan tiedostomuoto:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5866,322 +5921,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Salli julkinen rekisteröinti"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth asetukset"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Lataa tiedostomuoto"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Salli julkinen rekisteröinti"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Salli julkinen rekisteröinti"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Poista tiedostomuodot:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Hae metadata"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Arvostelu"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6571,7 +6626,7 @@ msgstr "Poista kirja"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6629,7 +6684,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Kirja poistetaan Calibren tietokannasta"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Lukemattomat kirjat"
@@ -6742,8 +6797,8 @@ msgstr "Syötä domainnimi"
 msgid "Denied Domains (Blacklist)"
 msgstr "Rekisteröinnissä sallitut domainit"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Seuraava"
 
@@ -7024,165 +7079,165 @@ msgstr "Asetukset"
 msgid "Refresh Library"
 msgstr "Sarjat kirjastossa"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 #, fuzzy
 msgid "Please do not refresh the page"
 msgstr "Päivitetään, älä päivitä sivua"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Selaa"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "luo hylly"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Tietoja"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Edellinen"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Kirjan tiedot"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Haluatko varmasti pysäyttää Calibre-Webin?"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Lataa tiedostomuoto"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Poista tiedostomuodot:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Poista kirja"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Poista kirja"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Tulosket haulle:"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Skaalaa parhaaseen"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Asetukset"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Lisää hyllyyn"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Merkitse lukemattomaksi"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Merkitse lukemattomaksi"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Poista kirja"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "luo hylly"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Yhteysvirhe"
@@ -8001,6 +8056,102 @@ msgstr ""
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web e-kirjaluettelo"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8304,14 +8455,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -25,7 +25,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2025-11-17 21:51+0100\n"
 "Last-Translator: Tex <tex@grosist.fr>\n"
 "Language-Team: \n"
@@ -2060,7 +2060,7 @@ msgstr "Livres classés par catégorie"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -2096,7 +2096,7 @@ msgstr "Formats de fichier"
 msgid "Books ordered by file formats"
 msgstr "Livres classés par formats de fichiers"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Etagères"
@@ -2244,6 +2244,11 @@ msgstr "Doubles"
 #: cps/render_template.py:144
 msgid "Show Duplicate Books"
 msgstr "Montrer les livres en double"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2435,7 +2440,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Etagères exclues"
@@ -2660,7 +2665,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Erreur lors de la création de l'étagère"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 msgid "Create Magic Shelf"
 msgstr "Créer une étagère magique"
 
@@ -3168,7 +3173,7 @@ msgstr "Ajouter à l'étagère"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3576,40 +3581,45 @@ msgstr "Détails"
 msgid "Update available"
 msgstr "La mise à jour a échoué :"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Canal de mise à jour"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Version actuelle"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Rechercher les mises à jour"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Effectuer la mise à jour"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Voulez-vous vraiment redémarrer Calibre-Web?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Chargement…"
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3620,8 +3630,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3631,11 +3641,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Voulez-vous vraiment arrêter Calibre-Web?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Mise à jour en cours, ne pas rafraîchir la page"
 
@@ -3689,7 +3699,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Téléversement en cours…"
 
@@ -3724,8 +3734,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr "Note :"
 
@@ -3796,9 +3806,10 @@ msgstr "Convertir le livre"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Fermer"
 
@@ -3825,7 +3836,7 @@ msgid "Imported as"
 msgstr "Important :"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Auteur"
 
@@ -3843,13 +3854,13 @@ msgstr "Date de publication"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Éditeur"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Langue"
@@ -4058,7 +4069,7 @@ msgstr "Insérer le titre"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Titre"
@@ -5504,9 +5515,9 @@ msgid ""
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
-"Cet outil a été adapté à partir de l'outil <a href=\"https://kindle-epub-fix."
-"netlify.app/\">kindle-epub-fix.netlify.app</a> créé par <a href=\"https://"
-"github.com/innocenat\">innocenat</a>."
+"Cet outil a été adapté à partir de l'outil <a href=\"https://kindle-epub-"
+"fix.netlify.app/\">kindle-epub-fix.netlify.app</a> créé par <a "
+"href=\"https://github.com/innocenat\">innocenat</a>."
 
 #: cps/templates/cwa_settings.html:181
 msgid "Enable KOReader Sync (NextGen Plugin)"
@@ -5992,11 +6003,56 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Réglages de sauvegarde automatisée"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+#, fuzzy
+msgid "Copy"
+msgstr "Copier l'UUID"
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "Activer les notifications de contributions aux traductions"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -6006,11 +6062,11 @@ msgstr ""
 "dans l’interface Web lorsque vous utilisez une langue autre que l’anglais, "
 "si la traduction de la langue choisie n’est pas complète."
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Synchroniser Magic Shelves avec Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -6019,11 +6075,11 @@ msgstr ""
 "votre appareil Kobo sous forme de collections. Remarque : vous devez "
 "également activer Kobo Sync dans la configuration de base."
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Activer les arrières plan flous sur Mobile (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -6032,15 +6088,15 @@ msgstr ""
 "également rendu sur les petits écrans. Désactivez cet effet si vous "
 "constatez un décalage dans le défilement ou l'animation."
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 msgid "Automatic Backup Settings"
 msgstr "Réglages de sauvegarde automatisée"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -6048,11 +6104,11 @@ msgstr ""
 "Si actif, une copie de tous les fichiers importés sera stockée dans <i>/"
 "config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -6060,21 +6116,21 @@ msgstr ""
 "Si actif, les fichiers originaux ingérés et convertis seront stockés dans le "
 "dossier /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -6087,11 +6143,11 @@ msgstr ""
 "les sous-répertoires de /config/processed_books organisés et de minimiser "
 "l’utilisation de l’espace disque."
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -6101,32 +6157,32 @@ msgstr ""
 "automatiquement converti au format choisit ici (sauf pour les formats "
 "sélectionnés dans la liste à ignorer ci-dessous)"
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 msgid "Choose a target format:"
 msgstr "Choisissez un format cible :"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -6134,21 +6190,21 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre peut détecter les titres de livre en double lors de l'import et en "
 "fonction du"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "fusion automatique"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -6156,35 +6212,35 @@ msgstr ""
 "paramétrage. Il peut être configuré pour supprimer l'un des doublons ou "
 "conserver les deux (par défaut)."
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Rejeter l'import en double, conserver la copie de librairie"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 "Ecrase la copie de la bibliothèque avec le fichier nouvellement importé"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Crée un enregistrement en double, en conservant les deux copies."
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -6193,31 +6249,31 @@ msgstr ""
 "désactivé, la recherche des doublons ne s'exécute pas et aucune notification "
 "n'est affichée."
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 msgid "Enable Duplicate Detection"
 msgstr "Activer la détection des doublons"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr "Méthode de détection des doublons"
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Hybride (préfiltrage SQL + validation Python)"
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr "Python uniquement (le plus lent, le plus robuste)"
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr "SQL hérité uniquement (expérimental)"
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -6226,11 +6282,11 @@ msgstr ""
 "candidats, puis applique la logique Python robuste pour obtenir les "
 "résultats finaux."
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 msgid "Automatic Duplicate Scanning"
 msgstr "Détection automatique des doublons"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -6238,27 +6294,27 @@ msgstr ""
 "Configurez les analyses en arrière-plan des doublons. Celles-ci s'exécutent "
 "automatiquement sans bloquer l'interface utilisateur."
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr "Activer la recherche automatique des doublons"
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr "Après les analyses d'importation"
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr "Exécuter après chaque importation (anti-rebond)"
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr "Manuel uniquement"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr "Après importation, délai anti-rebond (secondes)"
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -6266,16 +6322,16 @@ msgstr ""
 "Attendez ce nombre de secondes après la dernière importation avant de lancer "
 "une analyse en arrière-plan."
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr "Analyses programmées (expression cron)"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 "Laissez ce champ vide pour désactiver les analyses planifiées. Exemple :"
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -6285,15 +6341,15 @@ msgstr ""
 "désactiver les analyses après importation tout en conservant les "
 "planifications cron."
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr "Prochaine analyse prévue :"
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -6303,37 +6359,37 @@ msgstr ""
 "sont des doublons. Les livres doivent correspondre à TOUS les critères "
 "sélectionnés pour être considérés comme des doublons."
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr "Tenir compte des titres des livres lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 "Prendre en compte les auteurs des livres lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr "Tenir compte de la langue du livre lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 "Prendre en compte les séries de livres lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Prendre en compte l'éditeur du livre lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 msgid "Format"
 msgstr "Format"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr "Tenir compte du format de fichier lors de la détection des doublons"
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -6341,11 +6397,11 @@ msgstr ""
 "Au moins un critère doit être sélectionné. Le titre et l'auteur sont "
 "recommandés comme critères principaux."
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr "Classement des priorités des formats en double"
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -6356,11 +6412,11 @@ msgstr ""
 "déposez pour réorganiser les formats par ordre de priorité (plus élevé = "
 "meilleur)."
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr "Astuce :"
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -6370,11 +6426,11 @@ msgstr ""
 "haute qualité », les livres avec les formats les mieux classés seront "
 "conservés. Les formats moins prioritaires seront supprimés."
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Notifications en double et résolution automatique"
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -6382,11 +6438,11 @@ msgstr ""
 "Configurez la manière dont vous êtes averti des livres en double et activez "
 "éventuellement la résolution automatique."
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 msgid "Enable Duplicate Notifications"
 msgstr "Activer les notifications en double"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -6397,15 +6453,15 @@ msgstr ""
 "d'édition verront un badge sur le bouton de la barre latérale Doublons et "
 "une notification contextuelle lorsqu'ils se connecteront."
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Activer la résolution automatique des doublons"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr "Attention :"
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -6413,77 +6469,77 @@ msgstr ""
 "Cela supprimera automatiquement les livres selon la stratégie ci-dessous. "
 "Les fichiers originaux seront sauvegardés dans"
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr "Stratégie de résolution automatique"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr "Conserver les plus récents"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 "Supprimer les anciennes copies, conserver le livre ajouté le plus récemment"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr "Conserver le plus ancien"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr "Supprimer les copies les plus récentes, conserver les plus anciennes"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge Formats"
 msgstr "Fusionner les formats"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "Fusionner les formats dans le dernier livre, supprimer le reste"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr "Conserver le format de la plus haute qualité"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 "Préférez les formats en fonction de votre classement des priorités de format "
 "de duplication"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep Most Metadata"
 msgstr "Conserver la plupart des métadonnées"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr "Conserver le registre contenant les informations les plus complètes"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr "Conserver la taille de fichier la plus grande"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 "Conserver le livre dont la taille totale des fichiers est la plus importante"
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Choisissez le livre à conserver lorsque les doublons sont automatiquement "
 "résolus."
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 msgid "Rate Limiting"
 msgstr "Limitation de débit"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr "Période de refroidissement (minutes)"
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -6491,7 +6547,7 @@ msgstr ""
 "Délai minimum entre les résolutions automatiques (0 pour désactiver). "
 "Empêche les suppressions rapides lors des importations par lots."
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6886,7 +6942,7 @@ msgstr "Fusionner la sélection"
 msgid "Dismiss this duplicate group"
 msgstr "Supprimer ce groupe en double"
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr "Rejeter"
 
@@ -6944,7 +7000,7 @@ msgstr "Cette action ne peut être défaite !"
 msgid "The following books will be permanently deleted:"
 msgstr "Les livres suivants vont être effacés de manière permanante :"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 msgid "Merge Books"
 msgstr "Fusionner les livres"
 
@@ -7050,8 +7106,8 @@ msgstr "Saisir le nom de domaine"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domaines refusés (Liste noire)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Suivant"
 
@@ -7337,150 +7393,150 @@ msgstr "Paramètres"
 msgid "Refresh Library"
 msgstr "Actualiser la bibliothèque"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "Voir le Changelog"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Doubles"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "Contribuer ici !"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Veuillez ne pas rafraîchir la page"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Explorer"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 msgid "Create Shelf"
 msgstr "Créer une étagère"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr "Étagères magiques ✨"
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "À propos"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Précédent"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Détails du livre"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Cette action ne peut être défaite !"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Effacer la sélection"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Format"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Supprimer les formats :"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:644
+#: cps/templates/layout.html:650
 msgid "Duplicate Books Detected"
 msgstr "Livres en double détectés"
 
-#: cps/templates/layout.html:645
+#: cps/templates/layout.html:651
 msgid "You have unresolved duplicate books in your library"
 msgstr "Vous avez des livres en double non résolus dans votre bibliothèque"
 
-#: cps/templates/layout.html:650
+#: cps/templates/layout.html:656
 msgid "Duplicate Groups Found"
 msgstr "Groupes en double trouvés"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr "Rappelez-moi plus tard"
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr "Afficher et résoudre les doublons"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Mise à l’échelle optimale"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Astuce"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuration"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Ajouter à l'étagère"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Marquer les livres sélectionnés comme lus"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marqué comme non lu"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Supprimer le livre"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Supprimer le livre"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7489,12 +7545,12 @@ msgstr ""
 "Cela supprimera définitivement les livres. Les fichiers originaux seront "
 "sauvegardés sur"
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Sélectionner d'abord un livre"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Échec de la restauration : %(err)s"
@@ -8306,6 +8362,104 @@ msgstr "Élément planifié annulé avec succès"
 msgid "Error cancelling scheduled item"
 msgstr "Erreur lors de l'annulation d'un élément planifié"
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Catalogue de livres électroniques Calibre-Web Automated"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+#, fuzzy
+msgid "Portainer:"
+msgstr "Important :"
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+#, fuzzy
+msgid "Set up automatic updates"
+msgstr "Activer la recherche automatique des doublons"
+
 #: cps/templates/user_edit.html:173
 msgid "Your Profile"
 msgstr "Votre profil"
@@ -8633,15 +8787,6 @@ msgstr ""
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
 msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-#, fuzzy
-msgid "Copy"
-msgstr "Copier l'UUID"
 
 #: cps/templates/user_edit.html:625
 msgid "e.g. Kobo Forma, KOReader iPad"

--- a/cps/translations/gl/LC_MESSAGES/messages.po
+++ b/cps/translations/gl/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2022-08-11 16:46+0200\n"
 "Last-Translator: pollitor <pollitor@gmx.com>\n"
 "Language-Team: gl\n"
@@ -1950,7 +1950,7 @@ msgstr "Libros ordeados por categorías"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1986,7 +1986,7 @@ msgstr "Formatos de arquivo"
 msgid "Books ordered by file formats"
 msgstr "Libros ordeados por formato de arquivo"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Andeis"
@@ -2145,6 +2145,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Mostrar libros mellor valorados"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2332,7 +2337,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Excluir andeis"
@@ -2553,7 +2558,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Erro borrando o estante"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Crear un andel"
@@ -3075,7 +3080,7 @@ msgstr "Engadir ao andel"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3490,40 +3495,45 @@ msgstr "Detalles"
 msgid "Update available"
 msgstr "A actualización fallou:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Canle de actualización"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Versión actual"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Comprobar actualizacións"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Realizar actualización"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "De verdade queres reiniciar?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Cargando..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "Vale"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3534,8 +3544,8 @@ msgstr "Vale"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3545,11 +3555,11 @@ msgstr "Vale"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "De verdade quere deter?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Actualizando. Por favor, non recargue a páxina"
 
@@ -3602,7 +3612,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Cargando..."
 
@@ -3637,8 +3647,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3710,9 +3720,10 @@ msgstr "Convertir libro"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Pechar"
 
@@ -3739,7 +3750,7 @@ msgid "Imported as"
 msgstr "A actualización fallou:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Autor"
 
@@ -3757,13 +3768,13 @@ msgstr "Data de publicación"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Editor"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Lingua"
@@ -3974,7 +3985,7 @@ msgstr "Introduce título"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Título"
@@ -5799,78 +5810,122 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Axustes OAuth"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "sincronizar andeis seleccionados con Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Axustes OAuth"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5878,44 +5933,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Convertir formato de libro:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5923,322 +5978,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Permitir rexistro público"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Axustes OAuth"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Cargar formato"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Permitir rexistro público"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Permitir rexistro público"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Borrar formatos:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Obter metadatos"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Valoración"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6627,7 +6682,7 @@ msgstr "Unir libros seleccionados"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6685,7 +6740,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "O libro borrarase permanentemente da base de datos"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Libros non lidos"
@@ -6796,8 +6851,8 @@ msgstr "Introducir nome de dominio"
 msgid "Denied Domains (Blacklist)"
 msgstr "Dominios prohibidos (Blaclist)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Seguinte"
 
@@ -7084,165 +7139,165 @@ msgstr "Axustes"
 msgid "Refresh Library"
 msgstr "Buscar na librería"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Borrar libro"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Por favor, non actualice a páxina"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Navegar"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Crear un andel"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Acerca de"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Previo"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Detalles do libro"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "De verdade quere deter?"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Cargar formato"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Borrar formatos:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Borrar libro"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Borrar libro"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Non se atoparon resultados"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Escalar ao mellor"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Para:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuración"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Engadir ao andel"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Unir libros seleccionados"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marcar como non lido"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Borrar libro"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Borrar libro"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Crear un andel"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Erro de conexión"
@@ -8052,6 +8107,102 @@ msgstr "{} usuarios borrados con éxito"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Catálogo de libros electrónicos de Calibre-Web"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8356,14 +8507,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/hu/LC_MESSAGES/messages.po
+++ b/cps/translations/hu/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2026-05-12 00:06+0200\n"
 "Last-Translator: Gabor L. <nom@il.thx>\n"
 "Language-Team: \n"
@@ -1975,7 +1975,7 @@ msgstr "Könyvek címke szerint rendezve"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -2014,7 +2014,7 @@ msgstr "Fájlformátumok"
 msgid "Books ordered by file formats"
 msgstr "Könyvek sorozat szerint rendezve"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Polcok"
@@ -2162,6 +2162,11 @@ msgstr "Ismétlődő könyvek"
 #: cps/render_template.py:144
 msgid "Show Duplicate Books"
 msgstr "Ismétlődő könyvek mutatása"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2350,7 +2355,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr "Nem sikerült menteni a sorrendet"
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 msgid "Reorder Shelves"
 msgstr "Polcok átrendezése"
 
@@ -2567,7 +2572,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Hiba polc létrehozásakor"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 msgid "Create Magic Shelf"
 msgstr "Varázspolc létrehozása"
 
@@ -3069,7 +3074,7 @@ msgstr "Hozzáadás polchoz"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3475,40 +3480,45 @@ msgstr "Részletek"
 msgid "Update available"
 msgstr "A frissítés nem sikerült:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Frissítési forrás"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Jelenlegi verzió"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Frissítés keresése"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Frissítés elkezdése"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Valóban újra akarja indítani a Calibre-Web Automatedet?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Betöltés..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3519,8 +3529,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3530,11 +3540,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Valóban le akarja állítani a Calibre-Web Automatedet?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Frissítés folyamatban, ne töltse újra az oldalt"
 
@@ -3588,7 +3598,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Feltöltés..."
 
@@ -3623,8 +3633,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr "Megjegyzés:"
 
@@ -3695,9 +3705,10 @@ msgstr "Könyv konvertálása"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Bezárás"
 
@@ -3724,7 +3735,7 @@ msgid "Imported as"
 msgstr "Fontos:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Szerző"
 
@@ -3742,13 +3753,13 @@ msgstr "Kiadás éve"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Kiadó"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Nyelv"
@@ -3958,7 +3969,7 @@ msgstr "Cím bevitele"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Cím"
@@ -5871,11 +5882,56 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Automatikus biztonsági mentés beállításai"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+#, fuzzy
+msgid "Copy"
+msgstr "UUID másolása"
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "Fordításra felhívó értesítés engedélyezése"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -5884,11 +5940,11 @@ msgstr ""
 "Kikapcsolása esetén nem fog értesítéseket kapni a Web UI-ban ha angoltól "
 "eltérő nyelvet használ, aminek a fordítási állapota nem teljes."
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Kiválasztott varázspolcok szinkronizációja Kobo eszközzel"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -5897,11 +5953,11 @@ msgstr ""
 "eszközödre. Megjegyzés: a Kobo Sync-et is engedélyezned kell az Alap "
 "konfigurációban."
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Homályos háttér engedélyezése mobileszközökön (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5909,15 +5965,15 @@ msgstr ""
 "Engedélyezés esetén a homályos háttér hatás kis kijelzőkön is megjelenik. "
 "Kapcsolja ki amennyiben görgetési vagy animáció szaggatást észlel,"
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 msgid "Automatic Backup Settings"
 msgstr "Automatikus biztonsági mentés beállításai"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -5925,11 +5981,11 @@ msgstr ""
 "Engedélyezés esetén egy másolat készül az importált fájlokról a <i>/config/"
 "processed_books/imported</i> mappába"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -5937,21 +5993,21 @@ msgstr ""
 "Engedélyezés esetén egy másolat készül a beolvasott könyvek eredetijéről "
 "amelyek konvertáláson esnek át a /config/processed_books/converted mappába"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5964,11 +6020,11 @@ msgstr ""
 "tarthatja a /config/processed_books almappáit és csökkentheti a szükséges "
 "tárterületet."
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -5978,32 +6034,32 @@ msgstr ""
 "automatikusan az itt kiválasztott formátumra lesz konvertálva (kivéve az "
 "alább az ignorálási listában megadott formátumokat)."
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 msgid "Choose a target format:"
 msgstr "Válasszon célformátumot:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -6011,21 +6067,21 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "A Calibre importáláskor képes felismerni az azonos könyvcímeket, és ennek "
 "megfelelően a"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "automatikus egyesítés"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -6033,34 +6089,34 @@ msgstr ""
 "beállítástól függően. Beállítható úgy, hogy törölje a duplikált könyvek "
 "egyik példányát, vagy mindkettőt megtartsa (alapértelmezett)."
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Elveti a duplikált importot, a könyvtári példányt megtartja"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr "Felülírja a könyvtári példányt az újonnan importált fájllal"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Duplikált rekordot hoz létre, mindkét példányt megtartja"
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -6068,31 +6124,31 @@ msgstr ""
 "Engedélyezi vagy letiltja a duplikátum-észlelő rendszert. Kikapcsolt "
 "állapotban a duplikátumkeresés nem fut le, és nem jelennek meg értesítések."
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 msgid "Enable Duplicate Detection"
 msgstr "Ismétlődő könyvek felismerésének engedélyezése"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr "Ismétlődő könyvek felismerésének módja"
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Hibrid (SQL előszűrő + Python validáció)"
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr "Csak Python (leglassabb, legstabilabb)"
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr "Régi csak SQL (kísérleti)"
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -6101,11 +6157,11 @@ msgstr ""
 "szűkítésére, majd a végső eredményekhez egy megbízhatóbb Python logikát "
 "alkalmaz."
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 msgid "Automatic Duplicate Scanning"
 msgstr "Automatikus ismétlődő könyv keresés"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -6113,27 +6169,27 @@ msgstr ""
 "Állítsd be a háttérben futó duplikátum-ellenőrzéseket. Ezek automatikusan "
 "futnak, és nem blokkolják a felhasználói felületet."
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr "Automatikus ismétlődő könyv kereső engedélyezése"
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr "Import utáni keresés"
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr "Futás minden import után (várakoztatva)"
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr "Csak kézi"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr "Várakozás importálás után (másodpercben)"
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -6141,15 +6197,15 @@ msgstr ""
 "Ennyi másodpercet vár az utolsó import után, mielőtt elindítaná a háttérben "
 "futó ellenőrzést."
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr "Időzített keresések (cron kifejezés)"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "Hagyja üresen az ütemezett keresés letiltásához. Példa:"
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -6158,15 +6214,15 @@ msgstr ""
 "lefuthatnak. A „csak manuális” opcióval az import utáni ellenőrzések "
 "letilthatók, miközben a cron ütemezések továbbra is aktívak maradnak."
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr "Következő időzített keresés:"
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -6176,35 +6232,35 @@ msgstr ""
 "könyvek duplikátumok-e. A könyveknek az összes kiválasztott feltételnek meg "
 "kell felelniük ahhoz, hogy duplikátumnak számítsanak."
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr "Vegye figyelembe a könyvcímeket a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr "Vegye figyelembe a szerzőket a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr "Vegye figyelembe a könyv nyelvét a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr "Vegye figyelembe a könyvsorozatot a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Vegye figyelembe a kiadót a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 msgid "Format"
 msgstr "Fájlformátum"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr "Vegye figyelembe a fájlformátumot a duplikátumok észlelésekor"
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -6212,11 +6268,11 @@ msgstr ""
 "Legalább egy feltételt ki kell választani. A cím és a szerző használata "
 "ajánlott alapkritériumként."
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr "Ismétlődő könyvek formátum rangsorolás"
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -6227,11 +6283,11 @@ msgstr ""
 "formátumok sorrendje húzással módosítható, a magasabb pozíció nagyobb "
 "prioritást jelent."
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr "Tipp:"
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -6241,11 +6297,11 @@ msgstr ""
 "magasabb prioritású formátumokkal rendelkező könyvek kerülnek megtartásra. "
 "Az alacsonyabb prioritású formátumok törlésre kerülnek."
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Ismétlődő könyv értesítések és automatikus megszüntetés"
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -6253,11 +6309,11 @@ msgstr ""
 "Állítsd be, hogyan kapj értesítést a duplikált könyvekről, és opcionálisan "
 "engedélyezheted az automatikus feloldást is."
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 msgid "Enable Duplicate Notifications"
 msgstr "Ismétlődő könyv értesítések"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -6268,15 +6324,15 @@ msgstr ""
 "felhasználók jelzést (badge-et) látnak a Duplikátumok oldalsáv gombon, "
 "valamint bejelentkezéskor értesítő felugró ablakot kapnak."
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Automatikus ismétlődés megszüntetés engedélyezése"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr "Figyelmeztetés:"
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -6284,77 +6340,77 @@ msgstr ""
 "Ez a funkció automatikusan törli a könyveket az alábbi stratégia alapján. Az "
 "eredeti fájlokról biztonsági mentés készül ide:"
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr "Megszüntetési stratégia"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr "Legújabb megtartása"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 "Törölje a régebbi példányokat, és a legutóbb hozzáadott könyvet tartsa meg"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr "Legrégebbi megtartása"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 "Törölje az újabb példányokat, és a legkorábban hozzáadott könyvet tartsa meg"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge Formats"
 msgstr "Formátumok egyesítése"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "A formátumokat egyesíti a legújabb könyvbe, a többi példányt törli"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr "Legmagasabb minőségű formátum megtartása"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 "A formátumokat a Duplikátum Formátum Prioritási sorrended alapján részesíti "
 "előnyben"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep Most Metadata"
 msgstr "Legtöbb metaadat megőrzése"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr "Legtöbb információval rendelkező megtartása"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr "Legnagyobb méretű megtartása"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr "Legnagyobb méretű fájllal rendelkező könyv megtartása"
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Válaszd ki, melyik könyv maradjon meg a duplikátumok automatikus "
 "feloldásakor."
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 msgid "Rate Limiting"
 msgstr "Korlátozás"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr "Várakozási idő (percben)"
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -6362,7 +6418,7 @@ msgstr ""
 "Minimális idő az automatikus feloldások között (0 = kikapcsolva). "
 "Megakadályozza a gyors, egymás utáni törléseket tömeges importálások során."
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6755,7 +6811,7 @@ msgstr "Kijelöltek egyesítése"
 msgid "Dismiss this duplicate group"
 msgstr "Ismétlődő könyvcsoport elutasítása"
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr "Elrejtés"
 
@@ -6813,7 +6869,7 @@ msgstr "A művelet nem visszavonható!"
 msgid "The following books will be permanently deleted:"
 msgstr "A következő könyvek véglegesen törölve lesznek:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 msgid "Merge Books"
 msgstr "Könyvek egyesítése"
 
@@ -6918,8 +6974,8 @@ msgstr "Tartomány megadása"
 msgid "Denied Domains (Blacklist)"
 msgstr "Elutasított domainek (tiltólista)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Következő"
 
@@ -7202,150 +7258,150 @@ msgstr "Beállítások"
 msgid "Refresh Library"
 msgstr "Könyvtár frissítése"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "Változásnapló megtekintése"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Ismétlődő könyvek"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "Segíts te is!"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Kérjük ne frissítse az oldalt!"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Böngészés"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 msgid "Create Shelf"
 msgstr "Polc készítése"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr "Varázspolcok ✨"
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Névjegy"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Előző"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Könyv részletei"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "A művelet nem visszavonható!"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Kiválasztottak törlése"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Fájlformátum"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Formátumok törlése:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:644
+#: cps/templates/layout.html:650
 msgid "Duplicate Books Detected"
 msgstr "Ismétlődő könyvek találva"
 
-#: cps/templates/layout.html:645
+#: cps/templates/layout.html:651
 msgid "You have unresolved duplicate books in your library"
 msgstr "A könyvtáradban feloldatlan duplikált könyvek vannak."
 
-#: cps/templates/layout.html:650
+#: cps/templates/layout.html:656
 msgid "Duplicate Groups Found"
 msgstr "Ismétlődő csoport találva"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr "Emlékeztess később"
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr "Ismétlődések megtekintése és megszüntetése"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Méretezés a legjobbra"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Tipp"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfiguráció"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Hozzáadás polchoz"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Olvasottnak jelölve"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Olvasatlannak jelölve"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Könyv törlése"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Könyv törlése"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7354,12 +7410,12 @@ msgstr ""
 "Ez véglegesen törli a könyveket. Az eredeti fájlokról biztonsági mentés "
 "készül ide:"
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Először válasszon ki könyvet"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Visszaállítás sikertelen: %(err)s"
@@ -8164,6 +8220,104 @@ msgstr "Beütemezett feladat sikeresen visszavonva"
 msgid "Error cancelling scheduled item"
 msgstr "Hiba ütemezett feladat visszavonása közben"
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web Automated e-könyv katalógus"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+#, fuzzy
+msgid "Portainer:"
+msgstr "Fontos:"
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+#, fuzzy
+msgid "Set up automatic updates"
+msgstr "Automatikus ismétlődő könyv kereső engedélyezése"
+
 #: cps/templates/user_edit.html:173
 msgid "Your Profile"
 msgstr "Profilod"
@@ -8490,15 +8644,6 @@ msgstr ""
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-#, fuzzy
-msgid "Copy"
-msgstr "UUID másolása"
-
 #: cps/templates/user_edit.html:625
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr "pl.: Kobo Forma, KOReader iPad"
@@ -8780,9 +8925,9 @@ msgstr "Olvasott/olvasatlan mutatása"
 #~ "        <a href=\"https://github.com/crocodilestick/Calibre-Web-Automated/"
 #~ "wiki/Configuration#database-configuration\">see here</a>!"
 #~ msgstr ""
-#~ "A CWA úgy van konfigurálva, hogy a Calibre adatbázisa (a <code>metadata."
-#~ "db</code> fájl) mindig a <code>/calibre-library</code> könyvtáron belül "
-#~ "helyezkedjen el. \n"
+#~ "A CWA úgy van konfigurálva, hogy a Calibre adatbázisa (a "
+#~ "<code>metadata.db</code> fájl) mindig a <code>/calibre-library</code> "
+#~ "könyvtáron belül helyezkedjen el. \n"
 #~ "Induláskor a CWA automatikusan átvizsgálja azt a könyvtárat, amelyet a "
 #~ "docker-compose fájlban a <code>/calibre-library</code> útvonalhoz "
 #~ "rendelt, és meglévő Calibre \n"

--- a/cps/translations/id/LC_MESSAGES/messages.po
+++ b/cps/translations/id/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2023-01-21 10:00+0700\n"
 "Last-Translator: Arief Hidayat<arihid95@gmail.com>\n"
 "Language-Team: Arief Hidayat <arihid95@gmail.com>\n"
@@ -1940,7 +1940,7 @@ msgstr "Buku yang diurutkan menurut Kategori"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1976,7 +1976,7 @@ msgstr "Format berkas"
 msgid "Books ordered by file formats"
 msgstr "Buku yang diurutkan menurut format berkas"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Rak"
@@ -2135,6 +2135,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Tampilkan Buku Berperingkat Teratas"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2322,7 +2327,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Kecualikan Rak"
@@ -2542,7 +2547,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Kesalahan menghapus Rak"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Buat Rak"
@@ -3055,7 +3060,7 @@ msgstr "Tambah ke rak"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3470,40 +3475,45 @@ msgstr "Detail"
 msgid "Update available"
 msgstr "Pembaruan gagal:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Saluran Pembaruan"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Versi saat ini"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Periksa Pembaruan"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Lakukan Pembaruan"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Apa Anda yakin untuk memulai ulang?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Memuat..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3514,8 +3524,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3525,11 +3535,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Batal"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Apa Anda yakin untuk mematikan layanan?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Memperbarui, jangan memuat ulang halaman ini"
 
@@ -3582,7 +3592,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Mengunggah..."
 
@@ -3617,8 +3627,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3690,9 +3700,10 @@ msgstr "Konversi buku"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Tutup"
 
@@ -3719,7 +3730,7 @@ msgid "Imported as"
 msgstr "Pembaruan gagal:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Penulis"
 
@@ -3737,13 +3748,13 @@ msgstr "Tanggal Terbit"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Penerbit"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Bahasa"
@@ -3954,7 +3965,7 @@ msgstr "Masukkan Judul"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Judul"
@@ -5768,78 +5779,122 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Pengaturan OAuth"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Sinkronkan Rak yang dipilih dengan Kob"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Pengaturan OAuth"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5847,44 +5902,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "KOnversi format buku:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5892,322 +5947,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Izinkan Registrasi Publik"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Pengaturan OAuth"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Format Unggahan"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Izinkan Registrasi Publik"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Izinkan Registrasi Publik"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Hapus format:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Ambil Metadata"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Rating"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6596,7 +6651,7 @@ msgstr "Gabungkan buku terpiih"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6654,7 +6709,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Buku ini akan dihapus secara permanen dari basis data"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Buku yang Belum Dibaca"
@@ -6765,8 +6820,8 @@ msgstr "Masukkan Nama Domain"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domain yang Ditolak (Daftar Hitam)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Selanjutnya"
 
@@ -7051,165 +7106,165 @@ msgstr "Pengaturan"
 msgid "Refresh Library"
 msgstr "Cari di Pustaka"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Hapus"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Harap jangan segarkan halaman"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Jelajahi"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Buat Rak"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Tentang"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Sebelumnya"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Detail Buku"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Apa Anda yakin untuk mematikan layanan?"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Format Unggahan"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Hapus format:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Hapus"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Hapus"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Tidak ada hasil yang ditemukan"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Skala ke Terbaik"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Hingga:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Pengaturan"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Tambah ke rak"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Gabungkan buku terpiih"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Tandai sebagai Belum dibaca"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Hapus"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Hapus"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Buat Rak"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Kesalahan koneksi"
@@ -8019,6 +8074,102 @@ msgstr "{} pengguna berhasil dihapus"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Katalog eBook Calibre-Web"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8323,14 +8474,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/it/LC_MESSAGES/messages.po
+++ b/cps/translations/it/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2025-11-24 17:12+0100\n"
 "Last-Translator: Massimo Pissarello <mapi68@gmail.com>\n"
 "Language-Team: Italian\n"
@@ -1952,7 +1952,7 @@ msgstr "Libri ordinati per categoria"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1988,7 +1988,7 @@ msgstr "Formati di file"
 msgid "Books ordered by file formats"
 msgstr "Libri ordinati per formato di file"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Scaffali"
@@ -2137,6 +2137,11 @@ msgstr "Duplicati"
 #: cps/render_template.py:144
 msgid "Show Duplicate Books"
 msgstr "Mostra Libri duplicati"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2328,7 +2333,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Escludi scaffali"
@@ -2552,7 +2557,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Errore nell'eliminare lo scaffale"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Crea uno scaffale"
@@ -3057,7 +3062,7 @@ msgstr "Aggiungi allo scaffale"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3465,40 +3470,45 @@ msgstr "Dettagli"
 msgid "Update available"
 msgstr "Aggiornamento non riuscito:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Canale d'aggiornamento"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Versione attuale"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Ricerca aggiornamenti"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Esegui l'aggiornamento"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Sei sicuro di voler riavviare Calibre-Web?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Caricamento in corso..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3509,8 +3519,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3520,11 +3530,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Sei sicuro di voler fermare Calibre-Web?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Aggiornamento in corso, non ricaricare la pagina"
 
@@ -3577,7 +3587,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Caricamento in corso..."
 
@@ -3612,8 +3622,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3684,9 +3694,10 @@ msgstr "Converti libro"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Chiudi"
 
@@ -3713,7 +3724,7 @@ msgid "Imported as"
 msgstr "Aggiornamento non riuscito:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Autore"
 
@@ -3731,13 +3742,13 @@ msgstr "Data di pubblicazione"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Editore"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Lingua"
@@ -3943,7 +3954,7 @@ msgstr "Inserisci titolo"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Titolo"
@@ -5782,11 +5793,55 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Impostazioni backup automatico"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "Abilita le notifiche di contributo alla traduzione"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -5796,22 +5851,22 @@ msgstr ""
 "utilizzi una lingua diversa dall'inglese qualora le traduzioni per la lingua "
 "selezionata non siano complete."
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Sincronizza gli scaffali selezionati con Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Abilita la sfocatura degli sfondi sui dispositivi mobile (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5820,15 +5875,15 @@ msgstr ""
 "applicato anche sugli schermi di piccole dimensioni. Disabilitare in caso si "
 "riscontrino rallentamenti nello scorrimento o nelle animazioni."
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 msgid "Automatic Backup Settings"
 msgstr "Impostazioni backup automatico"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -5836,11 +5891,11 @@ msgstr ""
 "Se attivo, una copia di tutti i file importati verrà salvata in <i>/config/"
 "processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -5848,21 +5903,21 @@ msgstr ""
 "Se attivo, le versioni originali dei file aggiunti e convertiti mediante il "
 "servizio di Ingest verranno salvate in /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5875,11 +5930,11 @@ msgstr ""
 "Ciò aiuta a mantenere le sottocartelle di /config/processed_books "
 "organizzate e a minimizzare l'utilizzo di spazio su disco."
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -5890,32 +5945,32 @@ msgstr ""
 "formato qui selezionato (ad eccezione dei formati selezionati nell'elenco di "
 "esclusione di seguito)"
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 msgid "Choose a target format:"
 msgstr "Scegli il formato di destinazione:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5923,21 +5978,21 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre è in grado di individuare eventuali titoli di libri duplicati "
 "durante l'importazione e, agendo sulle"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "impostazioni"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -5945,305 +6000,305 @@ msgstr ""
 "di merge automatico, può essere impostato per cancellare una delle due "
 "istanze o per conservarle entrambe (impostazione predefinita)."
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Annulla l'importazione del duplicato, conserva la copia della libreria"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr "Sovrascrive la copia della libreria con il file di nuova importazione"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Crea una voce duplicata, mantenendo così entrambe le copie"
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Abilita la registrazione pubblica"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Impostazioni backup automatico"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 #, fuzzy
 msgid "Manual only"
 msgstr "Manuale?"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Formato Finale"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Abilita le notifiche di aggiornamento di CWA"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Abilita la registrazione pubblica"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Formato Originale"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Metadati di prova"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Valutazione"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6633,7 +6688,7 @@ msgstr "Unisci i libri selezionati"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6693,7 +6748,7 @@ msgstr "Questa funzione non può essere annullata!"
 msgid "The following books will be permanently deleted:"
 msgstr "I libri seguenti verranno eliminati in modo permanente:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Libri da leggere"
@@ -6800,8 +6855,8 @@ msgstr "Inserisci nome del dominio"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domini non consentiti (lista nera)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Successivo"
 
@@ -7088,166 +7143,166 @@ msgstr "Impostazioni"
 msgid "Refresh Library"
 msgstr "Aggiorna la libreria"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "Vedi Changelog"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Duplicati"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "Clicca per contribuire!"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Per favore non aggiornare la pagina"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Naviga"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Crea uno scaffale"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Informazioni su"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Precedente"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Dettagli del libro"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Questa funzione non può essere annullata!"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Elimina selezionati"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Formato Finale"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Elimina formati:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Libro duplicato"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Libro duplicato"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nessun libro duplicato trovato"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Seleziona i duplicati"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Adatta al meglio"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "A:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Configurazione"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Aggiungi allo scaffale"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Segna i libri selezionati come letti"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Contrassegna come da leggere"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Elimina libro"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Elimina libro"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Seleziona uno scaffale"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Errore di connessione"
@@ -8043,6 +8098,102 @@ msgstr "I libri duplicati selezionati sono stati eliminati!"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Catalogo eBook Calibre-Web"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8348,14 +8499,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/ja/LC_MESSAGES/messages.po
+++ b/cps/translations/ja/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2018-02-07 02:20-0500\n"
 "Last-Translator: subdiox <subdiox@gmail.com>\n"
 "Language-Team: ja <LL@li.org>\n"
@@ -1955,7 +1955,7 @@ msgstr "カテゴリ順"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1991,7 +1991,7 @@ msgstr "ファイル形式"
 msgid "Books ordered by file formats"
 msgstr "ファイル形式順"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "本棚"
@@ -2140,6 +2140,11 @@ msgstr "重複"
 #: cps/render_template.py:144
 msgid "Show Duplicate Books"
 msgstr "重複する書籍を表示"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2329,7 +2334,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "除外する本棚"
@@ -2561,7 +2566,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "本棚の削除中にエラーが発生しました"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Magic Shelfを作成"
@@ -3069,7 +3074,7 @@ msgstr "本棚に追加"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3476,40 +3481,45 @@ msgstr "詳細"
 msgid "Update available"
 msgstr "アップデート失敗:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "アップデートチャンネル"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "現在のバージョン"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "アップデートを確認"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "アップデートを実行"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "再起動してもよろしいですか？"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "読み込み中..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3520,8 +3530,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3531,11 +3541,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "シャットダウンしてもよろしいですか？"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "アップデート中です。このページをリロードしないでください"
 
@@ -3589,7 +3599,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "アップロード中..."
 
@@ -3624,8 +3634,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr "メモ："
 
@@ -3696,9 +3706,10 @@ msgstr "本を変換"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "閉じる"
 
@@ -3725,7 +3736,7 @@ msgid "Imported as"
 msgstr "重要："
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "著者"
 
@@ -3743,13 +3754,13 @@ msgstr "発売日"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "出版社"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "言語"
@@ -3953,7 +3964,7 @@ msgstr "タイトルを入力"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "タイトル"
@@ -5367,8 +5378,8 @@ msgid ""
 "innocenat\">innocenat</a>."
 msgstr ""
 "このツールは<a href=\"https://github.com/innocenat\">innocenat</a>氏が作成し"
-"た<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-fix.netlify."
-"app</a>ツールから移植されました。"
+"た<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-"
+"fix.netlify.app</a>ツールから移植されました。"
 
 #: cps/templates/cwa_settings.html:181
 msgid "Enable KOReader Sync (NextGen Plugin)"
@@ -5837,11 +5848,56 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "自動バックアップ設定"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+#, fuzzy
+msgid "Copy"
+msgstr "UUIDをコピー"
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "翻訳貢献通知を有効にする"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -5850,12 +5906,12 @@ msgstr ""
 "無効時、英語以外の言語を使用していて翻訳が完了していない場合、Web UIで通知を"
 "受け取らなくなります。"
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Magic ShelvesをKoboと同期"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -5863,11 +5919,11 @@ msgstr ""
 "有効にすると、Magic ShelvesがKoboデバイスにコレクションとして同期されます。注"
 "意：基本設定でKobo同期も有効にする必要があります。"
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "モバイルでぼかし背景を有効にする（&lt;768px）"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5875,15 +5931,15 @@ msgstr ""
 "有効時、ぼかしカバー背景効果が小さな画面でも表示されます。スクロールやアニ"
 "メーションの遅延が発生する場合は無効にしてください。"
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 msgid "Automatic Backup Settings"
 msgstr "自動バックアップ設定"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -5891,11 +5947,11 @@ msgstr ""
 "有効時、インポートされたすべてのファイルのコピーが<i>/config/processed_books/"
 "imported</i>に保存されます"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -5903,21 +5959,21 @@ msgstr ""
 "有効時、変換される取り込みファイルの元ファイルが/config/processed_books/"
 "convertedに保存されます"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5929,11 +5985,11 @@ msgstr ""
 "config/processed_booksのサブディレクトリを整理し、ディスク容量の使用を最小限"
 "に抑えるためです。"
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -5942,32 +5998,32 @@ msgstr ""
 "自動変換機能が有効な場合、すべての取り込まれた書籍がここで選択した形式に自動"
 "的に変換されます（以下の無視リストで選択した形式を除く）"
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 msgid "Choose a target format:"
 msgstr "変換先の形式を選択："
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5975,19 +6031,19 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr "Calibreはインポート時に重複した書籍タイトルを検出でき、"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "automerge"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -5995,34 +6051,34 @@ msgstr ""
 "設定に応じて動作します。重複書籍のいずれかのインスタンスを削除するか、両方を"
 "保持する（デフォルト）よう設定できます。"
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "重複インポートを破棄し、ライブラリのコピーを保持"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr "ライブラリのコピーを新しくインポートしたファイルで上書き"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "重複レコードを作成し、両方のコピーを保持"
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -6030,31 +6086,31 @@ msgstr ""
 "重複検出システムを有効化または無効化します。無効化すると重複スキャンは実行さ"
 "れず、通知も表示されません。"
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 msgid "Enable Duplicate Detection"
 msgstr "重複検出を有効化"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr "重複検出方式"
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "ハイブリッド（SQL事前フィルタ + Python検証）"
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr "Pythonのみ（最も低速、最も堅牢）"
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr "レガシーSQLのみ（実験的）"
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -6062,11 +6118,11 @@ msgstr ""
 "ハイブリッドモードは高速なSQL事前フィルタで候補を絞り込み、最終結果に堅牢な"
 "Pythonロジックを適用します。"
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 msgid "Automatic Duplicate Scanning"
 msgstr "自動重複スキャン"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -6074,27 +6130,27 @@ msgstr ""
 "バックグラウンドの重複スキャンを設定します。UIをブロックせずに自動実行されま"
 "す。"
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr "自動重複スキャンを有効化"
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr "インポート後のスキャン"
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr "各インポート後に実行（デバウンス付き）"
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr "手動のみ"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr "インポート後の待機時間（秒）"
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
@@ -6102,15 +6158,15 @@ msgstr ""
 "最後のインポートから何秒待機してからバックグラウンドスキャンを開始するかを設"
 "定します。"
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr "スケジュールスキャン（cron式）"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "空欄にするとスケジュールスキャンが無効化されます。例："
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -6119,15 +6175,15 @@ msgstr ""
 "ケジュールを残しつつインポート後スキャンを無効化するには「手動のみ」を使用し"
 "てください。"
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr "次回スケジュールスキャン："
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -6136,36 +6192,36 @@ msgstr ""
 "書籍が重複かを判定するメタデータフィールドを設定します。重複と見なされるに"
 "は、選択したすべての基準に一致する必要があります。"
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr "重複検出時に書籍タイトルを考慮"
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr "重複検出時に著者を考慮"
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr "重複検出時に言語を考慮"
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr "重複検出時にシリーズを考慮"
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr "重複検出時に出版社を考慮"
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "アップロード形式"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr "重複検出時にファイル形式を考慮"
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -6173,11 +6229,11 @@ msgstr ""
 "少なくとも1つの基準を選択する必要があります。タイトルと著者を主要な基準として"
 "推奨します。"
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr "重複フォーマットの優先順位"
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -6186,11 +6242,11 @@ msgstr ""
 "\"最高品質フォーマット\"の自動解決戦略を使用する際に優先するファイル形式を設"
 "定します。ドラッグ＆ドロップで優先順位を並び替えてください（上＝優先）。"
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr "TIP："
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -6199,22 +6255,22 @@ msgstr ""
 "\"最高品質フォーマット\"戦略で重複を解決する際、より上位のフォーマットを持つ"
 "書籍が保持されます。優先順位が低いフォーマットは削除されます。"
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "重複の通知と自動解決"
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr "重複書籍に関する通知方法を設定し、必要に応じて自動解決を有効化します。"
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "誰でも登録可能にする"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -6224,16 +6280,16 @@ msgstr ""
 "持つユーザーには重複サイドバーボタンにバッジが表示され、ログイン時に通知ポッ"
 "プアップが表示されます。"
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "誰でも登録可能にする"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr "警告："
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -6241,81 +6297,81 @@ msgstr ""
 "下記の戦略に基づいて書籍を自動削除します。元のファイルは次の場所にバックアッ"
 "プされます："
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr "自動解決戦略"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr "最新を保持"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr "古いコピーを削除し、最近追加された書籍を保持"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr "最古を保持"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr "新しいコピーを削除し、最初に追加されたものを保持"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "削除する形式:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "フォーマットを最新の書籍にマージし、残りを削除"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr "最高品質フォーマットを保持"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr "重複フォーマットの優先順位に基づいてフォーマットを優先"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "メタデータを取得"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr "最も情報が揃っている書籍を保持"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr "最大ファイルサイズを保持"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr "総ファイルサイズが最大の書籍を保持"
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr "重複が自動解決される際に保持する書籍を選択してください。"
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "評価"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr "クールダウン期間（分）"
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 "自動解決間の最小時間（0で無効化）。バッチインポート中の連続削除を防ぎます。"
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6715,7 +6771,7 @@ msgstr "選択した本を統合"
 msgid "Dismiss this duplicate group"
 msgstr "この重複グループを解除"
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr "解除"
 
@@ -6772,7 +6828,7 @@ msgstr "この操作は元に戻せません！"
 msgid "The following books will be permanently deleted:"
 msgstr "以下の書籍は完全に削除されます："
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "未読の本"
@@ -6879,8 +6935,8 @@ msgstr "ドメイン名を入力"
 msgid "Denied Domains (Blacklist)"
 msgstr "拒否するドメイン名 (ブラックリスト)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "次"
 
@@ -7175,153 +7231,153 @@ msgstr "設定"
 msgid "Refresh Library"
 msgstr "ライブラリを更新"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "変更履歴を見る"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "重複"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "ここで貢献！"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "ページを更新しないでください"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "閲覧"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "本棚を作成する"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr "Magic Shelves ✨"
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "このサイトについて"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "前"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "本の詳細"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "この操作は元に戻せません！"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "選択を削除"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "アップロード形式"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "削除する形式:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:644
+#: cps/templates/layout.html:650
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "本を削除"
 
-#: cps/templates/layout.html:645
+#: cps/templates/layout.html:651
 msgid "You have unresolved duplicate books in your library"
 msgstr "ライブラリに未解決の重複書籍があります"
 
-#: cps/templates/layout.html:650
+#: cps/templates/layout.html:656
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "結果が見つかりません"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr "あとで通知"
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr "重複を表示・解決"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "最適なサイズにする"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "TIP"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "設定"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "本棚に追加"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "未読に設定"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "未読に設定"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "本を削除"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "本を削除"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7330,12 +7386,12 @@ msgstr ""
 "これにより書籍が完全に削除されます。元のファイルは次の場所にバックアップされ"
 "ます："
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "本棚を選択"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "復元失敗：%(err)s"
@@ -8146,6 +8202,104 @@ msgstr "スケジュール項目をキャンセルしました"
 msgid "Error cancelling scheduled item"
 msgstr "スケジュール項目のキャンセルエラー"
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web Automated 電子書籍カタログ"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+#, fuzzy
+msgid "Portainer:"
+msgstr "重要："
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+#, fuzzy
+msgid "Set up automatic updates"
+msgstr "自動重複スキャンを有効化"
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8469,15 +8623,6 @@ msgstr ""
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
 msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-#, fuzzy
-msgid "Copy"
-msgstr "UUIDをコピー"
 
 #: cps/templates/user_edit.html:625
 msgid "e.g. Kobo Forma, KOReader iPad"

--- a/cps/translations/km/LC_MESSAGES/messages.po
+++ b/cps/translations/km/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2018-08-27 17:06+0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -1893,7 +1893,7 @@ msgstr ""
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Books ordered by file formats"
 msgstr ""
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 #, fuzzy
 msgid "Shelves"
@@ -2089,6 +2089,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "បង្ហាញសៀវភៅដែលមានការវាយតម្លៃល្អជាងគេ"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2275,7 +2280,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "លើកលែងស៊េរី"
@@ -2488,7 +2493,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "បង្កើតធ្នើ"
@@ -2984,7 +2989,7 @@ msgstr "បន្ថែមទៅធ្នើ"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3402,42 +3407,46 @@ msgstr "ព័ត៌មានលម្អិតរបស់សៀវភៅ"
 msgid "Update available"
 msgstr ""
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+msgid "Update now"
+msgstr ""
+
+#: cps/templates/admin.html:264
 #, fuzzy
 msgid "Current Version"
 msgstr "លេខ version ដែលបានតម្លើង"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "រកមើលបច្ចុប្បន្នភាព"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "ធ្វើបច្ចុប្បន្នភាព"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 #, fuzzy
 msgid "Are you sure you want to restart?"
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "កំពុងដំណើរការ..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "បាទ/ចាស"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3448,8 +3457,8 @@ msgstr "បាទ/ចាស"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3459,12 +3468,12 @@ msgstr "បាទ/ចាស"
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 #, fuzzy
 msgid "Are you sure you want to shutdown?"
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "កំពុងធ្វើបច្ចុប្បន្នភាព សូមកុំបើកទំព័រជាថ្មី"
 
@@ -3517,7 +3526,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "កំពុងអាប់ឡូត..."
 
@@ -3550,8 +3559,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3622,9 +3631,10 @@ msgstr ""
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "បិទ"
 
@@ -3650,7 +3660,7 @@ msgid "Imported as"
 msgstr ""
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "អ្នកនិពន្ធ"
 
@@ -3668,13 +3678,13 @@ msgstr "ថ្ងៃបោះពុម្ភ"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "អ្នកបោះពុម្ភ"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "ភាសា"
@@ -3884,7 +3894,7 @@ msgstr "ឧបករណ៍ Kindle"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "ចំណងជើង"
@@ -5695,77 +5705,121 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "ការកំណត់"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "ការកំណត់"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5773,44 +5827,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "ជ្រើសរើសឈ្មោះអ្នកប្រើប្រាស់"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5818,322 +5872,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "អនុញ្ញាតការចុះឈ្មោះសាធារណៈ"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "ការកំណត់"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "ទម្រង់អាប់ឡូដ"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "អនុញ្ញាតការចុះឈ្មោះសាធារណៈ"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "អនុញ្ញាតការចុះឈ្មោះសាធារណៈ"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "លុបឯកសារទម្រង់៖"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "មើលទិន្នន័យមេតា"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "ការវាយតម្លៃ"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6521,7 +6575,7 @@ msgstr "លុបសៀវភៅ"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6579,7 +6633,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "សៀវភៅនឹងត្រូវលុបចេញពី database របស់ Calibre"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "សៀវភៅដែលមិនទាន់បានអាន"
@@ -6688,8 +6742,8 @@ msgstr "ជ្រើសរើសឈ្មោះអ្នកប្រើប្រ
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "បន្ទាប់"
 
@@ -6971,163 +7025,163 @@ msgstr "ការកំណត់"
 msgid "Refresh Library"
 msgstr "ស៊េរីនានាក្នុងបណ្ណាល័យនេះ"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 #, fuzzy
 msgid "Please do not refresh the page"
 msgstr "កំពុងធ្វើបច្ចុប្បន្នភាព សូមកុំបើកទំព័រជាថ្មី"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "រុករក"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "អំពី"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "មុន"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "ព័ត៌មានលម្អិតរបស់សៀវភៅ"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "តើអ្នកពិតជាចង់លុបធ្នើនេះមែនទេ?"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "ទម្រង់អាប់ឡូដ"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "លុបឯកសារទម្រង់៖"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "លុបសៀវភៅ"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "លុបសៀវភៅ"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "លទ្ធផលសម្រាប់៖"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "បន្ថែមទៅធ្នើ"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, python-brace-format
 msgid "Marked {n} books as read"
 msgstr ""
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr ""
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "លុបសៀវភៅ"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "បង្កើតធ្នើ"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Ebook-converter បានបរាជ័យ៖ %(error)s"
@@ -7943,6 +7997,102 @@ msgstr ""
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "រក្សាទុកការកំណត់រួចផ្ញើអ៊ីមែលសាកល្បង"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8249,14 +8399,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/ko/LC_MESSAGES/messages.po
+++ b/cps/translations/ko/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2025-09-08 00:53+0900\n"
 "Last-Translator: limeade23 <admin@limeade.me>\n"
 "Language-Team: Korean <>\n"
@@ -1887,7 +1887,7 @@ msgstr "카테고리별 정렬"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1923,7 +1923,7 @@ msgstr "파일 형식"
 msgid "Books ordered by file formats"
 msgstr "파일 형식별 정렬"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "서재"
@@ -2072,6 +2072,11 @@ msgstr "중복인 책"
 #: cps/render_template.py:144
 msgid "Show Duplicate Books"
 msgstr "중복인 책 보기"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2261,7 +2266,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "서재 제외"
@@ -2482,7 +2487,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "서재를 삭제하는 중 오류가 발생했습니다."
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "서재 생성"
@@ -2985,7 +2990,7 @@ msgstr "책장에 추가"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3393,40 +3398,45 @@ msgstr "세부 정보"
 msgid "Update available"
 msgstr "업데이트 실패: "
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "업데이트 채널"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "현재 버전"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "업데이트 확인"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "업데이트 실행"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "재시작하시겠습니까?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "불러오는 중"
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "예"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3437,8 +3447,8 @@ msgstr "예"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3448,11 +3458,11 @@ msgstr "예"
 msgid "Cancel"
 msgstr "취소"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "종료하시겠습니까?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "업데이트 중입니다. 이 페이지를 새로고침 하지 마세요."
 
@@ -3505,7 +3515,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "업로드 중"
 
@@ -3540,8 +3550,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3612,9 +3622,10 @@ msgstr "책 변환"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "닫기"
 
@@ -3641,7 +3652,7 @@ msgid "Imported as"
 msgstr "업데이트 실패: "
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "저자"
 
@@ -3659,13 +3670,13 @@ msgstr "발행일"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "출판사"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "언어"
@@ -3869,7 +3880,7 @@ msgstr "제목 입력"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "제목"
@@ -5676,11 +5687,55 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "자동 백업 설정"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "번역 공헌 알림 켜기"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -5689,22 +5744,22 @@ msgstr ""
 "비활성화된 경우, 사용중인 언어가 번역 미완료인 경우 Web UI에서 알림을 받지 않"
 "습니다. (영어 제외)"
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "선택한 서재 Kobo 동기화"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "모바일에서 흐린 배경 활성화 (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5712,15 +5767,15 @@ msgstr ""
 "활성화된 경우, 흐림 효과는 작은 창에서도 나타납니다. 스크롤이나 전환 효과가 "
 "느린 경우 비활성화하십시오."
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 msgid "Automatic Backup Settings"
 msgstr "자동 백업 설정"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -5728,11 +5783,11 @@ msgstr ""
 "활성화된 경우, 모든 불러온 파일의 복사본이 <i>/config/processed_books/"
 "imported</i>에 저장됩니다."
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -5740,21 +5795,21 @@ msgstr ""
 "활성화된 경우, 변환 대상인 원본 파일이 /config/processed_books/converted에 저"
 "장됩니다."
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5766,11 +5821,11 @@ msgstr ""
 "포합합니다. /config/processed_books 이하 경로를 정리하고 저장소 사용량을 최소"
 "화합니다."
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -5779,32 +5834,32 @@ msgstr ""
 "자동 변환이 활성화된 경우, 가져오기 한 모든 책이 지정된 형식으로 변환됩니다. "
 "(예외처리된 이하의 형식 목록 제외)"
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 msgid "Choose a target format:"
 msgstr "목표 책 형식 지정:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5812,19 +5867,19 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr "Calibre는 가져오기 중 중복된 책을 감지합니다. 책 제목과 "
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "자동병합"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -5832,305 +5887,305 @@ msgstr ""
 "설정. 중복된 책 중 한 쪽을 삭제하거나, 모두 유지(기본값) 중 선택할 수 있습니"
 "다."
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "중복으로 가져오기 된 책을 삭제하고, 현재 서재에 있는 파일을 유지합니다"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr "서재에 있는 책을 새로 가져오기한 파일로 덮어씁니다"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "중복된 항목을 모두 저장합니다."
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "공개 등록 사용"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "자동 백업 설정"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 #, fuzzy
 msgid "Manual only"
 msgstr "수동?"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "결과 형식"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "CWA 업데이트 알림 켜기"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "공개 등록 사용"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "원본 형식"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "메타데이터 시험"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "평점"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6518,7 +6573,7 @@ msgstr "선택한 책 병합"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6574,7 +6629,7 @@ msgstr "되돌릴 수 없습니다!"
 msgid "The following books will be permanently deleted:"
 msgstr "다음 책이 영구히 삭제됩니다:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "읽지 않음"
@@ -6681,8 +6736,8 @@ msgstr "도메인 입력"
 msgid "Denied Domains (Blacklist)"
 msgstr "차단 도메인 (블랙리스트)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "다음"
 
@@ -6966,166 +7021,166 @@ msgstr "설정"
 msgid "Refresh Library"
 msgstr "서재 새로고침"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "변경점 확인"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "중복인 책"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "여기에서 기여하세요!"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "페이지를 새로고침하지 마세요."
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "탐색"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "서재 생성"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "서재 정보"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "이전"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "책 상세정보"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "되돌릴 수 없습니다!"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "선택한 책 삭제"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "결과 형식"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "형식 삭제:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "책 복제"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "책 복제"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "중복된 책이 없습니다"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "중복인 책을 선택"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "최적 크기"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "종료:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "설정"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "서재에 추가"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "선택한 책 병합"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "읽지 않음으로 표시"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "책 삭제"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "책 삭제"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "책장 생성"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "연결 오류가 발생했습니다."
@@ -7912,6 +7967,102 @@ msgstr "선택한 중복된 책이 삭제되었습니다!"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web Automated 책 목록"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8219,14 +8370,6 @@ msgstr ""
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
-msgstr ""
-
 #: cps/templates/user_edit.html:625
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
@@ -8523,8 +8666,8 @@ msgstr "읽음/읽지 않음 표시"
 #~ msgstr ""
 #~ "이 경로들은 CWA 내부에서만 사용됩니다. 콜론 왼쪽 경로는 자유롭게 변경가능"
 #~ "하나,\n"
-#~ "        오른쪽 경로는 변경할 이유가 없습니다.<br><br>만약 <code>metadata."
-#~ "db<code> 파일을 나머지 서재와 다른 위치에 두고 싶다면, \n"
+#~ "        오른쪽 경로는 변경할 이유가 없습니다.<br><br>만약 "
+#~ "<code>metadata.db<code> 파일을 나머지 서재와 다른 위치에 두고 싶다면, \n"
 #~ "<b>아래의 ‘책 파일을 서재와 분리하기’ 옵션을 사용하고, 거기에 라이브러리"
 #~ "의 나머지 경로를 입력하십시오.</b>"
 

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -10,10 +10,10 @@ msgstr ""
 "Project-Id-Version: Calibre-Web (GPLV3)\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2026-04-26 13:31+0200\n"
-"Last-Translator: Michiel Cornelissen <michiel.cornelissen+gitbhun at proton."
-"me>\n"
+"Last-Translator: Michiel Cornelissen <michiel.cornelissen+gitbhun at "
+"proton.me>\n"
 "Language-Team: ed.driesen@telenet.be\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -1948,7 +1948,7 @@ msgstr "Boeken gesorteerd op categorie"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1984,7 +1984,7 @@ msgstr "Bestandsformaten"
 msgid "Books ordered by file formats"
 msgstr "Boeken gesorteerd op bestandsformaat"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Boekenplanken"
@@ -2141,6 +2141,11 @@ msgstr "Duplicaten"
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Best beoordeelde boeken tonen"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2333,7 +2338,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Boekenplanken uitsluiten"
@@ -2554,7 +2559,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Fout bij aanmaken boekenplank"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 msgid "Create Magic Shelf"
 msgstr "Magische boekenplank maken"
 
@@ -2666,8 +2671,8 @@ msgstr "Kies e-mailadressen:"
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
-"Het boek is in de wachtrij geplaatst om te worden verstuurd aan "
-"%(eReadermail)s"
+"Het boek is in de wachtrij geplaatst om te worden verstuurd aan %"
+"(eReadermail)s"
 
 #: cps/web.py:2525
 msgid "Please wait one minute to register next user"
@@ -3056,7 +3061,7 @@ msgstr "Toevoegen aan boekenplank"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3472,40 +3477,45 @@ msgstr "Details"
 msgid "Update available"
 msgstr "Update mislukt:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Updatekanaal"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Huidige versie"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Controleren op updates"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Update uitvoeren"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Weet je zeker dat je Calibre-Web wilt herstarten?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Bezig met laden..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "Oké"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3516,8 +3526,8 @@ msgstr "Oké"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3527,11 +3537,11 @@ msgstr "Oké"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Weet je zeker dat je Calibre-Web wilt stoppen?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Bezig met bijwerken, vernieuw de pagina niet"
 
@@ -3584,7 +3594,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Bezig met uploaden..."
 
@@ -3619,8 +3629,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3691,9 +3701,10 @@ msgstr "Boek converteren"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Sluiten"
 
@@ -3720,7 +3731,7 @@ msgid "Imported as"
 msgstr "Update mislukt:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Auteur"
 
@@ -3738,13 +3749,13 @@ msgstr "Publicatiedatum"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Uitgever"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Taal"
@@ -3948,7 +3959,7 @@ msgstr "Geef titel"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Titel"
@@ -5759,33 +5770,77 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "OAuth Instellingen"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "Schakel Bijdragen Vertalingen Meldingen in"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Synchroniseer geselecteerde boekenplanken met Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Schakel Onscherpe Achtergronden in op Mobiel (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5794,16 +5849,16 @@ msgstr ""
 "op kleine schermen. Schakel uit als je scroll- of animatie vertraging "
 "opmerkt."
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth Instellingen"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -5811,11 +5866,11 @@ msgstr ""
 "Wanneer actief, wordt een kopie van alle geïmporteerde bestanden opgeslagen "
 "in <i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -5823,21 +5878,21 @@ msgstr ""
 "Wanneer actief, worden de originelen van opgenomen bestanden die conversie "
 "ondergaan opgeslagen in /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5850,11 +5905,11 @@ msgstr ""
 "processed_books georganiseerd te houden en om schijfruimtegebruik te "
 "minimaliseren."
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -5864,33 +5919,33 @@ msgstr ""
 "automatisch geconverteerd worden naar het hier gekozen formaat (behalve de "
 "formaten geselecteerd in de negeerlijst hieronder)"
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Boekformaat converteren:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5898,20 +5953,20 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre kan Dubbele Boektitels detecteren bij Import en afhankelijk van de"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "autosamenvoegen"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -5919,305 +5974,305 @@ msgstr ""
 "instelling. Deze kan ingesteld worden om een van de instanties van een "
 "gedupliceerd boek te verwijderen of beide te behouden (standaard)."
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Verwijdert dubbele import, behoudt bibliotheekexemplaar"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr "Overschrijft bibliotheekexemplaar met nieuw geïmporteerd bestand"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Creëert een dubbel record, behoudt beide exemplaren"
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Openbare registratie inschakelen"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth Instellingen"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 #, fuzzy
 msgid "Manual only"
 msgstr "Handmatig?"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Uploadformaat"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Schakel CWA Update Meldingen in"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Openbare registratie inschakelen"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Origineel Formaat"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Metagegevens ophalen"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Beoordeling"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6605,7 +6660,7 @@ msgstr "Geselecteerde boeken samenvoegen"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6664,7 +6719,7 @@ msgstr "Deze actie kan niet ongedaan worden gemaakt!"
 msgid "The following books will be permanently deleted:"
 msgstr "Het boek wordt verwijderd uit de Calibre-database"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Ongelezen boeken"
@@ -6771,8 +6826,8 @@ msgstr "Voer domeinnaam in"
 msgid "Denied Domains (Blacklist)"
 msgstr "Geweigerde domeinen voor registratie"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Volgende"
 
@@ -7063,163 +7118,163 @@ msgstr "Instellingen"
 msgid "Refresh Library"
 msgstr "Zoek in bibliotheek"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "Zie Changelog"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Duplicaten"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "Draag hier bij!"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Deze pagina niet vernieuwen"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Verkennen"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Boekenplank maken"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Informatie"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Vorige"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Boekgegevens"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Deze actie kan niet ongedaan worden gemaakt!"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Geselecteerde boeken verwijderen"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Uploadformaat"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Formaten verwijderen:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:644
+#: cps/templates/layout.html:650
 msgid "Duplicate Books Detected"
 msgstr "Duplicaat boek gevonden"
 
-#: cps/templates/layout.html:645
+#: cps/templates/layout.html:651
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:650
+#: cps/templates/layout.html:656
 msgid "Duplicate Groups Found"
 msgstr "Duplicaat groepen gevonden"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr "Bekijken en oplossen Duplicaten"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Optimaal inpassen"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Tot:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Instellingen"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Toevoegen aan boekenplank"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Geselecteerde boeken samenvoegen"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Gemarkeerd als ongelezen"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Boek verwijderen"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Boek verwijderen"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Kies eerst een boek"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Hertel mislukt: %(err)s"
@@ -8015,6 +8070,102 @@ msgstr "Geselecteerde dubbele boeken zijn succesvol verwijderd!"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web - e-boekcatalogus"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 msgid "Your Profile"
 msgstr "Je profiel"
@@ -8320,14 +8471,6 @@ msgstr ""
 msgid "New app password (cleartext)"
 msgstr ""
 
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
-msgstr ""
-
 #: cps/templates/user_edit.html:625
 msgid "e.g. Kobo Forma, KOReader iPad"
 msgstr ""
@@ -8613,10 +8756,11 @@ msgstr "Toon gelezen/niet gelezen selectie"
 #~ msgstr ""
 #~ "Deze paden zijn alleen intern voor CWA, je kunt aan de linkerkant naar "
 #~ "hartenlust wijzigen waar ze aan gekoppeld zijn, maar er is geen reden om "
-#~ "de paden aan de rechterkant te wijzigen.<br><br>Als je je <code>metadata."
-#~ "db</code> bestand op een andere locatie wilt dan de rest van je "
-#~ "bibliotheek, gebruik dan de <b>Scheid Boekbestanden van Bibliotheek Optie "
-#~ "hieronder en voer daar het pad naar de rest van de bibliotheek in</b>"
+#~ "de paden aan de rechterkant te wijzigen.<br><br>Als je je "
+#~ "<code>metadata.db</code> bestand op een andere locatie wilt dan de rest "
+#~ "van je bibliotheek, gebruik dan de <b>Scheid Boekbestanden van "
+#~ "Bibliotheek Optie hieronder en voer daar het pad naar de rest van de "
+#~ "bibliotheek in</b>"
 
 #~ msgid "Enable CWA Auto-Convert"
 #~ msgstr "Schakel CWA Auto-Conversie in"

--- a/cps/translations/no/LC_MESSAGES/messages.po
+++ b/cps/translations/no/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2023-01-06 11:00+0000\n"
 "Last-Translator: Vegard Fladby <vegard.fladby@gmail.com>\n"
 "Language-Team: \n"
@@ -1945,7 +1945,7 @@ msgstr "Bøker per side"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1985,7 +1985,7 @@ msgstr "Filformater"
 msgid "Books ordered by file formats"
 msgstr "Bøker per side"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr ""
@@ -2144,6 +2144,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Vis best rangerte bøker"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2329,7 +2334,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Skriv inn Språk"
@@ -2552,7 +2557,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Feil ved sletting av hylle"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Lag en hylle"
@@ -3063,7 +3068,7 @@ msgstr "Rediger en hylle"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 #, fuzzy
@@ -3482,41 +3487,46 @@ msgstr "Detaljer"
 msgid "Update available"
 msgstr "Oppdatering mislyktes:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Oppdater kanalen"
+
+#: cps/templates/admin.html:264
 #, fuzzy
 msgid "Current Version"
 msgstr "Gjeldende versjon"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Se etter oppdatering"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Utfør oppdatering"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Er du sikker på at du vil starte på nytt?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Laster inn..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3527,8 +3537,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3538,11 +3548,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Er du sikker på at du vil slå av?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Oppdaterer, vennligst ikke last inn denne siden på nytt"
 
@@ -3594,7 +3604,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 #, fuzzy
 msgid "Uploading..."
 msgstr "Laster inn..."
@@ -3630,8 +3640,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3703,9 +3713,10 @@ msgstr "Konverter bok"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Lukk"
 
@@ -3733,7 +3744,7 @@ msgid "Imported as"
 msgstr "Oppdatering mislyktes:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Forfatter"
 
@@ -3751,13 +3762,13 @@ msgstr "Publiseringsdato"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Forlegger"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Språk"
@@ -3967,7 +3978,7 @@ msgstr "Skriv inn tittel"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Tittel"
@@ -5783,77 +5794,121 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Vis forfattervalg"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Vis forfattervalg"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5861,44 +5916,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Konverter bokformat:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5906,322 +5961,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Aktiver offentlig registrering"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Vis forfattervalg"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Last opp format"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Aktiver offentlig registrering"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Aktiver offentlig registrering"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Slett formater:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Hent metadata"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Vurdering"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6614,7 +6669,7 @@ msgstr "Slå sammen valgte bøker"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6671,7 +6726,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Uleste bøker"
@@ -6780,8 +6835,8 @@ msgstr "Skriv inn kommentarer"
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 #, fuzzy
 msgid "Next"
 msgstr "Admin side"
@@ -7070,165 +7125,165 @@ msgstr "Vurderinger"
 msgid "Refresh Library"
 msgstr "I biblioteket"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Slett bok"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 #, fuzzy
 msgid "Please do not refresh the page"
 msgstr "Oppdaterer, vennligst ikke last inn denne siden på nytt"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr ""
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Lag en hylle"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr ""
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr ""
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 #, fuzzy
 msgid "Book Details"
 msgstr "Detaljer"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Er du sikker på at du vil slå av?"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Last opp format"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Slett formater:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Slett bok"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Slett bok"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Merket ble ikke funnet"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfigurasjon"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Rediger en hylle"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Slå sammen valgte bøker"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Slett bok"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Slett bok"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Lag en hylle"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Tilkoblingsfeil"
@@ -8065,6 +8120,102 @@ msgstr "{} brukere ble slettet"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web test e-post"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8370,14 +8521,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/pl/LC_MESSAGES/messages.po
+++ b/cps/translations/pl/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre Web - polski (POT: 2021-06-12 08:52)\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2021-06-12 15:35+0200\n"
 "Last-Translator: Radosław Kierznowski <radek.kierznowski@outlook.com>\n"
 "Language-Team: \n"
@@ -1950,7 +1950,7 @@ msgstr "Książki sortowane według kategorii"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1986,7 +1986,7 @@ msgstr "Formaty plików"
 msgid "Books ordered by file formats"
 msgstr "Ksiązki sortowane według formatu"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Półki"
@@ -2135,6 +2135,11 @@ msgstr "Duplikaty"
 #: cps/render_template.py:144
 msgid "Show Duplicate Books"
 msgstr "Pokaż zduplikowane książki"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2322,7 +2327,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Z wyłączeniem półek"
@@ -2545,7 +2550,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Błąd podczas usuwania półki"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Utwórz półkę"
@@ -3057,7 +3062,7 @@ msgstr "Dodaj do półki"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3468,40 +3473,45 @@ msgstr "Szczegóły"
 msgid "Update available"
 msgstr "Aktualizacja nieudana:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Kanał aktualizacji"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Bieżąca wersja"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Sprawdź aktualizacje"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Wykonaj aktualizację"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Na pewno chcesz uruchomić ponownie Calibre Web?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Ładowanie..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3512,8 +3522,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3523,11 +3533,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Na pewno chcesz zatrzymać Calibre Web?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Aktualizowanie, proszę nie odświeżać strony"
 
@@ -3580,7 +3590,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Wysyłanie…"
 
@@ -3615,8 +3625,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3689,9 +3699,10 @@ msgstr "Konwertuj książkę"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Zamknij"
 
@@ -3719,7 +3730,7 @@ msgid "Imported as"
 msgstr "Aktualizacja nieudana:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Autor"
 
@@ -3737,13 +3748,13 @@ msgstr "Data publikacji"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Wydawca"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Język"
@@ -3948,7 +3959,7 @@ msgstr "Wpisz tytuł"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Tytuł"
@@ -5774,11 +5785,55 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Ustawienia automatycznych kopii zapasowych"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "Włącz powiadomienia o tłumaczeniach"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -5788,22 +5843,22 @@ msgstr ""
 "podczas używania języka innego niż angielski, jeśli tłumaczenia dla "
 "wybranego języka nie są kompletne."
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Synchronizuj wybrane półki z Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Włącz rozmyte tła na urządzeniach mobilnych (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5811,15 +5866,15 @@ msgstr ""
 "Gdy aktywne, efekt rozmytego tła okładki jest również renderowany na małych "
 "ekranach. Wyłącz, jeśli zauważysz opóźnienia przewijania lub animacji."
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 msgid "Automatic Backup Settings"
 msgstr "Ustawienia automatycznych kopii zapasowych"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -5827,11 +5882,11 @@ msgstr ""
 "Gdy aktywne, kopia wszystkich zaimportowanych plików będzie przechowywana w "
 "<i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -5839,21 +5894,21 @@ msgstr ""
 "Gdy aktywne, oryginały zaimportowanych plików, które przeszły konwersję, "
 "będą przechowywane w /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5865,11 +5920,11 @@ msgstr ""
 "z danego dnia. Pomaga to utrzymać porządek w podkatalogach /config/"
 "processed_books i minimalizować wykorzystanie miejsca na dysku."
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -5879,32 +5934,32 @@ msgstr ""
 "książki będą automatycznie konwertowane do formatu wybranego tutaj (z "
 "wyjątkiem formatów wybranych na liście ignorowanych poniżej)"
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 msgid "Choose a target format:"
 msgstr "Wybierz format docelowy:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5912,21 +5967,21 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre może wykrywać zduplikowane tytuły książek podczas importu i w "
 "zależności od"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "automatycznego łączenia"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -5934,305 +5989,305 @@ msgstr ""
 "ustawienia. Można ustawić usunięcie jednej z kopii zduplikowanej książki lub "
 "zachowanie obu (domyślnie)."
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Odrzuca zduplikowany import, zachowuje kopię z biblioteki"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr "Nadpisuje kopię z biblioteki nowo zaimportowanym plikiem"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Tworzy zduplikowany rekord, zachowując obie kopie"
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Włącz publiczną rejestrację"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Ustawienia automatycznych kopii zapasowych"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 #, fuzzy
 msgid "Manual only"
 msgstr "Ręcznie?"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Format końcowy"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Włącz powiadomienia o aktualizacjach CWA"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Włącz publiczną rejestrację"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Oryginalny format"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Testuj metadane"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Ocena"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6623,7 +6678,7 @@ msgstr "Łączenie wybranych książek"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6683,7 +6738,7 @@ msgstr "Tej akcji nie można cofnąć!"
 msgid "The following books will be permanently deleted:"
 msgstr "Następujące książki zostaną trwale usunięte:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Nieprzeczytane"
@@ -6790,8 +6845,8 @@ msgstr "Podaj nazwę domeny"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domeny zabronione (czarna lista)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Następne"
 
@@ -7083,167 +7138,167 @@ msgstr "Ustawienia"
 msgid "Refresh Library"
 msgstr "Odśwież bibliotekę"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "Zobacz dziennik zmian"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Duplikaty"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "Wesprzyj tutaj!"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Proszę nie odświeżać strony"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Przeglądaj"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Utwórz półkę"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Informacje"
 
 # ???
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Poprzedni"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Szczegóły książki"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Tej akcji nie można cofnąć!"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Usuń zaznaczone"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Format końcowy"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Usuń formaty:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Zduplikowane książki"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Zduplikowane książki"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nie znaleziono zduplikowanych książek"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Wybierz duplikaty"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Skaluj do najlepszego"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Do:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfiguracja"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Dodaj do półki"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Łączenie wybranych książek"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Oznacz jako nieprzeczytane"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Usuń książkę"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Usuń książkę"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Wybierz półkę"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Błąd połączenia"
@@ -8039,6 +8094,102 @@ msgstr "Wybrane zduplikowane książki zostały pomyślnie usunięte!"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Katalog e-booków Calibre-Web Automated"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8344,14 +8495,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/pt/LC_MESSAGES/messages.po
+++ b/cps/translations/pt/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2023-07-25 11:30+0100\n"
 "Last-Translator: horus68 <https://github.com/horus68>\n"
 "Language-Team: pt-PT <>\n"
@@ -1971,7 +1971,7 @@ msgstr "Livros ordenados por categoria"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -2007,7 +2007,7 @@ msgstr "Formatos de ficheiro"
 msgid "Books ordered by file formats"
 msgstr "Livros ordenados por formatos de ficheiro"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Estantes"
@@ -2166,6 +2166,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Mostrar livros mais bem pontuados"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2352,7 +2357,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Excluir estante"
@@ -2574,7 +2579,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Erro a eliminar a estante"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Criar estante"
@@ -3101,7 +3106,7 @@ msgstr "Adicionar à estante"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3516,40 +3521,45 @@ msgstr "Detalhes"
 msgid "Update available"
 msgstr "Atualização falhou:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Canal de atualização"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Versão atual"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Verificar atualizações"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Aplicar atualizações"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Tem a certeza de que quer reiniciar?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "A carregar..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3560,8 +3570,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3571,11 +3581,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Tem certeza de que quer encerrar?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "A atualizar, por favor, não refresque esta página"
 
@@ -3628,7 +3638,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "A carregar..."
 
@@ -3663,8 +3673,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3735,9 +3745,10 @@ msgstr "Converter livro"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Fechar"
 
@@ -3764,7 +3775,7 @@ msgid "Imported as"
 msgstr "Atualização falhou:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Autor"
 
@@ -3782,13 +3793,13 @@ msgstr "Data de publicação"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Editora"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Idioma"
@@ -4001,7 +4012,7 @@ msgstr "Preencher título"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Título"
@@ -5826,78 +5837,122 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Configurações do OAuth"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Sincronizar com Kobo as estantes selecionadas"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5905,44 +5960,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Converter formato do livro:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5950,322 +6005,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Ativar inscrição pública"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Configurações do OAuth"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Formato de carregamento"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Ativar inscrição pública"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Ativar inscrição pública"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Apagar formatos:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Obter metadados"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Pontuação"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6655,7 +6710,7 @@ msgstr "Fundir livros selecionados"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6713,7 +6768,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Este livro será apagado permanentemente da base de dados"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Livros não lidos"
@@ -6823,8 +6878,8 @@ msgstr "Digite o nome do domínio"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domínios ngados (Lista Negra)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Seguinte"
 
@@ -7115,165 +7170,165 @@ msgstr "Configurações"
 msgid "Refresh Library"
 msgstr "Pesquisar na biblioteca"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Apagar livro"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Por favor, não refresque a página"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Navegar"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Criar estante"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Sobre"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Anterior"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Detalhes do livro"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Tem certeza de que quer encerrar?"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Formato de carregamento"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Apagar formatos:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Apagar livro"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Apagar livro"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nenhum resultado encontrado"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Dimensionar para melhor"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Para:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuração"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Adicionar à estante"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Fundir livros selecionados"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marcar como não Lido"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Apagar livro"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Apagar livro"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Criar estante"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Erro de ligação"
@@ -8083,6 +8138,102 @@ msgstr "{} utilizadores eliminados com sucesso"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Catálogo de ebooks Calibre-Web"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8387,14 +8538,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/cps/translations/pt_BR/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2025-12-02 12:00+0000\n"
 "Last-Translator: Alex <298750+alexantao@users.noreply.github.com>\n"
 "Language-Team: pt_BR <LL@li.org>\n"
@@ -1969,7 +1969,7 @@ msgstr "Livros ordenados por categoria"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -2005,7 +2005,7 @@ msgstr "Formatos de arquivo"
 msgid "Books ordered by file formats"
 msgstr "Livros ordenados por formatos de arquivo"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Estantes"
@@ -2164,6 +2164,11 @@ msgstr "Duplicados"
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Mostrar Livros Duplicados"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2350,7 +2355,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Excluir Estante"
@@ -2572,7 +2577,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Erro apagando Estante"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Crie uma Estante"
@@ -3097,7 +3102,7 @@ msgstr "Adicionar à estante"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3516,40 +3521,45 @@ msgstr "Detalhes"
 msgid "Update available"
 msgstr "Atualização falhou:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Canal de Atualização"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Versão atual"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Verificar Atualizações"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Aplicar Atualizações"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Tem a certeza que quer reiniciar?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Carregando..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3560,8 +3570,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3571,11 +3581,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Tem certeza que quer desligar?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Atualizando, por favor não recarregue esta página"
 
@@ -3628,7 +3638,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Enviando..."
 
@@ -3663,8 +3673,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3736,9 +3746,10 @@ msgstr "Converter livro"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Fechar"
 
@@ -3765,7 +3776,7 @@ msgid "Imported as"
 msgstr "Atualização falhou:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Autor"
 
@@ -3783,13 +3794,13 @@ msgstr "Data de Publicação"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Editora"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Idioma"
@@ -4000,7 +4011,7 @@ msgstr "Digite o Título"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Título"
@@ -5854,11 +5865,55 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Backup Automático das Configuração"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "Habilitar Notificação de Contribuição de Tradução"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -5868,22 +5923,22 @@ msgstr ""
 "quando estiver usando uma língua diferente do Inglês se a tradução para a "
 "língua escolhida não estiver completa."
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Sincronizar Estantes Selecionadas com Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Habilitar Fundos Borrados no Celular (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5891,16 +5946,16 @@ msgstr ""
 "Quando ativo, o efeito de fundo borrado será renderizado em telas pequenas. "
 "Desabilite se você notar demora na animação ou rolagem de tela."
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Backup Automático das Configuração"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -5908,11 +5963,11 @@ msgstr ""
 "Quando habilitado, uma cópia de todos os arquivos importados serão gravados "
 "em <i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -5920,21 +5975,21 @@ msgstr ""
 "Quando habilitado, os arquivos importados originais que passarem por "
 "conversão serão gravados em /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5947,11 +6002,11 @@ msgstr ""
 "subdiretórios em /config/processed_books organizados e para minimizar espaço "
 "em disco."
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -5961,33 +6016,33 @@ msgstr ""
 "convertidos para o formato escolhido aqui (exceto aqueles formatos "
 "selecionados na lista ignorar abaixo)"
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Escolha o Formato alvo:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5995,21 +6050,21 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre pode detectar Títulos de Livros Duplicados na Importação e "
 "dependendo de "
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "automesclar"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -6017,305 +6072,305 @@ msgstr ""
 "configuração. Pode ser configurada para apagar ambas instâncias ou de um "
 "livro duplicado ou deixar todas (padrão)."
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Descartar duplicata na importação, deixar cópia da biblioteca"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr "Sobreescreve cópia da biblioteca com a nova versão sendo importada"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Cria uma duplicata, deixando as duas cópias"
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Habilitar Registro Público"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Backup Automático das Configuração"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 #, fuzzy
 msgid "Manual only"
 msgstr "Manual?"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Formato Final"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Habilitar Notificações de Atualização do CWA"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Habilitar Registro Público"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Formato Original"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Testar Metadados"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Avaliação"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6710,7 +6765,7 @@ msgstr "Mesclar livros selecionados"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6770,7 +6825,7 @@ msgstr "Esta ação não pode ser desfeita!"
 msgid "The following books will be permanently deleted:"
 msgstr "Este livro será apagado permanentemente do banco de dados"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Livros Não Lidos"
@@ -6881,8 +6936,8 @@ msgstr "Digite o nome do domínio"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domínios Negados (Lista Negra)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Próximo"
 
@@ -7174,166 +7229,166 @@ msgstr "Configurações"
 msgid "Refresh Library"
 msgstr "Atualizar Biblioteca"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "Veja Log de Mudanças"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Duplicados"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "Contribuir aqui!"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Por favor, não atualize a página"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Navegue em"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Crie uma Estante"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Sobre"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Anterior"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Detalhes do Livro"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Esta ação não pode ser desfeita!"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Apagar livros selecionados"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Formato Final"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Apagar formatos:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Duplicar Livro"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Duplicar Livro"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nenhum Livro Duplicado encontrado"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Selecionar Duplicatas"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Dimensionar para Melhor"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Para:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Configuração"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Adicionar à estante"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Marcar livros selecionados como lidos"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Marcar como Não Lido"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Apagar Livro"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Apagar Livro"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Crie uma Estante"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Erro de conexão"
@@ -8145,6 +8200,102 @@ msgstr "Livros duplicados selecionados foram apagados com Sucesso!"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Catálogo de e-books Calibre-Web Automated"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8450,14 +8601,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/ru/LC_MESSAGES/messages.po
+++ b/cps/translations/ru/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2020-04-29 01:20+0400\n"
 "Last-Translator: ZIZA\n"
 "Language-Team: \n"
@@ -1993,7 +1993,7 @@ msgstr "Книги, упорядоченные по категории"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -2029,7 +2029,7 @@ msgstr "Форматы файлов"
 msgid "Books ordered by file formats"
 msgstr "Книги, упорядоченные по форматам файлов"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Полки"
@@ -2188,6 +2188,11 @@ msgstr "Дубликаты"
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Показать книги с наивысшим рейтингом"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Исключить полки"
@@ -2598,7 +2603,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Ошибка удаления полки"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Создать полку"
@@ -3122,7 +3127,7 @@ msgstr "Добавить на полку"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3543,40 +3548,45 @@ msgstr "Подробности"
 msgid "Update available"
 msgstr "Ошибка обновления:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Канал обновлений"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Текущая версия"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Проверить обновления"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Выполнить обновление"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Вы уверены, что хотите перезапустить?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Загрузка..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3587,8 +3597,8 @@ msgstr "OK"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3598,11 +3608,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Вы уверены, что хотите выключить?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Обновление, пожалуйста, не перезагружайте эту страницу"
 
@@ -3655,7 +3665,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Загрузка..."
 
@@ -3690,8 +3700,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3763,9 +3773,10 @@ msgstr "Конвертировать книгу"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Закрыть"
 
@@ -3792,7 +3803,7 @@ msgid "Imported as"
 msgstr "Ошибка обновления:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Автор"
 
@@ -3810,13 +3821,13 @@ msgstr "Дата публикации"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Издатель"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Язык"
@@ -4027,7 +4038,7 @@ msgstr "Введите название"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Название"
@@ -5888,11 +5899,55 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Настройки OAuth"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "Включить уведомления о необходимости помочь с переводами"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -5902,22 +5957,22 @@ msgstr ""
 "интерфейсе при использовании языка, отличного от английского, если переводы "
 "для выбранного языка неполные."
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Синхронизировать выбранные полки с Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Включить размытие фона на мобильных устройствах (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5925,16 +5980,16 @@ msgstr ""
 "Когда функция активна, эффект размытого фона обложки также отображается на "
 "маленьких экранах. Отключите, если заметите задержку прокрутки или анимации."
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Настройки OAuth"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -5942,11 +5997,11 @@ msgstr ""
 "Когда функция активна, копия всех импортированных файлов будет сохраняться в "
 "<i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -5954,21 +6009,21 @@ msgstr ""
 "Когда функция активна, оригиналы импортированных файлов, которые проходят "
 "конвертацию, будут сохраняться в /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5981,11 +6036,11 @@ msgstr ""
 "подкаталогах /config/processed_books и минимизировать использование "
 "дискового пространства."
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -5995,33 +6050,33 @@ msgstr ""
 "будут автоматически конвертированы в выбранный здесь формат (за исключением "
 "форматов, указанных в списке игнорируемых ниже)."
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Конвертировать формат книги:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -6029,21 +6084,21 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 "Calibre может обнаруживать дублирующиеся названия книг при импорте и в "
 "зависимости от"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "автослияние"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -6051,305 +6106,305 @@ msgstr ""
 "настройка. Можно выбрать удаление любой из копий дублированной книги или "
 "сохранение обеих (по умолчанию)."
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Отбрасывает дублирующий импорт, сохраняет копию в библиотеке"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr "Перезаписывает копию в библиотеке новым импортированным файлом"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Создает дубликат записи, сохраняя обе копии"
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Включить публичную регистрацию"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Настройки OAuth"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 #, fuzzy
 msgid "Manual only"
 msgstr "Вручную?"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Конечный формат"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Включить уведомления о обновлениях CWA"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Включить публичную регистрацию"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Исходный формат"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Получить метаданные"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Рейтинг"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6746,7 +6801,7 @@ msgstr "Объединить выбранные книги"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6807,7 +6862,7 @@ msgstr "Это действие нельзя отменить!"
 msgid "The following books will be permanently deleted:"
 msgstr "Следующие книги будут удалены:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Непрочитанные книги"
@@ -6918,8 +6973,8 @@ msgstr "Введите доменное имя"
 msgid "Denied Domains (Blacklist)"
 msgstr "Запрещенные домены (черный список)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Следующая"
 
@@ -7209,166 +7264,166 @@ msgstr "Настройки"
 msgid "Refresh Library"
 msgstr "Обновить библиотеку"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "Смотреть историю изменений"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Дубликаты"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "Внести вклад можно здесь!"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Пожалуйста, не обновляйте страницу"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Просмотр"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Создать полку"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "О программе"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Предыдущий"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Подробнее о книге"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Это действие нельзя отменить!"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Удалить выбранные книги"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Конечный формат"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Удалить форматы:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Удалить книгу"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Удалить книгу"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Результатов не найдено"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "Выбрать дубликаты"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Масштаб по лучшему соответствию"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "До:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Настройки сервера"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Добавить на полку"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Пометить выбранные книги как прочитанные"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Пометить как непрочитанное"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Удалить книгу"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Удалить книгу"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Выберите полку"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Ошибка соединения: %(err)s"
@@ -8195,6 +8250,102 @@ msgstr "Выбранные дубликаты книг успешно удале
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Автоматизированный каталог электронных книг Calibre-Web"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8500,14 +8651,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625
@@ -8828,9 +8971,9 @@ msgstr "Показать раздел прочитанного/непрочит�
 #~ "metadata.db при запуске. Если найдена только одна библиотека, она "
 #~ "монтируется автоматически; если найдено несколько, по умолчанию будет "
 #~ "смонтирована самая большая, а если ни одной нет, будет автоматически "
-#~ "создана и смонтирована новая. Для подробностей, <a href=\"https://github."
-#~ "com/crocodilestick/Calibre-Web-Automated/wiki/Configuration#database-"
-#~ "configuration\">см. здесь</a>!"
+#~ "создана и смонтирована новая. Для подробностей, <a href=\"https://"
+#~ "github.com/crocodilestick/Calibre-Web-Automated/wiki/"
+#~ "Configuration#database-configuration\">см. здесь</a>!"
 
 #~ msgid ""
 #~ "Therefore, when configuring your docker-compose file for CWA, <b>DO NOT "

--- a/cps/translations/sk/LC_MESSAGES/messages.po
+++ b/cps/translations/sk/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2023-11-01 06:12+0100\n"
 "Last-Translator: Branislav Hanáček <brango@brango.sk>\n"
 "Language-Team: \n"
@@ -1933,7 +1933,7 @@ msgstr "Knihy usporiadané podľa kategórie"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1969,7 +1969,7 @@ msgstr "Súborové formáty"
 msgid "Books ordered by file formats"
 msgstr "Knihy usporiadané podľa súborových formátov"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Police"
@@ -2119,6 +2119,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Zobraziť najlepšie hodnotené knihy"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2306,7 +2311,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Vylúčiť police"
@@ -2530,7 +2535,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Chyba pri mazaní police"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Vytvoriť policu"
@@ -3034,7 +3039,7 @@ msgstr "Pridať do police"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3448,40 +3453,45 @@ msgstr "Detaily"
 msgid "Update available"
 msgstr "Aktualizácia zlyhala:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Aktualizovať kanál"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Aktuálna verzia"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Kontrola aktualizácie"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Vykonať aktualizáciu"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Skutočne chcete reštartovať?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Načítava sa..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "V poriadku"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3492,8 +3502,8 @@ msgstr "V poriadku"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3503,11 +3513,11 @@ msgstr "V poriadku"
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Skutočne chcete vypnúťť?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Aktualizuje sa, neskúšajte znovu načítať stránku"
 
@@ -3560,7 +3570,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Nahráva sa..."
 
@@ -3595,8 +3605,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3667,9 +3677,10 @@ msgstr "Previesť knihu"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Zatvoriť"
 
@@ -3696,7 +3707,7 @@ msgid "Imported as"
 msgstr "Aktualizácia zlyhala:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Autor"
 
@@ -3714,13 +3725,13 @@ msgstr "Dátum vydania"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Vydavateľ"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Jazyk"
@@ -3929,7 +3940,7 @@ msgstr "Zadajte názov"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Názov"
@@ -5743,78 +5754,122 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Nastavenia OAuth"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Synchronizovať vybrané police s Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Nastavenia OAuth"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5822,44 +5877,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Previesť knihu s formátom:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5867,322 +5922,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Povoliť verejnú registráciu"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Nastavenia OAuth"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Formát nahrávania"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Povoliť verejnú registráciu"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Povoliť verejnú registráciu"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Zmazať formáty:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Načítať metadáta"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Hodnotenie"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6572,7 +6627,7 @@ msgstr "Zlúčiť vybrané knihy"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6630,7 +6685,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Táto kniha bude navždy vymazaná z databázy"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Neprečítané knihy"
@@ -6737,8 +6792,8 @@ msgstr "Zadajte doménové meno"
 msgid "Denied Domains (Blacklist)"
 msgstr "Zakázané domény (Čierny zoznam)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Ďalší"
 
@@ -7024,165 +7079,165 @@ msgstr "Nastavenia"
 msgid "Refresh Library"
 msgstr "Prehľadávať knižnicu"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Zmazať knihu"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Prosím, neskúšajte znovu načítať stránku"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Prechádzať"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Vytvoriť policu"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "O programe"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Predchádzajúci"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Detailu o knihe"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Skutočne chcete vypnúťť?"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Formát nahrávania"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Zmazať formáty:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Zmazať knihu"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Zmazať knihu"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Nič sa nenašlo"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Zmeniť mierku na najlepšie"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Do:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfigurácia"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Pridať do police"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Zlúčiť vybrané knihy"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Označiť ako neprečítané"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Zmazať knihu"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Zmazať knihu"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Vytvoriť policu"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Chyba spojenia"
@@ -7989,6 +8044,102 @@ msgstr "Zmazaných {} používateľov"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Katalóg e-kníh Calibre-Web"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8293,14 +8444,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/sl/LC_MESSAGES/messages.po
+++ b/cps/translations/sl/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2025-08-11 07:03+0000\n"
 "Last-Translator: Andrej Kralj\n"
 "Language-Team: Slovenian\n"
@@ -1995,7 +1995,7 @@ msgstr "Knjige, razvrščene po kategorijah"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -2031,7 +2031,7 @@ msgstr "Vrste datotek"
 msgid "Books ordered by file formats"
 msgstr "Knjige, razvrščene po vrstah datotek"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Police"
@@ -2181,6 +2181,11 @@ msgstr "Dvojniki"
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Prikaži najbolje ocenjene knjige"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2367,7 +2372,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Izključi police"
@@ -2589,7 +2594,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Napaka pri brisanju police"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Ustvari polico"
@@ -3099,7 +3104,7 @@ msgstr "Dodaj na polico"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3515,40 +3520,45 @@ msgstr "Podrobnosti"
 msgid "Update available"
 msgstr "Posodobitev ni uspela:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Kanal za posodobitve"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Trenutna različica"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Preveri za posodobitev"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Izvedite posodobitev"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Ali ste prepričani, da želite znova zagnati računalnik?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Nalaganje..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "V redu"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3559,8 +3569,8 @@ msgstr "V redu"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3570,11 +3580,11 @@ msgstr "V redu"
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Ste prepričani, da želite izklopiti?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Posodabljanje, prosimo, ne nalagajte te strani znova"
 
@@ -3628,7 +3638,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Nalaganje..."
 
@@ -3663,8 +3673,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr "Opomba:"
 
@@ -3735,9 +3745,10 @@ msgstr "Pretvori knjigo"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Zapri"
 
@@ -3764,7 +3775,7 @@ msgid "Imported as"
 msgstr "Pomembno:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Avtor"
 
@@ -3782,13 +3793,13 @@ msgstr "Datum objave"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Založnik"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Jezik"
@@ -3998,7 +4009,7 @@ msgstr "Vnesi naslov"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Naslov"
@@ -5449,8 +5460,8 @@ msgid ""
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
-"To orodje je bilo prilagojeno po orodju <a href=\"https://kindle-epub-fix."
-"netlify.app/\">kindle-epub-fix.netlify.app</a>, ki ga je izdelal <a "
+"To orodje je bilo prilagojeno po orodju <a href=\"https://kindle-epub-"
+"fix.netlify.app/\">kindle-epub-fix.netlify.app</a>, ki ga je izdelal <a "
 "href=\"https://github.com/innocenat\">innocenat</a>."
 
 #: cps/templates/cwa_settings.html:181
@@ -5921,11 +5932,56 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Nastavitve OAuth"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+#, fuzzy
+msgid "Copy"
+msgstr "Kopiraj UUID"
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "Omogoči obvestila za prispevanje prevodov"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
@@ -5934,12 +5990,12 @@ msgstr ""
 "Ko je onemogočeno, ne boste več prejemali obvestil v spletnem vmesniku, če "
 "uporabljate jezik, ki ni angleščina, in prevodi za ta jezik niso popolni."
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Usklajevanje izbrane police s Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -5947,11 +6003,11 @@ msgstr ""
 "Ko je aktivno, bodo vaše Čarobne police sinhronizirane z vašo napravo Kobo "
 "kot zbirke. Opomba: Omogočiti morate tudi Kobo Sync v Osnovnih nastavitvah."
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "Omogoči zamegljena ozadja na mobilnih napravah (&lt;768px)"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5959,16 +6015,16 @@ msgstr ""
 "Ko je aktivno, se učinek zamegljenega ozadja ovitka izriše tudi na majhnih "
 "zaslonih. Onemogočite, če opazite upočasnitev pri pomikanju ali animacijah."
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Nastavitve OAuth"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
@@ -5976,11 +6032,11 @@ msgstr ""
 "Ko je aktivno, bo kopija vseh uvoženih datotek shranjena v <i>/config/"
 "processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -5988,21 +6044,21 @@ msgstr ""
 "Ko je aktivno, bodo originali uvoženih datotek, ki so bile pretvorjene, "
 "shranjeni v /config/processed_books/converted"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -6014,11 +6070,11 @@ msgstr ""
 "spodletelih datotek tistega dne. To pomaga ohranjati red v podimenikih /"
 "config/processed_books in zmanjšuje porabo prostora na disku."
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -6028,33 +6084,33 @@ msgstr ""
 "samodejno pretvorjene v tukaj izbran format (razen formatov na spodnjem "
 "seznamu prezrtih)"
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Pretvori vrsto knjige:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -6062,19 +6118,19 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr "Calibre lahko ob uvozu zazna podvojene naslove knjig in glede na"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "samodejno združevanje"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
@@ -6082,34 +6138,34 @@ msgstr ""
 "nastavitev. Nastavi se lahko tako, da izbriše eno od obeh različic podvojene "
 "knjige ali pa ohrani obe (privzeto)."
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "Zavrže podvojen uvoz, ohrani kopijo v knjižnici"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr "Prepiše kopijo v knjižnici z novo uvoženo datoteko"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "Ustvari podvojen zapis in ohrani obe kopiji"
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
@@ -6117,32 +6173,32 @@ msgstr ""
 "Omogočite ali onemogočite sistem za zaznavanje dvojnikov. Ko je onemogočeno, "
 "se iskanje dvojnikov ne bo izvajalo in obvestila ne bodo prikazana."
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Omogočanje javne registracije"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr "Metoda zaznavanja dvojnikov"
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "Hibridno (SQL predfilter + Python validacija)"
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr "Samo Python (najpočasneje, najzanesljivejše)"
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr "Samo zastarel SQL (eksperimentalno)"
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -6150,12 +6206,12 @@ msgstr ""
 "Hibridni način uporablja hiter SQL predfilter za zožitev kandidatov, nato pa "
 "uporabi zanesljivo Python logiko za končne rezultate."
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Nastavitve OAuth"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
@@ -6163,42 +6219,42 @@ msgstr ""
 "Nastavite iskanje dvojnikov v ozadju. Ta se izvajajo samodejno brez "
 "blokiranja uporabniškega vmesnika."
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr "Omogoči samodejno iskanje dvojnikov"
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr "Iskanje po uvozu"
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr "Zaženi po vsakem uvozu (z omejitvijo pogostosti)"
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 #, fuzzy
 msgid "Manual only"
 msgstr "Ročno?"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr "Čas čakanja po uvozu (sekunde)"
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr "Počakaj toliko sekund po zadnjem uvozu pred začetkom iskanja v ozadju."
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr "Načrtovana iskanja (cron izraz)"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "Pustite prazno za onemogočanje načrtovanih iskanj. Primer:"
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -6207,15 +6263,15 @@ msgstr ""
 "iskanje (cron). Uporabite „Samo ročno“, da onemogočite iskanja po uvozu, a "
 "ohranite urnike cron."
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr "Naslednje načrtovano iskanje:"
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -6224,36 +6280,36 @@ msgstr ""
 "Nastavite, katera polja metapodatkov se uporabijo za določanje dvojnikov. "
 "Knjige se morajo ujemati v VSEH izbranih kriterijih, da štejejo za dvojnike."
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr "Upoštevaj naslove knjig pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr "Upoštevaj avtorje knjig pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr "Upoštevaj jezik knjig pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr "Upoštevaj zbirke (serije) knjig pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr "Upoštevaj založnika knjig pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Nalaganje vrsta"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr "Upoštevaj format datoteke pri zaznavanju dvojnikov"
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
@@ -6261,11 +6317,11 @@ msgstr ""
 "Izbran mora biti vsaj en kriterij. Kot osnovna kriterija sta priporočena "
 "naslov in avtor."
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr "Vrstni red prioritete formatov dvojnikov"
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -6275,11 +6331,11 @@ msgstr ""
 "razrešitve „Format najvišje kakovosti“. Povlecite in spustite za razvrščanje "
 "formatov po prioriteti (višje = bolje)."
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr "Nasvet:"
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -6289,11 +6345,11 @@ msgstr ""
 "knjige z višje uvrščenimi formati ohranjene, tiste z nižjo prioriteto pa "
 "izbrisane."
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "Obvestila o dvojnikih in samodejna razrešitev"
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
@@ -6301,12 +6357,12 @@ msgstr ""
 "Nastavite način obveščanja o podvojenih knjigah in po želji omogočite "
 "samodejno razreševanje."
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Omogočanje javne registracije"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -6316,16 +6372,16 @@ msgstr ""
 "uporabniki s pravico urejanja bodo ob prijavi videli značko na gumbu "
 "Dvojniki v stranski vrstici in pojavno obvestilo."
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Omogočanje javne registracije"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr "Opozorilo:"
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
@@ -6333,77 +6389,77 @@ msgstr ""
 "To bo samodejno izbrisalo knjige na podlagi spodnje strategije. Izvirne "
 "datoteke bodo varnostno kopirane v"
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr "Strategija samodejne razrešitve"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr "Ohrani najnovejšo"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr "Izbriši starejše kopije, ohrani nazadnje dodano knjigo"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr "Ohrani najstarejšo"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr "Izbriši novejše kopije, ohrani prvo dodano"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Izvirna oblika"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "Združi formate v najnovejšo knjigo, ostale izbriši"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr "Ohrani format najvišje kakovosti"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 "Prednost daj formatom na podlagi vašega vrstnega reda prioritete formatov"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Pridobivanje metapodatkov"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr "Ohrani knjigo z najbolj popolnimi informacijami"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr "Ohrani največjo datoteko"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr "Ohrani knjigo z največjo skupno velikostjo datotek"
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 "Izberite, katero knjigo želite obdržati pri samodejnem razreševanju "
 "dvojnikov."
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Ocena"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr "Obdobje mirovanja (minute)"
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
@@ -6411,7 +6467,7 @@ msgstr ""
 "Najkrajši čas med samodejnimi razrešitvami (0 za onemogočanje). Preprečuje "
 "zaporedne izbrise med množičnim uvozom."
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6815,7 +6871,7 @@ msgstr "Združevanje izbranih knjig"
 msgid "Dismiss this duplicate group"
 msgstr "Opusti to skupino dvojnikov"
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr "Opusti"
 
@@ -6877,7 +6933,7 @@ msgstr "Tega dejanja ni mogoče razveljaviti!"
 msgid "The following books will be permanently deleted:"
 msgstr "Naslednje knjige bodo izbrisane:"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Neprebrane knjige"
@@ -6984,8 +7040,8 @@ msgstr "Vnesi ime domene"
 msgid "Denied Domains (Blacklist)"
 msgstr "Zavrnjene domene (črni seznam)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Naslednji"
 
@@ -7282,152 +7338,152 @@ msgstr "Nastavitve"
 msgid "Refresh Library"
 msgstr "Iskanje po knjižnici"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "Poglej dnevnik sprememb"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Dvojniki"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "Prispevajte tukaj!"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Ne osvežuj strani"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Brskaj"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Ustvari polico"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr "Čarobne police ✨"
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "O programu"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Prejšnji"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Podrobnosti o knjigi"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Tega dejanja ni mogoče razveljaviti!"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Nalaganje vrsta"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Brisanje vrste:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:644
+#: cps/templates/layout.html:650
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "Izbriši knjigo"
 
-#: cps/templates/layout.html:645
+#: cps/templates/layout.html:651
 msgid "You have unresolved duplicate books in your library"
 msgstr "V vaši knjižnici so nerazrešeni dvojniki knjig"
 
-#: cps/templates/layout.html:650
+#: cps/templates/layout.html:656
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Ni bilo najdenih rezultatov"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr "Opomni me pozneje"
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr "Ogled in razreševanje dvojnikov"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Povečaj na najboljše"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Nasvet"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Dodaj na polico"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Združevanje izbranih knjig"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Označi kot neprebrano"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Izbriši knjigo"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Izbriši knjigo"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, fuzzy, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
@@ -7435,12 +7491,12 @@ msgid ""
 msgstr ""
 "To bo trajno izbrisalo knjige. Izvirne datoteke bodo varnostno kopirane v"
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Ustvari polico"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Napaka povezave"
@@ -8253,6 +8309,104 @@ msgstr "{} uporabnikov uspešno izbrisanih"
 msgid "Error cancelling scheduled item"
 msgstr "Napaka pri preklicu načrtovanega elementa"
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Katalog e-knjig Calibre-Web"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+#, fuzzy
+msgid "Portainer:"
+msgstr "Pomembno:"
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+#, fuzzy
+msgid "Set up automatic updates"
+msgstr "Omogoči samodejno iskanje dvojnikov"
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8574,15 +8728,6 @@ msgstr ""
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
 msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-#, fuzzy
-msgid "Copy"
-msgstr "Kopiraj UUID"
 
 #: cps/templates/user_edit.html:625
 msgid "e.g. Kobo Forma, KOReader iPad"

--- a/cps/translations/sv/LC_MESSAGES/messages.po
+++ b/cps/translations/sv/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2021-05-13 11:00+0000\n"
 "Last-Translator: Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>\n"
 "Language-Team: \n"
@@ -1936,7 +1936,7 @@ msgstr "Böcker ordnade efter kategori"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1972,7 +1972,7 @@ msgstr "Filformat"
 msgid "Books ordered by file formats"
 msgstr "Böcker ordnade av filformat"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Hyllor"
@@ -2131,6 +2131,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Visa böcker med bästa betyg"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2320,7 +2325,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Uteslut hyllor"
@@ -2543,7 +2548,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Fel vid hämtning av omslaget"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Skapa en hylla"
@@ -3054,7 +3059,7 @@ msgstr "Lägg till hyllan"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3471,40 +3476,45 @@ msgstr "Detaljer"
 msgid "Update available"
 msgstr "Uppdateringen misslyckades:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Uppdatera kanal"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Aktuell version"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Sök efter uppdatering"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Utför uppdatering"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Är du säker på att du vill starta om Calibre-Web?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Läser in..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3515,8 +3525,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3526,11 +3536,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Är du säker på att du vill stoppa Calibre-Web?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Uppdaterar, vänligen uppdatera inte sidan"
 
@@ -3583,7 +3593,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Laddar upp..."
 
@@ -3618,8 +3628,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3691,9 +3701,10 @@ msgstr "Konvertera boken"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Stäng"
 
@@ -3720,7 +3731,7 @@ msgid "Imported as"
 msgstr "Uppdateringen misslyckades:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Författare"
 
@@ -3738,13 +3749,13 @@ msgstr "Publiceringsdatum"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Förlag"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Språk"
@@ -3955,7 +3966,7 @@ msgstr "Ange titel"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Titel"
@@ -5770,77 +5781,121 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "OAuth-inställningar"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth-inställningar"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5848,44 +5903,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Konvertera bokformat:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5893,322 +5948,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Aktivera offentlig registrering"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth-inställningar"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Ladda upp format"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Aktivera offentlig registrering"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Aktivera offentlig registrering"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Ta bort format:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Hämta metadata"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Betyg"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6597,7 +6652,7 @@ msgstr "Slå ihop utvalda böcker"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6655,7 +6710,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Boken kommer att tas bort från Calibre-databasen"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Olästa böcker"
@@ -6766,8 +6821,8 @@ msgstr "Ange domännamn"
 msgid "Denied Domains (Blacklist)"
 msgstr "Avvisade domäner för registrering"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Nästa"
 
@@ -7055,164 +7110,164 @@ msgstr "Inställningar"
 msgid "Refresh Library"
 msgstr "Sök i bibliotek"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Ta bort boken"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Vänligen uppdatera inte sidan"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Bläddra"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Skapa en hylla"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Om"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Föregående"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Bokdetaljer"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Är du säker på att du vill stoppa Calibre-Web?"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Ladda upp format"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Ta bort format:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Ta bort boken"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Ta bort boken"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Inga resultat hittades"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "Skala till bäst"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Konfiguration"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Lägg till hyllan"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Slå ihop utvalda böcker"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Markera som oläst"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Ta bort boken"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Ta bort boken"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Skapa en hylla"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Anslutningsfel"
@@ -8023,6 +8078,102 @@ msgstr "{} användare har tagits bort"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web e-bokkatalog"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8325,14 +8476,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/tr/LC_MESSAGES/messages.po
+++ b/cps/translations/tr/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2020-04-23 22:47+0300\n"
 "Last-Translator: iz <iz7iz7iz@protonmail.ch>\n"
 "Language-Team: \n"
@@ -1906,7 +1906,7 @@ msgstr "Kategoriye göre sıralanmış eKitaplar"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1943,7 +1943,7 @@ msgstr "Biçimler"
 msgid "Books ordered by file formats"
 msgstr "Biçime göre sıralanmış eKitaplar"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 #, fuzzy
 msgid "Shelves"
@@ -2104,6 +2104,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "eKitabı Sil"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2294,7 +2299,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Serileri Hariç Tut"
@@ -2512,7 +2517,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Kitaplık oluştur"
@@ -3016,7 +3021,7 @@ msgstr "Kitaplığa ekle"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3445,41 +3450,46 @@ msgstr "Detaylar"
 msgid "Update available"
 msgstr "Güncelleme başarısız:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Güncelleme başarısız:"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Geçerli sürüm"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 #, fuzzy
 msgid "Check for Update"
 msgstr "Güncelle"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Güncelle"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr ""
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Yükleniyor..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr ""
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3490,8 +3500,8 @@ msgstr ""
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3501,11 +3511,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr ""
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 #, fuzzy
 msgid "Updating, please do not reload this page"
 msgstr ""
@@ -3560,7 +3570,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Yükleniyor..."
 
@@ -3595,8 +3605,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3668,9 +3678,10 @@ msgstr "eKitabı dönüştür"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Kapak"
 
@@ -3698,7 +3709,7 @@ msgid "Imported as"
 msgstr "Güncelleme başarısız:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Yazar"
 
@@ -3718,13 +3729,13 @@ msgstr "Yayınlanma (sonra)"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Yayınevi"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Dil"
@@ -3933,7 +3944,7 @@ msgstr "Deneme e-Postası"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Başlık"
@@ -5749,77 +5760,121 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "OAuth Ayarları"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth Ayarları"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5827,44 +5882,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Biçime dönüştür:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5872,319 +5927,319 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 msgid "Enable Duplicate Detection"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth Ayarları"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Yükleme"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 msgid "Enable Duplicate Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 msgid "Enable Automatic Duplicate Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Biçimleri Sil:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "metaveri düzenle"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Değerlendirme"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6574,7 +6629,7 @@ msgstr "eKitabı Sil"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6631,7 +6686,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Okunmamışlar"
@@ -6742,8 +6797,8 @@ msgstr "Servis adı girin"
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Sonraki"
 
@@ -7024,163 +7079,163 @@ msgstr "Ayarlar"
 msgid "Refresh Library"
 msgstr "Bu kitaplıktaki Seriler"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr ""
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Gözat"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Hakkında"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Önceki"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "eKitap Detayları"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 msgid "This cannot be undone."
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Yükleme"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Biçimleri Sil:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "eKitabı Sil"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "eKitabı Sil"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Sonuçlar:"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "En İyiye Ölçeklendir"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Ayarlar"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Kitaplığa ekle"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Okunmadı olarak işaretle"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Okunmadı olarak işaretle"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "eKitabı Sil"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Kitaplık oluştur"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Bağlantı hatası"
@@ -7995,6 +8050,102 @@ msgstr ""
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web deneme e-Postası"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8299,14 +8450,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/uk/LC_MESSAGES/messages.po
+++ b/cps/translations/uk/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2017-04-30 00:47+0300\n"
 "Last-Translator: ABIS Team <biblio.if.abis@gmail.com>\n"
 "Language-Team: \n"
@@ -1899,7 +1899,7 @@ msgstr "Книги відсортовані за категоріями"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1938,7 +1938,7 @@ msgstr "Формати файлів"
 msgid "Books ordered by file formats"
 msgstr "Книги відсортовані за серією"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 #, fuzzy
 msgid "Shelves"
@@ -2099,6 +2099,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Показувати книги з найвищим рейтингом"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2286,7 +2291,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Виключити серії"
@@ -2501,7 +2506,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "створити книжкову полицю"
@@ -3000,7 +3005,7 @@ msgstr "Додати на книжкову полицю"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3422,40 +3427,45 @@ msgstr "Деталі"
 msgid "Update available"
 msgstr "Оновлення неуспішне:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Канал оновлення"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Поточна версія"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Перевірка оновлень"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Встановити оновлення"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Впевнені що хочете перезавантажити?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Завантаження..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3466,8 +3476,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3477,12 +3487,12 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 #, fuzzy
 msgid "Are you sure you want to shutdown?"
 msgstr "Впевнені що хочете перезавантажити?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Встановлення оновлень, будь-ласка, не оновлюйте сторінку"
 
@@ -3535,7 +3545,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Завантаження..."
 
@@ -3570,8 +3580,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3643,9 +3653,10 @@ msgstr "Конвертувати книгу"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Закрити"
 
@@ -3672,7 +3683,7 @@ msgid "Imported as"
 msgstr "Оновлення неуспішне:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Автор"
 
@@ -3691,13 +3702,13 @@ msgstr "Опубліковано"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Видавець"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Мова"
@@ -3907,7 +3918,7 @@ msgstr "Kindle"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Заголовок"
@@ -5726,77 +5737,121 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Налаштування OAuth"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Налаштування OAuth"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5804,44 +5859,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Конвертувати книгу"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5849,322 +5904,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Дозволити публічну реєстрацію"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Налаштування OAuth"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Формат завантаження"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Дозволити публічну реєстрацію"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Дозволити публічну реєстрацію"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Видалити формати:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Отримати метадані"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Рейтинг"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6551,7 +6606,7 @@ msgstr "Видалити книгу"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6609,7 +6664,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "Книга буде видалена з БД Calibre"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Непрочитані книги"
@@ -6718,8 +6773,8 @@ msgstr "Введіть домен"
 msgid "Denied Domains (Blacklist)"
 msgstr "Заборонені домени (Чорний список)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Далі"
 
@@ -7001,165 +7056,165 @@ msgstr "Налаштування"
 msgid "Refresh Library"
 msgstr "Серій в цій бібліотеці"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 #, fuzzy
 msgid "Please do not refresh the page"
 msgstr "Встановлення оновлень, будь-ласка, не оновлюйте сторінку"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Перегляд"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "створити книжкову полицю"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "Про програму"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Попередній перегляд"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Деталі"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Впевнені що хочете перезавантажити?"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Формат завантаження"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Видалити формати:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Видалити книгу"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Видалити книгу"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Результати для:"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "До:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "Налаштування сервера"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Додати на книжкову полицю"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Відмітити як не прочитане"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Відмітити як не прочитане"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Видалити книгу"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "створити книжкову полицю"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Помилка зʼєднання"
@@ -7984,6 +8039,102 @@ msgstr "{} користувачі видалені успішно"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Зберегти налаштування і відправити тестове повідомлення"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8286,14 +8437,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/vi/LC_MESSAGES/messages.po
+++ b/cps/translations/vi/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2022-09-20 21:36+0700\n"
 "Last-Translator: Ha Link <halink0803@gmail.com>\n"
 "Language-Team: \n"
@@ -1900,7 +1900,7 @@ msgstr "Sách sắp xếp theo thể loại"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1936,7 +1936,7 @@ msgstr "Định dạng file"
 msgid "Books ordered by file formats"
 msgstr "Sách sắp xếp theo định dạng"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Giá sách"
@@ -2095,6 +2095,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "Hiện thị top những sách được đánh giá cao"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2279,7 +2284,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "Giá sách"
@@ -2498,7 +2503,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "Lỗi tải xuống ảnh bìa"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "Tạo một giá sách"
@@ -3004,7 +3009,7 @@ msgstr "Thêm vào giá sách"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3419,40 +3424,45 @@ msgstr "Chi tiết"
 msgid "Update available"
 msgstr "Cập nhật thất bại:"
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "Cập nhật thất bại:"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "Phiên bản hiện tại"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "Kiểm tra cập nhật"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "Bắt đầu cập nhật"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "Bạn có chắc chắn muốn khởi động lại?"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "Đang tải..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3463,8 +3473,8 @@ msgstr "Ok"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3474,11 +3484,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr "Huỷ bỏ"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "Bạn có chắc muốn tắt?"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "Đang update, làm ơn đừng load lại trang này"
 
@@ -3531,7 +3541,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "Đang tải lên..."
 
@@ -3566,8 +3576,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3639,9 +3649,10 @@ msgstr "Chuyển đổi sách"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "Đóng"
 
@@ -3668,7 +3679,7 @@ msgid "Imported as"
 msgstr "Cập nhật thất bại:"
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "Tác giả"
 
@@ -3686,13 +3697,13 @@ msgstr "Ngày xuất bản"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "Nhà xuất bản"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Ngôn ngữ"
@@ -3902,7 +3913,7 @@ msgstr "Nhập tên sách"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "Tên"
@@ -5721,78 +5732,122 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "Thiết lập OAuth"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "Đồng bộ những giá sách đã chọn với Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "Thiết lập OAuth"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5800,44 +5855,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "Chuyển đổi định dạng sách:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5845,322 +5900,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "Đăng ký công khai"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "Thiết lập OAuth"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "Định dạng tải lên"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "Đăng ký công khai"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "Đăng ký công khai"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "Xoá định dạng:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "Fetch Metadata"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "Đánh giá"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6549,7 +6604,7 @@ msgstr "Gộp những sách đã chọn"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6606,7 +6661,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "Sách chưa đọc"
@@ -6715,8 +6770,8 @@ msgstr "Nhập tên domain"
 msgid "Denied Domains (Blacklist)"
 msgstr "Domain bị từ chối (Blacklist)"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "Tiếp tục"
 
@@ -7006,163 +7061,163 @@ msgstr "Thiết lập"
 msgid "Refresh Library"
 msgstr "Tìm kiếm thư viện"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "Xoá sách"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "Làm ơn đừng load lại trang"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "Tìm kiếm"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "Tạo một giá sách"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "About"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "Trước"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "Chi tiết sách"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "Bạn có chắc muốn tắt?"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "Định dạng tải lên"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "Xoá định dạng:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "Xoá sách"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "Xoá sách"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "Không tìm thấy kết quả"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "Tới:"
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "Thêm vào giá sách"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "Gộp những sách đã chọn"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "Đánh dấu chưa đọc"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "Xoá sách"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "Xoá sách"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "Tạo một giá sách"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "Lỗi kết nối"
@@ -7973,6 +8028,102 @@ msgstr "{} người dung đã đươc xoá thành công"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Calibre-Web test e-mail"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8278,14 +8429,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2020-09-27 22:18+0800\n"
 "Last-Translator: xlivevil <xlivevil@aliyun.com>\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
@@ -1907,7 +1907,7 @@ msgstr "书籍按分类排序"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1943,7 +1943,7 @@ msgstr "文件格式"
 msgid "Books ordered by file formats"
 msgstr "书籍按文件格式排序"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "书架列表"
@@ -2093,6 +2093,11 @@ msgstr "重复书籍"
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "显示最高评分书籍"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2278,7 +2283,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "排除书架"
@@ -2496,7 +2501,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "删除书架时出错"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "创建书架"
@@ -2997,7 +3002,7 @@ msgstr "添加到书架"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3412,40 +3417,45 @@ msgstr "详情"
 msgid "Update available"
 msgstr "更新失败："
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "更新通道"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "当前版本"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr "-"
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "检查更新"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "执行更新"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "您确定要重启吗？"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "加载中..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "确定"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3456,8 +3466,8 @@ msgstr "确定"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3467,11 +3477,11 @@ msgstr "确定"
 msgid "Cancel"
 msgstr "取消"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "您确定要关闭吗？"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "正在更新，请不要刷新页面"
 
@@ -3524,7 +3534,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "正在上传..."
 
@@ -3559,8 +3569,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr "注意："
 
@@ -3631,9 +3641,10 @@ msgstr "转换书籍"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "关闭"
 
@@ -3660,7 +3671,7 @@ msgid "Imported as"
 msgstr "更新失败："
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "作者"
 
@@ -3678,13 +3689,13 @@ msgstr "出版日期"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "出版社"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "语言"
@@ -3893,7 +3904,7 @@ msgstr "输入书名"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "标题"
@@ -5779,23 +5790,67 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "OAuth 设置"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr "启用翻译贡献通知"
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr "当禁用时，如果您选择的语言的翻译不完整，您将不再收到 Web UI 中的通知。"
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "同步所选书架到 Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
@@ -5803,11 +5858,11 @@ msgstr ""
 "激活后，您的魔法书架将作为收藏同步到您的 Kobo 设备。注意：您还必须在“基本配"
 "置”中启用 Kobo 同步。"
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr "启用移动设备（&lt;768px）上的模糊背景"
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
@@ -5815,27 +5870,27 @@ msgstr ""
 "启用后，模糊封面背景效果也会在小屏幕上呈现。如果您注意到滚动或动画延迟，请禁"
 "用该功能。"
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth 设置"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 "启用后，所有导入的文件的副本将存储在 <i>/config/processed_books/imported</i>"
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
@@ -5843,21 +5898,21 @@ msgstr ""
 "启用后，进行转换的导入文件的原始文件将存储在 /config/processed_books/"
 "converted"
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5868,11 +5923,11 @@ msgstr ""
 "败的文件打包成 zip 压缩文件。这有助于保持 /config/processed_books 的子目录井"
 "然有序，并最大限度地减少磁盘空间使用。"
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
@@ -5881,33 +5936,33 @@ msgstr ""
 "当启用自动转换功能时，所有导入的书籍都将自动转换为此处选择的格式（下面的忽略"
 "列表中选择的格式除外）"
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "书籍格式转换:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5915,83 +5970,83 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr "Calibre 可以在导入时检测重复的书名，并根据"
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr "自动合并"
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr "设置删除重复书籍的任一实例或保留两者（默认）。"
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr "丢弃重复导入，保留库中的副本"
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr "用新导入的文件覆盖库中的副本"
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr "创建重复记录，保留两个副本"
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "启用注册"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr "重复检测方法"
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr "混合 (SQL 预过滤 + Python 验证)"
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr "仅 Python (最慢，最健壮)"
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr "仅传统 SQL (实验性)"
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
@@ -5999,53 +6054,53 @@ msgstr ""
 "混合模式使用快速 SQL 预过滤器缩小候选范围，然后应用健壮的 Python 逻辑获得最终"
 "结果。"
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth 设置"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr "配置后台重复扫描。这些扫描自动运行，不会阻塞 UI。"
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr "启用自动重复扫描"
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr "导入后扫描"
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr "每次导入后运行（去抖动）"
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 #, fuzzy
 msgid "Manual only"
 msgstr "手动？"
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr "导入后去抖动 (秒)"
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr "在最后一次导入后等待这么多秒，然后再开始后台扫描。"
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr "计划扫描 (cron 表达式)"
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr "留空以禁用计划扫描。例如："
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
@@ -6053,15 +6108,15 @@ msgstr ""
 "如果启用，导入后扫描和 cron 扫描都可以运行。使用“仅手动”可禁用导入后扫描，同"
 "时保留 cron 计划。"
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr "下一次计划扫描："
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
@@ -6070,46 +6125,46 @@ msgstr ""
 "配置使用哪些元数据字段来确定书籍是否重复。书籍必须匹配所有选定标准才会被视为"
 "重复。"
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr "在检测重复项时考虑书名"
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr "在检测重复项时考虑书籍作者"
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr "在检测重复项时考虑书籍语言"
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr "在检测重复项时考虑丛书"
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr "在检测重复项时考虑出版商"
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "上传格式"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr "在检测重复项时考虑文件格式"
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr "必须选择至少一个标准。建议将书名和作者作为核心标准。"
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr "重复格式优先级排序"
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
@@ -6118,11 +6173,11 @@ msgstr ""
 "配置在使用“最高质量格式”自动解决策略时首选哪些文件格式。拖放以按优先级重新排"
 "序格式（越高越好）。"
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr "提示："
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
@@ -6131,22 +6186,22 @@ msgstr ""
 "当使用“最高质量格式”策略解决重复项时，具有较高等级格式的书籍将被保留。较低优"
 "先级的格式将被删除。"
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr "重复通知和自动解决"
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr "配置如何接收有关重复书籍的通知，并可选择启用自动解决。"
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "启用 CWA 更新通知"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
@@ -6155,96 +6210,96 @@ msgstr ""
 "检测到未解决的重复项时显示弹出通知。管理员和具有编辑权限的用户在登录时，将在"
 "“重复项”侧边栏按钮上看到一个徽章，并会看到一个弹出通知。"
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "启用注册"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr "警告："
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr "这将根据下面的策略自动删除书籍。原始文件将备份到"
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr "自动解决策略"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr "保留最新的"
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr "删除较旧的副本，保留最近添加的书籍"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr "保留最旧的"
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr "删除较新的副本，保留最早添加的"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "原始格式"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr "将格式合并到最新书籍中，删除其余部分"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr "保留最高质量格式"
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr "根据您的重复格式优先级排序首选格式"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "获取元数据"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr "保留信息最完整的书籍"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr "保留最大文件大小"
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr "保留总文件大小最大的书籍"
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr "选择自动解决重复项时要保留的书籍。"
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "评分"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr "冷却期 (分钟)"
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 "两次自动解决之间的最短时间（0 表示禁用）。防止在批量导入期间发生快速删除。"
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6638,7 +6693,7 @@ msgstr "合并选中的书籍"
 msgid "Dismiss this duplicate group"
 msgstr "忽略此重复组"
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr "忽略"
 
@@ -6696,7 +6751,7 @@ msgstr "此操作无法撤销！"
 msgid "The following books will be permanently deleted:"
 msgstr "此书籍将从数据库中永久删除"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "未读书籍"
@@ -6803,8 +6858,8 @@ msgstr "输入域名"
 msgid "Denied Domains (Blacklist)"
 msgstr "禁止注册的域名（黑名单）"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "下一个"
 
@@ -7094,166 +7149,166 @@ msgstr "设置"
 msgid "Refresh Library"
 msgstr "搜索书库"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr "查看更新日志"
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "重复书籍"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr "在这里贡献！"
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "请不要刷新页面"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "按条件浏览"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "创建书架"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr "魔法书架 ✨"
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "关于"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "上一个"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "书籍详情"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "此操作无法撤销！"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "合并选中的书籍"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "上传格式"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "删除格式:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:644
+#: cps/templates/layout.html:650
 #, fuzzy
 msgid "Duplicate Books Detected"
 msgstr "删除书籍"
 
-#: cps/templates/layout.html:645
+#: cps/templates/layout.html:651
 msgid "You have unresolved duplicate books in your library"
 msgstr "您的书库中有未解决的重复书籍"
 
-#: cps/templates/layout.html:650
+#: cps/templates/layout.html:656
 #, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "无搜索结果"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr "稍后提醒我"
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 #, fuzzy
 msgid "View & Resolve Duplicates"
 msgstr "选择重复项"
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "缩放到最佳"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "到："
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "配置"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "添加到书架"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "合并选中的书籍"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "标为未读"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "删除书籍"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "删除书籍"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "创建书架"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "连接错误"
@@ -8056,6 +8111,104 @@ msgstr "选中的重复书籍已成功删除！"
 msgid "Error cancelling scheduled item"
 msgstr "取消计划项时出错"
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Caliebre-Web 电子书路径"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+#, fuzzy
+msgid "Portainer:"
+msgstr "重要："
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+#, fuzzy
+msgid "Set up automatic updates"
+msgstr "启用自动重复扫描"
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8367,14 +8520,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web NextGen\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-19 18:07+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: 2020-09-27 22:18+0800\n"
 "Last-Translator: xlivevil <xlivevil@aliyun.com>\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
@@ -1899,7 +1899,7 @@ msgstr "書籍按分類排序"
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1935,7 +1935,7 @@ msgstr "文件格式"
 msgid "Books ordered by file formats"
 msgstr "書籍按文件格式排序"
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "書架列表"
@@ -2094,6 +2094,11 @@ msgstr ""
 #, fuzzy
 msgid "Show Duplicate Books"
 msgstr "顯示最高評分書籍"
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
+msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
 #: cps/templates/cwa_epub_fixer.html:25 cps/templates/feed.xml:43
@@ -2280,7 +2285,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 #, fuzzy
 msgid "Reorder Shelves"
 msgstr "排除書架"
@@ -2497,7 +2502,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr "下載封面時出錯"
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 #, fuzzy
 msgid "Create Magic Shelf"
 msgstr "創建書架"
@@ -3008,7 +3013,7 @@ msgstr "添加到書架"
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3424,40 +3429,45 @@ msgstr "詳情"
 msgid "Update available"
 msgstr "更新失敗："
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+#, fuzzy
+msgid "Update now"
+msgstr "更新通道"
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr "當前版本"
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr "檢查更新"
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr "執行更新"
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr "您確定要重啟嗎？"
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 #, fuzzy
 msgid "Loading"
 msgstr "加載中..."
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr "確定"
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3468,8 +3478,8 @@ msgstr "確定"
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3479,11 +3489,11 @@ msgstr "確定"
 msgid "Cancel"
 msgstr "取消"
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr "您確定要關閉嗎？"
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr "正在更新，請不要刷新頁面"
 
@@ -3536,7 +3546,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr "正在上傳..."
 
@@ -3571,8 +3581,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3644,9 +3654,10 @@ msgstr "轉換書籍"
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr "關閉"
 
@@ -3673,7 +3684,7 @@ msgid "Imported as"
 msgstr "更新失敗："
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr "作者"
 
@@ -3691,13 +3702,13 @@ msgstr "出版日期"
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr "出版社"
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "語言"
@@ -3907,7 +3918,7 @@ msgstr "輸入書名"
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr "標題"
@@ -5717,78 +5728,122 @@ msgid ""
 "of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+#, fuzzy
+msgid "Automatic updates"
+msgstr "OAuth設置"
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a container "
+"can), so a small companion called Watchtower does it for you: it watches for "
+"a new image and swaps NextGen in safely, leaving your other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker compose "
+"up -d\". After that you stay up to date automatically — no button to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The 86400 "
+"interval checks once a day; \"cleanup\" removes the old image after each "
+"update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a "
+"setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI when "
 "using a language other than English if the translations for your chosen "
 "language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 #, fuzzy
 msgid "Sync Magic Shelves to Kobo"
 msgstr "同步所選書架到 Kobo"
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on small "
 "screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 #, fuzzy
 msgid "Automatic Backup Settings"
 msgstr "OAuth設置"
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in <i>/config/"
 "processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will be "
 "stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service will "
 "make zip archives of all the backed up converted, imported and failed files "
@@ -5796,44 +5851,44 @@ msgid ""
 "processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 #, fuzzy
 msgid "Choose a target format:"
 msgstr "轉換書籍格式:"
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support file "
 "in either EPUB and AZW3 format. Files in other formats will simply be "
 "ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after "
 "they have been converted to the target format. However, if the format is in "
@@ -5841,322 +5896,322 @@ msgid ""
 "Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest feature, "
 "meaning files in these formats won't be added to the library by NextGen "
 "during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, duplicate "
 "scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 #, fuzzy
 msgid "Enable Duplicate Detection"
 msgstr "啟用註冊"
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies "
 "the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 #, fuzzy
 msgid "Automatic Duplicate Scanning"
 msgstr "OAuth設置"
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background "
 "scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 #, fuzzy
 msgid "Format"
 msgstr "上傳格式"
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended as "
 "core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest Quality "
 "Format\" auto-resolution strategy. Drag and drop to reorder formats by "
 "priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books "
 "with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally enable "
 "automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 #, fuzzy
 msgid "Enable Duplicate Notifications"
 msgstr "啟用註冊"
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins and "
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 #, fuzzy
 msgid "Enable Automatic Duplicate Resolution"
 msgstr "啟用註冊"
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. Original "
 "files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 #, fuzzy
 msgid "Merge Formats"
 msgstr "刪除格式:"
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 #, fuzzy
 msgid "Keep Most Metadata"
 msgstr "獲取元數據"
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 #, fuzzy
 msgid "Rate Limiting"
 msgstr "評分"
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents rapid-"
 "fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. Dismissed "
 "duplicate groups are never auto-resolved."
@@ -6545,7 +6600,7 @@ msgstr "合併選中的書籍"
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6603,7 +6658,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr "此書籍將從數據庫中永久刪除"
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 #, fuzzy
 msgid "Merge Books"
 msgstr "未讀書籍"
@@ -6714,8 +6769,8 @@ msgstr "輸入網域名"
 msgid "Denied Domains (Blacklist)"
 msgstr "禁止註冊的網域名（黑名單）"
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr "下一個"
 
@@ -6999,165 +7054,165 @@ msgstr "設置"
 msgid "Refresh Library"
 msgstr "搜索書庫"
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 #, fuzzy
 msgid "Open Duplicates"
 msgstr "刪除書籍"
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr "請不要刷新頁面"
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr "瀏覽"
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 #, fuzzy
 msgid "Create Shelf"
 msgstr "創建書架"
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr "關於"
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr "上一個"
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr "書籍詳情"
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 #, fuzzy
 msgid "This cannot be undone."
 msgstr "您確定要關閉嗎？"
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 #, fuzzy
 msgid "Will be deleted"
 msgstr "合併選中的書籍"
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 #, fuzzy
 msgid "Formats:"
 msgstr "上傳格式"
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 #, fuzzy
 msgid "Result will have formats:"
 msgstr "刪除格式:"
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
-msgstr ""
-
-#: cps/templates/layout.html:644
-#, fuzzy
-msgid "Duplicate Books Detected"
-msgstr "刪除書籍"
-
-#: cps/templates/layout.html:645
-msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
 #: cps/templates/layout.html:650
 #, fuzzy
+msgid "Duplicate Books Detected"
+msgstr "刪除書籍"
+
+#: cps/templates/layout.html:651
+msgid "You have unresolved duplicate books in your library"
+msgstr ""
+
+#: cps/templates/layout.html:656
+#, fuzzy
 msgid "Duplicate Groups Found"
 msgstr "無搜索結果"
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 #, fuzzy
 msgid "Scroll to top"
 msgstr "縮放到最佳"
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 #, fuzzy
 msgid "Top"
 msgstr "到："
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 #, fuzzy
 msgid "Confirm"
 msgstr "配置"
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, fuzzy, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr "添加到書架"
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as read"
 msgstr "合併選中的書籍"
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, fuzzy, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr "標為未讀"
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, fuzzy, python-brace-format
 msgid "Deleted {n} books"
 msgstr "刪除書籍"
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 #, fuzzy
 msgid "Delete books?"
 msgstr "刪除書籍"
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot be "
 "undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 #, fuzzy
 msgid "Select at least one book first."
 msgstr "創建書架"
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, fuzzy, python-brace-format
 msgid "Request failed: {err}"
 msgstr "連接錯誤"
@@ -7958,6 +8013,102 @@ msgstr "成功刪除 {} 個用戶"
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+#, fuzzy
+msgid "Update Calibre-Web NextGen"
+msgstr "Caliebre-Web電子書路徑"
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, and "
+"your library, settings and reading progress are safe — they live in your "
+"mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options you "
+"started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your usual "
+"docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update (check "
+"for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin "
+"from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web NextGen "
+"→ Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the container → "
+"Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 #, fuzzy
 msgid "Your Profile"
@@ -8262,14 +8413,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/messages.pot
+++ b/messages.pot
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: Calibre-Web Automated v4.0.6\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-06-22 19:25+0000\n"
+"POT-Creation-Date: 2026-06-22 23:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1848,7 +1848,7 @@ msgstr ""
 
 #: cps/opds.py:223 cps/render_template.py:107 cps/templates/book_edit.html:143
 #: cps/templates/book_table.html:111 cps/templates/cwa_settings.html:362
-#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1103
+#: cps/templates/cwa_settings.html:364 cps/templates/cwa_settings.html:1133
 #: cps/templates/hardcover_review_matches.html:140
 #: cps/templates/search_form.html:70 cps/web.py:2076 cps/web.py:2088
 msgid "Series"
@@ -1884,7 +1884,7 @@ msgstr ""
 msgid "Books ordered by file formats"
 msgstr ""
 
-#: cps/opds.py:247 cps/templates/layout.html:413
+#: cps/opds.py:247 cps/templates/layout.html:415
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr ""
@@ -2029,6 +2029,11 @@ msgstr ""
 
 #: cps/render_template.py:144
 msgid "Show Duplicate Books"
+msgstr ""
+
+#: cps/render_template.py:239
+#, python-format
+msgid "Calibre-Web NextGen %(latest)s is available — you're on %(current)s."
 msgstr ""
 
 #: cps/search.py:53 cps/search.py:438 cps/templates/book_edit.html:338
@@ -2214,7 +2219,7 @@ msgstr ""
 msgid "Could not save order"
 msgstr ""
 
-#: cps/shelf.py:1031 cps/templates/layout.html:422
+#: cps/shelf.py:1031 cps/templates/layout.html:424
 msgid "Reorder Shelves"
 msgstr ""
 
@@ -2424,7 +2429,7 @@ msgstr ""
 msgid "Error creating shelf"
 msgstr ""
 
-#: cps/templates/layout.html:432 cps/web.py:1553
+#: cps/templates/layout.html:434 cps/web.py:1553
 msgid "Create Magic Shelf"
 msgstr ""
 
@@ -2891,7 +2896,7 @@ msgstr ""
 #: cps/templates/detail.html:820 cps/templates/detail.html:979
 #: cps/templates/detail.html:1601 cps/templates/feed.xml:109
 #: cps/templates/feed.xml:111 cps/templates/index.html:162
-#: cps/templates/layout.html:416 cps/templates/layout.html:429
+#: cps/templates/layout.html:418 cps/templates/layout.html:431
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:23 cps/templates/shelf_reorder.html:31
 msgid "(Public)"
@@ -3285,39 +3290,43 @@ msgstr ""
 msgid "Update available"
 msgstr ""
 
-#: cps/templates/admin.html:263
+#: cps/templates/admin.html:262 cps/templates/layout.html:262
+msgid "Update now"
+msgstr ""
+
+#: cps/templates/admin.html:264
 msgid "Current Version"
 msgstr ""
 
-#: cps/templates/admin.html:270 cps/templates/admin.html:275
+#: cps/templates/admin.html:271 cps/templates/admin.html:276
 msgid "-"
 msgstr ""
 
-#: cps/templates/admin.html:282
+#: cps/templates/admin.html:283
 msgid "Check for Update"
 msgstr ""
 
-#: cps/templates/admin.html:283
+#: cps/templates/admin.html:284
 msgid "Perform Update"
 msgstr ""
 
-#: cps/templates/admin.html:296
+#: cps/templates/admin.html:297
 msgid "Are you sure you want to restart?"
 msgstr ""
 
-#: cps/templates/admin.html:298 cps/templates/admin.html:330
+#: cps/templates/admin.html:299 cps/templates/admin.html:331
 #: cps/templates/config_db.html:4 cps/templates/config_edit.html:4
 #: cps/templates/cwa_settings.html:4 cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/templates/admin.html:301 cps/templates/admin.html:315
-#: cps/templates/admin.html:335 cps/templates/config_db.html:139
+#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:336 cps/templates/config_db.html:139
 #: cps/templates/duplicates.html:788 cps/templates/duplicates.html:810
 msgid "OK"
 msgstr ""
 
-#: cps/templates/admin.html:302 cps/templates/admin.html:316
+#: cps/templates/admin.html:303 cps/templates/admin.html:317
 #: cps/templates/book_edit.html:312 cps/templates/book_table.html:176
 #: cps/templates/book_table.html:195 cps/templates/book_table.html:215
 #: cps/templates/book_table.html:235 cps/templates/book_table.html:255
@@ -3328,8 +3337,8 @@ msgstr ""
 #: cps/templates/cwa_convert_library.html:23
 #: cps/templates/cwa_epub_fixer.html:40 cps/templates/detail.html:1173
 #: cps/templates/duplicates.html:696 cps/templates/duplicates.html:719
-#: cps/templates/duplicates.html:746 cps/templates/layout.html:606
-#: cps/templates/layout.html:761 cps/templates/modal_dialogs.html:64
+#: cps/templates/duplicates.html:746 cps/templates/layout.html:612
+#: cps/templates/layout.html:767 cps/templates/modal_dialogs.html:64
 #: cps/templates/modal_dialogs.html:99 cps/templates/modal_dialogs.html:117
 #: cps/templates/modal_dialogs.html:135 cps/templates/read.html:174
 #: cps/templates/schedule_edit.html:46 cps/templates/shelf.html:125
@@ -3339,11 +3348,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:314
+#: cps/templates/admin.html:315
 msgid "Are you sure you want to shutdown?"
 msgstr ""
 
-#: cps/templates/admin.html:326
+#: cps/templates/admin.html:327
 msgid "Updating, please do not reload this page"
 msgstr ""
 
@@ -3396,7 +3405,7 @@ msgstr ""
 
 #: cps/templates/annotations_import.html:49 cps/templates/book_edit.html:94
 #: cps/templates/book_edit.html:111 cps/templates/layout.html:204
-#: cps/templates/layout.html:335
+#: cps/templates/layout.html:337
 msgid "Uploading..."
 msgstr ""
 
@@ -3429,8 +3438,8 @@ msgstr ""
 msgid "%(count)d highlights"
 msgstr ""
 
-#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1122
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/annotations_view.html:23 cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1238
 msgid "Note:"
 msgstr ""
 
@@ -3501,9 +3510,10 @@ msgstr ""
 
 #: cps/templates/book_edit.html:94 cps/templates/book_edit.html:378
 #: cps/templates/book_table.html:346 cps/templates/duplicates.html:766
-#: cps/templates/layout.html:204 cps/templates/layout.html:506
-#: cps/templates/layout.html:643 cps/templates/modal_dialogs.html:34
-#: cps/templates/shelf.html:110 cps/templates/user_edit.html:673
+#: cps/templates/layout.html:204 cps/templates/layout.html:508
+#: cps/templates/layout.html:649 cps/templates/modal_dialogs.html:34
+#: cps/templates/shelf.html:110 cps/templates/update_now_modal.html:61
+#: cps/templates/user_edit.html:673
 msgid "Close"
 msgstr ""
 
@@ -3529,7 +3539,7 @@ msgid "Imported as"
 msgstr ""
 
 #: cps/templates/book_edit.html:135 cps/templates/book_edit.html:459
-#: cps/templates/cwa_settings.html:1091 cps/templates/search_form.html:12
+#: cps/templates/cwa_settings.html:1121 cps/templates/search_form.html:12
 msgid "Author"
 msgstr ""
 
@@ -3547,13 +3557,13 @@ msgstr ""
 
 #: cps/templates/book_edit.html:159 cps/templates/book_edit.html:460
 #: cps/templates/cwa_settings.html:348 cps/templates/cwa_settings.html:350
-#: cps/templates/cwa_settings.html:1109 cps/templates/detail.html:995
+#: cps/templates/cwa_settings.html:1139 cps/templates/detail.html:995
 #: cps/templates/hardcover_review_matches.html:148
 #: cps/templates/listenmp3.html:102 cps/templates/search_form.html:16
 msgid "Publisher"
 msgstr ""
 
-#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1097
+#: cps/templates/book_edit.html:163 cps/templates/cwa_settings.html:1127
 #: cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr ""
@@ -3756,7 +3766,7 @@ msgstr ""
 
 #: cps/templates/book_table.html:106 cps/templates/config_view_edit.html:39
 #: cps/templates/cwa_settings.html:327 cps/templates/cwa_settings.html:329
-#: cps/templates/cwa_settings.html:1085 cps/templates/shelf_edit.html:8
+#: cps/templates/cwa_settings.html:1115 cps/templates/shelf_edit.html:8
 #: cps/templates/tasks.html:41 cps/templates/tasks.html:64
 msgid "Title"
 msgstr ""
@@ -5507,76 +5517,121 @@ msgid ""
 "version of NextGen is released"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:755
+#: cps/templates/cwa_settings.html:751
+msgid "Automatic updates"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:753
+msgid ""
+"New versions ship regularly — often weekly. Calibre-Web NextGen cannot "
+"update itself from inside its container (nothing running inside a "
+"container can), so a small companion called Watchtower does it for you: "
+"it watches for a new image and swaps NextGen in safely, leaving your "
+"other containers alone."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:756
+msgid ""
+"Add these two services to your docker-compose file and run \"docker "
+"compose up -d\". After that you stay up to date automatically — no button"
+" to press."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copied!"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:28
+#: cps/templates/update_now_modal.html:37
+#: cps/templates/update_now_modal.html:55 cps/templates/user_edit.html:618
+msgid "Copy"
+msgstr ""
+
+#: cps/templates/cwa_settings.html:773
+msgid ""
+"The label means Watchtower only ever touches Calibre-Web NextGen. The "
+"86400 interval checks once a day; \"cleanup\" removes the old image after"
+" each update."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:776
+msgid ""
+"Running under Podman instead? Native \"podman auto-update\" works too — a"
+" setup guide is coming once we have verified it against this image."
+msgstr ""
+
+#: cps/templates/cwa_settings.html:785
 msgid "Enable Contribute Translations Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:757
+#: cps/templates/cwa_settings.html:787
 msgid ""
 "When disabled, you will no longer receive notifications in the Web UI "
 "when using a language other than English if the translations for your "
 "chosen language are not complete."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:765
+#: cps/templates/cwa_settings.html:795
 msgid "Sync Magic Shelves to Kobo"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:767
+#: cps/templates/cwa_settings.html:797
 msgid ""
 "When active, your Magic Shelves will be synced to your Kobo device as "
 "collections. Note: You must also enable Kobo Sync in Basic Configuration."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:775
+#: cps/templates/cwa_settings.html:805
 msgid "Enable Blurred Backgrounds on Mobile (&lt;768px)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:777
+#: cps/templates/cwa_settings.html:807
 msgid ""
 "When active, the blurred cover background effect is also rendered on "
 "small screens. Disable if you notice scrolling or animation lag."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:782
+#: cps/templates/cwa_settings.html:812
 msgid "Automatic Backup Settings"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:789
+#: cps/templates/cwa_settings.html:819
 msgid "Enable NextGen Import Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:791
+#: cps/templates/cwa_settings.html:821
 msgid ""
 "When active, a copy of all imported files will be stored in "
 "<i>/config/processed_books/imported</i>"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:799
+#: cps/templates/cwa_settings.html:829
 msgid "Enable NextGen Conversion Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:801
+#: cps/templates/cwa_settings.html:831
 msgid ""
 "When active, the originals of ingested files that undergo conversion will"
 " be stored in /config/processed_books/converted"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:809
+#: cps/templates/cwa_settings.html:839
 msgid "Enable NextGen EPUB Fixer Auto-Backup"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:811
+#: cps/templates/cwa_settings.html:841
 msgid ""
 "When active, the originals of EPUBs processed by the NextGen Kindle EPUB "
 "Fixer service will be stored in /config/processed_books/fixed_originals"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:821
+#: cps/templates/cwa_settings.html:851
 msgid "Enable NextGen Auto-Zip Backups"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:823
+#: cps/templates/cwa_settings.html:853
 msgid ""
 "When active, just before midnight each day, the cwa-auto-zipper service "
 "will make zip archives of all the backed up converted, imported and "
@@ -5584,43 +5639,43 @@ msgid ""
 "/config/processed_books organised and to minimise disk space usage."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:828
+#: cps/templates/cwa_settings.html:858
 msgid "NextGen Auto-Conversion Target Format - EPUB by Default"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:831
+#: cps/templates/cwa_settings.html:861
 msgid ""
 "When the Auto-Convert feature is active, all ingested books will be "
 "automatically converted to the format chosen here (except those formats "
 "selected in the ignore list below)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:833
+#: cps/templates/cwa_settings.html:863
 msgid "Choose a target format:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:845
+#: cps/templates/cwa_settings.html:875
 msgid ""
 "Note: NextGen's Metadata Enforcement service can currently only support "
 "file in either EPUB and AZW3 format. Files in other formats will simply "
 "be ignored by the service"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:851
+#: cps/templates/cwa_settings.html:881
 msgid "NextGen Auto-Convert - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:853
+#: cps/templates/cwa_settings.html:883
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Conversion "
 "feature when it's active, meaning they will be imported as is."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:878
+#: cps/templates/cwa_settings.html:908
 msgid "NextGen Auto-Convert - Retained Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:880
+#: cps/templates/cwa_settings.html:910
 msgid ""
 "The formats selected here will always be added to the library, even after"
 " they have been converted to the target format. However, if the format is"
@@ -5628,314 +5683,314 @@ msgid ""
 "imported. Note that the target format is always retained."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:907
+#: cps/templates/cwa_settings.html:937
 msgid "NextGen Auto-Ingest Automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "Calibre can detect Duplicate Book Titles on Import and depending on the"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:910
+#: cps/templates/cwa_settings.html:940
 msgid "automerge"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:911
+#: cps/templates/cwa_settings.html:941
 msgid ""
 "setting. It can be set to delete either instance of a duplicated book or "
 "keep both (default)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:929
+#: cps/templates/cwa_settings.html:959
 msgid "Discards duplicate import, keeps library copy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:933
+#: cps/templates/cwa_settings.html:963
 msgid "Overwrites library copy with newly imported file"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:937
+#: cps/templates/cwa_settings.html:967
 msgid "Creates a duplicate record, keeping both copies"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:943
+#: cps/templates/cwa_settings.html:973
 msgid "NextGen Auto-Ingest - Ignored Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:945
+#: cps/templates/cwa_settings.html:975
 msgid ""
 "The formats selected here will be ignored by NextGen's Auto-Ingest "
 "feature, meaning files in these formats won't be added to the library by "
 "NextGen during the ingest process"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:970
+#: cps/templates/cwa_settings.html:1000
 msgid "NextGen Duplicate Detection System"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:973
+#: cps/templates/cwa_settings.html:1003
 msgid ""
 "Enable or disable the duplicate detection system. When disabled, "
 "duplicate scanning will not run and no notifications will be shown."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:978
+#: cps/templates/cwa_settings.html:1008
 msgid "Enable Duplicate Detection"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:982
+#: cps/templates/cwa_settings.html:1012
 msgid "When enabled, NextGen will scan for duplicate books after each import"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:990
+#: cps/templates/cwa_settings.html:1020
 msgid "Duplicate Detection Method"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:993
+#: cps/templates/cwa_settings.html:1023
 msgid "Hybrid (SQL prefilter + Python validation)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:996
+#: cps/templates/cwa_settings.html:1026
 msgid "Python only (slowest, most robust)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:999
+#: cps/templates/cwa_settings.html:1029
 msgid "Legacy SQL only (experimental)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1005
+#: cps/templates/cwa_settings.html:1035
 msgid ""
 "Hybrid mode uses a fast SQL pre-filter to narrow candidates, then applies"
 " the robust Python logic for final results."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1014
+#: cps/templates/cwa_settings.html:1044
 msgid "Automatic Duplicate Scanning"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1017
+#: cps/templates/cwa_settings.html:1047
 msgid ""
 "Configure background duplicate scans. These run automatically without "
 "blocking the UI."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1022
+#: cps/templates/cwa_settings.html:1052
 msgid "Enable automatic duplicate scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1026
+#: cps/templates/cwa_settings.html:1056
 msgid "After import scans"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1029
+#: cps/templates/cwa_settings.html:1059
 msgid "Run after each import (debounced)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1032
+#: cps/templates/cwa_settings.html:1062
 msgid "Manual only"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1038
+#: cps/templates/cwa_settings.html:1068
 msgid "After import debounce (seconds)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1046
+#: cps/templates/cwa_settings.html:1076
 msgid ""
 "Wait this many seconds after the last import before starting a background"
 " scan."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1051
+#: cps/templates/cwa_settings.html:1081
 msgid "Scheduled scans (cron expression)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1057
+#: cps/templates/cwa_settings.html:1087
 msgid "Leave blank to disable scheduled scans. Example:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1062
+#: cps/templates/cwa_settings.html:1092
 msgid ""
 "If enabled, after-import scans and cron scans can both run. Use “Manual "
 "only” to disable after-import scans while keeping cron schedules."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1069 cps/templates/duplicates.html:522
+#: cps/templates/cwa_settings.html:1099 cps/templates/duplicates.html:522
 msgid "Next scheduled scan:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1076
+#: cps/templates/cwa_settings.html:1106
 msgid "NextGen Duplicate Detection Criteria"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1079
+#: cps/templates/cwa_settings.html:1109
 msgid ""
 "Configure which metadata fields are used to determine if books are "
 "duplicates. Books must match ALL selected criteria to be considered "
 "duplicates."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1086
+#: cps/templates/cwa_settings.html:1116
 msgid "Consider book titles when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1092
+#: cps/templates/cwa_settings.html:1122
 msgid "Consider book authors when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1098
+#: cps/templates/cwa_settings.html:1128
 msgid "Consider book language when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1104
+#: cps/templates/cwa_settings.html:1134
 msgid "Consider book series when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1110
+#: cps/templates/cwa_settings.html:1140
 msgid "Consider book publisher when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1115
+#: cps/templates/cwa_settings.html:1145
 msgid "Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1116
+#: cps/templates/cwa_settings.html:1146
 msgid "Consider file format when detecting duplicates"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1122
+#: cps/templates/cwa_settings.html:1152
 msgid ""
 "At least one criterion must be selected. Title and Author are recommended"
 " as core criteria."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1128
+#: cps/templates/cwa_settings.html:1158
 msgid "Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1131
+#: cps/templates/cwa_settings.html:1161
 msgid ""
 "Configure which file formats are preferred when using the \"Highest "
 "Quality Format\" auto-resolution strategy. Drag and drop to reorder "
 "formats by priority (higher = better)."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid "Tip:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1144
+#: cps/templates/cwa_settings.html:1174
 msgid ""
 "When resolving duplicates with \"Highest Quality Format\" strategy, books"
 " with higher-ranked formats will be kept. Lower priority formats will be "
 "deleted."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1152
+#: cps/templates/cwa_settings.html:1182
 msgid "Duplicate Notifications & Auto-Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1155
+#: cps/templates/cwa_settings.html:1185
 msgid ""
 "Configure how you are notified about duplicate books and optionally "
 "enable automatic resolution."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1160
+#: cps/templates/cwa_settings.html:1190
 msgid "Enable Duplicate Notifications"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1162
+#: cps/templates/cwa_settings.html:1192
 msgid ""
 "Show popup notifications when unresolved duplicates are detected. Admins "
 "and users with edit rights will see a badge on the Duplicates sidebar "
 "button and a notification popup when they login."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1166
+#: cps/templates/cwa_settings.html:1196
 msgid "Enable Automatic Duplicate Resolution"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169 cps/templates/duplicates.html:593
+#: cps/templates/cwa_settings.html:1199 cps/templates/duplicates.html:593
 msgid "Warning:"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1169
+#: cps/templates/cwa_settings.html:1199
 msgid ""
 "This will automatically delete books based on the strategy below. "
 "Original files will be backed up to"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1173
+#: cps/templates/cwa_settings.html:1203
 msgid "Auto-Resolution Strategy"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Keep Newest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1176
+#: cps/templates/cwa_settings.html:1206
 msgid "Delete older copies, keep the most recently added book"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Keep Oldest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1179
+#: cps/templates/cwa_settings.html:1209
 msgid "Delete newer copies, keep the earliest added"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge Formats"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1182
+#: cps/templates/cwa_settings.html:1212
 msgid "Merge formats into the newest book, delete the rest"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Keep Highest Quality Format"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1185
+#: cps/templates/cwa_settings.html:1215
 msgid "Prefer formats based on your Duplicate Format Priority Ranking"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep Most Metadata"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1188
+#: cps/templates/cwa_settings.html:1218
 msgid "Keep book with most complete information"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep Largest File Size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1191
+#: cps/templates/cwa_settings.html:1221
 msgid "Keep book with largest total file size"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1194
+#: cps/templates/cwa_settings.html:1224
 msgid "Choose which book to keep when duplicates are automatically resolved."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1198
+#: cps/templates/cwa_settings.html:1228
 msgid "Rate Limiting"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1199
+#: cps/templates/cwa_settings.html:1229
 msgid "Cooldown Period (minutes)"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1203
+#: cps/templates/cwa_settings.html:1233
 msgid ""
 "Minimum time between automatic resolutions (0 to disable). Prevents "
 "rapid-fire deletions during batch imports."
 msgstr ""
 
-#: cps/templates/cwa_settings.html:1208
+#: cps/templates/cwa_settings.html:1238
 msgid ""
 "Auto-resolution runs after duplicate scans detect new duplicates. "
 "Dismissed duplicate groups are never auto-resolved."
@@ -6296,7 +6351,7 @@ msgstr ""
 msgid "Dismiss this duplicate group"
 msgstr ""
 
-#: cps/templates/duplicates.html:618 cps/templates/layout.html:360
+#: cps/templates/duplicates.html:618 cps/templates/layout.html:362
 msgid "Dismiss"
 msgstr ""
 
@@ -6348,7 +6403,7 @@ msgstr ""
 msgid "The following books will be permanently deleted:"
 msgstr ""
 
-#: cps/templates/duplicates.html:730 cps/templates/layout.html:558
+#: cps/templates/duplicates.html:730 cps/templates/layout.html:564
 msgid "Merge Books"
 msgstr ""
 
@@ -6452,8 +6507,8 @@ msgstr ""
 msgid "Denied Domains (Blacklist)"
 msgstr ""
 
-#: cps/templates/feed.xml:31 cps/templates/layout.html:464
-#: cps/templates/layout.html:490
+#: cps/templates/feed.xml:31 cps/templates/layout.html:466
+#: cps/templates/layout.html:492
 msgid "Next"
 msgstr ""
 
@@ -6720,152 +6775,152 @@ msgstr ""
 msgid "Refresh Library"
 msgstr ""
 
-#: cps/templates/layout.html:261
+#: cps/templates/layout.html:263
 msgid "See Changelog"
 msgstr ""
 
-#: cps/templates/layout.html:271
+#: cps/templates/layout.html:273
 msgid "Open Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:293
+#: cps/templates/layout.html:295
 msgid "Contribute here!"
 msgstr ""
 
-#: cps/templates/layout.html:336
+#: cps/templates/layout.html:338
 msgid "Please do not refresh the page"
 msgstr ""
 
-#: cps/templates/layout.html:396
+#: cps/templates/layout.html:398
 msgid "Browse"
 msgstr ""
 
-#: cps/templates/layout.html:419
+#: cps/templates/layout.html:421
 msgid "Create Shelf"
 msgstr ""
 
-#: cps/templates/layout.html:427
+#: cps/templates/layout.html:429
 msgid "Magic Shelves ✨"
 msgstr ""
 
-#: cps/templates/layout.html:436 cps/templates/stats.html:3
+#: cps/templates/layout.html:438 cps/templates/stats.html:3
 msgid "About"
 msgstr ""
 
-#: cps/templates/layout.html:449 cps/templates/layout.html:475
+#: cps/templates/layout.html:451 cps/templates/layout.html:477
 msgid "Previous"
 msgstr ""
 
-#: cps/templates/layout.html:502
+#: cps/templates/layout.html:504
 msgid "Book Details"
 msgstr ""
 
-#: cps/templates/layout.html:564
+#: cps/templates/layout.html:570
 msgid "This cannot be undone."
 msgstr ""
 
-#: cps/templates/layout.html:570
+#: cps/templates/layout.html:576
 msgid "Will be deleted"
 msgstr ""
 
-#: cps/templates/layout.html:574 cps/templates/layout.html:587
+#: cps/templates/layout.html:580 cps/templates/layout.html:593
 msgid "Formats:"
 msgstr ""
 
-#: cps/templates/layout.html:583
+#: cps/templates/layout.html:589
 msgid "Will be kept"
 msgstr ""
 
-#: cps/templates/layout.html:595
+#: cps/templates/layout.html:601
 msgid "Format conflicts — choose what to do:"
 msgstr ""
 
-#: cps/templates/layout.html:601
+#: cps/templates/layout.html:607
 msgid "Result will have formats:"
 msgstr ""
 
-#: cps/templates/layout.html:610
+#: cps/templates/layout.html:616
 msgid "Merge &amp; Delete Source"
 msgstr ""
 
-#: cps/templates/layout.html:644
+#: cps/templates/layout.html:650
 msgid "Duplicate Books Detected"
 msgstr ""
 
-#: cps/templates/layout.html:645
+#: cps/templates/layout.html:651
 msgid "You have unresolved duplicate books in your library"
 msgstr ""
 
-#: cps/templates/layout.html:650
+#: cps/templates/layout.html:656
 msgid "Duplicate Groups Found"
 msgstr ""
 
-#: cps/templates/layout.html:658
+#: cps/templates/layout.html:664
 msgid "Remind Me Later"
 msgstr ""
 
-#: cps/templates/layout.html:661
+#: cps/templates/layout.html:667
 msgid "View & Resolve Duplicates"
 msgstr ""
 
-#: cps/templates/layout.html:670
+#: cps/templates/layout.html:676
 msgid "Scroll to top"
 msgstr ""
 
-#: cps/templates/layout.html:672
+#: cps/templates/layout.html:678
 msgid "Top"
 msgstr ""
 
-#: cps/templates/layout.html:762
+#: cps/templates/layout.html:768
 msgid "Confirm"
 msgstr ""
 
-#: cps/templates/layout.html:768
+#: cps/templates/layout.html:774
 #, python-brace-format
 msgid "Added {n} books to {shelf}"
 msgstr ""
 
-#: cps/templates/layout.html:769
+#: cps/templates/layout.html:775
 #, python-brace-format
 msgid "Added {ok} of {n} books to {shelf} (rest were already there)"
 msgstr ""
 
-#: cps/templates/layout.html:770
+#: cps/templates/layout.html:776
 #, python-brace-format
 msgid "All {n} book(s) were already on {shelf}."
 msgstr ""
 
-#: cps/templates/layout.html:771
+#: cps/templates/layout.html:777
 #, python-brace-format
 msgid "Marked {n} books as read"
 msgstr ""
 
-#: cps/templates/layout.html:772
+#: cps/templates/layout.html:778
 #, python-brace-format
 msgid "Marked {n} books as unread"
 msgstr ""
 
-#: cps/templates/layout.html:773
+#: cps/templates/layout.html:779
 #, python-brace-format
 msgid "Deleted {n} books"
 msgstr ""
 
-#: cps/templates/layout.html:774
+#: cps/templates/layout.html:780
 msgid "Delete books?"
 msgstr ""
 
-#: cps/templates/layout.html:775
+#: cps/templates/layout.html:781
 #, python-brace-format
 msgid ""
 "This will permanently delete {n} book(s) from your library. This cannot "
 "be undone."
 msgstr ""
 
-#: cps/templates/layout.html:776
+#: cps/templates/layout.html:782
 msgid "Select at least one book first."
 msgstr ""
 
-#: cps/templates/layout.html:777
+#: cps/templates/layout.html:783
 #, python-brace-format
 msgid "Request failed: {err}"
 msgstr ""
@@ -7631,6 +7686,101 @@ msgstr ""
 msgid "Error cancelling scheduled item"
 msgstr ""
 
+#: cps/templates/update_now_modal.html:11
+msgid "Update Calibre-Web NextGen"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:14
+msgid ""
+"Updating pulls the new image and recreates the container. It is quick, "
+"and your library, settings and reading progress are safe — they live in "
+"your mounted volumes, not in the container."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:16
+msgid "How do you run Calibre-Web NextGen?"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:17
+msgid "Setup type"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:18
+msgid "Docker Compose"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:19
+msgid "docker run"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:20
+msgid "Unraid"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:21
+msgid "Portainer / Synology"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:25
+msgid "Run this from the folder that holds your compose file:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:30
+msgid "Replace calibre-web-nextgen with your service name if it differs."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:34
+msgid ""
+"Pull the new image, then recreate your container with the same options "
+"you started it with:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:39
+msgid ""
+"Then stop and remove the old container and start a new one with your "
+"usual docker run command. Your mounted volumes keep all data."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:44
+msgid "Open the Docker tab in the Unraid web UI."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:45
+msgid ""
+"Click the Calibre-Web NextGen container icon and choose Force update "
+"(check for updates first if you want to see what changed)."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:47
+msgid ""
+"For hands-off updates, install the \"CA Auto Update Applications\" plugin"
+" from Community Applications."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid "Portainer:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:51
+msgid ""
+"Images → pull the image below, then Containers → select Calibre-Web "
+"NextGen → Recreate with \"Re-pull image\" enabled."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid "Synology Container Manager:"
+msgstr ""
+
+#: cps/templates/update_now_modal.html:52
+msgid ""
+"Registry → download the image below (tag: latest), then stop the "
+"container → Action → Reset to recreate it."
+msgstr ""
+
+#: cps/templates/update_now_modal.html:60
+msgid "Set up automatic updates"
+msgstr ""
+
 #: cps/templates/user_edit.html:173
 msgid "Your Profile"
 msgstr ""
@@ -7925,14 +8075,6 @@ msgstr ""
 
 #: cps/templates/user_edit.html:615
 msgid "New app password (cleartext)"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copied!"
-msgstr ""
-
-#: cps/templates/user_edit.html:618
-msgid "Copy"
 msgstr ""
 
 #: cps/templates/user_edit.html:625

--- a/tests/unit/test_admin_update_indicator.py
+++ b/tests/unit/test_admin_update_indicator.py
@@ -92,10 +92,11 @@ class TestAdminRoutePassesIndicator:
 @pytest.mark.unit
 class TestAdminTemplateRendersIndicator:
     """Template-source pin: when outdated, the admin.html Version
-    Information row renders 'Update available' with the latest tag and a
-    docker-pull command; otherwise the original 'Current Version' label.
-    We assert against the template source rather than full Jinja rendering
-    so this test stays independent of the Flask app context."""
+    Information row renders 'Update available' with the latest tag and an
+    'Update now' button that opens the guided update modal; otherwise the
+    original 'Current Version' label. We assert against the template source
+    rather than full Jinja rendering so this test stays independent of the
+    Flask app context."""
 
     def test_template_has_outdated_branch(self):
         import os
@@ -108,9 +109,14 @@ class TestAdminTemplateRendersIndicator:
         # The new branch must reference both variables.
         assert "cwa_is_outdated" in template
         assert "cwa_latest_tag" in template
-        # And it must surface the docker-pull command in the user-visible
-        # message so the user knows what to do next.
-        assert "docker pull ghcr.io/new-usemame/calibre-web-nextgen" in template
+        # And it must surface a way to act on the update: the "Update now"
+        # button that opens the guided update modal. This replaced the old
+        # inline `docker pull` command, which was incomplete on its own
+        # (pulling an image does not update a running container) — the modal
+        # now carries the full, setup-aware pull+recreate instructions.
+        # See cps/templates/update_now_modal.html.
+        assert "#updateNowDialog" in template
+        assert "Update now" in template
 
     def test_template_preserves_current_version_fallback(self):
         import os

--- a/tests/unit/test_update_banner_message.py
+++ b/tests/unit/test_update_banner_message.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for the "update available" banner message.
+
+These guard two things at once:
+
+1. The banner message must be built from a STATIC, translatable msgid with
+   named placeholders — not an f-string interpolated *before* gettext sees it.
+   The old code did ``_(f"... {current} ...")`` which makes the translation key
+   the fully-interpolated runtime string, so pybabel extracts nothing usable and
+   every non-English user gets the English fallback forever.
+
+2. The banner copy must be free of the ``⚡🚨`` emoji spam (Jellyfin-derived
+   human-facing tone policy) and must still show the user both versions.
+"""
+
+import inspect
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../scripts')))
+
+import cps.render_template as rt
+
+
+def test_format_update_banner_message_builds_translatable_emoji_free_string(monkeypatch):
+    """The gettext msgid is static; the rendered string carries both versions, no emoji."""
+    captured = {}
+
+    def fake_gettext(msgid):
+        captured['msgid'] = msgid
+        return msgid
+
+    monkeypatch.setattr(rt, "_", fake_gettext)
+
+    msg = rt._format_update_banner_message("v4.0.169", "v4.0.170")
+
+    # 1) The translatable key must be the STATIC template, not the interpolated
+    #    runtime string — named placeholders present, version numbers absent.
+    assert "%(latest)s" in captured['msgid']
+    assert "%(current)s" in captured['msgid']
+    assert "4.0.170" not in captured['msgid']
+    assert "4.0.169" not in captured['msgid']
+
+    # 2) The user-visible message still shows both versions.
+    assert "v4.0.170" in msg
+    assert "v4.0.169" in msg
+
+    # 3) No AI-tell emoji.
+    for junk in ("⚡", "🚨"):
+        assert junk not in msg
+
+
+def test_update_notification_drops_fstring_gettext_antipattern():
+    """Source-pin: the banner notification no longer ships the un-extractable
+    ``_(f"...")`` pattern or the emoji spam, and routes through the helper."""
+    src = inspect.getsource(rt.cwa_update_notification)
+
+    assert '_(f"' not in src and "_(f'" not in src, "f-string inside gettext is not extractable"
+    assert "⚡" not in src and "🚨" not in src, "emoji spam must be gone from the banner"
+    assert "_format_update_banner_message" in src, "must build the message via the translatable helper"


### PR DESCRIPTION
## What this adds

When a new version is available, users get a one-click path to update instead of hunting for the right Docker command:

- **"Update now" button** on the update banner and the Admin version row → opens a guided modal showing the exact one-line command for the user's setup (**Docker Compose**, **docker run**, **Unraid**, **Portainer/Synology**) with a copy button.
- **"Automatic updates" section** under Admin → NextGen Settings → walks through enabling hands-off updates with [Watchtower](https://github.com/nicholas-fedor/watchtower) (the maintained fork), label-scoped so it only touches this container.
- **README "Updating" guide** + a **"Running with Podman"** note (same OCI image).

All surfaces are **admin-only**.

## The design constraint (why no in-app updater)

A process inside a container can't recreate its own container, and the inherited `updater.py` file-swap path is hard-disabled in Docker for good reason — it only swaps Python files, not deps/binaries (exactly the py7zr/pyppmd break we just lived). So **nothing here touches the Docker socket or mutates the container**: the app shows the right command/labels and the user's runtime (or Watchtower) performs the update. Full design: `notes/easy-update-autoupdate-design.md`.

## Also fixes a latent i18n bug

The old banner used `_(f"...")` — an f-string inside `gettext` — so pybabel could never extract it and every locale fell back to English. The new banner builds from a **static msgid with named placeholders** (and drops the emoji spam). Regression-tested.

## Verification

**Tests (red/green):**
- `tests/unit/test_update_banner_message.py` (new) — proves the banner msgid is static/translatable (fails on the old `_(f"...")`) and emoji-free.
- `tests/unit/test_admin_update_indicator.py` — updated to pin the new "Update now" button surface (was pinning the old inline `docker pull`).
- Update-subsystem suite: 20/20 green.

**Live container** (`cwn-local`, v4.0.169 image + branch files, forced-outdated):
- Banner shows the plain-English message + `Update now`, no emoji; all 4 modal setup tabs switch; Copy → clipboard write + "Copied!" confirmed.
- Admin row button opens the same modal; Settings "Automatic updates" renders the Watchtower block + Podman line.
- **Mobile (390×844):** no overflow. **Anonymous/non-admin:** HTTP 200, zero `updateNowDialog`, no Jinja errors (admin-gating verified both ways).
- No `update_now.js` console errors; no 500s/tracebacks.

**i18n:** refreshed via `scripts/update_translations.sh` — 16 new strings into `messages.pot` + 29 `.po`; **no existing translations lost** (`msgfmt --statistics` before/after across de/es/fr/zh); `test_translations_compile.py` green (30 locales).

## Merge-gate self-check

- No new routes; no auth/session/CSRF/crypto/subprocess/file-path changes → `/security-review` not triggered.
- No new dependencies, no license change, no new app-level service URLs (Watchtower/Podman are documentation, not app calls).
- Admin-only; reversible (merges to `:dev` canary first).
