### PR TITLE
Fix Update-now modal: setup tabs overflowed on mobile

### DIFF
--- a/cps/templates/update_now_modal.html
+++ b/cps/templates/update_now_modal.html
@@ -3,6 +3,14 @@
    a container cannot recreate itself, so the update is run by the user's own
    container runtime. We show the right command/steps for their setup and let
    them run one line. See notes/easy-update-autoupdate-design.md. #}
+<style>
+  /* Responsive setup selector: a single non-wrapping row overflowed narrow
+     screens (the right-hand tabs got clipped). Wrap instead, and stack the
+     tabs full-width on phones so every option stays reachable. */
+  #update-setup-selector { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+  #update-setup-selector .btn { border-radius: 4px; }
+  @media (max-width: 480px) { #update-setup-selector .btn { flex: 1 1 100%; } }
+</style>
 <div id="updateNowDialog" class="modal fade" role="dialog" aria-labelledby="updateNowTitle">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
@@ -14,7 +22,7 @@
         <p>{{ _('Updating pulls the new image and recreates the container. It is quick, and your library, settings and reading progress are safe — they live in your mounted volumes, not in the container.') }}</p>
 
         <p><strong>{{ _('How do you run Calibre-Web NextGen?') }}</strong></p>
-        <div class="btn-group" role="group" aria-label="{{ _('Setup type') }}" id="update-setup-selector">
+        <div class="update-setup-tabs" role="group" aria-label="{{ _('Setup type') }}" id="update-setup-selector">
           <button type="button" class="btn btn-default active" data-update-setup="compose">{{ _('Docker Compose') }}</button>
           <button type="button" class="btn btn-default" data-update-setup="run">{{ _('docker run') }}</button>
           <button type="button" class="btn btn-default" data-update-setup="unraid">{{ _('Unraid') }}</button>

--- a/tests/unit/test_update_modal_responsive.py
+++ b/tests/unit/test_update_modal_responsive.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression test: the Update-now modal's setup-type selector must wrap on
+narrow screens.
+
+It was originally a Bootstrap ``btn-group`` — a single, non-wrapping row — so on
+a phone-width modal the right-hand tabs ("Unraid", "Portainer / Synology") were
+clipped off the right edge. This pins the responsive fix (a flex container that
+wraps, and stacks the tabs full-width on phones)."""
+
+import os
+
+
+def _modal_src():
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "..",
+        "cps", "templates", "update_now_modal.html",
+    )
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_setup_selector_is_a_wrapping_container_not_btn_group():
+    src = _modal_src()
+    selector_line = next(
+        (l for l in src.splitlines() if 'id="update-setup-selector"' in l),
+        "",
+    )
+    assert selector_line, "setup selector element missing"
+    # A non-wrapping btn-group clips the later tabs on mobile — the selector
+    # must not be one.
+    assert "btn-group" not in selector_line, \
+        "selector must not be a non-wrapping btn-group"
+    assert "update-setup-tabs" in selector_line
+
+
+def test_setup_selector_has_responsive_wrap_css():
+    src = _modal_src()
+    assert "flex-wrap: wrap" in src, "selector must wrap on narrow screens"
+    # phones (<=480px) stack the tabs full-width so none are clipped
+    assert "@media (max-width: 480px)" in src


### PR DESCRIPTION
Follow-up to #513. The Update-now modal's setup-type selector was a non-wrapping Bootstrap `btn-group`, so on a phone-width modal the later tabs (Unraid, Portainer/Synology) were clipped off the right edge (caught via a screenshot on mobile).

**Fix:** a flex container that wraps; below 480px the tabs stack full-width so all four stay reachable.

**Verified** at 390px (cwn-local, Playwright): all four tabs fully visible, no horizontal overflow, command box + Copy still reachable. Red/green source-pin in `tests/unit/test_update_modal_responsive.py` — fails on the old `btn-group`, passes on the fix.

Template + test only; no new routes, no deps; admin-only surface → no `/security-review`.