### PR TITLE
fix(duplicates): carry reverse-proxy sub-path prefix on Duplicate Books URLs (fork #514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ is for things you can see or feel when running the app.
   left edge and the slider readouts ("150%", "0px") were clipped at the right.
   The panel now insets its content again, and the "Settings" title keeps its
   full-width bar across the top. Reported by @sambong.
+- **The Duplicate Books page works again behind a reverse proxy on a sub-path.**
+  Behind a proxy mounted on a sub-path, the cover placeholder kept requesting
+  `generic_cover.svg` in an endless loop, and dismissing or resolving a duplicate
+  group failed with "Failed to update duplicate group." Both came from page URLs
+  that dropped the proxy's sub-path prefix; they now carry it. Reported by
+  @chloeroform.
 
 ## [v4.0.169] - 2026-06-22
 

--- a/cps/static/js/duplicates.js
+++ b/cps/static/js/duplicates.js
@@ -362,7 +362,7 @@ $(document).ready(function() {
         
         // Determine action
         var action = isDismissed ? 'undismiss' : 'dismiss';
-        var endpoint = '/duplicates/' + action + '/' + groupHash;
+        var endpoint = duplicateScanEndpoint('/duplicates/' + action + '/' + groupHash);
         
         // Disable button during request
         btn.prop('disabled', true);
@@ -649,7 +649,7 @@ $(document).ready(function() {
         btn.html('<span class="glyphicon glyphicon-refresh glyphicon-spin"></span> Loading...');
         
         $.ajax({
-            url: '/duplicates/preview-resolution',
+            url: duplicateScanEndpoint('/duplicates/preview-resolution'),
             method: 'POST',
             contentType: 'application/json',
             headers: {
@@ -688,7 +688,7 @@ $(document).ready(function() {
         btn.addClass('disabled').html('<span class="glyphicon glyphicon-refresh glyphicon-spin"></span> Executing...');
         
         $.ajax({
-            url: '/duplicates/execute-resolution',
+            url: duplicateScanEndpoint('/duplicates/execute-resolution'),
             method: 'POST',
             contentType: 'application/json',
             headers: {

--- a/cps/templates/duplicates.html
+++ b/cps/templates/duplicates.html
@@ -627,7 +627,7 @@
                 
                 <div class="book-cover">
                   <a href="{{ url_for('web.show_book', book_id=book.id) }}" title="{{_('View book details')}}">
-                    <img src="{{ book.cover_url }}" alt="Cover for {{ book.title }}" onerror="this.src='/static/generic_cover.svg'">
+                    <img src="{{ book.cover_url }}" alt="Cover for {{ book.title }}" onerror="this.onerror=null; this.src='{{ url_for('static', filename='generic_cover.svg') }}'">
                   </a>
                 </div>
                 

--- a/tests/unit/test_duplicates_proxy_path.py
+++ b/tests/unit/test_duplicates_proxy_path.py
@@ -1,0 +1,134 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for fork issue #514 (@chloeroform) — Duplicate Books
+page must build asset and API URLs with the application-root prefix so they
+work behind a reverse proxy mounted on a sub-path.
+
+Two symptoms the reporter hit behind a proxy:
+
+1. ``generic_cover.svg`` loads forever. The cover ``<img>`` fell back to a
+   hardcoded ``/static/generic_cover.svg`` on error, which 404s behind a
+   sub-path proxy, re-firing ``onerror`` with no ``this.onerror=null`` guard
+   — an infinite request loop. The canonical fallback used everywhere else
+   (cover_picker.html, book_edit.html, hardcover_review_matches.html) is
+   ``this.onerror=null; this.src='{{ url_for('static', ...) }}'``.
+
+2. "Failed to update duplicate group" / failed resolve. The dismiss,
+   preview-resolution and execute-resolution POSTs used bare ``/duplicates/...``
+   URLs instead of routing through the existing ``duplicateScanEndpoint()``
+   helper (which prepends ``getPath()``), so they 404 behind the proxy.
+
+These are structural pin-checks on the template + JS plus one behavioural
+check that proves ``url_for`` actually emits the prefix once the
+ReverseProxied middleware has set ``SCRIPT_NAME`` from ``X-Script-Name``.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DUP_HTML = REPO_ROOT / "cps" / "templates" / "duplicates.html"
+DUP_JS = REPO_ROOT / "cps" / "static" / "js" / "duplicates.js"
+
+
+@pytest.mark.unit
+class TestDuplicatesTemplateCoverFallback:
+    """The cover <img> onerror fallback must be proxy-safe and loop-guarded."""
+
+    def _cover_img_line(self):
+        for line in DUP_HTML.read_text().splitlines():
+            if "generic_cover.svg" in line and "onerror" in line:
+                return line
+        raise AssertionError("no cover <img> with generic_cover.svg onerror found in duplicates.html")
+
+    def test_fallback_uses_url_for_not_hardcoded_static(self):
+        line = self._cover_img_line()
+        assert "url_for('static'" in line or 'url_for("static"' in line, (
+            "fork #514: generic_cover.svg fallback must use url_for('static', ...) "
+            "so it carries the reverse-proxy sub-path prefix"
+        )
+        assert "'/static/generic_cover.svg'" not in line and '"/static/generic_cover.svg"' not in line, (
+            "fork #514: hardcoded /static/generic_cover.svg 404s behind a sub-path proxy"
+        )
+
+    def test_fallback_has_onerror_guard(self):
+        line = self._cover_img_line()
+        assert "this.onerror=null" in line.replace(" ", ""), (
+            "fork #514: without this.onerror=null a failing fallback re-fires "
+            "onerror forever (the infinite-loading symptom)"
+        )
+
+
+@pytest.mark.unit
+class TestDuplicatesJsProxySafeEndpoints:
+    """The dismiss/preview/execute POSTs must route through getPath()."""
+
+    def _js(self):
+        return DUP_JS.read_text()
+
+    def test_no_bare_absolute_duplicates_urls(self):
+        js = self._js()
+        # bare `url: '/duplicates/...'` or `'/duplicates/' +` (not wrapped by getPath/duplicateScanEndpoint)
+        bare_url = re.findall(r"""url:\s*['"]/duplicates/""", js)
+        bare_concat = re.findall(r"""=\s*['"]/duplicates/['"]\s*\+""", js)
+        assert not bare_url, (
+            f"fork #514: bare absolute /duplicates/ url(s) bypass the proxy prefix: {bare_url}"
+        )
+        assert not bare_concat, (
+            f"fork #514: bare '/duplicates/' concatenation bypasses the proxy prefix: {bare_concat}"
+        )
+
+    def test_dismiss_endpoint_routes_through_getpath(self):
+        js = self._js()
+        # the dismiss/undismiss endpoint must be built via the existing helper
+        assert "duplicateScanEndpoint('/duplicates/'" in js.replace('"', "'") or \
+               "getPath() + '/duplicates/'" in js.replace('"', "'") or \
+               re.search(r"duplicateScanEndpoint\(\s*['\"]/duplicates/['\"]", js), (
+            "fork #514: dismiss endpoint must be wrapped by duplicateScanEndpoint()/getPath()"
+        )
+
+    def test_resolution_endpoints_route_through_getpath(self):
+        js = self._js()
+        for path in ("/duplicates/preview-resolution", "/duplicates/execute-resolution"):
+            assert f"duplicateScanEndpoint('{path}')" in js or \
+                   f'duplicateScanEndpoint("{path}")' in js, (
+                f"fork #514: {path} POST must route through duplicateScanEndpoint() "
+                f"so it carries the reverse-proxy prefix"
+            )
+
+
+@pytest.mark.unit
+class TestReverseProxyUrlForPrefix:
+    """Behavioural proof that url_for emits the sub-path prefix once the
+    ReverseProxied middleware sets SCRIPT_NAME from X-Script-Name — the
+    mechanism the template fix relies on."""
+
+    def test_url_for_static_carries_x_script_name_prefix(self):
+        from flask import Flask, url_for
+
+        from cps.reverseproxy import ReverseProxied
+
+        app = Flask(__name__)
+        # ReverseProxied is WSGI middleware: it only sets SCRIPT_NAME when a
+        # real request flows through wsgi_app, so exercise it via test_client,
+        # not test_request_context (which bypasses the middleware stack).
+        app.wsgi_app = ReverseProxied(app.wsgi_app)
+
+        @app.route("/probe")
+        def probe():
+            return url_for("static", filename="generic_cover.svg")
+
+        # Simulate a request arriving from a proxy mounted at /myprefix.
+        resp = app.test_client().get("/myprefix/probe", headers={"X-Script-Name": "/myprefix"})
+        url = resp.get_data(as_text=True)
+
+        assert url == "/myprefix/static/generic_cover.svg", (
+            f"expected proxy-prefixed static url, got {url!r}; the duplicates.html "
+            f"fallback relies on this to avoid 404 + infinite retry behind a proxy"
+        )


### PR DESCRIPTION
## Why
Addresses fork #514 (reported by @chloeroform, who fixed the same proxy-prefix class earlier in #14). Behind a reverse proxy mounted on a sub-path, the **Duplicate Books** page broke two ways:

1. `generic_cover.svg` loads forever — the browser keeps re-requesting it.
2. Dismissing or resolving a duplicate group fails with `Error: Failed to update duplicate group`.

## Root cause
Two page URLs dropped the application-root prefix, so they 404'd behind a sub-path proxy:

- `duplicates.html` — the cover `<img>` fell back to a **hardcoded** `/static/generic_cover.svg` on error, with **no `this.onerror=null` guard**. The 404 re-fires `onerror`, which re-sets the same 404 URL → infinite request loop.
- `duplicates.js` — the dismiss/undismiss, `preview-resolution` and `execute-resolution` POSTs used **bare** `/duplicates/...` URLs instead of the existing `duplicateScanEndpoint()` helper (which prepends `getPath()`).

## Fix
- Template: switch to the canonical fallback already used in `cover_picker.html` / `book_edit.html` — `onerror="this.onerror=null; this.src='{{ url_for('static', filename='generic_cover.svg') }}'"`. Carries the proxy prefix **and** breaks the loop.
- JS: wrap the three endpoints in `duplicateScanEndpoint()`, exactly how the same file already wraps `trigger-scan`, `tasks` and `emailstat`. No new abstraction.

Audited both files afterward — no remaining bare absolute URLs. (The reporter's "add a global wrapper for every file" idea is broader cross-template work; scoped out as a follow-up.)

## Reproduction / Validation
`tests/unit/test_duplicates_proxy_path.py` — 6 tests:
- Source-pins on template (`url_for('static')` + `onerror=null`) and JS (all three endpoints via the helper, no bare `/duplicates/` URLs).
- A behavioural test that runs a real Flask app through `ReverseProxied` WSGI middleware with `X-Script-Name: /myprefix` and asserts `url_for('static', ...)` emits `/myprefix/static/generic_cover.svg`.

Red/green:
- Pre-fix: `5 failed, 1 passed` (the 1 is the middleware test — passes by design; it proves the mechanism the template fix relies on).
- Post-fix: `6 passed`.

Not run headless: a full live container behind an actual sub-path proxy. Confidence is high without it because the JS change reuses the **already-proven** `duplicateScanEndpoint()` helper (in production use for the sibling endpoints in this same file) and the template change matches the canonical fallback used elsewhere; the behavioural test exercises the real middleware path.

## Tier / Release
- Tier: fork-original, `needs-review`. No deps / license / external URLs (JS + template + test + CHANGELOG only). No auth/session/CSRF/crypto/subprocess/file-path/new-route surface → `/security-review` not required.
- Rides the next release train; CHANGELOG `[Unreleased]` carries a symptom-first entry crediting @chloeroform. Close-out on #514 waits for the published release (issue stays OPEN).