### PR TITLE
Stop false update banner on dev builds + stack overlapping flash toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+- **Beta (`:dev`) builds no longer nag about a "false" update.** If you run the
+  beta image, the "update available" banner kept pointing at the latest *stable*
+  release even though a beta build is actually ahead of it. Beta/unversioned
+  builds are now recognised and don't show the banner.
+- **Stacked notices no longer pile up into an unreadable blur.** When more than
+  one pop-up notice showed at once — e.g. the duplicate-scan setup notice plus
+  the update banner — they all floated to the same spot and rendered on top of
+  each other. They now stack neatly in a column.
+
 ## [v4.0.170] - 2026-06-23
 
 ### Added

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -205,11 +205,25 @@ def cwa_update_available() -> tuple[bool, str, str]:
                 parts.append(int(num) if num else 0)
             return tuple(parts)
 
+        def _is_release_version(value: str) -> bool:
+            # A real release is dotted-numeric ("4.0.170"). Dev / nightly
+            # builds ("DEV_BUILD-dev-247", a git SHA, etc.) are not — their
+            # first segment isn't numeric, so _version_tuple collapses them to
+            # (0, …) and they would falsely read as "older" than the latest
+            # stable tag (a dev box nagged about an update it is ahead of).
+            return value.split(".")[0].isdigit()
+
         current_normalized = _normalize_version(current_version)
         tag_normalized = _normalize_version(tag_name)
 
         if current_normalized in ("", "0.0.0") or tag_normalized in ("", "0.0.0"):
             return False, "0.0.0", "0.0.0"
+
+        # A :dev / unversioned build is intentionally ahead of any tagged
+        # release; comparing it to the latest stable tag is meaningless. Only
+        # compare two real release versions.
+        if not (_is_release_version(current_normalized) and _is_release_version(tag_normalized)):
+            return False, current_version, tag_name
 
         # Only flag an update when the published tag is strictly newer than
         # what's installed; a downgrade or equal version is not an update.
@@ -239,6 +253,16 @@ def _format_update_banner_message(current_version: str, latest_version: str) -> 
     return _("Calibre-Web NextGen %(latest)s is available — you're on %(current)s.") % {
         "latest": latest_version,
         "current": current_version,
+    }
+
+
+def _format_translation_missing_message(language: str, count: int) -> str:
+    # Static msgid with named placeholders (see _format_update_banner_message):
+    # the old ``_(f"...{language}...{count}...")`` interpolated before gettext,
+    # so pybabel could never extract it and every locale fell back to English.
+    return _("Help improve Calibre-Web NextGen's %(language)s translations — %(count)s strings in your language still need translating.") % {
+        "language": language,
+        "count": count,
     }
 
 
@@ -312,7 +336,8 @@ def translations_missing_notification() -> None:
                 with open(notice_file, 'r') as f:
                     last_notification = f.read().strip()
             if last_notification != current_date:
-                message = _(f"🌐 Help improve Calibre-Web NextGen's {constants.LANGUAGE_NAMES.get(lang, lang)} translations! {missing_count} strings in your language need translation. ")
+                message = _format_translation_missing_message(
+                    constants.LANGUAGE_NAMES.get(lang, lang), missing_count)
                 flash(message, category="translation_missing")
                 print(f"[translation-notification-service] {message}", flush=True)
                 with open(notice_file, 'w') as f:

--- a/cps/static/css/caliBlur_override.css
+++ b/cps/static/css/caliBlur_override.css
@@ -276,3 +276,48 @@ a#advanced_search > span.hidden-sm {
         padding-left: 10px;
     }
 }
+
+/* ---------------------------------------------------------------------------
+   Persistent flash-toast stack (fork).
+   caliBlur turns every .alert into a position:fixed toast (.alert-cwa). When
+   more than one persistent notice fired at once (e.g. the duplicate-scan-setup
+   notice + the "update available" banner) they all anchored to the same spot
+   and rendered on top of each other — a garbled overlap. The persistent toasts
+   now render inside a single .cwa-toast-stack flex column (see layout.html) so
+   they stack instead of overlap.
+   --------------------------------------------------------------------------- */
+.cwa-toast-stack {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 50%;
+    max-width: 640px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    z-index: 1050;
+    pointer-events: none; /* clicks fall through the gaps; toasts re-enable it */
+}
+.cwa-toast-stack > * { pointer-events: auto; }
+
+/* Neutralise caliBlur's per-toast fixed positioning so each toast simply flows
+   inside the stack column. The .cwa-toast-stack prefix raises specificity above
+   caliBlur's `.alert-info.alert-cwa { position: fixed }`. */
+.cwa-toast-stack .row-fluid,
+.cwa-toast-stack .alert-info.alert-cwa,
+.cwa-toast-stack .alert-danger.alert-cwa,
+.cwa-toast-stack .refresh-cwa {
+    position: static !important;
+    top: auto !important;
+    bottom: auto !important;
+    left: auto !important;
+    right: auto !important;
+    width: auto !important;
+    max-width: none !important;
+    margin: 0 !important;
+    -webkit-transform: none !important;
+    transform: none !important;
+}
+/* The mobile (<=767px) repositioning of .cwa-toast-stack lives in
+   fork-mobile-cards.css alongside the other mobile adaptations. */

--- a/cps/static/css/fork-mobile-cards.css
+++ b/cps/static/css/fork-mobile-cards.css
@@ -63,27 +63,25 @@
         font-size: 12px;
     }
 
-    /* Persistent .alert-cwa banners (duplicate-scan-setup, cwa-update,
-       translation-missing, etc.) are styled by caliBlur as
-       `position: fixed; bottom: 20px; left: 50%; width: 50%` — a
-       centered floating popup. On phones that floating popup overlaps
-       the book grid content underneath. Move it to TOP (below the
-       fixed navbar, ~60px from top) and full-width so it stops
-       blocking book content while staying visible. Desktop keeps the
-       caliBlur floating-bottom treatment. */
-    .alert-info.alert-cwa,
-    .alert-danger.alert-cwa {
+    /* Persistent .alert-cwa toasts stack in the .cwa-toast-stack container
+       (base/desktop positioning + the static-toast override live in
+       caliBlur_override.css; layout.html renders the container). On phones, dock
+       the whole stack below the fixed navbar instead of floating at the bottom
+       over the book grid, and keep the toast readability tweaks. */
+    .cwa-toast-stack {
         top: 64px !important;
         bottom: auto !important;
         left: 8px !important;
         right: 8px !important;
         width: auto !important;
         max-width: none !important;
+        -webkit-transform: none !important;
+        transform: none !important;
+    }
+    .cwa-toast-stack .alert-info.alert-cwa,
+    .cwa-toast-stack .alert-danger.alert-cwa {
         padding: 12px 14px !important;
         font-size: 13px !important;
-        -webkit-transform: none !important;
-        -ms-transform: none !important;
-        transform: none !important;
     }
 
     /* Pagination prev/next arrow vertical-alignment.

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -243,7 +243,10 @@
       </div>
     </div>
 
-    {% for message in get_flashed_messages(with_categories=True) %}
+    {% set cwa_flashes = get_flashed_messages(with_categories=True) %}
+    {# Inline flashes (form errors, info, warnings, success) render in normal
+       flow at the top of the page. #}
+    {% for message in cwa_flashes %}
       {%if message[0] == "error" %}
       <div class="row-fluid text-center" >
         <div id="flash_danger" class="alert alert-danger">{{ message[1] }}</div>
@@ -254,7 +257,25 @@
         <div id="flash_info" class="alert alert-info">{{ message[1] }}</div>
       </div>
       {%endif%}
-      <div id="messageContainer"></div>
+      {%if message[0] == "warning" %}
+      <div class="row-fluid text-center">
+        <div id="flash_warning" class="alert alert-warning">{{ message[1] }}</div>
+      </div>
+      {%endif%}
+      {%if message[0] == "success" %}
+      <div class="row-fluid text-center">
+        <div id="flash_success" class="alert alert-success">{{ message[1] }}</div>
+      </div>
+      {%endif%}
+    {% endfor %}
+    <div id="messageContainer"></div>
+    {# Persistent .alert-cwa popups stack inside one fixed container so they
+       never overlap when more than one fires. caliBlur turns every .alert into
+       a position:fixed toast; rendered loose they all piled onto the same spot
+       (the garbled overlap a user reported). The stack lays them out as a
+       column instead. #}
+    <div class="cwa-toast-stack">
+    {% for message in cwa_flashes %}
       {%if message[0] == "cwa_update" %}
       <div class="row-fluid text-center">
         <div id="flash_info" class="alert alert-info alert-cwa">
@@ -319,17 +340,8 @@
         </div>
       </div>
       {%endif%}
-      {%if message[0] == "warning" %}
-      <div class="row-fluid text-center">
-        <div id="flash_warning" class="alert alert-warning">{{ message[1] }}</div>
-      </div>
-      {%endif%}
-      {%if message[0] == "success" %}
-      <div class="row-fluid text-center">
-        <div id="flash_success" class="alert alert-success">{{ message[1] }}</div>
-      </div>
-      {%endif%}
     {% endfor %}
+    </div>
     {% block flash %}{% endblock %}
     {% if g.current_theme == 1 %}
       <div id="loader" hidden="true">

--- a/tests/unit/test_admin_update_indicator.py
+++ b/tests/unit/test_admin_update_indicator.py
@@ -74,6 +74,37 @@ class TestUpdateIndicatorHelper:
 
 
 @pytest.mark.unit
+class TestUpdateAvailableDevBuild:
+    """A :dev / unversioned build must NOT show a false "update available".
+
+    The :dev image stamps INSTALLED_VERSION as e.g. "DEV_BUILD-dev-247", which
+    parses to a ``(0,)`` version tuple — so a naive compare against the latest
+    stable tag always reads as "outdated", nagging the canary/dev box about an
+    update it is actually *ahead* of. Real releases must still be compared."""
+
+    def test_dev_build_does_not_flag_update(self, mocker):
+        from cps.render_template import cwa_update_available
+        mocker.patch("cps.constants.INSTALLED_VERSION", "DEV_BUILD-dev-247")
+        mocker.patch("cps.constants.STABLE_VERSION", "v4.0.170")
+        is_newer, _current, _latest = cwa_update_available()
+        assert is_newer is False
+
+    def test_real_release_still_flags_update(self, mocker):
+        from cps.render_template import cwa_update_available
+        mocker.patch("cps.constants.INSTALLED_VERSION", "v4.0.100")
+        mocker.patch("cps.constants.STABLE_VERSION", "v4.0.170")
+        is_newer, _current, _latest = cwa_update_available()
+        assert is_newer is True
+
+    def test_up_to_date_release_does_not_flag(self, mocker):
+        from cps.render_template import cwa_update_available
+        mocker.patch("cps.constants.INSTALLED_VERSION", "v4.0.170")
+        mocker.patch("cps.constants.STABLE_VERSION", "v4.0.170")
+        is_newer, _current, _latest = cwa_update_available()
+        assert is_newer is False
+
+
+@pytest.mark.unit
 class TestAdminRoutePassesIndicator:
     def test_admin_route_source_passes_indicator_kwargs(self):
         """Source-pin: ``admin()`` must include cwa_is_outdated and

--- a/tests/unit/test_flash_toast_stacking.py
+++ b/tests/unit/test_flash_toast_stacking.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression: the persistent ``.alert-cwa`` flash toasts must STACK.
+
+caliBlur turns every ``.alert`` into a ``position: fixed`` toast, so when more
+than one persistent notice fires at once (e.g. the duplicate-scan-setup notice
++ the "update available" banner on the same page) they all anchor to the same
+spot and render on top of each other — the garbled overlap a user reported.
+
+The fix wraps the persistent toasts in a single ``.cwa-toast-stack`` flex
+container so they lay out in a column. These are structural pins; the
+behavioural "two toasts don't overlap" proof is the Playwright pass.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+LAYOUT = REPO / "cps" / "templates" / "layout.html"
+CSS_OVERRIDE = REPO / "cps" / "static" / "css" / "caliBlur_override.css"
+
+PERSISTENT = [
+    "cwa_update", "duplicate_scan_setup", "cwa_arch_warning",
+    "translation_missing", "theme_migration", "cwa_refresh",
+]
+
+
+def test_persistent_toasts_live_in_a_stack_container():
+    src = LAYOUT.read_text()
+    assert "cwa-toast-stack" in src, (
+        "persistent toasts need a .cwa-toast-stack container so they stack "
+        "instead of overlapping"
+    )
+    stack_at = src.index("cwa-toast-stack")
+    for cat in PERSISTENT:
+        marker = 'message[0] == "%s"' % cat
+        assert marker in src, "toast category missing: " + cat
+        assert src.index(marker) > stack_at, (
+            cat + " toast must render inside the .cwa-toast-stack container"
+        )
+
+
+def test_inline_flashes_stay_outside_the_floating_stack():
+    """error/success flashes belong inline at the top, not in the floating
+    toast stack — only the persistent .alert-cwa popups stack."""
+    src = LAYOUT.read_text()
+    stack_at = src.index("cwa-toast-stack")
+    for cat in ("error", "success"):
+        marker = 'message[0] == "%s"' % cat
+        assert marker in src
+        assert src.index(marker) < stack_at, (
+            "inline '" + cat + "' flash must render before/outside the toast stack"
+        )
+
+
+def test_stack_css_is_a_vertical_flex_column():
+    css = CSS_OVERRIDE.read_text()
+    m = re.search(r"\.cwa-toast-stack\b[^{]*\{([^}]*)\}", css, re.S)
+    assert m, ".cwa-toast-stack rule must exist in caliBlur_override.css"
+    body = m.group(1)
+    assert "fixed" in body, "the stack must be position:fixed (the toast anchor point)"
+    assert "column" in body, "the stack must lay toasts out in a column so they stack"

--- a/tests/unit/test_mobile_substantive_layout_sweep.py
+++ b/tests/unit/test_mobile_substantive_layout_sweep.py
@@ -106,24 +106,26 @@ def test_book_card_title_wraps_to_two_lines_on_mobile():
     ), "must declare -webkit-line-clamp: 2 !important"
 
 
-def test_alert_cwa_banner_repositioned_top_on_mobile():
-    """The persistent .alert-cwa banner must move from caliBlur's
-    fixed-bottom-50%-width treatment to a top-anchored full-width
-    banner on mobile, so it doesn't overlap book grid content."""
+def test_alert_cwa_toast_stack_repositioned_top_on_mobile():
+    """The persistent .alert-cwa toasts now stack in the .cwa-toast-stack
+    container (base positioning in caliBlur_override.css; layout.html renders
+    it). On mobile the whole stack must move from caliBlur's fixed-bottom-50%
+    treatment to a top-anchored full-width column, so it doesn't overlap book
+    grid content. The positioning moved from the individual toasts to the
+    container."""
     src = MOBILE_CARDS.read_text()
     block = _mobile_block(src, 767)
-    # Selectors must cover both info + danger variants.
-    assert re.search(
-        r"\.alert-(?:info|danger)\.alert-cwa", block,
-    ), "must scope rule to .alert-info.alert-cwa + .alert-danger.alert-cwa"
-    # Must move top down from auto + clear bottom.
-    assert re.search(r"top:\s*\d+px\s*!important", block), (
-        "must set explicit top: Npx (below navbar)"
+    assert block, "mobile media query (max-width:767px) not found in fork-mobile-cards.css"
+    # The stack CONTAINER (not each toast) is re-anchored to top, full width.
+    stack_rule = re.search(r"\.cwa-toast-stack\s*\{[^}]*\}", block, re.DOTALL)
+    assert stack_rule, "must position .cwa-toast-stack in the mobile block"
+    body = stack_rule.group(0)
+    assert re.search(r"top:\s*\d+px\s*!important", body), (
+        ".cwa-toast-stack must set explicit top: Npx (below navbar) on mobile"
     )
-    assert re.search(r"bottom:\s*auto\s*!important", block), (
-        "must clear bottom: auto to override caliBlur's fixed-bottom positioning"
+    assert re.search(r"bottom:\s*auto\s*!important", body), (
+        ".cwa-toast-stack must clear bottom: auto to override the desktop fixed-bottom anchor"
     )
-    # Must clear caliBlur's width:50% so banner spans full width.
-    assert re.search(r"width:\s*auto\s*!important", block), (
-        "must override caliBlur's width: 50% to span full mobile width"
+    assert re.search(r"width:\s*auto\s*!important", body), (
+        ".cwa-toast-stack must span full mobile width (width: auto)"
     )

--- a/tests/unit/test_update_banner_message.py
+++ b/tests/unit/test_update_banner_message.py
@@ -64,3 +64,32 @@ def test_update_notification_drops_fstring_gettext_antipattern():
     assert '_(f"' not in src and "_(f'" not in src, "f-string inside gettext is not extractable"
     assert "⚡" not in src and "🚨" not in src, "emoji spam must be gone from the banner"
     assert "_format_update_banner_message" in src, "must build the message via the translatable helper"
+
+
+def test_format_translation_missing_message_is_static_translatable(monkeypatch):
+    """Same i18n contract as the update banner: the "translations needed" notice
+    must build from a STATIC msgid (named placeholders), not interpolate the
+    language/count into the gettext key (the old ``_(f"...")``), and be emoji-free."""
+    captured = {}
+
+    def fake_gettext(msgid):
+        captured["msgid"] = msgid
+        return msgid
+
+    monkeypatch.setattr(rt, "_", fake_gettext)
+
+    msg = rt._format_translation_missing_message("German", 42)
+
+    assert "%(language)s" in captured["msgid"]
+    assert "%(count)s" in captured["msgid"]
+    assert "German" not in captured["msgid"]
+    assert "42" not in captured["msgid"]
+    assert "German" in msg and "42" in msg
+    assert "🌐" not in msg
+
+
+def test_translations_missing_notification_drops_fstring_antipattern():
+    src = inspect.getsource(rt.translations_missing_notification)
+    assert '_(f"' not in src and "_(f'" not in src, "f-string inside gettext is not extractable"
+    assert "🌐" not in src, "drop the emoji for tone consistency"
+    assert "_format_translation_missing_message" in src, "route through the translatable helper"


### PR DESCRIPTION
## What this fixes

Two polish fixes around the update/settings UI, plus an i18n + CSS migration the second surfaced.

### 1. Dev/beta builds no longer show a false "update available"
`cwa_update_available()` compared a `:dev` build's version (`DEV_BUILD-dev-N`, which parses to a `(0,)` tuple) against the latest *stable* tag — so a beta box that's actually *ahead* of stable kept being nagged. Only real release versions are compared now.

### 2. Overlapping flash toasts now stack
caliBlur turns every `.alert` into a `position:fixed` toast; rendered loose, multiple persistent notices (e.g. the duplicate-scan-setup notice + the update banner) piled onto the same spot and overlapped into a garble. They now render inside one `.cwa-toast-stack` flex column.

### 3. (migration) "translations needed" notice i18n
It used the same un-extractable `_(f"...")` gettext antipattern the update banner did — pybabel never extracted it so every locale fell back to English. Migrated to a static msgid; emoji dropped for tone consistency.

## Verification
- **TDD red/green:** `test_admin_update_indicator` (dev-build ×3), `test_flash_toast_stacking` (new ×3), `test_update_banner_message` (translation ×2). The old mobile-sweep test that pinned the per-toast positioning is **migrated** to pin the stack-container positioning.
- **Live (cwn-local):** dev build returns `(False, …)`, real outdated returns `(True, …)`; all 3 admin pages render HTTP 200 with no tracebacks.
- **Playwright:** two toasts stack with **no overlap** at desktop and **390px mobile** (`position:fixed`, flex `column`, `stackTop:64`, 10px gap).
- **i18n:** new msgid extracts cleanly, 30 locales still compile (CI runs `update_translations.sh` to sync `.po` on merge).

## Notes
- No new routes, no deps, admin-only/cosmetic surfaces → `/security-review` not triggered.
- Follows the project's CSS convention: base/desktop stack rules in `caliBlur_override.css`, mobile re-anchor in `fork-mobile-cards.css`.
