### PR TITLE
feat(web): "Currently reading" badge for KOReader/Kobo in-progress books (#509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+- **Books you're partway through now show a "Currently reading" badge.** If you
+  read on KOReader (or a Kobo) and your progress syncs back, the book used to
+  look exactly like one you'd never opened — the web only marked books as read
+  once you finished them. Now an in-progress book gets an amber "Currently
+  reading" marker on its detail page and a badge on its cover in the grid,
+  shelves, search and author pages, so synced reading progress is actually
+  visible. Reported by @barukh27.
+
 ## [v4.0.171] - 2026-06-24
 
 ### Added

--- a/cps/static/css/book_organizer.css
+++ b/cps/static/css/book_organizer.css
@@ -410,6 +410,41 @@ body.book-organizer-select-mode .book-organizer-actions-row {
 .cover-badge-read .glyphicon { font-size: 11px; }
 .cover-badge-read-label { letter-spacing: 0.3px; }
 
+/* fork #509: "currently reading" badge — a book synced as in-progress from
+   KOReader/Kobo. Amber, distinct from the green "Read" badge so the two
+   states never look alike. Shares the .cover-badge pill geometry. */
+.cover-badge-in-progress {
+  background: #d98e04;
+  color: #fff;
+  padding: 3px 8px;
+}
+.cover-badge-in-progress .glyphicon { font-size: 11px; }
+.cover-badge-in-progress-label { letter-spacing: 0.3px; }
+
+/* Detail-page "Currently reading" marker (fork #509). A standalone amber
+   pill under the title/author — not a cover overlay, so it carries its own
+   inline-flex layout instead of the absolute-positioned .cover-badges stack. */
+.currently-reading {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 4px 0 8px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  background: #d98e04;
+  color: #fff;
+  letter-spacing: 0.3px;
+}
+.currently-reading .glyphicon { font-size: 12px; }
+
+/* Legacy random-books-strip badge variant (index.html), matched to the
+   absolute-positioned .cover .read slot but amber for the in-progress state. */
+.cover .badge.in-progress {
+  background: #d98e04;
+}
+
 .cover-badge-shelf {
   background: rgba(20, 30, 40, 0.92);
   color: #fff;

--- a/cps/static/css/caliBlur_override.css
+++ b/cps/static/css/caliBlur_override.css
@@ -21,7 +21,8 @@ input[type=checkbox] {accent-color: #cc7b19;}
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.6);
 } */
 
-.cover .read {
+.cover .read,
+.cover .in-progress {
   line-height: 15px;
   font-size: xx-small;
   position: absolute !important;
@@ -34,7 +35,8 @@ input[type=checkbox] {accent-color: #cc7b19;}
 }
 
 @media (max-width: 767px) {
-  .cover .read {
+  .cover .read,
+  .cover .in-progress {
     line-height: 15px;
     font-size: xx-small;
     position: absolute !important;

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -309,7 +309,8 @@ span.glyphicon.glyphicon-tags {
   background-color: #fff;
 }
 
-.cover .read {
+.cover .read,
+.cover .in-progress {
   position: relative;
   top: -20px;
   /*left: auto;

--- a/cps/static/js/caliBlur.js
+++ b/cps/static/js/caliBlur.js
@@ -1136,6 +1136,10 @@ $(function() {
                         // Remove read badge
                         $readBadge.remove();
                     } else {
+                        // Marking read: drop any "currently reading" badge first
+                        // so an in-progress book doesn't show Reading + Read at
+                        // once until the next reload (fork #509).
+                        $link.find('.cover-badge-in-progress, .badge.in-progress').remove();
                         // Add read badge — matches index.html / image.html
                         // glyphicon-check (fork #319 droM4X icon-standardization).
                         var $newBadge = $('<span class="badge read glyphicon glyphicon-check"></span>');

--- a/cps/templates/author.html
+++ b/cps/templates/author.html
@@ -40,7 +40,7 @@
            class="book-cover-link">
             <span class="img" title="{{entry.Books.title}}">
               {{ image.book_cover(entry.Books, alt=author.name|safe) }}
-              {{ image.cover_badges(entry.Books, is_read=(entry[2] == True)) }}
+              {{ image.cover_badges(entry.Books, read_status=(entry[2] or 0)) }}
             </span>
         </a>
       </div>

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -1261,6 +1261,11 @@
                          .toggleClass("glyphicon-check", !isRead);
                     var title = isRead ? $cb.data("checked") : $cb.data("unchecked");
                     $("#toggle-read-btn").attr("title", title).attr("aria-label", title);
+                    // Once the user explicitly marks the book read OR unread, the
+                    // sync-driven "Currently reading" pill is stale (the book is no
+                    // longer in-progress) — drop it so the page doesn't show
+                    // "Currently reading" next to "Mark As Unread" until reload (#509).
+                    $("#currently-reading-badge").remove();
                     var $btn = $("#toggle-read-btn");
                     var toastMsg = isRead ? $btn.data("toast-on") : $btn.data("toast-off");
                     showActionToast(toastMsg, $btn[0]);

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -839,6 +839,17 @@
                                 {% endif %}
                             {% endfor %}
                         </p>
+                        {# Passive "currently reading" marker (fork #509). Shows when the book's
+                           read state is IN_PROGRESS (read_status_raw == 2) — i.e. a book a user is
+                           partway through on KOReader/Kobo. The read toggle below stays a 2-state
+                           read/unread control; in-progress is sync-driven display only, not a
+                           user-set toggle position. #}
+                        {% if entry.read_status_raw == 2 %}
+                        <p class="currently-reading cover-badge-in-progress" id="currently-reading-badge">
+                            <span class="glyphicon glyphicon-book" aria-hidden="true"></span>
+                            {{ _('Currently reading') }}
+                        </p>
+                        {% endif %}
                         {% set current_rating = (entry.ratings[0].rating / 2)|int if entry.ratings|length > 0 else 0 %}
                         <div class="rating" id="detail-rating-block">
                             {% if current_user.role_edit() %}

--- a/cps/templates/image.html
+++ b/cps/templates/image.html
@@ -10,13 +10,21 @@
     />
 {%- endmacro %}
 
-{% macro cover_badges(book, is_read=false) -%}
+{# read_status is the tri-state ub.ReadBook.read_status: 0=unread, 1=finished,
+   2=in-progress (fork #509). It is passed as an int so an in-progress book
+   synced from KOReader/Kobo shows a distinct "Currently reading" badge instead
+   of looking identical to an unread one. Older callers passed a boolean is_read;
+   that flattened 2→falsey and dropped the in-progress state. #}
+{% macro cover_badges(book, read_status=0) -%}
 {% set shelves_here = g.book_shelves_map.get(book.id, []) if g.book_shelves_map is defined else [] %}
 {% set is_favorited = (g.favorite_book_ids is defined and book.id in g.favorite_book_ids) %}
-{% if is_read or shelves_here or is_favorited %}
+{% set is_read = (read_status == 1) %}
+{% set is_in_progress = (read_status == 2) %}
+{% if is_read or is_in_progress or shelves_here or is_favorited %}
 <div class="cover-badges">
   {% if is_favorited %}<span class="cover-badge cover-badge-favorite" title="{{ _('Favorite') }}"><span class="glyphicon glyphicon-star" style="color:#f5c518" aria-hidden="true"></span></span>{% endif %}
   {% if is_read %}<span class="cover-badge cover-badge-read" title="{{ _('Read') }}"><span class="glyphicon glyphicon-check" aria-hidden="true"></span><span class="cover-badge-read-label">{{ _('Read') }}</span></span>{% endif %}
+  {% if is_in_progress %}<span class="cover-badge cover-badge-in-progress" title="{{ _('Currently reading') }}"><span class="glyphicon glyphicon-book" aria-hidden="true"></span><span class="cover-badge-in-progress-label">{{ _('Reading') }}</span></span>{% endif %}
   {% set max_shown = 3 %}
   {% set extra = shelves_here|length - max_shown %}
   {% for sh in shelves_here[:max_shown] %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -42,7 +42,7 @@
              class="book-cover-link">
               <span class="img" title="{{ entry.Books.title }}">
                 {{ image.book_cover(entry.Books) }}
-                {% if entry[2] == True %}<span class="badge read glyphicon glyphicon-check"></span>{% endif %}
+                {% if entry[2] == 1 %}<span class="badge read glyphicon glyphicon-check"></span>{% elif entry[2] == 2 %}<span class="badge in-progress glyphicon glyphicon-book" title="{{ _('Currently reading') }}"></span>{% endif %}
               </span>
           </a>
       </div>
@@ -185,7 +185,7 @@
              class="book-cover-link">
             <span class="img" title="{{ entry.Books.title }}">
               {{ image.book_cover(entry.Books) }}
-              {{ image.cover_badges(entry.Books, is_read=(entry[2] == True)) }}
+              {{ image.cover_badges(entry.Books, read_status=(entry[2] or 0)) }}
             </span>
           </a>
       </div>

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -46,7 +46,7 @@
               class="book-cover-link">
             <span class="img" title="{{entry.Books.title}}" >
                 {{ image.book_cover(entry.Books) }}
-                {{ image.cover_badges(entry.Books, is_read=(entry[2] == True)) }}
+                {{ image.cover_badges(entry.Books, read_status=(entry[2] or 0)) }}
             </span>
           </a>
         {% endif %}

--- a/cps/templates/shelf.html
+++ b/cps/templates/shelf.html
@@ -42,7 +42,7 @@
                class="book-cover-link">
               <span class="img" title="{{entry.Books.title}}" >
                 {{ image.book_cover(entry.Books) }}
-                {{ image.cover_badges(entry.Books, is_read=(entry[2] == True)) }}
+                {{ image.cover_badges(entry.Books, read_status=(entry[2] or 0)) }}
               </span>
             </a>
       </div>

--- a/cps/web.py
+++ b/cps/web.py
@@ -1935,6 +1935,10 @@ def list_books():
         val = entry[0]
         val.is_archived = entry[1] is True
         val.read_status = entry[2] == ub.ReadBook.STATUS_FINISHED
+        # Carry the raw tri-state too (0 unread / 1 finished / 2 in-progress)
+        # so consumers can distinguish a book synced as in-progress from
+        # KOReader/Kobo from an unread one. fork #509.
+        val.read_status_raw = entry[2] or ub.ReadBook.STATUS_UNREAD
         for lang_index in range(0, len(val.languages)):
             val.languages[lang_index].language_name = isoLanguages.get_language_name(get_locale(), val.languages[
                 lang_index].lang_code)
@@ -3535,6 +3539,8 @@ def show_book(book_id):
         archived_book = entries[2]
         entry = entries[0]
         entry.read_status = read_book == ub.ReadBook.STATUS_FINISHED
+        # Raw tri-state for the "currently reading" detail-page marker. fork #509.
+        entry.read_status_raw = read_book or ub.ReadBook.STATUS_UNREAD
         entry.is_archived = archived_book
         for lang_index in range(0, len(entry.languages)):
             entry.languages[lang_index].language_name = isoLanguages.get_language_name(get_locale(), entry.languages[

--- a/cps/web.py
+++ b/cps/web.py
@@ -1935,10 +1935,6 @@ def list_books():
         val = entry[0]
         val.is_archived = entry[1] is True
         val.read_status = entry[2] == ub.ReadBook.STATUS_FINISHED
-        # Carry the raw tri-state too (0 unread / 1 finished / 2 in-progress)
-        # so consumers can distinguish a book synced as in-progress from
-        # KOReader/Kobo from an unread one. fork #509.
-        val.read_status_raw = entry[2] or ub.ReadBook.STATUS_UNREAD
         for lang_index in range(0, len(val.languages)):
             val.languages[lang_index].language_name = isoLanguages.get_language_name(get_locale(), val.languages[
                 lang_index].lang_code)

--- a/tests/unit/test_in_progress_read_state_509.py
+++ b/tests/unit/test_in_progress_read_state_509.py
@@ -144,16 +144,20 @@ class TestCoverBadgeMacroRendersInProgress:
 @pytest.mark.unit
 class TestCoercionCarriesRawStatus:
     def test_web_py_carries_raw_read_status(self):
-        """Both render paths in web.py (the books-table JSON serializer and
-        the detail page) must expose the raw integer read_status, not only
-        the ``== STATUS_FINISHED`` boolean — otherwise the template can never
-        tell in-progress from unread."""
+        """The detail page (``show_book``) must expose the raw integer
+        read_status, not only the ``== STATUS_FINISHED`` boolean — otherwise
+        detail.html can never tell in-progress from unread. (The grid/list
+        views read the raw tri-state straight off the query tuple as
+        ``entry[2]``, so they don't need a web.py field.)"""
         src = WEB_PY.read_text(encoding="utf-8")
-        assert src.count("read_status_raw") >= 2, (
-            "web.py must set a raw integer read-status field (e.g. "
-            "read_status_raw) at BOTH coercion sites (books-list serializer "
-            "~L1937 and detail page ~L3537) so the in-progress state "
-            "survives to the templates. fork #509."
+        assert "read_status_raw" in src, (
+            "web.py show_book must set read_status_raw (the raw tri-state) so "
+            "detail.html can render the in-progress marker. fork #509."
+        )
+        # Pin it to the detail page's read_book source, not the boolean.
+        assert "read_status_raw = read_book" in src, (
+            "read_status_raw must derive from the detail page's read_book "
+            "value (the raw int), e.g. `read_book or STATUS_UNREAD`. fork #509."
         )
 
     def test_detail_template_branches_on_in_progress(self):
@@ -169,6 +173,22 @@ class TestCoercionCarriesRawStatus:
             "detail.html must render a distinct in-progress marker "
             "(.cover-badge-in-progress / .currently-reading) for a book the "
             "user is partway through. fork #509."
+        )
+
+    def test_detail_toggle_removes_currently_reading_pill(self):
+        """When the user marks a book read/unread via the detail-page toggle,
+        the JS handler must remove the sync-driven "Currently reading" pill —
+        otherwise the page shows "Currently reading" next to "Mark As Unread"
+        until a reload (Greptile #520 finding, fork #509)."""
+        src = DETAIL_HTML.read_text(encoding="utf-8")
+        # The toggle handler and the pill removal must both be present, and the
+        # removal must target the pill's id.
+        assert "#toggle-read-btn" in src, "detail.html toggle handler missing"
+        assert '$("#currently-reading-badge").remove()' in src or \
+               "$('#currently-reading-badge').remove()" in src, (
+            "The #toggle-read-btn success handler must remove "
+            "#currently-reading-badge so an in-progress book marked read "
+            "doesn't show the stale pill until reload. fork #509 / Greptile #520."
         )
 
     def test_image_macro_takes_tristate_not_bool(self):

--- a/tests/unit/test_in_progress_read_state_509.py
+++ b/tests/unit/test_in_progress_read_state_509.py
@@ -1,0 +1,206 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for fork #509 — KOReader "currently reading" never
+surfaces in the web UI.
+
+Reporter @barukh27 (2026-06-22): progress synced from KOReader is stored
+in the database but "No webUI presence" — a book you are partway through
+on KOReader looks identical to an unread book everywhere in the web UI.
+
+Root cause (verified against source): ``ub.ReadBook.read_status`` is a
+tri-state — UNREAD=0, FINISHED=1, IN_PROGRESS=2. The kosync PUT handler
+writes all three correctly (``cps/progress_syncing/protocols/kosync.py``:
+>=99% FINISHED, >0% IN_PROGRESS), but every browsing surface flattens the
+tri-state to a boolean that is true only for FINISHED:
+
+  - ``cps/web.py`` (JSON serializer + detail page): ``read_status == STATUS_FINISHED``
+  - ``cps/templates/*`` grid/list cards: the cover_badges macro is called
+    with ``is_read=(entry[2] == True)`` — and ``2 == True`` is ``False``.
+
+So ``read_status == 2`` renders identically to ``0`` (unread). The data
+model already knows the third state (the smart-shelf filter even exposes
+"Currently Reading"), but the rendering throws it away.
+
+These tests pin the fix: the in-progress state must survive to the
+rendered UI as a distinct "Currently reading" badge, separate from the
+"Read" badge, without breaking the existing read/unread toggle.
+"""
+
+import pathlib
+import types
+
+import pytest
+
+try:
+    import jinja2
+except ImportError:  # pragma: no cover
+    jinja2 = None
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+TEMPLATES_DIR = REPO_ROOT / "cps" / "templates"
+WEB_PY = REPO_ROOT / "cps" / "web.py"
+DETAIL_HTML = REPO_ROOT / "cps" / "templates" / "detail.html"
+IMAGE_HTML = REPO_ROOT / "cps" / "templates" / "image.html"
+
+# The four grid/list templates that render cover badges through the macro.
+GRID_TEMPLATES = ["index.html", "shelf.html", "search.html", "author.html"]
+
+# Mirror of cps/ub.py ReadBook constants.
+STATUS_UNREAD = 0
+STATUS_FINISHED = 1
+STATUS_IN_PROGRESS = 2
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: the cover_badges macro must render a DISTINCT in-progress badge
+# for read_status == 2, the read badge for == 1, and neither for == 0.
+# This is the user-visible output; it fails on main because the macro takes
+# a boolean is_read and has no in-progress branch.
+# ---------------------------------------------------------------------------
+
+
+def _render_cover_badges(read_status: int) -> str:
+    """Render the cover_badges macro in isolation with a given read_status.
+
+    Calls the macro with the status as the second positional arg, which works
+    against both the old signature (``cover_badges(book, is_read=false)``) and
+    the new one (``cover_badges(book, read_status=0)``) so the test can run
+    RED on main and GREEN on the branch.
+    """
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(TEMPLATES_DIR)),
+        autoescape=True,
+    )
+    env.globals["_"] = lambda s: s
+    env.globals["g"] = types.SimpleNamespace(
+        book_shelves_map={}, favorite_book_ids=set()
+    )
+    env.globals["url_for"] = lambda *a, **k: "#"
+    # image.html's book_cover/series macros reference these filters; Jinja
+    # resolves filter names at COMPILE time when the module is imported, so
+    # they must exist even though cover_badges itself doesn't use them.
+    for _filt in ("get_cover_srcset", "get_series_srcset", "last_modified",
+                  "cache_timestamp"):
+        env.filters[_filt] = lambda value, *a, **k: ""
+    tmpl = env.from_string(
+        "{% import 'image.html' as image %}"
+        "{{ image.cover_badges(book, status) }}"
+    )
+    return tmpl.render(book=types.SimpleNamespace(id=1), status=read_status)
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(jinja2 is None, reason="jinja2 not installed")
+class TestCoverBadgeMacroRendersInProgress:
+    def test_in_progress_renders_distinct_badge(self):
+        """read_status == IN_PROGRESS must render a 'currently reading'
+        badge that is visually DISTINCT from the 'read' badge."""
+        out = _render_cover_badges(STATUS_IN_PROGRESS)
+        assert "cover-badge-in-progress" in out, (
+            "An in-progress book (read_status==2) must render a distinct "
+            "'.cover-badge-in-progress' badge. fork #509 @barukh27: KOReader "
+            "progress is stored but never surfaced in the web UI. Got:\n" + out
+        )
+        assert "cover-badge-read" not in out, (
+            "An in-progress book must NOT render the green 'Read' badge — "
+            "that is the bug (2 == True is False, so it currently renders "
+            "as unread, but flipping it to the read badge would be just as "
+            "wrong). In-progress is its own state. Got:\n" + out
+        )
+
+    def test_finished_still_renders_read_badge(self):
+        """No regression: a finished book keeps the existing read badge and
+        does not pick up the in-progress badge."""
+        out = _render_cover_badges(STATUS_FINISHED)
+        assert "cover-badge-read" in out, (
+            "A finished book (read_status==1) must still render the read "
+            "badge. Got:\n" + out
+        )
+        assert "cover-badge-in-progress" not in out, (
+            "A finished book must not render the in-progress badge. Got:\n" + out
+        )
+
+    def test_unread_renders_no_read_badges(self):
+        """No regression: an unread book renders neither read nor
+        in-progress badge."""
+        out = _render_cover_badges(STATUS_UNREAD)
+        assert "cover-badge-read" not in out, (
+            "An unread book must render no read badge. Got:\n" + out
+        )
+        assert "cover-badge-in-progress" not in out, (
+            "An unread book must render no in-progress badge. Got:\n" + out
+        )
+
+
+# ---------------------------------------------------------------------------
+# Source-pin: the Python coercion sites must carry the RAW tri-state, not
+# only the FINISHED boolean, so templates can render in-progress.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCoercionCarriesRawStatus:
+    def test_web_py_carries_raw_read_status(self):
+        """Both render paths in web.py (the books-table JSON serializer and
+        the detail page) must expose the raw integer read_status, not only
+        the ``== STATUS_FINISHED`` boolean — otherwise the template can never
+        tell in-progress from unread."""
+        src = WEB_PY.read_text(encoding="utf-8")
+        assert src.count("read_status_raw") >= 2, (
+            "web.py must set a raw integer read-status field (e.g. "
+            "read_status_raw) at BOTH coercion sites (books-list serializer "
+            "~L1937 and detail page ~L3537) so the in-progress state "
+            "survives to the templates. fork #509."
+        )
+
+    def test_detail_template_branches_on_in_progress(self):
+        """detail.html must render a 'currently reading' marker when the raw
+        status is IN_PROGRESS, keyed on the raw int (not the read boolean)."""
+        src = DETAIL_HTML.read_text(encoding="utf-8")
+        assert "read_status_raw" in src, (
+            "detail.html must consult the raw tri-state read status "
+            "(read_status_raw) to show a 'currently reading' marker for "
+            "in-progress books. fork #509 @barukh27."
+        )
+        assert "cover-badge-in-progress" in src or "currently-reading" in src, (
+            "detail.html must render a distinct in-progress marker "
+            "(.cover-badge-in-progress / .currently-reading) for a book the "
+            "user is partway through. fork #509."
+        )
+
+    def test_image_macro_takes_tristate_not_bool(self):
+        """The cover_badges macro must accept the tri-state read_status, not
+        a flattened is_read boolean, and emit the in-progress badge."""
+        src = IMAGE_HTML.read_text(encoding="utf-8")
+        assert "cover-badge-in-progress" in src, (
+            "image.html cover_badges macro must emit a "
+            "'.cover-badge-in-progress' badge for read_status == 2. fork #509."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Source-pin: the four grid/list call sites must pass the raw tri-state into
+# the macro, not the flattened ``entry[2] == True`` boolean (2 == True → False
+# silently drops every in-progress book to "unread").
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template_name", GRID_TEMPLATES)
+class TestGridCallSitesPassRawStatus:
+    def test_call_site_does_not_flatten_with_eq_true(self, template_name):
+        path = TEMPLATES_DIR / template_name
+        if not path.exists():  # author/search may differ across versions
+            pytest.skip(f"{template_name} not present")
+        src = path.read_text(encoding="utf-8")
+        if "cover_badges" not in src:
+            pytest.skip(f"{template_name} does not call cover_badges")
+        assert "is_read=(entry[2] == True)" not in src, (
+            f"{template_name} flattens the tri-state read status with "
+            f"'entry[2] == True', which silently drops in-progress (2 == True "
+            f"is False) to 'unread'. Pass the raw status to cover_badges "
+            f"instead. fork #509 @barukh27."
+        )


### PR DESCRIPTION
## Symptom
A book you're partway through on KOReader or Kobo looked identical to one you'd never opened. Reading progress synced fine and was stored, but the web only ever showed a marker once a book was **finished** — so in-progress books were invisible. Reported by @barukh27 (#509): "No webUI presence."

## Root cause
`ub.ReadBook.read_status` is a tri-state (0 unread / 1 finished / 2 in-progress) and kosync writes all three correctly. But the UI flattened it to a FINISHED-only boolean at two layers:
- `cps/web.py:1937` / `:3537`: `read_status = (x == STATUS_FINISHED)`
- the `cover_badges` macro was called `is_read=(entry[2] == True)` — and `2 == True` is `False`.

So status 2 rendered identically to unread everywhere.

## Fix
Carry the raw tri-state to the templates and render a distinct **"Currently reading"** state (amber, separate from the green "Read").
- `web.py`: add `read_status_raw` alongside the existing boolean at both sites (no new query — `db.py` already selects `read_status`).
- `image.html` `cover_badges`: take the tri-state int; emit `.cover-badge-in-progress` for status 2.
- `index/shelf/search/author.html`: pass `read_status=(entry[2] or 0)`.
- `detail.html`: passive "Currently reading" marker under the title. The read toggle stays **2-state** (read/unread) — in-progress is sync-driven display, not a user-set toggle position.
- `caliBlur.js`: marking an in-progress book read via the quick-toggle drops the stale in-progress badge.

Other `read_status` sites (user toggle, advanced-search filter, audiobook checkbox) stay intentionally 2-state. The smart-shelf "Currently Reading" filter already existed and now agrees visually with the badge. `cps/kobo.py` already maps `STATUS_IN_PROGRESS → "Reading"` for Kobo devices — only the web UI was dropping it.

## Verification
- **RED→GREEN** regression test (`tests/unit/test_in_progress_read_state_509.py`): Jinja-renders the `cover_badges` macro (status 2 → in-progress badge, 1 → read, 0 → none) + source-pins the coercion/call sites. Fails on `main`, passes here.
- **Zero regressions**: full unit suite set-diff between this branch and `main` is empty (85 == 85 pre-existing local-env failures, none new).
- **Live app + Playwright** (caliBlur — the only supported theme — desktop 1280 + mobile 390): amber "Currently reading" pill on the detail page, "Reading" badge on grid covers (exact `#d98e04`), finished books show no in-progress badge, no overflow at mobile width, no related console errors.

## Self-review
No 🔴/🟠. No new routes/inputs/auth/queries; badge text is static i18n (no XSS); macro signature change has all 4 callers updated and zero external callers; `read_status_raw` is JSON-safe (`AlchemyEncoder` iterates public attrs).

🟡 v2-track (separate): show the actual progress %, an in-progress column in the admin book table, a 3-state advanced-search read filter, and a plugin UX nudge for the Kindle auto-sync case (see below).

## Note on the Kindle "auto-sync only on manual tap" pushback
@barukh27 also reported the Kindle only syncs when tapped despite the toggle being on. Root-caused separately: `cwasync.koplugin/main.lua` intentionally force-disables auto-sync when `wifi_enable_action != "turn_on"` (background sync needs Wi-Fi). The accurate user fix is to set KOReader → *Network → Action when Wi-Fi is off → Turn on Wi-Fi*. That's a config answer (going in the issue reply), not part of this PR.

Ships fix for #509.