### PR TITLE
docs(install): NAS & Docker-GUI install/switch guides (#527)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ replit.nix
 .vscode
 .history
 cwa-wiki/
-docs/
+docs/*
+!docs/install/
 .venv-activate.sh
 test_venv
 cwa.code-workspace

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ docker compose pull && docker compose up -d
 
 Library, settings, users, OAuth tokens, and KOReader sync state are preserved. Switching back is the reverse one-line change.
 
+- **On a NAS or Docker GUI** (Synology, Unraid, Portainer, TrueNAS)? Follow the click-by-click [Install / Switch guides](docs/install/README.md) — no command line needed.
 - **Bug?** [File it here.](https://github.com/new-usemame/Calibre-Web-NextGen/issues/new?template=bug_report.md)
 - **Feature idea?** [Open a request.](https://github.com/new-usemame/Calibre-Web-NextGen/issues/new?template=feature_request.md) Anything goes, no checklist required — even half-formed ideas are welcome and help prioritize what to look at next.
 - **New here?** See [Quick start](#quick-start) below.
@@ -36,6 +37,7 @@ Library, settings, users, OAuth tokens, and KOReader sync state are preserved. S
 
 - [Why this fork exists](#why-this-fork-exists)
 - [What's included](#whats-included)
+- [Install / Switch guides (NAS & Docker GUIs)](docs/install/README.md)
 - [Quick start](#quick-start)
 - [Full Docker Compose setup](#full-docker-compose-setup)
 - [First run](#first-run)

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,0 +1,43 @@
+# Install / switch to Calibre-Web-NextGen
+
+These guides walk you through installing Calibre-Web-NextGen, or switching to it from
+the standard Calibre-Web-Automated (CWA) image, using the tool you already manage your
+containers with — no command line needed unless your platform is built around one.
+
+**Switching is safe and reversible.** Your books, users, settings, and the Read
+checkmarks you've set all live in the folders you mount into the container
+(`/config`, `/calibre-library`, `/cwa-book-ingest`), not inside the image. Nothing is
+converted or deleted, and you can switch back by pointing at the old image again.
+
+The image name is always:
+
+```
+ghcr.io/new-usemame/calibre-web-nextgen:latest
+```
+
+Keep the same volume folders and the same `PUID` / `PGID` / `TZ` you already had.
+
+## Pick your platform
+
+| Platform | Guide |
+|---|---|
+| Synology (Container Manager, DSM 7.2+) | [synology.md](synology.md) |
+| Unraid (Docker tab) | [unraid.md](unraid.md) |
+| Portainer (Stacks) | [portainer.md](portainer.md) |
+| TrueNAS SCALE (Apps → Custom App) | [truenas.md](truenas.md) |
+| Plain `docker compose` (CLI) | [compose.md](compose.md) |
+
+QNAP Container Station and Dockge guides are on the way. If you're on one of those and
+want a hand before they land, open an issue or ask on Discord (links at the bottom of
+every guide) and we'll walk you through it.
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.

--- a/docs/install/compose.md
+++ b/docs/install/compose.md
@@ -1,0 +1,78 @@
+# Install / switch to Calibre-Web-NextGen with `docker compose` (CLI)
+
+This is the baseline path for anyone comfortable on the command line. If you manage
+containers through a NAS or GUI instead, use the matching guide in the
+[index](README.md) — the idea is the same, the buttons differ.
+
+**Switching is safe and reversible.** Your books, users, settings and Read checkmarks live
+in the folders you mount (`/config`, `/calibre-library`, `/cwa-book-ingest`), not in the
+image. Nothing is converted or deleted.
+
+## Switch from CWA
+
+In your existing `docker-compose.yml`, change the image line:
+
+```diff
+- image: crocodilestick/calibre-web-automated:latest
++ image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+```
+
+Then pull and restart:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+Switching back is the same one-line change in reverse.
+
+## Fresh install
+
+Create `docker-compose.yml`, adjusting the volume paths and IDs for your host:
+
+```yaml
+services:
+  calibre-web-nextgen:
+    image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+    container_name: calibre-web-nextgen
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Berlin
+    volumes:
+      - ./config:/config
+      - ./library:/calibre-library
+      - ./ingest:/cwa-book-ingest
+    ports:
+      - 8083:8083
+    restart: unless-stopped
+```
+
+Bring it up:
+
+```bash
+docker compose up -d
+```
+
+Then open `http://<host>:8083` to finish setup. For the full configuration reference
+(Calibre binaries, advanced volumes, reverse proxy), see the main
+[README](../../README.md).
+
+## Updating later
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+`pull` fetches the newest `:latest` image; `up -d` recreates the container with your data
+mounted.
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.

--- a/docs/install/portainer.md
+++ b/docs/install/portainer.md
@@ -1,0 +1,73 @@
+# Install / switch to Calibre-Web-NextGen on Portainer (Stacks)
+
+This works whether you're installing fresh or switching from the standard
+Calibre-Web-Automated (CWA) image. **Your books, users, settings and the Read checkmarks
+you've set all live in the folders mapped into the container — nothing gets converted or
+deleted, and switching is reversible.**
+
+Portainer runs Calibre-Web from a **Stack** (a compose file it stores for you). Switching
+is a one-line edit to that stack.
+
+## Switch from CWA
+
+1. **Stacks** → click the stack that runs your Calibre-Web-Automated container → **Editor**.
+2. Find the `image:` line and change it from
+   `crocodilestick/calibre-web-automated:latest` to:
+
+   ```yaml
+   image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+   ```
+
+3. Leave the `volumes:` (`/config`, `/calibre-library`, `/cwa-book-ingest`) and the
+   `environment:` (`PUID`, `PGID`, `TZ`) exactly as they are.
+4. Scroll down and tick **Re-pull image and redeploy**, then click **Update the stack**.
+   Portainer pulls the new image and recreates the container with your same data mounted.
+5. Open the WebUI and log in as usual.
+
+> One-click undo: keep a copy of the old `image:` line. Switching back is the same edit in
+> reverse plus another **Update the stack**.
+
+## Fresh install
+
+1. **Stacks** → **Add stack**.
+2. **Name:** `calibre-web-nextgen`. Paste this into the **Web editor**, adjusting the
+   volume paths and IDs for your host:
+
+   ```yaml
+   services:
+     calibre-web-nextgen:
+       image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+       container_name: calibre-web-nextgen
+       environment:
+         - PUID=1000
+         - PGID=1000
+         - TZ=Europe/Berlin
+       volumes:
+         - /path/to/config:/config
+         - /path/to/library:/calibre-library
+         - /path/to/ingest:/cwa-book-ingest
+       ports:
+         - 8083:8083
+       restart: unless-stopped
+   ```
+
+3. Click **Deploy the stack**. Portainer pulls the image and starts it. Open the WebUI to
+   finish setup.
+
+## Updating later
+
+1. **Stacks** → your `calibre-web-nextgen` stack → **Editor**.
+2. Tick **Re-pull image and redeploy** and click **Update the stack**. Because the tag is
+   `:latest`, this pulls the newest published image and recreates the container; your data
+   stays in the mounted folders.
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.

--- a/docs/install/synology.md
+++ b/docs/install/synology.md
@@ -1,0 +1,85 @@
+# Install / switch to Calibre-Web-NextGen on Synology (Container Manager)
+
+This works whether you're installing fresh or switching from the standard
+Calibre-Web-Automated (CWA) image. **Your books, users, settings and the Read checkmarks
+you've set all live in the folders mapped into the container — nothing gets converted or
+deleted, and you can undo the whole thing in one click.**
+
+DSM is often localized; this guide notes the German labels alongside the English ones
+where they're known (e.g. *Speicherplatz / Volume*).
+
+## If you're switching from CWA — note your current setup first
+
+1. **Container Manager → Container** (*Behälter*), click your existing container (often
+   called `CMA` or `calibre-web-automated`) → **Details**.
+2. On the **Speicherplatz / Volume** tab, note which Synology folder maps to each of
+   `/config`, `/calibre-library`, and `/cwa-book-ingest`.
+3. On the **Umgebung / Environment** tab, note `PUID`, `PGID`, `TZ`.
+4. Back in **Container**, select it → **Aktion → Anhalten** (Action → Stop).
+   **Leave it — don't delete it.** A stopped CWA container is your instant undo.
+
+## Create the NextGen project
+
+5. **Container Manager → Projekt → Erstellen** (Project → Create).
+   - **Projektname:** `calibre-web-nextgen`
+   - **Quelle:** choose *"docker-compose.yml erstellen"* (Create docker-compose.yml) and
+     paste this, replacing the three `/volume1/...` paths and the `PUID` / `PGID` / `TZ`
+     with the values you noted above (fresh install: use your own folders and IDs):
+
+   ```yaml
+   services:
+     calibre-web-nextgen:
+       image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+       container_name: calibre-web-nextgen
+       environment:
+         - PUID=1026
+         - PGID=100
+         - TZ=Europe/Berlin
+       volumes:
+         - /volume1/docker/calibre/config:/config
+         - /volume1/docker/calibre/library:/calibre-library
+         - /volume1/docker/calibre/ingest:/cwa-book-ingest
+       ports:
+         - 8083:8083
+       restart: unless-stopped
+   ```
+
+6. Click through (**Weiter / Fertig** — Next / Done). Container Manager pulls the image
+   from ghcr.io on its own — no registry setup needed — and starts it.
+7. Open the same web address you always use and log in with your usual account. Your
+   library, users, and Read checkmarks are all there.
+
+## Updating later — important, and not the way standard Calibre-Web does it
+
+With a standalone Calibre-Web container, DSM shows an update under **Image** and you click
+it. A **Project** is different: the project keeps the image in use, so DSM refuses to
+delete or replace it while the container exists — you have to free it first by removing
+the container. Your data is safe through all of this because it lives in the mounted
+folders, not the container.
+
+1. **Container Manager → Projekt** → your `calibre-web-nextgen` project →
+   **Aktion → Anhalten** (Action → Stop).
+2. **Container Manager → Container** → select the stopped `calibre-web-nextgen` container
+   → **Aktion → Löschen** (Action → Delete). This removes only the container; it's
+   recreated in step 4, and your library/settings stay in the mounted folders.
+3. **Container Manager → Image** → click the
+   `ghcr.io/new-usemame/calibre-web-nextgen:latest` row → **Aktion → Löschen** (Delete).
+   Now that no container is using it, this succeeds. It only clears the cached image.
+4. **Container Manager → Projekt** → your project → **Aktion → Erstellen / Build**. With
+   the cached image gone, Container Manager pulls the newest one fresh and recreates the
+   container. Wait ~30 seconds and reload.
+
+> If deleting the image in step 3 still shows an "in use" error, the container in step 2
+> wasn't fully removed yet — refresh the **Container** tab and confirm it's gone, then
+> retry step 3.
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.

--- a/docs/install/truenas.md
+++ b/docs/install/truenas.md
@@ -1,0 +1,66 @@
+# Install / switch to Calibre-Web-NextGen on TrueNAS SCALE
+
+This works whether you're installing fresh or switching from the standard
+Calibre-Web-Automated (CWA) image. **Your books, users, settings and the Read checkmarks
+you've set all live in the storage you mount into the container — nothing gets converted
+or deleted, and switching is reversible.**
+
+On TrueNAS SCALE, Calibre-Web usually runs as a **Custom App**. The image is one field in
+that app's configuration. Labels match SCALE's **Apps** UI (Dragonfish / Electric Eel
+generation); older versions are close but may word things slightly differently.
+
+## Switch from CWA
+
+1. **Apps** → click your existing Calibre-Web-Automated app → **Edit**.
+2. Find the **Image Repository** field and change it from
+   `crocodilestick/calibre-web-automated` to:
+
+   ```
+   ghcr.io/new-usemame/calibre-web-nextgen
+   ```
+
+   Leave the **Image Tag** as `latest`.
+3. Leave **Storage** (the host-path mounts for `/config`, `/calibre-library`,
+   `/cwa-book-ingest`) and the environment variables (`PUID`, `PGID`, `TZ`) exactly as
+   they are.
+4. Click **Save / Update**. SCALE pulls the new image and redeploys the app with your
+   same storage mounted. Open the app's WebUI and log in as usual.
+
+> Undo path: note the old repository value before you change it. Switching back is the
+> same edit in reverse.
+
+## Fresh install
+
+1. **Apps** → **Discover Apps** → **Custom App** (top right).
+2. Set:
+   - **Application Name:** `calibre-web-nextgen`
+   - **Image Repository:** `ghcr.io/new-usemame/calibre-web-nextgen`
+   - **Image Tag:** `latest`
+3. **Container Environment Variables** — add `PUID`, `PGID`, `TZ` (e.g. `568`, `568`,
+   `Europe/Berlin`; match the user that owns your dataset).
+4. **Port Forwarding** — forward a host port (e.g. `8083`) to container port `8083`.
+5. **Storage** — add three host-path (or dataset) mounts:
+   - mount your config dataset → `/config`
+   - mount your Calibre library dataset → `/calibre-library`
+   - mount an ingest dataset → `/cwa-book-ingest`
+6. Click **Install**. SCALE pulls the image and deploys the app. Open the WebUI to finish
+   setup.
+
+## Updating later
+
+1. **Apps** → **Installed**. When a new image is published, the
+   `calibre-web-nextgen` app shows an **Update** badge (SCALE re-checks the `:latest` tag
+   on its own schedule; you can also hit **Refresh**).
+2. Click **Update**. SCALE pulls the newest image and redeploys; your datasets stay
+   mounted, so library and settings are untouched.
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.

--- a/docs/install/unraid.md
+++ b/docs/install/unraid.md
@@ -1,0 +1,64 @@
+# Install / switch to Calibre-Web-NextGen on Unraid
+
+This works whether you're installing fresh or switching from the standard
+Calibre-Web-Automated (CWA) image. **Your books, users, settings and the Read checkmarks
+you've set all live in the folders mapped into the container — nothing gets converted or
+deleted, and switching is reversible.**
+
+On Unraid the only thing that changes is the **Repository** (image) line. Every path
+mapping and variable stays the same.
+
+## Switch from CWA (the one-field change)
+
+1. **Docker** tab → click your existing Calibre-Web-Automated container → **Edit**.
+2. Change the **Repository** field from
+   `crocodilestick/calibre-web-automated:latest` to:
+
+   ```
+   ghcr.io/new-usemame/calibre-web-nextgen:latest
+   ```
+
+3. Leave every **Path** (`/config`, `/calibre-library`, `/cwa-book-ingest`) and every
+   variable (`PUID`, `PGID`, `TZ`) exactly as they are.
+4. Click **Apply**. Unraid pulls the new image and recreates the container with your same
+   data mounted. Open the WebUI and log in as usual.
+
+> Want a clean rollback path? Before editing, you can clone the container template
+> (Docker tab → **Add Container** → pick your CWA template) so the old image line is saved
+> as a separate, stopped entry.
+
+## Fresh install
+
+1. **Docker** tab → **Add Container**.
+2. Fill in:
+   - **Name:** `calibre-web-nextgen`
+   - **Repository:** `ghcr.io/new-usemame/calibre-web-nextgen:latest`
+   - **WebUI port:** map host `8083` → container `8083`
+   - **Path mappings** (Add another Path for each):
+     - `/config` → e.g. `/mnt/user/appdata/calibre-web-nextgen`
+     - `/calibre-library` → your Calibre library share
+     - `/cwa-book-ingest` → an ingest folder you'll drop books into
+   - **Variables:** `PUID` (usually `99`), `PGID` (usually `100`), `TZ` (e.g.
+     `Europe/Berlin`)
+3. Click **Apply**. Unraid pulls the image and starts it. Open the WebUI to finish setup.
+
+## Updating later
+
+Unraid makes this easy — no manual image deletion needed:
+
+1. **Docker** tab → toggle **Advanced View** (top right) if you don't see version info.
+2. Click **Check for Updates**. The `calibre-web-nextgen` row will show *update ready*
+   when a new image is published.
+3. Click **apply update** (or **Update** in the container's context menu). Unraid pulls
+   the new image and recreates the container with your data intact.
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.


### PR DESCRIPTION
## Why

Most CWA / Calibre-Web users run on a NAS or Docker GUI (Synology, Unraid, Portainer, TrueNAS), not a terminal, yet the only install path we documented was `docker compose` on the CLI. In #312, a Synology Container Manager user couldn't switch to NextGen because every instruction assumed a command line she never sees — the auto-"mark as read" feature she wanted was never the blocker, the onboarding was.

## What

Adds `docs/install/` with click-by-click guides for **Synology Container Manager, Unraid, Portainer, TrueNAS SCALE**, and plain **docker compose**, plus an index. Each guide:

- covers a fresh install **and** switching from stock CWA,
- opens with data-safety reassurance (books/users/settings/Read-marks live in the mounted folders, the switch is reversible),
- uses the platform's real on-screen labels (Synology notes the German labels too),
- includes the platform's **update-later** steps, and
- ends with the standard **Issues + Discord** help footer.

The Synology update steps follow @uschi1's correction on #527: Container Manager refuses to delete an image a project still holds, so the **container** must be removed before the cached image, then the project rebuilt to pull the new one.

README links the index from the switch section and the table of contents.

## Note on tier

This is docs-only **plus** one `.gitignore` line: upstream ignores all of `docs/` (loose working docs), so `docs/install/` would otherwise not be tracked. Un-ignoring the specific subtree (`docs/*` + `!docs/install/`) is the clean fix rather than force-adding files into an ignored dir, which would silently drop future guides. Because `.gitignore` is outside the `.po`/`.md`/`README` tier-1 allowlist, labeling **needs-review** for an operator merge.

## Validation

- `git check-ignore docs/install/synology.md` → no longer ignored.
- All 6 files carry the exact Issues + Discord footer; image name `ghcr.io/new-usemame/calibre-web-nextgen:latest` is exact throughout.
- No app code touched; no new dependencies, services, or env vars.

## Follow-up (not in this PR)

- QNAP Container Station + Dockge guides (acceptance criteria allows these to follow).
- Mirror top guides into the GitHub Wiki.

Addresses #527. Ships onboarding docs for #312.