### PR TITLE
feat(admin): email broadcast to users (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+- **Email your users straight from the admin area.** A new "Email Your Users"
+  page (Admin → Email Your Users) lets you write a message and send it by email
+  to everyone — or just the people you pick. Handy for announcing new books or
+  server updates to the people sharing your library. It uses the same mail
+  server you already set up for password resets, formats with HTML (links,
+  bold) with an automatic plain-text fallback, can pull in your announcement
+  banner text with one click, and has a "Send test to me" button so you can
+  preview before sending. Messages send in the background — check Tasks for
+  delivery. Requested by @froggybottomboys.
+
 ## [v4.0.172] - 2026-06-25
 
 ### Added

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1902,10 +1902,10 @@ def _broadcast_recipient_users():
     recipient picker. The Anonymous/guest account is excluded.
     """
     rows = ub.session.query(ub.User).filter(
-        ub.User.email != "", ub.User.email.isnot(None)
+        ub.User.email.isnot(None), func.trim(ub.User.email) != ""
     ).order_by(func.lower(ub.User.name)).all()
     return [{"id": u.id, "name": u.name, "email": u.email}
-            for u in rows if u.email and not u.role_anonymous()]
+            for u in rows if strip_whitespaces(u.email or "") and not u.role_anonymous()]
 
 
 def _render_broadcast_page(subject="", body=""):

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1904,8 +1904,19 @@ def _broadcast_recipient_users():
     rows = ub.session.query(ub.User).filter(
         ub.User.email.isnot(None), func.trim(ub.User.email) != ""
     ).order_by(func.lower(ub.User.name)).all()
-    return [{"id": u.id, "name": u.name, "email": u.email}
-            for u in rows if strip_whitespaces(u.email or "") and not u.role_anonymous()]
+    # Only offer users whose stored email yields at least one valid address,
+    # using the SAME canonicalizer the sender uses — so the picker shows exactly
+    # who would be mailed (no whitespace-only/malformed row that appears
+    # selectable then gets silently skipped) and displays the cleaned
+    # address(es).
+    out = []
+    for u in rows:
+        if u.role_anonymous():
+            continue
+        addrs = helper.valid_broadcast_addresses(u.email)
+        if addrs:
+            out.append({"id": u.id, "name": u.name, "email": ", ".join(addrs)})
+    return out
 
 
 def _render_broadcast_page(subject="", body=""):

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -37,7 +37,7 @@ from . import user_book_data
 from . import db, calibre_db, ub, web_server, config, updater_thread, gdriveutils, \
     kobo_sync_status, schedule
 from .helper import check_valid_domain, send_test_mail, reset_password, generate_password_hash, check_email, \
-    valid_email, check_username
+    valid_email, check_username, send_broadcast_email
 from .embed_helper import get_calibre_binarypath
 from .gdriveutils import is_gdrive_ready, gdrive_support
 from .render_template import render_title_template, get_sidebar_config
@@ -1886,6 +1886,104 @@ def update_mailsettings():
         flash(_("Email Server Settings updated"), category="success")
 
     return edit_mailsettings()
+
+
+# ---------------------------------------------------------------------------
+# Fork #225 (@froggybottomboys): admin email broadcast to users. Lets an admin
+# compose an HTML message and send it to selected users (or all users with an
+# email) via the existing async mail worker. Delivers the reporter's actual
+# ask (reach users proactively) on top of the v4.0.118 login banner.
+# ---------------------------------------------------------------------------
+
+def _broadcast_recipient_users():
+    """Users eligible to receive a broadcast: anyone with a non-empty email.
+
+    Returns lightweight dicts (id/name/email) ordered by name, for the
+    recipient picker. The Anonymous/guest account is excluded.
+    """
+    rows = ub.session.query(ub.User).filter(
+        ub.User.email != "", ub.User.email.isnot(None)
+    ).order_by(func.lower(ub.User.name)).all()
+    return [{"id": u.id, "name": u.name, "email": u.email}
+            for u in rows if u.email and not u.role_anonymous()]
+
+
+def _render_broadcast_page(subject="", body=""):
+    recipients = _broadcast_recipient_users()
+    return render_title_template(
+        "broadcast_email.html",
+        title=_("Email Your Users"),
+        page="broadcast",
+        recipients=recipients,
+        mail_configured=config.get_mail_server_configured(),
+        announcement=config.config_server_announcement or "",
+        subject_value=subject,
+        body_value=body,
+    )
+
+
+@admi.route("/admin/broadcast", methods=["GET"])
+@user_login_required
+@admin_required
+def broadcast_email():
+    return _render_broadcast_page()
+
+
+@admi.route("/admin/broadcast", methods=["POST"])
+@user_login_required
+@admin_required
+def send_broadcast():
+    subject = strip_whitespaces(request.form.get("subject", "") or "")
+    body = request.form.get("body", "") or ""
+    is_test = bool(request.form.get("test"))
+
+    if not config.get_mail_server_configured():
+        flash(_("Please configure the email server under Edit Email Server Settings first."),
+              category="error")
+        return _render_broadcast_page(subject, body)
+
+    if not subject:
+        flash(_("Please enter a subject for the announcement email."), category="error")
+        return _render_broadcast_page(subject, body)
+    if not strip_whitespaces(body):
+        flash(_("Please enter a message body for the announcement email."), category="error")
+        return _render_broadcast_page(subject, body)
+
+    if is_test:
+        # Send-to-self preview: only ever the current admin's own address.
+        if not current_user.email:
+            flash(_("Please set an email address on your own account first..."), category="error")
+            return _render_broadcast_page(subject, body)
+        recipients = [current_user.email]
+    else:
+        # Resolve recipient emails SERVER-SIDE from the posted user ids — never
+        # trust posted email strings. "select all" sends to every eligible user.
+        eligible = {str(u["id"]): u["email"] for u in _broadcast_recipient_users()}
+        if request.form.get("select_all"):
+            recipients = list(eligible.values())
+        else:
+            chosen = request.form.getlist("recipients")
+            recipients = [eligible[cid] for cid in chosen if cid in eligible]
+        if not recipients:
+            flash(_("Please select at least one recipient."), category="error")
+            return _render_broadcast_page(subject, body)
+
+    queued, skipped = send_broadcast_email(subject, body, recipients, current_user.name)
+
+    if queued == 0:
+        flash(_("No valid recipients — nothing was sent."), category="error")
+        return _render_broadcast_page(subject, body)
+
+    if is_test:
+        flash(_("Test announcement email queued to %(email)s — check Tasks for the result.",
+                email=current_user.email), category="info")
+        return _render_broadcast_page(subject, body)
+
+    msg = _("Announcement email queued for %(num)s recipient(s) — check Tasks for delivery.", num=queued)
+    if skipped:
+        msg += " " + _("%(num)s address(es) were skipped as invalid or duplicate.", num=skipped)
+    flash(msg, category="success")
+    return redirect(url_for('admin.broadcast_email'))
 
 
 @admi.route("/admin/scheduledtasks")

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -134,6 +134,103 @@ def get_email_body_text():
         _('This Email has been sent via Calibre-Web NextGen.'))
 
 
+# ---------------------------------------------------------------------------
+# Fork #225 (@froggybottomboys): admin email broadcast to users.
+# ---------------------------------------------------------------------------
+
+def html_to_text(html_body):
+    """Derive a plain-text fallback from an admin-authored HTML body.
+
+    Dependency-free (Hard Rule 6): turn block/line breaks into newlines,
+    drop every remaining tag, unescape entities, and collapse runaway blank
+    lines. This is the ``text/plain`` alternative shown by mail clients that
+    don't render HTML — it doesn't need to be perfect, only readable.
+    """
+    import html as _html
+    if not html_body:
+        return ""
+    text = html_body
+    # <br> and end-of-block tags become newlines so paragraphs survive.
+    text = re.sub(r"(?i)<\s*br\s*/?\s*>", "\n", text)
+    text = re.sub(r"(?i)</\s*(p|div|li|tr|h[1-6]|ul|ol|table|blockquote)\s*>", "\n", text)
+    # Strip every remaining tag, then unescape HTML entities.
+    text = re.sub(r"(?s)<[^>]+>", "", text)
+    text = _html.unescape(text)
+    # Collapse 3+ newlines to a blank-line separator; trim trailing space.
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return strip_whitespaces(text)
+
+
+def build_broadcast_html(body_html):
+    """Wrap the admin's HTML body in a minimal, email-safe skeleton.
+
+    The body is admin-authored and trusted (same model as the #323 custom-CSS
+    injection); it is delivered to recipients' mail clients, never rendered
+    inside CWNG, so there is no XSS surface against this app. The wrapper just
+    gives clients a well-formed document with sane default styling.
+    """
+    body_html = body_html or ""
+    return (
+        "<!DOCTYPE html><html><head><meta charset=\"utf-8\">"
+        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"></head>"
+        "<body style=\"margin:0;padding:16px;font-family:-apple-system,Segoe UI,Roboto,"
+        "Helvetica,Arial,sans-serif;font-size:15px;line-height:1.5;color:#222;\">"
+        "{}</body></html>".format(body_html)
+    )
+
+
+def _coerce_valid_recipient(raw_email):
+    """Return a single validated email, or None if empty/malformed.
+
+    Unlike :func:`valid_email` (which raises on the first bad address), this
+    is lenient: a broadcast skips an unparseable recipient rather than
+    aborting the whole send.
+    """
+    if not raw_email:
+        return None
+    try:
+        cleaned = valid_email(raw_email)
+    except Exception:
+        return None
+    return cleaned or None
+
+
+def send_broadcast_email(subject, body_html, recipients, sender_name):
+    """Queue an HTML broadcast email to each recipient via the worker thread.
+
+    ``recipients`` is an iterable of email strings already resolved from user
+    ids server-side (never trusted from the request). Each valid recipient
+    gets its own :class:`TaskEmail` (multipart/alternative: the wrapped HTML
+    body + a derived text fallback), enqueued on :class:`WorkerThread` so the
+    request returns immediately. Returns ``(queued, skipped)``.
+    """
+    settings = config.get_mail_settings()
+    text_fallback = html_to_text(body_html) or strip_whitespaces(body_html or "")
+    wrapped_html = build_broadcast_html(body_html)
+    queued = 0
+    skipped = 0
+    seen = set()
+    for raw in recipients:
+        email = _coerce_valid_recipient(raw)
+        if not email or email.lower() in seen:
+            skipped += 1
+            continue
+        seen.add(email.lower())
+        WorkerThread.add(sender_name, TaskEmail(
+            subject=subject,
+            filepath=None,
+            attachment=None,
+            settings=settings,
+            recipient=email,
+            task_message=N_("Announcement Email to %(email)s", email=email),
+            text=text_fallback,
+            html=wrapped_html,
+        ))
+        queued += 1
+    return queued, skipped
+
+
 # Convert existing book entry to new format
 def convert_book_format(book_id, calibre_path, old_book_format, new_book_format, user_id,
                         ereader_mail=None, subject=None, blocking=False):

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -181,11 +181,14 @@ def build_broadcast_html(body_html):
 
 
 def _coerce_valid_recipient(raw_email):
-    """Return a single validated email, or None if empty/malformed.
+    """Return validated email(s), or None if empty/malformed.
 
     Unlike :func:`valid_email` (which raises on the first bad address), this
     is lenient: a broadcast skips an unparseable recipient rather than
-    aborting the whole send.
+    aborting the whole send. A stored address field may itself hold a
+    comma-separated list (the same convention send-to-eReader uses), so the
+    return value can be a ``"a@x,b@y"`` string; the caller splits it and
+    enqueues one mail per individual address.
     """
     if not raw_email:
         return None
@@ -212,22 +215,31 @@ def send_broadcast_email(subject, body_html, recipients, sender_name):
     skipped = 0
     seen = set()
     for raw in recipients:
-        email = _coerce_valid_recipient(raw)
-        if not email or email.lower() in seen:
+        cleaned = _coerce_valid_recipient(raw)
+        if not cleaned:
             skipped += 1
             continue
-        seen.add(email.lower())
-        WorkerThread.add(sender_name, TaskEmail(
-            subject=subject,
-            filepath=None,
-            attachment=None,
-            settings=settings,
-            recipient=email,
-            task_message=N_("Announcement Email to %(email)s", email=email),
-            text=text_fallback,
-            html=wrapped_html,
-        ))
-        queued += 1
+        # A single stored field may hold a comma-separated list; enqueue one
+        # mail per individual address so the queued count and per-address
+        # de-duplication stay honest (a "select all" can never silently fan
+        # one selected row out to addresses the admin didn't pick).
+        for email in cleaned.split(","):
+            email = strip_whitespaces(email)
+            if not email or email.lower() in seen:
+                skipped += 1
+                continue
+            seen.add(email.lower())
+            WorkerThread.add(sender_name, TaskEmail(
+                subject=subject,
+                filepath=None,
+                attachment=None,
+                settings=settings,
+                recipient=email,
+                task_message=N_("Announcement Email to %(email)s", email=email),
+                text=text_fallback,
+                html=wrapped_html,
+            ))
+            queued += 1
     return queued, skipped
 
 

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -180,23 +180,25 @@ def build_broadcast_html(body_html):
     )
 
 
-def _coerce_valid_recipient(raw_email):
-    """Return validated email(s), or None if empty/malformed.
+def valid_broadcast_addresses(raw_email):
+    """Return the list of individual, validated addresses in ``raw_email``.
 
-    Unlike :func:`valid_email` (which raises on the first bad address), this
-    is lenient: a broadcast skips an unparseable recipient rather than
-    aborting the whole send. A stored address field may itself hold a
-    comma-separated list (the same convention send-to-eReader uses), so the
-    return value can be a ``"a@x,b@y"`` string; the caller splits it and
-    enqueues one mail per individual address.
+    A stored ``user.email`` can legitimately be a comma-separated list (the
+    input validator :func:`valid_email` accepts and joins several), so one user
+    may map to several real recipients. Return each as its own clean address
+    (empty list if none parse). Unlike :func:`valid_email`, this never raises,
+    so one bad value can't abort a broadcast. Used both to decide who is
+    *selectable* and to expand the actual *send* list, so the recipient picker
+    and the sender stay consistent (a whitespace-only or malformed stored email
+    is neither offered nor silently dropped).
     """
     if not raw_email:
-        return None
+        return []
     try:
         cleaned = valid_email(raw_email)
     except Exception:
-        return None
-    return cleaned or None
+        return []
+    return [a for a in (strip_whitespaces(p) for p in cleaned.split(',')) if a]
 
 
 def send_broadcast_email(subject, body_html, recipients, sender_name):
@@ -215,17 +217,15 @@ def send_broadcast_email(subject, body_html, recipients, sender_name):
     skipped = 0
     seen = set()
     for raw in recipients:
-        cleaned = _coerce_valid_recipient(raw)
-        if not cleaned:
-            skipped += 1
+        addresses = valid_broadcast_addresses(raw)
+        if not addresses:
+            skipped += 1  # this value yielded no usable address
             continue
         # A single stored field may hold a comma-separated list; enqueue one
         # mail per individual address so the queued count and per-address
-        # de-duplication stay honest (a "select all" can never silently fan
-        # one selected row out to addresses the admin didn't pick).
-        for email in cleaned.split(","):
-            email = strip_whitespaces(email)
-            if not email or email.lower() in seen:
+        # de-duplication stay honest.
+        for email in addresses:
+            if email.lower() in seen:
                 skipped += 1
                 continue
             seen.add(email.lower())

--- a/cps/tasks/mail.py
+++ b/cps/tasks/mail.py
@@ -100,7 +100,8 @@ class EmailSSL(EmailBase, smtplib.SMTP_SSL):
 
 
 class TaskEmail(CalibreTask):
-    def __init__(self, subject, filepath, attachment, settings, recipient, task_message, text, id=0, internal=False):
+    def __init__(self, subject, filepath, attachment, settings, recipient, task_message, text, id=0, internal=False,
+                 html=None):
         super(TaskEmail, self).__init__(task_message)
         self.subject = subject
         self.attachment = attachment
@@ -108,6 +109,12 @@ class TaskEmail(CalibreTask):
         self.filepath = filepath
         self.recipient = recipient
         self.text = text
+        # Fork #225: optional HTML alternative. When set, the message becomes
+        # multipart/alternative (text/plain + text/html) so HTML-capable mail
+        # clients render the rich body while plain-text clients fall back to
+        # ``text``. Defaults to None so every existing caller (send-to-eReader,
+        # registration, test mail) is unchanged single-part text/plain.
+        self.html = html
         self.asyncSMTP = None
         self.book_id = id
         self.results = dict()
@@ -134,6 +141,11 @@ class TaskEmail(CalibreTask):
         message['Date'] = formatdate(localtime=True)
         message['Message-ID'] = make_msgid(domain=self.get_msgid_domain())
         message.set_content(self.text.encode('UTF-8'), "text", "plain")
+        # Fork #225: add the HTML alternative before any attachment so the
+        # resulting structure is multipart/alternative (then nested under
+        # multipart/mixed if an attachment is also present).
+        if self.html:
+            message.add_alternative(self.html, subtype="html")
         if self.attachment:
             data = self._get_attachment(self.filepath, self.attachment)
             if data:

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -103,6 +103,7 @@
       {% endif %}
     {% endif %}
       <a class="btn btn-default emailconfig" id="admin_edit_email" href="{{url_for('admin.edit_mailsettings')}}">{{_('Edit Email Server Settings')}}</a>
+      <a class="btn btn-default" id="admin_broadcast_email" href="{{url_for('admin.broadcast_email')}}">{{_('Email Your Users')}}</a>
     </div>
   </div>
 

--- a/cps/templates/broadcast_email.html
+++ b/cps/templates/broadcast_email.html
@@ -64,7 +64,9 @@
 <script>
   (function () {
     var announcementText = {{ announcement|tojson }};
-    var confirmTemplate = {{ _('Send this announcement to %(num)s recipient(s)?')|tojson }};
+    // Token (not %(num)s) so server-side gettext doesn't try to interpolate at
+    // render time; the count is substituted client-side below.
+    var confirmTemplate = {{ _('Send this announcement to __NUM__ recipient(s)?')|tojson }};
 
     var prefillBtn = document.getElementById('prefill_announcement');
     if (prefillBtn) {
@@ -98,7 +100,7 @@
           ? boxes.length
           : boxes.filter(function (b) { return b.checked; }).length;
         if (count === 0) { return; } // let server-side validation flash the error
-        if (!window.confirm(confirmTemplate.replace('%(num)s', count))) {
+        if (!window.confirm(confirmTemplate.replace('__NUM__', count))) {
           e.preventDefault();
         }
       });

--- a/cps/templates/broadcast_email.html
+++ b/cps/templates/broadcast_email.html
@@ -1,0 +1,108 @@
+{% extends "layout.html" %}
+{% block body %}
+<div class="discover">
+  <h1>{{title}}</h1>
+
+  {% if not mail_configured %}
+  <div class="alert alert-warning">
+    {{_('The email server is not configured yet, so announcements cannot be sent.')}}
+    <a href="{{ url_for('admin.edit_mailsettings') }}">{{_('Edit Email Server Settings')}}</a>
+  </div>
+  {% endif %}
+
+  <p class="text-muted">{{_('Compose a message and send it by email to your users. Messages are queued and sent in the background — check Tasks for delivery status.')}}</p>
+
+  <form role="form" id="broadcastForm" class="col-md-10 col-lg-8" method="POST" action="{{ url_for('admin.send_broadcast') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+    <div class="form-group">
+      <label for="broadcast_subject">{{_('Subject')}}</label>
+      <input type="text" class="form-control" name="subject" id="broadcast_subject" maxlength="255"
+             value="{{ subject_value }}" required>
+    </div>
+
+    <div class="form-group">
+      <label for="broadcast_body">{{_('Message')}}</label>
+      <textarea class="form-control" name="body" id="broadcast_body" rows="10"
+                placeholder="{{_('Write your announcement here. HTML is allowed (links, bold, lists).')}}">{{ body_value }}</textarea>
+      <small class="help-block">
+        {{_('HTML is allowed for formatting (e.g. links and bold). Recipients on plain-text mail clients automatically get a text-only version.')}}
+        {% if announcement %}
+        <button type="button" id="prefill_announcement" class="btn btn-link btn-xs" style="padding:0">{{_('Use current announcement banner text')}}</button>
+        {% endif %}
+      </small>
+    </div>
+
+    <div class="form-group">
+      <label>{{_('Recipients')}}</label>
+      {% if recipients %}
+      <div class="checkbox">
+        <label><input type="checkbox" id="broadcast_select_all" name="select_all" value="1"> <strong>{{_('Select all users with an email address')}}</strong> ({{ recipients|length }})</label>
+      </div>
+      <div id="broadcast_recipient_list" style="max-height:260px;overflow-y:auto;border:1px solid #ddd;border-radius:4px;padding:8px;">
+        {% for u in recipients %}
+        <div class="checkbox" style="margin:2px 0">
+          <label><input type="checkbox" class="broadcast-recipient" name="recipients" value="{{ u.id }}"> {{ u.name }} &mdash; <span class="text-muted">{{ u.email }}</span></label>
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <p class="text-muted">{{_('No users have an email address set, so there is no one to send to yet.')}}</p>
+      {% endif %}
+    </div>
+
+    <button type="submit" name="send" value="send" id="broadcast_send" class="btn btn-primary"
+            {% if not mail_configured or not recipients %}disabled{% endif %}>{{_('Send announcement')}}</button>
+    <button type="submit" name="test" value="test" id="broadcast_test" class="btn btn-default"
+            {% if not mail_configured %}disabled{% endif %}>{{_('Send test to me')}}</button>
+    <a href="{{ url_for('admin.admin') }}" class="btn btn-default">{{_('Back')}}</a>
+  </form>
+</div>
+{% endblock %}
+
+{% block js %}
+<script>
+  (function () {
+    var announcementText = {{ announcement|tojson }};
+    var confirmTemplate = {{ _('Send this announcement to %(num)s recipient(s)?')|tojson }};
+
+    var prefillBtn = document.getElementById('prefill_announcement');
+    if (prefillBtn) {
+      prefillBtn.addEventListener('click', function () {
+        var body = document.getElementById('broadcast_body');
+        body.value = announcementText;
+        body.focus();
+      });
+    }
+
+    var selectAll = document.getElementById('broadcast_select_all');
+    var boxes = Array.prototype.slice.call(document.querySelectorAll('.broadcast-recipient'));
+    if (selectAll) {
+      selectAll.addEventListener('change', function () {
+        boxes.forEach(function (b) { b.checked = selectAll.checked; });
+      });
+      boxes.forEach(function (b) {
+        b.addEventListener('change', function () {
+          if (!b.checked) { selectAll.checked = false; }
+          else if (boxes.every(function (x) { return x.checked; })) { selectAll.checked = true; }
+        });
+      });
+    }
+
+    // Confirm only on the real broadcast (not the test-to-self button).
+    var form = document.getElementById('broadcastForm');
+    var sendBtn = document.getElementById('broadcast_send');
+    if (form && sendBtn) {
+      sendBtn.addEventListener('click', function (e) {
+        var count = (selectAll && selectAll.checked)
+          ? boxes.length
+          : boxes.filter(function (b) { return b.checked; }).length;
+        if (count === 0) { return; } // let server-side validation flash the error
+        if (!window.confirm(confirmTemplate.replace('%(num)s', count))) {
+          e.preventDefault();
+        }
+      });
+    }
+  })();
+</script>
+{% endblock %}

--- a/tests/unit/test_225_broadcast_email.py
+++ b/tests/unit/test_225_broadcast_email.py
@@ -1,0 +1,272 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for fork issue #225 (@froggybottomboys) phase 2: the
+admin EMAIL BROADCAST — the reporter's actual ask (reach users
+proactively), on top of the v4.0.118 login banner.
+
+Design note: notes/feat-225-broadcast-email-DESIGN.md. Operator decisions
+(2026-06-25): recipient picker (all + individuals), no opt-out, HTML body
+with plain-text fallback (multipart/alternative), dedicated compose page
+with prefill-from-banner.
+
+These pin, RED on main / GREEN on the branch:
+
+1. TaskEmail grows an optional `html=` kwarg → multipart/alternative with
+   BOTH text/plain and text/html; no html kwarg → single text/plain
+   (backward-compat for every existing caller).
+2. html_to_text derives a readable plain-text fallback (tags stripped,
+   entities unescaped, block breaks preserved).
+3. build_broadcast_html wraps the body in an email-safe skeleton.
+4. send_broadcast_email enqueues one TaskEmail per VALID recipient, skips
+   empty/invalid/duplicate addresses, returns (queued, skipped), and each
+   task carries the wrapped html + text fallback + subject + recipient.
+5. Route source-pins: both routes admin-gated; POST hard-gates on
+   get_mail_server_configured, resolves recipient emails SERVER-SIDE from
+   posted user ids (never trusts posted email strings), and routes the
+   test button to the current admin only.
+6. Template pins for the compose page.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------- #
+# 1. TaskEmail HTML alternative
+# --------------------------------------------------------------------------- #
+
+def _make_task(html=None):
+    from cps.tasks.mail import TaskEmail
+    settings = {"mail_from": "Library <lib@example.com>", "mail_server_type": 0}
+    return TaskEmail(
+        subject="Hello",
+        filepath=None,
+        attachment=None,
+        settings=settings,
+        recipient="reader@example.com",
+        task_message="msg",
+        text="Plain body",
+        html=html,
+    )
+
+
+class TestTaskEmailHtmlAlternative:
+    def test_html_kwarg_produces_multipart_alternative(self):
+        task = _make_task(html="<p>Rich <b>body</b></p>")
+        msg = task.prepare_message()
+        assert msg.get_content_type() == "multipart/alternative"
+        subtypes = {p.get_content_type() for p in msg.iter_parts()}
+        assert "text/plain" in subtypes
+        assert "text/html" in subtypes
+        # Inspect each part's decoded payload (the text/plain part is base64 on
+        # the wire — existing CWNG behaviour — so don't grep the flat string).
+        html_part = msg.get_body(preferencelist=("html",))
+        plain_part = msg.get_body(preferencelist=("plain",))
+        assert "Rich" in html_part.get_payload(decode=True).decode("utf-8")
+        assert "Plain body" in plain_part.get_payload(decode=True).decode("utf-8")
+
+    def test_text_part_is_the_fallback_text(self):
+        task = _make_task(html="<p>Rich</p>")
+        msg = task.prepare_message()
+        plain = msg.get_body(preferencelist=("plain",))
+        assert plain is not None
+        payload = plain.get_payload(decode=True).decode("utf-8")
+        assert "Plain body" in payload
+
+    def test_no_html_is_single_text_plain_backward_compat(self):
+        task = _make_task(html=None)
+        msg = task.prepare_message()
+        assert msg.get_content_type() == "text/plain"
+        assert not msg.is_multipart()
+
+    def test_html_kwarg_defaults_to_none(self):
+        """The new parameter must be OPTIONAL so every existing caller
+        (send-to-eReader, registration, test mail) is untouched."""
+        from cps.tasks.mail import TaskEmail
+        sig = inspect.signature(TaskEmail.__init__)
+        assert "html" in sig.parameters
+        assert sig.parameters["html"].default is None
+
+
+# --------------------------------------------------------------------------- #
+# 2 & 3. html_to_text / build_broadcast_html
+# --------------------------------------------------------------------------- #
+
+class TestHtmlToText:
+    def test_strips_tags_and_unescapes(self):
+        from cps.helper import html_to_text
+        out = html_to_text("<p>Hello &amp; welcome <b>friends</b></p>")
+        assert "Hello & welcome friends" in out
+        assert "<" not in out and ">" not in out
+
+    def test_preserves_block_and_line_breaks(self):
+        from cps.helper import html_to_text
+        out = html_to_text("Line one<br>Line two</p><p>Para two")
+        assert "Line one" in out and "Line two" in out and "Para two" in out
+        assert "\n" in out
+
+    def test_empty_is_empty(self):
+        from cps.helper import html_to_text
+        assert html_to_text("") == ""
+        assert html_to_text(None) == ""
+
+    def test_collapses_runaway_blank_lines(self):
+        from cps.helper import html_to_text
+        out = html_to_text("A</p></p></p></p>B")
+        assert "\n\n\n" not in out
+
+
+class TestBuildBroadcastHtml:
+    def test_wraps_and_preserves_body(self):
+        from cps.helper import build_broadcast_html
+        out = build_broadcast_html("<p>Keep me</p>")
+        assert out.lower().startswith("<!doctype html>")
+        assert "<body" in out and "Keep me" in out
+
+    def test_empty_body_still_valid_skeleton(self):
+        from cps.helper import build_broadcast_html
+        out = build_broadcast_html("")
+        assert out.lower().startswith("<!doctype html>") and "</html>" in out
+
+
+# --------------------------------------------------------------------------- #
+# 4. send_broadcast_email enqueue behaviour
+# --------------------------------------------------------------------------- #
+
+class TestSendBroadcastEmail:
+    @pytest.fixture
+    def captured(self, monkeypatch):
+        import cps.helper as helper
+        tasks = []
+        monkeypatch.setattr(helper.config, "get_mail_settings",
+                            lambda: {"mail_from": "Library <lib@example.com>", "mail_server_type": 0},
+                            raising=False)
+        monkeypatch.setattr(helper.WorkerThread, "add",
+                            classmethod(lambda cls, user, task, hidden=False: tasks.append((user, task))))
+        return tasks
+
+    def test_one_task_per_valid_recipient(self, captured):
+        from cps.helper import send_broadcast_email
+        queued, skipped = send_broadcast_email(
+            "Subject", "<p>Body</p>",
+            ["a@b.com", "c@d.com"], "admin")
+        assert queued == 2 and skipped == 0
+        assert len(captured) == 2
+        recips = {t.recipient for _, t in captured}
+        assert recips == {"a@b.com", "c@d.com"}
+
+    def test_skips_empty_invalid_and_duplicate(self, captured):
+        from cps.helper import send_broadcast_email
+        queued, skipped = send_broadcast_email(
+            "Subject", "<p>Body</p>",
+            ["a@b.com", "", "not-an-email", "a@b.com", "c@d.com"], "admin")
+        assert queued == 2
+        assert skipped == 3
+        recips = {t.recipient for _, t in captured}
+        assert recips == {"a@b.com", "c@d.com"}
+
+    def test_each_task_carries_html_text_subject(self, captured):
+        from cps.helper import send_broadcast_email
+        send_broadcast_email("My Subject", "<p>Hello &amp; hi</p>", ["a@b.com"], "admin")
+        _, task = captured[0]
+        assert task.subject == "My Subject"
+        assert task.html and task.html.lower().startswith("<!doctype html>")
+        assert "Hello" in task.html
+        # text fallback present and tag-free
+        assert "Hello & hi" in task.text
+        assert "<p>" not in task.text
+
+    def test_returns_zero_when_no_valid_recipients(self, captured):
+        from cps.helper import send_broadcast_email
+        queued, skipped = send_broadcast_email("S", "<p>B</p>", ["", "bad"], "admin")
+        assert queued == 0 and skipped == 2
+        assert captured == []
+
+
+# --------------------------------------------------------------------------- #
+# 5. Route source-pins (admin gate, mail gate, server-side recipient resolve)
+# --------------------------------------------------------------------------- #
+
+class TestBroadcastRoutes:
+    def test_routes_exist_and_are_admin_gated(self):
+        from cps import admin
+        get_src = inspect.getsource(admin.broadcast_email)
+        post_src = inspect.getsource(admin.send_broadcast)
+        # decorators sit just above each function in the module source
+        mod_src = inspect.getsource(admin)
+        assert '@admi.route("/admin/broadcast", methods=["GET"])' in mod_src
+        assert '@admi.route("/admin/broadcast", methods=["POST"])' in mod_src
+        # both functions are wrapped by admin_required
+        for fn_name in ("broadcast_email", "send_broadcast"):
+            idx = mod_src.index("def {}(".format(fn_name))
+            preamble = mod_src[max(0, idx - 200):idx]
+            assert "@admin_required" in preamble, fn_name
+        assert get_src and post_src  # silence unused
+
+    def test_post_hard_gates_on_mail_configured(self):
+        from cps import admin
+        src = inspect.getsource(admin.send_broadcast)
+        assert "get_mail_server_configured()" in src
+
+    def test_recipients_resolved_server_side_not_from_posted_emails(self):
+        """Defense in depth: the handler must map posted user IDS to emails
+        from the DB, never accept an email address straight off the form."""
+        from cps import admin
+        src = inspect.getsource(admin.send_broadcast)
+        assert 'getlist("recipients")' in src
+        assert "_broadcast_recipient_users()" in src
+        # must NOT pull a raw email field off the request for the send list
+        assert 'request.form.get("email"' not in src
+        assert 'request.form.getlist("emails")' not in src
+
+    def test_test_button_targets_current_admin_only(self):
+        from cps import admin
+        src = inspect.getsource(admin.send_broadcast)
+        assert "current_user.email" in src
+        # the test branch builds its recipient list from the admin's own email
+        assert 'request.form.get("test")' in src
+
+    def test_helper_excludes_anonymous_and_empty_email(self):
+        from cps import admin
+        src = inspect.getsource(admin._broadcast_recipient_users)
+        assert "role_anonymous()" in src
+        assert "ub.User.email" in src
+
+
+# --------------------------------------------------------------------------- #
+# 6. Template pins
+# --------------------------------------------------------------------------- #
+
+class TestBroadcastTemplate:
+    @pytest.fixture(scope="class")
+    def tpl(self):
+        path = REPO_ROOT / "cps" / "templates" / "broadcast_email.html"
+        return path.read_text(encoding="utf-8")
+
+    def test_has_subject_and_body_fields(self, tpl):
+        assert 'name="subject"' in tpl
+        assert 'name="body"' in tpl
+
+    def test_has_recipient_picker(self, tpl):
+        assert 'name="select_all"' in tpl
+        assert 'name="recipients"' in tpl
+        assert "for u in recipients" in tpl
+
+    def test_has_prefill_test_and_confirm(self, tpl):
+        assert "prefill_announcement" in tpl
+        assert 'name="test"' in tpl
+        assert "confirm(" in tpl  # confirm-before-send
+
+    def test_warns_when_mail_unconfigured(self, tpl):
+        assert "not mail_configured" in tpl
+        assert "edit_mailsettings" in tpl

--- a/tests/unit/test_225_broadcast_email.py
+++ b/tests/unit/test_225_broadcast_email.py
@@ -143,6 +143,29 @@ class TestBuildBroadcastHtml:
 # 4. send_broadcast_email enqueue behaviour
 # --------------------------------------------------------------------------- #
 
+class TestValidBroadcastAddresses:
+    """The shared canonicalizer used by BOTH the recipient picker and the
+    sender, so they never disagree (Greptile #529 hardening)."""
+
+    def test_single_valid(self):
+        from cps.helper import valid_broadcast_addresses
+        assert valid_broadcast_addresses("a@b.com") == ["a@b.com"]
+
+    def test_comma_separated_expands(self):
+        from cps.helper import valid_broadcast_addresses
+        assert valid_broadcast_addresses("a@b.com, c@d.com") == ["a@b.com", "c@d.com"]
+
+    def test_whitespace_only_is_empty(self):
+        from cps.helper import valid_broadcast_addresses
+        assert valid_broadcast_addresses("   ") == []
+        assert valid_broadcast_addresses("") == []
+        assert valid_broadcast_addresses(None) == []
+
+    def test_malformed_is_empty_not_raising(self):
+        from cps.helper import valid_broadcast_addresses
+        assert valid_broadcast_addresses("not-an-email") == []
+
+
 class TestSendBroadcastEmail:
     @pytest.fixture
     def captured(self, monkeypatch):
@@ -191,6 +214,16 @@ class TestSendBroadcastEmail:
         queued, skipped = send_broadcast_email("S", "<p>B</p>", ["", "bad"], "admin")
         assert queued == 0 and skipped == 2
         assert captured == []
+
+    def test_comma_separated_value_fans_out_and_counts_each(self, captured):
+        """A single stored comma-list must enqueue one mail PER address and
+        count each (not silently treated as one). Greptile #529 hardening."""
+        from cps.helper import send_broadcast_email
+        queued, skipped = send_broadcast_email(
+            "S", "<p>B</p>", ["a@b.com, c@d.com"], "admin")
+        assert queued == 2
+        recips = {t.recipient for _, t in captured}
+        assert recips == {"a@b.com", "c@d.com"}
 
     # -- Greptile P1 (#529): a single stored field may hold a comma-separated
     # list (the convention send-to-eReader already uses). It must fan out to
@@ -265,17 +298,21 @@ class TestBroadcastRoutes:
         src = inspect.getsource(admin._broadcast_recipient_users)
         assert "role_anonymous()" in src
         assert "ub.User.email" in src
+        # picker uses the SAME canonicalizer as the sender (no whitespace/
+        # malformed row shown-then-skipped)
+        assert "valid_broadcast_addresses" in src
 
     def test_helper_excludes_whitespace_only_email(self):
         """Greptile P2 (#529): a whitespace-only stored email must NOT appear
         in the picker — otherwise the admin selects it, the send helper strips
         and skips it, and the confirmed count silently exceeds what's queued.
-        Trim on BOTH the DB query and the Python projection so neither layer
-        can leak a blank-after-trim address."""
+        Trim on the DB query AND canonicalize in the Python projection (via the
+        shared validator the sender uses) so neither layer can leak a
+        blank-after-trim address."""
         from cps import admin
         src = inspect.getsource(admin._broadcast_recipient_users)
         assert "func.trim(ub.User.email)" in src
-        assert "strip_whitespaces(u.email" in src
+        assert "valid_broadcast_addresses(u.email)" in src
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_225_broadcast_email.py
+++ b/tests/unit/test_225_broadcast_email.py
@@ -305,3 +305,18 @@ class TestBroadcastTemplate:
     def test_warns_when_mail_unconfigured(self, tpl):
         assert "not mail_configured" in tpl
         assert "edit_mailsettings" in tpl
+
+    def test_no_printf_placeholder_inside_gettext(self, tpl):
+        """Regression: a ``_('... %(x)s ...')`` in the template makes Jinja's
+        gettext interpolate at RENDER time and 500s with KeyError when no
+        mapping is passed (caught live on cwn-local). The client-side confirm
+        string must use a plain token (__NUM__), substituted in JS, not a
+        printf placeholder. Pin that no gettext call carries a %(...)s."""
+        import re
+        # Find every _('...') / _("...") literal and ensure none contains %(...)s
+        for m in re.finditer(r"_\(\s*(['\"])(.*?)\1", tpl, re.DOTALL):
+            assert "%(" not in m.group(2), (
+                "gettext literal must not contain a printf placeholder "
+                "(crashes at render): {!r}".format(m.group(2))
+            )
+        assert "__NUM__" in tpl  # the confirm count token survives

--- a/tests/unit/test_225_broadcast_email.py
+++ b/tests/unit/test_225_broadcast_email.py
@@ -192,6 +192,30 @@ class TestSendBroadcastEmail:
         assert queued == 0 and skipped == 2
         assert captured == []
 
+    # -- Greptile P1 (#529): a single stored field may hold a comma-separated
+    # list (the convention send-to-eReader already uses). It must fan out to
+    # one TaskEmail PER individual address, with an honest queued count — not
+    # one task whose `recipient` is "a,b" (which SMTP would deliver to both
+    # while the admin sees a count of 1 and per-address dedupe never runs).
+    def test_comma_list_recipient_fans_out_to_each_address(self, captured):
+        from cps.helper import send_broadcast_email
+        queued, skipped = send_broadcast_email(
+            "Subject", "<p>Body</p>", ["a@b.com,c@d.com"], "admin")
+        assert queued == 2 and skipped == 0
+        recips = {t.recipient for _, t in captured}
+        assert recips == {"a@b.com", "c@d.com"}
+        # never a single combined To header
+        assert all("," not in t.recipient for _, t in captured)
+
+    def test_comma_list_dedupes_across_rows(self, captured):
+        from cps.helper import send_broadcast_email
+        queued, skipped = send_broadcast_email(
+            "Subject", "<p>Body</p>", ["a@b.com, c@d.com", "C@D.com"], "admin")
+        # a + c queued once each; the case-insensitive repeat of c is skipped
+        assert queued == 2 and skipped == 1
+        recips = {t.recipient for _, t in captured}
+        assert recips == {"a@b.com", "c@d.com"}
+
 
 # --------------------------------------------------------------------------- #
 # 5. Route source-pins (admin gate, mail gate, server-side recipient resolve)
@@ -241,6 +265,17 @@ class TestBroadcastRoutes:
         src = inspect.getsource(admin._broadcast_recipient_users)
         assert "role_anonymous()" in src
         assert "ub.User.email" in src
+
+    def test_helper_excludes_whitespace_only_email(self):
+        """Greptile P2 (#529): a whitespace-only stored email must NOT appear
+        in the picker — otherwise the admin selects it, the send helper strips
+        and skips it, and the confirmed count silently exceeds what's queued.
+        Trim on BOTH the DB query and the Python projection so neither layer
+        can leak a blank-after-trim address."""
+        from cps import admin
+        src = inspect.getsource(admin._broadcast_recipient_users)
+        assert "func.trim(ub.User.email)" in src
+        assert "strip_whitespaces(u.email" in src
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Lets an admin compose a message and **email it to selected users** (or all users with an email) — the actual ask in fork #225 from @froggybottomboys, who runs CWNG for a ~10-person book club and wanted to announce new books / server updates. The v4.0.118 login banner was the first step; this is the proactive channel.

Plain-English: **Admin → "Email Your Users" → write a message → pick who gets it → send.** Messages queue and send in the background via the mail server you already configured for password resets / send-to-eReader. No new dependency, no separate mail service.

## How it works

- **`TaskEmail` gains an optional `html=` kwarg** → `multipart/alternative` (HTML body + auto-derived plain-text fallback). Every existing caller (send-to-eReader, registration, test mail) is byte-for-byte unchanged.
- **`helper.send_broadcast_email`** enqueues one `TaskEmail` per validated recipient (skips empty / invalid / duplicate addresses), `html_to_text` builds the text fallback, `build_broadcast_html` wraps an email-safe skeleton.
- **New admin-gated routes** `GET/POST /admin/broadcast`. Recipient emails are resolved **server-side from posted user ids** (never trusts posted email strings); the "Send test to me" button targets only the current admin; the send path hard-gates on `get_mail_server_configured()`.
- **Dedicated compose page**: subject, HTML body, recipient picker (select-all + individuals), one-click prefill from the announcement-banner text, send-test-to-self, and a confirm-before-send dialog showing the recipient count. New admin nav button **"Email Your Users"**.

## Design decisions (operator)
Recipient picker (all + individuals) · no opt-out · HTML + text fallback · dedicated page with banner prefill. Full note: `notes/feat-225-broadcast-email-DESIGN.md`.

## Verification
- **23 red/green unit tests** (`tests/unit/test_225_broadcast_email.py`) — confirmed RED on main (all six new symbols absent), GREEN on branch. Cover: multipart structure + backward-compat, html→text fallback, enqueue/skip/dedupe, admin-gate + mail-gate + server-side recipient resolution source-pins, template pins.
- Adjacent suites green: mail, #225 banner, #428 custom body, admin-decorator coverage, `cps` import smoke.
- Security review (new routes): `notes/security-review-225-broadcast-email.md` — no HIGH/MEDIUM; reflected values auto-escaped, `announcement|tojson` safe, CSRF active, recipients resolved server-side.
- Live container e2e to follow before merge.

i18n: all new strings wrapped in `_()`/`N_()` (verified extractable, named placeholders, no f-string-in-gettext); the `update-translations.yml` pipeline propagates locales post-merge; English renders correctly immediately via fallback.

Addresses #225. Original feature request by @froggybottomboys.