### PR TITLE
docs: NAS & Docker-GUI install/switch guides (Synology, Unraid, Portainer, TrueNAS, compose) (#527)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ replit.nix
 .vscode
 .history
 cwa-wiki/
-docs/
+docs/*
+!docs/install/
 .venv-activate.sh
 test_venv
 cwa.code-workspace

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ docker compose pull && docker compose up -d
 
 Library, settings, users, OAuth tokens, and KOReader sync state are preserved. Switching back is the reverse one-line change.
 
+> **Not using a terminal?** If you run Docker through a NAS or a GUI, follow a step-by-step guide instead — they cover both a fresh install and switching from CWA, with the exact buttons for your platform: **[Synology](docs/install/synology.md) · [Unraid](docs/install/unraid.md) · [Portainer](docs/install/portainer.md) · [TrueNAS SCALE](docs/install/truenas.md) · [all guides](docs/install/)**. Configuration not matching? [Open an issue](https://github.com/new-usemame/Calibre-Web-NextGen/issues) or [ask on Discord](https://discord.gg/B8NXZmcp32) and we'll walk you through it.
+
 - **Bug?** [File it here.](https://github.com/new-usemame/Calibre-Web-NextGen/issues/new?template=bug_report.md)
 - **Feature idea?** [Open a request.](https://github.com/new-usemame/Calibre-Web-NextGen/issues/new?template=feature_request.md) Anything goes, no checklist required — even half-formed ideas are welcome and help prioritize what to look at next.
 - **New here?** See [Quick start](#quick-start) below.

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,0 +1,39 @@
+# Install / switch to Calibre-Web-NextGen
+
+Calibre-Web-NextGen ships as a single Docker image:
+
+```
+ghcr.io/new-usemame/calibre-web-nextgen:latest
+```
+
+It's a drop-in for the standard Calibre-Web-Automated (CWA) image. **Switching keeps
+everything** — your books, users, settings, shelves and the Read checkmarks you've set all
+live in the folders you mount into the container (`/config` and `/calibre-library`), not
+inside the image. Nothing is converted or deleted, and you can go back to your old image
+with the same one-line change in reverse.
+
+Pick the guide that matches how you run Docker:
+
+| You run Docker through… | Guide |
+|---|---|
+| **Synology** (Container Manager / DSM 7.2+) | [synology.md](synology.md) |
+| **Unraid** (Docker tab) | [unraid.md](unraid.md) |
+| **Portainer** (Stacks) | [portainer.md](portainer.md) |
+| **TrueNAS SCALE** (Apps) | [truenas.md](truenas.md) |
+| **A terminal / `docker compose`** | [compose.md](compose.md) |
+| QNAP, Dockge, something else | not written yet — see the help links below, we'll walk you through it |
+
+Every guide covers both a **fresh install** and **switching from stock CWA**, and tells you
+how to **update** later on that platform (on most NAS GUIs a "restart" does **not** pull a new
+image — you have to re-pull, and each guide shows exactly how).
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.

--- a/docs/install/compose.md
+++ b/docs/install/compose.md
@@ -1,0 +1,74 @@
+# Install / switch with `docker compose` (command line)
+
+The baseline path, on any machine with Docker installed. **Your books, users, settings and
+Read checkmarks live in the volumes you mount — not in the image — so switching keeps
+everything and is reversible.**
+
+## Fresh install
+
+1. Create a folder and a `docker-compose.yml` in it:
+
+   ```yaml
+   services:
+     calibre-web-nextgen:
+       image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+       container_name: calibre-web-nextgen
+       environment:
+         - PUID=1000
+         - PGID=1000
+         - TZ=America/New_York
+       volumes:
+         - ./config:/config
+         - ./library:/calibre-library
+         - ./ingest:/cwa-book-ingest
+       ports:
+         - 8083:8083
+       restart: unless-stopped
+   ```
+
+   Adjust the volume paths, `PUID`/`PGID` (run `id` to see yours), and `TZ`.
+2. Start it:
+
+   ```bash
+   docker compose up -d
+   ```
+3. Open `http://<host>:8083` and log in.
+
+## Switching from stock CWA
+
+In your existing `docker-compose.yml`, change only the image line:
+
+```diff
+- image: crocodilestick/calibre-web-automated:latest
++ image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+```
+
+Keep the same `volumes` (so `/config` and `/calibre-library` point at your existing data),
+then:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Your library, users and Read checkmarks carry over untouched. To roll back, change the image
+line back and run the same two commands.
+
+## Updating later
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+`pull` fetches the newest `:latest` image; `up -d` recreates the container with your data
+intact. (`restart` alone does **not** pull a new image.)
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see, or if sync / auto-ingest
+isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and what you ran, and we'll help you sort it out.

--- a/docs/install/portainer.md
+++ b/docs/install/portainer.md
@@ -1,0 +1,64 @@
+# Install / switch with Portainer (Stacks)
+
+For Portainer CE/BE on any host. The cleanest path is a **Stack** (Portainer's name for a
+docker-compose file you manage in the web UI).
+
+**Your books, users, settings and Read checkmarks live in the volumes you bind into the
+container — not in the image — so switching keeps everything and is reversible.**
+
+## Fresh install (Stack)
+
+1. **Stacks → Add stack.**
+2. **Name:** `calibre-web-nextgen`. Build method: **Web editor.** Paste:
+
+   ```yaml
+   services:
+     calibre-web-nextgen:
+       image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+       container_name: calibre-web-nextgen
+       environment:
+         - PUID=1000
+         - PGID=1000
+         - TZ=America/New_York
+       volumes:
+         - /path/on/host/config:/config
+         - /path/on/host/library:/calibre-library
+         - /path/on/host/ingest:/cwa-book-ingest
+       ports:
+         - 8083:8083
+       restart: unless-stopped
+   ```
+
+   Replace the three `/path/on/host/...` values with real folders on the Docker host, and set
+   `PUID`/`PGID`/`TZ` to your user and timezone.
+3. **Deploy the stack.** Portainer pulls the image and starts it. Open `http://<host>:8083`.
+
+## Switching from CWA
+
+- **If your CWA runs as a Stack:** open that stack → **Editor**, change the image line to
+  `ghcr.io/new-usemame/calibre-web-nextgen:latest`, keep the same volume binds, then
+  **Update the stack** with **Re-pull image and redeploy** ticked.
+- **If your CWA runs as a standalone container:** the tidiest switch is to recreate it as the
+  stack above, pointing the three volumes at the **same host folders** CWA already uses
+  (Containers → your CWA container → **Inspect** shows its current bind mounts). Stop the old
+  container first so only one app uses the library at a time.
+
+## Updating later
+
+1. **Stacks →** your `calibre-web-nextgen` stack → **Editor**.
+2. Click **Update the stack** and tick **Re-pull image and redeploy** (older Portainer:
+   **Pull and redeploy**). Portainer pulls the newest image and recreates the container with
+   your data intact.
+
+   *(Just restarting the container does not pull a new image — you must re-pull.)*
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.

--- a/docs/install/synology.md
+++ b/docs/install/synology.md
@@ -1,0 +1,84 @@
+# Install / switch on Synology (Container Manager)
+
+For DSM 7.2+ with **Container Manager**. Works whether you're installing fresh or switching
+from the standard Calibre-Web-Automated (CWA) image.
+
+**Your books, users, settings and the Read checkmarks you've set all live in the folders
+mapped into the container — nothing gets converted or deleted, and you can undo the whole
+thing in one click** by starting your old container again.
+
+> DSM is often shown in your local language. Where a button has a German label we list both,
+> e.g. *Speicherplatz / Volume*. If yours is in another language, the menu **position** is the
+> same — match the screenshots, and use the help links at the bottom if anything looks off.
+
+## Switching from CWA? Note your current setup first
+
+1. **Container Manager → Container**, click your existing container (often called `CMA` or
+   `calibre-web-automated`) → **Details**.
+2. On the **Speicherplatz / Volume** tab, note which Synology folder maps to each of
+   `/config`, `/calibre-library`, and `/cwa-book-ingest`.
+3. On the **Umgebung / Environment** tab, note `PUID`, `PGID`, `TZ`.
+4. Back in **Container**, select it → **Aktion / Action → Anhalten / Stop**.
+   **Leave it — don't delete it.** A stopped container is your instant undo.
+
+*(Fresh install? Skip the four steps above and just decide which Synology folders you want for
+`/config`, `/calibre-library` and `/cwa-book-ingest`, and your `PUID`/`PGID` — usually your
+own user's, shown under Control Panel → User → your account → details.)*
+
+## Create the NextGen project
+
+5. **Container Manager → Projekt / Project → Erstellen / Create.**
+   - **Projektname / Project name:** `calibre-web-nextgen`
+   - **Quelle / Source:** choose *"docker-compose.yml erstellen / create docker-compose.yml"*
+     and paste the block below. Replace the three `/volume1/...` paths and the
+     `PUID`/`PGID`/`TZ` with the values you noted:
+
+   ```yaml
+   services:
+     calibre-web-nextgen:
+       image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+       container_name: calibre-web-nextgen
+       environment:
+         - PUID=1026
+         - PGID=100
+         - TZ=Europe/Berlin
+       volumes:
+         - /volume1/docker/calibre/config:/config
+         - /volume1/docker/calibre/library:/calibre-library
+         - /volume1/docker/calibre/ingest:/cwa-book-ingest
+       ports:
+         - 8083:8083
+       restart: unless-stopped
+   ```
+
+6. Click through (**Weiter / Next**, then **Fertig / Done**). Container Manager pulls the image
+   from ghcr.io on its own — no registry setup needed — and starts it.
+7. Open the same web address you always use for Calibre-Web (the `8083` you mapped, or whatever
+   host port you chose), and log in with your usual account. Your library, users and Read
+   checkmarks are all there.
+
+## Updating later — important
+
+On Synology, **stopping and starting a container does NOT pull a newer image.** To actually
+update NextGen:
+
+1. **Container Manager → Projekt / Project** → your `calibre-web-nextgen` project →
+   **Aktion / Action → Stop**.
+2. **Container Manager → Image** → click the `ghcr.io/new-usemame/calibre-web-nextgen:latest`
+   row → **Aktion / Action → Delete**. This only clears the cached app image — if it warns
+   that it's in use, the container is already stopped, so it's safe to confirm. (Your data is
+   in the mounted folders, not here.)
+3. **Container Manager → Projekt / Project** → your project → **Aktion / Action → Build**.
+   Container Manager pulls the newest image fresh and recreates the container. Wait about
+   30 seconds, then reload the page.
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.

--- a/docs/install/truenas.md
+++ b/docs/install/truenas.md
@@ -1,0 +1,73 @@
+# Install / switch on TrueNAS SCALE (Apps)
+
+For TrueNAS SCALE. **Your books, users, settings and Read checkmarks live in the host-path
+storage you attach to the app — not in the image — so switching keeps everything.**
+
+> **A note on TrueNAS versions.** SCALE changed its Apps system between releases. On
+> **ElectricEel (24.10) and newer**, Apps run on a Docker Compose backend and there's an
+> **"Install via YAML" / Custom App** flow. On older releases (Dragonfish/Cobia) the
+> equivalent is **Apps → Discover Apps → Custom App** with form fields. The values below are
+> the same either way — only where you type them moves. If your screen differs, use the help
+> links at the bottom and we'll match it to your version.
+
+## Custom App (ElectricEel 24.10+)
+
+1. **Apps → Discover Apps → Custom App** (top-right). Choose **Install via YAML** if offered.
+2. Paste / fill:
+
+   ```yaml
+   services:
+     calibre-web-nextgen:
+       image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+       container_name: calibre-web-nextgen
+       environment:
+         - PUID=568
+         - PGID=568
+         - TZ=America/New_York
+       volumes:
+         - /mnt/pool/apps/calibre-web-nextgen/config:/config
+         - /mnt/pool/books:/calibre-library
+         - /mnt/pool/books-ingest:/cwa-book-ingest
+       ports:
+         - 8083:8083
+       restart: unless-stopped
+   ```
+
+   - Replace `/mnt/pool/...` with real dataset paths.
+   - `PUID`/`PGID` `568` is the built-in `apps` user on SCALE; use that unless your library
+     files are owned by a different user.
+3. **Install / Save.** SCALE pulls the image and starts the app. Open `http://<truenas-ip>:8083`.
+
+## Form-based Custom App (older SCALE)
+
+If you don't have a YAML box, use the form fields:
+- **Image repository:** `ghcr.io/new-usemame/calibre-web-nextgen` — **Image tag:** `latest`
+- **Container port:** `8083`, with a Node port to reach it on.
+- **Storage / Host Path Volumes** (add three): host dataset → `/config`,
+  your library → `/calibre-library`, an ingest folder → `/cwa-book-ingest`.
+- **Environment variables:** `PUID`, `PGID`, `TZ` as above.
+
+## Switching from CWA
+
+Point the new app's three storage paths at the **same datasets** your CWA app already uses
+(your old app's config dataset holds `app.db` with users + settings; the library dataset holds
+your books). Stop the old CWA app first so only one app uses the library at a time. Nothing in
+those datasets is modified by the switch, so you can re-enable CWA to roll back.
+
+## Updating later
+
+**Apps → Installed →** select `calibre-web-nextgen`. When an update is available SCALE shows an
+**Update** badge — click it to pull the newest image. (A simple **Stop/Start** does not pull a
+new image.) To force a re-pull of `:latest`, **Edit** the app and re-save, or **Update** when
+the badge appears.
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.

--- a/docs/install/unraid.md
+++ b/docs/install/unraid.md
@@ -1,0 +1,61 @@
+# Install / switch on Unraid
+
+For Unraid's **Docker** tab. Works whether you're installing fresh or switching from the
+standard Calibre-Web-Automated (CWA) image.
+
+**Your books, users, settings and Read checkmarks live in the appdata + library shares you
+map into the container — not in the image — so switching keeps everything and is reversible.**
+
+## Switching from CWA (fastest path)
+
+If you already run CWA on Unraid, you only need to change the image it uses:
+
+1. **Docker** tab → click your existing Calibre-Web-Automated container → **Edit**.
+2. Set **Repository** to:
+   ```
+   ghcr.io/new-usemame/calibre-web-nextgen:latest
+   ```
+3. Leave every **Path** mapping as-is — `/config`, `/calibre-library`, `/cwa-book-ingest`
+   should keep pointing at the same `/mnt/user/...` shares you already use. Leave `PUID`/`PGID`
+   (Unraid's default is `99`/`100`) and your port mapping unchanged.
+4. **Apply.** Unraid pulls the NextGen image and recreates the container with all your data
+   mounted. Open the WebUI and log in — everything's there.
+
+> Keeping the same container name and paths means it's a true in-place swap. If you'd rather
+> keep CWA around as a fallback, instead follow "Fresh install" below with a **different**
+> container name but the **same** library share, and only one of the two running at a time.
+
+## Fresh install
+
+1. **Docker** tab → **Add Container**.
+2. Fill in:
+   - **Name:** `calibre-web-nextgen`
+   - **Repository:** `ghcr.io/new-usemame/calibre-web-nextgen:latest`
+   - **Network Type:** `bridge`
+   - **Port:** add a Port mapping — Container Port `8083` → a Host Port of your choice (e.g. `8083`).
+   - **Path** mappings (add three):
+     - Container `/config` → Host `/mnt/user/appdata/calibre-web-nextgen`
+     - Container `/calibre-library` → Host `/mnt/user/books` (wherever your Calibre library lives)
+     - Container `/cwa-book-ingest` → Host `/mnt/user/books-ingest` (a folder to drop new books into)
+   - **Variables** (add three): `PUID=99`, `PGID=100`, `TZ=America/New_York` (use your timezone).
+3. **Apply.** Unraid pulls the image and starts it. Open the WebUI on the host port you chose.
+
+## Updating later
+
+1. **Docker** tab → toggle **Advanced View** (top-right) so the "version" column shows.
+2. NextGen will show **update ready** when a newer image is published. Click it (or
+   **force update** from the container's context menu) — Unraid re-pulls and recreates the
+   container with your data intact.
+
+   *(If you don't see "update ready", click **Check for Updates** at the bottom of the Docker tab.)*
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.


### PR DESCRIPTION
Executes #527.

## Why
Most CWA/Calibre-Web users self-host through a NAS or Docker-GUI, not a terminal. Switching to NextGen means editing the container image — exactly where GUI users get stuck. #312 is the case in point: a Synology Container Manager user who wanted a feature NextGen already had, but nearly gave up over the one-line image change. We had no GUI-platform docs.

## What
New `docs/install/` with beginner-friendly guides, each covering **fresh install + switch-from-CWA + how to update** on that platform:
- `synology.md` — Container Manager (DSM 7.2+), bilingual labels, from the verbatim steps that worked in #312
- `unraid.md` — Docker tab
- `portainer.md` — Stacks
- `truenas.md` — SCALE Apps (version-aware)
- `compose.md` — CLI baseline
- `README.md` — index

Every guide opens with data-safety reassurance (data lives in mounted volumes; reversible) and ends with a help footer linking the **issues page** and **Discord**, so config drift becomes reports we can fix and fold back in. README gets a "Not using a terminal?" callout.

## Verification
- All 6 files present; each has both footer links (issues + Discord); image name identical across all (10×); code fences balanced.
- GitHub markdown API renders the in-list YAML blocks as highlighted code (`highlight-source-yaml`).
- README links resolve to the new files.
- `.gitignore`: `docs/` was a local-ignore → narrowed to `docs/*` + `!docs/install/` so the tracked guides land without exposing other local scratch.

Docs-only (`safe-tier-1`). No app code touched. `/security-review` N/A.

Addresses #527 — QNAP/Dockge guides remain as a follow-up (noted in the ticket).