### PR TITLE
fix(caliBlur): show the "Discover (Random Books)" strip — dead for all users (#523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ is for things you can see or feel when running the app.
   preview before sending. Messages send in the background — check Tasks for
   delivery. Requested by @froggybottomboys.
 
+### Fixed
+- **The "Discover (Random Books)" row now actually appears.** Turning on "Show
+  Random Books in Detail View" did nothing — a leftover theme rule hid the
+  random-books row for everyone, so the "No. of Random Books to Display" setting
+  had no visible effect. The row now shows as a "Discover (Random Books)" strip
+  above your book list, on desktop and mobile. Reported by @chloeroform.
+
 ## [v4.0.172] - 2026-06-25
 
 ### Added

--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -1696,9 +1696,16 @@ app-loading-container {
     margin: 20px auto
 }
 
-.pace-progress, .random-books {
+.pace-progress {
     display: none
 }
+
+/* fork #523: the upstream caliBlur theme also hid `.random-books`, which is the
+   "Discover (Random Books)" strip shown when a user enables "Show Random Books
+   in Detail View". caliBlur is the only shipped theme, so that leftover hide
+   left the whole feature dead for every user. The strip's cards reuse the
+   standard `#books_rand` / `.book` styling caliBlur already defines, so it
+   renders consistently once shown. Reported by @chloeroform. */
 
 #main-nav + #scnd-nav::-webkit-scrollbar, #main-nav + .col-sm-2::-webkit-scrollbar, .navbar-collapse.collapse::-webkit-scrollbar, body > div.container-fluid > div.row-fluid > div.col-sm-2::-webkit-scrollbar, body > div.container-fluid > div > div.col-sm-10::-webkit-scrollbar {
     width: 14px;

--- a/cps/static/css/caliBlur_override.css
+++ b/cps/static/css/caliBlur_override.css
@@ -323,3 +323,27 @@ a#advanced_search > span.hidden-sm {
 }
 /* The mobile (<=767px) repositioning of .cwa-toast-stack lives in
    fork-mobile-cards.css alongside the other mobile adaptations. */
+
+/* fork #523: render the "Discover (Random Books)" strip heading as a section
+   title above the cover row. caliBlur (caliBlur.css) used to hide `.random-books`
+   outright; now that the strip is shown, caliBlur's `.discover > h2` rule would
+   pin THIS heading to the fixed header bar (position:fixed; top:60; left:240),
+   where it collides with the page title and renders as garbled overlapping text.
+   Match caliBlur's selector depth + the .random-books classes so this wins, and
+   put the heading back in normal flow above the covers. Reported by @chloeroform. */
+body:not(.admin) > div.container-fluid > div > div.col-sm-10 > div.discover.random-books > h2.random-books {
+    position: static !important;
+    top: auto !important;
+    left: auto !important;
+    width: auto !important;
+    max-width: none !important;
+    height: auto !important;
+    line-height: 1.3 !important;
+    margin: 0 0 14px !important;
+    padding: 4px 0 10px 2px !important;
+    font-size: 18px !important;
+    font-weight: 600 !important;
+    color: #fff !important;
+    white-space: normal !important;
+    overflow: visible !important;
+}

--- a/tests/unit/test_random_books_caliblur_523.py
+++ b/tests/unit/test_random_books_caliblur_523.py
@@ -1,0 +1,103 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression test for fork #523 — "No. of Random Books to Display" did nothing.
+
+Reporter @chloeroform (v4.0.170): enabling "Show Random Books in Detail View"
+never showed the random-books row anywhere.
+
+Root cause: the random-books strip IS rendered server-side
+(``cps/templates/index.html``: ``<div class="discover random-books">`` gated by
+``current_user.show_detail_random()``), but the caliBlur theme carried a leftover
+rule ``.pace-progress, .random-books { display: none }`` that hid the whole strip.
+caliBlur is the ONLY shipped theme (``admin.py`` forces ``g.current_theme = 1``),
+so the feature was dead for every user — there was no other theme to fall back to.
+
+These tests pin that caliBlur no longer hides the strip, and that the strip markup
+the feature depends on is still present and still gated on the per-user setting.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+CALIBLUR_CSS = REPO / "cps" / "static" / "css" / "caliBlur.css"
+CALIBLUR_OVERRIDE = REPO / "cps" / "static" / "css" / "caliBlur_override.css"
+INDEX_HTML = REPO / "cps" / "templates" / "index.html"
+
+
+def _css_rules(css: str):
+    """Yield (selector_list, body) for each top-level rule. Crude but sufficient
+    for a flat stylesheet with no nested at-rules around these selectors."""
+    for m in re.finditer(r"([^{}]+)\{([^{}]*)\}", css):
+        yield m.group(1).strip(), m.group(2)
+
+
+@pytest.mark.unit
+class TestCaliBlurDoesNotHideRandomBooks:
+    def test_no_display_none_on_random_books(self):
+        css = CALIBLUR_CSS.read_text(encoding="utf-8")
+        offenders = [
+            sel.strip()[:90]
+            for sel, body in _css_rules(css)
+            if ".random-books" in sel and re.search(r"display\s*:\s*none", body)
+        ]
+        assert not offenders, (
+            "caliBlur hides the Discover/Random Books strip via display:none on "
+            ".random-books. caliBlur is the only shipped theme, so 'Show Random "
+            "Books in Detail View' is dead for everyone (#523 @chloeroform). "
+            "Offending rule(s): " + " | ".join(offenders)
+        )
+
+    def test_pace_progress_still_hidden(self):
+        """The fix splits the shared rule — .pace-progress (the loading bar) must
+        STILL be hidden; only .random-books should be released."""
+        css = CALIBLUR_CSS.read_text(encoding="utf-8")
+        hidden = any(
+            ".pace-progress" in sel and re.search(r"display\s*:\s*none", body)
+            for sel, body in _css_rules(css)
+        )
+        assert hidden, (
+            ".pace-progress must remain display:none after splitting the rule — "
+            "don't accidentally un-hide the pace.js loading bar. #523"
+        )
+
+
+@pytest.mark.unit
+class TestRandomBooksHeadingNotPinnedToHeader:
+    def test_override_unpins_random_heading(self):
+        """Showing the strip means caliBlur's `.discover > h2` rule would pin the
+        'Discover (Random Books)' heading to the fixed header bar (position:fixed,
+        top:60), colliding with the page title. caliBlur_override.css must reset
+        the random heading to static flow above the covers."""
+        css = CALIBLUR_OVERRIDE.read_text(encoding="utf-8")
+        offending = [
+            (sel.strip()[:90], body)
+            for sel, body in _css_rules(css)
+            if "h2.random-books" in sel and "random-books" in sel
+        ]
+        assert offending, (
+            "caliBlur_override.css must carry a rule targeting the random-books "
+            "heading (h2.random-books inside .discover.random-books). #523"
+        )
+        assert any(re.search(r"position\s*:\s*static", body) for _sel, body in offending), (
+            "the random-books heading override must set position:static so the "
+            "heading sits above the covers instead of being pinned (position:fixed) "
+            "into the header bar where it collides with the page title. #523"
+        )
+
+
+@pytest.mark.unit
+class TestRandomBooksStripMarkupIntact:
+    def test_strip_container_present_and_gated(self):
+        html = INDEX_HTML.read_text(encoding="utf-8")
+        assert 'class="discover random-books"' in html, (
+            "index.html must still render the random-books strip container. #523"
+        )
+        assert "show_detail_random()" in html, (
+            "the random-books strip must stay gated on the per-user "
+            "show_detail_random() setting. #523"
+        )


### PR DESCRIPTION
## Symptom
Enabling **Show Random Books in Detail View** (with **No. of Random Books to Display** set) did nothing — the "Discover (Random Books)" row never appeared anywhere. Reported by @chloeroform (#523), who also confirmed caliBlur is the only theme in the dropdown.

## Root cause
The strip *is* generated and sent to the page (`index.html`: `<div class="discover random-books">`, gated on `current_user.show_detail_random()`), but caliBlur hid it via a leftover `.pace-progress, .random-books { display: none }` rule. **caliBlur is the only shipped theme** (`admin.py` forces `g.current_theme = 1`), so there was no fallback — the feature was dead for **every** user.

## Fix (theme CSS only)
- **caliBlur.css**: split the hide rule — `.pace-progress` (loading bar) stays hidden; `.random-books` is released.
- **caliBlur_override.css**: once shown, caliBlur's `.discover > h2` rule pins the heading to the fixed header bar (`position:fixed; top:60; left:240`), where it collides with the page title and renders as garbled overlapping text. Override the random heading (matching caliBlur's selector depth) to a **static section heading above the cover row**.

The strip's cards reuse the `#books_rand` / `.book` styling caliBlur already defines, so they render consistently once shown.

## Verification
- **RED→GREEN** tests (`tests/unit/test_random_books_caliblur_523.py`, 4): caliBlur no longer hides `.random-books`; `.pace-progress` stays hidden; the override unpins the heading (`position:static`); strip markup stays gated on `show_detail_random()`. RED on main, GREEN here.
- **No regression**: 29 caliBlur-CSS source-pin tests pass.
- **Live Playwright on caliBlur (the only theme), desktop 1280 + mobile 390**: the strip shows 4 covers (the configured count) with a clean "Discover (Random Books)" section heading above them; the "Books" page title stays clean in the header bar; `headingAboveCovers: true`, `position: static`, no overlap; only the pre-existing unrelated `user_profiles.json` 500 in console.

Theme-CSS only — no Python/app-logic touched. `/security-review` N/A.

Ships fix for #523.