### PR TITLE
Enable the new UI by default (opt-out) + version-keyed "Try the new UI" nudge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Changed
+- **The new interface is now offered to everyone — opt in when you're ready.**
+  After updating, a dismissible bar invites you to try the redesigned interface;
+  your classic view stays the default until you tap "Try the new UI" (or the
+  "Switch to New UI" button in the top bar). Dismiss it and it stays gone until
+  the next update, when it gently reminds you again. You can still turn the new
+  interface off entirely by setting `CWNG_SPA=0`. (Previously the new UI was
+  hidden unless an admin opted the whole instance in.)
+
 ### Added
 - **A "Discover" shelf of random picks on your library home (new UI).** The
   redesigned library now opens with a set-apart "Discover" box — a row of random

--- a/cps/spa.py
+++ b/cps/spa.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Serves the SPA shell at /app, gated by env CWNG_SPA. Replaced by the Vite build in Plan 02."""
+"""Serves the SPA shell at /app. Opt-OUT via env CWNG_SPA (default: enabled)."""
 import os
 from flask import Blueprint, send_from_directory, abort
 
-from . import logger
+from . import logger, constants
 
 log = logger.create()
 
@@ -12,17 +12,35 @@ spa = Blueprint("spa", __name__)
 
 _SPA_DIR = os.path.join(os.path.dirname(__file__), "static", "app")
 
+_DISABLE_VALUES = ("0", "false", "no", "off")
+
 
 def _spa_enabled():
-    return os.environ.get("CWNG_SPA", "").strip().lower() in ("1", "true", "yes")
+    """SPA availability — OPT-OUT (enabled by default).
+
+    Every updated instance should surface the new UI on its own so users can opt
+    in, without the operator having to set anything (rollout goal: show the
+    'Try the new UI' nudge to everyone, then eventually make it the default). Set
+    CWNG_SPA to a falsey value (0/false/no/off) to turn the new UI off entirely."""
+    return (os.environ.get("CWNG_SPA") or "").strip().lower() not in _DISABLE_VALUES
+
+
+def _spa_bundle_present():
+    """The compiled SPA must actually be on disk; a source checkout that never ran
+    the Vite build has no bundle, so the nudge would lead to a 404."""
+    return os.path.isfile(os.path.join(_SPA_DIR, "index.html"))
 
 
 @spa.app_context_processor
 def _inject_spa_flag():
-    """Expose whether the new SPA is available to ALL Jinja templates, so the
-    legacy layout can show a 'Switch to New UI' entry only when /app will actually
-    load (app_context_processor = app-wide, not just this blueprint)."""
-    return {"cwng_spa_enabled": _spa_enabled()}
+    """Expose to ALL Jinja templates whether the new SPA is available (so the
+    legacy layout shows the 'Switch to New UI' nudge only when /app will actually
+    load) plus the running version (so the nudge banner can reset its dismissal
+    on each update). app_context_processor = app-wide, not just this blueprint."""
+    return {
+        "cwng_spa_enabled": _spa_enabled() and _spa_bundle_present(),
+        "cwng_app_version": constants.INSTALLED_VERSION,
+    }
 
 
 @spa.route("/app")

--- a/cps/spa.py
+++ b/cps/spa.py
@@ -12,7 +12,9 @@ spa = Blueprint("spa", __name__)
 
 _SPA_DIR = os.path.join(os.path.dirname(__file__), "static", "app")
 
-_DISABLE_VALUES = ("0", "false", "no", "off")
+# An explicit empty value ("CWNG_SPA=") is treated as opt-out too — an operator
+# blanking the var clearly means "off". UNSET (env absent) keeps the default-on.
+_DISABLE_VALUES = ("", "0", "false", "no", "off")
 
 
 def _spa_enabled():
@@ -21,8 +23,11 @@ def _spa_enabled():
     Every updated instance should surface the new UI on its own so users can opt
     in, without the operator having to set anything (rollout goal: show the
     'Try the new UI' nudge to everyone, then eventually make it the default). Set
-    CWNG_SPA to a falsey value (0/false/no/off) to turn the new UI off entirely."""
-    return (os.environ.get("CWNG_SPA") or "").strip().lower() not in _DISABLE_VALUES
+    CWNG_SPA to a falsey value (empty/0/false/no/off) to turn the new UI off."""
+    value = os.environ.get("CWNG_SPA")
+    if value is None:  # env absent → default ON
+        return True
+    return value.strip().lower() not in _DISABLE_VALUES
 
 
 def _spa_bundle_present():

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -176,6 +176,68 @@
       @media (max-width: 767px) {
         a.cwng-switch-ui { width: 100%; justify-content: center; }
       }
+
+      /* Opt-in nudge banner — dismissible, reappears on each update (dismissal is
+         keyed to the running version in localStorage). Theme-agnostic light-amber
+         bar so it reads on both caliBlur (dark) and the standard (light) theme. */
+      .cwng-newui-banner {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 100000;
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 12px 20px;
+        background: #fff7ec;
+        color: #3a2a12;
+        border-top: 3px solid #cc7b19;
+        box-shadow: 0 -4px 20px rgba(0,0,0,.35);
+        font-size: 14px;
+        animation: cwngNewuiUp .28s cubic-bezier(.2,.7,.2,1);
+      }
+      @keyframes cwngNewuiUp { from { transform: translateY(100%); } to { transform: translateY(0); } }
+      @media (prefers-reduced-motion: reduce) { .cwng-newui-banner { animation: none; } }
+      .cwng-newui-banner[hidden] { display: none !important; }
+      .cwng-newui-banner .cwng-newui-icon { color: #cc7b19; top: 1px; }
+      .cwng-newui-banner .cwng-newui-text { flex: 1 1 auto; }
+      .cwng-newui-banner .cwng-newui-text strong { font-weight: 700; }
+      a.cwng-newui-try {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 15px;
+        border-radius: 999px;
+        background: linear-gradient(180deg, #e0902a 0%, #cc7b19 100%);
+        color: #1a1206 !important;
+        font-weight: 600;
+        white-space: nowrap;
+        text-decoration: none;
+        box-shadow: 0 2px 8px rgba(204,123,25,.32), inset 0 1px 0 rgba(255,255,255,.25);
+        transition: transform .12s cubic-bezier(.2,.7,.2,1), box-shadow .12s ease;
+      }
+      a.cwng-newui-try:hover, a.cwng-newui-try:focus {
+        transform: translateY(-1px);
+        box-shadow: 0 4px 14px rgba(204,123,25,.45), inset 0 1px 0 rgba(255,255,255,.3);
+        text-decoration: none;
+        color: #1a1206 !important;
+      }
+      .cwng-newui-banner .cwng-newui-dismiss {
+        background: transparent;
+        border: 0;
+        color: #8a6a3a;
+        font-size: 24px;
+        line-height: 1;
+        cursor: pointer;
+        padding: 0 4px;
+        opacity: .85;
+      }
+      .cwng-newui-banner .cwng-newui-dismiss:hover { color: #3a2a12; opacity: 1; }
+      @media (max-width: 600px) {
+        .cwng-newui-banner { flex-wrap: wrap; gap: 8px; font-size: 13px; padding: 10px 14px; }
+        .cwng-newui-banner .cwng-newui-text { flex-basis: 100%; }
+      }
     </style>
     {% endif %}
     <!-- Static navbar -->
@@ -274,7 +336,38 @@
         </div><!--/.nav-collapse -->
       </div>
     </div>
-    
+
+    {% if cwng_spa_enabled and (current_user.is_authenticated or g.allow_anonymous) %}
+    {# Opt-in nudge into the React SPA. Shown by default; dismissal is remembered
+       per running version, so it returns after each update to keep nudging until
+       the new UI becomes the default. The element starts hidden and is revealed
+       by JS only when not dismissed for this version — no flash for dismissers. #}
+    <div id="cwng-newui-banner" class="cwng-newui-banner" data-version="{{ cwng_app_version }}"
+         role="region" aria-label="{{_('New interface available')}}" hidden>
+      <span class="cwng-newui-icon glyphicon glyphicon-flash" aria-hidden="true"></span>
+      <span class="cwng-newui-text">{{_('A faster, redesigned Calibre-Web NextGen interface is ready.')}} <strong>{{_('Your classic view stays the default until you switch.')}}</strong></span>
+      <a class="cwng-newui-try" href="{{ url_for('spa.spa_shell') }}">
+        <span class="glyphicon glyphicon-flash" aria-hidden="true" style="font-size:11px;top:1px;"></span>
+        {{_('Try the new UI')}}
+      </a>
+      <button type="button" class="cwng-newui-dismiss" aria-label="{{_('Dismiss')}}">&times;</button>
+    </div>
+    <script>
+      (function () {
+        var b = document.getElementById('cwng-newui-banner');
+        if (!b) return;
+        var key = 'cwng_newui_banner_dismissed_' + (b.getAttribute('data-version') || '');
+        try { if (window.localStorage && localStorage.getItem(key) === '1') return; } catch (e) {}
+        b.hidden = false;
+        var x = b.querySelector('.cwng-newui-dismiss');
+        if (x) x.addEventListener('click', function () {
+          b.hidden = true;
+          try { localStorage.setItem(key, '1'); } catch (e) {}
+        });
+      })();
+    </script>
+    {% endif %}
+
     <div class="row-fluid text-center">
       <div id="message_library_refresh" style="display: none;" class="alert alert-info refresh-cwa">
         <p id="library_refresh_message"></p>

--- a/tests/unit/test_spa_shell.py
+++ b/tests/unit/test_spa_shell.py
@@ -19,10 +19,22 @@ def _spa_app(monkeypatch, tmp_spa_dir=None):
 
 
 @pytest.mark.unit
-def test_spa_disabled_404(monkeypatch):
-    monkeypatch.delenv("CWNG_SPA", raising=False)
+def test_spa_optout_404(monkeypatch):
+    """Explicit opt-out (CWNG_SPA=0) disables /app entirely."""
+    monkeypatch.setenv("CWNG_SPA", "0")
     app = _spa_app(monkeypatch)
     assert app.test_client().get("/app").status_code == 404
+
+
+@pytest.mark.unit
+def test_spa_default_on_serves_shell(monkeypatch, tmp_path):
+    """Default (CWNG_SPA unset) is ENABLED — every updated instance surfaces the
+    new UI without operator config. Serves the shell when the bundle is present."""
+    monkeypatch.delenv("CWNG_SPA", raising=False)
+    app = _spa_app(monkeypatch, tmp_path)
+    resp = app.test_client().get("/app")
+    assert resp.status_code == 200
+    assert b"NextGen" in resp.data
 
 
 @pytest.mark.unit
@@ -62,11 +74,34 @@ def test_spa_serves_all_client_routes(monkeypatch, tmp_path, path):
 
 
 @pytest.mark.unit
-def test_spa_context_processor_exposes_flag(monkeypatch):
-    """The legacy 'Switch to New UI' button is gated on cwng_spa_enabled, injected
-    app-wide by the spa blueprint's context processor."""
+def test_spa_context_processor_default_on_with_bundle(monkeypatch, tmp_path):
+    """Default-on + bundle present -> cwng_spa_enabled True, and the running
+    version is exposed (so the nudge banner can reset its dismissal per update)."""
     import cps.spa as spa_mod
-    monkeypatch.setenv("CWNG_SPA", "1")
-    assert spa_mod._inject_spa_flag() == {"cwng_spa_enabled": True}
+    (tmp_path / "index.html").write_text("x")
+    monkeypatch.setattr(spa_mod, "_SPA_DIR", str(tmp_path))
     monkeypatch.delenv("CWNG_SPA", raising=False)
-    assert spa_mod._inject_spa_flag() == {"cwng_spa_enabled": False}
+    out = spa_mod._inject_spa_flag()
+    assert out["cwng_spa_enabled"] is True
+    assert "cwng_app_version" in out
+
+
+@pytest.mark.unit
+def test_spa_context_processor_optout_false(monkeypatch, tmp_path):
+    """Explicit opt-out -> flag False even with a bundle present."""
+    import cps.spa as spa_mod
+    (tmp_path / "index.html").write_text("x")
+    monkeypatch.setattr(spa_mod, "_SPA_DIR", str(tmp_path))
+    monkeypatch.setenv("CWNG_SPA", "0")
+    assert spa_mod._inject_spa_flag()["cwng_spa_enabled"] is False
+
+
+@pytest.mark.unit
+def test_spa_context_processor_no_bundle_false(monkeypatch, tmp_path):
+    """Default-on but no bundle on disk -> flag False (don't nudge toward a 404)."""
+    import cps.spa as spa_mod
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setattr(spa_mod, "_SPA_DIR", str(empty))
+    monkeypatch.delenv("CWNG_SPA", raising=False)
+    assert spa_mod._inject_spa_flag()["cwng_spa_enabled"] is False

--- a/tests/unit/test_spa_shell.py
+++ b/tests/unit/test_spa_shell.py
@@ -38,6 +38,17 @@ def test_spa_default_on_serves_shell(monkeypatch, tmp_path):
 
 
 @pytest.mark.unit
+def test_spa_explicit_empty_env_is_optout(monkeypatch):
+    """An explicit empty value (CWNG_SPA=) means opt-out — distinct from UNSET,
+    which keeps the default-on. (An operator blanking the var means 'off'.)"""
+    import cps.spa as spa_mod
+    monkeypatch.setenv("CWNG_SPA", "")
+    assert spa_mod._spa_enabled() is False
+    app = _spa_app(monkeypatch)
+    assert app.test_client().get("/app").status_code == 404
+
+
+@pytest.mark.unit
 def test_spa_missing_bundle_404(monkeypatch, tmp_path):
     """Enabled but no build artifact present -> 404 (don't serve a broken shell)."""
     monkeypatch.setenv("CWNG_SPA", "1")


### PR DESCRIPTION
## Why
The `CWNG_SPA` flag was opt-**in** (default off), so users who simply update their image saw nothing new — there was no way to discover the redesign without an admin setting an env var. This flips it to opt-**out** so everyone is *offered* the new UI on update, while the classic view stays the default until the user actively switches. This is the rollout path toward eventually making the new UI the default.

## What
- **`cps/spa.py`** — `_spa_enabled()` now defaults **ON**; disabled only by an explicit falsey `CWNG_SPA` (`0/false/no/off`). The context processor also gates on the compiled bundle actually being present (so a source checkout that never ran the Vite build doesn't nudge toward a 404) and exposes the running version.
- **`layout.html`** — a dismissible **bottom** nudge bar ("Try the new UI"), shown by default. Dismissal is keyed to the running version in `localStorage`, so it returns after each update to keep nudging until the new UI becomes the default. The persistent **"Switch to New UI"** top-bar pill remains the always-available door. Fixed-bottom placement works on both caliBlur and the standard theme with no overlap/reflow.
- **tests** — opt-out 404, default-on serves, context-processor flag matrix (default-on+bundle / opt-out / no-bundle) + version exposure. 11 green.

## Not an auth-surface change
No new routes or deps. `/app` serves a public static shell; the API stays auth-gated, so the SPA being reachable exposes no data. This is a feature-flag default flip — `/security-review` not triggered per the conditional rule.

## Verification
Live on caliBlur (desktop 1440 + mobile 390): banner shows by default, **dismiss persists across reload and is version-scoped (reappears on the next update)**, "Try the new UI" → `/app`. Unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)