### PR TITLE
fix(docker): bump python-build-standalone pin (fixes failing dev/release builds)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ ARG KEPUBIFY_RELEASE=v4.0.4
 # Python is installed from python-build-standalone (CDN-backed GitHub releases)
 # rather than the deadsnakes PPA, which has a history of being unavailable.
 # Both x86_64 and aarch64 prebuilds are published by astral-sh.
-ARG PYTHON_BUILD_STANDALONE_RELEASE=20260414
-ARG PYTHON_VERSION=3.13.13
+ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
+ARG PYTHON_VERSION=3.13.14
 
 FROM ghcr.io/linuxserver/baseimage-ubuntu:noble AS dependencies
 


### PR DESCRIPTION
## Problem
Every image build since 06-27 has **failed** — `:dev` never published, so the new UI / banner can't reach any instance. Root cause is **not** application code: the Dockerfile's pinned `python-build-standalone` asset (release `20260414`, CPython `3.13.13`) returns **404** from the GitHub Actions runners (confirmed across 4 auto-builds + a manual re-run; the frontend stage builds fine, the Python-download step is what fails).

## Fix
Bump the pin to the current release: `20260623` / CPython `3.13.14`. Both `x86_64` and `aarch64` `install_only` assets verified present (HTTP 200). Same dependency, same host (`astral-sh/python-build-standalone`), patch-level Python bump.

## Validation
The image build only runs post-merge (PR CI doesn't build the Docker image), so this is validated by the dev build after merge. Asset availability pre-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)