### PR TITLE
fix(ci): authenticate python-build-standalone download (fixes all failing image builds)

### DIFF
--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -133,6 +133,11 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.repository.updated_at }}
             VERSION=DEV_BUILD-${{ env.IMAGE_TAG }}-${{ vars.CURRENT_DEV_BUILD_NUM }}
+          # Authenticate the in-Dockerfile python-build-standalone download so it
+          # isn't subject to the unauthenticated release-asset rate limit on the
+          # shared Actions egress IPs (which returns 404 and broke every build).
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
 
       # --- 4. Export Digest for Merge Job ---
       - name: Export digest
@@ -248,6 +253,11 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.repository.updated_at }}
             VERSION=DEV_BUILD-${{ env.IMAGE_TAG }}-${{ vars.CURRENT_DEV_BUILD_NUM }}
+          # Authenticate the in-Dockerfile python-build-standalone download so it
+          # isn't subject to the unauthenticated release-asset rate limit on the
+          # shared Actions egress IPs (which returns 404 and broke every build).
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
 
       # --- 4. Rotate Cache (Prevent Infinite Growth) ---
       - name: Move cache

--- a/.github/workflows/docker-image-build-release.yml
+++ b/.github/workflows/docker-image-build-release.yml
@@ -93,6 +93,11 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.release.created_at || github.event.repository.updated_at }}
             VERSION=${{ steps.ver.outputs.tag }}
+          # Authenticate the in-Dockerfile python-build-standalone download so it
+          # isn't subject to the unauthenticated release-asset rate limit on the
+          # shared Actions egress IPs (which returns 404 and broke every build).
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,11 @@ RUN \
   rm -rf /tmp/lsof*
 
 # STEP 1.5 - Install Python 3.13 from python-build-standalone (no deadsnakes PPA)
-RUN \
+# The GITHUB_TOKEN is passed as an optional BuildKit secret (required=false so a
+# local/source build without it still works). Authenticating the GitHub release
+# download lifts it off the unauthenticated, shared-Actions-IP rate limit that
+# was returning 404 and failing every CI image build.
+RUN --mount=type=secret,id=github_token,required=false \
   echo "**** install Python ${PYTHON_VERSION} from python-build-standalone (${PYTHON_BUILD_STANDALONE_RELEASE}) ****" && \
   case "$(uname -m)" in \
     x86_64)  PBS_ARCH="x86_64-unknown-linux-gnu" ;; \
@@ -121,15 +125,18 @@ RUN \
     *) echo "Unsupported arch: $(uname -m)"; exit 1 ;; \
   esac && \
   PBS_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PYTHON_BUILD_STANDALONE_RELEASE}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD_STANDALONE_RELEASE}-${PBS_ARCH}-install_only.tar.gz" && \
+  GH_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" && \
+  if [ -n "${GH_TOKEN}" ]; then echo "Authenticated GitHub download"; AUTH_HEADER=(--header "Authorization: Bearer ${GH_TOKEN}"); else echo "Unauthenticated GitHub download"; AUTH_HEADER=(); fi && \
   echo "Downloading Python from ${PBS_URL}" && \
+  DL_OK=0 && \
   for attempt in 1 2 3 4 5 6 7 8 9 10; do \
-    if curl -fL --connect-timeout 30 --retry 3 --retry-delay 3 --retry-all-errors "${PBS_URL}" -o /tmp/python.tar.gz; then \
-      echo "Python download succeeded on attempt ${attempt}"; break; \
+    if curl -fL "${AUTH_HEADER[@]}" --connect-timeout 30 --retry 3 --retry-delay 3 --retry-all-errors "${PBS_URL}" -o /tmp/python.tar.gz; then \
+      echo "Python download succeeded on attempt ${attempt}"; DL_OK=1; break; \
     fi; \
     echo "Python download attempt ${attempt} failed (HTTP error / 404 from the release CDN); retrying in 15s…"; \
     sleep 15; \
-    if [ "${attempt}" = "10" ]; then echo "ERROR: Python download failed after 10 attempts"; exit 22; fi; \
   done && \
+  if [ "${DL_OK}" != "1" ]; then echo "ERROR: Python download failed after 10 attempts"; exit 22; fi && \
   mkdir -p /opt && \
   tar -xzf /tmp/python.tar.gz -C /opt && \
   rm /tmp/python.tar.gz && \


### PR DESCRIPTION
## Root cause
Every image build (dev + release) fails at the in-Dockerfile Python download: `github.com/astral-sh/python-build-standalone/releases/download/...` returns **404 from GitHub-hosted runners** — the unauthenticated release-asset rate limit on the shared Actions egress IPs. (Repo is public → not minutes/billing; jobs run fine, only the download dies. Pin-bump + retry loop already merged confirmed it's the channel, not the asset.)

## Fix
Pass `GITHUB_TOKEN` into the Docker build as an **optional BuildKit secret** (`required=false` so local/source builds still work) and send it as a `Bearer` header on the download → authenticated 5000/hr limit instead of the throttled shared-IP unauth limit. Wired into dev (amd64+arm64) and release build-push steps.

## Verification
Local secret-mounted build: **'Authenticated GitHub download' → 91 MB tarball on attempt 1, PBS-TEST-PASS**. The rate-limit fix proves out in the post-merge CI dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)