### PR TITLE
fix(docker): hoist version build args to global scope so the image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,23 @@
 # --tag crocodilestick/calibre-web-automated:latest .
 
 # ==========================================================================
+# GLOBAL build args — declared before the FIRST `FROM` so their defaults are
+# in scope for EVERY stage that re-declares them (a bare `ARG FOO` inside a
+# stage only inherits a default when FOO is a global arg). These were trapped
+# inside the frontend-build stage when that Node stage was prepended, which
+# blanked them in the dependencies stage and produced malformed download URLs
+# (e.g. .../download//cpython-+-...  -> 404). Keep them here, above any FROM.
+# Bump versions in this one place.
+# ==========================================================================
+ARG CALIBRE_RELEASE=9.1.0
+ARG KEPUBIFY_RELEASE=v4.0.4
+# Python is installed from python-build-standalone (CDN-backed GitHub releases)
+# rather than the deadsnakes PPA, which has a history of being unavailable.
+# Both x86_64 and aarch64 prebuilds are published by astral-sh.
+ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
+ARG PYTHON_VERSION=3.13.14
+
+# ==========================================================================
 # STAGE 0: Frontend - Build the React SPA bundle (Vite).
 # Build-time only: Node/npm never enter the runtime image. The compiled
 # bundle (cps/static/app) is copied into the final stage below. The source
@@ -41,14 +58,6 @@ RUN npm run build
 # ==========================================================================
 # STAGE 1: Dependencies - Install system packages and Python dependencies
 # ==========================================================================
-ARG CALIBRE_RELEASE=9.1.0
-ARG KEPUBIFY_RELEASE=v4.0.4
-# Python is installed from python-build-standalone (CDN-backed GitHub releases)
-# rather than the deadsnakes PPA, which has a history of being unavailable.
-# Both x86_64 and aarch64 prebuilds are published by astral-sh.
-ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
-ARG PYTHON_VERSION=3.13.14
-
 FROM ghcr.io/linuxserver/baseimage-ubuntu:noble AS dependencies
 
 ARG CALIBRE_RELEASE

--- a/tests/unit/test_dockerfile_global_build_args.py
+++ b/tests/unit/test_dockerfile_global_build_args.py
@@ -1,0 +1,102 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Pin the version-defining build ARGs to GLOBAL scope (before the first FROM).
+
+A Dockerfile `ARG FOO` re-declared inside a build stage only inherits a
+default value when FOO is a *global* arg — one declared before the first
+`FROM`. If the defaulted declaration sits inside an earlier stage, the
+re-declaration in a later stage resolves to the empty string.
+
+That is exactly what broke every :dev image build on 2026-06-28: commit
+c1cd7b462 prepended a `FROM node:22-slim AS frontend-build` stage above the
+ARG block, which had been global until then. CALIBRE_RELEASE / KEPUBIFY_RELEASE
+/ PYTHON_VERSION / PYTHON_BUILD_STANDALONE_RELEASE became scoped to
+frontend-build, so the `dependencies` stage re-declared them empty. The Python
+install step then built the URL
+
+    https://github.com/astral-sh/python-build-standalone/releases/download//cpython-+-x86_64-unknown-linux-gnu-install_only.tar.gz
+
+(note the `download//cpython-+-` — empty release + empty version), which 404s.
+Bumping the pin (#544), adding retries (#545) and authenticating the download
+(#546) all chased the wrong layer because the URL itself was malformed.
+
+These tests fail on the broken layout (defaults trapped after the first FROM)
+and pass once the defaults are hoisted above every FROM. They also guard
+against a future stage being prepended above the ARG block again.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+# ARGs whose value feeds a download URL in a later stage. Each MUST carry its
+# default in global scope so every stage that re-declares it inherits a value.
+VERSION_ARGS = (
+    "CALIBRE_RELEASE",
+    "KEPUBIFY_RELEASE",
+    "PYTHON_BUILD_STANDALONE_RELEASE",
+    "PYTHON_VERSION",
+)
+
+
+@pytest.fixture(scope="module")
+def dockerfile_text() -> str:
+    return DOCKERFILE.read_text()
+
+
+@pytest.fixture(scope="module")
+def first_from_offset(dockerfile_text: str) -> int:
+    """Character offset of the first `FROM` instruction."""
+    match = re.search(r"^FROM\b", dockerfile_text, re.MULTILINE)
+    assert match, "Dockerfile must contain at least one FROM"
+    return match.start()
+
+
+@pytest.mark.parametrize("arg", VERSION_ARGS)
+def test_version_arg_default_is_global(arg: str, dockerfile_text: str, first_from_offset: int) -> None:
+    """The defaulted declaration (`ARG NAME=value`) must appear before the
+    first FROM, i.e. in global scope, so later-stage re-declarations inherit it."""
+    match = re.search(rf"^ARG {re.escape(arg)}=\S", dockerfile_text, re.MULTILINE)
+    assert match, f"Dockerfile must declare a default for ARG {arg} (e.g. `ARG {arg}=...`)"
+    assert match.start() < first_from_offset, (
+        f"ARG {arg}=... carries its default AFTER the first FROM, so it is scoped "
+        f"to that stage and the `dependencies` stage re-declares it empty — which "
+        f"produces malformed download URLs (404). Move the defaulted declaration "
+        f"above the first FROM (global scope)."
+    )
+
+
+def test_no_defaulted_version_arg_trapped_inside_a_stage(dockerfile_text: str, first_from_offset: int) -> None:
+    """Defense in depth: NO defaulted version-arg declaration may live after the
+    first FROM. A duplicate `ARG NAME=value` inside a stage re-introduces the
+    two-places-to-bump trap that hid the original regression (#544 bumped the
+    trapped copy and had no effect)."""
+    post_from = dockerfile_text[first_from_offset:]
+    for arg in VERSION_ARGS:
+        assert not re.search(rf"^ARG {re.escape(arg)}=\S", post_from, re.MULTILINE), (
+            f"A defaulted `ARG {arg}=...` appears after the first FROM. Keep the "
+            f"single source of truth in the global block; stages should re-declare "
+            f"with a bare `ARG {arg}` (no value) so they inherit the global default."
+        )
+
+
+def test_python_url_components_are_substituted(dockerfile_text: str) -> None:
+    """The Python download line must reference both version vars, and the global
+    defaults must be non-empty — together these guarantee the rendered URL is
+    `download/<release>/cpython-<version>+<release>-...` and never the empty-var
+    `download//cpython-+-...` that 404s."""
+    assert re.search(
+        r"releases/download/\$\{PYTHON_BUILD_STANDALONE_RELEASE\}/"
+        r"cpython-\$\{PYTHON_VERSION\}\+\$\{PYTHON_BUILD_STANDALONE_RELEASE\}",
+        dockerfile_text,
+    ), "Python download URL must interpolate PYTHON_BUILD_STANDALONE_RELEASE and PYTHON_VERSION"
+    for arg in ("PYTHON_BUILD_STANDALONE_RELEASE", "PYTHON_VERSION"):
+        match = re.search(rf"^ARG {re.escape(arg)}=(\S+)", dockerfile_text, re.MULTILINE)
+        assert match and match.group(1), f"Global default for {arg} must be non-empty"


### PR DESCRIPTION
## Why
Every `:dev` multi-arch image build has failed since 2026-06-28 ~02:21Z (last good 06-27). The teenyverse canary is stale and SPA-default-on can't be verified on a fresh image until builds are green again. Three fixes merged this afternoon (#544 pin bump, #545 retries, #546 GITHUB_TOKEN auth) did not resolve it.

## Root cause (observed, not inferred)
The failing build's own log emits the download URL it constructs:

```
Downloading Python from https://github.com/astral-sh/python-build-standalone/releases/download//cpython-+-x86_64-unknown-linux-gnu-install_only.tar.gz
```

Note `download//cpython-+-` — `${PYTHON_BUILD_STANDALONE_RELEASE}` and `${PYTHON_VERSION}` are **empty**. The asset itself exists and returns HTTP 200 off-CI; auth is applied ("Authenticated GitHub download"). The URL is just malformed.

Why empty: commit `c1cd7b462` (SPA rebuild) prepended `FROM node:22-slim AS frontend-build` above the ARG block. A `ARG NAME` re-declared inside a stage only inherits a default when NAME is a **global** arg (declared before the first `FROM`). Once the Node stage went in front, the defaulted `ARG CALIBRE_RELEASE=… / KEPUBIFY_RELEASE=… / PYTHON_*=…` became scoped to `frontend-build`, so the `dependencies` stage re-declared them empty. #544 bumped the trapped copy, which is never read by the consuming stage — hence no effect.

`KEPUBIFY_RELEASE` and `CALIBRE_RELEASE` share the bug; the build just dies at the Python step first (line 120, before the kepubify/calibre downloads at 172/195), so they were latent landmines.

## Fix
Move the four defaulted ARGs above the first `FROM` (global scope). Each stage keeps its bare `ARG NAME` re-declaration and now inherits the value. One source of truth for version bumps.

## Reproduction (red/green)
Minimal repro of the scoping, reproducing the exact malformed URL:

```
defaults AFTER first FROM  -> download//cpython-+-x86_64.tar.gz          (matches CI)
defaults BEFORE first FROM -> download/20260623/cpython-3.13.14+20260623-x86_64.tar.gz
```

`tests/unit/test_dockerfile_global_build_args.py` pins the version ARGs to global scope: **5 fail on origin/main** (trapped layout), **6 pass here**. Confirmed the published `20260623/3.13.14` and `kepubify v4.0.4` assets both return HTTP 200.

## Validation
- `pytest tests/unit/test_dockerfile_global_build_args.py tests/unit/test_dockerfile_healthcheck.py` → 11 passed.
- Full multi-arch green is only observable on a real `:dev` build after merge (same limitation as #544–#546). The malformed-URL → corrected-URL transition is proven above.

## Tier / release
Build-infra, fork-original. `needs-review`. No app-logic blast radius; no new deps. Not a user-facing change, so no CHANGELOG entry.