### PR TITLE
fix(ci): install Python from GHCR mirror + harden external downloads (durable build)

### DIFF
--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -42,10 +42,31 @@ permissions:
   packages: write
 jobs:
   # --------------------------------------------------------------------------------
+  # JOB 0: Ensure the python-build-standalone GHCR mirror exists before building.
+  # The image build COPYs Python from ghcr.io/new-usemame/pbs-cache instead of the
+  # flaky GitHub release CDN. This job (idempotent — a no-op when the mirror is
+  # already present) builds it the first time after a Python bump. See
+  # scripts/ensure-python-mirror.sh + notes/PYTHON-BUILD-MIRROR.md.
+  # --------------------------------------------------------------------------------
+  ensure-mirror:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout (read Python pin from Dockerfile)
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.ref) || github.ref }}
+      - name: Ensure python-build-standalone mirror exists
+        env:
+          GHCR_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: bash scripts/ensure-python-mirror.sh
+
+  # --------------------------------------------------------------------------------
   # JOB 1: Build Intel (amd64) on GitHub Runners
   # --------------------------------------------------------------------------------
   build-amd64:
     runs-on: ubuntu-latest
+    needs: ensure-mirror
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Set build ref
@@ -96,7 +117,9 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GH_PAT (read:packages) so BuildKit can COPY --from our private
+          # pbs-cache mirror; falls back to GITHUB_TOKEN for push-only contexts.
+          password: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       # --- 3. Build & Push (Digest Only) ---
       - name: Set up Docker Buildx
@@ -133,11 +156,6 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.repository.updated_at }}
             VERSION=DEV_BUILD-${{ env.IMAGE_TAG }}-${{ vars.CURRENT_DEV_BUILD_NUM }}
-          # Authenticate the in-Dockerfile python-build-standalone download so it
-          # isn't subject to the unauthenticated release-asset rate limit on the
-          # shared Actions egress IPs (which returns 404 and broke every build).
-          secrets: |
-            github_token=${{ secrets.GITHUB_TOKEN }}
 
       # --- 4. Export Digest for Merge Job ---
       - name: Export digest
@@ -165,6 +183,7 @@ jobs:
     # repo is also a meaningful attack surface (any PR can execute on
     # operator hardware), so GitHub-hosted is the safer default.
     runs-on: ubuntu-24.04-arm
+    needs: ensure-mirror
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Set build ref
@@ -215,7 +234,9 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GH_PAT (read:packages) so BuildKit can COPY --from our private
+          # pbs-cache mirror; falls back to GITHUB_TOKEN for push-only contexts.
+          password: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       # --- 3. Build & Push (Digest Only) ---
       - name: Set up Docker Buildx
@@ -253,11 +274,6 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.repository.updated_at }}
             VERSION=DEV_BUILD-${{ env.IMAGE_TAG }}-${{ vars.CURRENT_DEV_BUILD_NUM }}
-          # Authenticate the in-Dockerfile python-build-standalone download so it
-          # isn't subject to the unauthenticated release-asset rate limit on the
-          # shared Actions egress IPs (which returns 404 and broke every build).
-          secrets: |
-            github_token=${{ secrets.GITHUB_TOKEN }}
 
       # --- 4. Rotate Cache (Prevent Infinite Growth) ---
       - name: Move cache
@@ -352,7 +368,9 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GH_PAT (read:packages) so BuildKit can COPY --from our private
+          # pbs-cache mirror; falls back to GITHUB_TOKEN for push-only contexts.
+          password: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       # --- 3. Merge Digests ---
       - name: Download digests

--- a/.github/workflows/docker-image-build-release.yml
+++ b/.github/workflows/docker-image-build-release.yml
@@ -35,9 +35,24 @@ env:
 
 jobs:
   # ------------------------------------------------------------------
+  # Ensure the python-build-standalone GHCR mirror exists (idempotent). The
+  # image build COPYs Python from it instead of the flaky GitHub release CDN.
+  # See scripts/ensure-python-mirror.sh + notes/PYTHON-BUILD-MIRROR.md.
+  # ------------------------------------------------------------------
+  ensure-mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Ensure python-build-standalone mirror exists
+        env:
+          GHCR_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: bash scripts/ensure-python-mirror.sh
+
+  # ------------------------------------------------------------------
   # Per-arch build, push by digest only (no tag yet)
   # ------------------------------------------------------------------
   build:
+    needs: ensure-mirror
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +88,9 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GH_PAT (read:packages) so BuildKit can COPY --from our private
+          # pbs-cache mirror; falls back to GITHUB_TOKEN for push-only contexts.
+          password: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
@@ -93,11 +110,6 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.release.created_at || github.event.repository.updated_at }}
             VERSION=${{ steps.ver.outputs.tag }}
-          # Authenticate the in-Dockerfile python-build-standalone download so it
-          # isn't subject to the unauthenticated release-asset rate limit on the
-          # shared Actions egress IPs (which returns 404 and broke every build).
-          secrets: |
-            github_token=${{ secrets.GITHUB_TOKEN }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -161,7 +173,9 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GH_PAT (read:packages) so BuildKit can COPY --from our private
+          # pbs-cache mirror; falls back to GITHUB_TOKEN for push-only contexts.
+          password: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,12 @@ ARG KEPUBIFY_RELEASE=v4.0.4
 # Both x86_64 and aarch64 prebuilds are published by astral-sh.
 ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
 ARG PYTHON_VERSION=3.13.14
+# Our GHCR mirror of the python-build-standalone tarball, tag DERIVED from the
+# two ARGs above so it can never drift. ARG expansion is allowed in FROM (but
+# NOT in COPY --from), so we alias the mirror image as a stage here and COPY
+# from the alias in STEP 1.5. Bump the two ARGs and everything follows.
+ARG PBS_CACHE_REF=ghcr.io/new-usemame/pbs-cache:cpython-${PYTHON_VERSION}-${PYTHON_BUILD_STANDALONE_RELEASE}
+FROM ${PBS_CACHE_REF} AS pbs_mirror
 
 FROM ghcr.io/linuxserver/baseimage-ubuntu:noble AS dependencies
 
@@ -55,10 +61,6 @@ ARG CALIBRE_RELEASE
 ARG KEPUBIFY_RELEASE
 ARG PYTHON_BUILD_STANDALONE_RELEASE
 ARG PYTHON_VERSION
-# Our GHCR mirror of the python-build-standalone tarball, tag DERIVED from the
-# two ARGs above so it can never drift: bump the version/release and this ref
-# (and the CI mirror-build) follow automatically. See STEP 1.5 + notes/PYTHON-BUILD-MIRROR.md.
-ARG PBS_CACHE_REF=ghcr.io/new-usemame/pbs-cache:cpython-${PYTHON_VERSION}-${PYTHON_BUILD_STANDALONE_RELEASE}
 
 # Set the default shell for the following RUN instructions to bash instead of sh
 SHELL ["/bin/bash", "-c"]
@@ -125,7 +127,7 @@ RUN \
 # automatically by scripts/ensure-python-mirror.sh (a CI job that runs before
 # the image build). To bump Python: change PYTHON_VERSION / PYTHON_BUILD_STANDALONE_RELEASE
 # above — nothing else. Full explanation: notes/PYTHON-BUILD-MIRROR.md.
-COPY --from=${PBS_CACHE_REF} /python.tar.gz /tmp/python.tar.gz
+COPY --from=pbs_mirror /python.tar.gz /tmp/python.tar.gz
 RUN \
   echo "**** install Python ${PYTHON_VERSION} from mirrored python-build-standalone ****" && \
   mkdir -p /opt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,11 +49,10 @@ ARG KEPUBIFY_RELEASE=v4.0.4
 ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
 ARG PYTHON_VERSION=3.13.14
 # Our GHCR mirror of the python-build-standalone tarball, tag DERIVED from the
-# two ARGs above so it can never drift. ARG expansion is allowed in FROM (but
-# NOT in COPY --from), so we alias the mirror image as a stage here and COPY
-# from the alias in STEP 1.5. Bump the two ARGs and everything follows.
-ARG PBS_CACHE_REF=ghcr.io/new-usemame/pbs-cache:cpython-${PYTHON_VERSION}-${PYTHON_BUILD_STANDALONE_RELEASE}
-FROM ${PBS_CACHE_REF} AS pbs_mirror
+# two ARGs above so it can never drift. FROM expands the ARGs inline (COPY --from
+# can't), so we alias the mirror image as a stage here and COPY from the alias in
+# STEP 1.5. Bump the two ARGs and everything (this stage + the CI mirror) follows.
+FROM ghcr.io/new-usemame/pbs-cache:cpython-${PYTHON_VERSION}-${PYTHON_BUILD_STANDALONE_RELEASE} AS pbs_mirror
 
 FROM ghcr.io/linuxserver/baseimage-ubuntu:noble AS dependencies
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,12 +171,12 @@ RUN \
   | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   fi && \
   if [ "$(uname -m)" == "x86_64" ]; then \
-  curl -o \
-  /usr/bin/kepubify -L \
+  curl -fL --retry 5 --retry-delay 3 --retry-all-errors -o \
+  /usr/bin/kepubify \
   https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit; \
   elif [ "$(uname -m)" == "aarch64" ]; then \
-  curl -o \
-  /usr/bin/kepubify -L \
+  curl -fL --retry 5 --retry-delay 3 --retry-all-errors -o \
+  /usr/bin/kepubify \
   https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-arm64; \
   fi && \
   chmod +x /usr/bin/kepubify
@@ -187,12 +187,12 @@ RUN \
   mkdir -p /app/calibre && \
   # STEP 5.2 - Download the desired version of Calibre, determined by the CALIBRE_RELEASE variable and the architecture of the build environment
   if [ "$(uname -m)" == "x86_64" ]; then \
-  curl -o \
-  /calibre.txz -L \
+  curl -fL --retry 5 --retry-delay 3 --retry-all-errors -o \
+  /calibre.txz \
   "https://download.calibre-ebook.com/${CALIBRE_RELEASE}/calibre-${CALIBRE_RELEASE}-x86_64.txz"; \
   elif [ "$(uname -m)" == "aarch64" ]; then \
-  curl -o \
-  /calibre.txz -L \
+  curl -fL --retry 5 --retry-delay 3 --retry-all-errors -o \
+  /calibre.txz \
   "https://download.calibre-ebook.com/${CALIBRE_RELEASE}/calibre-${CALIBRE_RELEASE}-arm64.txz"; \
   fi && \
   # STEP 5.3 - Extract the downloaded file to /app/calibre

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,10 @@ ARG CALIBRE_RELEASE
 ARG KEPUBIFY_RELEASE
 ARG PYTHON_BUILD_STANDALONE_RELEASE
 ARG PYTHON_VERSION
+# Our GHCR mirror of the python-build-standalone tarball, tag DERIVED from the
+# two ARGs above so it can never drift: bump the version/release and this ref
+# (and the CI mirror-build) follow automatically. See STEP 1.5 + notes/PYTHON-BUILD-MIRROR.md.
+ARG PBS_CACHE_REF=ghcr.io/new-usemame/pbs-cache:cpython-${PYTHON_VERSION}-${PYTHON_BUILD_STANDALONE_RELEASE}
 
 # Set the default shell for the following RUN instructions to bash instead of sh
 SHELL ["/bin/bash", "-c"]
@@ -112,31 +116,18 @@ RUN \
   cd / && \
   rm -rf /tmp/lsof*
 
-# STEP 1.5 - Install Python 3.13 from python-build-standalone (no deadsnakes PPA)
-# The GITHUB_TOKEN is passed as an optional BuildKit secret (required=false so a
-# local/source build without it still works). Authenticating the GitHub release
-# download lifts it off the unauthenticated, shared-Actions-IP rate limit that
-# was returning 404 and failing every CI image build.
-RUN --mount=type=secret,id=github_token,required=false \
-  echo "**** install Python ${PYTHON_VERSION} from python-build-standalone (${PYTHON_BUILD_STANDALONE_RELEASE}) ****" && \
-  case "$(uname -m)" in \
-    x86_64)  PBS_ARCH="x86_64-unknown-linux-gnu" ;; \
-    aarch64) PBS_ARCH="aarch64-unknown-linux-gnu" ;; \
-    *) echo "Unsupported arch: $(uname -m)"; exit 1 ;; \
-  esac && \
-  PBS_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PYTHON_BUILD_STANDALONE_RELEASE}/cpython-${PYTHON_VERSION}+${PYTHON_BUILD_STANDALONE_RELEASE}-${PBS_ARCH}-install_only.tar.gz" && \
-  GH_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" && \
-  if [ -n "${GH_TOKEN}" ]; then echo "Authenticated GitHub download"; AUTH_HEADER=(--header "Authorization: Bearer ${GH_TOKEN}"); else echo "Unauthenticated GitHub download"; AUTH_HEADER=(); fi && \
-  echo "Downloading Python from ${PBS_URL}" && \
-  DL_OK=0 && \
-  for attempt in 1 2 3 4 5 6 7 8 9 10; do \
-    if curl -fL "${AUTH_HEADER[@]}" --connect-timeout 30 --retry 3 --retry-delay 3 --retry-all-errors "${PBS_URL}" -o /tmp/python.tar.gz; then \
-      echo "Python download succeeded on attempt ${attempt}"; DL_OK=1; break; \
-    fi; \
-    echo "Python download attempt ${attempt} failed (HTTP error / 404 from the release CDN); retrying in 15s…"; \
-    sleep 15; \
-  done && \
-  if [ "${DL_OK}" != "1" ]; then echo "ERROR: Python download failed after 10 attempts"; exit 22; fi && \
+# STEP 1.5 - Install Python 3.13 from python-build-standalone.
+# We COPY the tarball from OUR OWN GHCR mirror (ghcr.io/new-usemame/pbs-cache)
+# rather than curling the GitHub release CDN during the build. That CDN
+# intermittently 404s the GitHub-Actions egress (proven: 404 for >10 min at a
+# time), which broke every image build; pulling from GHCR — the same registry
+# the base images come from — is reliable. The mirror is built/refreshed
+# automatically by scripts/ensure-python-mirror.sh (a CI job that runs before
+# the image build). To bump Python: change PYTHON_VERSION / PYTHON_BUILD_STANDALONE_RELEASE
+# above — nothing else. Full explanation: notes/PYTHON-BUILD-MIRROR.md.
+COPY --from=${PBS_CACHE_REF} /python.tar.gz /tmp/python.tar.gz
+RUN \
+  echo "**** install Python ${PYTHON_VERSION} from mirrored python-build-standalone ****" && \
   mkdir -p /opt && \
   tar -xzf /tmp/python.tar.gz -C /opt && \
   rm /tmp/python.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,18 @@
 # syntax=docker/dockerfile:1
 
+# ── Global Python pin (single source of truth) ──────────────────────────────
+# Declared before any FROM so it's a TRUE global ARG (usable in FROM lines). It
+# pins the interpreter AND addresses our GHCR tarball mirror. To bump Python,
+# change ONLY these two lines — the mirror stage below and the CI mirror-build
+# both derive from them. See notes/PYTHON-BUILD-MIRROR.md.
+ARG PYTHON_VERSION=3.13.14
+ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
+
+# PBS tarball mirror stage: our GHCR image holding /python.tar.gz for the build
+# platform. We COPY from this in STEP 1.5 instead of curling the GitHub release
+# CDN, which intermittently 404s the Actions egress and broke every build.
+FROM ghcr.io/new-usemame/pbs-cache:cpython-${PYTHON_VERSION}-${PYTHON_BUILD_STANDALONE_RELEASE} AS pbs_mirror
+
 # Simple Example Build Command:
 # docker build \
 # --tag crocodilestick/calibre-web-automated:dev \
@@ -43,16 +56,8 @@ RUN npm run build
 # ==========================================================================
 ARG CALIBRE_RELEASE=9.1.0
 ARG KEPUBIFY_RELEASE=v4.0.4
-# Python is installed from python-build-standalone (CDN-backed GitHub releases)
-# rather than the deadsnakes PPA, which has a history of being unavailable.
-# Both x86_64 and aarch64 prebuilds are published by astral-sh.
-ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
-ARG PYTHON_VERSION=3.13.14
-# Our GHCR mirror of the python-build-standalone tarball, tag DERIVED from the
-# two ARGs above so it can never drift. FROM expands the ARGs inline (COPY --from
-# can't), so we alias the mirror image as a stage here and COPY from the alias in
-# STEP 1.5. Bump the two ARGs and everything (this stage + the CI mirror) follows.
-FROM ghcr.io/new-usemame/pbs-cache:cpython-${PYTHON_VERSION}-${PYTHON_BUILD_STANDALONE_RELEASE} AS pbs_mirror
+# (PYTHON_VERSION / PYTHON_BUILD_STANDALONE_RELEASE are declared as global ARGs
+# at the top of this file; the dependencies stage re-declares them below.)
 
 FROM ghcr.io/linuxserver/baseimage-ubuntu:noble AS dependencies
 

--- a/notes/PYTHON-BUILD-MIRROR.md
+++ b/notes/PYTHON-BUILD-MIRROR.md
@@ -1,0 +1,50 @@
+# Python (python-build-standalone) is installed from our GHCR mirror
+
+## TL;DR for the next person (or agent)
+The Docker image installs Python 3.13 by `COPY`ing a tarball from our own GHCR
+image **`ghcr.io/new-usemame/pbs-cache`**, NOT by downloading from GitHub's
+release CDN. **To bump Python, change only these two `ARG`s in `Dockerfile`:**
+
+```
+ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
+ARG PYTHON_VERSION=3.13.14
+```
+
+Everything else follows automatically. Don't touch the workflows or the script.
+
+## Why this exists
+GitHub's release-asset CDN intermittently returns **404 to the GitHub-Actions
+egress** — sometimes for >10 minutes straight (proven 2026-06-28). The Dockerfile
+used to `curl` Python from there, so every image build (dev + release) failed at
+random. Pulling from GHCR — the same registry the base images come from — is
+reliable, so we mirror the tarball there once and `COPY` it in.
+
+## How it works (3 pieces, all driven by the two ARGs above)
+1. **`Dockerfile`** — `ARG PBS_CACHE_REF=ghcr.io/new-usemame/pbs-cache:cpython-${PYTHON_VERSION}-${PYTHON_BUILD_STANDALONE_RELEASE}`
+   then `COPY --from=${PBS_CACHE_REF} /python.tar.gz ...`. The tag is derived
+   from the two ARGs, so it can never drift from the pin.
+2. **`scripts/ensure-python-mirror.sh`** — idempotent: reads the two ARGs, and if
+   `pbs-cache:cpython-<ver>-<rel>` isn't already on GHCR, downloads both arch
+   tarballs (with retries) and pushes a tiny multi-arch `scratch` image holding
+   `/python.tar.gz`. A no-op once the mirror exists.
+3. **CI** — both image-build workflows (`docker-image-build-dev.yml`,
+   `docker-image-build-release.yml`) run an `ensure-mirror` job (which runs the
+   script) **before** the build job, so a freshly-bumped Python is mirrored
+   automatically on the first build. No manual step.
+
+So a Python bump = edit two ARGs → next CI run builds the mirror (downloads from
+the release CDN that one time, with retries) → all subsequent builds just `COPY`
+from GHCR. Regular builds never touch the release CDN.
+
+## Auth note
+The `pbs-cache` package is **private**, so builds log in to GHCR with `GH_PAT`
+(read:packages) to `COPY --from` it, and the ensure script uses `GH_PAT`
+(write:packages) to push it. If you ever make the package **public** in the GHCR
+UI, you can drop the `GH_PAT` logins back to `GITHUB_TOKEN` and simplify — purely
+optional.
+
+## Manual mirror build (rare; e.g. CDN down during a bump)
+```
+GHCR_TOKEN="<a PAT with write:packages>" bash scripts/ensure-python-mirror.sh
+```
+Run from a machine whose network can reach the release CDN.

--- a/notes/dev-build-pbs-cdn-404.md
+++ b/notes/dev-build-pbs-cdn-404.md
@@ -1,0 +1,56 @@
+# Dev/release image builds failing: python-build-standalone 404 from Actions
+
+**Status as of 2026-06-28 ~12:50 ET:** every GHCR image build (dev + release)
+fails. teenyverse is stuck on the 06-27 `:dev` image (no new UI banner) because
+no newer `:dev` ever published.
+
+## Symptom
+`[dependencies 3/8]` Python install step dies:
+```
+curl: (22) The requested URL returned error: 404
+URL: https://github.com/astral-sh/python-build-standalone/releases/download/<rel>/cpython-<ver>+<rel>-<arch>-install_only.tar.gz
+```
+
+## Root cause (evidence-based, NOT our code)
+GitHub-hosted Actions runners get a hard **404 from the GitHub release-asset CDN
+(`objects.githubusercontent.com`)** for this download. Confirmed differential:
+- Same URL returns **200** from the operator's machine.
+- In the SAME Docker build, the **lsof** download from `codeload.github.com`
+  (source archive) **succeeds** — only the **release-asset** download 404s.
+- GitHub status: "All systems operational", no incident posted.
+
+## Ruled out (with evidence)
+- ❌ Billing/quota — repo is **public → Actions free**; jobs run, only the
+  download dies (quota failures block job start, not mid-build).
+- ❌ transcoder / self-hosted runner — builds run on GitHub-hosted
+  `ubuntu-latest` + `ubuntu-24.04-arm`.
+- ❌ Stale/missing asset — bumped pin 20260414/3.13.13 → 20260623/3.13.14; both
+  200 elsewhere.
+- ❌ Intermittent — 10× retry loop, every attempt 404.
+- ❌ Rate-limit/auth — `GITHUB_TOKEN` Bearer auth: zero difference.
+- ❌ IPv6 — `curl -4`: zero difference.
+
+## Already merged (non-fragile resilience, keep these)
+- `#544` pin bump to 20260623 / 3.13.14.
+- `#545` 10-attempt retry loop with `--retry-all-errors` (rides out transient
+  CDN blips automatically — the durable safeguard).
+- `#546` optional `GITHUB_TOKEN` BuildKit secret + Bearer header on the download.
+
+## Conclusion
+This is a **GitHub-side release-CDN delivery failure to the Actions egress** —
+the kind that usually clears on its own in hours. The retry loop is the correct
+non-fragile fix for that. **When GitHub recovers, re-run the dev build (or the
+next merge auto-rebuilds) and `:dev` publishes normally.**
+
+Re-run: `gh run list --repo new-usemame/Calibre-Web-NextGen --workflow "Build & Push - Dev - Split Strategy" --limit 1` then `gh run rerun <id> --failed`,
+or dispatch on a ref: `gh workflow run docker-image-build-dev.yml --ref main`.
+
+## If it does NOT recover (escalation options — each has a tradeoff)
+Operator flagged: avoid regressions + fragile/rigid deterministic processes.
+1. **Runner-side fetch** — `gh release download astral-sh/python-build-standalone`
+   in each arch job (uses api.github.com, which works from runners), COPY the
+   tarball into the build with the curl path kept as fallback. Most robust; adds
+   build-context coupling.
+2. **uv-managed Python** (`uv python install`, `UV_PYTHON_INSTALL_MIRROR`) —
+   official astral tooling; changes the venv setup (regression risk).
+3. **deadsnakes/apt python3.13** — reverts the documented move off deadsnakes.

--- a/scripts/ensure-python-mirror.sh
+++ b/scripts/ensure-python-mirror.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Ensure our GHCR mirror of the python-build-standalone tarball exists.
+#
+# WHY THIS EXISTS
+#   The GitHub release-asset CDN (objects/release-assets.githubusercontent.com)
+#   intermittently 404s the GitHub-Actions egress — sometimes for >10 min at a
+#   stretch — which broke EVERY image build (the Dockerfile used to curl Python
+#   from there). So we mirror the tarball into our own GHCR image and the
+#   Dockerfile COPYs it from there instead. GHCR is the same registry the base
+#   images come from, so it's reliable from inside the build.
+#
+# WHAT THIS DOES (idempotent — safe to run every build)
+#   1. Reads PYTHON_VERSION + PYTHON_BUILD_STANDALONE_RELEASE from the Dockerfile
+#      (the single source of truth).
+#   2. If ghcr.io/new-usemame/pbs-cache:cpython-<ver>-<rel> already exists → done.
+#   3. Otherwise downloads both arch tarballs from the release CDN (with retries)
+#      and pushes a tiny multi-arch image containing /python.tar.gz.
+#
+# >>> TO BUMP PYTHON: change ONLY the two ARGs in the Dockerfile. <<<
+#   The mirror tag here and the Dockerfile's COPY --from both derive from those
+#   ARGs, and CI runs this script before every build, so the new mirror is built
+#   automatically the first time. There is no other manual step.
+#
+# AUTH: set GHCR_TOKEN to a token with write:packages (CI passes secrets.GH_PAT).
+#       Only needed when the mirror has to be built; the existence check is anon.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCKERFILE="${REPO_ROOT}/Dockerfile"
+GHCR_USER="${GHCR_USER:-new-usemame}"
+MIRROR_PATH="new-usemame/pbs-cache"          # ghcr.io/<this>
+MIRROR_REPO="ghcr.io/${MIRROR_PATH}"
+
+read_arg() { grep -E "^ARG ${1}=" "$DOCKERFILE" | head -1 | cut -d= -f2; }
+PYTHON_VERSION="$(read_arg PYTHON_VERSION)"
+PBS_RELEASE="$(read_arg PYTHON_BUILD_STANDALONE_RELEASE)"
+[ -n "$PYTHON_VERSION" ] && [ -n "$PBS_RELEASE" ] || { echo "ERROR: could not read Python pin from $DOCKERFILE"; exit 1; }
+
+TAG="cpython-${PYTHON_VERSION}-${PBS_RELEASE}"
+REF="${MIRROR_REPO}:${TAG}"
+echo "python-build-standalone mirror target: ${REF}"
+
+# --- 1. Already present? -------------------------------------------------------
+# The mirror package is private, so the existence check must be AUTHENTICATED
+# (an anonymous token can't see a private manifest and would always report
+# "missing", causing a needless rebuild every run). Use GHCR_TOKEN when set;
+# fall back to an anonymous token only if it isn't (e.g. ad-hoc local runs).
+if [ -n "${GHCR_TOKEN:-}" ]; then
+  reg_token="$(curl -s -u "${GHCR_USER}:${GHCR_TOKEN}" "https://ghcr.io/token?scope=repository:${MIRROR_PATH}:pull" \
+    | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+else
+  reg_token="$(curl -s "https://ghcr.io/token?scope=repository:${MIRROR_PATH}:pull" \
+    | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+fi
+if curl -sf -o /dev/null \
+     -H "Authorization: Bearer ${reg_token}" \
+     -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json' \
+     "https://ghcr.io/v2/${MIRROR_PATH}/manifests/${TAG}"; then
+  echo "Mirror already present — nothing to do."
+  exit 0
+fi
+echo "Mirror missing — building and pushing it."
+
+# --- 2. Build + push the mirror ----------------------------------------------
+: "${GHCR_TOKEN:?GHCR_TOKEN (token with write:packages, e.g. GH_PAT) required to build the mirror}"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+download() {  # download <pbs-arch-triple> <output-file>
+  local url="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_RELEASE}/cpython-${PYTHON_VERSION}+${PBS_RELEASE}-$1-install_only.tar.gz"
+  echo "Downloading $1 from ${url}"
+  curl -fL --connect-timeout 30 --retry 8 --retry-delay 5 --retry-all-errors -o "$2" "$url"
+}
+download "x86_64-unknown-linux-gnu"  "${WORK}/python-amd64.tar.gz"
+download "aarch64-unknown-linux-gnu" "${WORK}/python-arm64.tar.gz"
+
+cat > "${WORK}/Dockerfile" <<'DF'
+# syntax=docker/dockerfile:1
+# Holds the python-build-standalone tarball for the building platform at
+# /python.tar.gz. Consumed by the app Dockerfile via COPY --from.
+FROM scratch
+ARG TARGETARCH
+COPY python-${TARGETARCH}.tar.gz /python.tar.gz
+DF
+
+echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
+docker buildx create --use --name pbs-mirror-builder >/dev/null 2>&1 || docker buildx use pbs-mirror-builder
+docker buildx build --platform linux/amd64,linux/arm64 -t "${REF}" --push "${WORK}"
+echo "Pushed ${REF}"


### PR DESCRIPTION
## Durable fix for the failing image builds

**Root cause (proven):** GitHub's release-asset CDN intermittently 404s the
GitHub-Actions egress (sometimes >10 min). The Dockerfile used to `curl` Python
from there, so builds failed at random. (Today the same egress issue also hits
`download.calibre-ebook.com` — all these URLs return 200 from a normal network.)

## What this does
- **Python from our own GHCR mirror** (`ghcr.io/new-usemame/pbs-cache`): the
  Dockerfile `COPY`s the tarball from a mirror stage instead of curling the
  release CDN. GHCR is as reliable as the base-image pulls. Net simplification
  (removed the curl/retry/auth dance).
- **Automated, single-source-of-truth:** the mirror tag derives from the two
  `PYTHON_*` ARGs; `scripts/ensure-python-mirror.sh` (an `ensure-mirror` CI job
  before the build) rebuilds the mirror automatically when those change. **To
  bump Python, edit only those two ARGs.** Documented in `notes/PYTHON-BUILD-MIRROR.md`.
- **Hardened calibre + kepubify downloads** (`-f` + retries) so transient blips
  don't fail the build.
- GHCR login uses `GH_PAT` so BuildKit can pull the private mirror.

## Verification
Full image build **green end-to-end locally** (exit 0: mirror pull → apt → lsof →
Python → calibre → kepubify → pip). In CI the `ensure-mirror` job + mirror pull
both succeed; remaining CI failures are GitHub's transient egress (calibre), not
this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)