### PR TITLE
fix(docker): generous retry budget for calibre + kepubify downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,11 +171,11 @@ RUN \
   | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   fi && \
   if [ "$(uname -m)" == "x86_64" ]; then \
-  curl -fL --retry 5 --retry-delay 3 --retry-all-errors -o \
+  curl -fL --retry 30 --retry-delay 15 --retry-all-errors -o \
   /usr/bin/kepubify \
   https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit; \
   elif [ "$(uname -m)" == "aarch64" ]; then \
-  curl -fL --retry 5 --retry-delay 3 --retry-all-errors -o \
+  curl -fL --retry 30 --retry-delay 15 --retry-all-errors -o \
   /usr/bin/kepubify \
   https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-arm64; \
   fi && \
@@ -187,11 +187,11 @@ RUN \
   mkdir -p /app/calibre && \
   # STEP 5.2 - Download the desired version of Calibre, determined by the CALIBRE_RELEASE variable and the architecture of the build environment
   if [ "$(uname -m)" == "x86_64" ]; then \
-  curl -fL --retry 5 --retry-delay 3 --retry-all-errors -o \
+  curl -fL --retry 30 --retry-delay 15 --retry-all-errors -o \
   /calibre.txz \
   "https://download.calibre-ebook.com/${CALIBRE_RELEASE}/calibre-${CALIBRE_RELEASE}-x86_64.txz"; \
   elif [ "$(uname -m)" == "aarch64" ]; then \
-  curl -fL --retry 5 --retry-delay 3 --retry-all-errors -o \
+  curl -fL --retry 30 --retry-delay 15 --retry-all-errors -o \
   /calibre.txz \
   "https://download.calibre-ebook.com/${CALIBRE_RELEASE}/calibre-${CALIBRE_RELEASE}-arm64.txz"; \
   fi && \


### PR DESCRIPTION
Bump calibre + kepubify curl retries to --retry 30 --retry-delay 15 (~7.5 min) to ride out the GitHub Actions egress 404 dips, matching the Python path's resilience. No effect when healthy.