### PR TITLE
fix(docker): hoist CALIBRE_RELEASE/KEPUBIFY_RELEASE to global ARG scope

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 # syntax=docker/dockerfile:1
 
-# ── Global Python pin (single source of truth) ──────────────────────────────
-# Declared before any FROM so it's a TRUE global ARG (usable in FROM lines). It
-# pins the interpreter AND addresses our GHCR tarball mirror. To bump Python,
-# change ONLY these two lines — the mirror stage below and the CI mirror-build
-# both derive from them. See notes/PYTHON-BUILD-MIRROR.md.
+# ── Global build version pins (single source of truth) ──────────────────────
+# Declared before any FROM so they are TRUE global ARGs: usable in FROM lines
+# AND inheritable by every later stage via a bare re-declare. PYTHON_* pin the
+# interpreter and address our GHCR tarball mirror; CALIBRE_RELEASE and
+# KEPUBIFY_RELEASE pin the binaries the dependencies stage downloads. A
+# stage-local ARG (declared after a FROM) only reaches that one stage, so a
+# bare re-declare elsewhere would inherit an empty string and build a malformed
+# download URL. To bump any pin, change ONLY the line here.
+# See notes/PYTHON-BUILD-MIRROR.md.
 ARG PYTHON_VERSION=3.13.14
 ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
+ARG CALIBRE_RELEASE=9.1.0
+ARG KEPUBIFY_RELEASE=v4.0.4
 
 # PBS tarball mirror stage: our GHCR image holding /python.tar.gz for the build
 # platform. We COPY from this in STEP 1.5 instead of curling the GitHub release
@@ -54,10 +60,9 @@ RUN npm run build
 # ==========================================================================
 # STAGE 1: Dependencies - Install system packages and Python dependencies
 # ==========================================================================
-ARG CALIBRE_RELEASE=9.1.0
-ARG KEPUBIFY_RELEASE=v4.0.4
-# (PYTHON_VERSION / PYTHON_BUILD_STANDALONE_RELEASE are declared as global ARGs
-# at the top of this file; the dependencies stage re-declares them below.)
+# CALIBRE_RELEASE / KEPUBIFY_RELEASE / PYTHON_VERSION / PYTHON_BUILD_STANDALONE_RELEASE
+# are declared as global ARGs at the top of this file; the dependencies stage
+# re-declares them bare below so they inherit those global default values.
 
 FROM ghcr.io/linuxserver/baseimage-ubuntu:noble AS dependencies
 

--- a/tests/unit/test_dockerfile_global_build_args.py
+++ b/tests/unit/test_dockerfile_global_build_args.py
@@ -1,0 +1,127 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Pin the version-defining build ARGs to GLOBAL scope (before the first FROM).
+
+A Dockerfile `ARG FOO` re-declared inside a build stage only inherits a
+default value when FOO is a *global* arg — one declared before the first
+`FROM`. If the defaulted declaration sits inside an earlier stage, the
+re-declaration in a later stage resolves to the empty string.
+
+That is exactly what broke every :dev image build on 2026-06-28: commit
+c1cd7b462 prepended a `FROM node:22-slim AS frontend-build` stage above the
+ARG block, which had been global until then. CALIBRE_RELEASE / KEPUBIFY_RELEASE
+/ PYTHON_VERSION / PYTHON_BUILD_STANDALONE_RELEASE became scoped to
+frontend-build, so the `dependencies` stage re-declared them empty. The
+download steps then built malformed URLs such as
+
+    https://github.com/pgaskin/kepubify/releases/download//kepubify-linux-64bit
+
+(note the `download//kepubify` — empty release), which 404s. Bumping the pin
+(#544), adding retries (#545/#550) and authenticating the download (#546) all
+chased the wrong layer because the URL itself was malformed. #549 hoisted the
+PYTHON_* pins (and moved Python to a GHCR mirror) but left CALIBRE_RELEASE /
+KEPUBIFY_RELEASE trapped in the frontend-build stage, so the build advanced
+past Python and died at the kepubify download instead.
+
+These tests fail on the broken layout (defaults trapped after the first FROM)
+and pass once the defaults are hoisted above every FROM. They also guard
+against a future stage being prepended above the ARG block again.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+# ARGs whose value feeds a download URL (or a FROM mirror tag) in a later
+# stage. Each MUST carry its default in global scope so every stage that
+# re-declares it inherits a value.
+VERSION_ARGS = (
+    "CALIBRE_RELEASE",
+    "KEPUBIFY_RELEASE",
+    "PYTHON_BUILD_STANDALONE_RELEASE",
+    "PYTHON_VERSION",
+)
+
+
+@pytest.fixture(scope="module")
+def dockerfile_text() -> str:
+    return DOCKERFILE.read_text()
+
+
+@pytest.fixture(scope="module")
+def first_from_offset(dockerfile_text: str) -> int:
+    """Character offset of the first `FROM` instruction."""
+    match = re.search(r"^FROM\b", dockerfile_text, re.MULTILINE)
+    assert match, "Dockerfile must contain at least one FROM"
+    return match.start()
+
+
+@pytest.mark.parametrize("arg", VERSION_ARGS)
+def test_version_arg_default_is_global(arg: str, dockerfile_text: str, first_from_offset: int) -> None:
+    """The defaulted declaration (`ARG NAME=value`) must appear before the
+    first FROM, i.e. in global scope, so later-stage re-declarations inherit it."""
+    match = re.search(rf"^ARG {re.escape(arg)}=\S", dockerfile_text, re.MULTILINE)
+    assert match, f"Dockerfile must declare a default for ARG {arg} (e.g. `ARG {arg}=...`)"
+    assert match.start() < first_from_offset, (
+        f"ARG {arg}=... carries its default AFTER the first FROM, so it is scoped "
+        f"to that stage and the `dependencies` stage re-declares it empty — which "
+        f"produces malformed download URLs (404). Move the defaulted declaration "
+        f"above the first FROM (global scope)."
+    )
+
+
+def test_no_defaulted_version_arg_trapped_inside_a_stage(dockerfile_text: str, first_from_offset: int) -> None:
+    """Defense in depth: NO defaulted version-arg declaration may live after the
+    first FROM. A duplicate `ARG NAME=value` inside a stage re-introduces the
+    two-places-to-bump trap that hid the original regression (#544 bumped the
+    trapped copy and had no effect)."""
+    post_from = dockerfile_text[first_from_offset:]
+    for arg in VERSION_ARGS:
+        assert not re.search(rf"^ARG {re.escape(arg)}=\S", post_from, re.MULTILINE), (
+            f"A defaulted `ARG {arg}=...` appears after the first FROM. Keep the "
+            f"single source of truth in the global block; stages should re-declare "
+            f"with a bare `ARG {arg}` (no value) so they inherit the global default."
+        )
+
+
+def test_download_urls_interpolate_their_release_args(dockerfile_text: str) -> None:
+    """The binary download lines must reference their release vars, and the
+    global defaults must be non-empty — together these guarantee the rendered
+    URLs carry a real version segment and never the empty-var `download//...`
+    form that 404s."""
+    # kepubify: .../releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-...
+    assert re.search(
+        r"releases/download/\$\{KEPUBIFY_RELEASE\}/kepubify-linux",
+        dockerfile_text,
+    ), "kepubify download URL must interpolate KEPUBIFY_RELEASE"
+    # calibre: https://download.calibre-ebook.com/${CALIBRE_RELEASE}/calibre-${CALIBRE_RELEASE}-...
+    assert re.search(
+        r"download\.calibre-ebook\.com/\$\{CALIBRE_RELEASE\}/calibre-\$\{CALIBRE_RELEASE\}",
+        dockerfile_text,
+    ), "calibre download URL must interpolate CALIBRE_RELEASE"
+    for arg in ("CALIBRE_RELEASE", "KEPUBIFY_RELEASE"):
+        match = re.search(rf"^ARG {re.escape(arg)}=(\S+)", dockerfile_text, re.MULTILINE)
+        assert match and match.group(1), f"Global default for {arg} must be non-empty"
+
+
+def test_python_mirror_from_uses_global_pins(dockerfile_text: str) -> None:
+    """Python is sourced from our GHCR mirror image whose tag embeds both
+    PYTHON_VERSION and PYTHON_BUILD_STANDALONE_RELEASE (introduced in #549). A
+    FROM line can only interpolate a *global* ARG, so this doubles as a guard
+    that those two pins stay global."""
+    assert re.search(
+        r"^FROM\s+ghcr\.io/[^\s:]+:cpython-\$\{PYTHON_VERSION\}-"
+        r"\$\{PYTHON_BUILD_STANDALONE_RELEASE\}",
+        dockerfile_text,
+        re.MULTILINE,
+    ), "Python mirror FROM must interpolate PYTHON_VERSION and PYTHON_BUILD_STANDALONE_RELEASE"
+    for arg in ("PYTHON_VERSION", "PYTHON_BUILD_STANDALONE_RELEASE"):
+        match = re.search(rf"^ARG {re.escape(arg)}=(\S+)", dockerfile_text, re.MULTILINE)
+        assert match and match.group(1), f"Global default for {arg} must be non-empty"


### PR DESCRIPTION
## Why
The `:dev` multi-arch image has been red since ~02:21Z on 2026-06-28, leaving the teenyverse canary stale and blocking SPA-default-on verification. #544 (pin bump), #545/#550 (retry budget) and #546 (auth download) all chased the wrong layer.

## Root cause (ground-truthed)
The SPA rebuild (commit `c1cd7b462`) prepended `FROM node:22-slim AS frontend-build` above the version ARG block. That trapped `CALIBRE_RELEASE` / `KEPUBIFY_RELEASE` inside the `frontend-build` stage scope. The `dependencies` stage re-declares them bare (`ARG CALIBRE_RELEASE`), which inherits a value only from a *global* ARG — and there was none — so they resolved to the empty string.

#549 correctly hoisted the `PYTHON_*` pins to global (and moved Python to a GHCR mirror), so the build now advances past Python and dies one step later at kepubify. Direct proof from the failed 19:56Z dev build (run 28334147334):

```
Dockerfile:167  RUN ... curl -fL ... https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit
12.62 curl: (22) The requested URL returned error: 404
ERROR: ... exit code: 22
```

`${KEPUBIFY_RELEASE}` is empty, so the URL is `releases/download//kepubify-linux-64bit`. A retry budget (#545/#550) cannot fix a malformed URL — every retry hits the same 404.

## Fix
Move `CALIBRE_RELEASE` and `KEPUBIFY_RELEASE` into the global ARG block alongside `PYTHON_VERSION` / `PYTHON_BUILD_STANDALONE_RELEASE`, before the first `FROM`. The `dependencies` stage's bare re-declares then inherit real values. Single source of truth preserved (one place to bump).

## Validation
- Regression test `tests/unit/test_dockerfile_global_build_args.py` pins every version-defining ARG to global scope and checks the download URLs interpolate their release vars. **Red on `origin/main`** (3 failed: CALIBRE_RELEASE/KEPUBIFY_RELEASE global + no-trapped-arg), **green on this branch** (7 passed).
- The identical transformation is already proven live: #549 hoisted the `PYTHON_*` pins to global and the 19:56Z CI build downloaded/installed Python successfully (it reached the kepubify step). This PR applies the same change to calibre/kepubify.
- A full multi-arch green is only observable on the live `:dev` build after merge.

## Tier
needs-review — build-infra, fork-original. Supersedes #547 (which hoisted all four ARGs but predates #549's Python-mirror restructure and would now conflict; #547 closed).