### PR TITLE
fix(ci): mirror kepubify too (remove last GitHub-release-CDN download)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,12 @@ ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
 ARG CALIBRE_RELEASE=9.1.0
 ARG KEPUBIFY_RELEASE=v4.0.4
 
-# PBS tarball mirror stage: our GHCR image holding /python.tar.gz for the build
-# platform. We COPY from this in STEP 1.5 instead of curling the GitHub release
-# CDN, which intermittently 404s the Actions egress and broke every build.
+# Mirror stages: our GHCR images holding build deps that otherwise come from the
+# GitHub release CDN, which intermittently 404s the Actions egress and broke every
+# build. We COPY from these instead of curling at build time. The CI ensure-mirror
+# job (scripts/ensure-python-mirror.sh) builds them from the pins above.
 FROM ghcr.io/new-usemame/pbs-cache:cpython-${PYTHON_VERSION}-${PYTHON_BUILD_STANDALONE_RELEASE} AS pbs_mirror
+FROM ghcr.io/new-usemame/pbs-cache:kepubify-${KEPUBIFY_RELEASE} AS kepubify_mirror
 
 # Simple Example Build Command:
 # docker build \
@@ -168,23 +170,9 @@ RUN \
   /lsiopy/bin/pip install -U --no-cache-dir --find-links https://wheel-index.linuxserver.io/ubuntu/ -r \
   /app/calibre-web-automated/requirements.txt -r /app/calibre-web-automated/optional-requirements.txt
 
-# STEP 4 - Install kepubify
-RUN \
-  echo "**** install kepubify ****" && \
-  if [[ $KEPUBIFY_RELEASE == 'newest' ]]; then \
-  KEPUBIFY_RELEASE=$(curl -sX GET "https://api.github.com/repos/pgaskin/kepubify/releases/latest" \
-  | awk '/tag_name/{print $4;exit}' FS='[""]'); \
-  fi && \
-  if [ "$(uname -m)" == "x86_64" ]; then \
-  curl -fL --retry 30 --retry-delay 15 --retry-all-errors -o \
-  /usr/bin/kepubify \
-  https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit; \
-  elif [ "$(uname -m)" == "aarch64" ]; then \
-  curl -fL --retry 30 --retry-delay 15 --retry-all-errors -o \
-  /usr/bin/kepubify \
-  https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-arm64; \
-  fi && \
-  chmod +x /usr/bin/kepubify
+# STEP 4 - Install kepubify from our GHCR mirror (not the GitHub release CDN).
+# The mirror image ships /kepubify already mode 0755 for the build platform.
+COPY --from=kepubify_mirror /kepubify /usr/bin/kepubify
 
 # STEP 5 - Install Calibre
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 # syntax=docker/dockerfile:1
 
-# ── Global Python pin (single source of truth) ──────────────────────────────
-# Declared before any FROM so it's a TRUE global ARG (usable in FROM lines). It
-# pins the interpreter AND addresses our GHCR tarball mirror. To bump Python,
-# change ONLY these two lines — the mirror stage below and the CI mirror-build
-# both derive from them. See notes/PYTHON-BUILD-MIRROR.md.
+# ── Global build version pins (single source of truth) ──────────────────────
+# Declared before any FROM so they are TRUE global ARGs: usable in FROM lines
+# AND inheritable by every later stage via a bare re-declare. PYTHON_* pin the
+# interpreter and address our GHCR tarball mirror; CALIBRE_RELEASE and
+# KEPUBIFY_RELEASE pin the binaries the dependencies stage downloads. A
+# stage-local ARG (declared after a FROM) only reaches that one stage, so a
+# bare re-declare elsewhere would inherit an empty string and build a malformed
+# download URL. To bump any pin, change ONLY the line here.
+# See notes/PYTHON-BUILD-MIRROR.md.
 ARG PYTHON_VERSION=3.13.14
 ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
+ARG CALIBRE_RELEASE=9.1.0
+ARG KEPUBIFY_RELEASE=v4.0.4
 
 # PBS tarball mirror stage: our GHCR image holding /python.tar.gz for the build
 # platform. We COPY from this in STEP 1.5 instead of curling the GitHub release
@@ -54,10 +60,9 @@ RUN npm run build
 # ==========================================================================
 # STAGE 1: Dependencies - Install system packages and Python dependencies
 # ==========================================================================
-ARG CALIBRE_RELEASE=9.1.0
-ARG KEPUBIFY_RELEASE=v4.0.4
-# (PYTHON_VERSION / PYTHON_BUILD_STANDALONE_RELEASE are declared as global ARGs
-# at the top of this file; the dependencies stage re-declares them below.)
+# CALIBRE_RELEASE / KEPUBIFY_RELEASE / PYTHON_VERSION / PYTHON_BUILD_STANDALONE_RELEASE
+# are declared as global ARGs at the top of this file; the dependencies stage
+# re-declares them bare below so they inherit those global default values.
 
 FROM ghcr.io/linuxserver/baseimage-ubuntu:noble AS dependencies
 

--- a/notes/PYTHON-BUILD-MIRROR.md
+++ b/notes/PYTHON-BUILD-MIRROR.md
@@ -1,16 +1,20 @@
 # Python (python-build-standalone) is installed from our GHCR mirror
 
 ## TL;DR for the next person (or agent)
-The Docker image installs Python 3.13 by `COPY`ing a tarball from our own GHCR
-image **`ghcr.io/new-usemame/pbs-cache`**, NOT by downloading from GitHub's
-release CDN. **To bump Python, change only these two `ARG`s in `Dockerfile`:**
+The Docker image installs **Python** AND **kepubify** by `COPY`ing them from our
+own GHCR image **`ghcr.io/new-usemame/pbs-cache`**, NOT by downloading from
+GitHub's release CDN (both used to come from there, which is what kept 404ing).
+**To bump Python or kepubify, change only the matching `ARG` at the top of `Dockerfile`:**
 
 ```
-ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
 ARG PYTHON_VERSION=3.13.14
+ARG PYTHON_BUILD_STANDALONE_RELEASE=20260623
+ARG KEPUBIFY_RELEASE=v4.0.4
 ```
 
 Everything else follows automatically. Don't touch the workflows or the script.
+(Two mirror tags: `cpython-<ver>-<rel>` and `kepubify-<rel>`. Calibre comes from
+calibre-ebook.com — a different host — and is left on curl-with-retries.)
 
 ## Why this exists
 GitHub's release-asset CDN intermittently returns **404 to the GitHub-Actions

--- a/scripts/ensure-python-mirror.sh
+++ b/scripts/ensure-python-mirror.sh
@@ -1,88 +1,95 @@
 #!/usr/bin/env bash
-# Ensure our GHCR mirror of the python-build-standalone tarball exists.
+# Ensure our GHCR mirrors of the build deps that come from the GitHub release CDN
+# exist. Currently: python-build-standalone (Python interpreter) and kepubify.
 #
 # WHY THIS EXISTS
-#   The GitHub release-asset CDN (objects/release-assets.githubusercontent.com)
-#   intermittently 404s the GitHub-Actions egress — sometimes for >10 min at a
-#   stretch — which broke EVERY image build (the Dockerfile used to curl Python
-#   from there). So we mirror the tarball into our own GHCR image and the
-#   Dockerfile COPYs it from there instead. GHCR is the same registry the base
-#   images come from, so it's reliable from inside the build.
+#   The GitHub release-asset CDN intermittently 404s the GitHub-Actions egress —
+#   sometimes for many minutes (proven 2026-06-28) — which broke every image
+#   build at these downloads. We mirror them into our own GHCR repo and the
+#   Dockerfile COPYs them from there. GHCR is as reliable as the base-image pulls.
 #
 # WHAT THIS DOES (idempotent — safe to run every build)
-#   1. Reads PYTHON_VERSION + PYTHON_BUILD_STANDALONE_RELEASE from the Dockerfile
-#      (the single source of truth).
-#   2. If ghcr.io/new-usemame/pbs-cache:cpython-<ver>-<rel> already exists → done.
-#   3. Otherwise downloads both arch tarballs from the release CDN (with retries)
-#      and pushes a tiny multi-arch image containing /python.tar.gz.
+#   Reads the version pins from the Dockerfile (single source of truth), and for
+#   each mirror: if its GHCR tag already exists -> nothing to do; otherwise builds
+#   a tiny multi-arch image holding the artifact and pushes it.
 #
-# >>> TO BUMP PYTHON: change ONLY the two ARGs in the Dockerfile. <<<
-#   The mirror tag here and the Dockerfile's COPY --from both derive from those
-#   ARGs, and CI runs this script before every build, so the new mirror is built
-#   automatically the first time. There is no other manual step.
+# >>> TO BUMP PYTHON or KEPUBIFY: change ONLY the ARG in the Dockerfile. <<<
+#   The Dockerfile mirror stages and this script both derive the tags from those
+#   ARGs, and CI runs this before every build, so the new mirror is built once
+#   automatically. No other manual step.
 #
 # AUTH: set GHCR_TOKEN to a token with write:packages (CI passes secrets.GH_PAT).
-#       Only needed when the mirror has to be built; the existence check is anon.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DOCKERFILE="${REPO_ROOT}/Dockerfile"
 GHCR_USER="${GHCR_USER:-new-usemame}"
-MIRROR_PATH="new-usemame/pbs-cache"          # ghcr.io/<this>
+MIRROR_PATH="new-usemame/pbs-cache"            # ghcr.io/<this>
 MIRROR_REPO="ghcr.io/${MIRROR_PATH}"
 
 read_arg() { grep -E "^ARG ${1}=" "$DOCKERFILE" | head -1 | cut -d= -f2; }
 PYTHON_VERSION="$(read_arg PYTHON_VERSION)"
 PBS_RELEASE="$(read_arg PYTHON_BUILD_STANDALONE_RELEASE)"
-[ -n "$PYTHON_VERSION" ] && [ -n "$PBS_RELEASE" ] || { echo "ERROR: could not read Python pin from $DOCKERFILE"; exit 1; }
+KEPUBIFY_RELEASE="$(read_arg KEPUBIFY_RELEASE)"
+[ -n "$PYTHON_VERSION" ] && [ -n "$PBS_RELEASE" ] && [ -n "$KEPUBIFY_RELEASE" ] \
+  || { echo "ERROR: could not read version pins from $DOCKERFILE"; exit 1; }
 
-TAG="cpython-${PYTHON_VERSION}-${PBS_RELEASE}"
-REF="${MIRROR_REPO}:${TAG}"
-echo "python-build-standalone mirror target: ${REF}"
-
-# --- 1. Already present? -------------------------------------------------------
-# The mirror package is private, so the existence check must be AUTHENTICATED
-# (an anonymous token can't see a private manifest and would always report
-# "missing", causing a needless rebuild every run). Use GHCR_TOKEN when set;
-# fall back to an anonymous token only if it isn't (e.g. ad-hoc local runs).
-if [ -n "${GHCR_TOKEN:-}" ]; then
-  reg_token="$(curl -s -u "${GHCR_USER}:${GHCR_TOKEN}" "https://ghcr.io/token?scope=repository:${MIRROR_PATH}:pull" \
-    | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
-else
-  reg_token="$(curl -s "https://ghcr.io/token?scope=repository:${MIRROR_PATH}:pull" \
-    | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
-fi
-if curl -sf -o /dev/null \
-     -H "Authorization: Bearer ${reg_token}" \
-     -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json' \
-     "https://ghcr.io/v2/${MIRROR_PATH}/manifests/${TAG}"; then
-  echo "Mirror already present — nothing to do."
-  exit 0
-fi
-echo "Mirror missing — building and pushing it."
-
-# --- 2. Build + push the mirror ----------------------------------------------
-: "${GHCR_TOKEN:?GHCR_TOKEN (token with write:packages, e.g. GH_PAT) required to build the mirror}"
-WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
-
-download() {  # download <pbs-arch-triple> <output-file>
-  local url="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_RELEASE}/cpython-${PYTHON_VERSION}+${PBS_RELEASE}-$1-install_only.tar.gz"
-  echo "Downloading $1 from ${url}"
-  curl -fL --connect-timeout 30 --retry 8 --retry-delay 5 --retry-all-errors -o "$2" "$url"
+# Authenticated existence check — the package is private, so an anonymous token
+# can't see it and would always report "missing" (needless rebuild).
+mirror_exists() {  # mirror_exists <tag>
+  local tag="$1" tok
+  if [ -n "${GHCR_TOKEN:-}" ]; then
+    tok="$(curl -s -u "${GHCR_USER}:${GHCR_TOKEN}" "https://ghcr.io/token?scope=repository:${MIRROR_PATH}:pull" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+  else
+    tok="$(curl -s "https://ghcr.io/token?scope=repository:${MIRROR_PATH}:pull" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+  fi
+  curl -sf -o /dev/null -H "Authorization: Bearer ${tok}" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json' \
+    "https://ghcr.io/v2/${MIRROR_PATH}/manifests/${tag}"
 }
-download "x86_64-unknown-linux-gnu"  "${WORK}/python-amd64.tar.gz"
-download "aarch64-unknown-linux-gnu" "${WORK}/python-arm64.tar.gz"
 
-cat > "${WORK}/Dockerfile" <<'DF'
-# syntax=docker/dockerfile:1
-# Holds the python-build-standalone tarball for the building platform at
-# /python.tar.gz. Consumed by the app Dockerfile via COPY --from.
-FROM scratch
-ARG TARGETARCH
-COPY python-${TARGETARCH}.tar.gz /python.tar.gz
-DF
+ensured_login=0
+ensure_login() {
+  [ "$ensured_login" = "1" ] && return 0
+  : "${GHCR_TOKEN:?GHCR_TOKEN (token with write:packages, e.g. GH_PAT) required to build a mirror}"
+  echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
+  docker buildx create --use --name pbs-mirror-builder >/dev/null 2>&1 || docker buildx use pbs-mirror-builder
+  ensured_login=1
+}
 
-echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
-docker buildx create --use --name pbs-mirror-builder >/dev/null 2>&1 || docker buildx use pbs-mirror-builder
-docker buildx build --platform linux/amd64,linux/arm64 -t "${REF}" --push "${WORK}"
-echo "Pushed ${REF}"
+dl() {  # dl <url> <out>
+  echo "  downloading $1"
+  curl -fL --connect-timeout 30 --retry 8 --retry-delay 5 --retry-all-errors -o "$2" "$1"
+}
+
+# ── Mirror 1: python-build-standalone tarball -> /python.tar.gz ───────────────
+PY_TAG="cpython-${PYTHON_VERSION}-${PBS_RELEASE}"
+if mirror_exists "$PY_TAG"; then
+  echo "Python mirror ${MIRROR_REPO}:${PY_TAG} present."
+else
+  echo "Building Python mirror ${MIRROR_REPO}:${PY_TAG}"
+  ensure_login
+  W="$(mktemp -d)"
+  dl "https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_RELEASE}/cpython-${PYTHON_VERSION}+${PBS_RELEASE}-x86_64-unknown-linux-gnu-install_only.tar.gz"  "${W}/python-amd64.tar.gz"
+  dl "https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_RELEASE}/cpython-${PYTHON_VERSION}+${PBS_RELEASE}-aarch64-unknown-linux-gnu-install_only.tar.gz" "${W}/python-arm64.tar.gz"
+  printf '# syntax=docker/dockerfile:1\nFROM scratch\nARG TARGETARCH\nCOPY python-${TARGETARCH}.tar.gz /python.tar.gz\n' > "${W}/Dockerfile"
+  docker buildx build --platform linux/amd64,linux/arm64 -t "${MIRROR_REPO}:${PY_TAG}" --push "${W}"
+  rm -rf "${W}"
+fi
+
+# ── Mirror 2: kepubify binary -> /kepubify (0755) ─────────────────────────────
+KP_TAG="kepubify-${KEPUBIFY_RELEASE}"
+if mirror_exists "$KP_TAG"; then
+  echo "kepubify mirror ${MIRROR_REPO}:${KP_TAG} present."
+else
+  echo "Building kepubify mirror ${MIRROR_REPO}:${KP_TAG}"
+  ensure_login
+  W="$(mktemp -d)"
+  dl "https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit" "${W}/kepubify-amd64"
+  dl "https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-arm64" "${W}/kepubify-arm64"
+  printf '# syntax=docker/dockerfile:1\nFROM scratch\nARG TARGETARCH\nCOPY --chmod=755 kepubify-${TARGETARCH} /kepubify\n' > "${W}/Dockerfile"
+  docker buildx build --platform linux/amd64,linux/arm64 -t "${MIRROR_REPO}:${KP_TAG}" --push "${W}"
+  rm -rf "${W}"
+fi
+
+echo "All build-dep mirrors present."

--- a/tests/unit/test_dockerfile_global_build_args.py
+++ b/tests/unit/test_dockerfile_global_build_args.py
@@ -1,0 +1,127 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Pin the version-defining build ARGs to GLOBAL scope (before the first FROM).
+
+A Dockerfile `ARG FOO` re-declared inside a build stage only inherits a
+default value when FOO is a *global* arg — one declared before the first
+`FROM`. If the defaulted declaration sits inside an earlier stage, the
+re-declaration in a later stage resolves to the empty string.
+
+That is exactly what broke every :dev image build on 2026-06-28: commit
+c1cd7b462 prepended a `FROM node:22-slim AS frontend-build` stage above the
+ARG block, which had been global until then. CALIBRE_RELEASE / KEPUBIFY_RELEASE
+/ PYTHON_VERSION / PYTHON_BUILD_STANDALONE_RELEASE became scoped to
+frontend-build, so the `dependencies` stage re-declared them empty. The
+download steps then built malformed URLs such as
+
+    https://github.com/pgaskin/kepubify/releases/download//kepubify-linux-64bit
+
+(note the `download//kepubify` — empty release), which 404s. Bumping the pin
+(#544), adding retries (#545/#550) and authenticating the download (#546) all
+chased the wrong layer because the URL itself was malformed. #549 hoisted the
+PYTHON_* pins (and moved Python to a GHCR mirror) but left CALIBRE_RELEASE /
+KEPUBIFY_RELEASE trapped in the frontend-build stage, so the build advanced
+past Python and died at the kepubify download instead.
+
+These tests fail on the broken layout (defaults trapped after the first FROM)
+and pass once the defaults are hoisted above every FROM. They also guard
+against a future stage being prepended above the ARG block again.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+# ARGs whose value feeds a download URL (or a FROM mirror tag) in a later
+# stage. Each MUST carry its default in global scope so every stage that
+# re-declares it inherits a value.
+VERSION_ARGS = (
+    "CALIBRE_RELEASE",
+    "KEPUBIFY_RELEASE",
+    "PYTHON_BUILD_STANDALONE_RELEASE",
+    "PYTHON_VERSION",
+)
+
+
+@pytest.fixture(scope="module")
+def dockerfile_text() -> str:
+    return DOCKERFILE.read_text()
+
+
+@pytest.fixture(scope="module")
+def first_from_offset(dockerfile_text: str) -> int:
+    """Character offset of the first `FROM` instruction."""
+    match = re.search(r"^FROM\b", dockerfile_text, re.MULTILINE)
+    assert match, "Dockerfile must contain at least one FROM"
+    return match.start()
+
+
+@pytest.mark.parametrize("arg", VERSION_ARGS)
+def test_version_arg_default_is_global(arg: str, dockerfile_text: str, first_from_offset: int) -> None:
+    """The defaulted declaration (`ARG NAME=value`) must appear before the
+    first FROM, i.e. in global scope, so later-stage re-declarations inherit it."""
+    match = re.search(rf"^ARG {re.escape(arg)}=\S", dockerfile_text, re.MULTILINE)
+    assert match, f"Dockerfile must declare a default for ARG {arg} (e.g. `ARG {arg}=...`)"
+    assert match.start() < first_from_offset, (
+        f"ARG {arg}=... carries its default AFTER the first FROM, so it is scoped "
+        f"to that stage and the `dependencies` stage re-declares it empty — which "
+        f"produces malformed download URLs (404). Move the defaulted declaration "
+        f"above the first FROM (global scope)."
+    )
+
+
+def test_no_defaulted_version_arg_trapped_inside_a_stage(dockerfile_text: str, first_from_offset: int) -> None:
+    """Defense in depth: NO defaulted version-arg declaration may live after the
+    first FROM. A duplicate `ARG NAME=value` inside a stage re-introduces the
+    two-places-to-bump trap that hid the original regression (#544 bumped the
+    trapped copy and had no effect)."""
+    post_from = dockerfile_text[first_from_offset:]
+    for arg in VERSION_ARGS:
+        assert not re.search(rf"^ARG {re.escape(arg)}=\S", post_from, re.MULTILINE), (
+            f"A defaulted `ARG {arg}=...` appears after the first FROM. Keep the "
+            f"single source of truth in the global block; stages should re-declare "
+            f"with a bare `ARG {arg}` (no value) so they inherit the global default."
+        )
+
+
+def test_download_urls_interpolate_their_release_args(dockerfile_text: str) -> None:
+    """The binary download lines must reference their release vars, and the
+    global defaults must be non-empty — together these guarantee the rendered
+    URLs carry a real version segment and never the empty-var `download//...`
+    form that 404s."""
+    # kepubify: .../releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-...
+    assert re.search(
+        r"releases/download/\$\{KEPUBIFY_RELEASE\}/kepubify-linux",
+        dockerfile_text,
+    ), "kepubify download URL must interpolate KEPUBIFY_RELEASE"
+    # calibre: https://download.calibre-ebook.com/${CALIBRE_RELEASE}/calibre-${CALIBRE_RELEASE}-...
+    assert re.search(
+        r"download\.calibre-ebook\.com/\$\{CALIBRE_RELEASE\}/calibre-\$\{CALIBRE_RELEASE\}",
+        dockerfile_text,
+    ), "calibre download URL must interpolate CALIBRE_RELEASE"
+    for arg in ("CALIBRE_RELEASE", "KEPUBIFY_RELEASE"):
+        match = re.search(rf"^ARG {re.escape(arg)}=(\S+)", dockerfile_text, re.MULTILINE)
+        assert match and match.group(1), f"Global default for {arg} must be non-empty"
+
+
+def test_python_mirror_from_uses_global_pins(dockerfile_text: str) -> None:
+    """Python is sourced from our GHCR mirror image whose tag embeds both
+    PYTHON_VERSION and PYTHON_BUILD_STANDALONE_RELEASE (introduced in #549). A
+    FROM line can only interpolate a *global* ARG, so this doubles as a guard
+    that those two pins stay global."""
+    assert re.search(
+        r"^FROM\s+ghcr\.io/[^\s:]+:cpython-\$\{PYTHON_VERSION\}-"
+        r"\$\{PYTHON_BUILD_STANDALONE_RELEASE\}",
+        dockerfile_text,
+        re.MULTILINE,
+    ), "Python mirror FROM must interpolate PYTHON_VERSION and PYTHON_BUILD_STANDALONE_RELEASE"
+    for arg in ("PYTHON_VERSION", "PYTHON_BUILD_STANDALONE_RELEASE"):
+        match = re.search(rf"^ARG {re.escape(arg)}=(\S+)", dockerfile_text, re.MULTILINE)
+        assert match and match.group(1), f"Global default for {arg} must be non-empty"


### PR DESCRIPTION
kepubify came from the GitHub release CDN (the flaky one). Mirror it into GHCR alongside Python and COPY it in; ensure-python-mirror.sh ensures both. Verified locally. Calibre kept on retries (different host).