### PR TITLE
test(docker): re-arm the build-ARG guard (CI marker + kepubify mirror assertion)

### DIFF
--- a/tests/unit/test_dockerfile_global_build_args.py
+++ b/tests/unit/test_dockerfile_global_build_args.py
@@ -25,6 +25,12 @@ PYTHON_* pins (and moved Python to a GHCR mirror) but left CALIBRE_RELEASE /
 KEPUBIFY_RELEASE trapped in the frontend-build stage, so the build advanced
 past Python and died at the kepubify download instead.
 
+The fix moved both binaries to GHCR mirror images (Python in #549, kepubify in
+#552), and #552 also hoisted CALIBRE_RELEASE / KEPUBIFY_RELEASE to the global
+ARG block. kepubify is now `COPY`-d from a `kepubify-${KEPUBIFY_RELEASE}` mirror
+stage rather than downloaded, so the guard below checks that the mirror FROM
+interpolates the pin; calibre is still fetched from its own CDN by URL.
+
 These tests fail on the broken layout (defaults trapped after the first FROM)
 and pass once the defaults are hoisted above every FROM. They also guard
 against a future stage being prepended above the ARG block again.
@@ -34,6 +40,14 @@ import re
 from pathlib import Path
 
 import pytest
+
+
+# These are pure file-parsing assertions (no Docker, no network): mark them
+# `unit` so CI's `pytest -m "smoke or unit"` selector actually collects them.
+# Without a marker, --strict-markers + that selector silently deselect the
+# whole module, leaving the regression guard dead — which is how a stale
+# assertion sat green in CI while failing on a direct run.
+pytestmark = pytest.mark.unit
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -91,16 +105,20 @@ def test_no_defaulted_version_arg_trapped_inside_a_stage(dockerfile_text: str, f
         )
 
 
-def test_download_urls_interpolate_their_release_args(dockerfile_text: str) -> None:
-    """The binary download lines must reference their release vars, and the
-    global defaults must be non-empty — together these guarantee the rendered
-    URLs carry a real version segment and never the empty-var `download//...`
-    form that 404s."""
-    # kepubify: .../releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-...
+def test_binary_source_lines_interpolate_their_release_args(dockerfile_text: str) -> None:
+    """The binary source lines must reference their release vars, and the global
+    defaults must be non-empty — together these guarantee the rendered ref
+    carries a real version segment and never the empty-var form that 404s.
+
+    Since #552 kepubify comes from a GHCR mirror stage tagged
+    `kepubify-${KEPUBIFY_RELEASE}` (not a GitHub-release download), so the guard
+    checks the mirror FROM. calibre is still fetched from its own CDN by URL."""
+    # kepubify: FROM ghcr.io/.../...:kepubify-${KEPUBIFY_RELEASE} AS kepubify_mirror
     assert re.search(
-        r"releases/download/\$\{KEPUBIFY_RELEASE\}/kepubify-linux",
+        r"^FROM\s+ghcr\.io/[^\s:]+:kepubify-\$\{KEPUBIFY_RELEASE\}",
         dockerfile_text,
-    ), "kepubify download URL must interpolate KEPUBIFY_RELEASE"
+        re.MULTILINE,
+    ), "kepubify mirror FROM must interpolate KEPUBIFY_RELEASE"
     # calibre: https://download.calibre-ebook.com/${CALIBRE_RELEASE}/calibre-${CALIBRE_RELEASE}-...
     assert re.search(
         r"download\.calibre-ebook\.com/\$\{CALIBRE_RELEASE\}/calibre-\$\{CALIBRE_RELEASE\}",


### PR DESCRIPTION
## Why
The Dockerfile build-ARG regression guard (`tests/unit/test_dockerfile_global_build_args.py`) — added in #552 to stop the 2026-06-28 ARG-trap `:dev` build outage from recurring — was both **never executed in CI** and **factually wrong**, so it protected nothing.

## Root cause
1. **No `unit`/`smoke` marker.** `pytest.ini` runs `--strict-markers`; CI's Fast Tests job selects `pytest -m "smoke or unit"`. With no marker on the module, all 7 tests were silently deselected (`0 collected`). The guard was dead weight in CI.
2. **Stale assertion.** `test_download_urls_interpolate_their_release_args` asserted the kepubify GitHub-release download URL `releases/download/${KEPUBIFY_RELEASE}/kepubify-linux`. But the *same PR (#552)* that added the test moved kepubify to a GHCR mirror (`COPY --from=kepubify_mirror /kepubify`) — deleting that download. The assertion failed on every direct run; only the missing marker hid it from CI.

## Fix
- Module-level `pytestmark = pytest.mark.unit` so CI's selector collects it (now 7 collected, was 0).
- Rewrote the kepubify check (`test_binary_source_lines_interpolate_their_release_args`) to assert the mirror `FROM ghcr.io/...:kepubify-${KEPUBIFY_RELEASE}` interpolates the pin. calibre is still downloaded by URL, so its assertion is unchanged.
- Module docstring updated to note both binaries are now mirrored (#549 Python, #552 kepubify).

Test-only — no production code, no Dockerfile change, no new deps/URLs.

## Validation (red/green)
- **CI collection:** `pytest -m "smoke or unit" --co` → **7 collected** (was 0 deselected).
- **Green on current main:** 7 passed.
- **Red on regression A** (kepubify mirror loses its `${KEPUBIFY_RELEASE}` pin): `test_binary_source_lines_interpolate_their_release_args` fails.
- **Red on regression B** (an ARG re-trapped after the first `FROM` — the exact c1cd7b462 outage): `test_version_arg_default_is_global[KEPUBIFY_RELEASE]` + `test_no_defaulted_version_arg_trapped_inside_a_stage` fail.

## Tier
needs-review (fork-original test change, headless tick — no in-session operator auth). Low blast radius: test-only, re-arms an existing guard the operator shipped in #552.