### PR TITLE
docs: queue specs for 'What's new' feature log + tutorial tooltips

### DIFF
--- a/notes/TUTORIAL-TOOLTIPS-DESIGN.md
+++ b/notes/TUTORIAL-TOOLTIPS-DESIGN.md
@@ -1,0 +1,103 @@
+# Tutorial tooltips (coach marks) — SPA, skill-driven, single-source design
+
+**Status:** QUEUED (design captured 2026-06-28; not yet built). Operator-requested.
+**Owner surface:** new React UI (`/app`) only.
+
+## The intent (operator's words, distilled)
+Add gentle, in-context tutorial tooltips ("coach marks") that teach features. They must:
+- be created with **frontend-design** quality and a **single, consistent style**;
+- be **scalable + AI-iterable** — a skill can add new tooltips without bespoke code each
+  time;
+- be **unobtrusive and non-invasive** — NOT bound into feature/functional code, NOT
+  blocking the UI, easy to ignore;
+- be **disableable AND resettable in Settings**, clearly and easily (operator is
+  emphatic: "I do not want people to get annoyed with this");
+- carry copy with the **same humanization standard as What's New** (benefit-led,
+  problem→solution, plain language, no AI tells);
+- have **one design definition** — change it in one place and every tooltip changes.
+  See [[whats-new-feature]] for the sibling copy standard.
+
+## Architecture (decoupling is the whole point)
+A **registry-driven overlay**, not props threaded through feature components.
+
+1. **Registry** — `frontend/src/tutorial/tooltips.ts`: a flat list of tooltip defs.
+   ```ts
+   export interface TooltipDef {
+     id: string;              // stable, e.g. 'discover-shuffle'
+     anchor: string;          // CSS selector OR data-attr the overlay finds at runtime
+     title: string;           // benefit-led, t()-wrapped
+     body: string;            // 1–2 sentences: what + why + how (tone rules below)
+     placement?: 'top'|'bottom'|'left'|'right';
+     route?: string;          // only show on this /app route (optional)
+     order?: number;          // sequencing within a guided tour (optional)
+     version?: string;        // release it was introduced (for "only show new ones")
+   }
+   export const TOOLTIPS: TooltipDef[] = [ ... ];
+   ```
+   Features opt in **non-invasively** by adding a `data-tip="discover-shuffle"` attribute
+   to the element they want anchored — that's the ONLY touch to feature code. The overlay
+   reads the attribute/selector at runtime; the feature has no logic, no imports, no
+   coupling. Removing a tooltip = delete the registry row (+ the stray data-attr).
+
+2. **Overlay engine** — `frontend/src/tutorial/TutorialOverlay.tsx` mounted once at the
+   app root (alongside the router, NOT inside any page). It:
+   - finds the anchor element, positions a single shared `<TutorialTip>` component near it;
+   - shows tips per the user's mode (see "Modes"); never traps focus or blocks clicks on
+     unrelated UI (dim/highlight is optional + light, dismissable with Esc/click-away);
+   - is fully keyboard accessible (focusable, Esc to dismiss, "Next/Got it" buttons),
+     respects `prefers-reduced-motion`.
+
+3. **Single design source** — `frontend/src/tutorial/TutorialTip.tsx` +
+   `TutorialTip.module.css` is the ONE visual definition (bubble, arrow, typography,
+   colors, motion). Built with the **frontend-design** skill, using the existing design
+   tokens (amber accent `--accent:#cc7b19`, dark surface, CSS Modules). **Every tooltip
+   renders through this component — no per-feature styling.** If the look changes, it
+   changes here and everywhere at once. This is a hard rule: do not inline tooltip styles
+   anywhere else.
+
+## Modes / behavior (anti-annoyance)
+- **Default:** show a tooltip at most once per `id` per user, the first time the user is
+  on the screen where its anchor exists. Persist "seen" set in `localStorage`
+  (e.g. `cwng_tips_seen`). Quiet by default — one tip at a time, never a wall.
+- Optionally a **"Take a tour"** action (Help menu or Settings) that walks the ordered
+  tips for the current area on demand.
+- **"What's new" tie-in (optional):** when a release adds tooltips, only surface tips
+  whose `version` is newer than the user's last-seen version, so updates teach just the
+  new things. Reuse the version-keyed pattern from the What's New unread dot.
+
+## Settings (clear + easy — required)
+Add to the SPA account/settings screen (`frontend/src/pages/Account*`), a clearly
+labeled control group:
+- **"Show tutorial tips"** — master on/off toggle (off = overlay never shows anything).
+- **"Reset tutorial tips"** — button that clears the `seen` set so all tips show again.
+- Persist via a small typed `localStorage` helper (reuse/extend `usePersistentBool`,
+  the same one Discover uses: `frontend/src/lib/usePersistentBool.ts`). If we later want
+  it server-synced per user, route through the account API — but localStorage is the
+  acceptable v1 (matches Discover/banners).
+- Copy must make it obvious how to turn off/reset, so nobody feels stuck with them.
+
+## Tone / humanization (copy standard — same as What's New)
+- Benefit-led title; 1–2 sentence body covering **what it is, why it helps, how to use**.
+- Plain language for smart non-technical readers. No jargon, no AI tells, no fluff.
+- Each tip earns its place — if it's obvious, don't tip it. Respect the user's intelligence.
+
+## Make it a skill (scalable + AI-iterable)
+Create `~/.claude/skills/add-tutorial-tip/SKILL.md` so any session can add tooltips
+**consistently**:
+1. Identify the feature element; add a single `data-tip="<id>"` attribute (the only
+   feature-code touch).
+2. Append a `TooltipDef` to the registry with tone-compliant copy + correct anchor +
+   placement + route + version.
+3. **Always render via the shared `TutorialTip` component — never introduce new tooltip
+   styling.** The skill must explicitly check for and reuse the existing design; if a
+   design change is wanted, it changes `TutorialTip.module.css` once (and the skill notes
+   that all tips inherit it).
+4. Verify placement on desktop + mobile (Playwright), and that the master toggle hides it
+   and reset re-shows it.
+
+## Verification (per Enterprise standard, when built)
+- Playwright desktop + mobile (390px): tip appears on first visit, positions correctly,
+  dismisses, doesn't reappear; doesn't block underlying controls.
+- Settings: master toggle suppresses all tips; reset restores them.
+- Accessibility: keyboard reachable, Esc dismiss, reduced-motion honored.
+- Consistency guard: every tip routes through `TutorialTip` (grep for stray tooltip CSS).

--- a/notes/WHATS-NEW-FEATURE-DESIGN.md
+++ b/notes/WHATS-NEW-FEATURE-DESIGN.md
@@ -1,0 +1,117 @@
+# "What's New" — in-app feature log (SPA) + per-release skill
+
+**Status:** QUEUED (design captured 2026-06-28; not yet built). Operator-requested.
+**Owner surface:** new React UI (`/app`) only. No classic-UI counterpart needed.
+
+## The intent (operator's words, distilled)
+Avid CWNG readers — smart but **not technical** — should be able to discover what's
+new without reading a GitHub changelog. Give them an in-app "What's New" page that
+reads like Claude Code's release notes, but:
+- written **for readers, not developers**;
+- each entry says **what it is, why it exists (the problem / the "why"), and how to
+  use it (the solution / the "how")**;
+- **deep-links into the actual feature inside CWNG wherever possible** — the whole
+  point is one-tap "show me," so a user might solve a problem they didn't know they had;
+- simple, thorough, well-worded, context-rich, deeply humanized (see tone rules).
+
+## UX placement
+1. **Entry point:** add a `What's new` item to the Help ("?") menu in the SPA top bar.
+   - File: `frontend/src/components/TopBar.tsx`, `HelpMenu()` (around lines 132–141).
+   - Add a `<MenuItem>` with an internal `to="/whats-new"` (wouter `Link`, NOT `href` —
+     internal nav, client-side; see the existing `to=` vs `href=` split in `MenuItem`).
+   - Icon: a lucide-react glyph consistent with the set already imported (e.g. `Sparkles`
+     or `Megaphone`). Keep it monochrome like the other Help items.
+   - Label string must go through `t('What's new')` for i18n (see i18n section).
+2. **Optional secondary nudge:** a small "•" unread dot on the Help button (and the
+   item) when there's a release the user hasn't opened yet, keyed in `localStorage`
+   to `constants.INSTALLED_VERSION` — same version-keyed pattern as the
+   `cwng_newui_banner_dismissed_<version>` banner. Dot clears once they open the page.
+   Keep it subtle; this is discovery, not nagging.
+
+## The page
+- **Route:** add `<Route path="/whats-new">` in `frontend/src/App.tsx` (authed branch,
+  inside the main `<Switch>` near the other top-level routes ~line 123+).
+- **Component:** `frontend/src/pages/WhatsNew.tsx` + `WhatsNew.module.css`.
+  Use the **frontend-design** skill — match the existing design tokens (dark
+  blue-charcoal surface, amber accent `--accent:#cc7b19`, CSS Modules, the card/section
+  rhythm already used by Catalog/BookDetail). It should feel like part of CWNG, not a
+  bolted-on doc. Consider: a vertical timeline of releases, newest first; each release
+  is a collapsible group with its date + version; each feature is a card with a title,
+  a 1–3 sentence human description, an optional "Try it" deep-link button, and a small
+  category chip (e.g. Reading, Library, Sync, Account, Admin).
+- **Deep-link buttons** route via wouter to in-app destinations, e.g.
+  `/app/account` (account settings), `/app/discover`, `/app/shelves`,
+  `/app/book/:id/annotations`, the reader, etc. Where a feature lives behind a setting,
+  deep-link to that settings screen and name the toggle in the copy. If a feature has no
+  navigable surface (e.g. a backend reliability fix), omit the button — don't fake one.
+
+## Data source (single source of truth)
+The feature log is **derived from `CHANGELOG.md`**, which already gets a symptom-first
+`[Unreleased]` entry on every user-facing merge (see CLAUDE.md "Release policy"). The
+What's New content is the **humanized, deep-linked** projection of those entries,
+grouped by published release.
+
+**Recommended shape:** a typed data file the page renders from, e.g.
+`frontend/src/data/whatsNew.ts` —
+```ts
+export interface WhatsNewItem {
+  title: string;            // human, benefit-led ("Find something to read tonight")
+  body: string;             // 1–3 sentences: what + why(problem) + how(solution)
+  category: 'Reading' | 'Library' | 'Sync' | 'Account' | 'Admin' | 'Under the hood';
+  link?: { to: string; label: string };  // in-app deep link, omit if none fits
+}
+export interface WhatsNewRelease {
+  version: string;          // e.g. "v4.0.170"
+  date: string;             // ISO; rendered humanized
+  items: WhatsNewItem[];
+}
+export const WHATS_NEW: WhatsNewRelease[] = [ /* newest first */ ];
+```
+Keeping it as data (not hand-written JSX per release) is what makes it
+**AI-iterable** and lets the per-release skill append a block deterministically.
+
+## i18n
+- All static chrome strings (`What's new`, category names, "Try it", section headers)
+  wrap in `t()` and get msgids via the SPA i18n bridge.
+- The per-release feature copy itself is **English-authored**; translating every
+  release's prose is out of scope (and would gate releases on translators). The page
+  copy/chrome is localized; the feature descriptions are English. Document this clearly
+  in the page (no surprise for non-English users — chrome is localized, entries are not).
+
+## Tone / humanization rules (copy standard — applies to every entry)
+Reuse the project's human-writing standard (memory: jellyfin-llm-tone, outreach-tighter-shape):
+- Lead with the **reader benefit**, not the mechanism. "Your highlights now follow you
+  between your Kobo and the web reader" > "Added KOReader annotation sync endpoint."
+- Name the **problem it solves** in plain words ("you used to lose your place when…").
+- Say **how to use it** concretely ("open any book → tap the ⋯ menu → Send to Kindle").
+- No AI tells, no marketing fluff, no "we're excited to announce," no emoji-spam, no
+  exclamation storms. Smart-reader register: warm, precise, concise.
+- 1–3 sentences per item. If it needs more, it's two items.
+- Credit nothing to specific contributors here (that's release notes / outreach); this
+  page is the reader's-eye view.
+
+## Make it a skill (so it's populated EVERY public release)
+Create a Claude Code skill, e.g. `~/.claude/skills/whats-new-populate/SKILL.md`,
+invoked as part of the release train (and referenced from CLAUDE.md "Release policy").
+On each **public versioned release** the skill must:
+1. Diff `CHANGELOG.md` (or git log) for everything user-facing **since the last
+   published release tag**.
+2. For each user-facing change, author a `WhatsNewItem` following the tone rules:
+   benefit title + what/why/how body + category + best-fit in-app deep link (resolve a
+   real route from `App.tsx`; verify it exists; omit if none fits).
+3. Prepend a new `WhatsNewRelease` block (newest first) to the data file.
+4. Be **comprehensive** — every shipped user-facing feature/fix since last release gets
+   an entry; nothing silently dropped (mirror the changelog coverage).
+5. Verify deep links resolve (route exists in `App.tsx`) before committing.
+6. Ship in the same release so the new page reflects the release that announces it.
+
+Add a one-line hook in CLAUDE.md "Release policy" / the release skill: **"Every public
+release: run the What's-New populate skill so the in-app feature log is updated with all
+user-facing changes since the last published release, deep-linked and humanized."**
+
+## Verification (per Enterprise standard, when built)
+- Playwright: Help menu → "What's new" opens the page on desktop + mobile; deep-link
+  buttons navigate to the right in-app screens; unread dot appears on a fresh version
+  and clears after opening.
+- i18n: chrome strings localized under a session-authenticated locale.
+- Render with an empty + multi-release dataset (no crash, sensible empty state).


### PR DESCRIPTION
Captures two operator-requested SPA usability features as executable design specs (docs-only, no code):

- **What's New feature log** (`notes/WHATS-NEW-FEATURE-DESIGN.md`) — reader-facing in-app release notes linked from the Help menu; each entry covers what/why(problem)/how(solution) with in-app deep links; humanized for non-technical avid readers; populated every public release via a dedicated skill.
- **Tutorial tooltips** (`notes/TUTORIAL-TOOLTIPS-DESIGN.md`) — registry-driven coach marks with one shared design component (single source), non-invasive `data-tip` opt-in, settings toggle + reset (anti-annoyance), add-via-skill.

Tracked as queue tasks #50/#51.