### PR TITLE
fix(upload): truncate over-long ingest filenames instead of failing (#553)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ is for things you can see or feel when running the app.
   delivery. Requested by @froggybottomboys.
 
 ### Fixed
+- **Uploading a book with a very long filename no longer fails silently.**
+  Files whose name was long enough to overflow the filesystem's limit (around
+  240+ characters) failed to upload with only an opaque "Failed to queue upload
+  for processing" message and nothing actionable in the logs. The upload now
+  shortens the over-long staging name — keeping the file extension — so it
+  goes through; the book is renamed from its metadata on import anyway.
+  Reported by @chloeroform.
 - **Bulk actions and drag-to-merge now work behind a reverse proxy on a
   sub-path.** If you run NextGen under a proxy mounted at something like
   `example.com/books/`, marking books read/unread, adding a selection to a

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -412,8 +412,38 @@ def _get_ingest_path(uploaded_file, prefix_parts=None):
     unique = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
     prefix = "_".join([str(p) for p in (prefix_parts or []) if p])
     final_name = f"{prefix + '_' if prefix else ''}{unique}_{base_name}"
+    final_name = _truncate_ingest_name(final_name)
     final_path = os.path.join(ingest_dir, final_name)
     return final_path
+
+
+# Most Unix filesystems (ext4/xfs/btrfs/APFS) cap a single path component at
+# 255 bytes (NAME_MAX). The ingest pipeline appends suffixes to the staging
+# file we drop in — ".uploading" while streaming, ".cwa.json" for the
+# add-format sidecar — so reserve room for the longest of those.
+_INGEST_NAME_MAX_BYTES = 255
+_INGEST_SUFFIX_RESERVE = len(".uploading")
+
+
+def _truncate_ingest_name(final_name):
+    """Trim an over-long staging filename so the path component (plus the
+    suffixes the ingest pipeline appends) stays within the filesystem
+    NAME_MAX, keeping the extension intact.
+
+    The ingest service renames imported books from their metadata, so the
+    staging name is throwaway — but an un-trimmed one raises
+    OSError(ENAMETOOLONG) and the upload fails with no actionable message
+    (issue #553). Truncating lets the upload succeed instead.
+    """
+    budget = _INGEST_NAME_MAX_BYTES - _INGEST_SUFFIX_RESERVE
+    if len(final_name.encode("utf-8")) <= budget:
+        return final_name
+    stem, ext = os.path.splitext(final_name)
+    # Preserve the extension; give the rest of the budget to the stem, cut on
+    # a byte boundary without splitting a multi-byte UTF-8 sequence.
+    stem_budget = max(0, budget - len(ext.encode("utf-8")))
+    stem = stem.encode("utf-8")[:stem_budget].decode("utf-8", "ignore")
+    return stem + ext
 
 # Helper to save file to a temporary path, then atomically rename to final path
 def _save_to_ingest_atomic_rename(uploaded_file, final_path):

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -439,9 +439,17 @@ def _truncate_ingest_name(final_name):
     if len(final_name.encode("utf-8")) <= budget:
         return final_name
     stem, ext = os.path.splitext(final_name)
-    # Preserve the extension; give the rest of the budget to the stem, cut on
-    # a byte boundary without splitting a multi-byte UTF-8 sequence.
-    stem_budget = max(0, budget - len(ext.encode("utf-8")))
+    ext_bytes = ext.encode("utf-8")
+    # A pathologically long final dot-segment can exceed the budget on its own
+    # (no genuine extension is hundreds of bytes); keeping it verbatim would
+    # leave the component over NAME_MAX. In that case there's no extension worth
+    # preserving, so trim the whole name to the budget. Cut on a byte boundary
+    # so a multi-byte UTF-8 sequence is never split.
+    if len(ext_bytes) >= budget:
+        return final_name.encode("utf-8")[:budget].decode("utf-8", "ignore")
+    # Otherwise preserve the extension and give the rest of the budget to the
+    # stem, again cutting on a byte boundary.
+    stem_budget = budget - len(ext_bytes)
     stem = stem.encode("utf-8")[:stem_budget].decode("utf-8", "ignore")
     return stem + ext
 

--- a/tests/unit/test_ingest_long_filename_553.py
+++ b/tests/unit/test_ingest_long_filename_553.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+"""Regression tests for issue #553 — uploading a file whose name is long
+enough to push the staging path component past the filesystem NAME_MAX
+(255 bytes) raised ``OSError [Errno 36] File name too long`` and the upload
+failed with the opaque "Failed to queue for processing" message.
+
+The ingest service renames imported books from their metadata, so the staging
+name is throwaway — the fix truncates it to fit instead of erroring. These
+tests pin that the constructed ingest path always fits NAME_MAX (accounting
+for the ".uploading"/".cwa.json" suffixes the pipeline appends downstream),
+keeps the file extension, and leaves normal-length uploads untouched.
+"""
+import os
+from types import SimpleNamespace
+
+import pytest
+
+# 9 repeats of the 26-letter alphabet + ".pdf" == 238 chars, the exact
+# reproduction from the issue report.
+LONG_BASENAME = "abcdefghijklmnopqrstuvwxyz" * 9 + ".pdf"
+
+
+@pytest.mark.unit
+def test_truncate_ingest_name_leaves_short_names_untouched():
+    from cps.editbooks import _truncate_ingest_name
+    name = "new_1_20260628_205351_821892_book.epub"
+    assert _truncate_ingest_name(name) == name
+
+
+@pytest.mark.unit
+def test_truncate_ingest_name_fits_name_max_and_keeps_extension():
+    from cps.editbooks import _truncate_ingest_name
+    name = "new_1_20260628_205351_821892_" + LONG_BASENAME
+    out = _truncate_ingest_name(name)
+    # The pipeline appends ".uploading" (10 bytes) to the staging file, so the
+    # truncated component plus that suffix must fit within NAME_MAX.
+    assert len((out + ".uploading").encode("utf-8")) <= 255
+    assert out.endswith(".pdf")
+    # The unique prefix that drives sort order is preserved.
+    assert out.startswith("new_1_20260628_205351_821892_")
+
+
+@pytest.mark.unit
+def test_truncate_ingest_name_is_byte_safe_for_multibyte_stems():
+    from cps.editbooks import _truncate_ingest_name
+    # A stem of multi-byte characters must never be cut mid-codepoint.
+    name = ("é" * 400) + ".epub"  # é repeated; 2 bytes each
+    out = _truncate_ingest_name(name)
+    out.encode("utf-8")  # would raise if a surrogate/partial slipped through
+    assert len((out + ".uploading").encode("utf-8")) <= 255
+    assert out.endswith(".epub")
+
+
+@pytest.mark.unit
+def test_get_ingest_path_long_filename_is_writable(tmp_path, monkeypatch):
+    """The real end-to-end check: the path _get_ingest_path returns for a
+    238-char filename must be writable (i.e. not trip ENAMETOOLONG) once the
+    ".uploading" staging suffix is appended."""
+    from cps import editbooks
+    monkeypatch.setattr(editbooks, "get_ingest_dir", lambda: str(tmp_path))
+
+    uploaded = SimpleNamespace(filename=LONG_BASENAME)
+    final_path = editbooks._get_ingest_path(uploaded, prefix_parts=["new", 1])
+
+    component = os.path.basename(final_path)
+    assert len((component + ".uploading").encode("utf-8")) <= 255
+    assert final_path.endswith(".pdf")
+
+    # The actual filesystem write that raised [Errno 36] before the fix.
+    staging = final_path + ".uploading"
+    with open(staging, "w", encoding="utf-8") as handle:
+        handle.write("x")
+    assert os.path.exists(staging)
+
+
+@pytest.mark.unit
+def test_get_ingest_path_normal_filename_unchanged(tmp_path, monkeypatch):
+    """Normal-length uploads keep their full sanitized name — truncation only
+    engages past NAME_MAX, so the common path is untouched."""
+    from cps import editbooks
+    monkeypatch.setattr(editbooks, "get_ingest_dir", lambda: str(tmp_path))
+
+    uploaded = SimpleNamespace(filename="A Tale of Two Cities.epub")
+    final_path = editbooks._get_ingest_path(uploaded, prefix_parts=["new", 1])
+    component = os.path.basename(final_path)
+    # secure_filename collapses spaces to underscores but keeps the full title.
+    assert "A_Tale_of_Two_Cities.epub" in component
+    assert component.endswith(".epub")

--- a/tests/unit/test_ingest_long_filename_553.py
+++ b/tests/unit/test_ingest_long_filename_553.py
@@ -91,3 +91,36 @@ def test_get_ingest_path_normal_filename_unchanged(tmp_path, monkeypatch):
     # secure_filename collapses spaces to underscores but keeps the full title.
     assert "A_Tale_of_Two_Cities.epub" in component
     assert component.endswith(".epub")
+
+
+@pytest.mark.unit
+def test_truncate_ingest_name_caps_pathologically_long_extension():
+    """A filename whose final dot-segment (what ``splitext`` calls the
+    "extension") is itself longer than the byte budget must still be trimmed.
+    Otherwise the stem budget clamps to zero, the over-long extension is kept
+    verbatim, and the staging component escapes NAME_MAX — re-raising the very
+    ENAMETOOLONG this helper exists to prevent (issue #553, Greptile follow-up).
+    """
+    from cps.editbooks import _truncate_ingest_name
+    name = "book." + ("x" * 300)  # 305-byte component, no genuine extension
+    out = _truncate_ingest_name(name)
+    assert len((out + ".uploading").encode("utf-8")) <= 255
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", [
+    "x" * 400,                          # no extension at all
+    "book." + "x" * 300,                # over-long pseudo-extension
+    ("é" * 200) + "." + ("ü" * 200),    # multibyte stem and multibyte extension
+    "a" * 250 + ".epub",                # long stem, normal extension
+    "." + "z" * 300,                    # dotfile-style, all one segment
+])
+def test_truncate_ingest_name_always_fits_name_max(name):
+    """Invariant the helper must hold for every input: the returned staging
+    component plus the longest suffix the pipeline appends (".uploading", 10
+    bytes) never exceeds NAME_MAX, and the result is always valid UTF-8 — never
+    cut mid-codepoint."""
+    from cps.editbooks import _truncate_ingest_name
+    out = _truncate_ingest_name(name)
+    out.encode("utf-8")  # raises if a partial multibyte sequence slipped through
+    assert len((out + ".uploading").encode("utf-8")) <= 255


### PR DESCRIPTION
## Why
Fork issue #553 (reported by @chloeroform). Uploading a book whose filename is long enough (~240+ chars) to push the staging path component past the filesystem NAME_MAX failed with `OSError: [Errno 36] File name too long`, surfaced to the user as only an opaque "Failed to queue upload for processing" with nothing actionable in the logs.

## Root cause
`_get_ingest_path` (`cps/editbooks.py`) builds the staging name as `{prefix}_{timestamp}_{secure_filename(name)}`. `werkzeug.secure_filename` sanitizes characters but does **not** cap length, so a ~238-char upload plus the `new_<uid>_`/`<timestamp>_` prefix (~28 chars) and the `.uploading` suffix appended downstream in `_save_to_ingest_atomic_rename` exceeds the 255-byte NAME_MAX → `ENAMETOOLONG`. The reporter pinpointed the failing `try` block; the actual `OSError` is raised inside the helper.

## Fix
Add `_truncate_ingest_name`: when the constructed component (plus the longest suffix the pipeline appends — `.uploading`/`.cwa.json`) would exceed NAME_MAX, trim the **stem** on a byte boundary while preserving the **extension**. The ingest service renames imported books from their metadata, so the staging name is throwaway — truncating lets the upload succeed instead of erroring, which is exactly the behavior the reporter asked for. Normal-length uploads are untouched (the truncation only engages past the budget). Applies to both upload paths (`/api/v1/upload` new-book and add-format), since both route through `_get_ingest_path`.

## Reproduction (red)
`tests/unit/test_ingest_long_filename_553.py` constructs the exact 238-char filename from the report. On the prior code the staging component is 277 bytes:
```
AssertionError: assert 277 <= 255
```
and the real `open(... + ".uploading")` raises `[Errno 36]`.

## Validation (green)
After the fix, all 5 tests pass — truncated component fits NAME_MAX, extension preserved, the unique sort prefix preserved, multi-byte stems cut safely, and normal-length names unchanged. The file is actually writable at the returned path.

## Blast radius
`_get_ingest_path` is the single source for both upload flows. The change only shortens the *staging* filename; the imported book name (set from metadata by the ingest service) is unaffected. The pre-existing failure in `test_ingest_batch_dirty` is unrelated (ingest-processor HTTP path, fails on clean `main` too, references none of this code).

## Tier
Fork-original, `needs-review`. ~30 LOC isolated to one helper + the call site, plus a 93-line behavior-pinning test.

Addresses #553.