### PR TITLE
feat(spa): native cover picker (candidate grid, URL/upload, lock, e-reader preview)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ is for things you can see or feel when running the app.
   hidden unless an admin opted the whole instance in.)
 
 ### Added
+- **A redesigned "Change cover" screen in the new UI.** Picking a new cover now
+  opens a polished page instead of the old one: your current cover with a one-tap
+  **lock** (so a metadata refresh can't overwrite it), a grid of candidates from
+  every source we search (plus the cover embedded in the book), and tabs to paste
+  a URL or upload your own. If you use a Kobo, flip on **E-reader preview** to see
+  how each candidate looks padded for your device before you choose. You can reach
+  it straight from a book — hover or tap its cover and choose **Change cover** —
+  or from the edit page. Keyboard- and screen-reader-friendly throughout.
 - **A "Discover" shelf of random picks on your library home (new UI).** The
   redesigned library now opens with a set-apart "Discover" box — a row of random
   books from your collection to stumble onto something to read. Hit the shuffle

--- a/cps/cover_picker.py
+++ b/cps/cover_picker.py
@@ -126,6 +126,26 @@ def cover_picker_page(book_id):
     )
 
 
+@cover_picker.route("/book/<int:book_id>/cover/state", methods=["GET"])
+@user_login_required
+@edit_required
+def cover_picker_state(book_id):
+    """Bootstrap state for the SPA cover picker: the current lock state plus
+    whether the e-reader padding preview is available and its admin defaults.
+    Title/authors/current-cover come from /api/v1/books/<id>; this supplies the
+    picker-specific bits the standard book payload doesn't carry. Read-only."""
+    _load_book(book_id)  # 404s if missing/hidden
+    return jsonify({
+        "locked": _get_lock_state(book_id),
+        "ereader_enabled": bool(config.config_kobo_cover_padding_enabled),
+        "ereader_defaults": {
+            "aspect": config.config_kobo_cover_padding_aspect or "kobo_libra_color",
+            "fill_mode": config.config_kobo_cover_padding_fill_mode or "edge_mirror",
+            "color": config.config_kobo_cover_padding_color or "",
+        },
+    })
+
+
 @cover_picker.route("/book/<int:book_id>/cover/candidates", methods=["POST"])
 @user_login_required
 @edit_required

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { Shelf } from './pages/Shelf';
 import { AdvancedSearch } from './pages/AdvancedSearch';
 import { Account } from './pages/Account';
 import { EditBook } from './pages/EditBook';
+import { CoverPicker } from './pages/CoverPicker';
 import { Upload } from './pages/Upload';
 import { Admin } from './pages/Admin';
 import { About } from './pages/About';
@@ -80,6 +81,7 @@ export function App() {
           <AppShell userName={me.name} onLogout={() => logout.mutate()}>
             <Switch>
           <Route path="/book/:id/edit">{(p) => <EditBook id={p.id} />}</Route>
+          <Route path="/book/:id/cover">{(p) => <CoverPicker id={p.id} />}</Route>
           <Route path="/book/:id/annotations">{(p) => <Annotations id={p.id} />}</Route>
           <Route path="/book/:id" component={BookDetail} />
 

--- a/frontend/src/lib/coverPicker.ts
+++ b/frontend/src/lib/coverPicker.ts
@@ -1,0 +1,189 @@
+/* Cover-picker API layer.
+ *
+ * The cover picker reuses the focused blueprint at /book/<id>/cover/* (candidates,
+ * preview, apply, lock, ereader-preview, state) rather than /api/v1 — those
+ * endpoints already return JSON and single-source the provider pool, SSRF guard
+ * and save path with the legacy picker. They use a {ok,error_code,error_message}
+ * / {valid,...} envelope (not the /api/v1 {error:{…}} shape), so these wrappers
+ * parse that here. CSRF + session cookie are reused from api.ts. */
+import { useQuery } from '@tanstack/react-query';
+import { ApiError, getCsrf } from './api';
+
+// ---- shapes (mirror cps/services/cover_picker.py + cover_url_validator.py) ----
+
+export interface CoverCandidate {
+  source_id: string;
+  source_name: string;
+  cover_url: string;
+  title: string | null;
+  authors: string[] | null;
+  publisher: string | null;
+  year: string | null;
+  width: number | null;
+  height: number | null;
+  candidate_id: string | null;
+  flags: string[] | null;
+}
+
+export type ProviderStatusKind =
+  | 'ok' | 'empty' | 'error' | 'disabled' | 'missing_key' | 'rate_limited' | 'blocked';
+
+export interface ProviderStatus {
+  id: string;
+  name: string;
+  status: ProviderStatusKind;
+  count: number;
+  message: string;
+  duration_ms: number;
+}
+
+export interface CandidatesResponse {
+  candidates: CoverCandidate[];
+  providers: ProviderStatus[];
+  query: string;
+}
+
+export interface UrlValidation {
+  valid: boolean;
+  url: string;
+  error_code: string | null;
+  error_message: string | null;
+  content_type: string | null;
+  size_bytes: number | null;
+  width: number | null;
+  height: number | null;
+}
+
+export interface CoverState {
+  locked: boolean;
+  ereader_enabled: boolean;
+  ereader_defaults: { aspect: string; fill_mode: string; color: string };
+}
+
+export interface ApplyResult { ok: boolean; cover_url?: string; error_message?: string }
+
+export interface ProviderKey {
+  id: string;
+  name: string;
+  configured: boolean;
+  can_edit: boolean;
+}
+
+export interface EreaderOptions {
+  aspect: string;
+  fill_mode: string;
+  color: string;
+}
+
+// Static enums mirrored from cover_picker.html (server defaults come from /state).
+export const EREADER_ASPECTS: { value: string; label: string }[] = [
+  { value: 'kobo_libra_color', label: 'Kobo Libra Color / Libra 2 (1264×1680)' },
+  { value: 'kobo_clara', label: 'Kobo Clara HD / 2E / BW / Colour (1072×1448)' },
+  { value: '3:4', label: '3:4 (generic)' },
+  { value: '2:3', label: '2:3 (publisher cover — no padding for typical covers)' },
+];
+export const EREADER_FILL_MODES: { value: string; label: string }[] = [
+  { value: 'edge_mirror', label: 'Edge mirror — extend the artwork (recommended)' },
+  { value: 'edge_blur', label: 'Edge blur — soft bokeh border' },
+  { value: 'gradient', label: 'Gradient — palette-matched top/bottom blend' },
+  { value: 'dominant', label: 'Solid: most-common colour in the cover' },
+  { value: 'average', label: 'Solid: average colour of the cover' },
+  { value: 'manual', label: 'Solid: custom colour' },
+];
+
+// ---- low-level fetch (CSRF + envelope parsing) -------------------------------
+
+/** Read the {ok:false,error_message} / {error_message} envelope these endpoints
+ *  use, falling back to HTTP status text. */
+async function envelopeError(res: Response): Promise<never> {
+  let msg = res.statusText;
+  try {
+    const d = await res.json() as { error_message?: string; error?: string | { message?: string } };
+    if (d.error_message) msg = d.error_message;
+    else if (typeof d.error === 'string') msg = d.error;
+    else if (d.error?.message) msg = d.error.message;
+  } catch { /* non-JSON (e.g. HTML 400 from a stale CSRF) — keep statusText */ }
+  throw new ApiError(res.status, msg);
+}
+
+async function cpGet<T>(path: string): Promise<T> {
+  const res = await fetch(path, { credentials: 'include', headers: { Accept: 'application/json' } });
+  if (!res.ok) return envelopeError(res);
+  return res.json() as Promise<T>;
+}
+
+/** POST JSON with the same one-shot CSRF refresh-and-retry as api.apiPost. */
+async function cpPostJson<T>(path: string, body: unknown): Promise<T> {
+  const doPost = (csrf: string) => fetch(path, {
+    method: 'POST', credentials: 'include',
+    headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
+    body: JSON.stringify(body ?? {}),
+  });
+  let res = await doPost(await getCsrf());
+  if (res.status === 400 && !(res.headers.get('content-type') || '').includes('application/json')) {
+    res = await doPost(await getCsrf()); // stale token → HTML 400; refresh once
+  }
+  if (!res.ok) return envelopeError(res);
+  return res.json() as Promise<T>;
+}
+
+/** POST multipart (file upload) — browser sets the boundary, so no Content-Type. */
+async function cpUpload<T>(path: string, form: FormData): Promise<T> {
+  const doPost = (csrf: string) => fetch(path, {
+    method: 'POST', credentials: 'include', headers: { 'X-CSRFToken': csrf }, body: form,
+  });
+  let res = await doPost(await getCsrf());
+  if (res.status === 400 && !(res.headers.get('content-type') || '').includes('application/json')) {
+    res = await doPost(await getCsrf());
+  }
+  if (!res.ok) return envelopeError(res);
+  return res.json() as Promise<T>;
+}
+
+const base = (id: string | number) => `/book/${id}/cover`;
+
+// ---- raw calls --------------------------------------------------------------
+
+export const coverApi = {
+  state: (id: string | number) => cpGet<CoverState>(`${base(id)}/state`),
+  candidates: (id: string | number, query?: string) =>
+    cpPostJson<CandidatesResponse>(`${base(id)}/candidates`, query ? { query } : {}),
+  validate: (id: string | number, url: string) =>
+    cpPostJson<UrlValidation>(`${base(id)}/preview`, { url }),
+  applyUrl: (id: string | number, url: string) =>
+    cpPostJson<ApplyResult>(`${base(id)}/apply`, { kind: 'url', url }),
+  applyEmbedded: (id: string | number) =>
+    cpPostJson<ApplyResult>(`${base(id)}/apply`, { kind: 'embedded' }),
+  applyFile: (id: string | number, file: File) => {
+    const fd = new FormData(); fd.append('file', file);
+    return cpUpload<ApplyResult>(`${base(id)}/apply`, fd);
+  },
+  setLock: (id: string | number, locked: boolean) =>
+    cpPostJson<{ locked: boolean }>(`${base(id)}/lock`, { locked }),
+  ereaderPreview: (
+    id: string | number,
+    opts: EreaderOptions & { candidate_url?: string; embedded?: boolean },
+  ) => cpPostJson<{ ok: boolean; data_url: string }>(`${base(id)}/ereader-preview`, opts),
+  keysList: () => cpGet<ProviderKey[]>(`/metadata/keys`),
+  saveKey: (provId: string, value: string) =>
+    cpPostJson<{ id: string; configured: boolean }>(`/metadata/keys/${encodeURIComponent(provId)}`, { value }),
+};
+
+// ---- hooks ------------------------------------------------------------------
+
+export function useCoverState(id: string) {
+  return useQuery({ queryKey: ['cover-state', id], queryFn: () => coverApi.state(id) });
+}
+
+export function useCandidates(id: string) {
+  return useQuery({
+    queryKey: ['cover-candidates', id],
+    queryFn: () => coverApi.candidates(id),
+    staleTime: 60_000, // provider fan-out is slow; don't refetch on remount
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useProviderKeys(enabled: boolean) {
+  return useQuery({ queryKey: ['cover-keys'], queryFn: () => coverApi.keysList(), enabled });
+}

--- a/frontend/src/pages/BookDetail.module.css
+++ b/frontend/src/pages/BookDetail.module.css
@@ -37,12 +37,53 @@
   top: calc(56px + var(--sp-5)); /* below TopBar */
 }
 
+.coverWrap { position: relative; }
+
 .cover {
   width: 100%;
   border-radius: var(--r-md);
   box-shadow: var(--cover-shadow);
   display: block;
 }
+
+/* "Change cover" affordance overlaid on the cover — discoverable for editors
+   without a trip through the edit page. Always present but quiet; lifts on
+   hover/focus. Visible on touch (no hover needed) and reachable by keyboard
+   (it's a focusable link, with a focus-visible ring). */
+.changeCover {
+  position: absolute;
+  left: 50%;
+  bottom: var(--sp-3);
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--r-full);
+  background: rgba(20, 28, 36, .82);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  text-decoration: none;
+  white-space: nowrap;
+  box-shadow: var(--elev-2);
+  opacity: .92;
+  transition: background var(--dur-fast) var(--ease), transform var(--dur-fast) var(--ease), opacity var(--dur-fast) var(--ease);
+}
+.coverWrap:hover .changeCover,
+.changeCover:hover,
+.changeCover:focus-visible {
+  background: var(--accent);
+  color: var(--on-accent);
+  border-color: var(--accent);
+  opacity: 1;
+  transform: translateX(-50%) translateY(-2px);
+}
+.changeCover:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--accent-ring); }
+@media (prefers-reduced-motion: reduce) { .changeCover { transition: none; } }
 
 .coverFallback {
   width: 100%;

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link, useParams } from 'wouter';
-import { Download, Pencil, Star, Archive, EyeOff, Eye, Send, Highlighter } from 'lucide-react';
+import { Download, Pencil, Star, Archive, EyeOff, Eye, Send, Highlighter, Image as ImageIcon } from 'lucide-react';
 import {
   useBook, useToggleRead, useToggleFavorite, useToggleArchived, useToggleHidden,
   useSendToEreader, useMe,
@@ -134,17 +134,24 @@ export function BookDetail() {
       <div className={styles.layout}>
         {/* LEFT: cover */}
         <div className={styles.coverCol}>
-          {book.cover_url ? (
-            <img
-              src={book.cover_url}
-              alt={book.title}
-              className={styles.cover}
-            />
-          ) : (
-            <div className={styles.coverFallback} aria-label={book.title}>
-              <span className={styles.coverFallbackTitle}>{book.title}</span>
-            </div>
-          )}
+          <div className={styles.coverWrap}>
+            {book.cover_url ? (
+              <img
+                src={book.cover_url}
+                alt={book.title}
+                className={styles.cover}
+              />
+            ) : (
+              <div className={styles.coverFallback} aria-label={book.title}>
+                <span className={styles.coverFallbackTitle}>{book.title}</span>
+              </div>
+            )}
+            {me?.role?.edit && (
+              <Link href={`/book/${book.id}/cover`} className={styles.changeCover}>
+                <ImageIcon size={15} /> {t('Change cover')}
+              </Link>
+            )}
+          </div>
         </div>
 
         {/* RIGHT: info */}

--- a/frontend/src/pages/CoverPicker.module.css
+++ b/frontend/src/pages/CoverPicker.module.css
@@ -1,0 +1,237 @@
+/* Cover picker — native SPA. Consumes design tokens (tokens.css); no hardcoded
+   colour. Dark, cover-forward, calm: the covers are the loud element, chrome
+   stays quiet. */
+
+.container {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: var(--sp-5) var(--sp-5) var(--sp-10);
+}
+
+/* ---- header ---- */
+.header { margin-bottom: var(--sp-5); }
+.back {
+  display: inline-flex; align-items: center; gap: var(--sp-1);
+  color: var(--text-muted); font-size: var(--fs-sm); text-decoration: none;
+  margin-bottom: var(--sp-3); transition: color var(--dur-fast) var(--ease);
+}
+.back:hover { color: var(--accent-hover); }
+.title {
+  font-family: var(--font-display); font-size: var(--fs-xl); line-height: var(--lh-tight);
+  font-weight: var(--fw-bold); color: var(--text); margin: 0 0 var(--sp-2);
+}
+.subtitle { color: var(--text-muted); font-size: var(--fs-base); margin: 0; max-width: 60ch; }
+
+/* ---- banner ---- */
+.bannerOk, .bannerErr {
+  display: flex; align-items: center; gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-4); border-radius: var(--r-md);
+  font-size: var(--fs-sm); margin-bottom: var(--sp-4);
+}
+.bannerOk { background: rgba(108,192,138,.13); color: var(--success); border: 1px solid rgba(108,192,138,.3); }
+.bannerErr { background: var(--danger-soft); color: var(--danger); border: 1px solid rgba(224,104,95,.32); }
+.bannerClose {
+  margin-left: auto; background: none; border: 0; color: inherit; cursor: pointer;
+  opacity: .7; display: inline-flex; padding: 2px;
+}
+.bannerClose:hover { opacity: 1; }
+
+/* ---- layout ---- */
+.layout {
+  display: grid; grid-template-columns: 320px 1fr; gap: var(--sp-6); align-items: start;
+}
+.rail { position: sticky; top: calc(var(--topbar-h) + var(--sp-4)); display: flex; flex-direction: column; gap: var(--sp-4); }
+@media (max-width: 860px) {
+  .layout { grid-template-columns: 1fr; }
+  .rail { position: static; }
+}
+
+/* ---- current cover card ---- */
+.currentCard, .addOwn {
+  background: var(--surface-1); border: 1px solid var(--border);
+  border-radius: var(--r-lg); padding: var(--sp-4);
+}
+.cardLabel {
+  font-size: var(--fs-xs); text-transform: uppercase; letter-spacing: .06em;
+  color: var(--text-faint); font-weight: var(--fw-semi); margin-bottom: var(--sp-3);
+}
+.currentFrame {
+  aspect-ratio: 2 / 3; border-radius: var(--r-md); overflow: hidden;
+  background: var(--surface-3); box-shadow: var(--cover-shadow);
+  display: grid; place-items: center; margin-bottom: var(--sp-3);
+}
+.currentImg { width: 100%; height: 100%; object-fit: cover; }
+.currentFallback { color: var(--text-faint); }
+.currentMeta { display: flex; flex-direction: column; gap: 2px; margin-bottom: var(--sp-4); }
+.currentMeta strong { color: var(--text); font-size: var(--fs-base); line-height: var(--lh-snug); }
+.currentMeta span { color: var(--text-muted); font-size: var(--fs-sm); }
+
+/* lock toggle — pill switch */
+.lockToggle {
+  width: 100%; display: flex; align-items: center; gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3); border-radius: var(--r-full);
+  background: var(--surface-3); border: 1px solid var(--border-strong);
+  color: var(--text); font-size: var(--fs-sm); font-weight: var(--fw-medium);
+  cursor: pointer; transition: background var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease);
+}
+.lockToggle:hover { background: var(--surface-2); }
+.lockOn { background: var(--accent-soft); border-color: var(--accent); color: var(--accent-hover); }
+.lockKnob {
+  display: inline-grid; place-items: center; width: 24px; height: 24px;
+  border-radius: var(--r-full); background: var(--surface-1); color: inherit;
+}
+.lockOn .lockKnob { background: var(--accent); color: var(--on-accent); }
+.lockHelp { color: var(--text-faint); font-size: var(--fs-xs); margin: var(--sp-2) 0 0; line-height: var(--lh-snug); }
+
+/* ---- add your own (URL / upload tabs) ---- */
+.tabs { display: flex; gap: var(--sp-1); background: var(--surface-3); border-radius: var(--r-md); padding: 3px; margin-bottom: var(--sp-3); }
+.tab, .tabOn {
+  flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: var(--sp-1);
+  padding: var(--sp-2); border: 0; border-radius: var(--r-sm); cursor: pointer;
+  font-size: var(--fs-sm); font-weight: var(--fw-medium); background: transparent; color: var(--text-muted);
+  transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+}
+.tab:hover { color: var(--text); }
+.tabOn { background: var(--surface-1); color: var(--text); box-shadow: var(--elev-1); }
+.tabBody { display: flex; flex-direction: column; gap: var(--sp-3); }
+.input {
+  width: 100%; padding: var(--sp-2) var(--sp-3); border-radius: var(--r-sm);
+  background: var(--surface-3); border: 1px solid var(--border-strong); color: var(--text);
+  font-size: var(--fs-sm); font-family: var(--font-body);
+}
+.input:focus-visible { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.feedbackMuted { color: var(--text-faint); font-size: var(--fs-xs); }
+.feedbackErr { color: var(--danger); font-size: var(--fs-xs); }
+.feedbackOk { color: var(--success); font-size: var(--fs-xs); display: inline-flex; align-items: center; gap: 4px; }
+.urlOk { display: flex; gap: var(--sp-3); align-items: center; }
+.urlThumb { width: 48px; height: 64px; object-fit: cover; border-radius: var(--r-sm); background: var(--surface-3); }
+.urlMeta { display: flex; flex-direction: column; gap: 2px; font-size: var(--fs-xs); color: var(--text-muted); }
+.fullBtn { width: 100%; justify-content: center; }
+.lockedHint { color: var(--text-faint); font-size: var(--fs-xs); margin: 0; }
+.dropZone {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--sp-2);
+  padding: var(--sp-5) var(--sp-3); border: 1.5px dashed var(--border-strong); border-radius: var(--r-md);
+  background: var(--surface-3); color: var(--text-muted); font-size: var(--fs-sm); cursor: pointer; text-align: center;
+  transition: border-color var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+}
+.dropZone:hover { border-color: var(--accent); color: var(--text); }
+
+/* ---- main column ---- */
+.main { min-width: 0; }
+
+/* collapsible panels (ereader, keys) */
+.panel { background: var(--surface-1); border: 1px solid var(--border); border-radius: var(--r-md); margin-bottom: var(--sp-3); }
+.panelSummary {
+  display: flex; align-items: center; gap: var(--sp-2); padding: var(--sp-3) var(--sp-4);
+  cursor: pointer; color: var(--text); font-weight: var(--fw-medium); font-size: var(--fs-sm); list-style: none;
+}
+.panelSummary::-webkit-details-marker { display: none; }
+.panelHint { color: var(--text-faint); font-weight: var(--fw-normal); font-size: var(--fs-xs); margin-left: auto; }
+.panelBody { padding: 0 var(--sp-4) var(--sp-4); display: flex; flex-direction: column; gap: var(--sp-3); }
+.panelNote { color: var(--text-faint); font-size: var(--fs-xs); margin: 0; }
+.switchRow { display: flex; align-items: center; gap: var(--sp-2); font-size: var(--fs-sm); color: var(--text); cursor: pointer; }
+.switchRow input { accent-color: var(--accent); width: 16px; height: 16px; }
+.ereaderGrid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-3); }
+@media (max-width: 600px) { .ereaderGrid { grid-template-columns: 1fr; } }
+.field { display: flex; flex-direction: column; gap: var(--sp-1); font-size: var(--fs-xs); color: var(--text-muted); }
+.field select, .field input {
+  padding: var(--sp-2); border-radius: var(--r-sm); background: var(--surface-3);
+  border: 1px solid var(--border-strong); color: var(--text); font-size: var(--fs-sm); font-family: var(--font-body);
+}
+.field select:focus-visible, .field input:focus-visible { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+
+/* ---- grid toolbar ---- */
+.gridToolbar { display: flex; align-items: center; gap: var(--sp-3); margin: var(--sp-4) 0 var(--sp-3); }
+.gridTitle { font-family: var(--font-display); font-size: var(--fs-lg); font-weight: var(--fw-semi); color: var(--text); margin: 0; }
+.provSummary { color: var(--text-faint); font-size: var(--fs-xs); margin-right: auto; }
+.gridLoading { display: flex; align-items: center; gap: var(--sp-2); color: var(--text-muted); font-size: var(--fs-sm); padding: var(--sp-8) 0; justify-content: center; }
+.spin { animation: cpspin 1s linear infinite; }
+@keyframes cpspin { to { transform: rotate(360deg); } }
+
+/* ---- candidate grid ---- */
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: var(--sp-4); }
+.card {
+  display: flex; flex-direction: column; padding: 0; background: var(--surface-1);
+  border: 1px solid var(--border); border-radius: var(--r-md); overflow: hidden; cursor: pointer;
+  text-align: left; transition: transform var(--dur-fast) var(--ease), box-shadow var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease);
+}
+.card:hover:not(:disabled) { transform: translateY(-2px); box-shadow: var(--elev-2); border-color: var(--border-strong); }
+.card:focus-visible { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.cardLocked { opacity: .55; cursor: not-allowed; }
+.cardImgWrap { position: relative; aspect-ratio: 2 / 3; background: var(--surface-3); display: grid; place-items: center; }
+.cardImg { width: 100%; height: 100%; object-fit: cover; display: block; }
+.cardFailed { display: flex; flex-direction: column; align-items: center; gap: var(--sp-1); color: var(--text-faint); font-size: var(--fs-xs); text-align: center; padding: var(--sp-2); }
+.cardShimmer { position: absolute; inset: 0; display: grid; place-items: center; background: rgba(20,28,36,.55); color: var(--accent-hover); }
+.badgeEmbedded, .badgeEreader, .badgeWarn {
+  position: absolute; top: 6px; font-size: 10px; font-weight: var(--fw-semi); padding: 2px 6px; border-radius: var(--r-full);
+  display: inline-flex; align-items: center; gap: 3px; backdrop-filter: blur(4px);
+}
+.badgeEmbedded { left: 6px; background: rgba(204,123,25,.92); color: var(--on-accent); }
+.badgeEreader { right: 6px; background: rgba(20,28,36,.82); color: var(--text); }
+.badgeWarn { left: 6px; bottom: 6px; top: auto; background: rgba(224,104,95,.9); color: #fff; }
+.cardInfo { display: flex; flex-direction: column; gap: 1px; padding: var(--sp-2) var(--sp-3); }
+.cardSource { font-size: var(--fs-sm); color: var(--text); font-weight: var(--fw-medium); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cardDims { font-size: var(--fs-xs); color: var(--text-faint); min-height: 1em; }
+
+/* ---- provider detail ---- */
+.provPanel { margin-top: var(--sp-5); border-top: 1px solid var(--border); }
+.provPanelSummary { padding: var(--sp-3) 0; cursor: pointer; color: var(--text-muted); font-size: var(--fs-sm); list-style: none; }
+.provPanelSummary::-webkit-details-marker { display: none; }
+.provList { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: var(--sp-1); }
+.provRow { display: flex; align-items: center; gap: var(--sp-3); font-size: var(--fs-sm); padding: var(--sp-1) 0; }
+.provPill {
+  flex: 0 0 auto; font-size: 10px; font-weight: var(--fw-semi); text-transform: uppercase; letter-spacing: .04em;
+  padding: 2px 8px; border-radius: var(--r-full); background: var(--surface-3); color: var(--text-muted);
+  min-width: 84px; text-align: center;
+}
+.provPill[data-status="ok"] { background: rgba(108,192,138,.16); color: var(--success); }
+.provPill[data-status="empty"] { background: var(--surface-3); color: var(--text-faint); }
+.provPill[data-status="error"], .provPill[data-status="blocked"] { background: var(--danger-soft); color: var(--danger); }
+.provPill[data-status="rate_limited"] { background: rgba(204,123,25,.16); color: var(--accent-hover); }
+.provPill[data-status="missing_key"] { background: rgba(204,123,25,.12); color: var(--accent-hover); }
+.provPill[data-status="disabled"] { opacity: .6; }
+.provName { color: var(--text); flex: 0 0 auto; }
+.provCount { color: var(--text-faint); margin-left: auto; font-size: var(--fs-xs); }
+
+/* ---- API keys ---- */
+.keysList { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: var(--sp-2); }
+.keyRow { display: flex; align-items: center; gap: var(--sp-2); flex-wrap: wrap; }
+.keyName { flex: 0 0 140px; color: var(--text); font-size: var(--fs-sm); }
+.keyOn { color: var(--success); font-size: var(--fs-xs); flex: 0 0 110px; }
+.keyOff { color: var(--text-faint); font-size: var(--fs-xs); flex: 0 0 110px; }
+.keyInput {
+  flex: 1 1 120px; min-width: 100px; padding: var(--sp-1) var(--sp-2); border-radius: var(--r-sm);
+  background: var(--surface-3); border: 1px solid var(--border-strong); color: var(--text); font-size: var(--fs-sm);
+}
+
+/* ---- confirm modal ---- */
+.overlay {
+  position: fixed; inset: 0; z-index: var(--z-overlay); background: rgba(8,12,16,.66);
+  display: grid; place-items: center; padding: var(--sp-4); backdrop-filter: blur(3px);
+  animation: cpfade var(--dur-fast) var(--ease);
+}
+@keyframes cpfade { from { opacity: 0; } to { opacity: 1; } }
+.modal {
+  width: min(560px, 100%); background: var(--surface-1); border: 1px solid var(--border-strong);
+  border-radius: var(--r-lg); box-shadow: var(--elev-3); overflow: hidden;
+  animation: cppop var(--dur-base) var(--ease-out);
+}
+@keyframes cppop { from { transform: translateY(10px) scale(.98); opacity: 0; } to { transform: none; opacity: 1; } }
+.modalHead { display: flex; align-items: center; justify-content: space-between; padding: var(--sp-4); border-bottom: 1px solid var(--border); }
+.modalHead h3 { margin: 0; font-family: var(--font-display); font-size: var(--fs-md); color: var(--text); }
+.modalClose { background: none; border: 0; color: var(--text-muted); cursor: pointer; display: inline-flex; padding: 4px; border-radius: var(--r-sm); }
+.modalClose:hover { color: var(--text); background: var(--surface-2); }
+.compare { display: grid; grid-template-columns: 1fr auto 1fr; gap: var(--sp-3); align-items: center; padding: var(--sp-5) var(--sp-4); }
+.compare figure { margin: 0; display: flex; flex-direction: column; gap: var(--sp-2); }
+.compare figcaption { font-size: var(--fs-xs); text-transform: uppercase; letter-spacing: .05em; color: var(--text-faint); text-align: center; }
+.compareFrame { aspect-ratio: 2 / 3; border-radius: var(--r-md); overflow: hidden; background: var(--surface-3); box-shadow: var(--cover-shadow); display: grid; place-items: center; }
+.compareFrame img { width: 100%; height: 100%; object-fit: cover; }
+.compareArrow { color: var(--accent); display: grid; place-items: center; }
+.compareMeta { display: flex; flex-direction: column; gap: 1px; font-size: var(--fs-xs); color: var(--text-muted); text-align: center; }
+.compareMeta strong { color: var(--text); font-size: var(--fs-sm); }
+.modalFoot { display: flex; justify-content: flex-end; gap: var(--sp-2); padding: var(--sp-3) var(--sp-4) var(--sp-4); border-top: 1px solid var(--border); }
+
+@media (prefers-reduced-motion: reduce) {
+  .spin, .overlay, .modal { animation: none; }
+  .card:hover:not(:disabled) { transform: none; }
+}

--- a/frontend/src/pages/CoverPicker.tsx
+++ b/frontend/src/pages/CoverPicker.tsx
@@ -236,7 +236,7 @@ function useEreaderPreviews(id: string, candidates: CoverCandidate[], s: Ereader
     const MAX = 6;
 
     const renderOne = async (c: CoverCandidate) => {
-      const key = `${candKey(c)}|${settingsKey}`;
+      const key = `${candKey(c)}|${c.cover_url}|${settingsKey}`;
       const cached = cache.current.get(key);
       if (cached) { if (!cancelled) setPreviews((p) => ({ ...p, [candKey(c)]: cached })); return; }
       setPreviews((p) => ({ ...p, [candKey(c)]: 'loading' }));
@@ -300,6 +300,9 @@ function CandidateCard({ candidate: c, locked, preview, onPick }: {
   const [failed, setFailed] = useState(false);
   const showPreview = preview && preview !== 'loading';
   const src = showPreview ? (preview as string) : c.cover_url;
+  // A refresh can reuse this component instance (same key) with a new image URL;
+  // clear a prior load error so the new image mounts instead of staying hidden.
+  useEffect(() => { setFailed(false); }, [src]);
   const dims = c.width && c.height ? `${c.width}×${c.height}` : null;
   const lowRes = c.flags?.includes('low_res');
   return (
@@ -388,21 +391,24 @@ function UrlTab({ id, locked, onApplied, onError }: {
   const [valid, setValid] = useState<UrlValidation | null>(null);
   const [checking, setChecking] = useState(false);
   const [applying, setApplying] = useState(false);
+  const seq = useRef(0); // ignore stale validation responses that resolve out of order
 
   useEffect(() => {
     const v = url.trim();
     if (!v) { setValid(null); setChecking(false); return; }
     setChecking(true);
+    const mySeq = ++seq.current;
     const h = setTimeout(async () => {
-      try { setValid(await coverApi.validate(id, v)); }
-      catch { setValid(null); }
-      finally { setChecking(false); }
+      try { const r = await coverApi.validate(id, v); if (mySeq === seq.current) setValid(r); }
+      catch { if (mySeq === seq.current) setValid(null); }
+      finally { if (mySeq === seq.current) setChecking(false); }
     }, 400);
     return () => clearTimeout(h);
   }, [url, id]);
 
   const apply = async () => {
-    if (!valid?.valid || locked) return;
+    // Guard against applying a URL that's no longer the one shown/validated.
+    if (!valid?.valid || checking || valid?.url !== url.trim() || locked) return;
     setApplying(true);
     try { const r = await coverApi.applyUrl(id, valid.url); onApplied(r.cover_url); setUrl(''); setValid(null); }
     catch (e) { onError(e); }
@@ -426,7 +432,7 @@ function UrlTab({ id, locked, onApplied, onError }: {
           </div>
         </div>
       )}
-      <Button onClick={apply} disabled={!valid?.valid || locked || applying} className={styles.fullBtn}>
+      <Button onClick={apply} disabled={!valid?.valid || checking || valid?.url !== url.trim() || locked || applying} className={styles.fullBtn}>
         {applying ? <Loader2 size={14} className={styles.spin} /> : <Check size={14} />} {t('Use this cover')}
       </Button>
       {locked && <p className={styles.lockedHint}>{t('Unlock the cover above to apply a new one.')}</p>}

--- a/frontend/src/pages/CoverPicker.tsx
+++ b/frontend/src/pages/CoverPicker.tsx
@@ -1,0 +1,617 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { Link } from 'wouter';
+import {
+  ChevronLeft, Lock, Unlock, Upload as UploadIcon, Link2, RefreshCw, Check, X,
+  Image as ImageIcon, AlertTriangle, KeyRound, Smartphone, Loader2, Sparkles,
+} from 'lucide-react';
+import { useBook } from '../lib/queries';
+import {
+  useCoverState, useCandidates, useProviderKeys, coverApi,
+  EREADER_ASPECTS, EREADER_FILL_MODES,
+  type CoverCandidate, type ProviderStatus, type UrlValidation,
+  type EreaderOptions, type ProviderKey,
+} from '../lib/coverPicker';
+import { useQueryClient } from '@tanstack/react-query';
+import { Button } from '../components/Button';
+import { SpinnerCentered } from '../components/Spinner';
+import { EmptyState } from '../components/EmptyState';
+import { ApiError } from '../lib/api';
+import { useT } from '../lib/i18n';
+import styles from './CoverPicker.module.css';
+
+type Banner = { ok: boolean; text: string } | null;
+const candKey = (c: CoverCandidate) => c.candidate_id ?? `${c.source_id}:${c.cover_url}`;
+const isEmbedded = (c: CoverCandidate) => c.source_id === 'embedded' || c.candidate_id === 'embedded';
+
+export function CoverPicker({ id }: { id: string }) {
+  const t = useT();
+  const qc = useQueryClient();
+  const { data: book } = useBook(id);
+  const { data: state } = useCoverState(id);
+  const candidatesQ = useCandidates(id);
+
+  const [locked, setLocked] = useState(false);
+  const [coverBust, setCoverBust] = useState<string | null>(null);
+  const [banner, setBanner] = useState<Banner>(null);
+  const [confirm, setConfirm] = useState<CoverCandidate | null>(null);
+  const [ereaderState, setEreaderState] = useState<EreaderState>({
+    enabled: false, aspect: 'kobo_libra_color', fill_mode: 'edge_mirror', color: '',
+  });
+
+  useEffect(() => { if (state) setLocked(state.locked); }, [state]);
+  useEffect(() => {
+    if (state?.ereader_defaults) {
+      setEreaderState((s) => ({ ...s, ...state.ereader_defaults }));
+    }
+  }, [state]);
+
+  const back = useBackTarget(id);
+
+  // Current cover, cache-busted after an apply.
+  const currentCover = useMemo(() => {
+    if (coverBust) return coverBust;
+    return book?.cover_url ?? null;
+  }, [book?.cover_url, coverBust]);
+
+  const onApplied = useCallback((coverUrl?: string) => {
+    setCoverBust(coverUrl ?? `/cover/${id}/og?ts=${Date.now()}`);
+    setBanner({ ok: true, text: t('Cover updated.') });
+    qc.invalidateQueries({ queryKey: ['book', id] });
+    qc.invalidateQueries({ queryKey: ['book-meta', id] });
+  }, [id, qc, t]);
+
+  const onError = useCallback((err: unknown) => {
+    setBanner({ ok: false, text: err instanceof ApiError ? err.message : t('Something went wrong. Try again.') });
+  }, [t]);
+
+  const toggleLock = async () => {
+    const next = !locked;
+    setLocked(next); // optimistic
+    try {
+      const r = await coverApi.setLock(id, next);
+      setLocked(r.locked);
+    } catch (e) { setLocked(!next); onError(e); }
+  };
+
+  if (!book) return <main className={styles.container}><SpinnerCentered /></main>;
+
+  return (
+    <main className={styles.container}>
+      <header className={styles.header}>
+        <Link href={back.href} className={styles.back}>
+          <ChevronLeft size={16} /> {back.label}
+        </Link>
+        <h1 className={styles.title}>{t('Change cover')}</h1>
+        <p className={styles.subtitle}>
+          {t('Pick a cover from any source we support, paste a URL, upload a file, or use the cover embedded in the book itself.')}
+        </p>
+      </header>
+
+      {banner && (
+        <div className={banner.ok ? styles.bannerOk : styles.bannerErr} role="status">
+          {banner.ok ? <Check size={15} /> : <AlertTriangle size={15} />}
+          <span>{banner.text}</span>
+          <button className={styles.bannerClose} onClick={() => setBanner(null)} aria-label={t('Dismiss')}><X size={14} /></button>
+        </div>
+      )}
+
+      <div className={styles.layout}>
+        <aside className={styles.rail}>
+          <div className={styles.currentCard}>
+            <div className={styles.cardLabel}>{t('Current cover')}</div>
+            <div className={styles.currentFrame}>
+              {currentCover
+                ? <img src={currentCover} alt={book.title} className={styles.currentImg}
+                       onError={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = 'hidden'; }} />
+                : <div className={styles.currentFallback}><ImageIcon size={30} /></div>}
+            </div>
+            <div className={styles.currentMeta}>
+              <strong>{book.title}</strong>
+              {book.authors?.length ? <span>{book.authors.map((a) => a.name).join(', ')}</span> : null}
+            </div>
+
+            <button className={`${styles.lockToggle} ${locked ? styles.lockOn : ''}`} onClick={toggleLock}
+                    type="button" aria-pressed={locked}>
+              <span className={styles.lockKnob}>{locked ? <Lock size={13} /> : <Unlock size={13} />}</span>
+              <span>{locked ? t('Cover locked') : t('Lock cover')}</span>
+            </button>
+            <p className={styles.lockHelp}>
+              {t('When locked, fetching metadata will not overwrite this cover.')}
+            </p>
+          </div>
+
+          <AddOwnPanel id={id} locked={locked} onApplied={onApplied} onError={onError} />
+        </aside>
+
+        <section className={styles.main}>
+          {state?.ereader_enabled && (
+            <EreaderPanel onChange={setEreaderState} value={ereaderState} />
+          )}
+          <ApiKeysPanel />
+
+          <div className={styles.gridToolbar}>
+            <h2 className={styles.gridTitle}>{t('Choose a cover')}</h2>
+            <ProviderSummary providers={candidatesQ.data?.providers} loading={candidatesQ.isFetching} />
+            <Button variant="ghost" size="sm" onClick={() => candidatesQ.refetch()} disabled={candidatesQ.isFetching}>
+              <RefreshCw size={14} className={candidatesQ.isFetching ? styles.spin : ''} /> {t('Refresh')}
+            </Button>
+          </div>
+
+          {candidatesQ.isLoading ? (
+            <div className={styles.gridLoading}><Loader2 size={22} className={styles.spin} /> {t('Searching every source…')}</div>
+          ) : candidatesQ.isError ? (
+            <EmptyState message={candidatesQ.error instanceof Error ? candidatesQ.error.message : t('Could not load candidates.')} />
+          ) : (
+            <CandidateGrid
+              id={id}
+              candidates={candidatesQ.data?.candidates ?? []}
+              locked={locked}
+              ereader={ereaderState}
+              onPick={setConfirm}
+            />
+          )}
+
+          <ProviderDetail providers={candidatesQ.data?.providers} />
+        </section>
+      </div>
+
+      {confirm && (
+        <ConfirmModal
+          id={id}
+          candidate={confirm}
+          currentCover={currentCover}
+          onClose={() => setConfirm(null)}
+          onApplied={(url) => { onApplied(url); setConfirm(null); }}
+          onError={(e) => { onError(e); setConfirm(null); }}
+        />
+      )}
+    </main>
+  );
+}
+
+// ============================================================================
+// E-reader settings + live preview wiring
+// ============================================================================
+
+interface EreaderState extends EreaderOptions { enabled: boolean }
+
+function EreaderPanel({ value, onChange }: {
+  value: EreaderState;
+  onChange: (s: EreaderState) => void;
+}) {
+  const t = useT();
+  const set = (patch: Partial<EreaderState>) => onChange({ ...value, ...patch });
+  return (
+    <details className={styles.panel}>
+      <summary className={styles.panelSummary}>
+        <Smartphone size={15} /> {t('E-reader preview')}
+        <span className={styles.panelHint}>{t('See how each cover looks padded for your device')}</span>
+      </summary>
+      <div className={styles.panelBody}>
+        <label className={styles.switchRow}>
+          <input type="checkbox" checked={value.enabled} onChange={(e) => set({ enabled: e.target.checked })} />
+          <span>{t('Show e-reader previews on each candidate')}</span>
+        </label>
+        <div className={styles.ereaderGrid}>
+          <label className={styles.field}>
+            <span>{t('Target aspect ratio')}</span>
+            <select value={value.aspect} onChange={(e) => set({ aspect: e.target.value })}>
+              {EREADER_ASPECTS.map((o) => <option key={o.value} value={o.value}>{t(o.label)}</option>)}
+            </select>
+          </label>
+          <label className={styles.field}>
+            <span>{t('Border fill style')}</span>
+            <select value={value.fill_mode} onChange={(e) => set({ fill_mode: e.target.value })}>
+              {EREADER_FILL_MODES.map((o) => <option key={o.value} value={o.value}>{t(o.label)}</option>)}
+            </select>
+          </label>
+          {value.fill_mode === 'manual' && (
+            <label className={styles.field}>
+              <span>{t('Custom border colour')}</span>
+              <input type="text" maxLength={9} placeholder="#1a1a1a" value={value.color}
+                     onChange={(e) => set({ color: e.target.value })} />
+            </label>
+          )}
+        </div>
+        <p className={styles.panelNote}>{t('Defaults live in Admin → Configuration → Kobo sync.')}</p>
+      </div>
+    </details>
+  );
+}
+
+/** Per-candidate e-reader render with a generation guard, concurrency cap and a
+ *  settings-keyed cache — mirrors the legacy picker's behaviour. */
+function useEreaderPreviews(id: string, candidates: CoverCandidate[], s: EreaderState) {
+  const [previews, setPreviews] = useState<Record<string, string | 'loading'>>({});
+  const cache = useRef<Map<string, string>>(new Map());
+  const gen = useRef(0);
+
+  const settingsKey = `${s.aspect}|${s.fill_mode}|${s.fill_mode === 'manual' ? s.color : ''}`;
+
+  useEffect(() => {
+    if (!s.enabled) { setPreviews({}); return; }
+    const myGen = ++gen.current;
+    let cancelled = false;
+    const queue = [...candidates];
+    const MAX = 6;
+
+    const renderOne = async (c: CoverCandidate) => {
+      const key = `${candKey(c)}|${settingsKey}`;
+      const cached = cache.current.get(key);
+      if (cached) { if (!cancelled) setPreviews((p) => ({ ...p, [candKey(c)]: cached })); return; }
+      setPreviews((p) => ({ ...p, [candKey(c)]: 'loading' }));
+      try {
+        const opts: EreaderOptions & { candidate_url?: string; embedded?: boolean } = {
+          aspect: s.aspect, fill_mode: s.fill_mode, color: s.color,
+        };
+        if (isEmbedded(c)) opts.embedded = true;
+        else if (c.cover_url) opts.candidate_url = c.cover_url;
+        const r = await coverApi.ereaderPreview(id, opts);
+        if (myGen !== gen.current) return; // settings changed mid-flight
+        if (r.ok && r.data_url) {
+          cache.current.set(key, r.data_url);
+          if (!cancelled) setPreviews((p) => ({ ...p, [candKey(c)]: r.data_url }));
+        } else if (!cancelled) {
+          setPreviews((p) => { const n = { ...p }; delete n[candKey(c)]; return n; });
+        }
+      } catch {
+        if (!cancelled) setPreviews((p) => { const n = { ...p }; delete n[candKey(c)]; return n; });
+      }
+    };
+
+    const workers = Array.from({ length: Math.min(MAX, queue.length) }, async () => {
+      while (queue.length && myGen === gen.current) { const c = queue.shift(); if (c) await renderOne(c); }
+    });
+    Promise.all(workers).catch(() => {});
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, s.enabled, settingsKey, candidates]);
+
+  return s.enabled ? previews : {};
+}
+
+// ============================================================================
+// Candidate grid + cards
+// ============================================================================
+
+function CandidateGrid({ id, candidates, locked, ereader, onPick }: {
+  id: string; candidates: CoverCandidate[]; locked: boolean;
+  ereader: EreaderState; onPick: (c: CoverCandidate) => void;
+}) {
+  const t = useT();
+  const previews = useEreaderPreviews(id, candidates, ereader);
+  if (!candidates.length) {
+    return <EmptyState message={t('No candidates found yet. Try a different search or refresh.')} />;
+  }
+  return (
+    <div className={styles.grid}>
+      {candidates.map((c) => (
+        <CandidateCard key={candKey(c)} candidate={c} locked={locked}
+          preview={previews[candKey(c)]} onPick={() => onPick(c)} />
+      ))}
+    </div>
+  );
+}
+
+function CandidateCard({ candidate: c, locked, preview, onPick }: {
+  candidate: CoverCandidate; locked: boolean; preview?: string | 'loading'; onPick: () => void;
+}) {
+  const t = useT();
+  const [failed, setFailed] = useState(false);
+  const showPreview = preview && preview !== 'loading';
+  const src = showPreview ? (preview as string) : c.cover_url;
+  const dims = c.width && c.height ? `${c.width}×${c.height}` : null;
+  const lowRes = c.flags?.includes('low_res');
+  return (
+    <button type="button" className={`${styles.card} ${locked ? styles.cardLocked : ''}`}
+            onClick={onPick} disabled={locked} title={locked ? t('Unlock the cover to change it') : undefined}>
+      <div className={styles.cardImgWrap}>
+        {failed
+          ? <div className={styles.cardFailed}><ImageIcon size={22} /><span>{t('Cover not reachable')}</span></div>
+          : <img src={src} alt={c.title || c.source_name} loading="lazy" className={styles.cardImg}
+                 onError={() => setFailed(true)} />}
+        {preview === 'loading' && <div className={styles.cardShimmer}><Loader2 size={18} className={styles.spin} /></div>}
+        {isEmbedded(c) && <span className={styles.badgeEmbedded}>{t('In your book')}</span>}
+        {showPreview && <span className={styles.badgeEreader}><Smartphone size={11} /> {t('e-reader')}</span>}
+        {lowRes && <span className={styles.badgeWarn}><AlertTriangle size={11} /> {t('Low-res')}</span>}
+      </div>
+      <div className={styles.cardInfo}>
+        <span className={styles.cardSource}>{c.source_name}</span>
+        <span className={styles.cardDims}>{dims || (c.year ? c.year : ' ')}</span>
+      </div>
+    </button>
+  );
+}
+
+// ============================================================================
+// Provider status
+// ============================================================================
+
+function ProviderSummary({ providers, loading }: { providers?: ProviderStatus[]; loading: boolean }) {
+  const t = useT();
+  if (loading && !providers?.length) return <span className={styles.provSummary}>{t('Searching…')}</span>;
+  if (!providers?.length) return <span className={styles.provSummary} />;
+  const ok = providers.filter((p) => p.status === 'ok').length;
+  const total = providers.length;
+  return <span className={styles.provSummary}>{t('{ok} of {total} sources answered', { ok, total })}</span>;
+}
+
+function ProviderDetail({ providers }: { providers?: ProviderStatus[] }) {
+  const t = useT();
+  if (!providers?.length) return null;
+  return (
+    <details className={styles.provPanel}>
+      <summary className={styles.provPanelSummary}>{t('Source details')}</summary>
+      <ul className={styles.provList}>
+        {providers.map((p) => (
+          <li key={p.id} className={styles.provRow}>
+            <span className={styles.provPill} data-status={p.status}>{p.status}</span>
+            <span className={styles.provName}>{p.name}</span>
+            <span className={styles.provCount}>{p.count ? t('{n} found', { n: p.count }) : (p.message || '—')}</span>
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
+// ============================================================================
+// "Add your own" — URL + upload tabs
+// ============================================================================
+
+function AddOwnPanel({ id, locked, onApplied, onError }: {
+  id: string; locked: boolean; onApplied: (url?: string) => void; onError: (e: unknown) => void;
+}) {
+  const t = useT();
+  const [tab, setTab] = useState<'url' | 'upload'>('url');
+  return (
+    <div className={styles.addOwn}>
+      <div className={styles.cardLabel}>{t('Add your own')}</div>
+      <div className={styles.tabs} role="tablist">
+        <button role="tab" aria-selected={tab === 'url'} className={tab === 'url' ? styles.tabOn : styles.tab}
+                onClick={() => setTab('url')}><Link2 size={14} /> {t('Paste URL')}</button>
+        <button role="tab" aria-selected={tab === 'upload'} className={tab === 'upload' ? styles.tabOn : styles.tab}
+                onClick={() => setTab('upload')}><UploadIcon size={14} /> {t('Upload')}</button>
+      </div>
+      {tab === 'url'
+        ? <UrlTab id={id} locked={locked} onApplied={onApplied} onError={onError} />
+        : <UploadTab id={id} locked={locked} onApplied={onApplied} onError={onError} />}
+    </div>
+  );
+}
+
+function UrlTab({ id, locked, onApplied, onError }: {
+  id: string; locked: boolean; onApplied: (url?: string) => void; onError: (e: unknown) => void;
+}) {
+  const t = useT();
+  const [url, setUrl] = useState('');
+  const [valid, setValid] = useState<UrlValidation | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [applying, setApplying] = useState(false);
+
+  useEffect(() => {
+    const v = url.trim();
+    if (!v) { setValid(null); setChecking(false); return; }
+    setChecking(true);
+    const h = setTimeout(async () => {
+      try { setValid(await coverApi.validate(id, v)); }
+      catch { setValid(null); }
+      finally { setChecking(false); }
+    }, 400);
+    return () => clearTimeout(h);
+  }, [url, id]);
+
+  const apply = async () => {
+    if (!valid?.valid || locked) return;
+    setApplying(true);
+    try { const r = await coverApi.applyUrl(id, valid.url); onApplied(r.cover_url); setUrl(''); setValid(null); }
+    catch (e) { onError(e); }
+    finally { setApplying(false); }
+  };
+
+  return (
+    <div className={styles.tabBody}>
+      <input className={styles.input} value={url} onChange={(e) => setUrl(e.target.value)}
+             placeholder="https://…" inputMode="url" aria-label={t('Cover image URL')} />
+      {checking && <div className={styles.feedbackMuted}>{t('Checking…')}</div>}
+      {!checking && valid && !valid.valid && (
+        <div className={styles.feedbackErr}>{valid.error_message || t('That URL is not a usable image.')}</div>
+      )}
+      {!checking && valid?.valid && (
+        <div className={styles.urlOk}>
+          <img src={valid.url} alt="" className={styles.urlThumb} />
+          <div className={styles.urlMeta}>
+            <span className={styles.feedbackOk}><Check size={13} /> {t('Looks good')}</span>
+            {valid.width && valid.height ? <span>{valid.width}×{valid.height}</span> : null}
+          </div>
+        </div>
+      )}
+      <Button onClick={apply} disabled={!valid?.valid || locked || applying} className={styles.fullBtn}>
+        {applying ? <Loader2 size={14} className={styles.spin} /> : <Check size={14} />} {t('Use this cover')}
+      </Button>
+      {locked && <p className={styles.lockedHint}>{t('Unlock the cover above to apply a new one.')}</p>}
+    </div>
+  );
+}
+
+function UploadTab({ id, locked, onApplied, onError }: {
+  id: string; locked: boolean; onApplied: (url?: string) => void; onError: (e: unknown) => void;
+}) {
+  const t = useT();
+  const [file, setFile] = useState<File | null>(null);
+  const [applying, setApplying] = useState(false);
+  const apply = async () => {
+    if (!file || locked) return;
+    setApplying(true);
+    try { const r = await coverApi.applyFile(id, file); onApplied(r.cover_url); setFile(null); }
+    catch (e) { onError(e); }
+    finally { setApplying(false); }
+  };
+  return (
+    <div className={styles.tabBody}>
+      <label className={styles.dropZone}>
+        <UploadIcon size={18} />
+        <span>{file ? file.name : t('Choose an image…')}</span>
+        <input type="file" accept=".jpg,.jpeg,.png,.webp,.bmp,.gif" hidden
+               aria-label={t('Choose a cover image to upload')}
+               onChange={(e) => setFile(e.target.files?.[0] ?? null)} />
+      </label>
+      <Button onClick={apply} disabled={!file || locked || applying} className={styles.fullBtn}>
+        {applying ? <Loader2 size={14} className={styles.spin} /> : <UploadIcon size={14} />} {t('Upload as cover')}
+      </Button>
+      {locked && <p className={styles.lockedHint}>{t('Unlock the cover above to apply a new one.')}</p>}
+    </div>
+  );
+}
+
+// ============================================================================
+// API keys (admin)
+// ============================================================================
+
+function ApiKeysPanel() {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const keysQ = useProviderKeys(open);
+  return (
+    <details className={styles.panel} onToggle={(e) => setOpen((e.currentTarget as HTMLDetailsElement).open)}>
+      <summary className={styles.panelSummary}>
+        <KeyRound size={15} /> {t('API keys')}
+        <span className={styles.panelHint}>{t('Some sources need a key for better covers')}</span>
+      </summary>
+      <div className={styles.panelBody}>
+        {keysQ.isLoading ? <div className={styles.feedbackMuted}>{t('Loading…')}</div>
+          : !keysQ.data?.length ? <div className={styles.feedbackMuted}>{t('No sources need a key.')}</div>
+          : <ul className={styles.keysList}>{keysQ.data.map((k) => <KeyRow key={k.id} k={k} />)}</ul>}
+      </div>
+    </details>
+  );
+}
+
+function KeyRow({ k }: { k: ProviderKey }) {
+  const t = useT();
+  const [val, setVal] = useState('');
+  const [configured, setConfigured] = useState(k.configured);
+  const [saving, setSaving] = useState(false);
+  const save = async () => {
+    setSaving(true);
+    try { const r = await coverApi.saveKey(k.id, val); setConfigured(r.configured); setVal(''); }
+    catch { /* surfaced inline below via title */ }
+    finally { setSaving(false); }
+  };
+  return (
+    <li className={styles.keyRow}>
+      <span className={styles.keyName}>{k.name}</span>
+      <span className={configured ? styles.keyOn : styles.keyOff}>
+        {configured ? t('Configured') : t('Not configured')}
+      </span>
+      {k.can_edit && (
+        <>
+          <input className={styles.keyInput} type="password" value={val} placeholder="••••••"
+                 onChange={(e) => setVal(e.target.value)} />
+          <Button size="sm" variant="ghost" onClick={save} disabled={saving || !val}>{t('Save')}</Button>
+        </>
+      )}
+    </li>
+  );
+}
+
+// ============================================================================
+// Confirm modal
+// ============================================================================
+
+function ConfirmModal({ id, candidate: c, currentCover, onClose, onApplied, onError }: {
+  id: string; candidate: CoverCandidate; currentCover: string | null;
+  onClose: () => void; onApplied: (url?: string) => void; onError: (e: unknown) => void;
+}) {
+  const t = useT();
+  const [applying, setApplying] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Accessibility: focus the dialog on open, trap Tab within it, and restore
+  // focus to the trigger on close. Escape closes.
+  useEffect(() => {
+    const prevFocus = document.activeElement as HTMLElement | null;
+    const node = modalRef.current;
+    const focusables = () => node
+      ? Array.from(node.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'))
+        .filter((el) => !el.hasAttribute('disabled'))
+      : [];
+    // Focus the confirm (last) action so Enter applies; falls back to the dialog.
+    const f = focusables();
+    (f[f.length - 1] ?? node)?.focus();
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { onClose(); return; }
+      if (e.key !== 'Tab') return;
+      const els = focusables();
+      if (!els.length) return;
+      const first = els[0], last = els[els.length - 1];
+      if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+      else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => { document.removeEventListener('keydown', onKey); prevFocus?.focus?.(); };
+  }, [onClose]);
+
+  const apply = async () => {
+    setApplying(true);
+    try {
+      const r = isEmbedded(c) ? await coverApi.applyEmbedded(id) : await coverApi.applyUrl(id, c.cover_url);
+      if (r.ok) onApplied(r.cover_url); else onError(new ApiError(400, r.error_message || t('Cover save failed.')));
+    } catch (e) { onError(e); }
+    finally { setApplying(false); }
+  };
+
+  return (
+    <div className={styles.overlay} onClick={onClose} role="presentation">
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}
+           ref={modalRef} role="dialog" aria-modal="true" aria-label={t('Replace cover?')} tabIndex={-1}>
+        <div className={styles.modalHead}>
+          <h3>{t('Replace cover with this one?')}</h3>
+          <button className={styles.modalClose} onClick={onClose} aria-label={t('Close')}><X size={18} /></button>
+        </div>
+        <div className={styles.compare}>
+          <figure>
+            <figcaption>{t('Current')}</figcaption>
+            <div className={styles.compareFrame}>
+              {currentCover ? <img src={currentCover} alt="" /> : <div className={styles.currentFallback}><ImageIcon size={26} /></div>}
+            </div>
+          </figure>
+          <div className={styles.compareArrow}><Sparkles size={18} /></div>
+          <figure>
+            <figcaption>{t('New')}</figcaption>
+            <div className={styles.compareFrame}>
+              <img src={c.cover_url} alt={c.title || c.source_name} />
+            </div>
+            <div className={styles.compareMeta}>
+              <strong>{c.source_name}</strong>
+              {c.title ? <span>{c.title}{c.year ? ` (${c.year})` : ''}</span> : null}
+              {c.width && c.height ? <span>{c.width}×{c.height}</span> : null}
+            </div>
+          </figure>
+        </div>
+        <div className={styles.modalFoot}>
+          <Button variant="ghost" onClick={onClose}>{t('Cancel')}</Button>
+          <Button onClick={apply} disabled={applying}>
+            {applying ? <Loader2 size={14} className={styles.spin} /> : <Check size={14} />} {t('Use this cover')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// helpers
+// ============================================================================
+
+/** The picker returns the user to where they came from: the edit page on
+ *  ?origin=edit, otherwise the book detail page (fork #26). */
+function useBackTarget(id: string) {
+  const t = useT();
+  const origin = new URLSearchParams(window.location.search).get('origin');
+  return origin === 'edit'
+    ? { href: `/book/${id}/edit`, label: t('Back to edit metadata') }
+    : { href: `/book/${id}`, label: t('Back to book') };
+}

--- a/frontend/src/pages/EditBook.tsx
+++ b/frontend/src/pages/EditBook.tsx
@@ -282,9 +282,9 @@ function CoverManager({ id }: { id: string }) {
             {t('Fetch')}
           </Button>
         </div>
-        <a className={styles.coverAdvanced} href={`/book/${id}/cover?origin=edit`}>
+        <Link className={styles.coverAdvanced} href={`/book/${id}/cover?origin=edit`}>
           <ExternalLink size={13} /> {t('More cover options (search providers, e-reader preview)')}
-        </a>
+        </Link>
         {msg && <span className={msg.ok ? styles.msgOk : styles.msgErr}>{msg.text}</span>}
       </div>
     </section>


### PR DESCRIPTION
Ports the focused cover picker (the classic `/book/<id>/cover` Jinja page) to a native React page under the redesign, **reusing the existing blueprint JSON endpoints** (candidates / preview / apply / lock / ereader-preview) — no new provider, SSRF, or save logic. One small **read-only** bootstrap endpoint added: `GET /book/<id>/cover/state` (lock state + e-reader availability/defaults; edit-gated).

### Parity with the classic picker
- Current cover + one-tap **lock** (blocks metadata-refresh overwrite); candidate cards disable while locked.
- **Candidate grid** from the provider pool + the book's embedded cover ("In your book" badge), provider status summary + per-source detail, refresh.
- **Confirm modal** (current vs new) before applying. Apply via candidate, embedded cover, pasted URL (live SSRF-aware validation + thumbnail), or file upload. Cover cache-busts on apply.
- **E-reader (Kobo) padding preview**: renders every candidate through the pad pipeline with session-local aspect / fill-mode / custom-colour; generation-guarded, concurrency-capped, settings-keyed cache.

### Easy to reach + accessible
- Discoverable **"Change cover"** affordance overlaid on the book-detail cover (edit role) + the existing edit-page link — both client-side routes now.
- Modal **traps focus**, restores it on close, Escape closes; candidate cards are real buttons; inputs have aria-labels; focus-visible rings; reduced-motion guards.

### Verification (live, cwn-local, Playwright — desktop + 390px mobile)
Grid loads (embedded + 12 provider candidates); confirm + apply **persists** the cover (verified cache-bust + current-cover swap); e-reader preview renders all 12 candidates padded with working aspect/fill controls; lock **persists server-side** (confirmed via `/state`) and gates apply; URL validation surfaces the SSRF guard; **zero console errors**.

Strangler-fig: the classic `/book/<id>/cover` page is untouched for non-SPA users.