### PR TITLE
fix(spa): Discover cards no longer clipped at the top on hover

### DIFF
--- a/frontend/src/components/DiscoverSection.module.css
+++ b/frontend/src/components/DiscoverSection.module.css
@@ -112,7 +112,12 @@
   gap: var(--sp-4);
   overflow-x: auto;
   scroll-snap-type: x proximity;
-  padding-bottom: var(--sp-2);
+  /* A scroll container with overflow-x:auto also clips the Y axis, so a card's
+     hover-lift (translateY) + focus outline would be cut off at the top/sides.
+     Pad the scroll viewport to give them headroom; negative margins cancel the
+     padding so the box's outer spacing is unchanged. */
+  padding: var(--sp-3) var(--sp-2);
+  margin: calc(-1 * var(--sp-3)) calc(-1 * var(--sp-2)) calc(-1 * var(--sp-1));
   -webkit-overflow-scrolling: touch;
   scrollbar-width: thin;
   scrollbar-color: var(--border-strong) transparent;


### PR DESCRIPTION
The Discover strip scrolls horizontally (`overflow-x: auto`), which also clips the Y axis — so a card's hover-lift (`translateY(-4px)`) and its accent focus outline were cut off at the top of the strip (reported with a screenshot).

Fix: pad the scroll viewport for headroom and cancel it with negative margins so the box's outer spacing is unchanged. CSS-only, one file.

**Verified live (Playwright):** on hover the lifted card top sits 8px *inside* the clip edge (was clipped before), clear of both the strip and the box; visually confirmed the outline shows fully.