### PR TITLE
fix(ui): 'Switch to New UI' pill collapses to an icon on tablet widths

### DIFF
--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -177,6 +177,14 @@
       }
       a.cwng-switch-ui:active { transform: translateY(0); }
       a.cwng-switch-ui .glyphicon { top: 1px; font-size: 12px; }
+      /* Tablet band (768–991px): the navbar is still expanded but cramped, and the
+         full-width pill pushes the toolbar over the edge so it wraps onto the page
+         content. Collapse it to an icon (matching the other icon-only toolbar
+         buttons); the bolt glyph + title keep it discoverable. */
+      @media (min-width: 768px) and (max-width: 991px) {
+        a.cwng-switch-ui { padding: 6px 10px !important; gap: 0; }
+        a.cwng-switch-ui .cwng-switch-label { display: none; }
+      }
       @media (max-width: 767px) {
         a.cwng-switch-ui { width: 100%; justify-content: center; }
       }


### PR DESCRIPTION
**Symptom (reported):** on tablet-width viewports the top-right "Switch to New UI" pill leaves its spot in the bar and overlaps the toolbar/content.

**Cause:** between 768–991px the caliBlur navbar is still expanded but cramped; the full-width pill (~156px) pushed the toolbar over the edge so it wrapped onto the page content.

**Fix:** in the 768–991px band, collapse the pill to just its bolt glyph — matching the other icon-only toolbar buttons (the `title` keeps the tooltip). The full "Switch to New UI" label returns at ≥992px; below 768px the pill already lives in the collapsed hamburger menu, so that band is untouched. Classic-template CSS only.

**Verified live (Playwright, caliBlur):** 768 / 900 / 991px → icon-only, no overflow, no wrap, sits cleanly with the toolbar icons; 1000px → full label restored.