### PR TITLE
fix(ui): keep 'Switch to New UI' pill icon-only until 1200px (pagination overlap)

### DIFF
--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -177,11 +177,15 @@
       }
       a.cwng-switch-ui:active { transform: translateY(0); }
       a.cwng-switch-ui .glyphicon { top: 1px; font-size: 12px; }
-      /* Tablet band (768–991px): the navbar is still expanded but cramped, and the
-         full-width pill pushes the toolbar over the edge so it wraps onto the page
-         content. Collapse it to an icon (matching the other icon-only toolbar
-         buttons); the bolt glyph + title keep it discoverable. */
-      @media (min-width: 768px) and (max-width: 991px) {
+      /* Tablet + small-desktop band (768–1199px): the navbar is expanded but
+         doesn't have room for the full-width pill alongside the search box,
+         toolbar icons and the fixed top-right pagination — so the pill wraps to a
+         second row and collides with the pagination. Collapse it to an icon in
+         this whole range (matching the other icon-only toolbar buttons; the bolt
+         glyph + title keep it discoverable). The full label returns at ≥1200px
+         (Bootstrap lg), where it's verified to sit on one row clear of the
+         pagination. Below 768px the pill lives in the collapsed hamburger menu. */
+      @media (min-width: 768px) and (max-width: 1199px) {
         a.cwng-switch-ui { padding: 6px 10px !important; gap: 0; }
         a.cwng-switch-ui .cwng-switch-label { display: none; }
       }


### PR DESCRIPTION
Follow-up to #564. On a **paginated** library, caliBlur pins the page buttons as `position: fixed` at the top-right — the pill's corner. At small-desktop widths (~992–1150px) the full-label pill still made the navbar wrap, dropping the pill onto a second row right against the fixed pagination (the overlap reported on a 215-book / 4-page library).

Extend the icon-only band to **768–1199px** (Bootstrap `lg`); the full "Switch to New UI" label returns at ≥1200px where the navbar stays on one row clear of the pagination.

**Verified live (Playwright, caliBlur, paginated lib):** 1024/1100/1150/1199px → icon-only, pill stays in the navbar row, no wrap, no pagination overlap; 1200/1440px → full label, single row, clear of pagination. Classic-template CSS only.