### PR TITLE
fix(upload): truncate over-long ingest staging filenames (#553)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ is for things you can see or feel when running the app.
   delivery. Requested by @froggybottomboys.
 
 ### Fixed
+- **Uploading a book with a very long filename no longer fails.** A file whose
+  name ran past the filesystem limit (~255 characters) used to fail to import
+  with an unhelpful "Failed to queue for processing" message. The temporary
+  staging name is now trimmed to fit (the file is renamed from its metadata on
+  import anyway), so the upload succeeds. Normal filenames are untouched.
+  Reported by @chloeroform (#553).
 - **Bulk actions and drag-to-merge now work behind a reverse proxy on a
   sub-path.** If you run NextGen under a proxy mounted at something like
   `example.com/books/`, marking books read/unread, adding a selection to a

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -412,8 +412,38 @@ def _get_ingest_path(uploaded_file, prefix_parts=None):
     unique = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
     prefix = "_".join([str(p) for p in (prefix_parts or []) if p])
     final_name = f"{prefix + '_' if prefix else ''}{unique}_{base_name}"
+    final_name = _truncate_ingest_name(final_name)
     final_path = os.path.join(ingest_dir, final_name)
     return final_path
+
+
+# Most Unix filesystems (ext4/xfs/btrfs/APFS) cap a single path component at
+# 255 bytes (NAME_MAX). The ingest pipeline appends suffixes to the staging
+# file we drop in — ".uploading" while streaming, ".cwa.json" for the
+# add-format sidecar — so reserve room for the longest of those.
+_INGEST_NAME_MAX_BYTES = 255
+_INGEST_SUFFIX_RESERVE = len(".uploading")
+
+
+def _truncate_ingest_name(final_name):
+    """Trim an over-long staging filename so the path component (plus the
+    suffixes the ingest pipeline appends) stays within the filesystem
+    NAME_MAX, keeping the extension intact.
+
+    The ingest service renames imported books from their metadata, so the
+    staging name is throwaway — but an un-trimmed one raises
+    OSError(ENAMETOOLONG) and the upload fails with no actionable message
+    (issue #553). Truncating lets the upload succeed instead.
+    """
+    budget = _INGEST_NAME_MAX_BYTES - _INGEST_SUFFIX_RESERVE
+    if len(final_name.encode("utf-8")) <= budget:
+        return final_name
+    stem, ext = os.path.splitext(final_name)
+    # Preserve the extension; give the rest of the budget to the stem, cut on
+    # a byte boundary without splitting a multi-byte UTF-8 sequence.
+    stem_budget = max(0, budget - len(ext.encode("utf-8")))
+    stem = stem.encode("utf-8")[:stem_budget].decode("utf-8", "ignore")
+    return stem + ext
 
 # Helper to save file to a temporary path, then atomically rename to final path
 def _save_to_ingest_atomic_rename(uploaded_file, final_path):

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -439,9 +439,17 @@ def _truncate_ingest_name(final_name):
     if len(final_name.encode("utf-8")) <= budget:
         return final_name
     stem, ext = os.path.splitext(final_name)
-    # Preserve the extension; give the rest of the budget to the stem, cut on
-    # a byte boundary without splitting a multi-byte UTF-8 sequence.
-    stem_budget = max(0, budget - len(ext.encode("utf-8")))
+    ext_bytes = ext.encode("utf-8")
+    # Pathological case: a crafted name whose "extension" alone exceeds the
+    # budget (e.g. "x." + 250 chars — os.path.splitext treats it all as the
+    # extension). Truncate the extension too so the result still fits NAME_MAX
+    # instead of re-tripping ENAMETOOLONG (the very error we're preventing).
+    if len(ext_bytes) > budget:
+        return ext_bytes[:budget].decode("utf-8", "ignore")
+    # Normal case: keep the extension, spend the rest of the budget on the stem.
+    # Cut on a byte boundary; decode(..., "ignore") drops a dangling partial
+    # multi-byte sequence so we never split a codepoint.
+    stem_budget = budget - len(ext_bytes)
     stem = stem.encode("utf-8")[:stem_budget].decode("utf-8", "ignore")
     return stem + ext
 

--- a/tests/unit/test_ingest_long_filename_553.py
+++ b/tests/unit/test_ingest_long_filename_553.py
@@ -53,6 +53,17 @@ def test_truncate_ingest_name_is_byte_safe_for_multibyte_stems():
 
 
 @pytest.mark.unit
+def test_truncate_ingest_name_overlong_extension_still_fits():
+    """A crafted name whose 'extension' alone exceeds the budget (os.path.splitext
+    treats everything after the last dot as the extension) must still be trimmed
+    to fit NAME_MAX — not returned full-length, which would re-trip ENAMETOOLONG."""
+    from cps.editbooks import _truncate_ingest_name
+    name = "x." + ("a" * 300)  # 302-char "extension", well past the budget
+    out = _truncate_ingest_name(name)
+    assert len((out + ".uploading").encode("utf-8")) <= 255
+
+
+@pytest.mark.unit
 def test_get_ingest_path_long_filename_is_writable(tmp_path, monkeypatch):
     """The real end-to-end check: the path _get_ingest_path returns for a
     238-char filename must be writable (i.e. not trip ENAMETOOLONG) once the

--- a/tests/unit/test_ingest_long_filename_553.py
+++ b/tests/unit/test_ingest_long_filename_553.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression tests for issue #553 — uploading a file whose name is long
+enough to push the staging path component past the filesystem NAME_MAX
+(255 bytes) raised ``OSError [Errno 36] File name too long`` and the upload
+failed with the opaque "Failed to queue for processing" message.
+
+The ingest service renames imported books from their metadata, so the staging
+name is throwaway — the fix truncates it to fit instead of erroring. These
+tests pin that the constructed ingest path always fits NAME_MAX (accounting
+for the ".uploading"/".cwa.json" suffixes the pipeline appends downstream),
+keeps the file extension, and leaves normal-length uploads untouched.
+"""
+import os
+from types import SimpleNamespace
+
+import pytest
+
+# 9 repeats of the 26-letter alphabet + ".pdf" == 238 chars, the exact
+# reproduction from the issue report.
+LONG_BASENAME = "abcdefghijklmnopqrstuvwxyz" * 9 + ".pdf"
+
+
+@pytest.mark.unit
+def test_truncate_ingest_name_leaves_short_names_untouched():
+    from cps.editbooks import _truncate_ingest_name
+    name = "new_1_20260628_205351_821892_book.epub"
+    assert _truncate_ingest_name(name) == name
+
+
+@pytest.mark.unit
+def test_truncate_ingest_name_fits_name_max_and_keeps_extension():
+    from cps.editbooks import _truncate_ingest_name
+    name = "new_1_20260628_205351_821892_" + LONG_BASENAME
+    out = _truncate_ingest_name(name)
+    # The pipeline appends ".uploading" (10 bytes) to the staging file, so the
+    # truncated component plus that suffix must fit within NAME_MAX.
+    assert len((out + ".uploading").encode("utf-8")) <= 255
+    assert out.endswith(".pdf")
+    # The unique prefix that drives sort order is preserved.
+    assert out.startswith("new_1_20260628_205351_821892_")
+
+
+@pytest.mark.unit
+def test_truncate_ingest_name_is_byte_safe_for_multibyte_stems():
+    from cps.editbooks import _truncate_ingest_name
+    # A stem of multi-byte characters must never be cut mid-codepoint.
+    name = ("é" * 400) + ".epub"  # é repeated; 2 bytes each
+    out = _truncate_ingest_name(name)
+    out.encode("utf-8")  # would raise if a surrogate/partial slipped through
+    assert len((out + ".uploading").encode("utf-8")) <= 255
+    assert out.endswith(".epub")
+
+
+@pytest.mark.unit
+def test_get_ingest_path_long_filename_is_writable(tmp_path, monkeypatch):
+    """The real end-to-end check: the path _get_ingest_path returns for a
+    238-char filename must be writable (i.e. not trip ENAMETOOLONG) once the
+    ".uploading" staging suffix is appended."""
+    from cps import editbooks
+    monkeypatch.setattr(editbooks, "get_ingest_dir", lambda: str(tmp_path))
+
+    uploaded = SimpleNamespace(filename=LONG_BASENAME)
+    final_path = editbooks._get_ingest_path(uploaded, prefix_parts=["new", 1])
+
+    component = os.path.basename(final_path)
+    assert len((component + ".uploading").encode("utf-8")) <= 255
+    assert final_path.endswith(".pdf")
+
+    # The actual filesystem write that raised [Errno 36] before the fix.
+    staging = final_path + ".uploading"
+    with open(staging, "w", encoding="utf-8") as handle:
+        handle.write("x")
+    assert os.path.exists(staging)
+
+
+@pytest.mark.unit
+def test_get_ingest_path_normal_filename_unchanged(tmp_path, monkeypatch):
+    """Normal-length uploads keep their full sanitized name — truncation only
+    engages past NAME_MAX, so the common path is untouched."""
+    from cps import editbooks
+    monkeypatch.setattr(editbooks, "get_ingest_dir", lambda: str(tmp_path))
+
+    uploaded = SimpleNamespace(filename="A Tale of Two Cities.epub")
+    final_path = editbooks._get_ingest_path(uploaded, prefix_parts=["new", 1])
+    component = os.path.basename(final_path)
+    # secure_filename collapses spaces to underscores but keeps the full title.
+    assert "A_Tale_of_Two_Cities.epub" in component
+    assert component.endswith(".epub")


### PR DESCRIPTION
**Symptom (issue #553, reported by @chloeroform):** uploading a file whose name is longer than the filesystem limit (~255 bytes) fails to import with an opaque "Failed to queue for processing."

**Root cause:** `_get_ingest_path` builds a staging name `{prefix}_{timestamp}_{secure_filename(original)}`. A long original pushes the path component past NAME_MAX (255 bytes), so when the pipeline appends `.uploading`, `open()` raises `OSError 36 ENAMETOOLONG` and the upload dies.

**Fix:** the staging name is throwaway (the ingest service renames imported books from their metadata), so trim it to fit NAME_MAX — reserving for the `.uploading`/`.cwa.json` suffixes, preserving the extension, cutting on a UTF-8 boundary. Normal-length names are unchanged. It's the **single shared helper** used by both the classic `/upload` and the SPA `/api/v1/upload`, so both paths are fixed.

**Verification**
- 5 unit tests: short untouched · long fits + keeps extension · multibyte byte-safe · `_get_ingest_path` writable end-to-end · normal filename unchanged.
- Red/green at the filesystem level: pre-fix 277-byte write → `errno 36`; post-fix 255-byte → OK.
- Real `/api/v1/upload` on cwn-local: a **239-char** file now **queues** (was failing); a normal-named upload still queues (no regression); ingest-processor picked up the truncated file; no ENAMETOOLONG in logs.

Touches user-controlled file paths, so `/security-review` was run and `@greptileai` invoked.