### PR TITLE
fix(#579): new-UI read badge + filters honor a custom read column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+- **The read/unread checkmark shows again in the new UI when read status is
+  linked to a Calibre column.** If you set Admin → View Configuration → "Link
+  Read/Unread Status to Calibre Column" to a custom column, the new interface
+  showed every book as unread (no checkmark) and the read/unread filters returned
+  everything. The new UI now reads that column, so finished books get their badge
+  and the Read/Unread/Discover filters work again. The built-in read status is
+  unchanged. Reported by @uschi1 (#579).
+
 ## [v4.1.0] - 2026-06-30
 
 ### Changed

--- a/cps/api/books.py
+++ b/cps/api/books.py
@@ -8,10 +8,12 @@ from sqlalchemy.sql.functions import coalesce
 
 from . import api_v1
 from .serializers import serialize_book_list_item, serialize_book_detail
-from .. import calibre_db, config, db, ub, isoLanguages
+from .. import calibre_db, config, db, ub, isoLanguages, logger
 from ..cw_login import current_user
 from ..helper import edit_book_read_status
 from ..usermanagement import login_required_if_no_ano
+
+log = logger.create()
 
 # Stateless sort map — mirrors web.py sort options without calling get_sort_function
 # (which writes per-user state and must not be called from a read-only API endpoint).
@@ -30,7 +32,14 @@ SORT_MAP = {
 def _row_to_item(e):
     """Unwrap a SQLAlchemy Row (Books, is_archived, read_status) or plain Books object."""
     book = getattr(e, "Books", e)
-    read = getattr(e, "read_status", None) == ub.ReadBook.STATUS_FINISHED
+    if config.config_read_column:
+        # Custom read column: generate_linked_query selects read_column.value as the
+        # third column (Row attr "value"), NOT ub.ReadBook.read_status — a truthy
+        # value means the book is read. Without this the badge is always false when
+        # an admin links read status to a Calibre column (fork #579).
+        read = bool(getattr(e, "value", None))
+    else:
+        read = getattr(e, "read_status", None) == ub.ReadBook.STATUS_FINISHED
     archived = bool(getattr(e, "is_archived", False))
     return serialize_book_list_item(book, read=read, archived=archived)
 
@@ -71,14 +80,24 @@ def _build_entity_filter(author, series, tag, publisher, language, rating=None, 
 
 
 def _build_read_filter(filter_val):
-    """Return a db_filter for ?filter=read|unread (config_read_column==0 path).
+    """Return a db_filter for ?filter=read|unread.
 
-    When a custom read column is configured this returns True (no-op) — the
-    API consumer should be informed via the response that the filter was skipped,
-    but for now we silently fall back to unfiltered rather than 500.
+    When an admin links read status to a Calibre column (config_read_column),
+    filter on that column's value (mirrors web.py's books_list); otherwise use the
+    built-in per-user ub.ReadBook table. The join for the custom column is provided
+    by generate_linked_query inside fill_indexpage, so the value is queryable here.
     """
     if config.config_read_column:
-        # Custom read column path — not yet supported; return no-op filter
+        try:
+            read_col = db.cc_classes[config.config_read_column].value
+        except (KeyError, AttributeError):
+            log.error("Custom Column No.%s does not exist in calibre database",
+                      config.config_read_column)
+            return True
+        if filter_val == "read":
+            return coalesce(read_col, False) == True   # noqa: E712
+        if filter_val == "unread":
+            return coalesce(read_col, False) != True   # noqa: E712
         return True
     if filter_val == "read":
         return and_(
@@ -172,7 +191,10 @@ def list_books():
         if not config.config_read_column:
             disc_filter = coalesce(ub.ReadBook.read_status, 0) != ub.ReadBook.STATUS_FINISHED
         else:
-            disc_filter = True
+            try:
+                disc_filter = coalesce(db.cc_classes[config.config_read_column].value, False) != True  # noqa: E712
+            except (KeyError, AttributeError):
+                disc_filter = True
         entries, _random, _pg = calibre_db.fill_indexpage(
             1, per_page, db.Books, disc_filter, [func.randomblob(2)],
             True, config.config_read_column)
@@ -254,9 +276,14 @@ def book_detail(book_id):
                   .filter(ub.UserHiddenBook.user_id == uid, ub.UserHiddenBook.book_id == book_id)
                   .first() is not None)
 
+    # With a custom read column, get_book_read_archived returns the column's value
+    # (truthy = read); otherwise the built-in ub.ReadBook.read_status. Match the
+    # list badge's logic (fork #579) so both surfaces agree.
+    read = bool(read_status) if config.config_read_column \
+        else read_status == ub.ReadBook.STATUS_FINISHED
     return jsonify(serialize_book_detail(
         book,
-        read=(read_status == ub.ReadBook.STATUS_FINISHED),
+        read=read,
         archived=bool(is_archived),
         favorited=favorited,
         hidden=hidden,

--- a/tests/unit/test_579_new_ui_read_column.py
+++ b/tests/unit/test_579_new_ui_read_column.py
@@ -1,0 +1,107 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for fork #579 — the new UI's read/unread checkmark was missing
+for admins who link read status to a Calibre column (config_read_column).
+
+Root cause: for the custom-column path, generate_linked_query selects
+`read_column.value` (Row attr `value`), but `_row_to_item` only read
+`read_status`, so the read flag was always False and no badge ever rendered. The
+read/unread filter and Discover's unread filter also no-op'd for custom columns.
+
+These pin the fix on both paths (custom column + built-in ub.ReadBook) so a
+regression can't silently drop the badge again.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+BOOKS_PY = Path(__file__).resolve().parents[2] / "cps" / "api" / "books.py"
+
+
+def _inner():
+    return SimpleNamespace(id=1, title="A", series_index="1.0", has_cover=1,
+                           authors=[SimpleNamespace(name="Auth")], series=[],
+                           data=[SimpleNamespace(format="EPUB")])
+
+
+# ── read badge: custom column path (the reported regression) ─────────────────
+def test_read_badge_custom_column_truthy_is_read():
+    from cps.api import books as books_mod
+    with patch.object(books_mod.config, "config_read_column", 5, create=True):
+        # generate_linked_query aliases the custom column as `.value`
+        row = SimpleNamespace(Books=_inner(), is_archived=False, value=1)
+        item = books_mod._row_to_item(row)
+    assert item["read"] is True
+
+
+def test_read_badge_custom_column_falsy_is_unread():
+    from cps.api import books as books_mod
+    with patch.object(books_mod.config, "config_read_column", 5, create=True):
+        row = SimpleNamespace(Books=_inner(), is_archived=False, value=None)
+        item = books_mod._row_to_item(row)
+    assert item["read"] is False
+
+
+def test_read_badge_custom_column_ignores_stale_read_status_attr():
+    """With a custom column configured, a leftover read_status attr must NOT be
+    used — only the custom column's value decides."""
+    from cps.api import books as books_mod
+    from cps import ub
+    with patch.object(books_mod.config, "config_read_column", 5, create=True):
+        row = SimpleNamespace(Books=_inner(), is_archived=False, value=0,
+                              read_status=ub.ReadBook.STATUS_FINISHED)
+        item = books_mod._row_to_item(row)
+    assert item["read"] is False
+
+
+# ── read badge: built-in path still works (no regression) ────────────────────
+def test_read_badge_builtin_column_still_works():
+    from cps.api import books as books_mod
+    from cps import ub
+    with patch.object(books_mod.config, "config_read_column", 0, create=True):
+        row = SimpleNamespace(Books=_inner(), is_archived=False,
+                              read_status=ub.ReadBook.STATUS_FINISHED)
+        assert books_mod._row_to_item(row)["read"] is True
+        row2 = SimpleNamespace(Books=_inner(), is_archived=False, read_status=None)
+        assert books_mod._row_to_item(row2)["read"] is False
+
+
+# ── read/unread filter honors the custom column (source-pin) ──────────────────
+def _func_src(name: str) -> str:
+    tree = ast.parse(BOOKS_PY.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return ast.get_source_segment(BOOKS_PY.read_text(), node)
+    raise AssertionError(f"{name} not found in books.py")
+
+
+def test_read_filter_custom_column_no_longer_noop():
+    src = _func_src("_build_read_filter")
+    assert "not yet supported" not in src, "custom read column filter must be implemented"
+    assert "cc_classes[config.config_read_column].value" in src, (
+        "custom-column read filter must query the linked column's value"
+    )
+    # both directions covered
+    assert re.search(r"filter_val\s*==\s*[\"']read[\"']", src)
+    assert re.search(r"filter_val\s*==\s*[\"']unread[\"']", src)
+
+
+def test_discover_unread_filter_handles_custom_column():
+    src = BOOKS_PY.read_text()
+    # The discover branch must filter unread via the custom column, not fall back to
+    # showing every book when a read column is configured.
+    assert src.count("cc_classes[config.config_read_column].value") >= 2, (
+        "both the read/unread filter and the discover unread filter must use the "
+        "custom column value"
+    )


### PR DESCRIPTION
## Symptom
On the new UI, users who link read status to a Calibre column (Admin → View Configuration → "Link Read/Unread Status to Calibre Column") saw **every book as unread** — no checkmark badge — and the Read/Unread/Discover filters returned everything. Reported by @uschi1 (#579), with screenshots of a full grid missing all badges.

## Root cause
For the custom-column path, `generate_linked_query` selects `read_column.value` (Row attr `value`), but the `/api/v1/books` serializer only read `read_status`, so the read flag was **always False**. `_build_read_filter` and the Discover unread filter were explicit no-ops for custom columns.

## Fix (mirrors the classic UI's `web.py:books_list`, proven in production)
- `_row_to_item`: read the custom column's value (truthy = read) when `config_read_column` is set; else the built-in `ub.ReadBook.read_status`.
- `_build_read_filter`: filter on `coalesce(cc_classes[col].value, False)` for read/unread; log + fall back if the column is misconfigured.
- `discover`: filter unread via the custom column instead of returning everything.
- `book_detail`: same logic, so list + detail agree.
- Built-in read status path unchanged.

## Verification
- **Unit (red/green):** `tests/unit/test_579_new_ui_read_column.py` — badge maps custom-column truthy/falsy, ignores a stale `read_status` attr, built-in path still works, and source-pins the filter queries. 37 relevant tests green (incl. existing books/detail/discover suites).
- **Live, reporter-mirror repro (containerised current code):** created a custom bool `read` column with `calibredb add_custom_column`, added a book, linked `config_read_column`, marked the book read via `calibredb set_custom`, then hit the real endpoints:
  - `/api/v1/books` → `read: true` (was `false` before the fix)
  - `?filter=read` → the book; `?filter=unread` → empty
  - `/api/v1/books/<id>` → `read: true`
  - no errors in the container log.

No new routes, deps, or external URLs; no auth/CSRF/crypto/subprocess/file-path surface (so no `/security-review` trigger). The light-theme half of #579 is tracked separately.

Ships fix for #579.