### PR TITLE
feat(#580): edit identifiers + per-field metadata apply in the new UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Added
+- **The new-UI edit page can now edit identifiers, and you choose which fetched
+  values to apply.** Editing a book in the new interface now has an Identifiers
+  table — add, change or remove ISBN, ASIN/Amazon, Google, DOI and the rest — and
+  when you fetch metadata from the web, each result has a "Choose fields" checklist
+  so you apply just the title, cover, description, identifiers (or whatever you
+  pick) instead of overwriting everything. Reported by @uschi1 (#580).
 - **Switching back to the classic view now asks (optionally) what made you
   switch.** The new interface's user menu has a "Back to the classic view" item;
   when you use it, the classic page shows a short, two-step prompt — pick what

--- a/cps/api/edit.py
+++ b/cps/api/edit.py
@@ -20,7 +20,7 @@ from ..cw_login import current_user
 from ..usermanagement import login_required_if_no_ano
 import time
 
-from ..editbooks import edit_book_param, delete_book_from_table
+from ..editbooks import edit_book_param, delete_book_from_table, modify_identifiers
 from ..helper import convert_book_format, save_cover, save_cover_from_url
 
 # Fields the SPA edit form can change, applied in this order. Title/authors come
@@ -81,6 +81,11 @@ def _editable_metadata(book):
         "comments": comments[0].text if comments else "",
         # calibre ratings are stored 0-10 (half-stars); expose 0-5.
         "rating": (rating_rows[0].rating / 2) if rating_rows else 0,
+        # ISBN/ASIN/etc. — editable as a table in the SPA (fork #580).
+        "identifiers": [
+            {"type": i.type, "val": i.val}
+            for i in (getattr(book, "identifiers", None) or [])
+        ],
     }
 
 
@@ -119,6 +124,30 @@ def update_metadata(book_id):
         ok, message = _parse_edit_result(edit_book_param(field, vals))
         if not ok:
             errors[field] = message
+
+    # Identifiers (ISBN/ASIN/…) — a list of {type, val}, reconciled against the
+    # book's existing rows via the same helper the legacy editor uses (fork #580).
+    if "identifiers" in data:
+        raw_ids = data.get("identifiers") or []
+        input_identifiers = []
+        for entry in raw_ids if isinstance(raw_ids, list) else []:
+            if not isinstance(entry, dict):
+                continue
+            id_type = str(entry.get("type") or "").strip().lower()
+            id_val = str(entry.get("val") or "").strip()
+            if not id_type or not id_val:
+                continue  # skip blank rows (a half-filled row isn't an error)
+            input_identifiers.append(db.Identifiers(id_val, id_type, book_id))
+        changed, id_error = modify_identifiers(
+            input_identifiers, book.identifiers, calibre_db.session)
+        if id_error:
+            errors["identifiers"] = "Duplicate identifier type — each type may appear once."
+        if changed:
+            try:
+                calibre_db.session.commit()
+            except Exception as exc:  # noqa: BLE001 — surface as a field error, don't 500
+                calibre_db.session.rollback()
+                errors["identifiers"] = str(exc)
 
     # Re-fetch so the response reflects the committed state.
     fresh = calibre_db.get_book(book_id)

--- a/cps/api/edit.py
+++ b/cps/api/edit.py
@@ -141,8 +141,11 @@ def update_metadata(book_id):
         changed, id_error = modify_identifiers(
             input_identifiers, book.identifiers, calibre_db.session)
         if id_error:
+            # A duplicate type may have already queued partial add/deletes on the
+            # session — discard them so a rejected payload never persists partially.
+            calibre_db.session.rollback()
             errors["identifiers"] = "Duplicate identifier type — each type may appear once."
-        if changed:
+        elif changed:
             try:
                 calibre_db.session.commit()
             except Exception as exc:  # noqa: BLE001 — surface as a field error, don't 500

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -176,6 +176,7 @@ export interface BookMetadata {
   languages: string;
   comments: string;
   rating: number;
+  identifiers: { type: string; val: string }[];
   errors?: Record<string, string>;
 }
 

--- a/frontend/src/pages/EditBook.module.css
+++ b/frontend/src/pages/EditBook.module.css
@@ -153,8 +153,47 @@
 .metaSearchRow .input { flex: 1; }
 .metaResults { list-style: none; display: flex; flex-direction: column; gap: var(--sp-2); max-height: 420px; overflow-y: auto; }
 .metaResult {
-  display: flex; align-items: center; gap: var(--sp-3);
+  display: flex; flex-direction: column; gap: var(--sp-2);
   padding: var(--sp-2); border: 1px solid var(--border); border-radius: var(--r-md);
+}
+.metaResultHead { display: flex; align-items: center; gap: var(--sp-3); }
+
+/* Per-field apply checklist (fork #580) */
+.applyPanel {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: var(--sp-2); border-top: 1px solid var(--border);
+}
+.applyRow {
+  display: grid; grid-template-columns: auto minmax(80px, 120px) 1fr; align-items: center;
+  gap: var(--sp-2); padding: 4px 2px; font-size: var(--fs-sm); cursor: pointer;
+}
+.applyRow input { accent-color: var(--accent); }
+.applyLabel { color: var(--text); font-weight: 500; }
+.applyPreview { color: var(--text-muted); font-size: var(--fs-xs); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.applyActions { display: flex; justify-content: flex-end; margin-top: var(--sp-2); }
+
+/* Identifiers table (fork #580) */
+.identSection { display: flex; flex-direction: column; gap: var(--sp-2); }
+.identTable { display: flex; flex-direction: column; gap: var(--sp-2); }
+.identRow { display: flex; gap: var(--sp-2); align-items: center; }
+.identType { width: 160px; flex-shrink: 0; }
+.identVal { flex: 1; min-width: 0; }
+.identRemove {
+  flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center;
+  width: 32px; height: 32px; border: 1px solid var(--border); border-radius: var(--r-sm);
+  background: none; color: var(--text-muted); cursor: pointer;
+}
+.identRemove:hover { color: var(--danger); border-color: var(--danger); }
+.identAdd {
+  align-self: flex-start; display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 12px; border: 1px dashed var(--border-strong); border-radius: var(--r-sm);
+  background: none; color: var(--text); font-size: var(--fs-sm); cursor: pointer;
+}
+.identAdd:hover { border-color: var(--accent); color: var(--accent); }
+@media (max-width: 560px) {
+  .identType { width: 110px; }
+  .applyRow { grid-template-columns: auto 1fr; }
+  .applyRow .applyPreview { grid-column: 1 / -1; padding-left: 26px; }
 }
 .metaCover { width: 40px; height: 60px; object-fit: cover; border-radius: var(--r-sm); flex-shrink: 0; }
 .metaInfo { flex: 1; display: flex; flex-direction: column; gap: 2px; min-width: 0; }

--- a/frontend/src/pages/EditBook.tsx
+++ b/frontend/src/pages/EditBook.tsx
@@ -313,6 +313,14 @@ function ResultRow({ r, onApply }: { r: MetaResult; onApply: (r: MetaResult, sel
   const [expanded, setExpanded] = useState(false);
   const [sel, setSel] = useState<Set<ApplyKey>>(() => new Set(fields.map((f) => f.key)));
 
+  // Results are keyed by index, so a new search reuses this instance rather than
+  // remounting — reset the checklist (and collapse) whenever the result changes,
+  // or a prior result's selection would leak onto a different book.
+  useEffect(() => {
+    setSel(new Set(APPLY_FIELDS.filter((f) => f.has(r)).map((f) => f.key)));
+    setExpanded(false);
+  }, [r]);
+
   const toggle = (k: ApplyKey) => setSel((s) => {
     const n = new Set(s);
     if (n.has(k)) n.delete(k); else n.add(k);

--- a/frontend/src/pages/EditBook.tsx
+++ b/frontend/src/pages/EditBook.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'wouter';
-import { ChevronLeft, Save, Trash2, RefreshCw, Image as ImageIcon, Upload as UploadIcon, ExternalLink, Sparkles, Search } from 'lucide-react';
+import { ChevronLeft, Save, Trash2, RefreshCw, Image as ImageIcon, Upload as UploadIcon, ExternalLink, Sparkles, Search, Plus, X } from 'lucide-react';
 import {
   useBookMetadata, useUpdateMetadata, useBook, useMe, useDeleteFormat, useConvertFormat,
   useSetCover, useMetadataSearch, useAddFormat,
@@ -13,6 +13,8 @@ import { ApiError } from '../lib/api';
 import { useT } from '../lib/i18n';
 import styles from './EditBook.module.css';
 
+interface Ident { type: string; val: string }
+
 interface FormState {
   title: string;
   authors: string;
@@ -23,14 +25,34 @@ interface FormState {
   languages: string;
   rating: string;
   comments: string;
+  identifiers: Ident[];
 }
 
 const RATINGS = ['', '1', '2', '3', '4', '5'];
+
+/** Which fields a fetched result can contribute, in display order. `has` decides
+ *  whether the result actually offers the field (so we only show applicable rows),
+ *  and `preview` renders the incoming value in the per-field apply checklist. */
+type ApplyKey = 'title' | 'authors' | 'series' | 'tags' | 'publisher' | 'rating' | 'description' | 'identifiers' | 'cover';
+const APPLY_FIELDS: { key: ApplyKey; label: string; has: (r: MetaResult) => boolean; preview: (r: MetaResult) => string }[] = [
+  { key: 'title', label: 'Title', has: (r) => !!r.title, preview: (r) => r.title },
+  { key: 'authors', label: 'Authors', has: (r) => !!r.authors?.length, preview: (r) => (r.authors || []).join(', ') },
+  { key: 'series', label: 'Series', has: (r) => !!r.series, preview: (r) => `${r.series}${r.series_index ? ` #${r.series_index}` : ''}` },
+  { key: 'tags', label: 'Tags', has: (r) => !!r.tags?.length, preview: (r) => (r.tags || []).join(', ') },
+  { key: 'publisher', label: 'Publisher', has: (r) => !!r.publisher, preview: (r) => r.publisher || '' },
+  { key: 'rating', label: 'Rating', has: (r) => !!r.rating, preview: (r) => `${Math.round(r.rating || 0)} ★` },
+  { key: 'description', label: 'Description', has: (r) => !!r.description, preview: (r) => stripTags(r.description || '').slice(0, 140) },
+  { key: 'identifiers', label: 'Identifiers', has: (r) => !!r.identifiers && Object.keys(r.identifiers).length > 0, preview: (r) => Object.entries(r.identifiers || {}).map(([k, v]) => `${k}:${v}`).join(', ') },
+  { key: 'cover', label: 'Cover', has: (r) => !!r.cover, preview: () => '' },
+];
+
+function stripTags(s: string) { return s.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim(); }
 
 export function EditBook({ id }: { id: string }) {
   const t = useT();
   const { data: meta, isLoading, error } = useBookMetadata(id);
   const update = useUpdateMetadata(id);
+  const setCover = useSetCover(id);
   const [, navigate] = useLocation();
 
   const [form, setForm] = useState<FormState | null>(null);
@@ -49,6 +71,7 @@ export function EditBook({ id }: { id: string }) {
       languages: meta.languages,
       rating: meta.rating ? String(meta.rating) : '',
       comments: meta.comments,
+      identifiers: (meta.identifiers || []).map((i) => ({ type: i.type, val: i.val })),
     });
   }, [meta]);
 
@@ -66,19 +89,46 @@ export function EditBook({ id }: { id: string }) {
   const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
     setForm((f) => (f ? { ...f, [key]: value } : f));
 
-  // Apply an online metadata result into the form (one merged update).
-  const applyResult = (r: MetaResult) =>
-    setForm((f) => (f ? {
-      ...f,
-      title: r.title || f.title,
-      authors: r.authors?.length ? r.authors.join(' & ') : f.authors,
-      tags: r.tags?.length ? r.tags.join(', ') : f.tags,
-      publishers: r.publisher || f.publishers,
-      comments: r.description || f.comments,
-      series: r.series || f.series,
-      series_index: r.series_index ? String(r.series_index) : f.series_index,
-      rating: r.rating ? String(Math.round(r.rating)) : f.rating,
-    } : f));
+  // Apply only the user-selected fields of an online result into the form. Cover
+  // is applied as a side effect (it isn't a form field). Identifiers merge by
+  // type (result overrides same-type rows, keeps the rest).
+  const applySelected = (r: MetaResult, sel: Set<ApplyKey>) => {
+    setForm((f) => {
+      if (!f) return f;
+      const next = { ...f };
+      if (sel.has('title') && r.title) next.title = r.title;
+      if (sel.has('authors') && r.authors?.length) next.authors = r.authors.join(' & ');
+      if (sel.has('tags') && r.tags?.length) next.tags = r.tags.join(', ');
+      if (sel.has('publisher') && r.publisher) next.publishers = r.publisher;
+      if (sel.has('series') && r.series) {
+        next.series = r.series;
+        if (r.series_index) next.series_index = String(r.series_index);
+      }
+      if (sel.has('rating') && r.rating) next.rating = String(Math.round(r.rating));
+      if (sel.has('description') && r.description) next.comments = r.description;
+      if (sel.has('identifiers') && r.identifiers) {
+        const byType = new Map(next.identifiers.map((i) => [i.type.toLowerCase(), i]));
+        for (const [type, val] of Object.entries(r.identifiers)) {
+          const ty = String(type || '').trim().toLowerCase();
+          const vv = String(val ?? '').trim();
+          if (ty && vv) byType.set(ty, { type: ty, val: vv });
+        }
+        next.identifiers = [...byType.values()];
+      }
+      return next;
+    });
+    if (sel.has('cover') && r.cover) {
+      setCover.mutate({ url: r.cover }, {
+        onSuccess: () => setBanner({ ok: true, text: t('Cover updated from the selected result.') }),
+        onError: (err) => setBanner({ ok: false, text: err instanceof ApiError ? err.message : 'Cover update failed.' }),
+      });
+    }
+  };
+
+  const setIdent = (i: number, patch: Partial<Ident>) =>
+    setForm((f) => (f ? { ...f, identifiers: f.identifiers.map((row, j) => (j === i ? { ...row, ...patch } : row)) } : f));
+  const addIdent = () => setForm((f) => (f ? { ...f, identifiers: [...f.identifiers, { type: '', val: '' }] } : f));
+  const removeIdent = (i: number) => setForm((f) => (f ? { ...f, identifiers: f.identifiers.filter((_, j) => j !== i) } : f));
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -94,6 +144,10 @@ export function EditBook({ id }: { id: string }) {
       languages: form.languages,
       rating: form.rating ? Number(form.rating) : 0,
       comments: form.comments,
+      // Drop blank rows; the backend reconciles the rest against existing rows.
+      identifiers: form.identifiers
+        .map((i) => ({ type: i.type.trim().toLowerCase(), val: i.val.trim() }))
+        .filter((i) => i.type && i.val),
     };
     update.mutate(payload, {
       onSuccess: (data) => {
@@ -119,7 +173,7 @@ export function EditBook({ id }: { id: string }) {
 
       <CoverManager id={id} />
 
-      <MetadataFetch defaultQuery={form.title} onApply={applyResult} />
+      <MetadataFetch defaultQuery={form.title} onApply={applySelected} />
 
       <form className={styles.form} onSubmit={onSubmit}>
         <Field label={t('Title')} error={fieldErrors.title}>
@@ -163,6 +217,30 @@ export function EditBook({ id }: { id: string }) {
           <span className={styles.hint}>{t('HTML is allowed and sanitized on display.')}</span>
         </Field>
 
+        {/* Identifiers table (ISBN/ASIN/…) — fork #580. */}
+        <div className={styles.identSection}>
+          <span className={styles.label}>{t('Identifiers')}</span>
+          {fieldErrors.identifiers && <span className={styles.fieldError}>{fieldErrors.identifiers}</span>}
+          {form.identifiers.length > 0 && (
+            <div className={styles.identTable} role="group" aria-label={t('Identifiers')}>
+              {form.identifiers.map((idn, i) => (
+                <div key={i} className={styles.identRow}>
+                  <input className={styles.identType} value={idn.type} aria-label={t('Identifier type')}
+                    placeholder={t('type (isbn, amazon, doi…)')} onChange={(e) => setIdent(i, { type: e.target.value })} />
+                  <input className={styles.identVal} value={idn.val} aria-label={t('Identifier value')}
+                    placeholder={t('value')} onChange={(e) => setIdent(i, { val: e.target.value })} />
+                  <button type="button" className={styles.identRemove} onClick={() => removeIdent(i)}
+                    aria-label={t('Remove identifier')}><X size={15} /></button>
+                </div>
+              ))}
+            </div>
+          )}
+          <button type="button" className={styles.identAdd} onClick={addIdent}>
+            <Plus size={14} /> {t('Add identifier')}
+          </button>
+          <span className={styles.hint}>{t('Each type (isbn, amazon, google, doi…) may appear once.')}</span>
+        </div>
+
         <div className={styles.actions}>
           <Button type="submit" disabled={update.isPending}>
             <Save size={16} /> {t('Save changes')}
@@ -178,9 +256,11 @@ export function EditBook({ id }: { id: string }) {
 }
 
 /** Fetch metadata from online providers (Google Books, OpenLibrary, Amazon,
- *  ComicVine, …) and apply a result to the form. Reuses the legacy
- *  /metadata/search endpoint (per-user provider toggles live there). */
-function MetadataFetch({ defaultQuery, onApply }: { defaultQuery: string; onApply: (r: MetaResult) => void }) {
+ *  ComicVine, …). Each result expands a per-field checklist so you apply only the
+ *  values you want (fork #580) instead of overwriting the whole form. Reuses the
+ *  legacy /metadata/search endpoint (per-user provider toggles live there). */
+function MetadataFetch({ defaultQuery, onApply }:
+  { defaultQuery: string; onApply: (r: MetaResult, sel: Set<ApplyKey>) => void }) {
   const t = useT();
   const search = useMetadataSearch();
   const [open, setOpen] = useState(false);
@@ -216,22 +296,60 @@ function MetadataFetch({ defaultQuery, onApply }: { defaultQuery: string; onAppl
           {err && <span className={styles.msgErr}>{err}</span>}
           {results.length > 0 && (
             <ul className={styles.metaResults}>
-              {results.map((r, i) => (
-                <li key={i} className={styles.metaResult}>
-                  {r.cover && <img src={r.cover} alt="" className={styles.metaCover} loading="lazy" />}
-                  <div className={styles.metaInfo}>
-                    <span className={styles.metaTitle}>{r.title}</span>
-                    <span className={styles.metaAuthors}>{(r.authors || []).join(', ')}</span>
-                    {r.source?.id && <span className={styles.metaSource}>{r.source.id}</span>}
-                  </div>
-                  <Button type="button" variant="ghost" onClick={() => onApply(r)}>{t('Use')}</Button>
-                </li>
-              ))}
+              {results.map((r, i) => <ResultRow key={i} r={r} onApply={onApply} />)}
             </ul>
           )}
         </div>
       )}
     </section>
+  );
+}
+
+/** One search result: shows the book, and (on "Choose fields") a checklist of the
+ *  values it offers so the user applies exactly what they want. */
+function ResultRow({ r, onApply }: { r: MetaResult; onApply: (r: MetaResult, sel: Set<ApplyKey>) => void }) {
+  const t = useT();
+  const fields = APPLY_FIELDS.filter((f) => f.has(r));
+  const [expanded, setExpanded] = useState(false);
+  const [sel, setSel] = useState<Set<ApplyKey>>(() => new Set(fields.map((f) => f.key)));
+
+  const toggle = (k: ApplyKey) => setSel((s) => {
+    const n = new Set(s);
+    if (n.has(k)) n.delete(k); else n.add(k);
+    return n;
+  });
+
+  return (
+    <li className={styles.metaResult}>
+      <div className={styles.metaResultHead}>
+        {r.cover && <img src={r.cover} alt="" className={styles.metaCover} loading="lazy" />}
+        <div className={styles.metaInfo}>
+          <span className={styles.metaTitle}>{r.title}</span>
+          <span className={styles.metaAuthors}>{(r.authors || []).join(', ')}</span>
+          {r.source?.id && <span className={styles.metaSource}>{r.source.id}</span>}
+        </div>
+        <Button type="button" variant="ghost" onClick={() => setExpanded((v) => !v)}>
+          {expanded ? t('Hide fields') : t('Choose fields')}
+        </Button>
+      </div>
+      {expanded && (
+        <div className={styles.applyPanel}>
+          {fields.map((f) => (
+            <label key={f.key} className={styles.applyRow}>
+              <input type="checkbox" checked={sel.has(f.key)} onChange={() => toggle(f.key)} />
+              <span className={styles.applyLabel}>{t(f.label)}</span>
+              <span className={styles.applyPreview}>{f.key === 'cover' ? t('(replace cover)') : f.preview(r)}</span>
+            </label>
+          ))}
+          <div className={styles.applyActions}>
+            <Button type="button" disabled={sel.size === 0}
+              onClick={() => { onApply(r, sel); setExpanded(false); }}>
+              {t('Apply selected')}
+            </Button>
+          </div>
+        </div>
+      )}
+    </li>
   );
 }
 

--- a/tests/unit/test_580_edit_identifiers.py
+++ b/tests/unit/test_580_edit_identifiers.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Fork #580 — the SPA edit page can now edit identifiers (ISBN/ASIN/…).
+
+Backend: /api/v1/books/<id>/metadata accepts an `identifiers` list of {type,val},
+reconciles it against the book's existing rows via the same modify_identifiers
+helper the legacy editor uses, and returns the current identifiers in the editable
+metadata so the form can seed the table.
+"""
+import inspect
+import json
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import flask
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx(path, body=None):
+    app = flask.Flask(__name__)
+    app.config["WTF_CSRF_ENABLED"] = False
+    kwargs = {"method": "POST"}
+    if body is not None:
+        kwargs["json"] = body
+        kwargs["content_type"] = "application/json"
+    return app.test_request_context(path, **kwargs)
+
+
+def _editor():
+    return SimpleNamespace(is_authenticated=True, is_anonymous=False, name="ed",
+                           role_edit=lambda: True, role_delete_books=lambda: True, id=1)
+
+
+def _fake_book(identifiers=None):
+    return SimpleNamespace(
+        id=5, title="T", authors=[], series=[], series_index=1.0,
+        tags=[], publishers=[], languages=[], comments=[], ratings=[],
+        identifiers=identifiers if identifiers is not None else [],
+    )
+
+
+def test_editable_metadata_includes_identifiers():
+    from cps.api import edit as mod
+    book = _fake_book([SimpleNamespace(type="isbn", val="123"),
+                       SimpleNamespace(type="amazon", val="B01")])
+    out = mod._editable_metadata(book)
+    assert out["identifiers"] == [
+        {"type": "isbn", "val": "123"},
+        {"type": "amazon", "val": "B01"},
+    ]
+
+
+def test_update_metadata_persists_identifiers_lowercased_and_skips_blank_rows():
+    from cps.api import edit as mod
+    session = MagicMock()
+    captured = {}
+
+    def fake_modify(inp, dbids, sess):
+        captured["input"] = inp
+        captured["dbids"] = dbids
+        return True, False  # changed, no error
+
+    body = {"identifiers": [
+        {"type": "ISBN", "val": "9780000000001"},
+        {"type": "", "val": "orphan-value"},   # blank type -> skipped
+        {"type": "amazon", "val": ""},          # blank value -> skipped
+        {"type": "Amazon", "val": "B01ABCDEFG"},
+    ]}
+    with _ctx("/api/v1/books/5/metadata", body=body):
+        with patch.object(mod, "current_user", _editor()), \
+             patch.object(mod, "calibre_db",
+                          SimpleNamespace(get_book=lambda _id: _fake_book(), session=session)), \
+             patch.object(mod, "modify_identifiers", side_effect=fake_modify), \
+             patch.object(mod, "get_locale", return_value="en"):
+            resp = inspect.unwrap(mod.update_metadata)(5)
+
+    # only the two well-formed rows are built, types lowercased, book id threaded
+    assert len(captured["input"]) == 2
+    assert sorted(i.type for i in captured["input"]) == ["amazon", "isbn"]
+    assert all(i.book == 5 for i in captured["input"])
+    session.commit.assert_called_once()
+    assert resp.status_code == 200
+
+
+def test_update_metadata_duplicate_identifier_reports_field_error():
+    from cps.api import edit as mod
+    session = MagicMock()
+
+    def fake_modify(inp, dbids, sess):
+        return False, True  # no change, duplicate-type error
+
+    body = {"identifiers": [{"type": "isbn", "val": "1"}, {"type": "isbn", "val": "2"}]}
+    with _ctx("/api/v1/books/5/metadata", body=body):
+        with patch.object(mod, "current_user", _editor()), \
+             patch.object(mod, "calibre_db",
+                          SimpleNamespace(get_book=lambda _id: _fake_book(), session=session)), \
+             patch.object(mod, "modify_identifiers", side_effect=fake_modify), \
+             patch.object(mod, "get_locale", return_value="en"):
+            resp = inspect.unwrap(mod.update_metadata)(5)
+
+    payload = json.loads(resp.get_data())
+    assert "identifiers" in payload.get("errors", {})
+    session.commit.assert_not_called()
+
+
+def test_update_metadata_without_identifiers_key_does_not_touch_them():
+    """Omitting the key leaves identifiers alone (only present-in-payload fields
+    are changed) — no modify_identifiers call, no commit."""
+    from cps.api import edit as mod
+    session = MagicMock()
+    with _ctx("/api/v1/books/5/metadata", body={"title": "New"}):
+        with patch.object(mod, "current_user", _editor()), \
+             patch.object(mod, "calibre_db",
+                          SimpleNamespace(get_book=lambda _id: _fake_book(), session=session)), \
+             patch.object(mod, "modify_identifiers", side_effect=AssertionError("must not be called")), \
+             patch.object(mod, "edit_book_param",
+                          return_value=flask.Response(json.dumps({"success": True}),
+                                                      mimetype="application/json")), \
+             patch.object(mod, "get_locale", return_value="en"):
+            resp = inspect.unwrap(mod.update_metadata)(5)
+    assert resp.status_code == 200
+    session.commit.assert_not_called()

--- a/tests/unit/test_580_edit_identifiers.py
+++ b/tests/unit/test_580_edit_identifiers.py
@@ -89,7 +89,10 @@ def test_update_metadata_duplicate_identifier_reports_field_error():
     session = MagicMock()
 
     def fake_modify(inp, dbids, sess):
-        return False, True  # no change, duplicate-type error
+        # Realistic duplicate case: modify_identifiers may queue partial add/deletes
+        # (changed=True) AND flag the duplicate (error=True). A rejected payload must
+        # roll back, not commit the partial changes.
+        return True, True
 
     body = {"identifiers": [{"type": "isbn", "val": "1"}, {"type": "isbn", "val": "2"}]}
     with _ctx("/api/v1/books/5/metadata", body=body):
@@ -102,7 +105,8 @@ def test_update_metadata_duplicate_identifier_reports_field_error():
 
     payload = json.loads(resp.get_data())
     assert "identifiers" in payload.get("errors", {})
-    session.commit.assert_not_called()
+    session.commit.assert_not_called()   # rejected payload must NOT persist
+    session.rollback.assert_called()     # partial staged changes discarded
 
 
 def test_update_metadata_without_identifiers_key_does_not_touch_them():


### PR DESCRIPTION
## What & why
The new-UI edit page was missing two things the classic editor had (reported by @uschi1, #580):
1. **No way to edit identifiers** (ISBN/ASIN/Amazon/Google/DOI…).
2. **Fetched metadata overwrote everything** — no per-field control.

## Changes
**Backend — `cps/api/edit.py`:**
- `POST /api/v1/books/<id>/metadata` now accepts an `identifiers` list of `{type,val}`, reconciled against the book's existing rows via the same `modify_identifiers` helper the legacy editor uses. Blank rows skipped, types lowercased, duplicate types surfaced as a field error, committed only when changed.
- The editable-metadata response now returns the book's current identifiers so the form seeds its table.

**Frontend — `EditBook.tsx`:**
- **Identifiers table**: add / edit / remove rows (type + value), saved with the form.
- **Per-field apply**: each online-search result expands a "Choose fields" checklist (title, authors, series, tags, publisher, rating, description, identifiers, cover) so you apply only what you pick. Cover uses the existing set-cover call; identifiers merge by type.

## Verification
- **Unit (red/green):** `tests/unit/test_580_edit_identifiers.py` — identifiers round-trip (lowercase + skip-blank rows), duplicate-type field error, no-op when the key is absent, identifiers present in editable metadata. 23 edit-API tests green. SPA typechecks + builds.
- **Live (containerised current code):** `GET .../metadata` returns identifiers; `POST {identifiers:[ISBN, amazon, blank]}` → 200, blank skipped, types lowercased, persisted on re-GET. (Playwright drive of the SPA edit table + "Choose fields" panel run separately.)

No new deps or external URLs; no auth/CSRF/crypto/subprocess/file-path/new-route surface. Ships fix for #580.