### PR TITLE
fix(#571): new UI works behind a reverse proxy with a path prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ is for things you can see or feel when running the app.
   appears right after you switch back, and won't nag you again.
 
 ### Fixed
+- **The new UI now works behind a reverse proxy with a path prefix.** If you
+  serve Calibre-Web NextGen under a subpath (e.g. `https://host/cwa/` via nginx,
+  Traefik or similar), the new interface showed a blank white page because its
+  scripts, styles, API calls, covers and downloads were requested without the
+  prefix and 404'd. Everything now honours the mount prefix automatically, so the
+  new UI loads and works the same behind a subpath as at the domain root. Reported
+  by @chloeroform (#571).
 - **The read/unread checkmark shows again in the new UI when read status is
   linked to a Calibre column.** If you set Admin → View Configuration → "Link
   Read/Unread Status to Calibre Column" to a custom column, the new interface

--- a/cps/spa.py
+++ b/cps/spa.py
@@ -54,7 +54,8 @@ def _inject_spa_flag():
 # unreserved URL chars. Anything else (quotes, angle brackets, spaces) is
 # rejected to "" so a spoofed X-Forwarded-Prefix / X-Script-Name header can't
 # break out of the injected <script> string or the asset-URL rewrite below.
-_SAFE_PREFIX_RE = re.compile(r"^(/[A-Za-z0-9._~-]+)+$")
+# \Z (not $) so a trailing newline can't sneak past the end anchor.
+_SAFE_PREFIX_RE = re.compile(r"^(/[A-Za-z0-9._~-]+)+\Z")
 
 
 def _mount_prefix():

--- a/cps/spa.py
+++ b/cps/spa.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Serves the SPA shell at /app. Opt-OUT via env CWNG_SPA (default: enabled)."""
+import json
 import os
-from flask import Blueprint, send_from_directory, abort
+import re
+from flask import Blueprint, request, Response, abort
 
 from . import logger, constants
 
@@ -48,6 +50,45 @@ def _inject_spa_flag():
     }
 
 
+# A reverse-proxy mount prefix is a URL path: leading-slash segments of
+# unreserved URL chars. Anything else (quotes, angle brackets, spaces) is
+# rejected to "" so a spoofed X-Forwarded-Prefix / X-Script-Name header can't
+# break out of the injected <script> string or the asset-URL rewrite below.
+_SAFE_PREFIX_RE = re.compile(r"^(/[A-Za-z0-9._~-]+)+$")
+
+
+def _mount_prefix():
+    """The reverse-proxy path prefix the app is mounted under (e.g. ``/cwa``),
+    or ``""`` at the domain root. Sourced from ``request.script_root`` — set by
+    ReverseProxied (X-Script-Name) / ProxyFix (X-Forwarded-Prefix) upstream, the
+    same value ``url_for`` already uses to build prefixed links for the classic
+    UI. Sanitized so it's safe to reflect into HTML/JS."""
+    prefix = (request.script_root or "").rstrip("/")
+    if prefix and (not _SAFE_PREFIX_RE.match(prefix) or ".." in prefix):
+        log.warning("Ignoring unexpected script_root/prefix %r for SPA shell", prefix)
+        return ""
+    return prefix
+
+
+def _render_shell(index_path, prefix):
+    """Serve the built index.html adapted to the current mount prefix.
+
+    The Vite build hardcodes root-absolute asset URLs (``/static/app/…``); behind
+    a reverse-proxy subpath those 404 (the reporter's white page, #571). Rewrite
+    them to ``<prefix>/static/app/…`` and expose the prefix to the SPA runtime via
+    ``window.__CWNG_PREFIX__`` so its API calls, router base and resource URLs are
+    prefixed too. At the domain root (prefix="") the file is served unchanged."""
+    with open(index_path, "r", encoding="utf-8") as fh:
+        html = fh.read()
+    if prefix:
+        html = html.replace("/static/app/", prefix + "/static/app/")
+    # Always inject the prefix (even "") so the SPA reads an authoritative value
+    # rather than guessing from the URL. json.dumps → safely-quoted JS string.
+    inject = "<script>window.__CWNG_PREFIX__=%s;</script>" % json.dumps(prefix)
+    html = html.replace("</head>", inject + "</head>", 1)
+    return Response(html, mimetype="text/html")
+
+
 @spa.route("/app")
 @spa.route("/app/")
 @spa.route("/app/<path:path>")
@@ -59,4 +100,4 @@ def spa_shell(path=""):
         log.warning("SPA shell requested but build artifact not found: %s — run the Vite build "
                     "or set CWNG_SPA=0 to suppress this warning", index_path)
         abort(404)
-    return send_from_directory(_SPA_DIR, "index.html")
+    return _render_shell(index_path, _mount_prefix())

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react';
 import { Router, Route, Switch } from 'wouter';
+import { BASE_PREFIX } from './lib/api';
 import { useMe, useLogout } from './lib/queries';
 import { Login } from './pages/Login';
 import { MagicLink } from './pages/MagicLink';
@@ -32,6 +33,11 @@ const Reader = lazy(() => import('./pages/Reader').then((m) => ({ default: m.Rea
 // Native multi-format reader (PDF/audio/text) — also lazy, full-screen.
 const NativeReader = lazy(() => import('./pages/NativeReader').then((m) => ({ default: m.NativeReader })));
 
+// The SPA is mounted at <prefix>/app — where <prefix> is the reverse-proxy mount
+// path (empty at the domain root). wouter needs the full base so client-side
+// links resolve to <prefix>/app/… rather than a prefix-less /app/….
+const ROUTER_BASE = BASE_PREFIX + '/app';
+
 export function App() {
   const { data: me, isLoading } = useMe();
   const logout = useLogout();
@@ -45,7 +51,7 @@ export function App() {
     // Login can navigate to it via wouter. On success the me-cache flips and the
     // authenticated tree below mounts.
     return (
-      <Router base="/app">
+      <Router base={ROUTER_BASE}>
         <Switch>
           <Route path="/magic-link">{() => <MagicLink />}</Route>
           <Route>{() => <Login />}</Route>
@@ -56,7 +62,7 @@ export function App() {
 
   return (
     <I18nProvider locale={me.locale}>
-    <Router base="/app">
+    <Router base={ROUTER_BASE}>
       <Switch>
         {/* Full-screen reader — outside the app shell (no sidebar/topbar). */}
         <Route path="/read/:id">

--- a/frontend/src/components/BookCover.tsx
+++ b/frontend/src/components/BookCover.tsx
@@ -1,3 +1,4 @@
+import { resourceUrl } from '../lib/api';
 import styles from './BookCover.module.css';
 
 interface BookCoverProps {
@@ -10,7 +11,7 @@ export function BookCover({ coverUrl, title }: BookCoverProps) {
     return (
       <div className={styles.wrap}>
         <img
-          src={coverUrl}
+          src={resourceUrl(coverUrl)}
           alt={title}
           loading="lazy"
           className={styles.img}

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react'
 import { BookMarked, LogOut, Menu, Search, ChevronDown, User, Bug, BookOpen, Undo2 } from 'lucide-react';
 import { Link, useLocation } from 'wouter';
 import { GithubMark, DiscordMark } from './BrandIcons';
+import { BASE_PREFIX } from '../lib/api';
 import { useT } from '../lib/i18n';
 import styles from './TopBar.module.css';
 
@@ -151,8 +152,7 @@ function HelpMenu() {
  *  "what made you switch back?" feedback prompt on arrival. The base prefix (if
  *  the app is served under a reverse-proxy subpath, before /app) is preserved. */
 function backToClassicView() {
-  const prefix = window.location.pathname.replace(/\/app(\/.*)?$/, '');
-  window.location.assign((prefix || '') + '/?cwng_feedback=newui');
+  window.location.assign(BASE_PREFIX + '/?cwng_feedback=newui');
 }
 
 function UserMenu({ userName, onLogout }: { userName: string; onLogout: () => void }) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,9 +26,12 @@ export function apiUrl(path: string): string {
 
 /** Prefix a server-generated resource URL (cover/download/read) with the mount
  *  prefix. Leaves absolute (http/https/protocol-relative) and data: URLs — e.g.
- *  an external metadata provider's cover — untouched. */
+ *  an external metadata provider's cover — untouched, and is idempotent: a value
+ *  that already carries the prefix (e.g. a Flask url_for path returned by an
+ *  apply endpoint) is not prefixed a second time. */
 export function resourceUrl(u: string): string {
   if (/^(https?:)?\/\//i.test(u) || u.startsWith('data:')) return u;
+  if (BASE_PREFIX && (u === BASE_PREFIX || u.startsWith(BASE_PREFIX + '/'))) return u;
   return BASE_PREFIX + u;
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,37 @@
 /* Typed fetch helpers — same-origin, credentials included. */
 
+declare global {
+  interface Window { __CWNG_PREFIX__?: string; }
+}
+
+// Reverse-proxy mount prefix (e.g. "/cwa" when the app is served at
+// https://host/cwa/). The server injects window.__CWNG_PREFIX__ into the SPA
+// shell from request.script_root; fall back to deriving it from the current
+// path (strip the "/app…" SPA segment) so a stale cached shell still works.
+// Empty string when mounted at the domain root — the common case.
+function _detectPrefix(): string {
+  if (typeof window === 'undefined') return '';
+  const injected = window.__CWNG_PREFIX__;
+  if (injected !== undefined && injected !== null) return injected.replace(/\/+$/, '');
+  const derived = window.location.pathname.replace(/\/app(\/.*)?$/, '');
+  return derived.replace(/\/+$/, '');
+}
+
+export const BASE_PREFIX: string = _detectPrefix();
+
+/** Prefix an app-internal API/route path with the reverse-proxy mount prefix. */
+export function apiUrl(path: string): string {
+  return BASE_PREFIX + path;
+}
+
+/** Prefix a server-generated resource URL (cover/download/read) with the mount
+ *  prefix. Leaves absolute (http/https/protocol-relative) and data: URLs — e.g.
+ *  an external metadata provider's cover — untouched. */
+export function resourceUrl(u: string): string {
+  if (/^(https?:)?\/\//i.test(u) || u.startsWith('data:')) return u;
+  return BASE_PREFIX + u;
+}
+
 export interface ServerFeatures {
   hide_books: boolean;
   mail_configured: boolean;
@@ -244,7 +276,7 @@ let _csrfCache: string | null = null;
 
 export async function getCsrf(): Promise<string> {
   if (_csrfCache) return _csrfCache;
-  const res = await fetch('/api/v1/auth/csrf', { credentials: 'include' });
+  const res = await fetch(apiUrl('/api/v1/auth/csrf'), { credentials: 'include' });
   if (!res.ok) throw new ApiError(res.status, 'Failed to fetch CSRF token');
   const data = await res.json() as { csrf_token: string };
   _csrfCache = data.csrf_token;
@@ -256,7 +288,7 @@ function clearCsrf() {
 }
 
 export async function apiGet<T>(path: string): Promise<T> {
-  const res = await fetch(path, { credentials: 'include' });
+  const res = await fetch(apiUrl(path), { credentials: 'include' });
   if (!res.ok) {
     let msg = res.statusText;
     // API errors are shaped { error: { code, message } }; fall back to a bare
@@ -273,7 +305,7 @@ export async function apiGet<T>(path: string): Promise<T> {
 
 export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
   const doPost = async (csrf: string): Promise<Response> => {
-    return fetch(path, {
+    return fetch(apiUrl(path), {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -322,7 +354,7 @@ export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
  *  rather than duplicating it under /api/v1. Same CSRF-retry as apiPost. */
 export async function apiPostForm<T>(path: string, fields: Record<string, string>): Promise<T> {
   const doPost = async (csrf: string): Promise<Response> =>
-    fetch(path, {
+    fetch(apiUrl(path), {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRFToken': csrf },
@@ -374,7 +406,7 @@ export interface MetaSearchResponse {
  *  browser set the multipart Content-Type + boundary (so we must NOT set it). */
 export async function apiUpload<T>(path: string, formData: FormData): Promise<T> {
   const doPost = async (csrf: string): Promise<Response> =>
-    fetch(path, {
+    fetch(apiUrl(path), {
       method: 'POST',
       credentials: 'include',
       headers: { 'X-CSRFToken': csrf },

--- a/frontend/src/lib/coverPicker.ts
+++ b/frontend/src/lib/coverPicker.ts
@@ -7,7 +7,7 @@
  * / {valid,...} envelope (not the /api/v1 {error:{…}} shape), so these wrappers
  * parse that here. CSRF + session cookie are reused from api.ts. */
 import { useQuery } from '@tanstack/react-query';
-import { ApiError, getCsrf } from './api';
+import { ApiError, getCsrf, apiUrl } from './api';
 
 // ---- shapes (mirror cps/services/cover_picker.py + cover_url_validator.py) ----
 
@@ -107,14 +107,14 @@ async function envelopeError(res: Response): Promise<never> {
 }
 
 async function cpGet<T>(path: string): Promise<T> {
-  const res = await fetch(path, { credentials: 'include', headers: { Accept: 'application/json' } });
+  const res = await fetch(apiUrl(path), { credentials: 'include', headers: { Accept: 'application/json' } });
   if (!res.ok) return envelopeError(res);
   return res.json() as Promise<T>;
 }
 
 /** POST JSON with the same one-shot CSRF refresh-and-retry as api.apiPost. */
 async function cpPostJson<T>(path: string, body: unknown): Promise<T> {
-  const doPost = (csrf: string) => fetch(path, {
+  const doPost = (csrf: string) => fetch(apiUrl(path), {
     method: 'POST', credentials: 'include',
     headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
     body: JSON.stringify(body ?? {}),
@@ -129,7 +129,7 @@ async function cpPostJson<T>(path: string, body: unknown): Promise<T> {
 
 /** POST multipart (file upload) — browser sets the boundary, so no Content-Type. */
 async function cpUpload<T>(path: string, form: FormData): Promise<T> {
-  const doPost = (csrf: string) => fetch(path, {
+  const doPost = (csrf: string) => fetch(apiUrl(path), {
     method: 'POST', credentials: 'include', headers: { 'X-CSRFToken': csrf }, body: form,
   });
   let res = await doPost(await getCsrf());

--- a/frontend/src/pages/Annotations.tsx
+++ b/frontend/src/pages/Annotations.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'wouter';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronLeft, Download, Upload as UploadIcon, Highlighter } from 'lucide-react';
-import { apiGet } from '../lib/api';
+import { apiGet, apiUrl } from '../lib/api';
 import { useBook } from '../lib/queries';
 import { SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
@@ -49,10 +49,10 @@ export function Annotations({ id }: { id: string }) {
       </div>
 
       <div className={styles.toolbar}>
-        <a className={styles.toolBtn} href={`/annotations/${id}/export.md`}><Download size={14} /> Markdown</a>
-        <a className={styles.toolBtn} href={`/annotations/${id}/export.csv`}><Download size={14} /> CSV</a>
-        <a className={styles.toolBtn} href={`/annotations/${id}/export.json`}><Download size={14} /> JSON</a>
-        <a className={styles.toolBtn} href="/annotations/import"><UploadIcon size={14} /> {t('Import from Kobo')}</a>
+        <a className={styles.toolBtn} href={apiUrl(`/annotations/${id}/export.md`)}><Download size={14} /> Markdown</a>
+        <a className={styles.toolBtn} href={apiUrl(`/annotations/${id}/export.csv`)}><Download size={14} /> CSV</a>
+        <a className={styles.toolBtn} href={apiUrl(`/annotations/${id}/export.json`)}><Download size={14} /> JSON</a>
+        <a className={styles.toolBtn} href={apiUrl('/annotations/import')}><UploadIcon size={14} /> {t('Import from Kobo')}</a>
       </div>
 
       {error ? (

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -10,7 +10,7 @@ import { AddToShelf } from '../components/AddToShelf';
 import { SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import type { BookFormat } from '../lib/api';
-import { ApiError } from '../lib/api';
+import { ApiError, resourceUrl } from '../lib/api';
 import { useT } from '../lib/i18n';
 import styles from './BookDetail.module.css';
 
@@ -137,7 +137,7 @@ export function BookDetail() {
           <div className={styles.coverWrap}>
             {book.cover_url ? (
               <img
-                src={book.cover_url}
+                src={resourceUrl(book.cover_url)}
                 alt={book.title}
                 className={styles.cover}
               />
@@ -244,7 +244,7 @@ export function BookDetail() {
             {book.formats.map((fmt) => (
               <a
                 key={fmt.format}
-                href={fmt.download_url}
+                href={resourceUrl(fmt.download_url)}
                 className={styles.downloadBtn}
                 download
               >

--- a/frontend/src/pages/CoverPicker.tsx
+++ b/frontend/src/pages/CoverPicker.tsx
@@ -15,7 +15,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '../components/Button';
 import { SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
-import { ApiError } from '../lib/api';
+import { ApiError, resourceUrl } from '../lib/api';
 import { useT } from '../lib/i18n';
 import styles from './CoverPicker.module.css';
 
@@ -47,10 +47,11 @@ export function CoverPicker({ id }: { id: string }) {
 
   const back = useBackTarget(id);
 
-  // Current cover, cache-busted after an apply.
+  // Current cover, cache-busted after an apply. resourceUrl() applies the
+  // reverse-proxy mount prefix (both branches are server /cover/… resources).
   const currentCover = useMemo(() => {
-    if (coverBust) return coverBust;
-    return book?.cover_url ?? null;
+    const raw = coverBust ?? book?.cover_url ?? null;
+    return raw ? resourceUrl(raw) : null;
   }, [book?.cover_url, coverBust]);
 
   const onApplied = useCallback((coverUrl?: string) => {

--- a/frontend/src/pages/Duplicates.tsx
+++ b/frontend/src/pages/Duplicates.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'wouter';
 import { Files, X } from 'lucide-react';
 import { useDuplicates, useDismissDuplicate } from '../lib/queries';
+import { resourceUrl } from '../lib/api';
 import { SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import { useT } from '../lib/i18n';
@@ -55,7 +56,7 @@ export function Duplicates() {
                 {g.books.map((b) => (
                   <li key={b.id} className={styles.book}>
                     {b.cover_url
-                      ? <img src={b.cover_url} alt="" className={styles.cover} loading="lazy" />
+                      ? <img src={resourceUrl(b.cover_url)} alt="" className={styles.cover} loading="lazy" />
                       : <div className={styles.coverEmpty} />}
                     <div className={styles.bookInfo}>
                       <Link href={`/book/${b.id}`} className={styles.bookTitle}>{b.title}</Link>

--- a/frontend/src/pages/EditBook.tsx
+++ b/frontend/src/pages/EditBook.tsx
@@ -9,7 +9,7 @@ import { Button } from '../components/Button';
 import { Spinner, SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import type { MetadataUpdate, MetaResult } from '../lib/api';
-import { ApiError } from '../lib/api';
+import { ApiError, resourceUrl } from '../lib/api';
 import { useT } from '../lib/i18n';
 import styles from './EditBook.module.css';
 
@@ -393,7 +393,7 @@ function CoverManager({ id }: { id: string }) {
     <section className={styles.coverSection}>
       <div className={styles.coverPreview}>
         {book?.cover_url
-          ? <img src={book.cover_url} alt={t('Current cover')} className={styles.coverImg} />
+          ? <img src={resourceUrl(book.cover_url)} alt={t('Current cover')} className={styles.coverImg} />
           : <div className={styles.coverPlaceholder}><ImageIcon size={28} /></div>}
       </div>
       <div className={styles.coverControls}>
@@ -464,7 +464,7 @@ function FormatsManager({ id }: { id: string }) {
         {book!.formats.map((f) => (
           <li key={f.format} className={styles.formatItem}>
             <span className={styles.formatName}>{f.format}</span>
-            <a className={styles.formatDownload} href={f.download_url} download>{t('Download')}</a>
+            <a className={styles.formatDownload} href={resourceUrl(f.download_url)} download>{t('Download')}</a>
             {canDelete && (
               <button className={styles.formatDelete}
                 onClick={() => {

--- a/frontend/src/pages/NativeReader.tsx
+++ b/frontend/src/pages/NativeReader.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'wouter';
 import { X, ChevronLeft, ChevronRight } from 'lucide-react';
-import { apiGet } from '../lib/api';
+import { apiGet, apiUrl } from '../lib/api';
 import { SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import { useT } from '../lib/i18n';
@@ -17,7 +17,7 @@ const COMIC = new Set(['cbz', 'cbr', 'cbt']);
 export function NativeReader({ id, format }: { id: string; format: string }) {
   const t = useT();
   const fmt = format.toLowerCase();
-  const src = `/show/${id}/${fmt}`;
+  const src = apiUrl(`/show/${id}/${fmt}`);
   const [text, setText] = useState<string | null>(null);
   const [textErr, setTextErr] = useState(false);
 
@@ -65,7 +65,7 @@ export function NativeReader({ id, format }: { id: string; format: string }) {
           // djvu / other — server reader handles rendering
           <div className={styles.fallback}>
             <p>{t('This format opens in the full-screen reader.')}</p>
-            <a className={styles.fallbackBtn} href={`/read/${id}/${fmt}`}>{t('Open reader')}</a>
+            <a className={styles.fallbackBtn} href={apiUrl(`/read/${id}/${fmt}`)}>{t('Open reader')}</a>
           </div>
         )}
       </div>
@@ -110,7 +110,7 @@ function ComicViewer({ id }: { id: string }) {
     <div className={styles.comic}>
       <button className={styles.comicNav} onClick={() => go(-1)} disabled={page === 0}
         aria-label={t('Previous page')}><ChevronLeft size={28} /></button>
-      <img className={styles.comicPage} src={`/api/v1/books/${id}/comic/${page}`} alt={`Page ${page + 1}`} />
+      <img className={styles.comicPage} src={apiUrl(`/api/v1/books/${id}/comic/${page}`)} alt={`Page ${page + 1}`} />
       <button className={styles.comicNav} onClick={() => go(1)} disabled={page >= pages - 1}
         aria-label={t('Next page')}><ChevronRight size={28} /></button>
       <div className={styles.comicPager}>{page + 1} / {pages}</div>

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'wouter';
+import { BASE_PREFIX } from '../lib/api';
 import { useT } from '../lib/i18n';
 import { EmptyState } from '../components/EmptyState';
 
@@ -7,9 +8,11 @@ import { EmptyState } from '../components/EmptyState';
  *  content area. Also links to the legacy UI in case the path exists there. */
 export function NotFound() {
   const t = useT();
-  // The path after the /app base, so the legacy-UI suggestion points at the
-  // equivalent classic route the user may have been looking for.
-  const legacyPath = window.location.pathname.replace(/^\/app/, '') || '/';
+  // The path after the <prefix>/app base, so the legacy-UI suggestion points at
+  // the equivalent classic route the user may have been looking for. Keep the
+  // reverse-proxy mount prefix so the classic link stays under the same subpath.
+  const afterApp = window.location.pathname.replace(new RegExp(`^${BASE_PREFIX}/app`), '') || '/';
+  const legacyPath = BASE_PREFIX + afterApp;
   return (
     <main style={{ padding: '48px 24px', maxWidth: 560, margin: '0 auto', textAlign: 'center' }}>
       <EmptyState message={t("This page doesn't exist here.")} />

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -11,7 +11,11 @@ export function NotFound() {
   // The path after the <prefix>/app base, so the legacy-UI suggestion points at
   // the equivalent classic route the user may have been looking for. Keep the
   // reverse-proxy mount prefix so the classic link stays under the same subpath.
-  const afterApp = window.location.pathname.replace(new RegExp(`^${BASE_PREFIX}/app`), '') || '/';
+  // Plain string slice (not a RegExp) so a dotted prefix like /app.v2 is matched
+  // literally rather than as a wildcard.
+  const appBase = `${BASE_PREFIX}/app`;
+  const { pathname } = window.location;
+  const afterApp = pathname.startsWith(appBase) ? pathname.slice(appBase.length) || '/' : '/';
   const legacyPath = BASE_PREFIX + afterApp;
   return (
     <main style={{ padding: '48px 24px', maxWidth: 560, margin: '0 auto', textAlign: 'center' }}>

--- a/frontend/src/pages/Reader.tsx
+++ b/frontend/src/pages/Reader.tsx
@@ -5,7 +5,7 @@ import {
   ChevronLeft, ChevronRight, X, List, Type, Sun, Moon, Coffee, Loader2,
 } from 'lucide-react';
 import { useBook, useBookmark, useSaveBookmark } from '../lib/queries';
-import { apiPost } from '../lib/api';
+import { apiPost, apiUrl, resourceUrl } from '../lib/api';
 import { EmptyState } from '../components/EmptyState';
 import { useT } from '../lib/i18n';
 import styles from './Reader.module.css';
@@ -151,7 +151,7 @@ export function Reader({ id }: { id: string }) {
       try {
         // Fetch the .epub ourselves (same-origin cookie auth) and hand epub.js
         // an ArrayBuffer — reliable archive open regardless of the URL extension.
-        const res = await fetch(epubFormat.download_url, { credentials: 'include' });
+        const res = await fetch(resourceUrl(epubFormat.download_url), { credentials: 'include' });
         if (!res.ok) throw new Error(`Could not load the book file (${res.status})`);
         const buf = await res.arrayBuffer();
         if (cancelled) return;
@@ -202,7 +202,7 @@ export function Reader({ id }: { id: string }) {
         });
 
         // Render existing highlights (the CFI-anchored ones we can place).
-        fetch(`/annotations/${id}/data.json`, { credentials: 'include' })
+        fetch(apiUrl(`/annotations/${id}/data.json`), { credentials: 'include' })
           .then((r) => (r.ok ? r.json() : null))
           .then((d) => {
             if (cancelled || !d) return;
@@ -308,7 +308,7 @@ export function Reader({ id }: { id: string }) {
       <div className={styles.fullCenter}>
         <EmptyState message={t('In-browser reading currently supports EPUB. Use download or the classic reader for other formats.')} />
         <div className={styles.fallbackRow}>
-          {other && <a className={styles.exitLink} href={other.read_url}>{t('Open classic reader')}</a>}
+          {other && <a className={styles.exitLink} href={resourceUrl(other.read_url)}>{t('Open classic reader')}</a>}
           <Link href={`/book/${id}`} className={styles.exitLink}>{t('← Back to book')}</Link>
         </div>
       </div>

--- a/frontend/src/pages/Table.tsx
+++ b/frontend/src/pages/Table.tsx
@@ -7,6 +7,7 @@ import { Spinner, SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import { useT } from '../lib/i18n';
 import type { Book } from '../lib/api';
+import { resourceUrl } from '../lib/api';
 import styles from './Table.module.css';
 
 // Column key -> the API sort tokens for ascending / descending.
@@ -117,7 +118,7 @@ export function Table() {
                   <tr key={b.id}>
                     <td className={styles.coverCol}>
                       {b.cover_url
-                        ? <img src={b.cover_url} alt="" className={styles.coverThumb} loading="lazy" />
+                        ? <img src={resourceUrl(b.cover_url)} alt="" className={styles.coverThumb} loading="lazy" />
                         : <div className={styles.coverThumbEmpty} />}
                     </td>
                     {visible.map((c) => (

--- a/tests/unit/test_571_reverse_proxy_prefix.py
+++ b/tests/unit/test_571_reverse_proxy_prefix.py
@@ -147,6 +147,24 @@ def test_app_router_base_uses_prefix():
 
 
 @pytest.mark.unit
+def test_resource_url_is_idempotent():
+    """resourceUrl must not double-prefix a value that already carries the mount
+    prefix (e.g. a Flask url_for path from an apply endpoint) → /cwa/cwa/…."""
+    src = (_FE / "lib" / "api.ts").read_text()
+    assert "u.startsWith(BASE_PREFIX + '/')" in src, "resourceUrl missing double-prefix guard"
+
+
+@pytest.mark.unit
+def test_notfound_prefix_matched_literally():
+    """The NotFound legacy-link must strip the <prefix>/app base with a literal
+    string compare, not an unescaped RegExp (a dotted prefix like /app.v2 would
+    otherwise match loosely)."""
+    src = (_FE / "pages" / "NotFound.tsx").read_text()
+    assert "startsWith(appBase)" in src
+    assert "new RegExp(" not in src
+
+
+@pytest.mark.unit
 def test_resource_urls_prefixed_at_consumption():
     """Covers/downloads served by the backend must be routed through resourceUrl
     so they resolve under the mount prefix."""

--- a/tests/unit/test_571_reverse_proxy_prefix.py
+++ b/tests/unit/test_571_reverse_proxy_prefix.py
@@ -1,0 +1,142 @@
+"""Regression tests for #571 — the new UI was a white page behind a reverse
+proxy with a path prefix (e.g. https://host/cwa/) because the built SPA shell
+hardcodes root-absolute asset URLs (/static/app/…) and the runtime hardcoded
+/api/v1, the wouter router base /app and /cover|/download|/read resource URLs —
+all missing the proxy prefix, so they 404'd.
+
+Server side (this file): the shell is now served through Flask, which rewrites
+the asset URLs to <prefix>/static/app/… and injects window.__CWNG_PREFIX__ from
+request.script_root (the same value url_for uses for the classic UI, set by
+ReverseProxied / ProxyFix upstream). Client side is source-pinned below.
+"""
+import pathlib
+import re
+
+import flask
+import pytest
+
+REALISTIC_INDEX = (
+    '<!doctype html><html lang="en"><head>'
+    '<meta charset="UTF-8" />'
+    '<title>Calibre-Web NextGen</title>'
+    '<script type="module" crossorigin src="/static/app/assets/index-abc.js"></script>'
+    '<link rel="stylesheet" crossorigin href="/static/app/assets/index-def.css">'
+    '</head><body><div id="root"></div></body></html>'
+)
+
+
+def _spa_app(monkeypatch, tmp_path, reverseproxied=False):
+    import cps.spa as spa_mod
+    (tmp_path / "index.html").write_text(REALISTIC_INDEX)
+    monkeypatch.setattr(spa_mod, "_SPA_DIR", str(tmp_path))
+    monkeypatch.setenv("CWNG_SPA", "1")
+    app = flask.Flask(__name__)
+    app.register_blueprint(spa_mod.spa)
+    if reverseproxied:
+        from cps.reverseproxy import ReverseProxied
+        app.wsgi_app = ReverseProxied(app.wsgi_app)
+    return app
+
+
+@pytest.mark.unit
+def test_no_prefix_serves_shell_unchanged_but_injects_empty(monkeypatch, tmp_path):
+    """At the domain root the asset URLs are untouched and the prefix global is
+    injected as "" (authoritative — the SPA shouldn't have to guess)."""
+    app = _spa_app(monkeypatch, tmp_path)
+    resp = app.test_client().get("/app")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert '/static/app/assets/index-abc.js' in body
+    assert 'window.__CWNG_PREFIX__="";' in body
+    assert "/cwa/" not in body
+
+
+@pytest.mark.unit
+def test_prefix_rewrites_assets_and_injects(monkeypatch, tmp_path):
+    """Behind a subpath (script_root=/cwa) every /static/app/ asset URL gains the
+    prefix and window.__CWNG_PREFIX__ is set to it. This is the core #571 fix; on
+    main (raw send_from_directory) the file is served verbatim and this fails."""
+    app = _spa_app(monkeypatch, tmp_path)
+    resp = app.test_client().get("/app", environ_overrides={"SCRIPT_NAME": "/cwa"})
+    body = resp.get_data(as_text=True)
+    assert 'src="/cwa/static/app/assets/index-abc.js"' in body
+    assert 'href="/cwa/static/app/assets/index-def.css"' in body
+    assert 'window.__CWNG_PREFIX__="/cwa";' in body
+    # No leftover un-prefixed asset URL.
+    assert 'src="/static/app/' not in body
+
+
+@pytest.mark.unit
+def test_prefix_via_reverseproxied_header(monkeypatch, tmp_path):
+    """Faithful to production: the real ReverseProxied middleware reads
+    X-Script-Name → SCRIPT_NAME → request.script_root, and the shell picks it up.
+    Mirrors the reporter's nginx sending the prefix as a header."""
+    app = _spa_app(monkeypatch, tmp_path, reverseproxied=True)
+    resp = app.test_client().get("/cwa/app", headers={"X-Script-Name": "/cwa"})
+    body = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert '/cwa/static/app/assets/index-abc.js' in body
+    assert 'window.__CWNG_PREFIX__="/cwa";' in body
+
+
+@pytest.mark.unit
+def test_trailing_slash_prefix_normalized(monkeypatch, tmp_path):
+    """A prefix arriving with a trailing slash (X-Forwarded-Prefix: /cwa/) must
+    not produce //static/app or a doubled slash in the injected value."""
+    app = _spa_app(monkeypatch, tmp_path)
+    resp = app.test_client().get("/app", environ_overrides={"SCRIPT_NAME": "/cwa/"})
+    body = resp.get_data(as_text=True)
+    assert 'window.__CWNG_PREFIX__="/cwa";' in body
+    assert "//static/app" not in body
+    assert '/cwa/static/app/assets/index-abc.js' in body
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", ['/a"><script>evil</script>', "/a b", "/a;b", "/../etc"])
+def test_malicious_prefix_rejected(monkeypatch, tmp_path, bad):
+    """A spoofed/garbage script_root can't break out of the injected <script> or
+    poison the asset rewrite — it's rejected to "" and assets stay root-relative."""
+    app = _spa_app(monkeypatch, tmp_path)
+    resp = app.test_client().get("/app", environ_overrides={"SCRIPT_NAME": bad})
+    body = resp.get_data(as_text=True)
+    assert 'window.__CWNG_PREFIX__="";' in body
+    assert "evil" not in body
+    assert 'src="/static/app/assets/index-abc.js"' in body  # untouched
+
+
+# ---- client-side source pins (guard the runtime prefix wiring) ---------------
+
+_FE = pathlib.Path(__file__).resolve().parents[2] / "frontend" / "src"
+
+
+@pytest.mark.unit
+def test_api_ts_wraps_fetches_with_prefix():
+    """api.ts must derive BASE_PREFIX and prefix every fetch via apiUrl(), else
+    API calls 404 behind a subpath. resourceUrl() must exist for cover/download."""
+    src = (_FE / "lib" / "api.ts").read_text()
+    assert "__CWNG_PREFIX__" in src
+    assert "export const BASE_PREFIX" in src
+    assert "export function apiUrl" in src
+    assert "export function resourceUrl" in src
+    # Every fetch( in api.ts must go through apiUrl(...) — no bare fetch(path.
+    for m in re.finditer(r"fetch\(([^)]*)", src):
+        arg = m.group(1)
+        assert "apiUrl(" in arg, f"un-prefixed fetch in api.ts: fetch({arg}"
+
+
+@pytest.mark.unit
+def test_app_router_base_uses_prefix():
+    src = (_FE / "App.tsx").read_text()
+    assert "BASE_PREFIX + '/app'" in src
+    assert 'base="/app"' not in src  # the old hardcoded base must be gone
+
+
+@pytest.mark.unit
+def test_resource_urls_prefixed_at_consumption():
+    """Covers/downloads served by the backend must be routed through resourceUrl
+    so they resolve under the mount prefix."""
+    bc = (_FE / "components" / "BookCover.tsx").read_text()
+    assert "resourceUrl(coverUrl)" in bc
+    detail = (_FE / "pages" / "BookDetail.tsx").read_text()
+    assert "resourceUrl(book.cover_url)" in detail
+    assert "resourceUrl(fmt.download_url)" in detail

--- a/tests/unit/test_571_reverse_proxy_prefix.py
+++ b/tests/unit/test_571_reverse_proxy_prefix.py
@@ -104,6 +104,21 @@ def test_malicious_prefix_rejected(monkeypatch, tmp_path, bad):
     assert 'src="/static/app/assets/index-abc.js"' in body  # untouched
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize("value,ok", [
+    ("/cwa", True), ("/a/b/c", True), ("/lib_2", True),
+    ("/cwa\n", False),          # trailing newline must not slip past the anchor
+    ("/cwa\n/evil", False), ("//evil.com", False), ("/../etc", False),
+    ("/a b", False), ('/a"x', False), ("", False),
+])
+def test_safe_prefix_regex(value, ok):
+    """Direct check of the prefix allowlist, incl. the \\Z anchor rejecting a
+    trailing newline (defence-in-depth; HTTP headers can't carry raw newlines)."""
+    import cps.spa as spa_mod
+    matched = bool(spa_mod._SAFE_PREFIX_RE.match(value)) and ".." not in value
+    assert matched is ok
+
+
 # ---- client-side source pins (guard the runtime prefix wiring) ---------------
 
 _FE = pathlib.Path(__file__).resolve().parents[2] / "frontend" / "src"


### PR DESCRIPTION
## Problem
Behind a reverse proxy with a path prefix (e.g. `https://host/cwa/`), the new UI was a **blank white page** (#571, reported by @chloeroform). The Vite-built shell hardcodes root-absolute asset URLs (`/static/app/…`), and the runtime hardcoded `/api/v1`, the wouter router base `/app`, and `/cover|/download|/read` resource URLs — all missing the prefix, so they 404'd.

## Fix
**Server** (`cps/spa.py`): the SPA shell is now served through Flask, which rewrites `/static/app/` asset URLs to `<prefix>/static/app/` and injects `window.__CWNG_PREFIX__` from `request.script_root` — the same value `url_for` already uses for the classic UI (set upstream by `ReverseProxied` / `ProxyFix`). The prefix is sanitized (URL-path charset, no `..`) before being reflected into HTML/JS.

**Client** (`api.ts` + friends): derives `BASE_PREFIX` from the injected global (URL-derivation fallback) and exposes `apiUrl()`/`resourceUrl()`; every fetch, the wouter `Router` base, and every cover/download/read URL is prefixed. External (`http`/`data:`) URLs are left untouched.

## Verification
- **Unit** (`tests/unit/test_571_reverse_proxy_prefix.py`): asset rewrite + prefix injection under both `SCRIPT_NAME` and the real `ReverseProxied` header path; malicious-prefix rejected; client-side source pins (every `fetch` wrapped, router base uses prefix, resource URLs routed through `resourceUrl`).
- **Wire**: verified via both `X-Forwarded-Prefix` (ProxyFix) and `X-Script-Name` (ReverseProxied) — shell rewrite + prefixed asset/API all 200.
- **Browser (reporter-faithful)**: behind a real nginx `/cwa` proxy — SPA boots (no white page), library + book detail render, and **every** asset/API/cover/download request carries `/cwa` and returns 200; back-nav works.
- Root-relative (no prefix) case unchanged.

Ships fix for #571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)