### PR TITLE
fix(#574): show the favicon in the new UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ is for things you can see or feel when running the app.
   appears right after you switch back, and won't nag you again.
 
 ### Fixed
+- **The new UI now shows the Calibre-Web favicon in the browser tab.** The
+  redesigned interface had a blank tab icon; it now uses the same favicon as the
+  classic UI (and it works behind a reverse-proxy subpath too). Reported in #574.
 - **The new UI now works behind a reverse proxy with a path prefix.** If you
   serve Calibre-Web NextGen under a subpath (e.g. `https://host/cwa/` via nginx,
   Traefik or similar), the new interface showed a blank white page because its

--- a/cps/spa.py
+++ b/cps/spa.py
@@ -83,9 +83,17 @@ def _render_shell(index_path, prefix):
         html = fh.read()
     if prefix:
         html = html.replace("/static/app/", prefix + "/static/app/")
-    # Always inject the prefix (even "") so the SPA reads an authoritative value
-    # rather than guessing from the URL. json.dumps → safely-quoted JS string.
-    inject = "<script>window.__CWNG_PREFIX__=%s;</script>" % json.dumps(prefix)
+    # Inject, into <head>:
+    #  * the favicon (#574 — the Vite shell ships none, so the new UI had a blank
+    #    tab icon); reuse the app's existing /static/favicon.ico, prefix-aware.
+    #  * the mount prefix (even "") so the SPA reads an authoritative value rather
+    #    than guessing from the URL. json.dumps → safely-quoted JS string.
+    static = prefix + "/static"
+    inject = (
+        '<link rel="icon" href="%s/favicon.ico">'
+        '<link rel="apple-touch-icon" sizes="140x140" href="%s/favicon.ico">'
+        '<script>window.__CWNG_PREFIX__=%s;</script>'
+    ) % (static, static, json.dumps(prefix))
     html = html.replace("</head>", inject + "</head>", 1)
     return Response(html, mimetype="text/html")
 

--- a/tests/unit/test_574_spa_favicon.py
+++ b/tests/unit/test_574_spa_favicon.py
@@ -1,0 +1,51 @@
+"""Regression tests for #574 — the new UI had no favicon (blank browser-tab
+icon) because the Vite-built shell ships no <link rel="icon">. The Flask-served
+shell now injects the app's existing /static/favicon.ico, prefix-aware.
+"""
+import flask
+import pytest
+
+INDEX = (
+    '<!doctype html><html><head><title>Calibre-Web NextGen</title>'
+    '<script type="module" src="/static/app/assets/index-abc.js"></script>'
+    '</head><body><div id="root"></div></body></html>'
+)
+
+
+def _spa_app(monkeypatch, tmp_path):
+    import cps.spa as spa_mod
+    (tmp_path / "index.html").write_text(INDEX)
+    monkeypatch.setattr(spa_mod, "_SPA_DIR", str(tmp_path))
+    monkeypatch.setenv("CWNG_SPA", "1")
+    app = flask.Flask(__name__)
+    app.register_blueprint(spa_mod.spa)
+    return app
+
+
+@pytest.mark.unit
+def test_favicon_injected_at_root(monkeypatch, tmp_path):
+    app = _spa_app(monkeypatch, tmp_path)
+    body = app.test_client().get("/app").get_data(as_text=True)
+    assert '<link rel="icon" href="/static/favicon.ico">' in body
+    assert 'apple-touch-icon' in body
+    assert '/static/favicon.ico' in body
+
+
+@pytest.mark.unit
+def test_favicon_prefixed_behind_proxy(monkeypatch, tmp_path):
+    """The favicon href must carry the reverse-proxy mount prefix too, else it
+    404s behind a subpath (same class of bug as #571)."""
+    app = _spa_app(monkeypatch, tmp_path)
+    body = app.test_client().get(
+        "/app", environ_overrides={"SCRIPT_NAME": "/cwa"}).get_data(as_text=True)
+    assert '<link rel="icon" href="/cwa/static/favicon.ico">' in body
+    assert 'href="/static/favicon.ico"' not in body
+
+
+@pytest.mark.unit
+def test_favicon_file_present_on_disk():
+    """The referenced asset must actually exist (served by Flask's /static)."""
+    import os
+    import cps
+    fav = os.path.join(os.path.dirname(cps.__file__), "static", "favicon.ico")
+    assert os.path.isfile(fav)


### PR DESCRIPTION
The Vite-built SPA shell ships no `<link rel="icon">`, so the new UI had a blank browser-tab icon. The Flask-served shell now injects the app's existing `/static/favicon.ico` (+ apple-touch-icon), prefix-aware so it also works behind a reverse-proxy subpath.

Verified: unit tests (injected at root + prefixed under a subpath + asset present on disk); live (favicon link present at `/app` and `/cwa/app`; `favicon.ico` returns 200 both ways). The browser's root `/favicon.ico` 404 that showed on the new UI is gone.

Ships fix for #574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)