### PR TITLE
fix(#576): mobile nav drawer is solid + scrolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ is for things you can see or feel when running the app.
   appears right after you switch back, and won't nag you again.
 
 ### Fixed
+- **The mobile menu drawer in the new UI is now solid and scrolls properly.** On
+  phones, opening the navigation menu showed a see-through panel that couldn't be
+  scrolled — trying to scroll it moved the page behind instead, so lower items
+  (like Magic Shelves) were unreachable. The drawer now has a solid background and
+  scrolls on its own. Reported in #576.
 - **The new UI now shows the Calibre-Web favicon in the browser tab.** The
   redesigned interface had a blank tab icon; it now uses the same favicon as the
   classic UI (and it works behind a reverse-proxy subpath too). Reported in #574.

--- a/frontend/src/components/Sidebar.module.css
+++ b/frontend/src/components/Sidebar.module.css
@@ -1,5 +1,9 @@
-/* Persistent left rail on desktop; slide-in drawer on mobile. */
-.nav {
+/* Persistent left rail on desktop; slide-in drawer on mobile.
+   These base declarations must cover BOTH the closed (.nav) and open (.navOpen)
+   classes: the open mobile drawer uses .navOpen, and if it lacked the background
+   / overflow it rendered transparent and couldn't scroll (#576). */
+.nav,
+.navOpen {
   background: var(--surface-1);
   border-right: 1px solid var(--border);
   padding: var(--sp-4) var(--sp-3);
@@ -128,6 +132,10 @@
     z-index: var(--z-overlay);
     transition: transform var(--dur-base) var(--ease-out);
     box-shadow: var(--elev-3);
+    /* Keep drawer scrolling self-contained — don't chain to the page behind it
+       when you reach the top/bottom of the menu (#576). */
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
   }
 
   .nav {

--- a/tests/unit/test_576_mobile_sidebar.py
+++ b/tests/unit/test_576_mobile_sidebar.py
@@ -1,0 +1,47 @@
+"""Regression pin for #576 — the mobile navigation drawer was transparent and
+un-scrollable. Root cause: the base .nav rule (background / padding / overflow-y)
+did NOT apply to the open-drawer class .navOpen, so the open mobile drawer had no
+background (see-through) and no overflow-y (couldn't scroll — the page behind
+scrolled instead). Desktop uses .nav (drawer never opens), so it was unaffected.
+
+Fix: the base declarations cover both .nav and .navOpen, and the mobile drawer
+contains its own scroll (overscroll-behavior: contain).
+"""
+import pathlib
+import re
+
+import pytest
+
+CSS = (pathlib.Path(__file__).resolve().parents[2]
+       / "frontend" / "src" / "components" / "Sidebar.module.css").read_text()
+
+
+def _rule_block(css, selector_contains):
+    """Return the declaration block of the first rule whose selector list
+    contains `selector_contains`."""
+    for m in re.finditer(r"([^{}]+)\{([^}]*)\}", css):
+        if selector_contains in m.group(1):
+            return m.group(1), m.group(2)
+    return None, None
+
+
+@pytest.mark.unit
+def test_open_drawer_has_background_and_scroll():
+    """The base block that sets background + overflow-y must list BOTH .nav and
+    .navOpen — the exact regression: an open drawer (.navOpen) with neither."""
+    # Find the base block that declares the background.
+    sel, block = None, None
+    for m in re.finditer(r"([^{}]+)\{([^}]*)\}", CSS):
+        if "background: var(--surface-1)" in m.group(2) and "overflow-y" in m.group(2):
+            sel, block = m.group(1), m.group(2)
+            break
+    assert block is not None, "no base nav block with background+overflow-y found"
+    assert ".nav" in sel and ".navOpen" in sel, (
+        "background/overflow base block must cover both .nav and .navOpen")
+    assert "overflow-y: auto" in block
+
+
+@pytest.mark.unit
+def test_mobile_drawer_contains_its_scroll():
+    """The mobile drawer must not chain its scroll to the page behind it."""
+    assert "overscroll-behavior: contain" in CSS


### PR DESCRIPTION
On phones the open navigation drawer was see-through and couldn't be scrolled (scrolling it moved the page behind), so lower items (Magic Shelves) were unreachable.

**Root cause:** the base declarations (background, padding, overflow-y, border) targeted only `.nav`, but the open mobile drawer uses `.navOpen` — so it had no background and no `overflow-y`. Desktop uses `.nav` (the drawer never opens), which is why desktop was fine.

**Fix:** base declarations now cover both `.nav` and `.navOpen`; the mobile drawer also sets `overscroll-behavior: contain` so its scroll doesn't chain to the page.

Verified: source pin + live mobile (390px) Playwright — computed `background-color: rgb(27,37,48)` (opaque), `overflow-y: auto`, scrolls internally (`scrollTop` 0→373), no content bleed-through. Ships fix for #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)