### PR TITLE
fix(#578): keep library scroll position + loaded pages on Back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ is for things you can see or feel when running the app.
   appears right after you switch back, and won't nag you again.
 
 ### Fixed
+- **The new UI now keeps your place in the library when you go back from a book.**
+  Scrolling down, opening a book, then pressing Back used to jump you to the top
+  of the library (losing loaded pages) — annoying when opening several books in a
+  row. It now restores your scroll position and the books you'd already loaded.
+  Reported in #578.
 - **The mobile menu drawer in the new UI is now solid and scrolls properly.** On
   phones, opening the navigation menu showed a see-through panel that couldn't be
   scrolled — trying to scroll it moved the page behind instead, so lower items

--- a/frontend/src/lib/scrollCache.ts
+++ b/frontend/src/lib/scrollCache.ts
@@ -1,0 +1,46 @@
+/* In-memory catalog scroll/state cache.
+ *
+ * The library/browse grid is an accumulating "Load more" list scrolled on the
+ * window. When you open a book and press Back, wouter remounts the catalog fresh
+ * — losing the loaded pages and the scroll position (#578). Browsers can't
+ * restore scroll here because the content is fetched client-side and isn't in the
+ * DOM at restore time.
+ *
+ * So we stash the catalog's render-relevant state (loaded pages + filters +
+ * scrollY) in a module-level Map keyed by route, and rehydrate it on remount.
+ * It's in-memory (not sessionStorage): it survives client-side back/forward
+ * within the SPA session — the exact case that broke — without serialization
+ * cost or storage limits, and is intentionally dropped on a full page reload
+ * (where a top-of-page start is expected). Bounded so a long session can't grow
+ * it without limit.
+ */
+import type { Book } from './api';
+
+export interface CatalogSnapshot {
+  resetKey: string;      // filter/sort signature the pages were loaded under
+  page: number;          // highest page loaded
+  books: Book[];         // the accumulated grid
+  scrollY: number;       // window scroll offset when the user left
+  search: string;
+  searchInput: string;
+  sort: string;
+  readFilter: string;
+}
+
+const _cache = new Map<string, CatalogSnapshot>();
+const _MAX = 12;         // keep the dozen most-recent catalog views
+
+export function saveCatalog(key: string, snap: CatalogSnapshot): void {
+  // Refresh recency (Map preserves insertion order → re-insert to move to end).
+  _cache.delete(key);
+  _cache.set(key, snap);
+  while (_cache.size > _MAX) {
+    const oldest = _cache.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    _cache.delete(oldest);
+  }
+}
+
+export function loadCatalog(key: string): CatalogSnapshot | undefined {
+  return _cache.get(key);
+}

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -10,6 +10,7 @@ import { DiscoverSection } from '../components/DiscoverSection';
 import { useBooks, useEntityList, ENTITY_PLURAL } from '../lib/queries';
 import type { EntityKind, ReadFilter, DiscoveryView } from '../lib/queries';
 import type { Book } from '../lib/api';
+import { saveCatalog, loadCatalog } from '../lib/scrollCache';
 import { usePersistentBool } from '../lib/usePersistentBool';
 import { useT } from '../lib/i18n';
 import styles from './Catalog.module.css';
@@ -71,12 +72,21 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
   // hidden for both entity-scoped and discovery views.
   const hideLibraryControls = filtered || isView;
 
-  const [page, setPage] = useState(1);
-  const [allBooks, setAllBooks] = useState<Book[]>([]);
-  const [searchInput, setSearchInput] = useState('');
-  const [search, setSearch] = useState('');
-  const [sort, setSort] = useState('new');
-  const [readFilter, setReadFilter] = useState<ReadFilter>('all');
+  // Scroll/state restoration (#578): identity of THIS catalog instance (library
+  // vs a specific entity vs a discovery view) — stable across a book → Back trip.
+  const restoreKey = `catalog:${entityKind ?? ''}:${entityId ?? ''}:${view ?? ''}`;
+  const snapRef = useRef(loadCatalog(restoreKey));
+  const snap = snapRef.current;
+  // True only for this first restored mount — used to stop the reset/urlQ effects
+  // from clobbering the rehydrated page/filters before the user does anything.
+  const restoringRef = useRef(!!snap);
+
+  const [page, setPage] = useState(() => snap?.page ?? 1);
+  const [allBooks, setAllBooks] = useState<Book[]>(() => snap?.books ?? []);
+  const [searchInput, setSearchInput] = useState(() => snap?.searchInput ?? '');
+  const [search, setSearch] = useState(() => snap?.search ?? '');
+  const [sort, setSort] = useState(() => snap?.sort ?? 'new');
+  const [readFilter, setReadFilter] = useState<ReadFilter>(() => (snap?.readFilter as ReadFilter) ?? 'all');
 
   // Multi-select / bulk mode
   const [selecting, setSelecting] = useState(false);
@@ -87,7 +97,7 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const settingsRef = useRef<HTMLDivElement>(null);
 
-  const accKeyRef = useRef<string>('');
+  const accKeyRef = useRef<string>(snap?.resetKey ?? '');
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Resolve the entity's display name (for the heading) from its browse list —
@@ -103,6 +113,9 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
   const urlQ = new URLSearchParams(rawSearch).get('q') || '';
   useEffect(() => {
     if (filtered || isView) return;
+    // On the first restored mount, keep the rehydrated search rather than letting
+    // the (empty) URL query clobber it (#578).
+    if (restoringRef.current) return;
     setSearchInput(urlQ);
     setSearch(urlQ);
   }, [urlQ, filtered, isView]);
@@ -134,10 +147,44 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
 
   const resetKey = [search, sort, readFilter, entityKind ?? '', entityId ?? '', view ?? ''].join('|');
 
-  // Any filter change resets paging to the first page.
+  // Any filter change resets paging to the first page — except on the first
+  // restored mount, where the rehydrated page must survive (#578).
   useEffect(() => {
+    if (restoringRef.current) return;
     setPage(1);
   }, [resetKey]);
+
+  // Clear the restoring flag after the initial mount so later filter/URL changes
+  // behave normally. Runs after the two guarded effects above (effect order).
+  useEffect(() => {
+    restoringRef.current = false;
+  }, []);
+
+  // Persist this catalog's state on unmount (e.g. navigating into a book) so a
+  // later Back rehydrates the loaded pages, filters and scroll position (#578).
+  const persistRef = useRef({ page, books: allBooks, resetKey: accKeyRef.current, search, searchInput, sort, readFilter });
+  persistRef.current = { page, books: allBooks, resetKey: accKeyRef.current, search, searchInput, sort, readFilter };
+  useEffect(() => {
+    return () => {
+      const s = persistRef.current;
+      saveCatalog(restoreKey, { ...s, scrollY: window.scrollY });
+    };
+  }, [restoreKey]);
+
+  // Restore the saved scroll position on the first mount, once the rehydrated
+  // grid has painted (its height comes from the restored books, so the offset is
+  // reachable). Retry briefly to cover late layout (fonts/cover boxes).
+  useEffect(() => {
+    const y = snap?.scrollY ?? 0;
+    if (!y) return;
+    let tries = 0;
+    const tick = () => {
+      window.scrollTo(0, y);
+      if (++tries < 6 && Math.abs(window.scrollY - y) > 2) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { data, isLoading, isFetching, isPlaceholderData, error } = useBooks({
     page,

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -75,7 +75,15 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
   // Scroll/state restoration (#578): identity of THIS catalog instance (library
   // vs a specific entity vs a discovery view) — stable across a book → Back trip.
   const restoreKey = `catalog:${entityKind ?? ''}:${entityId ?? ''}:${view ?? ''}`;
-  const snapRef = useRef(loadCatalog(restoreKey));
+  // Only restore a snapshot when it's consistent with the current URL query. A
+  // fresh top-bar search navigates to /?q=… on the SAME library route; a stale
+  // snapshot must not be rehydrated there or it would ignore the new search
+  // (Greptile #593). Entity/discovery views carry no ?q, so any snapshot applies.
+  const urlQAtMount = new URLSearchParams(
+    typeof window !== 'undefined' ? window.location.search : '').get('q') || '';
+  const rawSnap = loadCatalog(restoreKey);
+  const snapRef = useRef(
+    (filtered || isView || (rawSnap?.search ?? '') === urlQAtMount) ? rawSnap : undefined);
   const snap = snapRef.current;
   // True only for this first restored mount — used to stop the reset/urlQ effects
   // from clobbering the rehydrated page/filters before the user does anything.

--- a/tests/unit/test_578_scroll_restore.py
+++ b/tests/unit/test_578_scroll_restore.py
@@ -29,6 +29,9 @@ def test_catalog_restores_and_persists():
     assert "window.scrollTo(0, y)" in src
     # The rehydrated page/filters must survive the mount reset + urlQ effects.
     assert "restoringRef" in src
+    # A snapshot is only restored when consistent with the URL query, so a fresh
+    # top-bar search (/?q=…) isn't ignored in favour of a stale snapshot.
+    assert "urlQAtMount" in src
 
 
 @pytest.mark.unit

--- a/tests/unit/test_578_scroll_restore.py
+++ b/tests/unit/test_578_scroll_restore.py
@@ -1,0 +1,40 @@
+"""Source pins for #578 — the new UI didn't keep the library scroll position when
+going Back from a book. The Catalog now stashes its loaded pages + filters +
+scrollY in an in-memory cache (lib/scrollCache) keyed by route and rehydrates
+them on remount, restoring the scroll offset. Behavioural coverage is the live
+Playwright scroll test; these guard the wiring from silent removal.
+"""
+import pathlib
+
+import pytest
+
+_FE = pathlib.Path(__file__).resolve().parents[2] / "frontend" / "src"
+
+
+@pytest.mark.unit
+def test_scroll_cache_module_present():
+    src = (_FE / "lib" / "scrollCache.ts").read_text()
+    assert "export function saveCatalog" in src
+    assert "export function loadCatalog" in src
+    assert "scrollY" in src
+
+
+@pytest.mark.unit
+def test_catalog_restores_and_persists():
+    src = (_FE / "pages" / "Catalog.tsx").read_text()
+    assert "loadCatalog(restoreKey)" in src
+    assert "saveCatalog(restoreKey" in src
+    # scrollY is captured on unmount and re-applied on mount.
+    assert "window.scrollY" in src
+    assert "window.scrollTo(0, y)" in src
+    # The rehydrated page/filters must survive the mount reset + urlQ effects.
+    assert "restoringRef" in src
+
+
+@pytest.mark.unit
+def test_catalog_state_seeded_from_snapshot():
+    """State initializers read from the snapshot so the grid renders at full
+    height on first paint (making the saved scroll offset reachable)."""
+    src = (_FE / "pages" / "Catalog.tsx").read_text()
+    assert "snap?.page ?? 1" in src
+    assert "snap?.books ?? []" in src


### PR DESCRIPTION
Scrolling the library, opening a book, then pressing Back jumped to the top and lost the accumulated "Load more" pages — the catalog remounts fresh and browsers can't restore scroll for client-fetched content.

**Fix:** the catalog stashes its render state (loaded pages, filters, scrollY) in an in-memory, route-keyed cache (`lib/scrollCache`) and rehydrates it on remount — state initializers seed the grid so it paints at full height, the mount reset/urlQ effects are skipped on the restored mount, and the saved offset is re-applied (short retry for late layout). In-memory (survives SPA back/forward, dropped on full reload), bounded to 12 views.

Verified: source pins + live Playwright at 520×640 — scroll to Y=600, open book, Back → `window.scrollY` restored to 600 (0px diff), same 17 books/order intact.

Ships fix for #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)