### PR TITLE
fix(#582): identifiers are clickable links in the new UI book page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ is for things you can see or feel when running the app.
   appears right after you switch back, and won't nag you again.
 
 ### Fixed
+- **Book identifiers are clickable links again in the new UI.** On a book's page,
+  identifiers like Goodreads, StoryGraph, Hardcover, Amazon and ISBN now link out
+  to the book on that site (as they did in the classic UI) instead of showing as
+  plain text. Reported by @alva-seal (#582).
 - **The new UI now keeps your place in the library when you go back from a book.**
   Scrolling down, opening a book, then pressing Back used to jump you to the top
   of the library (losing loaded pages) — annoying when opening several books in a

--- a/cps/api/serializers.py
+++ b/cps/api/serializers.py
@@ -99,11 +99,21 @@ def serialize_book_detail(book, read=False, archived=False, favorited=False, hid
     # Publishers — {id, name} for linking
     publishers = [{"id": p.id, "name": p.name} for p in (getattr(book, "publishers", None) or [])]
 
-    # Identifiers
-    identifiers = [
-        {"type": i.type, "val": i.val}
-        for i in (getattr(book, "identifiers", None) or [])
-    ]
+    # Identifiers — expose a clickable link (Goodreads, StoryGraph, Hardcover,
+    # Amazon, ISBN…) and a display label, mirroring the classic detail page (#582).
+    # The link is the model's own URL rule (Identifiers.__repr__), but only emitted
+    # when it's a real http(s) URL — never a javascript:/data:/raw-value repr — so
+    # a crafted identifier can't inject a dangerous href. Non-linkable IDs stay as
+    # plain text (url=None).
+    identifiers = []
+    for i in (getattr(book, "identifiers", None) or []):
+        try:
+            link = repr(i)
+        except Exception:
+            link = None
+        url = link if (link and (link.startswith("http://") or link.startswith("https://"))) else None
+        label = i.format_type() if hasattr(i, "format_type") else i.type
+        identifiers.append({"type": i.type, "val": i.val, "url": url, "label": label})
 
     # Formats
     formats = []

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -90,7 +90,7 @@ export interface BookDetail {
   tags: EntityRef[];
   languages: EntityRef[];
   publishers: EntityRef[];
-  identifiers: { type: string; val: string }[];
+  identifiers: { type: string; val: string; url: string | null; label: string }[];
   formats: BookFormat[];
   read: boolean;
   archived: boolean;

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, Fragment } from 'react';
 import { Link, useParams } from 'wouter';
 import { Download, Pencil, Star, Archive, EyeOff, Eye, Send, Highlighter, Image as ImageIcon } from 'lucide-react';
 import {
@@ -346,11 +346,15 @@ export function BookDetail() {
                 </dd>
               </>
             )}
-            {book.identifiers.map((id) => (
-              <>
-                <dt key={`dt-${id.type}`} className={styles.metaLabel}>{id.type.toUpperCase()}</dt>
-                <dd key={`dd-${id.type}`} className={styles.metaValue}>{id.val}</dd>
-              </>
+            {book.identifiers.map((id, i) => (
+              <Fragment key={`id-${i}`}>
+                <dt className={styles.metaLabel}>{id.label || id.type.toUpperCase()}</dt>
+                <dd className={styles.metaValue}>
+                  {id.url
+                    ? <a href={id.url} target="_blank" rel="noopener noreferrer" className={styles.metaLink}>{id.val}</a>
+                    : id.val}
+                </dd>
+              </Fragment>
             ))}
           </dl>
 

--- a/tests/unit/test_582_identifier_links.py
+++ b/tests/unit/test_582_identifier_links.py
@@ -1,0 +1,67 @@
+"""Regression tests for #582 — identifiers (Goodreads, StoryGraph, Hardcover,
+Amazon, ISBN…) render as plain text in the new UI's book detail; they used to be
+clickable links in the classic UI. serialize_book_detail now emits a safe http(s)
+link + a display label per identifier so the SPA can render an anchor.
+"""
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+
+from cps.db import Identifiers
+from cps.api.serializers import serialize_book_detail
+
+
+def _book(identifiers):
+    # Minimal stub: serialize_book_detail reads most attrs via getattr(..., None);
+    # only id/title/series_index are direct. has_cover=0 → cover_url None.
+    return SimpleNamespace(id=1, title="T", series_index="1", has_cover=0,
+                           identifiers=identifiers)
+
+
+@pytest.mark.unit
+def test_known_providers_get_links_and_labels():
+    ids = [
+        Identifiers("12345", "goodreads", 1),
+        Identifiers("B00XYZ", "amazon", 1),
+        Identifiers("9780306406157", "isbn", 1),
+        Identifiers("some-slug", "storygraph", 1),
+    ]
+    out = {d["type"]: d for d in serialize_book_detail(_book(ids))["identifiers"]}
+    assert out["goodreads"]["url"] == "https://www.goodreads.com/book/show/12345"
+    assert out["goodreads"]["label"] == "Goodreads"
+    assert out["amazon"]["url"] == "https://amazon.com/dp/B00XYZ"
+    assert out["isbn"]["url"] == "https://www.worldcat.org/isbn/9780306406157"
+    assert out["storygraph"]["url"] == "https://app.thestorygraph.com/books/some-slug"
+    assert out["storygraph"]["label"] == "StoryGraph"
+
+
+@pytest.mark.unit
+def test_unknown_identifier_has_no_link():
+    """An identifier type with no URL rule stays plain text (url None)."""
+    ids = [Identifiers("xyz", "customthing", 1)]
+    out = serialize_book_detail(_book(ids))["identifiers"][0]
+    assert out["url"] is None
+    assert out["val"] == "xyz"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", ["javascript:alert(1)", "data:text/html,<script>x</script>"])
+def test_dangerous_scheme_identifier_never_linked(bad):
+    """A crafted javascript:/data: identifier must NOT become a clickable href —
+    only real http(s) URLs are emitted (stricter than the classic template)."""
+    ids = [Identifiers(bad, "evil", 1)]
+    out = serialize_book_detail(_book(ids))["identifiers"][0]
+    assert out["url"] is None
+    assert out["val"] == bad
+
+
+@pytest.mark.unit
+def test_book_detail_renders_identifier_link():
+    """The SPA book detail must render a linkable identifier as an anchor with a
+    safe target/rel, and fall back to plain text otherwise."""
+    src = (pathlib.Path(__file__).resolve().parents[2]
+           / "frontend" / "src" / "pages" / "BookDetail.tsx").read_text()
+    assert "id.url" in src
+    assert 'rel="noopener noreferrer"' in src
+    assert "href={id.url}" in src

--- a/tests/unit/test_api_v1_detail.py
+++ b/tests/unit/test_api_v1_detail.py
@@ -8,6 +8,7 @@ import pytest
 import flask
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
+from cps.db import Identifiers
 
 
 # ---------------------------------------------------------------------------
@@ -28,7 +29,7 @@ def _make_book(**kwargs):
         tags=[SimpleNamespace(id=11, name="sci-fi")],
         languages=[SimpleNamespace(lang_code="eng", language_name="English")],
         publishers=[SimpleNamespace(id=5, name="Chilton Books")],
-        identifiers=[SimpleNamespace(type="isbn", val="9780441013593")],
+        identifiers=[Identifiers("9780441013593", "isbn", 1)],
         pubdate=datetime.datetime(1965, 8, 1),
     )
     defaults.update(kwargs)
@@ -56,7 +57,10 @@ def test_serialize_book_detail_full():
     assert out["tags"] == [{"id": 11, "name": "sci-fi"}]
     assert out["languages"] == [{"id": "eng", "name": "English"}]
     assert out["publishers"] == [{"id": 5, "name": "Chilton Books"}]
-    assert out["identifiers"] == [{"type": "isbn", "val": "9780441013593"}]
+    assert out["identifiers"] == [{
+        "type": "isbn", "val": "9780441013593",
+        "url": "https://www.worldcat.org/isbn/9780441013593", "label": "ISBN",
+    }]
     assert len(out["formats"]) == 1
     fmt = out["formats"][0]
     assert fmt["format"] == "EPUB"


### PR DESCRIPTION
The detail API sent each identifier's type + value but no link, so the new UI showed them as plain text (the classic UI linked them). `serialize_book_detail` now emits a display label (Goodreads, StoryGraph, …) and a URL from the model's own rule (`Identifiers.__repr__`) — **only** when it's a real `http(s)` URL (never `javascript:`/`data:`/raw repr), so a crafted identifier can't inject a dangerous href. `BookDetail` renders a linkable identifier as `<a target=_blank rel=noopener>`, plain text otherwise.

Verified: unit tests (known providers get links+labels; unknown → plain text; `javascript:`/`data:` never linked) and live on the wire — `GET /api/v1/books/7` returns goodreads/amazon/storygraph with correct https URLs + labels.

Reported by @alva-seal. Ships fix for #582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)