### PR TITLE
fix(#577): correct Dutch labels on the new-UI book buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ is for things you can see or feel when running the app.
   appears right after you switch back, and won't nag you again.
 
 ### Fixed
+- **Dutch: the new UI's book buttons read correctly.** The button that opens the
+  reader said "Gelezen" ("has been read") instead of a "read now" verb, and the
+  already-read marker showed the English word "Read". The reader button now says
+  "Nu lezen" and the marker shows "Gelezen ✓". (Under the hood the reader action
+  and the read-status label are now separate strings, so this collision can't
+  recur in other languages either.) Reported in #577.
 - **Book identifiers are clickable links again in the new UI.** On a book's page,
   identifiers like Goodreads, StoryGraph, Hardcover, Amazon and ISBN now link out
   to the book on that site (as they did in the classic UI) instead of showing as

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -6600,6 +6600,11 @@ msgstr ""
 msgid "Read"
 msgstr "Gelezen"
 
+#. New-UI "open the reader" button — distinct from the "Read" read-status label
+#. above (which is "Gelezen"/past tense). This one is the verb "to read".
+msgid "Read now"
+msgstr "Nu lezen"
+
 #: cps/templates/detail.html:692 cps/templates/detail.html:693
 #: cps/templates/detail.html:1069 cps/templates/listenmp3.html:158
 msgid "Mark As Unread"

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -184,13 +184,13 @@ export function BookDetail() {
             {hasEpub ? (
               // EPUB opens in the in-browser SPA reader (resumes saved progress).
               <Link href={`/read/${book.id}`} className={styles.actionPrimary}>
-                {t('Read')}
+                {t('Read now')}
               </Link>
             ) : primaryReadable ? (
               // PDF/audio/text open in the native multi-format reader; comics/
               // DjVu fall through there to the server reader for image extraction.
               <Link href={`/view/${book.id}/${primaryReadable.format.toLowerCase()}`} className={styles.actionPrimary}>
-                {t('Read')}
+                {t('Read now')}
               </Link>
             ) : null}
 
@@ -200,7 +200,7 @@ export function BookDetail() {
               disabled={toggleRead.isPending}
               aria-label={book.read ? t('Mark as unread') : t('Mark as read')}
             >
-              {book.read ? t('Read ✓') : t('Mark as read')}
+              {book.read ? `${t('Read')} ✓` : t('Mark as read')}
             </button>
 
             <AddToShelf bookId={book.id} />

--- a/messages.pot
+++ b/messages.pot
@@ -6302,6 +6302,11 @@ msgstr ""
 msgid "Read"
 msgstr ""
 
+#. New-UI "open the reader" button — the verb "to read", distinct from the
+#. "Read" read-status label above (a past participle in many languages).
+msgid "Read now"
+msgstr ""
+
 #: cps/templates/detail.html:692 cps/templates/detail.html:693
 #: cps/templates/detail.html:1069 cps/templates/listenmp3.html:158
 msgid "Mark As Unread"

--- a/tests/unit/test_577_dutch_read_label.py
+++ b/tests/unit/test_577_dutch_read_label.py
@@ -1,0 +1,38 @@
+"""Regression tests for #577 — in Dutch the new-UI "open the reader" button read
+"Gelezen" (past participle, "has been read") because it reused the msgid "Read",
+whose nl translation is the read-*status* label "Gelezen" (correct there). The
+button now uses a distinct msgid "Read now" ("Nu lezen"), and the already-read
+toggle reuses "Read" (the correct status word) + a separate ✓ instead of the
+untranslated "Read ✓".
+"""
+import pathlib
+
+import pytest
+
+_FE = pathlib.Path(__file__).resolve().parents[2] / "frontend" / "src"
+
+
+@pytest.mark.unit
+def test_nl_catalog_disambiguates_read_verb_from_status():
+    from cps.api.i18n import _load_catalog
+    cat = _load_catalog("nl")
+    # The reader-open verb and the read-status label are now different strings.
+    assert cat.get("Read now") == "Nu lezen"
+    assert cat.get("Read") == "Gelezen"
+
+
+@pytest.mark.unit
+def test_bookdetail_uses_disambiguated_msgids():
+    src = (_FE / "pages" / "BookDetail.tsx").read_text()
+    assert "t('Read now')" in src, "reader-open button must use the 'Read now' msgid"
+    # The old ambiguous/untranslated forms are gone.
+    assert "t('Read ✓')" not in src
+    # The already-read state reuses the status word 'Read' (→ Gelezen) + a ✓.
+    assert "`${t('Read')} ✓`" in src
+
+
+@pytest.mark.unit
+def test_read_now_in_pot_template():
+    """The new msgid is tracked in the POT so msgmerge propagates it to locales."""
+    pot = (pathlib.Path(__file__).resolve().parents[2] / "messages.pot").read_text()
+    assert 'msgid "Read now"' in pot


### PR DESCRIPTION
In Dutch, the new UI's reader-open button showed **"Gelezen"** ("has been read") instead of a *read-now* verb, and the already-read marker showed the English word **"Read"**.

**Root cause:** the reader-open button reused the msgid `Read`, whose nl translation is the read-**status** label "Gelezen" — which is *correct* for the status badge in the classic UI, so re-translating `Read` isn't the fix. Instead the button now uses a distinct msgid `Read now` (nl "Nu lezen", added to the POT + nl catalog), and the already-read marker reuses `Read` (correct status word → "Gelezen") + a separate ✓. This also fixes the identical collision in every other language.

Verified: unit tests (nl catalog serves `Read now`→"Nu lezen" and `Read`→"Gelezen"; BookDetail uses the disambiguated msgids), `nl.po` passes `msgfmt -c`, TS build clean.

Reported in #577. Ships fix for #577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)