### PR TITLE
fix(#587): show KOReader/Kobo reading progress on the new-UI book page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ is for things you can see or feel when running the app.
   appears right after you switch back, and won't nag you again.
 
 ### Fixed
+- **The new UI's book page now shows your KOReader/Kobo reading progress.** If
+  you sync progress from KOReader or a Kobo, the book page again shows "KOReader
+  progress: X%" (it was only on the classic page before — the synced progress was
+  never lost). Reported by @alva-seal (#587).
 - **Dutch: the new UI's book buttons read correctly.** The button that opens the
   reader said "Gelezen" ("has been read") instead of a "read now" verb, and the
   already-read marker showed the English word "Read". The reader button now says

--- a/cps/api/books.py
+++ b/cps/api/books.py
@@ -267,6 +267,7 @@ def book_detail(book_id):
     # Per-user favorite + hidden state (presence-based rows). Anonymous/guest
     # sessions have no real id, so they simply read back as not-favorited/hidden.
     favorited = hidden = False
+    kosync_progress = None
     if current_user.is_authenticated and not current_user.is_anonymous:
         uid = int(current_user.id)
         favorited = (ub.session.query(ub.FavoriteBook)
@@ -275,19 +276,33 @@ def book_detail(book_id):
         hidden = (ub.session.query(ub.UserHiddenBook)
                   .filter(ub.UserHiddenBook.user_id == uid, ub.UserHiddenBook.book_id == book_id)
                   .first() is not None)
+        # KOReader/Kobo synced reading progress (#587) — surfaced on the new-UI
+        # book page like the classic detail view. Same source as web.show_book:
+        # KoboReadingState.current_bookmark.progress_percent (None when unsynced).
+        try:
+            kobo_state = (ub.session.query(ub.KoboReadingState)
+                          .filter(ub.KoboReadingState.user_id == uid,
+                                  ub.KoboReadingState.book_id == book_id)
+                          .first())
+            if kobo_state and kobo_state.current_bookmark:
+                kosync_progress = kobo_state.current_bookmark.progress_percent
+        except Exception:
+            log.debug("Failed to load KOReader progress for book %s", book_id, exc_info=True)
 
     # With a custom read column, get_book_read_archived returns the column's value
     # (truthy = read); otherwise the built-in ub.ReadBook.read_status. Match the
     # list badge's logic (fork #579) so both surfaces agree.
     read = bool(read_status) if config.config_read_column \
         else read_status == ub.ReadBook.STATUS_FINISHED
-    return jsonify(serialize_book_detail(
+    body = serialize_book_detail(
         book,
         read=read,
         archived=bool(is_archived),
         favorited=favorited,
         hidden=hidden,
-    ))
+    )
+    body["kosync_progress"] = kosync_progress
+    return jsonify(body)
 
 
 @api_v1.route("/books/<int:book_id>/read", methods=["POST"])

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -96,6 +96,9 @@ export interface BookDetail {
   archived: boolean;
   favorited: boolean;
   hidden: boolean;
+  /** KOReader/Kobo synced reading progress as a percentage (0–100), or null when
+   *  not synced. */
+  kosync_progress: number | null;
 }
 
 export interface BooksPage {

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -314,6 +314,12 @@ export function BookDetail() {
 
           {/* Metadata definition list */}
           <dl className={styles.meta}>
+            {book.kosync_progress != null && (
+              <>
+                <dt className={styles.metaLabel}>{t('KOReader progress')}</dt>
+                <dd className={styles.metaValue}>{book.kosync_progress.toFixed(1)}%</dd>
+              </>
+            )}
             {book.pubdate && (
               <>
                 <dt className={styles.metaLabel}>{t('Published')}</dt>

--- a/tests/unit/test_587_koreader_progress.py
+++ b/tests/unit/test_587_koreader_progress.py
@@ -1,0 +1,93 @@
+"""Regression tests for #587 — the new-UI book page didn't show the KOReader/Kobo
+synced reading progress (the classic page shows "KOReader Progress: X%"). The
+detail endpoint now surfaces it and the SPA book page renders it.
+
+The endpoint reads the same source as the classic view
+(KoboReadingState.current_bookmark.progress_percent); these pins fail on main
+(which has neither the query nor the field) and the behaviour is additionally
+verified live on the wire. A behavioural endpoint test with a real progress row
+follows.
+"""
+import inspect
+import pathlib
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import flask
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.unit
+def test_detail_endpoint_surfaces_kosync_progress():
+    """An authenticated user with a synced KoboReadingState gets kosync_progress
+    in the detail payload; the favorite/hidden lookups still read as absent."""
+    from cps.api import books as books_mod
+    from cps import ub
+
+    fake_book = SimpleNamespace(
+        id=7, title="The Time Machine", series_index="1.0", has_cover=1,
+        authors=[], series=[], data=[], comments=[], tags=[],
+        languages=[], publishers=[], identifiers=[], pubdate=None,
+    )
+
+    def query_side_effect(model):
+        q = MagicMock()
+        if model is ub.KoboReadingState:
+            q.filter.return_value.first.return_value = SimpleNamespace(
+                current_bookmark=SimpleNamespace(progress_percent=45.0))
+        else:  # FavoriteBook / UserHiddenBook — not present
+            q.filter.return_value.first.return_value = None
+        return q
+
+    app = flask.Flask(__name__)
+    with app.test_request_context("/api/v1/books/7"):
+        with patch.object(books_mod.calibre_db, "get_book_read_archived",
+                          return_value=(fake_book, 0, False)), \
+             patch.object(books_mod.config, "config_read_column", 0, create=True), \
+             patch.object(books_mod, "current_user",
+                          SimpleNamespace(is_authenticated=True, is_anonymous=False, id=1)), \
+             patch.object(books_mod.ub, "session", MagicMock(query=MagicMock(side_effect=query_side_effect))), \
+             patch("cps.api.books.get_locale", return_value="en"), \
+             patch("cps.api.books.isoLanguages.get_language_name", return_value="English"):
+            import json
+            resp = inspect.unwrap(books_mod.book_detail)(7)
+    data = json.loads(resp.get_data(as_text=True))
+    assert data["kosync_progress"] == 45.0
+
+
+@pytest.mark.unit
+def test_detail_endpoint_null_progress_when_unsynced():
+    from cps.api import books as books_mod
+    from cps import ub
+
+    fake_book = SimpleNamespace(
+        id=7, title="T", series_index="1.0", has_cover=0,
+        authors=[], series=[], data=[], comments=[], tags=[],
+        languages=[], publishers=[], identifiers=[], pubdate=None,
+    )
+    app = flask.Flask(__name__)
+    with app.test_request_context("/api/v1/books/7"):
+        with patch.object(books_mod.calibre_db, "get_book_read_archived",
+                          return_value=(fake_book, 0, False)), \
+             patch.object(books_mod.config, "config_read_column", 0, create=True), \
+             patch.object(books_mod, "current_user",
+                          SimpleNamespace(is_authenticated=True, is_anonymous=False, id=1)), \
+             patch.object(books_mod.ub, "session",
+                          MagicMock(query=MagicMock(return_value=MagicMock(
+                              filter=MagicMock(return_value=MagicMock(
+                                  first=MagicMock(return_value=None))))))), \
+             patch("cps.api.books.get_locale", return_value="en"), \
+             patch("cps.api.books.isoLanguages.get_language_name", return_value="English"):
+            import json
+            resp = inspect.unwrap(books_mod.book_detail)(7)
+    data = json.loads(resp.get_data(as_text=True))
+    assert data["kosync_progress"] is None
+
+
+@pytest.mark.unit
+def test_bookdetail_renders_progress():
+    src = (_ROOT / "frontend" / "src" / "pages" / "BookDetail.tsx").read_text()
+    assert "book.kosync_progress != null" in src
+    assert "KOReader progress" in src


### PR DESCRIPTION
The classic book page shows "KOReader Progress: X%" but the new UI's book page didn't — the synced progress was never lost, just not displayed. The detail endpoint now returns `kosync_progress` from the same source as the classic view (`KoboReadingState.current_bookmark.progress_percent`, per-user, null when unsynced), and `BookDetail` renders a "KOReader progress" row when present.

Verified: endpoint unit tests (progress present with a synced state; null when unsynced), render source-pin, and live on the wire (`GET /api/v1/books/7` returns the `kosync_progress` field).

Reported by @alva-seal. Ships fix for #587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)