### PR TITLE
release: v4.1.1 — new-UI bug-fix roundup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+## [v4.1.1] - 2026-07-01
+
 ### Added
 - **The new-UI edit page can now edit identifiers, and you choose which fetched
   values to apply.** Editing a book in the new interface now has an Identifiers


### PR DESCRIPTION
Rolls the `[Unreleased]` changelog into `v4.1.1`. Bug-fix release for the new UI. See CHANGELOG for the full list. No code changes — changelog bookkeeping ahead of the GitHub release/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)