### PR TITLE
fix(#577): anchor SPA-only msgids so translations survive auto-extract

### DIFF
--- a/cps/spa_strings.py
+++ b/cps/spa_strings.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Extraction anchors for SPA-only translatable strings.
+
+The React SPA's English source strings ARE the gettext msgids (see
+cps/api/i18n.py — the per-locale JSON catalog is derived from the same .po files
+the classic UI uses). But pybabel only scans Python + Jinja (babel.cfg), so a
+string that appears ONLY in the .tsx SPA is dropped from messages.pot on the
+next re-extract — and msgmerge then marks its translations obsolete, so the SPA
+silently falls back to English (this is exactly how #577's "Read now" → "Nu
+lezen" was lost after the auto-translation job ran).
+
+Referencing those SPA-only msgids here, with the gettext marker, keeps them in
+the catalog across re-extracts. This module is never imported and does nothing at
+runtime — babel reads the *source*, not the call result; ``_`` is a local no-op,
+not flask_babel's request-scoped gettext (which can't run at import time).
+
+Add a SPA-only msgid here the moment you introduce it in the frontend.
+"""
+
+
+def _(message):  # noqa: E743 - intentional gettext extraction marker, not the builtin
+    return message
+
+
+# #577 — the new-UI "open the reader" button. A distinct msgid from the "Read"
+# read-status label (which is a past participle in many languages, e.g. nl
+# "Gelezen") so the verb and the status can be translated separately.
+_("Read now")

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -10,10 +10,10 @@ msgstr ""
 "Project-Id-Version: Calibre-Web (GPLV3)\n"
 "Report-Msgid-Bugs-To: https://github.com/crocodilestick/Calibre-Web-"
 "Automated\n"
-"POT-Creation-Date: 2026-07-01 19:35+0000\n"
+"POT-Creation-Date: 2026-07-01 15:58-0400\n"
 "PO-Revision-Date: 2026-04-26 13:31+0200\n"
-"Last-Translator: Michiel Cornelissen <michiel.cornelissen+gitbhun at proton."
-"me>\n"
+"Last-Translator: Michiel Cornelissen <michiel.cornelissen+gitbhun at "
+"proton.me>\n"
 "Language-Team: ed.driesen@telenet.be\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -2458,6 +2458,10 @@ msgstr ""
 msgid "Manual (drag below)"
 msgstr ""
 
+#: cps/spa_strings.py:29
+msgid "Read now"
+msgstr "Nu lezen"
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:369
 #: cps/templates/tasks.html:7
 msgid "Tasks"
@@ -2750,8 +2754,8 @@ msgstr "Kies e-mailadressen:"
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
-"Het boek is in de wachtrij geplaatst om te worden verstuurd aan "
-"%(eReadermail)s"
+"Het boek is in de wachtrij geplaatst om te worden verstuurd aan %"
+"(eReadermail)s"
 
 #: cps/web.py:2562
 msgid "Please wait one minute to register next user"
@@ -8938,9 +8942,6 @@ msgstr "Synchroniseer geselecteerde boekenplanken met Kobo"
 msgid "Show Read/Unread Section"
 msgstr "Toon gelezen/niet gelezen selectie"
 
-#~ msgid "Read now"
-#~ msgstr "Nu lezen"
-
 #~ msgid "Read in Browser"
 #~ msgstr "Lezen in webbrowser"
 
@@ -9078,10 +9079,11 @@ msgstr "Toon gelezen/niet gelezen selectie"
 #~ msgstr ""
 #~ "Deze paden zijn alleen intern voor CWA, je kunt aan de linkerkant naar "
 #~ "hartenlust wijzigen waar ze aan gekoppeld zijn, maar er is geen reden om "
-#~ "de paden aan de rechterkant te wijzigen.<br><br>Als je je <code>metadata."
-#~ "db</code> bestand op een andere locatie wilt dan de rest van je "
-#~ "bibliotheek, gebruik dan de <b>Scheid Boekbestanden van Bibliotheek Optie "
-#~ "hieronder en voer daar het pad naar de rest van de bibliotheek in</b>"
+#~ "de paden aan de rechterkant te wijzigen.<br><br>Als je je "
+#~ "<code>metadata.db</code> bestand op een andere locatie wilt dan de rest "
+#~ "van je bibliotheek, gebruik dan de <b>Scheid Boekbestanden van "
+#~ "Bibliotheek Optie hieronder en voer daar het pad naar de rest van de "
+#~ "bibliotheek in</b>"
 
 #~ msgid "Enable CWA Auto-Convert"
 #~ msgstr "Schakel CWA Auto-Conversie in"

--- a/messages.pot
+++ b/messages.pot
@@ -2328,6 +2328,10 @@ msgstr ""
 msgid "Manual (drag below)"
 msgstr ""
 
+#: cps/spa_strings.py:29
+msgid "Read now"
+msgstr ""
+
 #: cps/tasks_status.py:37 cps/templates/layout.html:369
 #: cps/templates/tasks.html:7
 msgid "Tasks"

--- a/tests/unit/test_577_dutch_read_label.py
+++ b/tests/unit/test_577_dutch_read_label.py
@@ -36,3 +36,12 @@ def test_read_now_in_pot_template():
     """The new msgid is tracked in the POT so msgmerge propagates it to locales."""
     pot = (pathlib.Path(__file__).resolve().parents[2] / "messages.pot").read_text()
     assert 'msgid "Read now"' in pot
+
+
+@pytest.mark.unit
+def test_spa_only_msgid_is_extraction_anchored():
+    """SPA-only msgids (not in any .py/.jinja the classic UI uses) must be anchored
+    in cps/spa_strings.py, or the auto-extract drops them from the POT and their
+    translations go obsolete (the #577 regression). Guard the anchor."""
+    anchor = (pathlib.Path(__file__).resolve().parents[2] / "cps" / "spa_strings.py").read_text()
+    assert '"Read now"' in anchor


### PR DESCRIPTION
Follow-up to #577. The `Read now` msgid (nl "Nu lezen") is **SPA-only** — it's in the .tsx frontend but not in any .py/.jinja, and `babel.cfg` only scans Python + Jinja. So the post-merge auto-translation job re-extracted the POT without it and msgmerge marked "Nu lezen" obsolete → the reader button fell back to English "Read now" for Dutch, and `test_577` broke on main.

**Fix:** `cps/spa_strings.py` — an extraction anchor that references SPA-only msgids with the gettext marker (runtime no-op; babel scans the source). Re-extracted the POT (now includes `Read now`) and msgmerged nl (restores active "Nu lezen"). Future SPA-only strings go here so they can't silently lose translations.

Verified: `pybabel extract` from repo root emits `Read now`; `test_577` + all per-locale `msgfmt` compile tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)