### PR TITLE
harden new-UI fixes (adversarial-review pass; v4.1.1 was retracted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
-## [v4.1.1] - 2026-07-01
-
 ### Added
 - **The new-UI edit page can now edit identifiers, and you choose which fetched
   values to apply.** Editing a book in the new interface now has an Identifiers

--- a/cps/api/serializers.py
+++ b/cps/api/serializers.py
@@ -112,7 +112,10 @@ def serialize_book_detail(book, read=False, archived=False, favorited=False, hid
         except Exception:
             link = None
         url = link if (link and (link.startswith("http://") or link.startswith("https://"))) else None
-        label = i.format_type() if hasattr(i, "format_type") else i.type
+        try:
+            label = i.format_type() if hasattr(i, "format_type") else i.type
+        except Exception:
+            label = i.type
         identifiers.append({"type": i.type, "val": i.val, "url": url, "label": label})
 
     # Formats

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useState, useEffect, type ReactNode } from 'react';
 import { TopBar } from './TopBar';
 import { Sidebar } from './Sidebar';
 import { HelpBanner } from './HelpBanner';
@@ -12,6 +12,16 @@ interface AppShellProps {
 
 export function AppShell({ userName, onLogout, children }: AppShellProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // Lock the page behind the mobile drawer: overscroll-behavior only stops scroll
+  // chaining AT the drawer's edge, not touches on the scrim, so without this the
+  // page still scrolled behind the open drawer (#576). Only affects the open state.
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = prev; };
+  }, [drawerOpen]);
 
   return (
     <div className={styles.shell}>

--- a/frontend/src/components/Sidebar.module.css
+++ b/frontend/src/components/Sidebar.module.css
@@ -136,6 +136,11 @@
        when you reach the top/bottom of the menu (#576). */
     overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;
+    /* Respect notch / status bar / home indicator when the drawer runs edge to
+       edge (notched phones in landscape, installed PWA). */
+    padding-left: max(var(--sp-3), env(safe-area-inset-left));
+    padding-top: max(var(--sp-4), env(safe-area-inset-top));
+    padding-bottom: max(var(--sp-4), env(safe-area-inset-bottom));
   }
 
   .nav {
@@ -153,6 +158,10 @@
     background: rgba(0, 0, 0, 0.55);
     z-index: var(--z-overlay);
     animation: scrimIn var(--dur-fast) var(--ease) both;
+    /* Swallow touch-scroll on the backdrop so dragging it doesn't scroll the
+       page behind the drawer (belt-and-braces with the body scroll-lock). */
+    touch-action: none;
+    overscroll-behavior: contain;
   }
 
   @keyframes scrimIn {

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiGet, apiPost, apiUpload, apiPostForm, ApiError } from './api';
+import { removeBookFromCache } from './scrollCache';
 import type { MetaSearchResponse } from './api';
 import type {
   Me, BooksPage, BookDetail, EntityList, Shelf, ShelfDetail,
@@ -516,7 +517,12 @@ export function useBulkActions() {
   });
   const remove = useMutation({
     mutationFn: (ids: number[]) => settle(ids.map((id) => apiPost(`/api/v1/books/${id}/delete`))),
-    onSuccess: refresh,
+    onSuccess: (_data, ids) => {
+      // Evict deleted books from every cached catalog snapshot so a later
+      // scroll-restore can't resurrect them as ghost cards (#578).
+      ids.forEach(removeBookFromCache);
+      refresh();
+    },
   });
   // Bulk metadata: apply the same partial field set to every selected book via
   // the per-book metadata endpoint (replace semantics for the filled fields).

--- a/frontend/src/lib/scrollCache.ts
+++ b/frontend/src/lib/scrollCache.ts
@@ -44,3 +44,14 @@ export function saveCatalog(key: string, snap: CatalogSnapshot): void {
 export function loadCatalog(key: string): CatalogSnapshot | undefined {
   return _cache.get(key);
 }
+
+/** Drop a book from every cached snapshot — call when a book is deleted so a
+ *  later scroll-restore can't resurrect it as a ghost card that 404s on click
+ *  (#578). A re-fetch would still contain it on pages we don't re-request, so we
+ *  evict it from the snapshots directly. */
+export function removeBookFromCache(id: number): void {
+  for (const snap of _cache.values()) {
+    const filtered = snap.books.filter((b) => b.id !== id);
+    if (filtered.length !== snap.books.length) snap.books = filtered;
+  }
+}

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -316,7 +316,7 @@ export function BookDetail() {
           <dl className={styles.meta}>
             {book.kosync_progress != null && (
               <>
-                <dt className={styles.metaLabel}>{t('KOReader progress')}</dt>
+                <dt className={styles.metaLabel}>{t('KOReader Progress')}</dt>
                 <dd className={styles.metaValue}>{book.kosync_progress.toFixed(1)}%</dd>
               </>
             )}

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -58,10 +58,24 @@ interface CatalogProps {
   view?: DiscoveryView;
 }
 
+// Merge a freshly-fetched page into the accumulator: UPSERT existing books by id
+// (a re-fetch — e.g. after restoring a scroll snapshot then react-query
+// revalidates — brings updated fields, which must replace the stale copy, #578)
+// and append genuinely-new ones. Add-only append would leave edited books showing
+// their old title/cover after edit → Back.
 function dedupAppend(prev: Book[], next: Book[]): Book[] {
+  if (!next.length) return prev;
+  const byId = new Map(next.map((b) => [b.id, b]));
+  let changed = false;
+  const merged = prev.map((b) => {
+    const upd = byId.get(b.id);
+    if (upd && upd !== b) { changed = true; return upd; }
+    return b;
+  });
   const seen = new Set(prev.map((b) => b.id));
   const fresh = next.filter((b) => !seen.has(b.id));
-  return fresh.length ? [...prev, ...fresh] : prev;
+  if (!fresh.length && !changed) return prev;
+  return [...merged, ...fresh];
 }
 
 export function Catalog({ entityKind, entityId, view }: CatalogProps) {
@@ -186,11 +200,17 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
     const y = snap?.scrollY ?? 0;
     if (!y) return;
     let tries = 0;
+    let raf = 0;
+    let cancelled = false;
     const tick = () => {
+      if (cancelled) return;
       window.scrollTo(0, y);
-      if (++tries < 6 && Math.abs(window.scrollY - y) > 2) requestAnimationFrame(tick);
+      if (++tries < 6 && Math.abs(window.scrollY - y) > 2) raf = requestAnimationFrame(tick);
     };
-    requestAnimationFrame(tick);
+    raf = requestAnimationFrame(tick);
+    // Cancel on unmount: without this, a quick book-open right after Back keeps
+    // the retry alive and scrolls the NEXT page to this offset / fights the user (#578).
+    return () => { cancelled = true; cancelAnimationFrame(raf); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,4 +5,20 @@ export default defineConfig({
   base: '/static/app/',
   plugins: [react()],
   build: { outDir: '../cps/static/app', emptyOutDir: true },
+  // Reverse-proxy prefix support (#571 follow-up). base:'/static/app/' is absolute
+  // and gets baked into the runtime chunk loader, so lazily-imported JS/CSS (the
+  // EPUB + native readers) were requested WITHOUT the proxy mount prefix and 404'd
+  // behind a subpath — those pages rendered unstyled. For JS-computed asset URLs
+  // (the chunk loader / modulepreload / dynamic CSS <link>), emit a runtime
+  // expression that prepends window.__CWNG_PREFIX__ (injected by the server; empty
+  // at the domain root). HTML-referenced assets (index.html's module script + main
+  // CSS) keep the static base — the server rewrites those in the served shell.
+  experimental: {
+    renderBuiltUrl(filename, { hostType }) {
+      if (hostType === 'js') {
+        return { runtime: `(window.__CWNG_PREFIX__||"")+"/static/app/"+${JSON.stringify(filename)}` }
+      }
+      return { relative: false }
+    },
+  },
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,7 +18,12 @@ export default defineConfig({
       if (hostType === 'js') {
         return { runtime: `(window.__CWNG_PREFIX__||"")+"/static/app/"+${JSON.stringify(filename)}` }
       }
-      return { relative: false }
+      // CSS url() refs (fonts/images) → relative, so they resolve against the
+      // stylesheet's own (already-prefixed) /…/static/app/assets/ location behind
+      // a subpath. HTML refs (index.html script/CSS) stay absolute — the shell is
+      // served at <prefix>/app, not under /static/app/, and the server rewrites
+      // that base in the served index.html.
+      return { relative: hostType === 'css' }
     },
   },
 })

--- a/tests/unit/test_571_reverse_proxy_prefix.py
+++ b/tests/unit/test_571_reverse_proxy_prefix.py
@@ -173,3 +173,14 @@ def test_resource_urls_prefixed_at_consumption():
     detail = (_FE / "pages" / "BookDetail.tsx").read_text()
     assert "resourceUrl(book.cover_url)" in detail
     assert "resourceUrl(fmt.download_url)" in detail
+
+
+@pytest.mark.unit
+def test_vite_runtime_asset_base_is_prefix_aware():
+    """The lazy chunk loader must derive asset URLs from window.__CWNG_PREFIX__ at
+    runtime (renderBuiltUrl), else code-split JS/CSS (the readers) 404 behind a
+    proxy prefix and render unstyled — the server index.html rewrite can't reach
+    runtime-computed URLs. Regression guard for the v4.1.1 reader-CSS bug."""
+    cfg = (_FE.parent / "vite.config.ts").read_text()
+    assert "renderBuiltUrl" in cfg
+    assert "__CWNG_PREFIX__" in cfg

--- a/tests/unit/test_576_mobile_sidebar.py
+++ b/tests/unit/test_576_mobile_sidebar.py
@@ -45,3 +45,18 @@ def test_open_drawer_has_background_and_scroll():
 def test_mobile_drawer_contains_its_scroll():
     """The mobile drawer must not chain its scroll to the page behind it."""
     assert "overscroll-behavior: contain" in CSS
+
+
+@pytest.mark.unit
+def test_body_scroll_locked_while_drawer_open():
+    """The page behind the open mobile drawer must be scroll-locked (overscroll
+    only stops chaining at the drawer edge, not scrim touches) — adversarial-review
+    finding. AppShell toggles body overflow while the drawer is open."""
+    import pathlib
+    fe = pathlib.Path(__file__).resolve().parents[2] / "frontend" / "src"
+    shell = (fe / "components" / "AppShell.tsx").read_text()
+    assert "document.body.style.overflow" in shell
+    assert "drawerOpen" in shell
+    css = (fe / "components" / "Sidebar.module.css").read_text()
+    assert "touch-action: none" in css          # scrim swallows backdrop drags
+    assert "env(safe-area-inset" in css          # notch/PWA safe areas

--- a/tests/unit/test_578_scroll_restore.py
+++ b/tests/unit/test_578_scroll_restore.py
@@ -41,3 +41,32 @@ def test_catalog_state_seeded_from_snapshot():
     src = (_FE / "pages" / "Catalog.tsx").read_text()
     assert "snap?.page ?? 1" in src
     assert "snap?.books ?? []" in src
+
+
+@pytest.mark.unit
+def test_dedupappend_upserts_not_append_only():
+    """A re-fetched page must UPDATE existing books by id (edits propagate), not be
+    add-only — else edit→Back shows the stale card (adversarial-review regression)."""
+    src = (_FE / "pages" / "Catalog.tsx").read_text()
+    # upsert shape: build a by-id map from the incoming page and merge.
+    assert "new Map(next.map" in src
+    assert "byId.get(b.id)" in src
+
+
+@pytest.mark.unit
+def test_scroll_restore_raf_is_cancelled():
+    """The scroll-restore retry must cancel on unmount, or a quick book-open right
+    after Back scrolls the next page / fights the user (adversarial-review finding)."""
+    src = (_FE / "pages" / "Catalog.tsx").read_text()
+    assert "cancelAnimationFrame" in src
+    assert "cancelled = true" in src
+
+
+@pytest.mark.unit
+def test_deleted_book_evicted_from_scroll_cache():
+    """Deleting a book must purge it from cached snapshots so scroll-restore can't
+    resurrect a ghost card that 404s on click (adversarial-review finding)."""
+    cache = (_FE / "lib" / "scrollCache.ts").read_text()
+    assert "export function removeBookFromCache" in cache
+    queries = (_FE / "lib" / "queries.ts").read_text()
+    assert "removeBookFromCache" in queries

--- a/tests/unit/test_587_koreader_progress.py
+++ b/tests/unit/test_587_koreader_progress.py
@@ -90,4 +90,4 @@ def test_detail_endpoint_null_progress_when_unsynced():
 def test_bookdetail_renders_progress():
     src = (_ROOT / "frontend" / "src" / "pages" / "BookDetail.tsx").read_text()
     assert "book.kosync_progress != null" in src
-    assert "KOReader progress" in src
+    assert "KOReader Progress" in src  # aligned to the classic, translatable msgid


### PR DESCRIPTION
v4.1.1 was cut after a single verify pass and **retracted** (release+tag deleted, `:latest`→v4.1.0). A second adversarial-review pass (agents trying to break each merged fix) surfaced real issues; fixed here, each re-verified live behind the nginx `/cwa` proxy.

- **#571 (HIGH):** lazy-route JS/CSS (EPUB + native readers) 404'd behind a proxy prefix → readers rendered **unstyled**. Vite's absolute base is baked into the runtime chunk loader (the server index.html rewrite can't reach it). `experimental.renderBuiltUrl` now derives JS-computed asset URLs from `window.__CWNG_PREFIX__`. **Verified:** Reader CSS loads at `/cwa/static/app/assets/Reader-*.css` (200, 37 rules applied), reader fully styled.
- **#578:** (a) restored grid kept **stale/ghost cards** after edit/delete + Back (`dedupAppend` was add-only) → now upserts by id; deletes evict from cached snapshots. (b) scroll-restore RAF wasn't cancelled on unmount → could scroll the next page; now cancelled.
- **#576:** page behind the mobile drawer still scrolled → body scroll-lock while open + scrim `touch-action:none` + safe-area insets. **Verified:** `body overflow=hidden` while open.
- **#587/#577:** aligned the divergent `KOReader progress` label to the classic translatable `KOReader Progress` (nl "Voortgang").
- **#582 (nit):** guard `format_type()`.

Kept the `resourceUrl` idempotency guard — verified the cover-apply endpoint returns a `url_for`'d (already-prefixed) URL, so dropping it (as one reviewer suggested) would double-prefix.

55 unit tests + live Playwright. Feeds the re-earned v4.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)