### PR TITLE
release: v4.1.2 — corrective re-release of v4.1.1 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+## [v4.1.2] - 2026-07-01
+
+This release carries exactly the same fixes as v4.1.1, re-published under a new
+version number so the in-app "update available" prompt reaches everyone. If you
+updated to v4.1.1 in the short window right after it first went out, you may have
+landed on an earlier build of it; moving to v4.1.2 guarantees you're on the
+corrected version. Nothing else changed — the full list of what's fixed is in the
+v4.1.1 notes below.
+
 ## [v4.1.1] - 2026-07-01
 
 ### Added


### PR DESCRIPTION
Bumps the version to **v4.1.2** carrying the exact same code as the current (hardened) v4.1.1.

**Why a new number instead of re-tagging v4.1.1:** the in-app updater (`cps/updater.py`) compares the installed version string to the latest release tag and reports "already current" when they match. Anyone who pulled an early v4.1.1 build (before it was corrected) reports `v4.1.1`, so a same-tag re-publish is invisible to them — they never get the fixed reader-CSS / scroll / mobile-drawer build. A higher version (`v4.1.2`) makes every v4.1.1 instance see an update and move to the known-good image.

- CHANGELOG-only change (adds the `[v4.1.2]` section); **no code changes vs v4.1.1**.
- Ships `:v4.1.2` and moves `:latest` to it.

Standing policy going forward: never retract/move a published release tag — always increment.