### PR TITLE
fix(feedback-popup): make the hidden attribute authoritative so the popup can close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+- **The classic view no longer shows a feedback popup you can't close.** In
+  v4.1.1 and v4.1.2, the optional "what made you switch back?" prompt appeared
+  on every classic page — not just after switching from the new UI — and none of
+  its buttons could dismiss it (on phones it didn't even fit the screen). It now
+  stays hidden unless you've just switched back from the new interface, every
+  button closes it, and it fits and scrolls on small screens. Reported by
+  @iroQuai (#576).
+
 ## [v4.1.2] - 2026-07-01
 
 This release carries exactly the same fixes as v4.1.1, re-published under a new

--- a/cps/templates/cwng_feedback_popup.html
+++ b/cps/templates/cwng_feedback_popup.html
@@ -96,10 +96,16 @@
     animation:cwng-fb-fade .18s ease;
     font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
   }
+  /* display:flex above would silently defeat the [hidden] attribute (author CSS
+     outranks the UA's [hidden]{display:none}) — keep hidden authoritative, or the
+     popup renders on every page and no dismiss button can close it (#576). */
+  .cwng-fb-overlay[hidden]{display:none !important;}
   @keyframes cwng-fb-fade{from{opacity:0}to{opacity:1}}
   @keyframes cwng-fb-rise{from{opacity:0;transform:translateY(10px) scale(.985)}to{opacity:1;transform:none}}
   .cwng-fb-card{
     position:relative; width:100%; max-width:440px;
+    max-height:calc(100vh - 40px); max-height:calc(100dvh - 40px);
+    overflow-y:auto; -webkit-overflow-scrolling:touch;
     background:linear-gradient(180deg,#1b2530,#141c24);
     color:#ece8e1; border:1px solid rgba(255,255,255,.09);
     border-radius:16px; padding:26px 24px 20px;

--- a/tests/unit/test_60_feedback_popup_dismiss.py
+++ b/tests/unit/test_60_feedback_popup_dismiss.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression pin for the #60 feedback popup being undismissable (reported in #576).
+
+Root cause: the popup overlay is hidden via the HTML ``hidden`` attribute, but the
+partial's own stylesheet declares ``.cwng-fb-overlay { display:flex; ... }``. Author
+CSS overrides the UA/normalize ``[hidden] { display:none }`` rule, so the overlay
+rendered on EVERY classic page (the partial ships in layout.html unconditionally for
+logged-in users; the JS only decides whether to attach listeners). With no
+``?cwng_feedback`` marker the script returns early, so no dismiss listener was ever
+attached — and even with the marker, ``close()`` sets ``overlay.hidden = true``,
+which the ``display:flex`` rule visually ignored. Result: a permanent full-screen
+modal no button could close.
+
+Fix: an explicit ``.cwng-fb-overlay[hidden] { display:none !important }`` guard makes
+the ``hidden`` attribute authoritative, and the card gets a viewport-bounded
+max-height + own scroll so it fits small (mobile) screens.
+"""
+import pathlib
+import re
+
+import pytest
+
+TEMPLATE = (pathlib.Path(__file__).resolve().parents[2]
+            / "cps" / "templates" / "cwng_feedback_popup.html").read_text()
+
+
+def _rule_blocks(css_or_html):
+    """Yield (selector, declarations) for every CSS rule in the text."""
+    for m in re.finditer(r"([^{}]+)\{([^}]*)\}", css_or_html):
+        yield m.group(1).strip(), m.group(2)
+
+
+def _block_for(selector_contains):
+    for sel, block in _rule_blocks(TEMPLATE):
+        if selector_contains in sel:
+            return sel, block
+    return None, None
+
+
+@pytest.mark.unit
+def test_hidden_attribute_actually_hides_the_overlay():
+    """THE regression: .cwng-fb-overlay sets display:flex, which silently defeats
+    the [hidden] attribute unless an explicit [hidden] override exists."""
+    sel, block = _block_for(".cwng-fb-overlay[hidden]")
+    assert block is not None, (
+        "missing '.cwng-fb-overlay[hidden]' rule — the hidden attribute is "
+        "overridden by the overlay's display:flex and the popup can never be "
+        "dismissed (#576)")
+    assert re.search(r"display\s*:\s*none\s*!important", block), (
+        "'.cwng-fb-overlay[hidden]' must set display:none !important so the "
+        "hidden attribute stays authoritative over the display:flex base rule")
+
+
+@pytest.mark.unit
+def test_overlay_base_rule_still_uses_display_flex():
+    """Companion pin: the base rule keeps display:flex (centering), which is WHY
+    the [hidden] guard above must exist. If someone drops flex for a different
+    show/hide mechanism, both tests flag the area for a rethink together."""
+    sel, block = None, None
+    for s, b in _rule_blocks(TEMPLATE):
+        # the first rule's captured selector includes the <style> tag text, so
+        # match on the selector's tail rather than exact equality
+        if s.endswith(".cwng-fb-overlay"):
+            sel, block = s, b
+            break
+    assert block is not None, "base .cwng-fb-overlay rule not found"
+    assert "display:flex" in block.replace(" ", ""), (
+        "base overlay rule no longer uses display:flex — revisit the [hidden] "
+        "guard pinned by test_hidden_attribute_actually_hides_the_overlay")
+
+
+@pytest.mark.unit
+def test_card_fits_small_viewports():
+    """#576 mobile symptom: the card (707px tall on a 720px viewport at desktop
+    width) overflowed small screens with no way to scroll it. The card must be
+    viewport-bounded and scroll its own overflow."""
+    sel, block = _block_for(".cwng-fb-card")
+    assert block is not None, "base .cwng-fb-card rule not found"
+    compact = block.replace(" ", "")
+    assert re.search(r"max-height:calc\(100(d?)vh-", compact), (
+        ".cwng-fb-card needs a viewport-relative max-height so it cannot "
+        "overflow small screens")
+    assert "overflow-y:auto" in compact, (
+        ".cwng-fb-card must scroll its own overflow (overflow-y:auto)")


### PR DESCRIPTION
## Why

@iroQuai reported in #576 (follow-up comment) that after updating, a "survey about moving back to old UI" appeared that no button could dismiss, and on mobile it didn't fit the screen. They downgraded to v4.1.0 because of it. This is the #60 feedback popup that shipped in v4.1.1.

## Root cause

The overlay is hidden with the HTML `hidden` attribute, but the partial's own stylesheet declares `.cwng-fb-overlay { display:flex; … }`. Author CSS outranks the UA/normalize `[hidden] { display:none }` rule, so `hidden` was visually ignored. Two consequences:

1. The partial ships on every classic page (layout.html, logged-in gate) with the JS deciding whether to activate — so the popup rendered **on every classic page load**, marker or not. Without the marker the script exits before wiring any dismiss listener, leaving every button dead; with the marker, `close()` only toggles the impotent `hidden` attribute. Either way it could not be closed.
2. The card had no viewport-bounded height (measured 707px on a 720px viewport at desktop width), so on phones it overflowed with no way to scroll — the reporter's second symptom.

Both adversarial-review passes before v4.1.1/v4.1.2 missed this because they focused on the SPA files; the popup partial was untouched by the hardening commit (8a39e7dda).

## Reproduction

Live on cwn-local (v4.1.x image, plain page load, **no** `?cwng_feedback` marker):

```
{hiddenAttr: true, computedDisplay: "flex", visible: true, overlayRect: {w:1280, h:720}}
```

Regression test red on the previous template:

```
FAILED test_hidden_attribute_actually_hides_the_overlay - missing '.cwng-fb-overlay[hidden]' rule
FAILED test_card_fits_small_viewports - .cwng-fb-card needs a viewport-relative max-height
```

## Fix

Two CSS additions in the partial, no JS/behavior changes:

- `.cwng-fb-overlay[hidden] { display:none !important; }` — makes the `hidden` attribute authoritative over the `display:flex` centering rule.
- `.cwng-fb-card` gets `max-height:calc(100vh - 40px)` (with a `100dvh` upgrade), `overflow-y:auto`, `-webkit-overflow-scrolling:touch` — the card can never exceed the viewport and scrolls its own overflow.

## Validation

- `tests/unit/test_60_feedback_popup_dismiss.py` — 3 pins, red before / green after.
- Live e2e on cwn-local (Playwright, computed-style assertions, not screenshots):
  - no-marker classic page load → overlay `display:none` (the shipped bug showed it full-screen)
  - `?cwng_feedback=newui` → popup opens, URL marker stripped, body scroll locked
  - "No thanks" → closes, body scroll restored, per-version suppression written
  - mobile 375×667 → card 627px (fits), scrolls own overflow, dismiss reachable
  - Escape → closes
- Theme-independent: all popup CSS is scoped `cwng-fb-*` in the partial; neither `caliBlur.css` nor `style.css` declares `cwng-fb` or `[hidden]` rules (verified by grep). Repro + verify ran under caliBlur; the mechanism (author CSS vs UA `[hidden]`) is identical under the default theme.

## Tier / release

needs-review class by size? No — 2-file production diff (template CSS only) + 1 test file, no auth/session/subprocess/file-path/route surface, no new deps. This is a regression fix for the release published today; it repairs the classic UI for every v4.1.1/v4.1.2 user, so it should ship in a corrective release (v4.1.3) rather than wait for tomorrow's train. For #576 (does not close it — the original mobile-drawer fix still awaits the reporter's verification).