### PR TITLE
fix(#578): keep first-page scroll position on Back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+- **The library now keeps your scroll position when you scroll the first page
+  and go Back from a book.** The scroll-restore added in v4.1.1 worked once you'd
+  loaded more pages, but if you only scrolled the first screen of books, opened
+  one, and came back, the list jumped to the top. Reported by @KucharczykL.
+
 ## [v4.1.3] - 2026-07-01
 
 Corrective release: if you're on v4.1.1 or v4.1.2, update — those versions show

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -186,10 +186,27 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
   // later Back rehydrates the loaded pages, filters and scroll position (#578).
   const persistRef = useRef({ page, books: allBooks, resetKey: accKeyRef.current, search, searchInput, sort, readFilter });
   persistRef.current = { page, books: allBooks, resetKey: accKeyRef.current, search, searchInput, sort, readFilter };
+
+  // Track the live scroll offset in a ref. Reading window.scrollY in the unmount
+  // cleanup is too late: by then the catalog has been swapped for the (shorter)
+  // book page and the browser has already clamped window.scrollY down to that
+  // page's max scroll — so a first-page position (nothing tall enough to survive
+  // the clamp) was saved as ~0 and Back landed back at the top (#578 first-page
+  // regression, reported by @KucharczykL). We record every scroll here and save
+  // the tracked value; the click that triggers navigation is a discrete event,
+  // so React flushes this unmount cleanup before the clamp's async scroll event,
+  // and the real offset is preserved.
+  const lastScrollYRef = useRef(snap?.scrollY ?? 0);
+  useEffect(() => {
+    const onScroll = () => { lastScrollYRef.current = window.scrollY; };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
   useEffect(() => {
     return () => {
       const s = persistRef.current;
-      saveCatalog(restoreKey, { ...s, scrollY: window.scrollY });
+      saveCatalog(restoreKey, { ...s, scrollY: lastScrollYRef.current });
     };
   }, [restoreKey]);
 

--- a/tests/unit/test_578_scroll_restore.py
+++ b/tests/unit/test_578_scroll_restore.py
@@ -70,3 +70,24 @@ def test_deleted_book_evicted_from_scroll_cache():
     assert "export function removeBookFromCache" in cache
     queries = (_FE / "lib" / "queries.ts").read_text()
     assert "removeBookFromCache" in queries
+
+
+@pytest.mark.unit
+def test_scroll_saved_from_tracked_ref_not_clamped_unmount_read():
+    """#578 first-page regression (@KucharczykL): the loaded pages rehydrated but
+    the scroll landed at the top. Reading window.scrollY in the unmount cleanup is
+    too late — the catalog has already been replaced by the shorter book page and
+    the browser has clamped window.scrollY down to that page's max scroll, so the
+    first-page offset was saved as ~0. The save must record a scroll position
+    tracked live during scrolling (a ref fed by a scroll listener), which survives
+    the clamp because the navigating click flushes this cleanup before the clamp's
+    async scroll event.
+    """
+    src = (_FE / "pages" / "Catalog.tsx").read_text()
+    # A live scroll listener feeds a ref with the real offset.
+    assert ("addEventListener('scroll'" in src) or ('addEventListener("scroll"' in src)
+    assert "lastScrollYRef" in src
+    # The unmount save records the tracked ref, not a fresh (clamped) read.
+    assert "scrollY: lastScrollYRef.current" in src
+    # Regression guard: never revert to reading window.scrollY inline at save time.
+    assert "scrollY: window.scrollY" not in src


### PR DESCRIPTION
## Why
@KucharczykL reported on #578 that scroll position still isn't kept after the v4.1.1 fix: *"Even scrolling down the first page (without clicking Load more) doesn't keep its scroll position. I also tried the ← Library link."* Reproduced live — the loaded pages rehydrate correctly, but the scroll jumps to the top.

## Root cause
The #593 scroll-restore saved `window.scrollY` in the Catalog **unmount cleanup**. That cleanup runs *after* wouter has swapped the catalog for the (shorter) book detail page, so the browser has already **clamped** `window.scrollY` down to the book page's max scroll. A first-page offset (nothing tall enough to survive the clamp) was saved as ~0, and Back restored to the top.

Proven on teenyverse (72-book library): scroll to 1400 → open a book whose detail page has `maxScroll = 37` → the saved value was 37, and Back landed at 37.

## Fix
Track the live scroll offset in a ref fed by a passive `scroll` listener, and save that ref on unmount instead of reading `window.scrollY` (already clamped) at teardown. The navigating click is a discrete event, so React flushes the unmount cleanup before the clamp's async scroll event — the real offset is preserved.

## Validation
- Red/green regression pin in `tests/unit/test_578_scroll_restore.py::test_scroll_saved_from_tracked_ref_not_clamped_unmount_read` (fails on pre-fix source, passes on fix). Full #578 file: 7 passed.
- Live e2e on cwn-local (420×560 viewport, 28-card grid): scroll to 1000 → open book/8 (detail clamps at 818) → Back → **restores to exactly 1000** and holds (was 818/top). `tsc -b && vite build` clean.

## Tier
Fork-original SPA fix. No deps/license/URL changes. No auth/CSRF/route surface.

Ships fix for #578.