### PR TITLE
fix(spa): stop shelf navigation from mixing both shelves' books

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- **Switching shelves no longer mixes both shelves' books.** In the new UI,
+  going from one shelf straight to another kept the first shelf's books on
+  screen and drew the next shelf's books after them — and removing one of the
+  leftover books actually removed it from the shelf you were now on. Each
+  shelf (and smart shelf) now shows only its own books, and the page counter
+  resets when you switch. Reported by @mstewart14.
 - **Table view covers are no longer squished.** In the new UI's Table view,
   cover thumbnails rendered as narrow 32px slivers that cropped the sides off
   the artwork. They now display at a proper book-cover shape (48×72), and on

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -256,7 +256,11 @@ export function useShelf(id: string | number | undefined, page = 1) {
     queryKey: ['shelf', String(id), page],
     queryFn: () => apiGet<ShelfDetail>(`/api/v1/shelves/${id}?page=${page}&per_page=24`),
     enabled: id !== undefined && id !== '',
-    placeholderData: (prev) => prev,
+    // Keep the previous page's rows only while paging within the SAME shelf —
+    // never carry one shelf's rows across an id change, where they'd render
+    // under the next shelf's key and mix both shelves' books (#612).
+    placeholderData: (prev, prevQuery) =>
+      prevQuery && String(prevQuery.queryKey[1]) === String(id) ? prev : undefined,
   });
 }
 
@@ -795,7 +799,9 @@ export function useMagicShelfBooks(id: string | number, page = 1) {
   return useQuery<{ id: number; name: string; icon: string; is_owner: boolean } & BooksPage>({
     queryKey: ['magicshelf', String(id), page],
     queryFn: () => apiGet(`/api/v1/magicshelf/${id}?page=${page}`),
-    placeholderData: (prev) => prev,
+    // Same-shelf paging only — see useShelf (#612).
+    placeholderData: (prev, prevQuery) =>
+      prevQuery && String(prevQuery.queryKey[1]) === String(id) ? prev : undefined,
   });
 }
 

--- a/frontend/src/pages/MagicShelfView.tsx
+++ b/frontend/src/pages/MagicShelfView.tsx
@@ -23,15 +23,22 @@ export function MagicShelfView({ id }: { id: string }) {
   const [page, setPage] = useState(1);
   const [books, setBooks] = useState<Book[]>([]);
   const accKey = useRef('');
-  const { data, isLoading, isFetching, error } = useMagicShelfBooks(id, page);
+  const { data, isLoading, isFetching, isPlaceholderData, error } = useMagicShelfBooks(id, page);
   const del = useDeleteMagicShelf();
   const dup = useDuplicateMagicShelf();
 
+  // Route reuse: reset paging when the shelf id changes (#612).
   useEffect(() => {
-    if (!data) return;
+    setPage(1);
+  }, [id]);
+
+  // Skip placeholder data — accumulating the previous shelf's briefly-served
+  // rows under the new id would mix both shelves' books (#612, see Shelf.tsx).
+  useEffect(() => {
+    if (!data || isPlaceholderData) return;
     if (String(id) !== accKey.current) { setBooks(data.items); accKey.current = String(id); }
     else setBooks((p) => dedupAppend(p, data.items));
-  }, [data, id]);
+  }, [data, id, isPlaceholderData]);
 
   if (isLoading && !data) return <SpinnerCentered size={40} />;
   if (error || !data) {

--- a/frontend/src/pages/Shelf.tsx
+++ b/frontend/src/pages/Shelf.tsx
@@ -28,7 +28,7 @@ export function Shelf({ id }: { id: string }) {
   const [books, setBooks] = useState<Book[]>([]);
   const accKeyRef = useRef<string>('');
 
-  const { data, isLoading, isFetching, error } = useShelf(id, page);
+  const { data, isLoading, isFetching, isPlaceholderData, error } = useShelf(id, page);
   const updateShelf = useUpdateShelf(id);
   const deleteShelf = useDeleteShelf();
   const reorder = useReorderShelfBooks(id);
@@ -40,9 +40,21 @@ export function Shelf({ id }: { id: string }) {
   const [actionError, setActionError] = useState<string | null>(null);
   const [reordering, setReordering] = useState(false);
 
-  // Reset accumulation if the shelf id changes (route reuse) or membership shrinks.
+  // Route reuse (/shelf/A -> /shelf/B keeps this component mounted): reset
+  // paging and per-shelf UI modes when the shelf changes (#612).
   useEffect(() => {
-    if (!data) return;
+    setPage(1);
+    setEditing(false);
+    setReordering(false);
+    setActionError(null);
+  }, [id]);
+
+  // Accumulate pages; replace when the shelf changes. Skip placeholder data:
+  // on an id change react-query would briefly serve the PREVIOUS shelf's rows
+  // (placeholderData) — accumulating those stamps them as the new shelf's and
+  // appends the real rows behind them, mixing both shelves' books (#612).
+  useEffect(() => {
+    if (!data || isPlaceholderData) return;
     const key = String(id);
     if (key !== accKeyRef.current) {
       setBooks(data.items);
@@ -50,7 +62,7 @@ export function Shelf({ id }: { id: string }) {
     } else {
       setBooks((prev) => dedupAppend(prev, data.items));
     }
-  }, [data, id]);
+  }, [data, id, isPlaceholderData]);
 
   if (isLoading && !data) return <SpinnerCentered size={40} />;
   if (error || !data) {

--- a/tests/unit/test_612_shelf_nav_accumulation.py
+++ b/tests/unit/test_612_shelf_nav_accumulation.py
@@ -1,0 +1,133 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Acceptance tests for fork #612 — navigating between shelves in the new UI
+mixed both shelves' books: the previous shelf's grid stayed rendered and the
+next shelf's books were appended after it.
+
+Root cause: ``useShelf``/``useMagicShelfBooks`` used an unscoped
+``placeholderData: (prev) => prev``, so on an id change (wouter reuses the
+component for /shelf/A -> /shelf/B) react-query briefly served shelf A's rows
+under shelf B's query key. The page accumulators keyed by the ROUTE id at
+effect-run time, so they stamped shelf A's rows as "shelf B, seen" and then
+appended shelf B's real rows behind them. Catalog/Table/AdvancedSearch already
+guard this with ``isPlaceholderData`` — Shelf and MagicShelfView were the two
+stragglers.
+
+These pin all three layers of the fix so a refactor can't silently regress it:
+placeholder data must not cross shelf ids, accumulators must skip placeholder
+data, and paging must reset when the id changes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+FRONTEND = Path(__file__).resolve().parents[2] / "frontend" / "src"
+SHELF_TSX = FRONTEND / "pages" / "Shelf.tsx"
+MAGIC_TSX = FRONTEND / "pages" / "MagicShelfView.tsx"
+QUERIES_TS = FRONTEND / "lib" / "queries.ts"
+
+
+@pytest.fixture(scope="module")
+def shelf_src() -> str:
+    return SHELF_TSX.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def magic_src() -> str:
+    return MAGIC_TSX.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def queries_src() -> str:
+    return QUERIES_TS.read_text(encoding="utf-8")
+
+
+def _function_block(src: str, name: str) -> str:
+    """Extract the source of `export function <name>(...)` up to the next export."""
+    match = re.search(
+        r"export function %s\b.*?(?=\nexport |\Z)" % re.escape(name), src, re.S
+    )
+    assert match, f"export function {name} not found"
+    return match.group(0)
+
+
+# --- layer 1: placeholder data must not cross shelf ids -----------------------
+
+
+def test_use_shelf_placeholder_scoped_to_same_shelf(queries_src):
+    """#612: unscoped `placeholderData: (prev) => prev` carried shelf A's rows
+    under shelf B's key. The placeholder must check the previous query's id."""
+    block = _function_block(queries_src, "useShelf")
+    assert not re.search(r"placeholderData:\s*\(\s*prev\s*\)\s*=>\s*prev", block), (
+        "useShelf still uses an unscoped placeholderData — previous shelf's rows "
+        "leak across an id change"
+    )
+    assert "prevQuery" in block, "useShelf placeholderData must compare prevQuery's shelf id"
+
+
+def test_use_magic_shelf_books_placeholder_scoped_to_same_shelf(queries_src):
+    block = _function_block(queries_src, "useMagicShelfBooks")
+    assert not re.search(r"placeholderData:\s*\(\s*prev\s*\)\s*=>\s*prev", block), (
+        "useMagicShelfBooks still uses an unscoped placeholderData"
+    )
+    assert "prevQuery" in block
+
+
+# --- layer 2: accumulators must never act on placeholder data -----------------
+
+
+def test_shelf_accumulator_skips_placeholder_data(shelf_src):
+    """Catalog-parity guard: the accumulation effect early-returns on
+    isPlaceholderData so stale rows are never stamped as the new shelf's."""
+    assert re.search(
+        r"if\s*\(\s*!data\s*\|\|\s*isPlaceholderData\s*\)\s*return", shelf_src
+    ), "Shelf.tsx accumulator lacks the isPlaceholderData early-return guard"
+    assert re.search(r"\bisPlaceholderData\b[^=]*=\s*useShelf\(|useShelf\(", shelf_src)
+    assert "isPlaceholderData" in re.search(
+        r"const\s*\{[^}]*\}\s*=\s*useShelf\(", shelf_src
+    ).group(0), "Shelf.tsx must destructure isPlaceholderData from useShelf"
+
+
+def test_magic_shelf_accumulator_skips_placeholder_data(magic_src):
+    assert re.search(
+        r"if\s*\(\s*!data\s*\|\|\s*isPlaceholderData\s*\)\s*return", magic_src
+    ), "MagicShelfView.tsx accumulator lacks the isPlaceholderData guard"
+    assert "isPlaceholderData" in re.search(
+        r"const\s*\{[^}]*\}\s*=\s*useMagicShelfBooks\(", magic_src
+    ).group(0), "MagicShelfView.tsx must destructure isPlaceholderData"
+
+
+# --- layer 3: paging must reset when the shelf id changes ---------------------
+
+
+def _has_page_reset_on_id(src: str) -> bool:
+    """An effect that calls setPage(1) with [id] as its dependency array."""
+    return bool(
+        re.search(
+            r"useEffect\(\s*\(\)\s*=>\s*\{[^}]*setPage\(1\)[^}]*\}\s*,\s*\[\s*id\s*\]\s*\)",
+            src,
+            re.S,
+        )
+    )
+
+
+def test_shelf_resets_page_on_id_change(shelf_src):
+    """#612 follow-on: arriving on shelf B while paged to A's page N skipped
+    shelf B's first pages entirely."""
+    assert _has_page_reset_on_id(shelf_src), (
+        "Shelf.tsx must reset page to 1 when the shelf id changes"
+    )
+
+
+def test_magic_shelf_resets_page_on_id_change(magic_src):
+    assert _has_page_reset_on_id(magic_src), (
+        "MagicShelfView.tsx must reset page to 1 when the shelf id changes"
+    )


### PR DESCRIPTION
## Why

Fork #612 (@mstewart14): in the new UI, going from one shelf straight to another keeps the first shelf's books on screen and draws the next shelf's books after them. Removing one of the leftover books removes it from the shelf you're now viewing.

## Root cause

`/shelf/A -> /shelf/B` reuses the mounted `Shelf` component (wouter param-only change), and `useShelf`'s unscoped `placeholderData: (prev) => prev` briefly serves shelf A's rows under shelf B's query key. The accumulation effect keys by the **route id at effect-run time**, so it stamps A's rows as "B, seen" (`accKeyRef = B` while `books` holds A's items), then B's real rows arrive on the append path and land behind them. `MagicShelfView` has the identical latent bug. `Catalog`, `Table`, and `AdvancedSearch` already guard this exact failure with `isPlaceholderData` — Shelf and MagicShelfView were the two stragglers of a known bug class.

## Fix (three layers)

1. `useShelf` / `useMagicShelfBooks`: `placeholderData` now only carries data while paging **within the same shelf id** — one shelf's rows never render under another's key (this also closes the brief window where Rename/Delete rendered shelf A's header while acting on shelf B).
2. Both accumulators skip placeholder data (Catalog parity, same comment style).
3. `page` and per-shelf UI modes (rename/reorder/error) reset when the id changes — previously arriving on shelf B while paged to A's page N skipped B's first pages.

## Reproduction (red)

Live on cwn-local (v-HEAD image, bind-mounted `repo/cps`): two shelves, A = books 179/178/177, B = 176/20/19. Client-side nav A→B rendered **6 cards** under the "Repro612-B · 3 books" header, A's books first — the reporter's symptom verbatim. Evidence: `notes/evidence-612/before-shelfB-accumulated.jpeg` (project scratch, not committed).

## Validation (green)

- `tests/unit/test_612_shelf_nav_accumulation.py` — 6 pins across all three layers; all 6 fail at HEAD, pass with the fix.
- Live Playwright after rebuild+deploy: A→B→A each shows only its own 3 books; **rapid switch** (120 ms between clicks, response in flight) settles clean; **rename mode opened on A does not survive navigation to B**. `notes/evidence-612/after-shelfB-clean.jpeg`.
- Full unit suite: 2145 passed; the single failure (`test_ingest_batch_dirty`) fails identically with the fix stashed — pre-existing local-env issue, unrelated (main CI is green on the same test).
- Container log scan over the verification window: no new ERROR/Traceback.

## Blast radius

Swept every `dedupAppend` accumulator in the SPA: Catalog/Table/AdvancedSearch already guarded (untouched); Shelf + MagicShelfView fixed here. `placeholderData` scoping only affects the two shelf queries; same-shelf "Load more" paging keeps its smooth placeholder behavior (not exercised live — repro shelves are single-page; behavior is pinned by the same pattern Catalog ships in production).

## Tier / review

Fork-original SPA state fix, 3 production files, ~40 production LOC + tests. Routine high-confidence SPA iteration — no auth/session/subprocess/file-path/route surface, so no `/security-review`; Greptile not invoked per opt-in cost policy.

Ships fix for #612