### PR TITLE
fix(caliBlur): restore mobile profile slot so the logout menu opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- **You can log out again on mobile in the classic view.** With the caliBlur
+  theme on a phone, tapping your username in the menu did nothing — an
+  invisible upload control was swallowing the tap, so the account submenu
+  with Logout never opened, and the drawer's profile area rendered squashed
+  with overlapping text. The profile block now sits in its own space again
+  and tapping your name reliably opens the menu. Reported by @iroQuai.
 - **Switching shelves no longer mixes both shelves' books.** In the new UI,
   going from one shelf straight to another kept the first shelf's books on
   screen and drew the next shelf's books after them — and removing one of the

--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -6312,6 +6312,26 @@ body.edituser.admin > div.container-fluid > div.row-fluid > div.col-sm-10 > div.
         z-index: 99
     }
 
+    /* Fork #602: the slot-1 rule above assumes the profile dropdown is the
+       first item, but the "Switch to New UI" pill renders ahead of it. Give
+       the pill its natural height and assign the 130px profile band to the
+       dropdown li by class (identical when the pill is absent); without this
+       the 120px profileDrop anchor overflows under the invisible #btn-upload
+       file input and taps on the username never open the logout menu. */
+    #main-nav > li.cwng-switch-li:nth-child(1) {
+        height: auto;
+        z-index: auto
+    }
+
+    #main-nav > li.dropdown {
+        margin-left: 0;
+        width: 100%;
+        height: 130px;
+        z-index: 99;
+        border-bottom: 1px solid hsla(0, 0%, 78%, .15);
+        float: left
+    }
+
     body > div.navbar.navbar-default.navbar-static-top > div > div.navbar-collapse.collapse > ul > li > a.profileDrop {
         height: 120px;
         width: 100%

--- a/tests/unit/test_602_caliblur_mobile_profile_slot.py
+++ b/tests/unit/test_602_caliblur_mobile_profile_slot.py
@@ -1,0 +1,100 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Fork #602 (@iroQuai) — logout submenu unreachable on mobile (caliBlur).
+
+caliBlur's ``max-width: 767px`` block lays the drawer out by slot: the rule
+``#main-nav > li:nth-child(1)`` reserves a 130px full-width band for the
+profile dropdown, and ``a.profileDrop`` is forced to 120px tall with the
+username label absolutely placed at ``top: 70px``. The fork's "Switch to New
+UI" pill (``li.cwng-switch-li``) is rendered as the *first* item of
+``#main-nav``, so the pill stole the 130px slot and the profile li collapsed
+to a 60px row. Its 120px anchor then overflowed into the Upload row, whose
+invisible ``opacity: 0`` ``#btn-upload`` file input sits on top — every tap on
+the username landed on the file input and the logout menu never opened.
+
+Fix: give the pill its natural height when it occupies slot 1, and assign the
+slot properties to ``#main-nav > li.dropdown`` explicitly (identical outcome
+when the pill is absent, because the profile li is then nth-child(1) anyway).
+
+Pinned by source so a future caliBlur edit can't silently drop the guard while
+the pill is still rendered ahead of the profile dropdown.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+HERE = os.path.dirname(__file__)
+CALIBLUR = os.path.normpath(
+    os.path.join(HERE, "..", "..", "cps", "static", "css", "caliBlur.css")
+)
+LAYOUT = os.path.normpath(
+    os.path.join(HERE, "..", "..", "cps", "templates", "layout.html")
+)
+
+
+def _mobile_block():
+    """Return the body of the ``@media only screen and (max-width: 767px)``
+    block, extracted by brace counting (the block nests rule braces)."""
+    with open(CALIBLUR, encoding="utf-8") as fh:
+        css = fh.read()
+    m = re.search(r"@media\s+only\s+screen\s+and\s*\(max-width:\s*767px\)\s*\{", css)
+    assert m, "caliBlur mobile (max-width: 767px) block not found"
+    depth, i = 1, m.end()
+    while depth and i < len(css):
+        if css[i] == "{":
+            depth += 1
+        elif css[i] == "}":
+            depth -= 1
+        i += 1
+    return re.sub(r"/\*.*?\*/", "", css[m.end():i - 1], flags=re.DOTALL)
+
+
+def _rule(block, selector_re):
+    m = re.search(selector_re + r"\s*\{([^}]*)\}", block)
+    return m.group(1) if m else None
+
+
+def test_switch_pill_does_not_keep_the_130px_profile_slot():
+    """The pill in slot 1 must fall back to its natural height, not the
+    130px profile band (which mis-stacked every drawer row below it)."""
+    body = _rule(_mobile_block(), r"#main-nav\s*>\s*li\.cwng-switch-li:nth-child\(1\)")
+    assert body is not None, (
+        "caliBlur mobile block must neutralize the slot-1 rule for "
+        "li.cwng-switch-li (fork #602)"
+    )
+    assert re.search(r"height:\s*auto", body), "pill must not keep height:130px"
+
+
+def test_profile_dropdown_gets_the_slot_by_class_not_position():
+    """The profile li must receive the 130px band + z-index regardless of its
+    position, so its 120px anchor can't overflow under the invisible upload
+    file input (which swallowed the logout tap)."""
+    body = _rule(_mobile_block(), r"#main-nav\s*>\s*li\.dropdown")
+    assert body is not None, (
+        "caliBlur mobile block must style #main-nav > li.dropdown explicitly "
+        "(fork #602)"
+    )
+    assert re.search(r"height:\s*130px", body)
+    assert re.search(r"width:\s*100%", body)
+    # z-index keeps the opened .profileDropli above #btn-upload — load-bearing
+    # for the tap actually reaching the Logout link.
+    assert re.search(r"z-index:\s*99", body)
+
+
+def test_layout_still_renders_pill_before_profile_dropdown():
+    """Documents the ordering assumption the CSS guard exists for: the pill is
+    rendered ahead of the theme-1 profile dropdown inside #main-nav. If this
+    ever flips, the guard is harmless — but if the pill stays first and the
+    guard is gone, #602 regresses."""
+    with open(LAYOUT, encoding="utf-8") as fh:
+        html = fh.read()
+    pill = html.find("cwng-switch-li")
+    profile = html.find('class="dropdown-toggle profileDrop"')
+    assert pill != -1 and profile != -1
+    assert pill < profile, (
+        "pill no longer precedes the profile dropdown — revisit the #602 "
+        "caliBlur slot guard (safe to relax this pin if intentional)"
+    )


### PR DESCRIPTION
## Why

Fork #602 (@iroQuai): on a phone in the classic UI (caliBlur theme), opening the menu and tapping your username did nothing — the account submenu with Logout never appeared, so users couldn't log out on mobile. The reporter's screenshot also shows the profile area rendering squashed, with the username, Tasks, and Logout entries overlapping each other and the MANAGE label misplaced.

## Root cause

caliBlur's `max-width: 767px` block lays the drawer out **by slot**: `#main-nav > li:nth-child(1)` reserves a 130px full-width band for the profile dropdown, `a.profileDrop` is forced to 120px tall, and the username label is absolutely placed at `top: 70px`. Our "Switch to New UI" pill (`li.cwng-switch-li`) renders as the **first** item of `#main-nav`, so the pill stole the 130px slot. The profile li collapsed to a 60px row, its 120px anchor overflowed into the Upload row below — and the invisible `opacity: 0` `#btn-upload` file input that sits over that row swallowed every tap on the username (`document.elementFromPoint` at the username's center returned `#btn-upload`). The entire visible username (top:70px) sat inside the intercepted band.

Reproduced live on cwn-local at 360×740: Playwright's click on `.profileDrop` timed out with "`#btn-upload` … subtree intercepts pointer events". Removing the pill from the DOM restored the stock geometry — controlled confirmation the pill insertion is the trigger.

## Fix

Two additive rules in the same media block (`cps/static/css/caliBlur.css`):

- `#main-nav > li.cwng-switch-li:nth-child(1) { height: auto; z-index: auto }` — the pill no longer keeps the 130px profile band.
- `#main-nav > li.dropdown { … height: 130px; z-index: 99; … }` — the profile li gets the slot **by class, not position**. Identical outcome when the pill is absent (the profile li is then nth-child(1) anyway, receiving the same properties from the original rule). `z-index: 99` also keeps the opened `.profileDropli` above the file input.

## Validation

- **Red/green**: `tests/unit/test_602_caliblur_mobile_profile_slot.py` — 2 CSS pins fail on `main`, pass on this branch; a third pin documents the pill-before-profile ordering assumption the guard exists for. Adjacent caliBlur suites (`test_caliblur_mobile_search_425`, `test_random_books_caliblur_523`, `test_mobile_hamburger_left`) all green (11 passed).
- **Live e2e on cwn-local (real file, no injection), 360×740**: drawer rows stack cleanly (pill 43px → profile 130px slot → Upload → MANAGE/Tasks/Admin/Refresh); hit-test at the username returns `.profileDrop` (was `#btn-upload`); tapping the username opens the dropdown (`li.dropdown.open`); tapping **Logout** lands on `/login` with the login form — the exact flow the reporter couldn't complete. Screenshots in `notes/evidence-602/` (reporter symptom + fixed drawer closed/open + desktop).
- **Desktop caliBlur (1280px)**: dropdown opens, Logout clickable, anchor stays 60px — unchanged.
- **Default theme**: untouched by construction — caliBlur.css only loads when theme 1 is active; `layout.html` is not modified (the test's ordering pin reads it, nothing more).
- **Container logs** clean after restart (only the pre-existing flask_limiter in-memory warning).

Skipped checklist rows: stress/concurrency (static CSS, no request-handler or DB surface), i18n (no strings), OPDS/Kobo (no protocol surface), network-down/rollback (no external calls, additive CSS is trivially revertible).

## Blast radius

Only theme-1 (caliBlur) mobile ≤767px. The two rules are additive; no existing rule is edited. Configurations without the pill (`cwng_spa_enabled` off) get identical computed styles to today. Anonymous sessions follow the same profile-li path (login/register links live inside the same dropdown).

## Tier

Fork-original behavior change, single CSS file +26/-0 production lines (rest is test) — within the autonomous-gate size cap. Routine theme CSS: no auth/session/CSRF/subprocess/file-path/new-route surface (no `/security-review` needed) and no Greptile trigger per opt-in policy.

## Release target

Rides the v4.1.4 train (~18:30Z today) with #578/#586/#608/#612.