### PR TITLE
fix(i18n): 'Mark as read' no longer carries the unread sense in 17 locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- **French (and 16 other languages) no longer offer "mark as unread" on a book
+  you haven't read.** The new UI's read toggle said "Marquer comme non lu"
+  (mark as unread) on unread books because the translation for "Mark as read"
+  carried the opposite meaning — the same copy-paste slip existed in Arabic,
+  Czech, Greek, Spanish, Finnish, Galician, Indonesian, Portuguese, Slovak,
+  Slovenian, Swedish, Turkish, Ukrainian, Vietnamese, and both Chinese
+  variants. All 17 are fixed. The classic detail page's big read button also
+  said "Lu" (has been read) in French where it meant "open the reader" — it
+  now says "Lire", and the status badge keeps "Lu" where that's correct.
+  Reported by @hayvan96.
 - **You can log out again on mobile in the classic view.** With the caliBlur
   theme on a phone, tapping your username in the menu did nothing — an
   invisible upload control was swallowing the tap, so the account submenu

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -631,7 +631,7 @@
                 <a class="book-read-cta" target="_blank"
                    href="{{ url_for('web.read_book', book_id=entry.id, book_format=entry.reader_list[0]) }}">
                     <span class="glyphicon glyphicon-book" aria-hidden="true"></span>
-                    <span>{{ _('Read') }}</span>
+                    <span>{{ _('Read now') }}</span>
                 </a>
                 {% endif %}
                 </div>

--- a/cps/translations/ar/LC_MESSAGES/messages.po
+++ b/cps/translations/ar/LC_MESSAGES/messages.po
@@ -3107,7 +3107,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "وضع علامة كـ غير مقروء"
+msgstr "وضع علامة كـ مقروء"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/cs/LC_MESSAGES/messages.po
+++ b/cps/translations/cs/LC_MESSAGES/messages.po
@@ -3131,7 +3131,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Označit jako nepřečtené"
+msgstr "Označit jako přečtené"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/el/LC_MESSAGES/messages.po
+++ b/cps/translations/el/LC_MESSAGES/messages.po
@@ -3192,7 +3192,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Σήμανση ως Αδιάβαστο"
+msgstr "Σήμανση ως Διαβασμένο"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/es/LC_MESSAGES/messages.po
+++ b/cps/translations/es/LC_MESSAGES/messages.po
@@ -3224,7 +3224,7 @@ msgstr ""
 #: cps/templates/_book_organizer.html:139 cps/templates/book_table.html:60
 #: cps/templates/book_table.html:254
 msgid "Mark as read"
-msgstr "Marcar como no leído"
+msgstr "Marcar como leído"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/fi/LC_MESSAGES/messages.po
+++ b/cps/translations/fi/LC_MESSAGES/messages.po
@@ -3117,7 +3117,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Merkitse lukemattomaksi"
+msgstr "Merkitse luetuksi"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -2568,9 +2568,8 @@ msgid "Manual (drag below)"
 msgstr "Manuel (glisser pour réorganiser)"
 
 #: cps/spa_strings.py:29
-#, fuzzy
 msgid "Read now"
-msgstr "Lire dans le navigateur"
+msgstr "Lire"
 
 #: cps/tasks_status.py:37 cps/templates/layout.html:369
 #: cps/templates/tasks.html:7
@@ -3270,7 +3269,7 @@ msgstr ""
 #: cps/templates/_book_organizer.html:139 cps/templates/book_table.html:60
 #: cps/templates/book_table.html:254
 msgid "Mark as read"
-msgstr "Marquer comme non lu"
+msgstr "Marquer comme lu"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/gl/LC_MESSAGES/messages.po
+++ b/cps/translations/gl/LC_MESSAGES/messages.po
@@ -3178,7 +3178,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Marcar como non lido"
+msgstr "Marcar como lido"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/id/LC_MESSAGES/messages.po
+++ b/cps/translations/id/LC_MESSAGES/messages.po
@@ -3158,7 +3158,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Tandai sebagai Belum dibaca"
+msgstr "Tandai sebagai dibaca"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/pt/LC_MESSAGES/messages.po
+++ b/cps/translations/pt/LC_MESSAGES/messages.po
@@ -3204,7 +3204,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Marcar como não Lido"
+msgstr "Marcar como lido"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/sk/LC_MESSAGES/messages.po
+++ b/cps/translations/sk/LC_MESSAGES/messages.po
@@ -3137,7 +3137,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Označiť ako neprečítané"
+msgstr "Označiť ako prečítané"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/sl/LC_MESSAGES/messages.po
+++ b/cps/translations/sl/LC_MESSAGES/messages.po
@@ -3202,7 +3202,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Označi kot neprebrano"
+msgstr "Označi kot prebrano"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/sv/LC_MESSAGES/messages.po
+++ b/cps/translations/sv/LC_MESSAGES/messages.po
@@ -3157,7 +3157,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Markera som oläst"
+msgstr "Markera som läst"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/tr/LC_MESSAGES/messages.po
+++ b/cps/translations/tr/LC_MESSAGES/messages.po
@@ -3114,7 +3114,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Okunmadı olarak işaretle"
+msgstr "Okundu olarak işaretle"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/uk/LC_MESSAGES/messages.po
+++ b/cps/translations/uk/LC_MESSAGES/messages.po
@@ -3098,7 +3098,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Відмітити як не прочитане"
+msgstr "Відмітити як прочитане"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/vi/LC_MESSAGES/messages.po
+++ b/cps/translations/vi/LC_MESSAGES/messages.po
@@ -3101,7 +3101,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "Đánh dấu chưa đọc"
+msgstr "Đánh dấu đã đọc"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -3096,7 +3096,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "标为未读"
+msgstr "标为已读"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -3107,7 +3107,7 @@ msgstr ""
 #: cps/templates/book_table.html:254
 #, fuzzy
 msgid "Mark as read"
-msgstr "標為未讀"
+msgstr "標為已讀"
 
 #: cps/templates/_book_organizer.html:145 cps/templates/book_table.html:63
 #: cps/templates/book_table.html:274

--- a/tests/unit/test_615_mark_as_read_inversion.py
+++ b/tests/unit/test_615_mark_as_read_inversion.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression tests for #615 — "Mark as read" translated with the *unread* sense.
+
+French (and 16 other locales) translated the lowercase msgid "Mark as read"
+identically to "Mark as unread" (fr: both "Marquer comme non lu"). The new UI
+uses exactly this msgid pair (BookDetail action button / aria-label), so an
+unread book offered "Marquer comme non lu". The classic detail page uses the
+title-case pair "Mark As Read"/"Mark As Unread", which is translated correctly
+everywhere — that pair is the donor for the fix.
+
+Second symptom on the same page: the classic detail read CTA reused the
+read-*status* msgid "Read" (fr "Lu", a past participle) as a verb button.
+It now uses the verb msgid "Read now" introduced for the SPA by #577, so the
+status translations ("Lu", "Gelezen", …) stay untouched where they are correct
+(cover badges, listenmp3 checkbox label).
+"""
+import pathlib
+
+import pytest
+from babel.messages.pofile import read_po
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_TRANSLATIONS = _ROOT / "cps" / "translations"
+
+
+def _catalog(po_path):
+    with open(po_path, "rb") as fh:
+        return read_po(fh)
+
+
+def _msgstr(cat, msgid):
+    msg = cat.get(msgid)
+    if msg is None:
+        return None
+    return msg.string if isinstance(msg.string, str) else None
+
+
+@pytest.mark.unit
+def test_no_locale_translates_mark_as_read_as_unread():
+    """The bug class: any locale where both strings are translated must keep
+    them different — identical strings mean the "read" side carries the
+    "unread" sense (that is how all 17 broken locales were broken)."""
+    checked = 0
+    offenders = []
+    for po in sorted(_TRANSLATIONS.glob("*/LC_MESSAGES/messages.po")):
+        cat = _catalog(po)
+        mar = _msgstr(cat, "Mark as read")
+        mau = _msgstr(cat, "Mark as unread")
+        if mar and mau:
+            checked += 1
+            if mar == mau:
+                offenders.append(po.parts[-3])
+    assert checked >= 20, "expected the msgid pair in most shipped locales"
+    assert offenders == [], (
+        "locales translating 'Mark as read' identically to 'Mark as unread': %s"
+        % offenders
+    )
+
+
+@pytest.mark.unit
+def test_fr_mark_as_read_matches_reporter_expectation():
+    """#615's exact symptom: fr must say 'Marquer comme lu' for the read side."""
+    cat = _catalog(_TRANSLATIONS / "fr" / "LC_MESSAGES" / "messages.po")
+    assert _msgstr(cat, "Mark as read") == "Marquer comme lu"
+    assert _msgstr(cat, "Mark as unread") == "Marquer comme non lu"
+
+
+@pytest.mark.unit
+def test_fr_spa_catalog_serves_correct_labels():
+    """What the new UI actually receives: the api catalog is derived from the
+    same .po, so the fixed pair must come through, and the read-status word
+    must stay the past participle (naive fixes flip 'Read' → 'Lire' and break
+    the cover badge / status label)."""
+    from cps.api.i18n import _load_catalog
+
+    cat = _load_catalog("fr")
+    assert cat.get("Mark as read") == "Marquer comme lu"
+    assert cat.get("Mark as unread") == "Marquer comme non lu"
+    assert cat.get("Read") == "Lu"
+
+
+@pytest.mark.unit
+def test_fr_read_now_translated_and_not_fuzzy():
+    """The classic UI reads the compiled .mo, and msgfmt DROPS fuzzy entries —
+    a fuzzy 'Read now' means French users silently get the English button
+    (that is how the first live verify of this fix failed). Pin the flag off
+    and the reporter's requested wording."""
+    cat = _catalog(_TRANSLATIONS / "fr" / "LC_MESSAGES" / "messages.po")
+    msg = cat.get("Read now")
+    assert msg is not None
+    assert msg.string == "Lire"
+    assert not msg.fuzzy
+
+
+@pytest.mark.unit
+def test_detail_template_read_cta_uses_verb_msgid():
+    """The classic detail CTA opens the reader — a verb — so it must use the
+    'Read now' msgid, not the status msgid 'Read' (fr 'Lu' on the big button
+    was the first half of #615)."""
+    src = (_ROOT / "cps" / "templates" / "detail.html").read_text()
+    cta_at = src.find('class="book-read-cta"')
+    assert cta_at != -1, "read CTA anchor missing from detail.html"
+    cta_block = src[cta_at : src.index("</a>", cta_at)]
+    assert "_('Read now')" in cta_block
+    assert "_('Read')" not in cta_block
+
+
+@pytest.mark.unit
+def test_status_contexts_keep_status_msgid():
+    """The past-participle contexts must keep msgid 'Read': the cover badge
+    (image.html) and the listenmp3 read checkbox label."""
+    image = (_ROOT / "cps" / "templates" / "image.html").read_text()
+    assert "_('Read')" in image
+    listen = (_ROOT / "cps" / "templates" / "listenmp3.html").read_text()
+    assert "_('Read')" in listen


### PR DESCRIPTION
## Why

Fork issue #615 (@hayvan96): in French, the new UI's read toggle on an **unread** book said "Marquer comme non lu" (mark as unread), and the classic detail page's big read button said "Lu" (has been read) where it means "open the reader".

## Root cause

Two independent msgid-level bugs:

1. **Inverted pair, 17 locales wide.** The lowercase msgid pair `Mark as read` / `Mark as unread` (used by `_book_organizer.html`, `book_table.html`, and the SPA `BookDetail`) had `Mark as read` translated with the *unread* sense — byte-identical to `Mark as unread` — in ar, cs, el, es, fi, fr, gl, id, pt, sk, sl, sv, tr, uk, vi, zh_Hans_CN, zh_Hant_TW. The title-case pair `Mark As Read` / `Mark As Unread` (classic detail page) is correct everywhere, which is why the reporter saw classic right / new UI wrong.
2. **Verb/status msgid collision.** The classic detail CTA reused msgid `Read`, whose translations are the read-*status* past participle (fr "Lu", nl "Gelezen" — correct for the cover badge and the listenmp3 checkbox label). Same class as #577; the SPA already uses the verb msgid `Read now` for this button.

## Fix

- Each broken locale's `Mark as read` msgstr repaired from its **own** human-translated title-case `Mark As Read` entry (no new translations invented).
- `detail.html` CTA switched to `_('Read now')` — aligns classic with the SPA button; status contexts keep `Read` untouched.
- fr `Read now` de-fuzzed and set to "Lire" (the reporter's requested wording). The fuzzy flag mattered: **msgfmt drops fuzzy entries from the compiled .mo**, so the classic UI would have silently shown English (caught in live verify, now pinned).

## Validation

- `tests/unit/test_615_mark_as_read_inversion.py` — 6 pins, RED on main (4 failed pre-fix) → GREEN: cross-locale identical-pair scan, fr reporter expectation, SPA catalog parity (`_load_catalog`), CTA verb msgid, status contexts keep `Read`, fr `Read now` non-fuzzy.
- `test_577_dutch_read_label.py`, `test_translations_compile.py` (msgfmt on every locale): green. The 5 pre-existing pybabel placeholder warnings in fr.po are unchanged from main (lines 537–3833, none touched).
- **Live cwn-local, French session (admin locale=fr), deployed files:** classic `/book/7` renders `<span>Lire</span>` in the CTA and the correct toggle pair; SPA `/app/book/7` (unread) shows button + aria "Marquer comme lu", `/app/book/4` (read) shows "Lu ✓"; `/api/v1/i18n/fr.json` serves the corrected pair. Evidence JPEGs in `notes/evidence-615/`.

## Blast radius

All other `Mark as read` consumers (book_table single + bulk, book organizer) want exactly this meaning. No JS text-matches the CTA label (grepped). `Read` status translations untouched in all locales. English UI: classic CTA label changes "Read" → "Read now" (matches the SPA button).

Tier: needs-review · Release target: next train (v4.1.4)