### PR TITLE
fix(spa): honor the admin-configured instance title in the new UI

### DIFF
--- a/cps/api/auth.py
+++ b/cps/api/auth.py
@@ -72,6 +72,14 @@ def auth_csrf():
     return jsonify({"csrf_token": token})
 
 
+def _instance_name():
+    """The admin-configured site title (config_calibre_web_title). The classic
+    UI shows it in the navbar and <title> on every page (render_template.py
+    passes instance=…); the SPA reads it from here. Blank falls back to the
+    stock name."""
+    return getattr(config, "config_calibre_web_title", None) or "Calibre-Web NextGen"
+
+
 def _server_features():
     """Instance-level capability flags the SPA gates UI off (mirrors the Jinja
     template gates: hide-books button, send-to-e-reader, register link, …).
@@ -95,6 +103,7 @@ def auth_me():
         return jsonify({"error": {"code": "unauthenticated", "message": "Login required"}}), 401
     payload = serialize_user(current_user)
     payload["features"] = _server_features()
+    payload["instance_name"] = _instance_name()
     return jsonify(payload)
 
 
@@ -116,6 +125,7 @@ def auth_login():
         login_user(user, remember=bool(data.get("remember")))
         payload = serialize_user(user)
         payload["features"] = _server_features()
+        payload["instance_name"] = _instance_name()
         return jsonify(payload)
     return jsonify({"error": {"code": "invalid_credentials",
                               "message": "Invalid username or password"}}), 401
@@ -142,6 +152,7 @@ def auth_config():
     except Exception:
         remote_login_url = ""
     return jsonify({
+        "instance_name": _instance_name(),
         "public_registration": bool(getattr(config, "config_public_reg", False)),
         "register_email": bool(getattr(config, "config_register_email", False)),
         "mail_configured": mail_ok,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { Router, Route, Switch } from 'wouter';
 import { BASE_PREFIX } from './lib/api';
 import { useMe, useLogout } from './lib/queries';
@@ -42,6 +42,12 @@ export function App() {
   const { data: me, isLoading } = useMe();
   const logout = useLogout();
 
+  // #609: the classic UI puts the configured instance title in <title> on every
+  // page; index.html ships the stock name as the pre-boot fallback.
+  useEffect(() => {
+    if (me?.instance_name) document.title = me.instance_name;
+  }, [me?.instance_name]);
+
   if (isLoading) {
     return <SpinnerCentered size={40} />;
   }
@@ -84,7 +90,7 @@ export function App() {
 
         {/* Everything else lives inside the shell. */}
         <Route>
-          <AppShell userName={me.name} onLogout={() => logout.mutate()}>
+          <AppShell userName={me.name} instanceName={me.instance_name} onLogout={() => logout.mutate()}>
             <Switch>
           <Route path="/book/:id/edit">{(p) => <EditBook id={p.id} />}</Route>
           <Route path="/book/:id/cover">{(p) => <CoverPicker id={p.id} />}</Route>

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -6,11 +6,12 @@ import styles from './AppShell.module.css';
 
 interface AppShellProps {
   userName: string;
+  instanceName?: string;
   onLogout: () => void;
   children: ReactNode;
 }
 
-export function AppShell({ userName, onLogout, children }: AppShellProps) {
+export function AppShell({ userName, instanceName, onLogout, children }: AppShellProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   // Lock the page behind the mobile drawer: overscroll-behavior only stops scroll
@@ -25,7 +26,7 @@ export function AppShell({ userName, onLogout, children }: AppShellProps) {
 
   return (
     <div className={styles.shell}>
-      <TopBar userName={userName} onLogout={onLogout} onMenu={() => setDrawerOpen(true)} />
+      <TopBar userName={userName} instanceName={instanceName} onLogout={onLogout} onMenu={() => setDrawerOpen(true)} />
       <HelpBanner />
       <div className={styles.body}>
         <Sidebar open={drawerOpen} onNavigate={() => setDrawerOpen(false)} />

--- a/frontend/src/components/BrandName.tsx
+++ b/frontend/src/components/BrandName.tsx
@@ -1,0 +1,21 @@
+// #609: the brand honors the admin-configured instance title everywhere the
+// classic UI does (navbar + login card). A custom title renders as plain text;
+// the stock name keeps the two-tone accent treatment.
+export const DEFAULT_INSTANCE_NAME = 'Calibre-Web NextGen';
+
+interface BrandNameProps {
+  /** Server-provided instance_name (from /auth/config or /auth/me). */
+  name?: string;
+  accentClassName?: string;
+}
+
+export function BrandName({ name, accentClassName }: BrandNameProps) {
+  if (name && name !== DEFAULT_INSTANCE_NAME) {
+    return <>{name}</>;
+  }
+  return (
+    <>
+      Calibre-Web <span className={accentClassName}>NextGen</span>
+    </>
+  );
+}

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -2,12 +2,14 @@ import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react'
 import { BookMarked, LogOut, Menu, Search, ChevronDown, User, Bug, BookOpen, Undo2 } from 'lucide-react';
 import { Link, useLocation } from 'wouter';
 import { GithubMark, DiscordMark } from './BrandIcons';
+import { BrandName } from './BrandName';
 import { BASE_PREFIX } from '../lib/api';
 import { useT } from '../lib/i18n';
 import styles from './TopBar.module.css';
 
 interface TopBarProps {
   userName: string;
+  instanceName?: string;
   onLogout: () => void;
   onMenu?: () => void;
 }
@@ -182,7 +184,7 @@ function UserMenu({ userName, onLogout }: { userName: string; onLogout: () => vo
   );
 }
 
-export function TopBar({ userName, onLogout, onMenu }: TopBarProps) {
+export function TopBar({ userName, instanceName, onLogout, onMenu }: TopBarProps) {
   const t = useT();
   const [, setLocation] = useLocation();
   const [q, setQ] = useState('');
@@ -201,9 +203,8 @@ export function TopBar({ userName, onLogout, onMenu }: TopBarProps) {
         )}
         <Link href="/" className={styles.brand}>
           <BookMarked size={22} className={styles.brandIcon} />
-          <span className={styles.brandText}>
-            <span className={styles.brandMain}>Calibre-Web </span>
-            <span className={styles.brandAccent}>NextGen</span>
+          <span className={`${styles.brandText} ${styles.brandMain}`}>
+            <BrandName name={instanceName} accentClassName={styles.brandAccent} />
           </span>
         </Link>
       </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -50,6 +50,7 @@ export interface Me {
   theme: string;
   role: Record<string, boolean>;
   features?: ServerFeatures;
+  instance_name?: string;
 }
 
 export interface Book {
@@ -243,6 +244,7 @@ export interface OAuthProvider {
 }
 
 export interface AuthConfig {
+  instance_name?: string;
   public_registration: boolean;
   register_email: boolean;
   mail_configured: boolean;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'wouter';
 import { BookMarked, KeyRound, Eye, EyeOff } from 'lucide-react';
 import { Button } from '../components/Button';
+import { BrandName } from '../components/BrandName';
 import { Spinner } from '../components/Spinner';
 import { useLogin, useAuthConfig, useRegister, useForgotPassword } from '../lib/queries';
 import { ApiError } from '../lib/api';
@@ -25,6 +26,11 @@ export function Login() {
   const register = useRegister();
   const forgot = useForgotPassword();
   const { data: cfg } = useAuthConfig();
+
+  // #609: the classic login page titles itself with the configured instance name.
+  useEffect(() => {
+    if (cfg?.instance_name) document.title = cfg.instance_name;
+  }, [cfg?.instance_name]);
 
   const reset = () => { setErrorMsg(null); setOkMsg(null); };
 
@@ -66,7 +72,7 @@ export function Login() {
       <div className={styles.card}>
         <div className={styles.brandMark}>
           <BookMarked size={32} className={styles.brandIcon} />
-          <span className={styles.brandText}>Calibre-Web <span className={styles.brandAccent}>NextGen</span></span>
+          <span className={styles.brandText}><BrandName name={cfg?.instance_name} accentClassName={styles.brandAccent} /></span>
         </div>
         <p className={styles.tagline}>
           {mode === 'register' ? t('Create your account')

--- a/frontend/src/pages/MagicLink.tsx
+++ b/frontend/src/pages/MagicLink.tsx
@@ -6,7 +6,8 @@ import {
 } from 'lucide-react';
 import { Spinner } from '../components/Spinner';
 import { Button } from '../components/Button';
-import { useMagicLinkStart, useMagicLinkPoll } from '../lib/queries';
+import { BrandName } from '../components/BrandName';
+import { useMagicLinkStart, useMagicLinkPoll, useAuthConfig } from '../lib/queries';
 import { useT } from '../lib/i18n';
 import styles from './MagicLink.module.css';
 
@@ -26,6 +27,7 @@ export function MagicLink() {
   const [, navigate] = useLocation();
   const start = useMagicLinkStart();
   const poll = useMagicLinkPoll();
+  const { data: cfg } = useAuthConfig();
 
   const [phase, setPhase] = useState<Phase>('starting');
   const [token, setToken] = useState<string | null>(null);
@@ -122,7 +124,7 @@ export function MagicLink() {
         <div className={styles.brandMark}>
           <BookMarked size={28} className={styles.brandIcon} />
           <span className={styles.brandText}>
-            Calibre-Web <span className={styles.brandAccent}>NextGen</span>
+            <BrandName name={cfg?.instance_name} accentClassName={styles.brandAccent} />
           </span>
         </div>
 

--- a/tests/unit/test_609_instance_title_api.py
+++ b/tests/unit/test_609_instance_title_api.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""#609: the new UI must honor the custom instance title (config_calibre_web_title).
+
+The classic UI renders the configured title in the navbar and <title> on every
+page (render_template.py passes instance=config.config_calibre_web_title). The
+SPA hardcoded the brand, so a custom title never showed. These tests pin the
+API contract that fixes it: instance_name on /auth/config (public — the login
+screen needs it), /auth/me and the login payload (the app shell needs it).
+"""
+import re
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import flask
+import pytest
+
+import cps.api.auth
+
+FRONTEND = Path(__file__).resolve().parents[2] / "frontend" / "src"
+
+
+def _app():
+    from cps.api import api_v1
+    app = flask.Flask(__name__)
+    app.testing = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    app.config["SECRET_KEY"] = "test"
+    app.config["RATELIMIT_ENABLED"] = False
+    app.register_blueprint(api_v1)
+    return app
+
+
+@pytest.mark.unit
+def test_auth_config_exposes_custom_instance_name():
+    app = _app()
+    with patch.object(cps.api.auth, "config") as cfg, \
+         patch.object(cps.api.auth, "_oauth_providers", return_value=[]):
+        cfg.config_calibre_web_title = "Glenn's Book Emporium"
+        cfg.config_public_reg = False
+        cfg.config_register_email = False
+        cfg.get_mail_server_configured.return_value = False
+        cfg.config_disable_standard_login = False
+        cfg.config_remote_login = False
+        resp = app.test_client().get("/api/v1/auth/config")
+    assert resp.status_code == 200
+    assert resp.get_json()["instance_name"] == "Glenn's Book Emporium"
+
+
+@pytest.mark.unit
+def test_auth_config_instance_name_falls_back_when_blank():
+    app = _app()
+    for blank in ("", None):
+        with patch.object(cps.api.auth, "config") as cfg, \
+             patch.object(cps.api.auth, "_oauth_providers", return_value=[]):
+            cfg.config_calibre_web_title = blank
+            cfg.config_public_reg = False
+            cfg.config_register_email = False
+            cfg.get_mail_server_configured.return_value = False
+            cfg.config_disable_standard_login = False
+            cfg.config_remote_login = False
+            resp = app.test_client().get("/api/v1/auth/config")
+        assert resp.get_json()["instance_name"] == "Calibre-Web NextGen"
+
+
+@pytest.mark.unit
+def test_auth_me_includes_instance_name():
+    app = _app()
+    from cps import ub, constants
+    u = ub.User()
+    u.id, u.name, u.locale, u.theme = 5, "maggie", "en", 1
+    u.role = constants.ROLE_USER
+    with patch("cps.api.auth.current_user", u), \
+         patch.object(cps.api.auth, "config") as cfg:
+        cfg.config_calibre_web_title = "Maggie's Library"
+        cfg.config_user_hide_enabled = False
+        cfg.get_mail_server_configured.return_value = False
+        cfg.config_public_reg = False
+        cfg.config_anonbrowse = False
+        cfg.config_kobo_sync = False
+        resp = app.test_client().get("/api/v1/auth/me")
+    assert resp.status_code == 200
+    assert resp.get_json()["instance_name"] == "Maggie's Library"
+
+
+@pytest.mark.unit
+def test_login_payload_includes_instance_name():
+    app = _app()
+    from cps import ub, constants
+    u = ub.User()
+    u.id, u.name, u.password, u.locale, u.theme = 1, "admin", "hash", "en", 1
+    u.role = constants.ROLE_ADMIN
+    mock_session = MagicMock()
+    mock_session.query.return_value.filter.return_value.first.return_value = u
+    with patch("cps.api.auth.ub.session", mock_session), \
+         patch("cps.api.auth.check_password_hash", return_value=True), \
+         patch.object(cps.api.auth, "config") as cfg, \
+         patch("cps.api.auth.login_user"):
+        cfg.config_disable_standard_login = False
+        cfg.config_calibre_web_title = "Maggie's Library"
+        cfg.config_user_hide_enabled = False
+        cfg.get_mail_server_configured.return_value = False
+        cfg.config_public_reg = False
+        cfg.config_anonbrowse = False
+        cfg.config_kobo_sync = False
+        resp = app.test_client().post("/api/v1/auth/login",
+                                      json={"username": "admin", "password": "x"})
+    assert resp.status_code == 200
+    assert resp.get_json()["instance_name"] == "Maggie's Library"
+
+
+# --- Frontend source pins (no JS test runner in this repo; same idiom as the
+# --- reload-delay pin in test_duplicate_manager_race_fix.py) ---------------
+
+@pytest.mark.unit
+def test_topbar_consumes_instance_name_not_only_hardcoded_brand():
+    src = (FRONTEND / "components" / "TopBar.tsx").read_text()
+    assert "instanceName" in src, "TopBar must take the server-provided instance name"
+
+
+@pytest.mark.unit
+def test_app_sets_document_title_from_instance_name():
+    src = (FRONTEND / "App.tsx").read_text()
+    assert re.search(r"document\.title", src), "App must sync document.title (classic <title> parity)"
+
+
+@pytest.mark.unit
+def test_api_types_declare_instance_name():
+    src = (FRONTEND / "lib" / "api.ts").read_text()
+    assert src.count("instance_name") >= 2, "Me and AuthConfig must both carry instance_name"

--- a/tests/unit/test_api_v1_auth.py
+++ b/tests/unit/test_api_v1_auth.py
@@ -146,12 +146,14 @@ def test_auth_config_is_public_and_shaped():
         cfg.config_register_email = False
         cfg.get_mail_server_configured.return_value = True
         cfg.config_disable_standard_login = False
+        cfg.config_calibre_web_title = "Calibre-Web NextGen"
         resp = app.test_client().get("/api/v1/auth/config")
     assert resp.status_code == 200
     d = resp.get_json()
     assert d["public_registration"] is True
     assert d["mail_configured"] is True
     assert d["oauth_providers"] == []
+    assert d["instance_name"] == "Calibre-Web NextGen"
 
 
 @pytest.mark.unit
@@ -324,6 +326,7 @@ def test_auth_config_exposes_remote_login():
         cfg.get_mail_server_configured.return_value = True
         cfg.config_disable_standard_login = False
         cfg.config_remote_login = True
+        cfg.config_calibre_web_title = "Calibre-Web NextGen"
         d = app.test_client().get("/api/v1/auth/config").get_json()
     assert d["remote_login"] is True
     assert d["remote_login_url"] == "/remote/login"


### PR DESCRIPTION
## Why
#609 (@Glennza1962, me-too from @iroQuai): the new UI shows "Calibre Web Nextgen" regardless of the site title configured under Admin → Basic Configuration. The classic UI puts that title in the navbar and `<title>` on every page.

## Root cause
The SPA hardcoded the brand in `TopBar.tsx`, `Login.tsx`, `MagicLink.tsx`, and `index.html`, and no `/api/v1` endpoint exposed `config_calibre_web_title` outside the admin-gated settings API.

## Fix
- `cps/api/auth.py`: `instance_name` added to `/auth/config` (public — the login screen renders before auth), `/auth/me`, and the login payload; blank falls back to the stock name.
- `frontend/src/components/BrandName.tsx` (new, shared): a custom title renders as plain text; the stock name keeps the two-tone accent treatment.
- `TopBar`/`AppShell`/`App`: brand + `document.title` follow `me.instance_name`. `Login`/`MagicLink`: brand + `document.title` follow `/auth/config`.

## Validation
- **Red/green:** `tests/unit/test_609_instance_title_api.py` — 4 endpoint tests (custom title, blank fallback, /auth/me, login payload) failed with `KeyError: 'instance_name'` on the old code, green after; 3 frontend source pins (TopBar consumes `instanceName`, App syncs `document.title`, both API types carry the field). Full `test_api_v1_auth.py` suite green (33 tests total).
- **Live cwn-local e2e (bind-mounted branch code):** with the default title, login page and top bar are pixel-identical two-tone brand; after setting `config_calibre_web_title = "Glenn's Book Emporium"` (the reporter's example) in app.db + restart: login card, authenticated top bar, and `document.title` all show it, verified via real `/auth/login` POST on the wire and Playwright at desktop 1280 and mobile 375 (title wraps cleanly, no overflow/clipping). Evidence: `notes/evidence-609/` (project dir).
- XSS: the title renders as React text nodes (no `dangerouslySetInnerHTML`); JSON-encoded on the wire.

## Tier
Small multi-file SPA + one additive API field; no new routes with side effects, no deps, no auth/session logic change (login/me payloads gain one read-only config string). Rides the next train.

Ships fix for #609.