### PR TITLE
fix(spa): stop Admin's legacy config links from reverting the whole new UI (#584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ is for things you can see or feel when running the app.
   at something like `https://host/cwa/` they broke out of the app and landed on
   a 404. They now stay inside the sub-path like the rest of the interface.
   Installs mounted at the domain root are unaffected. Reported by @chloeroform.
+- **Opening a "More server configuration" page no longer throws you out of the
+  new UI.** Those cards on the Admin page link to the deep, classic
+  configuration screens (database path, scheduled tasks, logs, and the like).
+  Clicking one used to replace the whole new interface with the old page, so it
+  felt like the app had reverted to the old UI. They now open in a new browser
+  tab, so the new UI stays exactly where it was and you can close the tab to
+  come back. The full native rebuild of those config screens is still on the
+  roadmap. Reported by @Glennza1962.
 - **The new UI now shows your site's name.** If you set a custom title under
   Admin → Basic Configuration, the new UI ignored it — the top bar, the login
   screen, and the browser tab always said "Calibre-Web NextGen". All three now

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -228,10 +228,16 @@ export function Admin() {
       </p>
       <div className={styles.settingsGrid}>
         {SERVER_SETTINGS.map(({ href, label, icon: Icon }) => (
-          <a key={href} href={resourceUrl(href)} className={styles.settingsCard}>
-            <Icon size={18} className={styles.settingsIcon} />
+          <a
+            key={href}
+            href={resourceUrl(href)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.settingsCard}
+          >
+            <Icon size={18} className={styles.settingsIcon} aria-hidden="true" />
             <span className={styles.settingsLabel}>{t(label)}</span>
-            <ExternalLink size={13} className={styles.settingsExt} />
+            <ExternalLink size={13} className={styles.settingsExt} aria-hidden="true" />
           </a>
         ))}
       </div>

--- a/tests/unit/test_584_admin_legacy_link_new_tab.py
+++ b/tests/unit/test_584_admin_legacy_link_new_tab.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression tests for #584 — "More server configuration" links revert the whole UI.
+
+The new-UI Admin page keeps a set of "More server configuration" cards that link
+out to the deep, rarely-touched legacy (Jinja) config pages — DB path, scheduled
+tasks, logs, etc. Rebuilding all of those natively is the SPA admin-migration
+project (tracked in notes/DEFERRED-NEWUI-FEATURES.md), not this release.
+
+The reporter's concrete complaint (@Glennza1962): entering one of those sub-menus
+"reverts the whole UI back to the old one." That happened because the card anchors
+navigated in the *same* tab, so the SPA document was replaced wholesale by the
+classic page — even though each card already renders an ExternalLink icon
+advertising that it leaves the new UI.
+
+The pragmatic, no-rebuild fix: open those legacy pages in a new tab
+(target="_blank" rel="noopener noreferrer"), so the new UI stays put and the
+classic config page is a clearly-separate context the user can close to return.
+This makes the ExternalLink affordance truthful and removes the jarring
+whole-app revert without waiting on the native admin rebuild.
+
+Client-side source pins (the SPA bundle is built in Docker, not committed, so a
+runtime assertion isn't reachable here — pin the source that the build compiles).
+"""
+import pathlib
+import re
+
+import pytest
+
+_FE = pathlib.Path(__file__).resolve().parents[2] / "frontend" / "src"
+_ADMIN = _FE / "pages" / "Admin.tsx"
+
+
+def _admin_src() -> str:
+    return _ADMIN.read_text()
+
+
+def _settings_card_anchor(src: str) -> str:
+    """Return the JSX for the settings-card <a> element (the SERVER_SETTINGS map)."""
+    # The anchor opens with the resourceUrl'd href (#603) and closes at </a>.
+    m = re.search(r"<a\s+key=\{href\}.*?</a>", src, re.S)
+    assert m, "settings-card <a> element not found in Admin.tsx"
+    return m.group(0)
+
+
+@pytest.mark.unit
+def test_settings_cards_open_in_new_tab():
+    """Each 'More server configuration' card must open the legacy page in a new
+    tab so entering a sub-menu doesn't replace the whole new UI (#584).
+    RED on main, where the anchor had no target attribute."""
+    anchor = _settings_card_anchor(_admin_src())
+    assert 'target="_blank"' in anchor, \
+        "settings-card anchor must set target=\"_blank\" so legacy config opens " \
+        "in a new tab instead of reverting the whole new UI (#584)"
+
+
+@pytest.mark.unit
+def test_settings_cards_new_tab_is_secure():
+    """target=\"_blank\" without rel=noopener lets the opened legacy page reach
+    back into window.opener. Pin the secure rel so the new-tab fix can't
+    introduce a reverse-tabnabbing vector."""
+    anchor = _settings_card_anchor(_admin_src())
+    rel = re.search(r'rel="([^"]*)"', anchor)
+    assert rel, "settings-card anchor must carry a rel attribute alongside target=_blank"
+    tokens = set(rel.group(1).split())
+    assert "noopener" in tokens, "rel must include noopener (block window.opener access)"
+    assert "noreferrer" in tokens, "rel must include noreferrer"
+
+
+@pytest.mark.unit
+def test_settings_cards_still_carry_reverse_proxy_prefix():
+    """The new-tab fix must not regress #603 — the href must still route through
+    the reverse-proxy prefix helper so a /cwa-mounted install opens the legacy
+    page inside the mount."""
+    anchor = _settings_card_anchor(_admin_src())
+    assert "href={resourceUrl(href)}" in anchor, \
+        "settings-card anchor must keep href={resourceUrl(href)} (#603 prefix fix)"


### PR DESCRIPTION
## Why
Fork issue **#584** — reporter @Glennza1962: on the new UI, opening a card under **Admin → More server configuration** (Basic configuration, Database & library path, Scheduled tasks, Logs, CWA settings, etc.) "reverts the whole UI back to the old one."

Sibling issue **#603** (reverse-proxy prefix on these same cards) is **already fixed and shipped** — PR #621 wrapped the hrefs in `resourceUrl()` and merged to main, with regression test `tests/unit/test_603_admin_legacy_link_prefix.py`. This PR does **not** touch that; it preserves it and pins that it stays intact.

## Root cause
Those cards link to the deep, classic (Jinja) configuration screens, which are intentionally still server-rendered during the SPA admin-migration (`notes/DEFERRED-NEWUI-FEATURES.md`). Each card already renders an `ExternalLink` icon advertising that it leaves the new UI — but the anchor had **no `target`**, so clicking navigated the same tab and replaced the entire SPA document with the classic page. That whole-document swap is what reads as "the app reverted to the old UI."

## Fix
Open those cards with `target="_blank" rel="noopener noreferrer"`, so the legacy page loads in a **new tab** and the new UI stays exactly where it was — the user closes the tab to return. This makes the existing `ExternalLink` affordance truthful and removes the jarring whole-app revert, without waiting on the native admin rebuild. Decorative icons marked `aria-hidden`. `rel=noopener noreferrer` closes the reverse-tabnabbing vector that bare `target=_blank` would open. The href keeps `resourceUrl(href)`, so #603's reverse-proxy prefix behavior is preserved under a `/cwa`-style mount.

## Validation
- **Red/green source-pin test** — `tests/unit/test_584_admin_legacy_link_new_tab.py`: asserts the settings-card anchor carries `target="_blank"` + `rel` with `noopener`/`noreferrer` and still routes through `resourceUrl`. RED on main (no `target`), GREEN on branch. Existing `test_603_admin_legacy_link_prefix.py` still passes (prefix un-regressed). 8/8 green.
- **Frontend build** — `npm ci && npm run build` clean (TSX compiles).
- Source-pin approach because the SPA bundle is Docker-built, not committed — the test pins the source the build compiles, matching the #603 test's pattern.

## Deferred to the SPA-parity roadmap (#584's other half)
The reporter's title also asks for these config pages to be **"converted to the new UI."** Rebuilding Basic config / UI config / DB config / scheduled tasks / logs as native React forms is a multi-page project tracked under the SPA admin migration (`notes/DEFERRED-NEWUI-FEATURES.md`, hybrid-cutover decision — admin/config groups J–L deliberately fall through to the classic UI during the transition). That is **not** in this PR. This PR fixes the concrete, shippable UX regression (the whole-UI revert) now; the native rebuild remains roadmap.

## Tier
`needs-review` — single-file SPA UX change + tests, no auth/CSRF/session/route surface touched.

Addresses #584.