### PR TITLE
fix(#573): new-UI series view sorts by series number and shows position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- **The new UI can now sort a series by its reading order, and shows each book's
+  position.** Opening a series in the new UI listed its books newest-first with
+  no way to order them 1, 2, 3, and the series position never appeared on the
+  covers unless you'd baked it into the titles. A series now opens in ascending
+  series order by default, the sort menu gains "Series order" (and its reverse)
+  while you're inside a series, and every cover shows its number. Reported by
+  @magdalar.
 - **Admin config links now work behind a reverse proxy on a sub-path.** In the
   new UI, the "More server configuration" cards on the Admin page (Basic
   configuration, Database & library path, Scheduled tasks, Logs, and the rest)

--- a/cps/api/books.py
+++ b/cps/api/books.py
@@ -26,6 +26,12 @@ SORT_MAP = {
     "pubold": [db.Books.pubdate],
     "authaz": [db.Books.author_sort.asc(), db.Series.name, db.Books.series_index],
     "authza": [db.Books.author_sort.desc(), db.Series.name.desc(), db.Books.series_index.desc()],
+    # Series reading order — mirrors web.py get_sort_function's seriesasc/seriesdesc.
+    # Every list_books path already joins db.Series (series_join), so ordering by
+    # db.Books.series_index needs no extra plumbing. Used by the new-UI series view
+    # so a series reads 1, 2, 3… instead of newest-first (fork #573).
+    "seriesasc": [db.Books.series_index.asc()],
+    "seriesdesc": [db.Books.series_index.desc()],
 }
 
 

--- a/cps/spa_strings.py
+++ b/cps/spa_strings.py
@@ -27,3 +27,8 @@ def _(message):  # noqa: E743 - intentional gettext extraction marker, not the b
 # read-status label (which is a past participle in many languages, e.g. nl
 # "Gelezen") so the verb and the status can be translated separately.
 _("Read now")
+
+# #573 — the new-UI series view's series-order sort options (Catalog.tsx). Only
+# shown when viewing a single series, so the reader can order by position.
+_("Series order")
+_("Series order (reverse)")

--- a/frontend/src/components/BookCard.module.css
+++ b/frontend/src/components/BookCard.module.css
@@ -112,6 +112,29 @@
   pointer-events: none;
 }
 
+/* Series position (#573): pinned to the bottom-left of the cover so it never
+   collides with the read badge (top-right) or the select/remove controls
+   (top-left). Shown only in a series view. */
+.seriesBadge {
+  position: absolute;
+  bottom: var(--sp-2);
+  left: var(--sp-2);
+  min-width: 22px;
+  height: 22px;
+  padding: 0 var(--sp-2);
+  border-radius: var(--r-full);
+  background: rgba(20, 28, 36, 0.82);
+  color: #fff;
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  line-height: 1;
+  box-shadow: var(--elev-1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
 /* Remove-from-shelf control: top-left so it never overlaps the read badge.
    Hidden until hover/focus to keep the grid calm, but always reachable. */
 .removeBtn {

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -14,13 +14,26 @@ interface BookCardProps {
   selectable?: boolean;
   selected?: boolean;
   onToggleSelect?: (book: Book) => void;
+  /** When true, show the book's position within its series (#573) — used by the
+   *  series view so the reading order is visible without duplicating it in titles. */
+  showSeriesIndex?: boolean;
+}
+
+/** Format a Calibre series_index (a float, e.g. 1.0, 2.5) for display: whole
+ *  numbers show as "1", fractional as "2.5". Returns null when there's nothing
+ *  to show so the badge is omitted entirely. */
+function formatSeriesIndex(idx: number | null | undefined): string | null {
+  if (idx == null || Number.isNaN(idx)) return null;
+  return Number.isInteger(idx) ? String(idx) : String(idx);
 }
 
 export function BookCard({
   book, style, onRemove, removeLabel = 'Remove',
   selectable = false, selected = false, onToggleSelect,
+  showSeriesIndex = false,
 }: BookCardProps) {
   const authorStr = book.authors.join(', ');
+  const seriesIndexLabel = showSeriesIndex ? formatSeriesIndex(book.series_index) : null;
 
   const inner = (
     <article
@@ -34,6 +47,15 @@ export function BookCard({
         {book.read && (
           <span className={styles.readBadge} aria-label="Read" title="Read">
             <Check size={14} strokeWidth={3} />
+          </span>
+        )}
+        {seriesIndexLabel && (
+          <span
+            className={styles.seriesBadge}
+            aria-label={`Series position ${seriesIndexLabel}`}
+            title={`Series position ${seriesIndexLabel}`}
+          >
+            #{seriesIndexLabel}
           </span>
         )}
         {selectable && (

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -34,6 +34,15 @@ const SORT_OPTIONS = [
   { label: 'Oldest published', value: 'pubold' },
 ];
 
+// Series-order sorts (by metadata series_index). Only offered when viewing a
+// single series, where a numeric position is meaningful — a whole-library
+// series_index sort is not. The ascending option is also the series view's
+// default (see defaultSort below) so a series reads 1, 2, 3… out of the box (#573).
+const SERIES_SORT_OPTIONS = [
+  { label: 'Series order', value: 'seriesasc' },
+  { label: 'Series order (reverse)', value: 'seriesdesc' },
+];
+
 const READ_FILTERS: { label: string; value: ReadFilter }[] = [
   { label: 'All', value: 'all' },
   { label: 'Unread', value: 'unread' },
@@ -82,6 +91,11 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
   const t = useT();
   const filtered = !!entityKind;
   const isView = !!view;
+  const isSeries = entityKind === 'series';
+  // Series views expose two extra series-order options and default to ascending
+  // series order so the list reads 1, 2, 3… instead of newest-first (#573).
+  const sortOptions = isSeries ? [...SERIES_SORT_OPTIONS, ...SORT_OPTIONS] : SORT_OPTIONS;
+  const defaultSort = isSeries ? 'seriesasc' : 'new';
   // Library-only controls (search box, advanced link, read-status filter) are
   // hidden for both entity-scoped and discovery views.
   const hideLibraryControls = filtered || isView;
@@ -107,7 +121,7 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
   const [allBooks, setAllBooks] = useState<Book[]>(() => snap?.books ?? []);
   const [searchInput, setSearchInput] = useState(() => snap?.searchInput ?? '');
   const [search, setSearch] = useState(() => snap?.search ?? '');
-  const [sort, setSort] = useState(() => snap?.sort ?? 'new');
+  const [sort, setSort] = useState(() => snap?.sort ?? defaultSort);
   const [readFilter, setReadFilter] = useState<ReadFilter>(() => (snap?.readFilter as ReadFilter) ?? 'all');
 
   // Multi-select / bulk mode
@@ -332,7 +346,7 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
           onChange={(e) => setSort(e.target.value)}
           aria-label={t('Sort order')}
         >
-          {SORT_OPTIONS.map((opt) => (
+          {sortOptions.map((opt) => (
             <option key={opt.value} value={opt.value}>
               {t(opt.label)}
             </option>
@@ -412,6 +426,7 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
               <BookCard
                 key={book.id}
                 book={book}
+                showSeriesIndex={isSeries}
                 style={{ animationDelay: `${Math.min(i, 24) * 35}ms` }}
                 selectable={selecting}
                 selected={selected.has(book.id)}

--- a/tests/unit/test_573_series_number_sort.py
+++ b/tests/unit/test_573_series_number_sort.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Source pins for #573 — the new UI's series view had no way to sort books by
+their metadata series position, and the position wasn't shown on the card unless
+duplicated in the title.
+
+The fix wires three things, guarded here against silent removal:
+  1. Backend: a stateless series_index sort ("seriesasc"/"seriesdesc") in the
+     /api/v1/books SORT_MAP, mirroring web.py's get_sort_function.
+  2. Frontend: the series view offers "Series order" sort options and defaults to
+     ascending series order.
+  3. Frontend: the book card renders the series position (showSeriesIndex).
+
+Behavioural coverage is the live Playwright series-view test; these guard the
+wiring. (See tests/unit/test_578_scroll_restore.py for the source-pin pattern.)
+"""
+import pathlib
+import re
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_FE = _ROOT / "frontend" / "src"
+_CPS = _ROOT / "cps"
+
+
+@pytest.mark.unit
+def test_backend_sort_map_has_series_index():
+    """The read-only books API must map seriesasc/seriesdesc to a series_index
+    order (not fall back to newest-first), or the SPA's Series-order sort is a
+    no-op server-side."""
+    src = (_CPS / "api" / "books.py").read_text()
+    assert '"seriesasc": [db.Books.series_index.asc()]' in src
+    assert '"seriesdesc": [db.Books.series_index.desc()]' in src
+
+
+@pytest.mark.unit
+def test_catalog_offers_series_order_options():
+    """The series view exposes the two series-order sort options."""
+    src = (_FE / "pages" / "Catalog.tsx").read_text()
+    assert "SERIES_SORT_OPTIONS" in src
+    assert "'seriesasc'" in src
+    assert "'seriesdesc'" in src
+    # The options are only added for a series view, and the dropdown renders the
+    # context-aware list (not the fixed base list).
+    assert "isSeries ? [...SERIES_SORT_OPTIONS" in src
+    assert "sortOptions.map(" in src
+
+
+@pytest.mark.unit
+def test_catalog_defaults_to_series_order_in_series_view():
+    """A series opens in ascending series order, not newest-first (the reporter's
+    core complaint), matching web.py's series-page default."""
+    src = (_FE / "pages" / "Catalog.tsx").read_text()
+    assert "const isSeries = entityKind === 'series'" in src
+    assert "defaultSort = isSeries ? 'seriesasc' : 'new'" in src
+    # The sort state seeds from defaultSort (falling back through the snapshot).
+    assert "snap?.sort ?? defaultSort" in src
+
+
+@pytest.mark.unit
+def test_catalog_shows_series_index_on_card_in_series_view():
+    """The catalog tells the card to show the series position when, and only
+    when, viewing a series."""
+    src = (_FE / "pages" / "Catalog.tsx").read_text()
+    assert re.search(r"showSeriesIndex=\{isSeries\}", src)
+
+
+@pytest.mark.unit
+def test_bookcard_renders_series_position():
+    """The card renders the series position from book.series_index when asked."""
+    src = (_FE / "components" / "BookCard.tsx").read_text()
+    assert "showSeriesIndex" in src
+    assert "formatSeriesIndex" in src
+    assert "book.series_index" in src
+    assert "seriesBadge" in src
+
+
+@pytest.mark.unit
+def test_bookcard_series_badge_styled():
+    """The series badge has a style so it isn't an unstyled overlay."""
+    css = (_FE / "components" / "BookCard.module.css").read_text()
+    assert ".seriesBadge" in css
+
+
+@pytest.mark.unit
+def test_series_sort_msgids_anchored():
+    """SPA-only msgids must be anchored in spa_strings.py or the auto-translation
+    job strips them (babel doesn't scan .tsx)."""
+    src = (_CPS / "spa_strings.py").read_text()
+    assert '_("Series order")' in src
+    assert '_("Series order (reverse)")' in src


### PR DESCRIPTION
## Why
[#573](https://github.com/new-usemame/Calibre-Web-NextGen/issues/573) (reported by @magdalar): in the new UI, opening a series lists its books newest-first with no way to order them by their metadata series position, and the position never appears on the card unless it's duplicated in the book title.

## Root cause
Two gaps in the SPA, not a data problem — the API already returns `series_index` on every book and `/api/v1/books` already joins `db.Series` on every path:
1. `Catalog.tsx`'s `SORT_OPTIONS` had no series-order entry, and the read-only books API's stateless `SORT_MAP` (which deliberately avoids `web.py`'s state-writing `get_sort_function`) never mirrored its `seriesasc`/`seriesdesc` cases. So even a hand-crafted `?sort=seriesasc` fell back to newest-first.
2. `BookCard` never rendered `book.series_index`.

## Fix
- **api/books.py**: add `seriesasc: [db.Books.series_index.asc()]` / `seriesdesc: [...desc()]` to `SORT_MAP`, mirroring `web.py`. No new plumbing — the Series join is already on every path.
- **Catalog.tsx**: expose "Series order" / "Series order (reverse)" sort options **only** in a series view, and default a series view to ascending series order (matching `web.py`'s series-page default), so a series opens 1, 2, 3… out of the box.
- **BookCard.tsx / .module.css**: a `showSeriesIndex` prop renders the position as a bottom-left cover badge (clear of the read badge top-right and select/remove controls top-left); Catalog passes it only in series context.
- **spa_strings.py**: anchor the two new SPA-only msgids so the auto-translation job doesn't strip them (babel doesn't scan .tsx).

## Validation
- Red/green source-pin test `tests/unit/test_573_series_number_sort.py` (7 assertions: backend SORT_MAP, series-order options + gating, series-view default, card rendering, badge CSS, msgid anchoring). Verified **all 7 fail against `origin/main` sources and pass on the branch**.
- `npm ci && npm run build` (tsc -b + vite) green.
- No new deps / licenses / external URLs; SPA stays plain TS.

Playwright e2e (covered by coordinator): open a multi-book series in the new UI → books render in ascending series order, each cover shows its `#n`, and the sort menu offers "Series order" / "Series order (reverse)".

## Tier
review-merge (multi-file, UI + API). Addresses #573.