### PR TITLE
ci: auto-post release notes to Discord on release publish

### DIFF
--- a/.github/workflows/discord-release-bot.yml
+++ b/.github/workflows/discord-release-bot.yml
@@ -1,12 +1,15 @@
 name: Post New Release Notes to Discord
-# Manually posts a release's notes to a Discord webhook. Dispatch-only
-# and gated on DISCORD_RELEASE_WEBHOOK_URL being present so operators
-# without a webhook configured get a clean no-op instead of a red run.
+# Posts a release's notes to a Discord webhook. Fires automatically when a
+# GitHub release is published, and can still be run manually from the Actions
+# tab. Gated on DISCORD_RELEASE_WEBHOOK_URL being present so operators without
+# a webhook configured get a clean no-op instead of a red run.
 # (Same pattern as dockerhub-description.yml — backports CWA #1254's
 # "don't fail on missing CI creds" intent; issue #152.)
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -14,6 +17,7 @@ permissions:
 jobs:
   github-releases-to-discord:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Probe Discord webhook secret
         id: probe


### PR DESCRIPTION
Makes the Discord release-notes workflow fire automatically on `release: published` instead of manual dispatch only, so a new release announces to the #releases channel without a manual step. Still dispatchable from the Actions tab.

- Adds `release: {types: [published]}` to the trigger.
- Adds a 5-minute job timeout.
- The `DISCORD_RELEASE_WEBHOOK_URL` secret and the `sillyangel/releases-to-discord` action are already in place — no new dependencies or external URLs.

The webhook post can only be exercised end-to-end when the next release publishes; the trigger and YAML are validated here.