### PR TITLE
ci(translations): survive push races to main with rebase-retry + serialized runs

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -12,6 +12,16 @@ on:
       - '.github/workflows/update-translations.yml'
   workflow_dispatch:
 
+# Two merges to main in quick succession trigger two runs; both commit a
+# translation update and the loser's push is rejected non-fast-forward.
+# Serialize runs so only pushes from outside this workflow can race the
+# commit step (those are handled by the rebase-and-retry loop below).
+# cancel-in-progress stays false: cancelling a run mid-push could strand
+# a half-finished commit.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   actions: write
@@ -83,7 +93,29 @@ jobs:
             echo "TRANSLATION_COMMITTED=0" >> $GITHUB_ENV
           else
             git commit -m "Update translations [skip ci]"
-            git push
+            # The autopilot pushes docs commits to main minutes after each
+            # merge, so a bare `git push` here loses that race and fails
+            # non-fast-forward (3 of the last 30 runs). The commit holds
+            # only generated files; rebasing it onto updated main is safe.
+            # On a genuine rebase conflict, abort and fail — the push that
+            # beat us triggers its own run, which regenerates everything.
+            pushed=0
+            for attempt in 1 2 3; do
+              if git push; then
+                pushed=1
+                break
+              fi
+              echo "push rejected (attempt ${attempt}/3); rebasing onto updated main"
+              if ! git pull --rebase origin main; then
+                git rebase --abort
+                echo "::error::rebase conflict while retrying translation push"
+                exit 1
+              fi
+            done
+            if [ "${pushed}" != "1" ]; then
+              echo "::error::translation push failed after 3 attempts"
+              exit 1
+            fi
             echo "TRANSLATION_COMMITTED=1" >> $GITHUB_ENV
             echo "TRANSLATION_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
           fi

--- a/tests/unit/test_update_translations_push_race.py
+++ b/tests/unit/test_update_translations_push_race.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Pin the push-race hardening in update-translations.yml.
+
+The workflow commits regenerated translation files back to main. Anything
+else landing on main between its checkout and its push (autopilot docs
+backfills, a second run triggered by a quick follow-up merge) used to make
+the bare ``git push`` fail non-fast-forward — 3 of the last 30 runs died
+this way (runs 28635515788, 28590300379, 28422116634, all with the
+identical ``! [rejected] main -> main (fetch first)`` signature).
+
+Two walls, each pinned below:
+
+  1. A ``concurrency`` group serializes runs of this workflow so two
+     quick merges can't race each other's translation commit. It must
+     NOT cancel in-progress runs — cancelling mid-push could strand a
+     half-finished commit.
+
+  2. The commit step retries its push behind ``git pull --rebase`` so a
+     race with an external push (docs backfill) recovers instead of
+     failing the job.
+
+If either goes red, restore the property in the workflow — don't weaken
+the test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - yaml ships with most distros
+    yaml = None  # type: ignore[assignment]
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WF_PATH = REPO_ROOT / ".github" / "workflows" / "update-translations.yml"
+
+
+def _load() -> dict:
+    if yaml is None:
+        pytest.skip("PyYAML not installed in this environment")
+    with WF_PATH.open() as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _commit_step() -> dict:
+    wf = _load()
+    for step in wf["jobs"]["update-translations"]["steps"]:
+        if isinstance(step, dict) and step.get("name") == "Commit translation updates":
+            return step
+    raise AssertionError(
+        "update-translations.yml no longer has a 'Commit translation updates' "
+        "step — if it was renamed, update this test's lookup"
+    )
+
+
+def test_workflow_serializes_its_own_runs():
+    wf = _load()
+    concurrency = wf.get("concurrency")
+    assert isinstance(concurrency, dict), (
+        "update-translations.yml has no concurrency group: two merges to "
+        "main in quick succession run concurrently and the loser's "
+        "translation push fails non-fast-forward"
+    )
+    assert concurrency.get("group"), "concurrency block must set a group"
+    assert concurrency.get("cancel-in-progress") is False, (
+        "cancel-in-progress must be false: cancelling a run mid-push can "
+        "strand a half-finished translation commit"
+    )
+
+
+def test_translation_push_retries_with_rebase():
+    script = _commit_step().get("run", "")
+    assert "git pull --rebase origin main" in script, (
+        "translation push must rebase onto updated main and retry — a bare "
+        "`git push` loses the race with autopilot docs pushes to main "
+        "(non-fast-forward, 3 failures in 30 runs)"
+    )
+    assert "if git push" in script, (
+        "push must be attempted inside a retry guard, not as a bare "
+        "fail-the-job command"
+    )
+    assert "git rebase --abort" in script, (
+        "a rebase conflict must abort cleanly (and fail loudly) rather "
+        "than leave the checkout mid-rebase"
+    )
+
+
+def test_push_failure_still_fails_the_job():
+    """The retry loop must not swallow a persistent failure: after the
+    attempts are exhausted the job has to exit non-zero, otherwise a
+    broken push goes green and translations silently stop landing."""
+    script = _commit_step().get("run", "")
+    assert 'if [ "${pushed}" != "1" ]' in script and "exit 1" in script, (
+        "exhausted retries must exit 1 so the run stays red instead of "
+        "silently dropping the translation commit"
+    )


### PR DESCRIPTION
## Why

The \`Update Translations and Wiki Status\` workflow went red on main at 2026-07-03T03:01Z (run 28635515788). Its \`git push\` of the regenerated translation commit was rejected non-fast-forward because the autopilot's CHANGES-backfill commit (ecda39d3e) landed on main between the workflow's checkout and its push. This is not a one-off: runs 28590300379 (Jul 2) and 28422116634 (Jun 30) failed with the byte-identical \`! [rejected] main -> main (fetch first)\` signature — 3 of the last 30 runs, a structural race, since every autopilot merge is followed within minutes by a docs push to main.

## Root cause

Two race sources, both unguarded:
1. External pushes to main (docs backfills, follow-up merges) racing the workflow's single bare \`git push\`.
2. Two quick merges triggering two concurrent runs of this workflow, each committing a translation update — the loser's push is rejected.

## Fix

- Top-level \`concurrency\` group (\`cancel-in-progress: false\`) serializes runs of this workflow — eliminates race source 2. Cancelling stays off so a run can't be killed mid-push with a half-finished commit.
- The push runs in a 3-attempt loop behind \`git pull --rebase origin main\` — recovers race source 1. The commit holds only generated files (\`messages.pot\`, \`.po\`, \`README.md\`), so rebasing onto updated main is safe. A genuine rebase conflict aborts cleanly and fails loudly (the push that beat us triggers its own run, which regenerates everything). Exhausted retries \`exit 1\` so the job can never go green without the commit actually landing.

## Validation

- **Red/green**: \`tests/unit/test_update_translations_push_race.py\` — 3/3 FAIL against main's workflow, 3/3 pass with the fix. Pins the concurrency group (incl. \`cancel-in-progress: false\`), the rebase-retry loop, the clean conflict abort, and the exhausted-retries-fail-the-job property.
- Existing \`tests/unit/test_workflow_safety_invariants.py\` (all 9 walls) green with the change — no new permissions, no untrusted interpolation (only new expression is \`\${{ github.workflow }}\` in the concurrency group), no fork-PR surface (workflow triggers on push-to-main + dispatch only).
- The lost translation content from the failed runs is not data loss — the workflow regenerates from scratch on the next main push; this fix stops the red runs and the silent skew.

## Tier

CI-workflow + test only, no production code paths touched. Not user-facing — no CHANGELOG entry.