### PR TITLE
fix(kosync): register filename-hash checksums so filename-matching clients resolve books

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- **KOReader sync now works when your reader matches books by filename.**
+  KOReader's sync plugin (and apps like Crossink) can identify a book by a
+  hash of its filename instead of its file contents. The server only ever
+  knew the content hash, so filename-mode devices always got "no book found"
+  and progress never linked up. The server now registers a filename digest
+  for every book — on download and, for your existing library, automatically
+  at startup. This also gives devices holding older copies of a book (from
+  before an update, or side-loaded) a way back into sync without re-sending
+  every file: switch the KOReader sync plugin's document-matching method to
+  "filename". Reported by @natabat, seconded by @Metamatam; also relevant to
+  reports from @uschi1 and @Glalith121.
 - **A single problem PDF can no longer hang the whole server on download.**
   Downloading certain PDFs (UI or OPDS) triggered a metadata-embedding step
   that could hang inside Calibre's PDF writer, pinning a CPU core, eating

--- a/cps/progress_syncing/__init__.py
+++ b/cps/progress_syncing/__init__.py
@@ -31,7 +31,12 @@ Architecture:
 # Export commonly used components
 # NOTE: kosync blueprint is NOT imported here to avoid circular imports
 # Import it directly from .protocols.kosync where needed
-from .checksums.koreader import calculate_koreader_partial_md5, CHECKSUM_VERSION
+from .checksums.koreader import (
+    calculate_koreader_partial_md5,
+    calculate_koreader_filename_md5,
+    CHECKSUM_VERSION,
+    FILENAME_CHECKSUM_VERSION,
+)
 from .checksums.manager import (
     store_checksum,
     calculate_and_store_checksum,
@@ -49,7 +54,9 @@ from .models import (
 __all__ = [
     # Checksum functions
     'calculate_koreader_partial_md5',
+    'calculate_koreader_filename_md5',
     'CHECKSUM_VERSION',
+    'FILENAME_CHECKSUM_VERSION',
     'store_checksum',
     'calculate_and_store_checksum',
     'get_latest_checksum',

--- a/cps/progress_syncing/checksums/__init__.py
+++ b/cps/progress_syncing/checksums/__init__.py
@@ -13,7 +13,12 @@ Provides checksum calculation and management for book files.
 Supports KOReader's partial MD5 algorithm for efficient file identification.
 """
 
-from .koreader import calculate_koreader_partial_md5, CHECKSUM_VERSION
+from .koreader import (
+    calculate_koreader_partial_md5,
+    calculate_koreader_filename_md5,
+    CHECKSUM_VERSION,
+    FILENAME_CHECKSUM_VERSION,
+)
 from .manager import (
     store_checksum,
     calculate_and_store_checksum,
@@ -23,7 +28,9 @@ from .manager import (
 
 __all__ = [
     'calculate_koreader_partial_md5',
+    'calculate_koreader_filename_md5',
     'CHECKSUM_VERSION',
+    'FILENAME_CHECKSUM_VERSION',
     'store_checksum',
     'calculate_and_store_checksum',
     'get_latest_checksum',

--- a/cps/progress_syncing/checksums/koreader.py
+++ b/cps/progress_syncing/checksums/koreader.py
@@ -18,6 +18,8 @@ Reference: https://github.com/koreader/koreader/blob/master/frontend/util.lua#L1
 
 Version History:
 - Version 'koreader': Initial implementation of KOReader partialMD5 algorithm (November 2025)
+- Version 'koreader_filename': MD5 of the export basename, for clients in
+  'filename' document-matching mode (fork #525 / #627, July 2026)
 """
 
 import hashlib
@@ -30,6 +32,33 @@ log = logger.create()
 
 # Current algorithm version - use string identifier for clarity
 CHECKSUM_VERSION = 'koreader'
+
+# Filename-matching channel: KOReader's kosync plugin (and Crossink/x4) can be
+# configured to identify a document by md5 of its FILENAME instead of its
+# bytes. Byte-verified against the #525 reporter's oracle:
+# md5("More Everything Forever - Adam Becker.epub") == 9ea1b31e133214bb1169acce6ff4affb
+FILENAME_CHECKSUM_VERSION = 'koreader_filename'
+
+
+def calculate_koreader_filename_md5(filename: Optional[str]) -> Optional[str]:
+    """
+    Calculate the filename-matching digest KOReader/Crossink send when the
+    kosync plugin is set to 'filename' document matching.
+
+    The digest is the MD5 of the UTF-8 bytes of the basename INCLUDING the
+    lowercase format extension, with no case folding or sanitization —
+    exactly the OPDS/Kobo download name CW-NG serves
+    (``data.name + "." + book_format``).
+
+    Args:
+        filename: Basename with extension, e.g. "Title - Author.epub"
+
+    Returns:
+        32-character hexadecimal MD5 string, or None for empty input
+    """
+    if not filename:
+        return None
+    return hashlib.md5(filename.encode('utf-8')).hexdigest()  # nosec - identification, not security
 
 
 def calculate_koreader_partial_md5(filepath: str) -> Optional[str]:

--- a/cps/progress_syncing/checksums/manager.py
+++ b/cps/progress_syncing/checksums/manager.py
@@ -198,7 +198,8 @@ def calculate_and_store_checksum(
 
 def get_latest_checksum(
     book_id: int,
-    book_format: str
+    book_format: str,
+    version: str = CHECKSUM_VERSION
 ) -> Optional[str]:
     """
     Get the most recent checksum for a book/format (by created timestamp).
@@ -206,6 +207,9 @@ def get_latest_checksum(
     Args:
         book_id: Calibre book ID
         book_format: File format (EPUB, AZW3, etc.)
+        version: Algorithm channel to read (default: the binary
+            partial-MD5). Without this filter a newer filename-digest row
+            (version 'koreader_filename') would shadow the binary checksum.
 
     Returns:
         The most recent checksum string, or None if not found
@@ -219,11 +223,13 @@ def get_latest_checksum(
                 SELECT checksum FROM book_format_checksums
                 WHERE book = :book_id
                 AND format = :format
+                AND version = :version
                 ORDER BY created DESC
                 LIMIT 1
             '''), {
                 'book_id': book_id,
-                'format': book_format.upper()
+                'format': book_format.upper(),
+                'version': version
             }).fetchone()
 
             return result[0] if result else None

--- a/cps/progress_syncing/checksums/manager.py
+++ b/cps/progress_syncing/checksums/manager.py
@@ -26,7 +26,12 @@ from datetime import datetime, timezone
 from typing import Optional, List, Tuple
 
 from ... import logger
-from .koreader import calculate_koreader_partial_md5, CHECKSUM_VERSION
+from .koreader import (
+    calculate_koreader_partial_md5,
+    calculate_koreader_filename_md5,
+    CHECKSUM_VERSION,
+    FILENAME_CHECKSUM_VERSION,
+)
 
 log = logger.create()
 
@@ -170,6 +175,20 @@ def calculate_and_store_checksum(
         version=CHECKSUM_VERSION,
         db_connection=db_connection
     )
+
+    # Also register the filename-matching digest of the served basename so
+    # clients in 'filename' document-matching mode (kosync plugin option,
+    # Crossink/x4) resolve this book too. Fork #525 / #627. Failure here
+    # must not disturb the binary-channel result.
+    filename_digest = calculate_koreader_filename_md5(os.path.basename(file_path))
+    if filename_digest:
+        store_checksum(
+            book_id=book_id,
+            book_format=book_format,
+            checksum=filename_digest,
+            version=FILENAME_CHECKSUM_VERSION,
+            db_connection=db_connection
+        )
 
     if success:
         return checksum

--- a/scripts/generate_book_checksums.py
+++ b/scripts/generate_book_checksums.py
@@ -122,7 +122,9 @@ def generate_checksums(library_path: str, books_path: str = None, force: bool = 
     # etc.), but the cost is amortized over actual checksum computation.
     from cps.progress_syncing.checksums import (  # noqa: E402
         calculate_koreader_partial_md5,
+        calculate_koreader_filename_md5,
         CHECKSUM_VERSION,
+        FILENAME_CHECKSUM_VERSION,
     )
 
     metadata_db = os.path.join(library_path, 'metadata.db')
@@ -179,7 +181,13 @@ def generate_checksums(library_path: str, books_path: str = None, force: bool = 
     total = len(formats)
 
     if total == 0:
-        print("✓ All books already have checksums!")
+        print("✓ All books already have binary checksums!")
+        # The filename-hash pass still has to run: pairs with binary rows
+        # can be missing their filename digest (fork #525 / #627).
+        filename_queued = _backfill_filename_hashes(
+            metadata_db, calculate_koreader_filename_md5,
+            FILENAME_CHECKSUM_VERSION, batch_size)
+        print(f"  Filename hashes: {filename_queued}")
         return
 
     print(f"Found {total} book format(s) to process\n")
@@ -219,6 +227,16 @@ def generate_checksums(library_path: str, books_path: str = None, force: bool = 
     if batch_rows:
         _flush_batch(metadata_db, batch_rows)
 
+    # Filename-hash pass (fork #525 / #627): register the digest of the
+    # OPDS/Kobo export basename for every (book, format) pair missing one,
+    # so clients in 'filename' document-matching mode resolve books. Runs
+    # independently of the binary pass above — pairs that already carry a
+    # binary row (skipped by the any-row LEFT JOIN) still need this.
+    # No file I/O: the digest is derived from database fields alone.
+    filename_queued = _backfill_filename_hashes(
+        metadata_db, calculate_koreader_filename_md5,
+        FILENAME_CHECKSUM_VERSION, batch_size)
+
     print()
     print("=" * 60)
     print("Summary:")
@@ -226,7 +244,65 @@ def generate_checksums(library_path: str, books_path: str = None, force: bool = 
     print(f"  Queued:          {queued}")
     print(f"  Failed:          {failed}")
     print(f"  Skipped:         {skipped}")
+    print(f"  Filename hashes: {filename_queued}")
     print("=" * 60)
+
+
+def _backfill_filename_hashes(metadata_db, digest_fn, version, batch_size=100):
+    """Insert missing 'koreader_filename' checksum rows.
+
+    The hashed string is ``data.name + "." + lower(data.format)`` — the
+    basename CW-NG serves on OPDS/Kobo downloads and the on-disk library
+    basename, which is what a device in filename-matching mode hashes.
+    Returns the number of rows queued for insert.
+    """
+    try:
+        conn = sqlite3.connect(metadata_db, timeout=30)
+        cur = conn.cursor()
+        missing = cur.execute('''
+            SELECT b.id, d.format, d.name
+            FROM books b
+            JOIN data d ON b.id = d.book
+            LEFT JOIN book_format_checksums bfc ON (
+                bfc.book = b.id
+                AND bfc.format = d.format
+                AND bfc.version = ?
+            )
+            WHERE bfc.id IS NULL
+            ORDER BY b.id
+        ''', (version,)).fetchall()
+    except sqlite3.Error as e:
+        print(f"WARNING: filename-hash pass could not read library: {e}")
+        return 0
+    finally:
+        if 'conn' in locals():
+            conn.close()
+
+    if not missing:
+        return 0
+
+    print(f"\nFilename-hash pass: {len(missing)} format(s) missing a filename digest")
+
+    queued = 0
+    batch_rows = []
+    for book_id, format_ext, format_name in missing:
+        digest = digest_fn(f"{format_name}.{format_ext.lower()}")
+        if not digest:
+            continue
+        fmt = format_ext.upper()
+        created = datetime.now(timezone.utc).isoformat()
+        batch_rows.append((book_id, fmt, digest, version, created,
+                           book_id, fmt, digest))
+        queued += 1
+        if len(batch_rows) >= batch_size:
+            _flush_batch(metadata_db, batch_rows)
+            batch_rows = []
+
+    if batch_rows:
+        _flush_batch(metadata_db, batch_rows)
+
+    print(f"Filename-hash pass: committed {queued} digest(s)")
+    return queued
 
 
 def get_books_path():

--- a/scripts/generate_book_checksums.py
+++ b/scripts/generate_book_checksums.py
@@ -160,6 +160,10 @@ def generate_checksums(library_path: str, books_path: str = None, force: bool = 
             '''
             formats = cur.execute(query).fetchall()
         else:
+            # Only a binary-channel row satisfies the binary pass. Filename
+            # rows (version 'koreader_filename') are created without file
+            # I/O, so an any-version join would permanently skip books whose
+            # files were unreadable when the filename pass first ran.
             query = '''
                 SELECT b.id, b.path, b.title, d.format, d.name
                 FROM books b
@@ -167,11 +171,12 @@ def generate_checksums(library_path: str, books_path: str = None, force: bool = 
                 LEFT JOIN book_format_checksums bfc ON (
                     bfc.book = b.id
                     AND bfc.format = d.format
+                    AND bfc.version = ?
                 )
                 WHERE bfc.id IS NULL
                 ORDER BY b.id
             '''
-            formats = cur.execute(query).fetchall()
+            formats = cur.execute(query, (CHECKSUM_VERSION,)).fetchall()
     except sqlite3.Error as e:
         print(f"ERROR: Database error: {e}")
         sys.exit(1)

--- a/tests/unit/test_627_525_filename_checksum.py
+++ b/tests/unit/test_627_525_filename_checksum.py
@@ -230,3 +230,82 @@ class TestLookupIsVersionAgnostic:
             "get_book_by_checksum must only filter by version when the "
             "caller asks — the filename-hash channel (#525/#627) relies on "
             "version-agnostic matching.")
+
+
+@pytest.mark.unit
+class TestBinaryPassNotMaskedByFilenameRows:
+    """Greptile finding on PR #636, confirmed: the binary pass's LEFT JOIN
+    matched rows of ANY version. Since the filename pass needs no file I/O,
+    a book whose file was unreadable at boot got a filename row anyway —
+    and every later boot's binary pass then skipped the pair permanently.
+    The binary pass must only treat version='koreader' rows as satisfying."""
+
+    @pytest.fixture
+    def library_with_absent_file(self, tmp_path, monkeypatch):
+        lib = tmp_path / "library"
+        lib.mkdir()
+        db = sqlite3.connect(lib / "metadata.db")
+        db.execute("CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT, path TEXT)")
+        db.execute("CREATE TABLE data (id INTEGER PRIMARY KEY, book INTEGER, format TEXT, name TEXT)")
+        db.execute(CHECKSUM_TABLE_SQL)
+        # The book's file is NOT on disk yet (mid-move, unreadable mount…).
+        db.execute("INSERT INTO books VALUES (1, 'Ghost Book', 'ghost')")
+        db.execute("INSERT INTO data VALUES (1, 1, 'EPUB', 'Ghost Book - Author')")
+        db.commit()
+        db.close()
+
+        cfg = tmp_path / "config"
+        cfg.mkdir()
+        cdb = sqlite3.connect(cfg / "cwa.db")
+        cdb.execute("CREATE TABLE cwa_settings (koreader_sync_enabled INTEGER)")
+        cdb.execute("INSERT INTO cwa_settings VALUES (1)")
+        cdb.commit()
+        cdb.close()
+        monkeypatch.setenv("CWA_DB_PATH", str(cfg) + "/")
+        return lib
+
+    def _rows(self, library, version):
+        conn = sqlite3.connect(library / "metadata.db")
+        try:
+            return conn.execute(
+                "SELECT book FROM book_format_checksums WHERE version=?",
+                (version,)).fetchall()
+        finally:
+            conn.close()
+
+    def test_binary_pass_retries_after_filename_row_exists(
+            self, library_with_absent_file):
+        import generate_book_checksums as gbc
+        lib = library_with_absent_file
+
+        # Boot 1: file absent — binary pass can't hash it, filename pass
+        # (DB-only) registers its row regardless.
+        gbc.generate_checksums(str(lib), batch_size=10)
+        assert self._rows(lib, CHECKSUM_VERSION) == []
+        assert self._rows(lib, FILENAME_CHECKSUM_VERSION) == [(1,)]
+
+        # File appears (move completed / mount back).
+        (lib / "ghost").mkdir()
+        (lib / "ghost" / "Ghost Book - Author.epub").write_bytes(b"z" * 4096)
+
+        # Boot 2: the filename row must NOT satisfy the binary pass —
+        # the pair still needs its partial-MD5 computed.
+        gbc.generate_checksums(str(lib), batch_size=10)
+        assert self._rows(lib, CHECKSUM_VERSION) == [(1,)], (
+            "binary pass skipped a pair that only carries a filename-digest "
+            "row — its LEFT JOIN must filter on version='koreader'")
+
+
+@pytest.mark.unit
+class TestGetLatestChecksumScopedToBinaryChannel:
+    """Source-pin: get_latest_checksum must filter by version (default
+    binary 'koreader'). A newer filename-digest row would otherwise shadow
+    the binary checksum for any future caller of this exported API."""
+
+    def test_query_filters_on_version(self):
+        import inspect
+        from cps.progress_syncing.checksums import manager
+        src = inspect.getsource(manager.get_latest_checksum)
+        assert "version = :version" in src
+        sig = inspect.signature(manager.get_latest_checksum)
+        assert sig.parameters["version"].default == CHECKSUM_VERSION

--- a/tests/unit/test_627_525_filename_checksum.py
+++ b/tests/unit/test_627_525_filename_checksum.py
@@ -1,0 +1,232 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for fork #525 / #627 — KOReader sync filename-hash channel.
+
+KOReader's kosync plugin (and Crossink/x4) can identify a document by a hash
+of its FILENAME instead of the partial-MD5 of its bytes. CW-NG only ever
+stored the binary partial-MD5, so:
+
+- #525: clients in 'filename' matching mode always get "No book found".
+- #627/#633 class: device files whose bytes no longer match any stored
+  binary checksum (pre-update downloads, metadata re-embeds) cannot sync at
+  all; the filename channel is the no-re-download rescue path.
+
+The filename digest algorithm was byte-verified against the #525 reporter's
+oracle: md5("More Everything Forever - Adam Becker.epub") ==
+9ea1b31e133214bb1169acce6ff4affb (UTF-8, basename WITH lowercase extension,
+no case folding). See notes/525-kosync-filename-matching-design.md.
+"""
+
+import hashlib
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "scripts"))
+
+from cps.progress_syncing.checksums import (
+    CHECKSUM_VERSION,
+    FILENAME_CHECKSUM_VERSION,
+    calculate_and_store_checksum,
+    calculate_koreader_filename_md5,
+)
+
+# The #525 reporter's real-world oracle (Crossink sent this hash for this file).
+ORACLE_BASENAME = "More Everything Forever - Adam Becker.epub"
+ORACLE_DIGEST = "9ea1b31e133214bb1169acce6ff4affb"
+
+CHECKSUM_TABLE_SQL = '''
+    CREATE TABLE book_format_checksums (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        book INTEGER NOT NULL,
+        format TEXT NOT NULL COLLATE NOCASE,
+        checksum TEXT NOT NULL,
+        version TEXT NOT NULL DEFAULT 'koreader',
+        created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+'''
+
+
+@pytest.mark.unit
+class TestFilenameDigest:
+    def test_matches_reporter_oracle(self):
+        assert calculate_koreader_filename_md5(ORACLE_BASENAME) == ORACLE_DIGEST
+
+    def test_plain_md5_of_utf8_bytes(self):
+        name = "Ökobuch – Ää.epub"
+        assert calculate_koreader_filename_md5(name) == \
+            hashlib.md5(name.encode("utf-8")).hexdigest()
+
+    def test_no_case_folding_or_extension_stripping(self):
+        # Tried-and-rejected variants from the oracle brute-force must NOT
+        # be what we compute.
+        assert calculate_koreader_filename_md5(ORACLE_BASENAME.lower()) != ORACLE_DIGEST
+        assert calculate_koreader_filename_md5(
+            ORACLE_BASENAME.rsplit(".", 1)[0]) != ORACLE_DIGEST
+
+    def test_empty_and_none_return_none(self):
+        assert calculate_koreader_filename_md5("") is None
+        assert calculate_koreader_filename_md5(None) is None
+
+    def test_version_constant_distinct(self):
+        assert FILENAME_CHECKSUM_VERSION == "koreader_filename"
+        assert FILENAME_CHECKSUM_VERSION != CHECKSUM_VERSION
+
+
+@pytest.mark.unit
+class TestDownloadChokepointStoresBothVersions:
+    """calculate_and_store_checksum (the download/export chokepoint,
+    cps/helper.py caller) must register BOTH the binary partial-MD5 and the
+    filename hash of the served basename."""
+
+    @pytest.fixture
+    def conn(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute(CHECKSUM_TABLE_SQL)
+        conn.commit()
+        yield conn
+        conn.close()
+
+    def test_stores_binary_and_filename_rows(self, conn, tmp_path):
+        exported = tmp_path / ORACLE_BASENAME
+        exported.write_bytes(b"epub bytes " * 500)
+
+        result = calculate_and_store_checksum(
+            book_id=7, book_format="EPUB", file_path=str(exported),
+            db_connection=conn)
+        assert result  # still returns the binary checksum
+
+        rows = conn.execute(
+            "SELECT version, checksum FROM book_format_checksums WHERE book=7"
+        ).fetchall()
+        by_version = dict(rows)
+        assert set(by_version) == {CHECKSUM_VERSION, FILENAME_CHECKSUM_VERSION}
+        assert by_version[CHECKSUM_VERSION] == result
+        assert by_version[FILENAME_CHECKSUM_VERSION] == ORACLE_DIGEST
+
+    def test_idempotent_on_repeat_download(self, conn, tmp_path):
+        exported = tmp_path / ORACLE_BASENAME
+        exported.write_bytes(b"epub bytes " * 500)
+        for _ in range(2):
+            calculate_and_store_checksum(
+                book_id=7, book_format="EPUB", file_path=str(exported),
+                db_connection=conn)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM book_format_checksums").fetchone()[0]
+        assert count == 2  # one binary row + one filename row, no dupes
+
+
+@pytest.mark.unit
+class TestBackfillScriptFilenamePass:
+    """The boot backfill (scripts/generate_book_checksums.py, run by the
+    cwa-checksum-backfill s6 service) must register filename hashes for
+    every (book, format) pair — including pairs that already carry binary
+    rows, which the binary pass's any-row LEFT JOIN skips."""
+
+    @pytest.fixture
+    def library(self, tmp_path, monkeypatch):
+        lib = tmp_path / "library"
+        lib.mkdir()
+        db = sqlite3.connect(lib / "metadata.db")
+        db.execute("CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT, path TEXT)")
+        db.execute("CREATE TABLE data (id INTEGER PRIMARY KEY, book INTEGER, format TEXT, name TEXT)")
+        db.execute(CHECKSUM_TABLE_SQL)
+        # Book 1: the oracle book, on disk, no checksum rows at all.
+        db.execute("INSERT INTO books VALUES (1, 'More Everything Forever', 'oracle')")
+        db.execute("INSERT INTO data VALUES (1, 1, 'EPUB', 'More Everything Forever - Adam Becker')")
+        (lib / "oracle").mkdir()
+        (lib / "oracle" / ORACLE_BASENAME).write_bytes(b"x" * 4096)
+        # Book 2: already has a binary row (downloaded once) — the binary
+        # pass skips it, but the filename pass must still cover it.
+        db.execute("INSERT INTO books VALUES (2, 'Second Book', 'second')")
+        db.execute("INSERT INTO data VALUES (2, 2, 'EPUB', 'Second Book - Author')")
+        db.execute(
+            "INSERT INTO book_format_checksums (book, format, checksum, version, created)"
+            " VALUES (2, 'EPUB', 'deadbeef', 'koreader', '2026-01-01T00:00:00')")
+        (lib / "second").mkdir()
+        (lib / "second" / "Second Book - Author.epub").write_bytes(b"y" * 4096)
+        db.commit()
+        db.close()
+
+        # Enabled cwa.db so the script's early-exit gate passes.
+        cfg = tmp_path / "config"
+        cfg.mkdir()
+        cdb = sqlite3.connect(cfg / "cwa.db")
+        cdb.execute("CREATE TABLE cwa_settings (koreader_sync_enabled INTEGER)")
+        cdb.execute("INSERT INTO cwa_settings VALUES (1)")
+        cdb.commit()
+        cdb.close()
+        monkeypatch.setenv("CWA_DB_PATH", str(cfg) + "/")
+        return lib
+
+    def _rows(self, library, version):
+        conn = sqlite3.connect(library / "metadata.db")
+        try:
+            return conn.execute(
+                "SELECT book, checksum FROM book_format_checksums"
+                " WHERE version=? ORDER BY book", (version,)).fetchall()
+        finally:
+            conn.close()
+
+    def test_filename_pass_covers_all_pairs(self, library):
+        import generate_book_checksums as gbc
+        gbc.generate_checksums(str(library), batch_size=10)
+
+        fname_rows = self._rows(library, FILENAME_CHECKSUM_VERSION)
+        assert fname_rows == [
+            (1, ORACLE_DIGEST),
+            (2, hashlib.md5(b"Second Book - Author.epub").hexdigest()),
+        ]
+        # Binary pass semantics unchanged: book 1 gained a binary row,
+        # book 2's pre-existing row is untouched and not duplicated.
+        bin_rows = self._rows(library, CHECKSUM_VERSION)
+        assert [r[0] for r in bin_rows] == [1, 2]
+        assert ("deadbeef" in dict(bin_rows).values()) or dict(bin_rows)[2] == "deadbeef"
+
+    def test_filename_pass_idempotent(self, library):
+        import generate_book_checksums as gbc
+        gbc.generate_checksums(str(library), batch_size=10)
+        first = self._rows(library, FILENAME_CHECKSUM_VERSION)
+        gbc.generate_checksums(str(library), batch_size=10)
+        assert self._rows(library, FILENAME_CHECKSUM_VERSION) == first
+
+    def test_filename_pass_runs_when_binary_pass_has_nothing_to_do(self, library):
+        """Caught live on cwn-local: when every pair already has a binary
+        row, the binary pass early-returns ('All books already have
+        checksums!') — the filename pass must still run."""
+        import generate_book_checksums as gbc
+        conn = sqlite3.connect(library / "metadata.db")
+        conn.execute(
+            "INSERT INTO book_format_checksums (book, format, checksum, version, created)"
+            " VALUES (1, 'EPUB', 'cafebabe', 'koreader', '2026-01-01T00:00:00')")
+        conn.commit()
+        conn.close()
+
+        gbc.generate_checksums(str(library), batch_size=10)
+        assert [r[0] for r in self._rows(library, FILENAME_CHECKSUM_VERSION)] == [1, 2]
+
+
+@pytest.mark.unit
+class TestLookupIsVersionAgnostic:
+    """Source-pin: get_book_by_checksum must keep matching ANY stored
+    version when called without a version filter — that is what makes the
+    filename rows resolve without touching the lookup."""
+
+    def test_lookup_has_no_hardcoded_version_filter(self):
+        import inspect
+        import cps.progress_syncing.protocols.kosync  # noqa: F401
+        mod = sys.modules["cps.progress_syncing.protocols.kosync"]
+        src = inspect.getsource(mod.get_book_by_checksum)
+        assert "if version is not None" in src, (
+            "get_book_by_checksum must only filter by version when the "
+            "caller asks — the filename-hash channel (#525/#627) relies on "
+            "version-agnostic matching.")

--- a/tests/unit/test_book_format_checksum_history.py
+++ b/tests/unit/test_book_format_checksum_history.py
@@ -104,8 +104,14 @@ class TestChecksumHistoryPreserved:
         assert h1 is not None and h2 is not None
         assert h1 != h2, "different file contents must produce different partial-MD5"
 
+        # Scope to the binary partial-MD5 channel: since #636,
+        # calculate_and_store_checksum also registers a filename-digest row
+        # (version 'koreader_filename') per call. That channel has its own
+        # coverage in test_627_525_filename_checksum.py; this test's subject
+        # is binary-checksum history preservation.
         rows = test_db.execute(
-            "SELECT checksum FROM book_format_checksums WHERE book = 7 ORDER BY created"
+            "SELECT checksum FROM book_format_checksums"
+            " WHERE book = 7 AND version = 'koreader' ORDER BY created"
         ).fetchall()
         assert len(rows) == 2
         assert {r[0] for r in rows} == {h1, h2}


### PR DESCRIPTION
## Why

KOReader's kosync plugin (and Crossink/x4) can identify a document by the md5 of its **filename** instead of the partial-MD5 of its bytes. CW-NG only ever stored the binary digest, so:

- Fork #525 (@natabat, seconded by @Metamatam): filename-mode clients always log `KOReader sync: No book found for checksum`, progress never links to a book.
- Fork #627 (@uschi1) / #633-class: devices holding files whose bytes no longer match any stored binary checksum (downloads from before the checksum feature, metadata re-embeds, side-loads) have no path back into sync short of re-downloading every book. The filename channel is that path — switch the kosync plugin's document-matching method to "filename".

## Root cause

The lookup (`get_book_by_checksum`) is already version-agnostic — the gap was purely that no filename digest was ever computed or stored. The digest algorithm was byte-verified against @natabat's real-world oracle: `md5("More Everything Forever - Adam Becker.epub") = 9ea1b31e133214bb1169acce6ff4affb` (UTF-8 basename with lowercase extension, no case folding; brute-forced over 7 candidate normalizations, unique hit — see `notes/525-kosync-filename-matching-design.md`).

## Fix

- `calculate_koreader_filename_md5` + `FILENAME_CHECKSUM_VERSION = 'koreader_filename'` in `cps/progress_syncing/checksums/koreader.py`.
- The download/export chokepoint (`calculate_and_store_checksum`) also registers the digest of the served basename.
- The boot backfill (`scripts/generate_book_checksums.py`, run every boot by the `cwa-checksum-backfill` s6 service) grows a filename pass covering every (book, format) pair — including pairs the binary pass skips via its any-row LEFT JOIN, and the all-binary-rows-present early-return path (**a live-caught bug**: the first container run exited before the new pass; pinned by `test_filename_pass_runs_when_binary_pass_has_nothing_to_do`).
- Lookup, PUT/GET handlers, models: zero changes.

## Validation

- **12 RED→GREEN tests** `tests/unit/test_627_525_filename_checksum.py`: oracle pin, UTF-8/no-case-folding/rejected-variant pins, chokepoint stores both versions + idempotent, backfill covers binary-row-carrying pairs, idempotent, early-return path, lookup version-agnosticism source-pin. RED on main (ImportError at collection); 12/12 green on branch. Adjacent suites green (`test_generate_checksums`, `test_kosync_book_id_keyed_lookup`, `test_helper_koreader_checksum_guard`, `test_book_format_checksums_table_creation`: 24 passed, 12 skipped-by-env).
- **Live e2e on cwn-local** (files docker-cp'd, kosync enabled, restarted healthy):
  1. Boot-backfill script in-container: `Filename-hash pass: committed 20 digest(s)` → `book_format_checksums` now `koreader|23, koreader_filename|20`.
  2. Filename-mode client simulation: `PUT /kosync/syncs/progress` with `document = md5("The Picture of Dorian Gray - Oscar Wilde.epub")` → **HTTP 200, matched book 2 via `koreader_filename`**, log shows `Saved kosync progress` + `Updated ReadBook status` (the exact chain that silently no-ops'd in #627), `book_read_link` row written.
  3. Cross-device pull: `GET /kosync/syncs/progress/<digest>` → 200 with progress + book info.
  4. Chokepoint live: deleted book 3's filename row, OPDS-downloaded it → row re-created. Repeat download → no duplicate rows (dedupe).
  5. No new ERROR/Traceback in container logs.
- OPDS download of book 2 also demonstrated the #627 phenomenon live: the freshly exported file stored a **new** binary checksum differing from the library-bytes one — exactly why binary-only matching strands older device copies.

## Blast radius

- `get_latest_checksum`/`get_checksum_history`: no callers outside the manager (grep-verified).
- Filename collisions (two books with the same export basename): both rows stored; lookup tie-breaks by `created DESC` — inherent to the client-chosen filename mode, documented in the design note.
- `store_checksum` dedupes on (book, format, checksum), so repeat downloads/boots add no rows.

## Tier

Multi-file logic in the sync subsystem → review-gated; Greptile invoked per policy. No new dependencies, routes, or config. No security surface (`/security-review` not required per operator directive: no auth/session/CSRF/crypto-secrets/subprocess/user-controlled-path changes; md5 here is identification, pre-existing pattern).

Ships fix for #525. Rescue path for #627 / #633-class devices (release notes will include the "switch matching method to filename" guidance).

## Release target

Next train (v4.1.5).