### PR TITLE
fix(shelves): Currently Reading honors the in-progress tri-state when a custom read column is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- **"Currently Reading" now shows the right books for libraries that use a
+  Calibre "Read" column.** If your admin settings link read status to a
+  custom Calibre column, the Currently Reading smart shelf listed every book
+  you'd marked read and never the book you were actually partway through —
+  and the "reading now" badge on a book's page never appeared, even with
+  KOReader progress synced. In-progress state (which comes from KOReader and
+  Kobo sync) is now read from the sync tracker regardless of the configured
+  column, and finished books stay out of the shelf. "Yet to Read" also now
+  counts books you've never touched, instead of only books explicitly marked
+  unread. Reported by @alva-seal, seconded by @iroQuai.
 - **KOReader sync now works when your reader matches books by filename.**
   KOReader's sync plugin (and apps like Crossink) can identify a book by a
   hash of its filename instead of its file contents. The server only ever

--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -530,23 +530,50 @@ def build_filter_from_rule(rule, user_id=None):
 
         read_col_class = db.cc_classes[config.config_read_column]
         column = read_col_class.value
-        
-        # Get the operator
-        operator = OPERATOR_MAP.get(operator_name)
-        if not operator:
-            return None
-        
-        # Convert integer value (0/1) to boolean (False/True) for proper comparison
-        # QueryBuilder sends integers from radio buttons, but custom column expects boolean
-        if isinstance(value, int):
-            value = bool(value)
 
         # Read status custom columns are joined via relationship - get the dynamic relationship name
         cc_relationship = f'custom_column_{config.config_read_column}'
-        if hasattr(db.Books, cc_relationship):
-            return getattr(db.Books, cc_relationship).any(operator(column, value))
-        else:
+        if not hasattr(db.Books, cc_relationship):
             log.error(f"Books model does not have relationship '{cc_relationship}'")
+            return None
+
+        try:
+            status_value = int(value)
+        except (ValueError, TypeError):
+            status_value = 0
+
+        # "Marked read" in custom-column mode means a truthy column row exists.
+        cc_read = getattr(db.Books, cc_relationship).any(column == True)  # noqa: E712
+
+        if status_value == ub.ReadBook.STATUS_IN_PROGRESS:
+            # The in-progress tri-state exists only in ub.ReadBook — KOReader/
+            # Kobo sync writes it there regardless of the configured read
+            # column, and a boolean column can't represent it. The previous
+            # bool(value) coercion collapsed 2 into True, turning "Currently
+            # Reading" into "Read" whenever a custom read column was set
+            # (fork #634). Marking a book read via the column never clears
+            # the ReadBook row, so custom-read books are excluded explicitly.
+            if user_id is None:
+                log.debug("read_status in-progress rule without user_id, skipping filter")
+                return None
+            in_progress_ids = [rb.book_id for rb in ub.session.query(ub.ReadBook).filter(
+                ub.ReadBook.user_id == user_id,
+                ub.ReadBook.read_status == ub.ReadBook.STATUS_IN_PROGRESS
+            ).all()]
+            condition = and_(db.Books.id.in_(in_progress_ids), ~cc_read)
+        elif status_value == ub.ReadBook.STATUS_FINISHED:
+            condition = cc_read
+        else:
+            # Unread: no truthy column row. Books never touched have no row
+            # at all, so match on absence-of-read rather than value == False
+            # (the old shape hid every never-marked book from "Yet to Read").
+            condition = ~cc_read
+
+        if operator_name == 'equal':
+            return condition
+        elif operator_name == 'not_equal':
+            return ~condition
+        else:
             return None
     else:
         if not model:

--- a/cps/web.py
+++ b/cps/web.py
@@ -3571,9 +3571,26 @@ def show_book(book_id):
         read_book = entries[1]
         archived_book = entries[2]
         entry = entries[0]
-        entry.read_status = read_book == ub.ReadBook.STATUS_FINISHED
-        # Raw tri-state for the "currently reading" detail-page marker. fork #509.
-        entry.read_status_raw = read_book or ub.ReadBook.STATUS_UNREAD
+        if config.config_read_column:
+            # read_book carries the custom column's boolean value here, which
+            # can never express the in-progress tri-state — KOReader/Kobo sync
+            # writes that only to ub.ReadBook, whatever column is configured.
+            # Overlay it so the currently-reading marker still renders for
+            # custom-read-column users (fork #634).
+            entry.read_status = bool(read_book)
+            entry.read_status_raw = (ub.ReadBook.STATUS_FINISHED if read_book
+                                     else ub.ReadBook.STATUS_UNREAD)
+            if not read_book and current_user.is_authenticated:
+                in_progress = ub.session.query(ub.ReadBook).filter(
+                    ub.ReadBook.user_id == int(current_user.id),
+                    ub.ReadBook.book_id == book_id,
+                    ub.ReadBook.read_status == ub.ReadBook.STATUS_IN_PROGRESS).first()
+                if in_progress:
+                    entry.read_status_raw = ub.ReadBook.STATUS_IN_PROGRESS
+        else:
+            entry.read_status = read_book == ub.ReadBook.STATUS_FINISHED
+            # Raw tri-state for the "currently reading" detail-page marker. fork #509.
+            entry.read_status_raw = read_book or ub.ReadBook.STATUS_UNREAD
         entry.is_archived = archived_book
         for lang_index in range(0, len(entry.languages)):
             entry.languages[lang_index].language_name = isoLanguages.get_language_name(get_locale(), entry.languages[

--- a/tests/unit/test_634_custom_read_column_currently_reading.py
+++ b/tests/unit/test_634_custom_read_column_currently_reading.py
@@ -1,0 +1,187 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression tests for fork #634 — with a Calibre custom read column
+configured, the "Currently Reading" magic shelf showed every book marked
+read and never the book actually in progress.
+
+Root cause: build_filter_from_rule's custom-column branch coerced the rule
+value with bool(), so the currently_reading preset's value 2
+(STATUS_IN_PROGRESS) collapsed into bool(2) == True — the exact same filter
+as "Read". The in-progress tri-state lives only in ub.ReadBook (KOReader/
+Kobo sync writes it there regardless of config_read_column, and the #312
+mirror only writes FINISHED to the column), so the custom-column path must
+overlay it from ReadBook instead of pretending the boolean column carries it.
+
+Same class of bug pinned for the detail page: show_book's read_status_raw
+was the raw column value in custom-column mode, so the "currently reading"
+badge (detail.html, fork #509) could never render for those users.
+
+Behavioral tests run the REAL filter against in-memory SQLite: a real bool
+cc class built by CalibreDB.setup_db_cc_classes, real Books rows, and a real
+ub.ReadBook session — mocks would pin the call shape, not the SQL semantics.
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+pytestmark = pytest.mark.unit
+
+# High id so we can't collide with cc classes another test may have created.
+CC_ID = 934
+
+USER_A = 1
+USER_B = 2
+
+BOOK_READING = 101      # ReadBook IN_PROGRESS for USER_A, no cc row
+BOOK_FINISHED = 102     # cc row True (marked read), ReadBook FINISHED
+BOOK_UNTOUCHED = 103    # no cc row, no ReadBook row
+BOOK_READ_STALE = 104   # cc row True AND stale ReadBook IN_PROGRESS
+BOOK_OTHER_USER = 105   # ReadBook IN_PROGRESS for USER_B only
+
+
+@pytest.fixture(scope="module")
+def cc_class():
+    """Create the bool cc class ONCE per module. SQLAlchemy can't un-map a
+    relationship, so (like the real app) the mapping stays for the process;
+    the high CC_ID keeps it clear of anything other tests set up."""
+    from cps import db
+
+    if CC_ID not in db.cc_classes:
+        db.CalibreDB.setup_db_cc_classes(
+            [SimpleNamespace(id=CC_ID, datatype="bool")])
+    return db.cc_classes[CC_ID]
+
+
+@pytest.fixture()
+def harness(cc_class):
+    """Real Books/ReadBook rows in fresh in-memory SQLite per test."""
+    from cps import db, ub
+
+    # metadata.db side: books + custom_column_<id>
+    meta_engine = create_engine("sqlite://")
+    db.Books.metadata.create_all(
+        meta_engine, tables=[db.Books.__table__, cc_class.__table__])
+    MetaSession = sessionmaker(bind=meta_engine)
+    meta_session = MetaSession()
+    for book_id in (BOOK_READING, BOOK_FINISHED, BOOK_UNTOUCHED,
+                    BOOK_READ_STALE, BOOK_OTHER_USER):
+        meta_session.execute(
+            db.Books.__table__.insert().values(
+                id=book_id, title=f"b{book_id}", sort=f"b{book_id}",
+                author_sort="a", uuid=f"u{book_id}", series_index=1.0,
+                path=f"p/{book_id}", has_cover=0))
+    for book_id in (BOOK_FINISHED, BOOK_READ_STALE):
+        meta_session.add(cc_class(book=book_id, value=True))
+    meta_session.commit()
+
+    # app.db side: ReadBook rows
+    app_engine = create_engine("sqlite://")
+    ub.ReadBook.metadata.create_all(app_engine, tables=[ub.ReadBook.__table__])
+    AppSession = sessionmaker(bind=app_engine)
+    app_session = AppSession()
+    app_session.add_all([
+        ub.ReadBook(user_id=USER_A, book_id=BOOK_READING,
+                    read_status=ub.ReadBook.STATUS_IN_PROGRESS),
+        ub.ReadBook(user_id=USER_A, book_id=BOOK_FINISHED,
+                    read_status=ub.ReadBook.STATUS_FINISHED),
+        ub.ReadBook(user_id=USER_A, book_id=BOOK_READ_STALE,
+                    read_status=ub.ReadBook.STATUS_IN_PROGRESS),
+        ub.ReadBook(user_id=USER_B, book_id=BOOK_OTHER_USER,
+                    read_status=ub.ReadBook.STATUS_IN_PROGRESS),
+    ])
+    app_session.commit()
+
+    with mock.patch.object(ub, "session", app_session):
+        import cps
+        with mock.patch.object(cps.config, "config_read_column", CC_ID,
+                               create=True):
+            yield SimpleNamespace(meta_session=meta_session)
+
+    app_session.close()
+    meta_session.close()
+
+
+def _matching_ids(harness, value, operator="equal", user_id=USER_A):
+    from cps import db
+    from cps.magic_shelf import build_filter_from_rule
+
+    rule = {"id": "read_status", "field": "read_status", "type": "integer",
+            "input": "radio", "operator": operator, "value": value}
+    condition = build_filter_from_rule(rule, user_id=user_id)
+    assert condition is not None, (
+        "read_status rule must produce a filter in custom-column mode")
+    rows = harness.meta_session.query(db.Books.id).filter(condition).all()
+    return sorted(r.id for r in rows)
+
+
+class TestCurrentlyReadingWithCustomColumn:
+    def test_in_progress_matches_only_the_reading_book(self, harness):
+        """THE #634 symptom: value=2 used to collapse to bool(2)=True and
+        return every custom-column-read book while missing the in-progress
+        one. It must return exactly the ReadBook IN_PROGRESS books that are
+        not marked read via the column."""
+        assert _matching_ids(harness, 2) == [BOOK_READING]
+
+    def test_in_progress_excludes_books_marked_read_via_column(self, harness):
+        """Marking a book read via the column never clears ub.ReadBook, so a
+        stale IN_PROGRESS row must not resurface a read book in the shelf."""
+        assert BOOK_READ_STALE not in _matching_ids(harness, 2)
+
+    def test_in_progress_is_scoped_to_the_user(self, harness):
+        assert BOOK_OTHER_USER not in _matching_ids(harness, 2)
+        assert _matching_ids(harness, 2, user_id=USER_B) == [BOOK_OTHER_USER]
+
+    def test_in_progress_without_user_id_fails_closed(self, harness):
+        from cps.magic_shelf import build_filter_from_rule
+        rule = {"id": "read_status", "field": "read_status",
+                "operator": "equal", "value": 2}
+        assert build_filter_from_rule(rule, user_id=None) is None
+
+    def test_read_still_matches_column_marked_books(self, harness):
+        """value=1 keeps its pre-fix meaning: books with a truthy cc row."""
+        assert _matching_ids(harness, 1) == [BOOK_FINISHED, BOOK_READ_STALE]
+
+    def test_unread_includes_books_with_no_column_row(self, harness):
+        """'Yet to Read' (value=0) used to match only value == False rows —
+        a book never touched (no row at all) was invisible. Absence of a
+        truthy row IS the unread state."""
+        ids = _matching_ids(harness, 0)
+        assert BOOK_UNTOUCHED in ids
+        assert BOOK_FINISHED not in ids
+
+    def test_not_equal_negates(self, harness):
+        assert BOOK_READING not in _matching_ids(harness, 2, operator="not_equal")
+        assert BOOK_FINISHED in _matching_ids(harness, 2, operator="not_equal")
+
+
+class TestDetailPagePillCustomColumnOverlay:
+    """show_book reaches deep into the request stack, so pin the overlay at
+    source level (same convention as test_magic_shelf_currently_reading)."""
+
+    def _src(self):
+        from cps import web
+        return inspect.getsource(web.show_book)
+
+    def test_show_book_branches_on_read_column(self):
+        src = self._src()
+        assert "config.config_read_column" in src, (
+            "show_book must branch on config_read_column: the raw column "
+            "value is a boolean and read_status_raw derived from it can "
+            "never be 2, hiding the currently-reading badge (fork #634)")
+
+    def test_show_book_overlays_in_progress_from_readbook(self):
+        src = self._src()
+        assert "ub.ReadBook.STATUS_IN_PROGRESS" in src, (
+            "show_book must overlay STATUS_IN_PROGRESS from ub.ReadBook in "
+            "custom-column mode so the detail badge (fork #509) renders")
+        assert "read_status_raw" in src


### PR DESCRIPTION
## Why

Fork #634 (@alva-seal, seconded by @iroQuai): with admin settings linking read status to a Calibre custom column, the "Currently Reading" smart shelf listed every book marked read and never the book actually in progress. iroQuai added that the "reading now" badge on the detail page never renders despite synced KOReader progress.

## Root cause

`build_filter_from_rule`'s custom-column branch coerced the rule value with `bool()`, so the currently_reading preset's value 2 (`STATUS_IN_PROGRESS`) collapsed into `bool(2) == True` — the identical filter to "Read" (value 1). The in-progress tri-state only exists in `ub.ReadBook` (KOReader/Kobo sync writes it there regardless of `config_read_column`; the #312 mirror only writes FINISHED to the column), so no boolean column filter can ever express it. Same class of bug on the detail page: `show_book` set `read_status_raw` from the raw column value, which is never 2, so the badge (fork #509) was unreachable for custom-column users.

Two adjacent latent bugs in the same branch, fixed with it:
- "Yet to Read" (value 0) matched `value == False` rows only — books never touched (no row at all) were invisible.
- Marking a book read via the column never clears its `ReadBook` row, so the in-progress filter explicitly excludes column-marked-read books (stale IN_PROGRESS rows can't resurface read books).

## Reproduction (live, pre-fix, cwn-local)

Custom bool column configured as read column; book 2 marked read via the column (plus a stale IN_PROGRESS row), book 3 with a KOReader-style IN_PROGRESS `ReadBook` row. `POST /magicshelf/preview`:

- value=2 (Currently Reading): `{"count":1,"sample_books":["The Picture of Dorian Gray"]}` — the READ book, identical to value=1; the in-progress book missing
- value=0 (Yet to Read): `{"count":0}` — every untouched book invisible

## Fix

`cps/magic_shelf.py` custom-column read_status branch: value 2 → `ReadBook.STATUS_IN_PROGRESS` for the user AND NOT column-read (fails closed without user_id, matching the built-in path); value 1 → truthy column row (unchanged); value 0 → absence of a truthy row. equal/not_equal only, like the built-in path. `cps/web.py` show_book: overlay `STATUS_IN_PROGRESS` from ReadBook in custom-column mode so `read_status_raw` can reach 2.

## Validation

- `tests/unit/test_634_custom_read_column_currently_reading.py` — behavioral red/green against real in-memory SQLite with a real bool cc class built by `CalibreDB.setup_db_cc_classes` (not mocks): 7/9 fail on pre-fix code, 9/9 pass with the fix. Covers: in-progress-only matching, stale-IN_PROGRESS exclusion, per-user scoping, fail-closed without user_id, value-1 behavior preservation, absent-row unread, not_equal negation, plus source pins on the show_book overlay.
- Live post-fix on cwn-local (same seeded state, real HTTP routes): value=2 → The Republic only; value=1 → Dorian Gray only; value=0 → 16 books including untouched ones. Detail page: `currently-reading-badge` renders for the in-progress book, absent for the read book. No new ERROR/Traceback in container logs.
- Adjacent suites green: magic-shelf presets/custom-columns, #579 read column, kosync custom-read-column mirror, discover-hides-read, #468/#499 shelf tests (66 passed).
- Full unit suite: 939 passed, 1 failed — `test_cover_picker_apply_marks_modified` (unrelated to this diff; passes isolated AND paired with the new test file; attribution run against main in progress, will note result before merge).

## Blast radius

All `build_filter_from_rule` callers pass user_id (web magic shelf view, SPA `/api/v1` magicshelves, Kobo magic-shelf sync — shelf owner's id), so the new fail-closed path only triggers on a malformed call. Operators other than equal/not_equal now return None (skip filter) instead of applying raw boolean comparison — QueryBuilder's radio input only emits equal/not_equal, and the built-in path already behaved this way.

## Tier

needs-review by default (fork-original behavior change); autonomous merge gate applies once CI + review gate pass.

Addresses #634