### PR TITLE
ci: authenticate Integration Tests job to GHCR for the pbs-cache mirror

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -185,6 +185,9 @@ jobs:
   integration-tests:
     name: Integration Tests (Docker)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read   # pull the private pbs-cache mirror images the Dockerfile COPYs from
     # Tier-2 auto-merge requires Integration Tests as a hard gate — small
     # code changes still need to clear the actual ingest/Calibre flow.
     # We keep the broad-PR exemption: tier-1 (.po / *.md) PRs and PRs
@@ -215,7 +218,17 @@ jobs:
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      
+
+      - name: Log in to GHCR (pbs-cache mirror pull)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          # GH_PAT (read:packages) so BuildKit can COPY --from our private
+          # pbs-cache mirror; falls back to GITHUB_TOKEN where the PAT
+          # secret isn't in scope.
+          password: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/tests/unit/test_workflow_safety_invariants.py
+++ b/tests/unit/test_workflow_safety_invariants.py
@@ -435,6 +435,66 @@ def test_no_merges_still_catches_foreign_non_merge_commit():
         )
 
 
+# ─── Wall 8: image-building test jobs authenticate to GHCR ─────────────
+#
+# The Dockerfile COPYs from the private ghcr.io/new-usemame/pbs-cache
+# mirror, so any tests.yml job that builds the image from source must
+# (a) hold `packages: read` and (b) run a docker/login-action step
+# against ghcr.io before the build. Without both, BuildKit's pull of
+# the mirror is anonymous and dies with 401 — which continue-on-error
+# then masks on main pushes, leaving integration coverage silently
+# dead (observed 2026-07-03, run 28677049810).
+
+
+def _steps(job: dict) -> list[dict]:
+    return [s for s in (job.get("steps") or []) if isinstance(s, dict)]
+
+
+def test_integration_tests_job_authenticates_to_ghcr():
+    """The integration-tests job builds the image from source, so it
+    needs packages:read + a ghcr.io login step ordered before the
+    docker build step. This went missing while the dev/e2e jobs had
+    it, and the job failed 401 on every main push unnoticed."""
+    wf = _load(WF_DIR / "tests.yml")
+    job = (wf.get("jobs") or {}).get("integration-tests")
+    assert isinstance(job, dict), "tests.yml must define an integration-tests job"
+
+    perms = job.get("permissions") or {}
+    assert perms.get("packages") == "read", (
+        "integration-tests must grant `packages: read` so the private "
+        "pbs-cache mirror the Dockerfile COPYs from can be pulled"
+    )
+
+    steps = _steps(job)
+    login_idx = next(
+        (
+            i
+            for i, s in enumerate(steps)
+            if str(s.get("uses", "")).startswith("docker/login-action")
+            and (s.get("with") or {}).get("registry") == "ghcr.io"
+        ),
+        None,
+    )
+    assert login_idx is not None, (
+        "integration-tests must log in to ghcr.io before building — the "
+        "Dockerfile COPYs from the private pbs-cache mirror and an "
+        "anonymous pull 401s"
+    )
+    build_idx = next(
+        (
+            i
+            for i, s in enumerate(steps)
+            if str(s.get("uses", "")).startswith("docker/build-push-action")
+        ),
+        None,
+    )
+    assert build_idx is not None, "integration-tests must build the image"
+    assert login_idx < build_idx, (
+        "GHCR login must come before the image build, or BuildKit still "
+        "pulls the pbs-cache mirror anonymously"
+    )
+
+
 def test_all_workflows_have_minimum_permissions_block():
     """Every workflow that does any mutating action (commenting,
     labeling, merging) must have an explicit top-level OR job-level


### PR DESCRIPTION
## Why

The Integration Tests (Docker) job has been failing on every main push with a 401 pulling the private `ghcr.io/new-usemame/pbs-cache` mirror anonymously, and `continue-on-error` keeps the Test Suite run green — so integration coverage has been silently dead. Observed on run 28677049810 (main, 2026-07-03):

```
#6 ERROR: failed to authorize: failed to fetch anonymous token: ... repository%3Anew-usemame%2Fpbs-cache%3Apull ... 401 Unauthorized
```

## Root cause

The job builds the image from source, and the Dockerfile `COPY --from`s the private pbs-cache mirror. Unlike the dev-build workflow and the e2e job in this same file, the integration job had no `packages: read` permission and no GHCR login step, so BuildKit's metadata fetch for the mirror stages was anonymous.

## Fix

Mirror the existing pattern: grant `contents: read` + `packages: read` at the job level and add a `docker/login-action@v3` step against ghcr.io with `secrets.GH_PAT || secrets.GITHUB_TOKEN` before the build step.

## Validation

- Regression test (red on main, green here): `tests/unit/test_workflow_safety_invariants.py::test_integration_tests_job_authenticates_to_ghcr` — Wall 8 pin that the integration-tests job holds `packages: read` and runs a ghcr.io login step ordered before the docker build. Full invariants file: 10 passed locally.
- Practical verification: this PR carries `safe-tier-2`, which makes the Integration Tests job run (and gate) on this PR itself — the job reaching past the image build is the end-to-end proof the 401 is gone.
- Security review run (change touches workflow secrets wiring): no findings. GH_PAT is never in scope for fork-origin code (GitHub withholds secrets there), login creds are not visible to Dockerfile RUN steps, and the new expressions use only `github.repository_owner`/`secrets.*`.

## Tier

safe-tier-2 — single production file, +15 lines of workflow config following an established in-repo pattern; test file addition alongside.