### PR TITLE
fix(spa): list a user's shelves under the SHELVES sidebar header

### DIFF
--- a/frontend/e2e/sidebar.spec.ts
+++ b/frontend/e2e/sidebar.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect, Locator } from '@playwright/test';
+
+/*
+ * Sidebar shelves grouping — the reported new-UI regression: the user's shelves
+ * were listed as the LAST block of the nav (below Tasks / About / Table view /
+ * Smart shelves), disconnected from the "SHELVES" section header they belong to.
+ * The header said "SHELVES" with the info pages directly under it and the actual
+ * shelves pushed below the fold.
+ *
+ * The contract this pins: within the sidebar, a user's shelf link renders
+ *   (a) BELOW the SHELVES section header, and
+ *   (b) ABOVE the Tasks / About info pages
+ * i.e. the shelves are grouped with their header, not orphaned at the bottom.
+ *
+ * DOM order in a vertical nav = smaller boundingBox().y. Asserting on y is the
+ * user-visible truth (where the shelves actually appear on screen).
+ */
+
+async function topY(loc: Locator): Promise<number> {
+  const box = await loc.boundingBox();
+  if (!box) throw new Error('element has no bounding box (not rendered/visible)');
+  return box.y;
+}
+
+test.describe('sidebar shelves grouping', () => {
+  test('desktop: user shelves render under the SHELVES header, above Tasks/About', async ({ page }) => {
+    await page.goto('/app');
+    await expect(page.locator('a[href*="/book/"]').first()).toBeVisible();
+
+    const nav = page.locator('nav[aria-label="Browse"]');
+    const shelvesHeader = nav.locator('a[href$="/shelves"]');
+    const firstShelf = nav.locator('a[href*="/shelf/"]').first();  // /shelf/<id>, not /shelves
+    const tasks = nav.locator('a[href$="/tasks"]');
+
+    await expect(shelvesHeader, 'SHELVES section header present').toBeVisible();
+    await expect(firstShelf, "at least one of the user's shelves is listed in the sidebar").toBeVisible();
+    await expect(tasks, 'Tasks info link present').toBeVisible();
+
+    const headerY = await topY(shelvesHeader);
+    const shelfY = await topY(firstShelf);
+    const tasksY = await topY(tasks);
+
+    expect(shelfY, 'user shelves must render BELOW the SHELVES header').toBeGreaterThan(headerY);
+    expect(shelfY, 'user shelves must render ABOVE the Tasks/About info pages (not orphaned at the bottom)').toBeLessThan(tasksY);
+  });
+
+  test('mobile: shelves are grouped under the header inside the opened drawer', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile', 'drawer + hamburger exist only on the mobile project');
+
+    await page.goto('/app');
+    await expect(page.locator('a[href*="/book/"]').first()).toBeVisible();
+    await page.getByRole('button', { name: /open navigation/i }).click();
+
+    const nav = page.getByRole('navigation');
+    const shelvesHeader = nav.locator('a[href$="/shelves"]');
+    const firstShelf = nav.locator('a[href*="/shelf/"]').first();
+    const tasks = nav.locator('a[href$="/tasks"]');
+
+    await expect(firstShelf).toBeVisible();
+    const headerY = await topY(shelvesHeader);
+    const shelfY = await topY(firstShelf);
+    const tasksY = await topY(tasks);
+
+    expect(shelfY, 'shelves below the SHELVES header in the drawer').toBeGreaterThan(headerY);
+    expect(shelfY, 'shelves above Tasks/About in the drawer').toBeLessThan(tasksY);
+  });
+});

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -151,7 +151,11 @@ export function Sidebar({ open, onNavigate }: SidebarProps) {
           </ul>
         )}
 
-        {/* Shelves: header links to the manage page; user's shelves listed below. */}
+        {/* Shelves: the section header links to the manage page and the user's
+            own shelves are listed directly beneath it (the group they belong to).
+            Smart shelves + power tools follow, and the low-frequency info pages
+            (Tasks / About) come last. Regression guard: the shelves used to
+            render as the very last block of the nav, orphaned below Tasks/About. */}
         <div className={styles.sectionHeader}>
           <Link
             href="/shelves"
@@ -163,27 +167,31 @@ export function Sidebar({ open, onNavigate }: SidebarProps) {
           </Link>
         </div>
 
-        <ul className={styles.list}>
-          {SYSTEM.map(({ href, label, icon: Icon }) => {
-            const active = isActive(location, href, true);
-            return (
-              <li key={href}>
-                <Link
-                  href={href}
-                  className={active ? styles.itemActive : styles.item}
-                  aria-current={active ? 'page' : undefined}
-                  onClick={onNavigate}
-                >
-                  <Icon size={18} className={styles.icon} />
-                  <span>{t(label)}</span>
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+        {shelves.length > 0 && (
+          <ul className={styles.shelfList}>
+            {shelves.map((s) => {
+              const href = `/shelf/${s.id}`;
+              const active = location === href;
+              return (
+                <li key={s.id}>
+                  <Link
+                    href={href}
+                    className={active ? styles.shelfItemActive : styles.shelfItem}
+                    aria-current={active ? 'page' : undefined}
+                    onClick={onNavigate}
+                    title={s.name}
+                  >
+                    <span className={styles.shelfName}>{s.name}</span>
+                    <span className={styles.shelfCount}>{s.count}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
 
-        {/* Power features served by the legacy UI under the hybrid cutover —
-            plain <a> so they leave the SPA. Reachable, not omitted. */}
+        {/* Smart shelves + power features served by the legacy UI under the
+            hybrid cutover — plain <a> so they leave the SPA. Reachable, not omitted. */}
         <ul className={styles.list}>
           {showList && (
             <li>
@@ -241,28 +249,25 @@ export function Sidebar({ open, onNavigate }: SidebarProps) {
           )}
         </ul>
 
-        {shelves.length > 0 && (
-          <ul className={styles.shelfList}>
-            {shelves.map((s) => {
-              const href = `/shelf/${s.id}`;
-              const active = location === href;
-              return (
-                <li key={s.id}>
-                  <Link
-                    href={href}
-                    className={active ? styles.shelfItemActive : styles.shelfItem}
-                    aria-current={active ? 'page' : undefined}
-                    onClick={onNavigate}
-                    title={s.name}
-                  >
-                    <span className={styles.shelfName}>{s.name}</span>
-                    <span className={styles.shelfCount}>{s.count}</span>
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        )}
+        {/* Low-frequency info pages, last. */}
+        <ul className={styles.list}>
+          {SYSTEM.map(({ href, label, icon: Icon }) => {
+            const active = isActive(location, href, true);
+            return (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className={active ? styles.itemActive : styles.item}
+                  aria-current={active ? 'page' : undefined}
+                  onClick={onNavigate}
+                >
+                  <Icon size={18} className={styles.icon} />
+                  <span>{t(label)}</span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
       </nav>
     </>
   );


### PR DESCRIPTION
## Symptom

In the new UI, the left sidebar showed the **SHELVES** header, but a user's own shelves weren't listed beneath it. Instead **Tasks / About / Table view / Smart shelves** sat directly under the header, and the actual shelves (Archive, Calibre, Favorites, …) rendered as the very last block of the nav — below the fold and disconnected from the header they belong to. A user with 10 shelves saw a "SHELVES" label with none of their shelves under it.

## Root cause

The shelf list started life directly under the SHELVES header (commit `914b1975f`). As later feature commits added nav blocks — About/Tasks (`5d02bc16c`), Table view (`e70c600b0`), Smart shelves (`3849c245a`), Duplicates (`76f9d957b`) — each was inserted *between* the header and the shelf list, so the user's shelves drifted to the last child of `<nav>`. Nobody moved the list on purpose; it got pushed down.

## Fix

Reorder the sidebar JSX so the group reads coherently:

- **SHELVES** header → the user's own shelves directly beneath it
- Smart shelves + power tools (Table view, magic shelves, Duplicates)
- low-frequency info pages (Tasks, About) last

Pure DOM reorder — the changed region's code multiset is identical (verified line-for-line); only ordering and comments change. No visibility/role/gating logic touched (the #585 `sidebar` map filtering is untouched), and the `shelves.length > 0` guard is preserved.

## Verification

- **RED → GREEN** e2e regression test (`frontend/e2e/sidebar.spec.ts`): pins that a shelf link renders below the SHELVES header and above Tasks. RED against the unfixed build (shelf at y≈1103, Tasks at y≈746 — shelf below Tasks); GREEN after the fix, on **desktop and inside the opened mobile drawer**.
- **Full e2e suite** (desktop + mobile, cwn-local): 15 passed / 2 pre-existing skips. Mobile drawer (#576) and gear-menu (#628) regressions still pass; a11y clean; console clean.
- **Sub-path axis**: sidebar shelf links carry the full `/cwa/app/` base prefix identically to every other nav link (`/cwa/app/shelf/4`), ordering holds under the reverse-proxy rig.
- Screenshots (desktop + mobile) confirm shelves render directly under the SHELVES header.

## Confidence

96% — pure DOM reorder proven by an identical code multiset, pinned by a desktop+mobile regression test; residual risk is only the subjective grouping choice for the lower nav sections.