### PR TITLE
fix(ci): keep the Update Translations job green after the wiki page was consolidated

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,4 +1,4 @@
-name: Update Translations and Wiki Status
+name: Update Translations
 
 on:
   push:
@@ -149,32 +149,10 @@ jobs:
             exit 1
           fi
 
-      - name: Clone wiki repo
-        # The wiki is optional. Calibre-Web-NextGen is a standalone repo and the
-        # GitHub wiki has never been initialized (the .wiki.git remote 404s
-        # until someone creates the first page in the Wiki tab). We let the
-        # clone fail soft and skip the downstream wiki steps so the job stays
-        # green; if/when the wiki is initialized, the rest light up
-        # automatically.
-        if: steps.commit_pat.outputs.available == 'true'
-        id: clone_wiki
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          git clone https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git wiki-tmp
-
-      - name: Generate translation status table (in wiki repo)
-        if: steps.commit_pat.outputs.available == 'true' && steps.clone_wiki.outcome == 'success'
-        run: |
-          python scripts/generate_translation_status.py wiki-tmp/Contributing-Translations.md
-
-      - name: Commit and push wiki update
-        if: steps.commit_pat.outputs.available == 'true' && steps.clone_wiki.outcome == 'success'
-        run: |
-          cd wiki-tmp
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Contributing-Translations.md
-          git commit -m "Update translation status table [skip ci]" || echo "No changes to commit"
-          git push
+      # The per-language translation-status table lives in the repo README
+      # (single source of truth) — see the "Translations" section of the
+      # wiki's Contributing page. The old steps here cloned the wiki and
+      # wrote the table into a `Contributing-Translations` page; that page
+      # was consolidated away, so the generator crashed on the missing file
+      # and this job went red on every push. The README refresh above is the
+      # canonical output, so the wiki-write steps are gone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ is for things you can see or feel when running the app.
   beneath it, while your actual shelves were pushed to the very bottom of the
   menu, off the end of the drawer. Shelves now appear right under the SHELVES
   heading, with Tasks and About moved to the bottom where they belong.
+- **The "Contribute here!" link on the translation banner works again.** When
+  your language is only partly translated, the banner offering to help now points
+  at the wiki page that exists instead of a renamed one that returned a "page not
+  found".
 
 ## [v4.1.5] - 2026-07-03
 

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -513,7 +513,7 @@
       {%if message[0] == "translation_missing" %}
       <div class="row-fluid text-center">
         <div id="flash_info" class="alert alert-info alert-cwa">
-          {{ message[1] }} <a href="https://github.com/new-usemame/Calibre-Web-NextGen/wiki/Contributing-Translations">{{ _('Contribute here!') }}</a>
+          {{ message[1] }} <a href="https://github.com/new-usemame/Calibre-Web-NextGen/wiki/Contributing">{{ _('Contribute here!') }}</a>
           <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>

--- a/scripts/generate_translation_status.py
+++ b/scripts/generate_translation_status.py
@@ -112,7 +112,14 @@ def render_wiki_table(stats):
 def update_between_markers(path: Path, body: str) -> bool:
     """Replace text between START_MARKER and END_MARKER. Returns True if
     file was modified (or markers needed to be inserted), False if the
-    file lacked markers AND we're not allowed to invent them."""
+    file lacked markers AND we're not allowed to invent them.
+
+    A non-existent path has no markers to update, so this returns False
+    without raising. main() relies on that to fall through to its
+    seed-on-first-run fallback; reading unconditionally here would raise
+    FileNotFoundError and defeat it."""
+    if not path.exists():
+        return False
     text = path.read_text(encoding="utf-8")
     block = f"{START_MARKER}\n{body}\n{END_MARKER}"
     if START_MARKER in text and END_MARKER in text:

--- a/tests/unit/test_generate_translation_status.py
+++ b/tests/unit/test_generate_translation_status.py
@@ -1,0 +1,81 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Unit tests for scripts/generate_translation_status.py.
+
+Regression guard for the chronic `Update Translations` CI failure: the
+wiki-status generator crashed with FileNotFoundError when handed a path
+that does not exist yet (the `Contributing-Translations` wiki page was
+consolidated away). `update_between_markers` must return False on a
+missing path instead of raising, so main()'s seed fallback can run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_translation_status.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "generate_translation_status", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+START = mod.START_MARKER
+END = mod.END_MARKER
+
+
+def test_missing_path_returns_false_without_raising(tmp_path):
+    """The regression: a non-existent target must not raise
+    FileNotFoundError — that was the chronic CI crash."""
+    missing = tmp_path / "does-not-exist.md"
+    assert missing.exists() is False
+    assert mod.update_between_markers(missing, "body") is False
+    # And it must not have created the file as a side effect.
+    assert missing.exists() is False
+
+
+def test_replaces_content_between_markers(tmp_path):
+    page = tmp_path / "page.md"
+    page.write_text(
+        f"intro\n{START}\nOLD TABLE\n{END}\noutro\n", encoding="utf-8"
+    )
+    changed = mod.update_between_markers(page, "NEW TABLE")
+    assert changed is True
+    text = page.read_text(encoding="utf-8")
+    assert "NEW TABLE" in text
+    assert "OLD TABLE" not in text
+    # Surrounding content is preserved.
+    assert text.startswith("intro\n")
+    assert text.rstrip().endswith("outro")
+
+
+def test_unchanged_content_returns_false(tmp_path):
+    page = tmp_path / "page.md"
+    page.write_text(f"{START}\nSAME\n{END}\n", encoding="utf-8")
+    assert mod.update_between_markers(page, "SAME") is False
+
+
+def test_no_markers_returns_false_no_write(tmp_path):
+    page = tmp_path / "page.md"
+    original = "no markers here\n"
+    page.write_text(original, encoding="utf-8")
+    assert mod.update_between_markers(page, "body") is False
+    assert page.read_text(encoding="utf-8") == original
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Why
`main` has been red on **every push** since ~2026-07-04T14:31Z. The `Update Translations` workflow's *Generate translation status table (in wiki repo)* step died with:

```
FileNotFoundError: [Errno 2] No such file or directory: 'wiki-tmp/Contributing-Translations.md'
```

The wiki's `Contributing-Translations` page was consolidated into `Contributing`, whose Translations section now points readers at the README table as the single source of truth. The workflow kept trying to write the table into the removed page, and the generator crashed on the missing file. Nothing user-facing broke, but a chronically-red workflow masks any real future failure of this job (breadcrumb: `notes/CHRONIC-translations-wiki-status-fail.md`).

## Root cause
Two independent defects, same origin (the page rename):
1. The workflow's three wiki steps (clone → generate → commit) write to a page that no longer exists. The README refresh — the canonical output per the documented decision — runs earlier and is unaffected.
2. `generate_translation_status.update_between_markers()` calls `path.read_text()` unconditionally, so a non-existent target raises `FileNotFoundError` *before* `main()`'s documented seed-on-first-run fallback can run.

A third, user-facing loose end from the same rename: the in-app translation banner's "Contribute here!" link pointed at `wiki/Contributing-Translations` (now a 404).

## Fix
- Drop the deprecated wiki clone/generate/commit steps; rename the workflow to `Update Translations`. README refresh stays as the single source of truth.
- Guard `update_between_markers` against a non-existent path so it returns `False` (honouring its own docstring contract) and lets the seed fallback run instead of raising.
- Point the "Contribute here!" link at `wiki/Contributing`, the page that exists.

## Reproduction (red)
```
$ python scripts/generate_translation_status.py /tmp/x/Contributing-Translations.md
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/x/Contributing-Translations.md'   # exit 1
```

## Validation (green)
- New `tests/unit/test_generate_translation_status.py` — 4 tests; the `test_missing_path_returns_false_without_raising` case fails on the pre-fix script (verified by stashing the guard) and passes after.
- Same repro command now exits 0 and seeds the file gracefully.
- Workflow YAML re-parsed: no wiki steps remain; the README-refresh + dev-build-trigger steps are intact.
- `wiki/Contributing` confirmed present in the live wiki (13 pages: `Contributing.md` yes, `Contributing-Translations.md` no).

## Tier / release
Infra + one-line dead-link fix. Required checks: `validate-author`, `Fast Tests (Smoke + Unit)`, `Test Suite Summary`. The `Update Translations` workflow itself is push-triggered, so it re-runs on merge — its green run on `main` is the final proof. Rides the pending v4.1.6 train (user-facing part: the banner link).

No new dependencies, secrets, or external service URLs. No auth/session/CSRF/subprocess/user-controlled-path surface → no `/security-review` class.