### PR TITLE
fix(ui): remove the stray count number in the admin title (#669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ is for things you can see or feel when running the app.
   inherited upstream icon.
 
 ### Fixed
+- **Removed the stray number next to "User administration" in the new
+  interface.** The admin page showed a bare, unlabeled count (e.g. "1") beside
+  the title that read as a glitch rather than information. It's gone; the user
+  count is already clear from the list itself. Reported by @chloeroform (#669),
+  patch by @chloeroform.
 - **KOReader reading position now syncs between two devices even after a book
   is re-uploaded or edited.** If one reader was ahead (say 80%) and the other
   behind (67%), the second device could refuse to jump forward — a manual pull

--- a/frontend/src/pages/Admin.module.css
+++ b/frontend/src/pages/Admin.module.css
@@ -19,11 +19,6 @@
   color: var(--text);
 }
 
-.count {
-  color: var(--text-muted);
-  font-size: var(--fs-sm);
-}
-
 .addBtn {
   margin-left: auto;
   display: inline-flex;

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -122,7 +122,6 @@ export function Admin() {
       <div className={styles.header}>
         <Shield size={22} className={styles.headerIcon} />
         <h1 className={styles.title}>{t('User administration')}</h1>
-        <span className={styles.count}>{data.items.length}</span>
         <button
           type="button"
           className={styles.addBtn}


### PR DESCRIPTION
## Symptom
Reported by @chloeroform (#669): the new-UI admin page (`/app/admin`) showed a bare, unlabeled number (e.g. "1") next to the "User administration" title. With no label it reads as a rendering glitch, not information.

## Fix
Removes the `<span className={styles.count}>{data.items.length}</span>` badge (as proposed in @chloeroform's fork PR #703) **and** the now-orphaned `.count` CSS rule, so no dead style is left behind. `.addBtn` keeps `margin-left: auto`, so the header layout (title left, "New user" button right) is unchanged.

## Verification
- `npm run build` (Vite) green — no type errors; `data` is still consumed by the user table (no unused-var).
- No remaining reference to `styles.count` / `.count` in `Admin.tsx` or `Admin.module.css`.

Design note: the count was ambiguous (an unlabeled "1"); the user list itself already conveys how many users exist, so removal is the cleaner call and matches the reporter's request.

Credit: patch by @chloeroform (#703).

Addresses #669