### PR TITLE
fix(#716): open new-UI downloads in a new tab so iPhone users aren't stranded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+- **Downloading a book on an iPhone no longer strands you.** In the new
+  interface, tapping a format to download it used to navigate Safari away from
+  the app to a page it couldn't show — leaving iPhone users stuck until they
+  force-restarted the app to get back. Downloads now open in a separate tab, so
+  the app stays put and you land right back where you were. Reported by
+  @Arjan61 (#716). Also applies to the download buttons on the edit-book screen
+  and the annotation exports.
+
 ## [v4.1.6] - 2026-07-07
 
 ### Added

--- a/frontend/e2e/download.spec.ts
+++ b/frontend/e2e/download.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, Page } from '@playwright/test';
+
+/*
+ * #716 — "After downloading a book I can't come back to the app, I stay on the
+ * download page on my iPhone, I have to restart to come back."
+ *
+ * Book files are served with `Content-Disposition: inline` (needed for
+ * byte-range / in-browser reading), and iOS Safari ignores the anchor's
+ * `download` hint — so a same-tab tap navigates the SPA away to a file the
+ * browser can't render, stranding the user on a dead page until they force
+ * a restart. The fix opens download links in a new tab (`target="_blank"`) so
+ * the app tab always survives; desktop browsers still honour `download` and
+ * don't spawn a stray tab.
+ *
+ * The iOS-Safari stranding itself can't be reproduced under Chromium (Chromium
+ * honours `download`), so the regression guard is the rendered anchor: it must
+ * carry `target="_blank"` + `rel~=noopener`. If a future edit drops that, iOS
+ * users strand again and this goes red. The desktop test guards the reverse
+ * risk — that adding `target="_blank"` doesn't break the download or leave a
+ * stray tab.
+ */
+
+async function firstBookDownloadLink(page: Page) {
+  await page.goto('/app');
+  await page.locator('a[href*="/book/"]').first().click();
+  await expect(page).toHaveURL(/\/book\/\d+/);
+  // Formats load async, so wait for the download control to mount rather than
+  // race the query with an immediate count() (which flakily skipped on mobile).
+  const dl = page.locator('a[href*="/download/"]').first();
+  try {
+    await dl.waitFor({ state: 'visible', timeout: 10_000 });
+  } catch {
+    test.skip(true, 'first book has no downloadable format in this seed');
+  }
+  return dl;
+}
+
+test('book download link opens in a new tab so the SPA is never unloaded (#716)', async ({ page }) => {
+  const dl = await firstBookDownloadLink(page);
+  await expect(dl).toHaveAttribute('target', '_blank');
+  await expect(dl).toHaveAttribute('rel', /noopener/);
+  // `download` is a boolean attribute — present, empty value.
+  await expect(dl).toHaveAttribute('download', '');
+});
+
+test('desktop: download still fires and leaves no stray tab (#716 regression guard)', async ({ page, context }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop', 'download-event behaviour is checked on the desktop project');
+  const dl = await firstBookDownloadLink(page);
+  const tabsBefore = context.pages().length;
+  const downloadPromise = page.waitForEvent('download', { timeout: 8_000 });
+  await dl.click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename().length).toBeGreaterThan(0);
+  // adding target="_blank" must not spawn a lingering blank tab on desktop
+  expect(context.pages().length).toBeLessThanOrEqual(tabsBefore);
+});

--- a/frontend/src/pages/Annotations.tsx
+++ b/frontend/src/pages/Annotations.tsx
@@ -52,9 +52,9 @@ export function Annotations({ id }: { id: string }) {
       </div>
 
       <div className={styles.toolbar}>
-        <a className={styles.toolBtn} href={apiUrl(`/annotations/${id}/export.md`)}><Download size={14} aria-hidden="true" focusable={false} /> Markdown</a>
-        <a className={styles.toolBtn} href={apiUrl(`/annotations/${id}/export.csv`)}><Download size={14} aria-hidden="true" focusable={false} /> CSV</a>
-        <a className={styles.toolBtn} href={apiUrl(`/annotations/${id}/export.json`)}><Download size={14} aria-hidden="true" focusable={false} /> JSON</a>
+        <a className={styles.toolBtn} href={apiUrl(`/annotations/${id}/export.md`)} download target="_blank" rel="noopener"><Download size={14} aria-hidden="true" focusable={false} /> Markdown</a>
+        <a className={styles.toolBtn} href={apiUrl(`/annotations/${id}/export.csv`)} download target="_blank" rel="noopener"><Download size={14} aria-hidden="true" focusable={false} /> CSV</a>
+        <a className={styles.toolBtn} href={apiUrl(`/annotations/${id}/export.json`)} download target="_blank" rel="noopener"><Download size={14} aria-hidden="true" focusable={false} /> JSON</a>
         <a className={styles.toolBtn} href={apiUrl('/annotations/import')}><UploadIcon size={14} aria-hidden="true" focusable={false} /> {t('Import from Kobo')}</a>
       </div>
 

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -344,6 +344,15 @@ export function BookDetail() {
                 href={resourceUrl(fmt.download_url)}
                 className={styles.downloadBtn}
                 download
+                // iOS Safari ignores the `download` hint and the server serves book
+                // files with `Content-Disposition: inline` (needed for byte-range /
+                // in-browser reading), so a same-tab tap navigates the SPA away to a
+                // file the browser can't render — stranding the user on a dead page
+                // until they force-restart (#716). Opening in a new tab preserves the
+                // app tab; desktop browsers still honour `download` and don't spawn a
+                // stray tab. `noopener` keeps the download context from reaching back.
+                target="_blank"
+                rel="noopener"
               >
                 <Download size={15} />
                 {fmt.format} · {formatBytes(fmt.size_bytes)}

--- a/frontend/src/pages/EditBook.tsx
+++ b/frontend/src/pages/EditBook.tsx
@@ -656,7 +656,7 @@ function FormatsManager({ id }: { id: string }) {
         {book!.formats.map((f) => (
           <li key={f.format} className={styles.formatItem}>
             <span className={styles.formatName}>{f.format}</span>
-            <a className={styles.formatDownload} href={resourceUrl(f.download_url)} download>{t('Download')}</a>
+            <a className={styles.formatDownload} href={resourceUrl(f.download_url)} download target="_blank" rel="noopener">{t('Download')}</a>
             {canDelete && (
               <button className={styles.formatDelete}
                 onClick={() => {


### PR DESCRIPTION
## Why
Fork issue #716 (@Arjan61): *"After downloading a book I can't come back to the app and I stay at the download page on my iPhone. I have to restart to come back."* A flagship new-UI bug on the reporter's exact platform (iOS Safari).

## Root cause
Book files are served with `Content-Disposition: inline` (`cps/web.py:2416` — deliberate, for byte-range / in-browser reading). iOS Safari ignores the anchor's `download` hint, so a **same-tab** tap on a download link navigates the SPA away to a binary the browser can't render — the app is unloaded and the user is stranded on a dead page until they force-restart. The download anchors in the SPA (`BookDetail.tsx`, `EditBook.tsx`, `Annotations.tsx`) had no `target`.

The `inline` header is shared reader infrastructure (byte-range reads, epub.js), so flipping it to `attachment` has wide blast radius (OPDS, Kobo, reader) and is out of scope. The right-sized root fix is SPA-side: never let a download unload the app tab.

## Fix
Add `target="_blank" rel="noopener"` to the download anchors:
- `BookDetail.tsx` — book format downloads (the reported flow)
- `EditBook.tsx` — format downloads (identical bug)
- `Annotations.tsx` — the three annotation exports (.md/.csv/.json)

The app tab now always survives. Desktop browsers still honour `download` and don't spawn a stray tab.

## Validation (red/green, `e2e/download.spec.ts`)
Driven against the real SPA in `cwn-local` (desktop 1280×800 + mobile 375×667):
- **RED** on the pre-fix v4.1.6 bundle: download anchor `target` is `null` → attribute pin fails on desktop **and** mobile.
- **GREEN** after building the fix into the container: `target="_blank"` + `rel~=noopener` present on both viewports.
- **Desktop guard**: clicking the download still fires a `download` event (real filename) and leaves **no** stray tab — proves `target="_blank"` doesn't regress desktop.
- Full Layer-2 e2e gate: 48 passed, 10 skipped, 1 pre-existing cover-image-width flake in `browse.spec.ts` (passes deterministically in isolation; unrelated to this diff — anchor attributes can't cause horizontal overflow).

**Residual gap (honest):** the iOS-Safari stranding itself cannot be reproduced under Chromium (Chromium honours `download`, so there is no "stuck" state to observe). The mechanism is standard browser behaviour — `target="_blank"` preserves the origin tab — but this was **not** verified on a real iPhone. That gap is why this is `needs-review` rather than auto-merged.

## Tier
`needs-review` — fork-original UI change on the primary download flow, with an un-closeable-headless iOS verification gap.

## Release target
v4.1.7 (next train).

Addresses #716.