### PR TITLE
Book detail: star rating + "More by this author"; fix broken %()s i18n placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+- **Book pages now show star ratings and more from the same author.** In the
+  redesigned interface, a book's page now displays its star rating (matching the
+  classic view), and — below the details — a "More by this author" row of other
+  books by that author, so a book page is a place to keep browsing instead of a
+  dead end. Books with no cover art or description no longer leave the page
+  looking half-empty.
+
 ### Fixed
 - **Admins can find the Admin page in the new interface again.** In the
   redesigned UI the Admin/Settings entry lived only in the left sidebar rail, so
@@ -25,6 +33,11 @@ is for things you can see or feel when running the app.
   find admin. The account menu now shows an **Admin** link (for admin accounts
   only) that opens the in-app admin page. Reported through the in-app feedback
   form (#659).
+- **The bulk-edit toolbar no longer shows a raw code placeholder.** In the new
+  interface, selecting several books and choosing merge or bulk-apply showed
+  literal text like "Merge %(n)s books…" and "Apply to %(n)s books" instead of
+  the actual count. Both now read correctly (e.g. "Merge 3 books…"). The same
+  underlying issue was corrected on the book page's tag controls.
 - **Downloading a book on an iPhone no longer strands you.** In the new
   interface, tapping a format to download it used to navigate Safari away from
   the app to a page it couldn't show — leaving iPhone users stuck until they

--- a/cps/api/serializers.py
+++ b/cps/api/serializers.py
@@ -140,6 +140,13 @@ def serialize_book_detail(book, read=False, archived=False, favorited=False, hid
     series = ({"id": series_list[0].id, "name": series_list[0].name}
               if series_list else None)
 
+    # Rating — Calibre stores 0–10 (half-star granularity: 9 → 4.5 stars), so
+    # expose the raw value and let the UI render halves. None when unrated.
+    # Mirrors the classic detail page's star block (detail.html:
+    # entry.ratings[0].rating). first entry only, matching the model's uniqueness.
+    ratings_list = getattr(book, "ratings", None) or []
+    rating = ratings_list[0].rating if ratings_list else None
+
     # Cover
     cover_url = f"/cover/{bid}/og" if getattr(book, "has_cover", 0) else None
 
@@ -208,6 +215,7 @@ def serialize_book_detail(book, read=False, archived=False, favorited=False, hid
                     for a in (getattr(book, "authors", None) or [])],
         "series": series,
         "series_index": book.series_index,
+        "rating": rating,
         "cover_url": cover_url,
         "pubdate": pubdate_str,
         "description_html": description_html,

--- a/cps/spa_strings.py
+++ b/cps/spa_strings.py
@@ -44,7 +44,23 @@ _("Series order (reverse)")
 _("Add tag")
 _("New tag")
 _("Remove tag")
-_("Remove tag %(name)s")
+# NB: the SPA's interpolate() uses {brace} placeholders, not gettext %(name)s —
+# a %()s msgid renders its placeholder literally (was a latent bug here + in
+# BulkBar). Keep SPA msgids on the {brace} form.
+_("Remove tag {name}")
+
+# Book detail completeness pass — star rating (parity with the classic detail
+# page) and the "More by this author" browse strip that fills the page for
+# sparse books. SPA-only strings (BookDetail.tsx / StarRating.tsx /
+# MoreByAuthor.tsx), anchored so the auto-translation job keeps them.
+_("Rated {rating} out of 5")
+_("More by {name}")
+
+# Bulk-selection toolbar (BulkBar.tsx) — previously unanchored AND written with
+# %(n)s, so they were dropped on re-extract and rendered the placeholder
+# literally in a visible confirm dialog + button. Anchored on the {brace} form.
+_("Merge {n} books into the first selected? The others are removed after their formats are copied over.")
+_("Apply to {n} books")
 
 
 # ============================================================================

--- a/frontend/e2e/book-detail.spec.ts
+++ b/frontend/e2e/book-detail.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, Page } from '@playwright/test';
+import { collectPageErrors, assertNoPageErrors, assertNoHorizontalOverflow } from './utils';
+
+/*
+ * Book-detail completeness pass:
+ *   - Star rating (parity with the classic detail page) — the serializer now
+ *     emits `rating` (0–10) and the page renders it as five stars.
+ *   - "More by this author" strip — fills the page for sparse/description-less
+ *     books and turns the detail page into a browse surface.
+ *   - i18n regression guard — the SPA interpolates {brace} placeholders, NOT
+ *     gettext %(name)s; a %()s msgid renders its placeholder literally. This
+ *     shipped a literal "More by %(name)s" in dev before the fix, and the same
+ *     class of bug was live in BulkBar. The heading below must never contain a
+ *     raw placeholder.
+ *
+ * Seed-resilient: the specs query the API for a rated book / a multi-book author
+ * and skip (not fail) when the seed lacks one, so they stay green on any library.
+ */
+
+interface DetailProbe {
+  ratedBookId: number | null;
+  ratedValue: number | null;
+  multiAuthorBookId: number | null;   // a book whose author has >1 title
+}
+
+async function probeSeed(page: Page): Promise<DetailProbe> {
+  // A handful of light entity-browse requests — no per-book detail fan-out,
+  // which would backlog the single-worker dev server and stall the run.
+  return page.evaluate(async () => {
+    const j = (u: string): Promise<any> =>
+      fetch(u, { headers: { Accept: 'application/json' } })
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null);
+
+    // A rated book via the ratings-bucket browse, then its exact 0–10 value.
+    let ratedBookId: number | null = null;
+    let ratedValue: number | null = null;
+    const rid = (await j('/api/v1/ratings'))?.items?.[0]?.id;
+    if (rid != null) {
+      ratedBookId = (await j(`/api/v1/books?rating=${rid}&per_page=1`))?.items?.[0]?.id ?? null;
+      if (ratedBookId != null) ratedValue = (await j(`/api/v1/books/${ratedBookId}`))?.rating ?? null;
+    }
+
+    // A book whose author has more than one title, via the authors browse.
+    let multiAuthorBookId: number | null = null;
+    const multi = ((await j('/api/v1/authors'))?.items ?? []).find(
+      (a: { count: number }) => a.count > 1,
+    );
+    if (multi) {
+      multiAuthorBookId = (await j(`/api/v1/books?author=${multi.id}&per_page=1`))?.items?.[0]?.id ?? null;
+    }
+
+    return { ratedBookId, ratedValue, multiAuthorBookId };
+  });
+}
+
+test('a rated book shows a star rating with an accurate out-of-5 label', async ({ page }) => {
+  await page.goto('/app');
+  const seed = await probeSeed(page);
+  test.skip(seed.ratedBookId == null, 'seed has no rated book');
+
+  const errors = collectPageErrors(page);
+  await page.goto(`/app/book/${seed.ratedBookId}`, { waitUntil: 'domcontentloaded' });
+
+  const rating = page.locator('[role="img"][aria-label^="Rated"]');
+  await expect(rating).toBeVisible({ timeout: 10_000 });
+
+  // Label reflects the value: 0–10 Calibre rating → 0–5 stars (value / 2).
+  const expectedStars = (seed.ratedValue! / 2).toString();
+  await expect(rating).toHaveAttribute('aria-label', new RegExp(`Rated ${expectedStars} out of 5`));
+  // Exactly five star slots are rendered.
+  await expect(rating.locator('> span')).toHaveCount(5);
+
+  assertNoPageErrors(errors);
+});
+
+test('"More by this author" strip renders with a fully-interpolated heading (no raw placeholder)', async ({ page }) => {
+  await page.goto('/app');
+  const seed = await probeSeed(page);
+  test.skip(seed.multiAuthorBookId == null, 'seed has no author with multiple books');
+
+  const errors = collectPageErrors(page);
+  await page.goto(`/app/book/${seed.multiAuthorBookId}`, { waitUntil: 'domcontentloaded' });
+
+  const strip = page.locator('section[aria-label^="More by"]');
+  await expect(strip).toBeVisible({ timeout: 10_000 });
+
+  // The heading must be interpolated — never the literal msgid placeholder.
+  const heading = strip.locator('h2');
+  await expect(heading).not.toContainText('{name}');
+  await expect(heading).not.toContainText('%(name)s');
+  // Strip has at least one sibling book, and never the book we're viewing.
+  await expect(strip.locator('a[href*="/book/"]').first()).toBeVisible();
+  await expect(strip.locator(`a[href$="/book/${seed.multiAuthorBookId}"]`)).toHaveCount(0);
+
+  assertNoPageErrors(errors);
+});
+
+test('book detail with a "More by" strip has no horizontal overflow on mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/app');
+  const seed = await probeSeed(page);
+  test.skip(seed.multiAuthorBookId == null, 'seed has no author with multiple books');
+
+  await page.goto(`/app/book/${seed.multiAuthorBookId}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('section[aria-label^="More by"]')).toBeVisible({ timeout: 10_000 });
+  await assertNoHorizontalOverflow(page);
+});

--- a/frontend/src/components/BulkBar.tsx
+++ b/frontend/src/components/BulkBar.tsx
@@ -54,7 +54,7 @@ export function BulkBar({ ids, onClear, onChanged }: BulkBarProps) {
 
   const onMerge = () => {
     if (count < 2) return;
-    if (!window.confirm(t('Merge %(n)s books into the first selected? The others are removed after their formats are copied over.', { n: count }))) return;
+    if (!window.confirm(t('Merge {n} books into the first selected? The others are removed after their formats are copied over.', { n: count }))) return;
     mergeBooks.mutate(ids, { onSuccess: () => { onChanged?.(); onClear(); } });
   };
 
@@ -118,7 +118,7 @@ export function BulkBar({ ids, onClear, onChanged }: BulkBarProps) {
             onChange={(e) => setMeta({ ...meta, languages: e.target.value })} />
         </div>
         <button className={styles.metaApply} onClick={applyMeta} disabled={setMetadata.isPending}>
-          {setMetadata.isPending ? t('Applying…') : t('Apply to %(n)s books', { n: count })}
+          {setMetadata.isPending ? t('Applying…') : t('Apply to {n} books', { n: count })}
         </button>
       </div>
     )}

--- a/frontend/src/components/MoreByAuthor.module.css
+++ b/frontend/src/components/MoreByAuthor.module.css
@@ -1,0 +1,44 @@
+.box {
+  margin-top: var(--sp-8);
+  padding-top: var(--sp-6);
+  border-top: 1px solid var(--border);
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  color: var(--text);
+  margin: 0 0 var(--sp-4);
+}
+
+.strip {
+  display: flex;
+  gap: var(--sp-4);
+  overflow-x: auto;
+  scroll-snap-type: x proximity;
+  /* Pad the scroll viewport so a card's hover-lift + focus outline isn't clipped
+     by the overflow container; negative margins cancel the padding so the
+     section's outer spacing is unchanged. Mirrors DiscoverSection. */
+  padding: var(--sp-3) var(--sp-2);
+  margin: calc(-1 * var(--sp-3)) calc(-1 * var(--sp-2)) calc(-1 * var(--sp-1));
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+
+.strip::-webkit-scrollbar { height: 8px; }
+.strip::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: var(--r-full);
+}
+.strip::-webkit-scrollbar-track { background: transparent; }
+
+.item {
+  flex: 0 0 132px;
+  width: 132px;
+  scroll-snap-align: start;
+}
+
+@media (max-width: 600px) {
+  .item { flex-basis: 116px; width: 116px; }
+}

--- a/frontend/src/components/MoreByAuthor.tsx
+++ b/frontend/src/components/MoreByAuthor.tsx
@@ -1,0 +1,34 @@
+import { BookCard } from './BookCard';
+import { useBooks } from '../lib/queries';
+import { useT } from '../lib/i18n';
+import styles from './MoreByAuthor.module.css';
+
+const MAX = 12;
+
+/** A full-width strip of other books by the same author, shown below the book
+ *  detail two-column layout. Fills the page for sparse (description-less) books
+ *  and turns a dead end into a browse surface. Renders nothing when the author
+ *  has no other books, so it never leaves an empty heading. Reuses the library's
+ *  author-filtered books query — no new endpoint. */
+export function MoreByAuthor({ authorId, authorName, excludeBookId }:
+  { authorId: number | string; authorName: string; excludeBookId: number }) {
+  const t = useT();
+  const { data } = useBooks({ page: 1, entityKind: 'author', entityId: authorId, sort: 'new' });
+  const books = (data?.items ?? []).filter((b) => b.id !== excludeBookId).slice(0, MAX);
+
+  if (books.length === 0) return null;
+
+  const heading = t('More by {name}', { name: authorName });
+  return (
+    <section className={styles.box} aria-label={heading}>
+      <h2 className={styles.title}>{heading}</h2>
+      <div className={styles.strip}>
+        {books.map((b) => (
+          <div className={styles.item} key={b.id}>
+            <BookCard book={b} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/StarRating.module.css
+++ b/frontend/src/components/StarRating.module.css
@@ -1,0 +1,32 @@
+.stars {
+  display: inline-flex;
+  gap: 2px;
+  line-height: 0;
+}
+
+.slot {
+  position: relative;
+  display: inline-block;
+  flex: none;
+}
+
+/* Empty star outline (the track). */
+.base {
+  display: block;
+  color: var(--text-faint);
+}
+
+/* Left-anchored clip whose width encodes the fill fraction (0.5 → 50%). */
+.fillWrap {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  overflow: hidden;
+  line-height: 0;
+}
+
+.fill {
+  display: block;
+  color: var(--accent);
+}

--- a/frontend/src/components/StarRating.tsx
+++ b/frontend/src/components/StarRating.tsx
@@ -1,0 +1,33 @@
+import { Star } from 'lucide-react';
+import { useT } from '../lib/i18n';
+import styles from './StarRating.module.css';
+
+/** Read-only star display for a Calibre 0–10 rating (half-star granularity:
+ *  9 → 4.5 stars). Renders five stars with fractional fill so the new-UI book
+ *  page reaches parity with the classic detail page's rating block. Exposed as a
+ *  single labelled image to assistive tech rather than five ambiguous glyphs. */
+export function StarRating({ rating, size = 16 }: { rating: number; size?: number }) {
+  const t = useT();
+  const stars = Math.max(0, Math.min(5, rating / 2));
+  const shown = Number.isInteger(stars) ? String(stars) : stars.toFixed(1);
+  const label = t('Rated {rating} out of 5', { rating: shown });
+  return (
+    <div className={styles.stars} role="img" aria-label={label} title={label}>
+      {Array.from({ length: 5 }, (_, i) => {
+        // 0..1 fill fraction for this slot (e.g. 4.5 stars → slot 4 is half full).
+        const fill = Math.max(0, Math.min(1, stars - i));
+        return (
+          <span className={styles.slot} style={{ width: size, height: size }} key={i}>
+            <Star size={size} className={styles.base} aria-hidden="true" focusable={false} />
+            {fill > 0 && (
+              <span className={styles.fillWrap} style={{ width: `${fill * 100}%` }}>
+                <Star size={size} className={styles.fill} fill="currentColor" strokeWidth={0}
+                      aria-hidden="true" focusable={false} />
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -99,6 +99,9 @@ export interface BookDetail {
   authors: EntityRef[];
   series: EntityRef | null;
   series_index: string;
+  /** Calibre rating on a 0–10 scale (half-star granularity: 9 → 4.5 stars),
+   *  or null when the book is unrated. Divide by 2 for a 0–5 star display. */
+  rating: number | null;
   cover_url: string | null;
   pubdate: string | null;
   description_html: string | null;

--- a/frontend/src/pages/BookDetail.module.css
+++ b/frontend/src/pages/BookDetail.module.css
@@ -133,6 +133,11 @@
   margin: var(--sp-1) 0 0;
 }
 
+/* Star rating row — sits under the title/author/series header block. */
+.rating {
+  margin: var(--sp-2) 0 0;
+}
+
 /* Sync-driven "currently reading" marker (fork #634) — an accent-tinted inline
    pill, distinct from the read/unread toggle. */
 .currentlyReading {

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -7,6 +7,8 @@ import {
 } from '../lib/queries';
 import { Pill } from '../components/Pill';
 import { AddToShelf } from '../components/AddToShelf';
+import { StarRating } from '../components/StarRating';
+import { MoreByAuthor } from '../components/MoreByAuthor';
 import { SpinnerCentered, Spinner } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import type { BookFormat, EntityRef } from '../lib/api';
@@ -142,7 +144,7 @@ function TagEditor({ bookId, tags, canEdit }:
           <button
             type="button"
             className={styles.tagRemove}
-            aria-label={t('Remove tag %(name)s', { name: tag.name })}
+            aria-label={t('Remove tag {name}', { name: tag.name })}
             title={t('Remove tag')}
             disabled={update.isPending}
             onClick={() => removeTag(tag.name)}
@@ -262,6 +264,14 @@ export function BookDetail() {
                 {' · Book '}
                 {book.series_index}
               </p>
+            )}
+            {/* Rating — star parity with the classic detail page. Calibre stores
+                0–10 (half-star granularity); null means unrated (no stars shown,
+                not zero stars). */}
+            {book.rating != null && book.rating > 0 && (
+              <div className={styles.rating}>
+                <StarRating rating={book.rating} size={16} />
+              </div>
             )}
             {/* Passive "currently reading" marker (fork #634) — mirrors the classic
                 detail page. Sync-driven display only; the read toggle below stays a
@@ -476,6 +486,19 @@ export function BookDetail() {
           )}
         </div>
       </div>
+
+      {/* More by this author — a full-width browse strip below the two-column
+          layout. Fills the page for sparse/description-less books and turns the
+          detail page into a browse surface. Keyed on the book so switching books
+          refetches; renders nothing when the author has no other titles. */}
+      {book.authors.length > 0 && (
+        <MoreByAuthor
+          key={book.id}
+          authorId={book.authors[0].id}
+          authorName={book.authors[0].name}
+          excludeBookId={book.id}
+        />
+      )}
     </main>
   );
 }

--- a/tests/unit/test_api_v1_serializers.py
+++ b/tests/unit/test_api_v1_serializers.py
@@ -76,3 +76,35 @@ def test_serialize_book_detail_sanitizes_description_xss():
     assert "<img" not in out["description_html"]   # img tag escaped/neutralized
     assert "<script" not in out["description_html"]
     assert "<p>Safe</p>" in out["description_html"]
+
+
+def _detail_book(**overrides):
+    """A minimal fake Book for serialize_book_detail — all list attrs empty."""
+    base = dict(
+        id=9, title="X", series_index="1.0", has_cover=0, pubdate=None,
+        authors=[], series=[], data=[], tags=[], languages=[], publishers=[],
+        identifiers=[], comments=[],
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.unit
+def test_serialize_book_detail_rating_present():
+    """A rated book exposes its raw 0–10 Calibre rating so the UI can render
+    half-stars (9 → 4.5). Parity with the classic detail page's star block."""
+    from cps.api.serializers import serialize_book_detail
+    book = _detail_book(ratings=[SimpleNamespace(rating=9)])
+    out = serialize_book_detail(book)
+    assert out["rating"] == 9
+
+
+@pytest.mark.unit
+def test_serialize_book_detail_rating_absent_is_null():
+    """An unrated book (no ratings link, or the attr missing entirely) emits
+    rating=None rather than 0 — 0 stars and 'not rated' are different states."""
+    from cps.api.serializers import serialize_book_detail
+    # Empty ratings list.
+    assert serialize_book_detail(_detail_book(ratings=[]))["rating"] is None
+    # Attribute absent entirely (getattr fallback path).
+    assert serialize_book_detail(_detail_book())["rating"] is None


### PR DESCRIPTION
## What & why

The redesigned book page was missing two things a book page should have, and the fix surfaced a class of i18n bug worth cleaning up in the same pass.

### Added
- **Star rating** — parity with the classic detail page. `serialize_book_detail` now emits `rating` (Calibre's native 0–10, half-star granularity); the page renders five stars under the author with true fractional fill (`9 → 4.5`). `null` stays "not rated" (no stars), distinct from `0`.
- **"More by this author"** — a full-width browse strip below the two-column layout. Fills the page for description-less / cover-less books (which otherwise leave the right column mostly empty) and turns a dead end into a browse surface. Reuses the existing author-filtered books query + `BookCard` — **no new endpoint**. Renders nothing when the author has no other titles.

### Fixed (audit finding)
The SPA's `interpolate()` substitutes `{brace}` placeholders, but several msgids used gettext-style `%(n)s` / `%(name)s`, which rendered **literally**. Two were user-visible in the bulk-selection toolbar — the merge confirm dialog (`Merge %(n)s books…`) and the apply button (`Apply to %(n)s books`) — plus the book-page tag remove aria-label. All switched to `{brace}` and anchored in `spa_strings.py` (the BulkBar strings were also previously unanchored, so they'd have been dropped on the next msgid re-extract).

## Tests (red/green)
The rating element and the strip don't exist on `main`, so the specs are red without this change by construction; the interpolation guard asserts the heading never contains a raw `%(name)s` (the exact pre-fix symptom I observed live).
- `tests/unit/test_api_v1_serializers.py` — `rating` present (0–10) and null/absent. ✅ green in-container (7/7).
- `frontend/e2e/book-detail.spec.ts` — rating stars + accurate out-of-5 label, "More by" strip with a fully-interpolated heading, no mobile horizontal overflow. Seed-resilient (skips if the library lacks a rated / multi-book author). ✅ green desktop+mobile at CI parallelism.

## Verification
- Rebuilt the **Docker image off `repo/`**, recreated `cwn-local` from it, and ran both suites against the real image (not just a local build).
- Live Playwright on rated (`8 → 4★`) + sparse books, desktop + mobile — rating renders, strip renders + interpolates, **zero console errors**, no horizontal overflow.
- Confirmed all five SPA msgids extract into `messages.pot` (so the auto-translation job keeps them).
- SPA is dark-only today (single theme), so the theme matrix axis is covered.

No new dependencies, license changes, or external URLs. No auth/session/CSRF/crypto/subprocess/file-path/new-route surface, so `/security-review` isn't triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)