### PR TITLE
fix(#659): surface Admin link in new-UI account menu for admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- **Admins can find the Admin page in the new interface again.** In the
+  redesigned UI the Admin/Settings entry lived only in the left sidebar rail, so
+  admins who looked in the account (avatar) menu — the usual home for
+  "Settings/Admin" — saw only *My account*, *Back to the classic view* and *Sign
+  out*, and some switched back to the classic interface because they couldn't
+  find admin. The account menu now shows an **Admin** link (for admin accounts
+  only) that opens the in-app admin page. Reported through the in-app feedback
+  form (#659).
 - **Downloading a book on an iPhone no longer strands you.** In the new
   interface, tapping a format to download it used to navigate Safari away from
   the app to a page it couldn't show — leaving iPhone users stuck until they

--- a/frontend/e2e/account-menu-admin.spec.ts
+++ b/frontend/e2e/account-menu-admin.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+/*
+ * #659 / #720 — "Couldn't find Admin/Settings view" in the new UI.
+ *
+ * The Admin entry point existed only as a Shield item in the sidebar rail.
+ * Several admins looked in the account/avatar dropdown — the conventional place
+ * for "Settings/Admin" — found only My account / Back to classic / Sign out, and
+ * switched back to the classic UI because they couldn't find admin.
+ *
+ * The contract this pins: for an ADMIN user, the account (avatar) menu contains a
+ * role-gated "Admin" link that navigates to the SPA's own /admin route. Without
+ * the fix the account menu has no /admin link and this spec fails (red/green).
+ *
+ * The e2e default user (admin / admin123, cwn-local seed) is an admin, so the
+ * item is expected present. Scoped to the account menu wrapper so it does not
+ * accidentally pass on the separate sidebar Admin link.
+ */
+
+async function openAccountMenu(page: import('@playwright/test').Page) {
+  await page.goto('/app');
+  // Authed shell rendered.
+  await expect(page.locator('a[href*="/book/"]').first()).toBeVisible({ timeout: 20_000 });
+  const trigger = page.getByRole('button', { name: /account:/i });
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+  // Scope to the account menu wrapper (the div that owns the trigger) so we never
+  // match the sidebar's own Admin link.
+  return trigger.locator('xpath=ancestor::div[1]');
+}
+
+test.describe('account menu — Admin entry (#659/#720)', () => {
+  test('desktop: admin sees an Admin link to /admin in the account menu', async ({ page }) => {
+    const menu = await openAccountMenu(page);
+
+    const adminLink = menu.getByRole('link', { name: 'Admin', exact: true });
+    await expect(adminLink, 'account menu exposes an Admin item for admins').toBeVisible();
+    await expect(adminLink).toHaveAttribute('href', /\/admin$/);
+
+    // The link is wired to the SPA admin route (not a dead/placeholder link):
+    // clicking it lands on the in-app admin page.
+    await adminLink.click();
+    await expect(page).toHaveURL(/\/admin(\/|$|\?)/);
+  });
+
+  test('mobile: admin sees the Admin link in the account menu too', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile', 'mobile viewport project only');
+    const menu = await openAccountMenu(page);
+
+    const adminLink = menu.getByRole('link', { name: 'Admin', exact: true });
+    await expect(adminLink).toBeVisible();
+    await expect(adminLink).toHaveAttribute('href', /\/admin$/);
+  });
+});

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react';
-import { BookMarked, LogOut, Menu, Search, ChevronDown, User, Bug, BookOpen, Undo2, Sparkles } from 'lucide-react';
+import { BookMarked, LogOut, Menu, Search, ChevronDown, User, Bug, BookOpen, Undo2, Sparkles, Shield } from 'lucide-react';
 import { Link, useLocation } from 'wouter';
 import { GithubMark, DiscordMark } from './BrandIcons';
 import { BrandName } from './BrandName';
@@ -180,7 +180,13 @@ function backToClassicView() {
 function UserMenu({ userName, onLogout }: { userName: string; onLogout: () => void }) {
   const t = useT();
   const { open, close, wrapperProps, onTriggerClick } = useMenu();
-  const avatar = useMe().data?.avatar;
+  const me = useMe().data;
+  const avatar = me?.avatar;
+  // #659/#720: admins looked for the Admin/Settings entry in the account menu (the
+  // conventional place) and only found it buried in the sidebar rail, so several
+  // switched back to the classic UI. Surface it here too, role-gated, pointing at
+  // the SPA's own /admin route (same target as the sidebar link).
+  const isAdmin = !!me?.role?.admin;
   return (
     <div className={styles.menu} {...wrapperProps}>
       <button
@@ -199,6 +205,9 @@ function UserMenu({ userName, onLogout }: { userName: string; onLogout: () => vo
       {open && (
         <div className={styles.panel}>
           <MenuItem icon={<User size={15} />} label={t('My account')} to="/account" onSelect={close} />
+          {isAdmin && (
+            <MenuItem icon={<Shield size={15} />} label={t('Admin')} to="/admin" onSelect={close} />
+          )}
           <MenuItem icon={<Undo2 size={15} />} label={t('Back to the classic view')} onClick={backToClassicView} onSelect={close} />
           <MenuItem icon={<LogOut size={15} />} label={t('Sign out')} danger onClick={onLogout} onSelect={close} />
         </div>


### PR DESCRIPTION
## Why
Fork feedback-form issue **#659** ("Couldn't find Admin/Settings view", New UI) — an anonymous admin switched back to the classic interface because the Admin entry point was hard to find. #720 was deduped into this. In the redesigned UI the Admin/Settings link lived **only** in the left sidebar rail; admins who looked in the account (avatar) dropdown — the conventional home for "Settings/Admin" — found only *My account*, *Back to the classic view*, *Sign out*.

## Root cause
`UserMenu` in `TopBar.tsx` rendered no admin entry. The only Admin link was in `Sidebar.tsx` (role-gated on `me?.role?.admin`, target `/admin`). Users who don't scan the sidebar never see it.

## Fix
Add a role-gated **Admin** link to the account menu, reusing the **same** `me?.role?.admin` gate and `/admin` route target already used by the sidebar (`Sidebar.tsx:75`/`274`) — one source of truth for the admin check, both entry points stay in sync. Non-admins see no new item. Reuses the existing `Shield` icon and the already-anchored `t('Admin')` msgid (`spa_strings.py:202`) — **no new deps, no new strings, no i18n work**.

## Reproduction (red/green)
`frontend/e2e/account-menu-admin.spec.ts` — opens the account menu as an admin, asserts an `Admin` link exists and navigates to `/admin`. Desktop + mobile viewports.

- **RED** (deployed pre-fix build in `cwn-local`): 3 failed — Admin link not found in the account menu.
- **GREEN** (fix built + `docker cp`'d into `cwn-local` + restart): `4 passed (1 mobile-gate skip)`.

## Verification
- `tsc --noEmit` clean.
- e2e run against live `cwn-local` (`localhost:8086`), admin flow, **desktop + mobile** — admin opens menu → Admin link visible → click → lands on `/admin`.
- Blast radius: `UserMenu` only; gated by `isAdmin`, non-admins unaffected; surfaces a link to the **existing** `/admin` route (no new route, no auth/session/CSRF surface touched → `/security-review` not applicable).

## Tier
Fork-original UI change, single production file (`TopBar.tsx`, +11/-2), plus test + changelog. Ships via `:dev` on merge.

Addresses #659.