### PR TITLE
fix(hardcover): score full API result pool for auto-fetch matching

### DIFF
--- a/cps/tasks/auto_hardcover_id.py
+++ b/cps/tasks/auto_hardcover_id.py
@@ -254,7 +254,7 @@ class TaskAutoHardcoverID(CalibreTask):
         
         # Calculate confidence scores for each result
         scored_results = []
-        for result in results[:10]:  # Limit to top 10 results
+        for result in results[:50]:  # Score all hits returned (API per_page=50)
             # Get book's ISBN for matching
             book_isbn = None
             for identifier in book.identifiers:
@@ -355,11 +355,11 @@ class TaskAutoHardcoverID(CalibreTask):
             # state can't be poisoned by worker commits.
             ub_session = ub.init_db_thread()
             
-            # Prepare results for JSON storage (top 5 candidates)
+            # Prepare results for JSON storage (top 3 candidates; matches review UI)
             results_json = []
             scores_json = []
             
-            for item in scored_results[:5]:
+            for item in scored_results[:3]:
                 result = item['result']
                 results_json.append({
                     'id': str(result.id),


### PR DESCRIPTION
I was noticing when running hardcover sync that the UI says it's showing the top 5 (and I think that rejecting them might reject all 5?) but only shows 3 results.
<img width="1056" height="164" alt="image" src="https://github.com/user-attachments/assets/020c92c5-0b02-43fa-8c7a-638c89480e34" />
I limited it to 3 to avoid needing to rethink the UI layout for now

I also found that in some cases I was getting terrible results. For instance `Dune Frank Herbert` returns the actual Dune book in the #19th position, because Hardcover prioritizes results with the author in the title, which ends up moving study guides, anthologies, etc much higher in the results.

It's potentially worth investigating making a more structured query, but for now, it seems like we're throwing away a lot of the results we're getting from HC. Looks like we only rank the first 10 of the potential 50 results, and the ranking isn't very expensive, so we should just rank them all? This results in much better results on my end.