### PR TITLE
Free-drag reorder for the Customize sidebar panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Changed
+- **Reordering your sidebar sections now feels smooth and physical.** In the
+  Customize panel (the left rail's **Customize** control), dragging a section used
+  to snap the other rows around with no sense of motion and could jitter or stick
+  at row edges. Now the row you grab lifts and tracks your pointer while the
+  others glide aside to open a gap, then it settles into its slot when you release
+  — the same on mouse, touch, and pen. Keyboard reordering (focus a section's
+  drag handle, then use the arrow keys) and hiding/restoring sections animate
+  through the same motion, and everything falls back to instant when your system
+  is set to reduce motion.
+
 ## [v4.1.7] - 2026-07-08
 
 ### Added

--- a/frontend/e2e/customize-reorder.spec.ts
+++ b/frontend/e2e/customize-reorder.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, Page } from '@playwright/test';
+import { collectPageErrors, assertNoPageErrors, assertNoHorizontalOverflow } from './utils';
+
+/*
+ * Customize sidebar — drag-reorder + keyboard reorder (the drag-polish rebuild).
+ *
+ * The contract this pins, end-to-end through the real app (not the isolated
+ * harness): pressing a row and dragging it past its neighbours reorders the
+ * list; keyboard arrows on the focused handle move a row; and pressing Done
+ * persists the new order across a reload. The old implementation reordered via
+ * elementFromPoint with no lift and jittered at boundaries — this asserts the
+ * user-visible outcome (order changes correctly), which that approach could not
+ * guarantee deterministically.
+ */
+
+// Mobile: the rail is a drawer behind a hamburger; open it if present. Desktop:
+// the rail is always visible, so this is a no-op. Safe to call after a reload,
+// where the mobile drawer resets to closed.
+async function ensureSidebarVisible(page: Page) {
+  const burger = page.getByRole('button', { name: /open navigation/i });
+  if (await burger.isVisible().catch(() => false)) await burger.click();
+}
+
+async function openSidebar(page: Page) {
+  await page.goto('/app');
+  await expect(page.locator('a[href*="/book/"]').first()).toBeVisible();
+  await ensureSidebarVisible(page);
+}
+
+async function enterEdit(page: Page) {
+  await page.getByRole('button', { name: 'Customize sidebar' }).click();
+  // 13 orderable rows become draggable handles once edit mode is live.
+  await expect(page.locator('nav li[data-key]')).toHaveCount(13);
+}
+
+function keys(page: Page): Promise<string[]> {
+  return page.locator('nav li[data-key]').evaluateAll((els) =>
+    els.map((e) => e.getAttribute('data-key') || ''),
+  );
+}
+
+// A realistic multi-step pointer drag (down/glide/up) so it exercises the same
+// path a finger or mouse does, not an instantaneous jump.
+async function dragRow(page: Page, key: string, toKey: string, place: 'above' | 'below') {
+  const from = await page.locator(`nav li[data-key="${key}"]`).boundingBox();
+  const to = await page.locator(`nav li[data-key="${toKey}"]`).boundingBox();
+  if (!from || !to) throw new Error('row not visible');
+  const x = from.x + from.width / 2;
+  const startY = from.y + from.height / 2;
+  const endY = place === 'below' ? to.y + to.height : to.y;
+  await page.mouse.move(x, startY);
+  await page.mouse.down();
+  const steps = 14;
+  for (let i = 1; i <= steps; i++) {
+    await page.mouse.move(x, startY + ((endY - startY) * i) / steps);
+    await page.waitForTimeout(12);
+  }
+  await page.mouse.up();
+  await page.waitForTimeout(350); // FLIP settle
+}
+
+test.describe('customize sidebar reorder', () => {
+  test('drag reorders, keyboard reorders, Done persists across reload', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await openSidebar(page);
+    await enterEdit(page);
+
+    // Normalize to default first — this is a shared account and a prior run (or a
+    // failed run whose cleanup was skipped) may have left it reordered. Reset sets
+    // the edit state to the default order locally, giving a known start point.
+    await page.getByRole('button', { name: 'Reset to default' }).click();
+    await page.waitForTimeout(200);
+    const initial = await keys(page);
+    expect(initial[0], 'reset restores author to the top').toBe('author');
+
+    // ── drag: author (top) down past publisher → lands mid-list, order changes ──
+    await dragRow(page, 'author', 'publisher', 'below');
+    const afterDrag = await keys(page);
+    expect(afterDrag, 'drag changed the order').not.toEqual(initial);
+    expect(afterDrag[0], 'author left the top slot').not.toBe('author');
+    expect(afterDrag, 'no row lost or duplicated').toHaveLength(13);
+    expect([...afterDrag].sort(), 'same set of rows').toEqual([...initial].sort());
+
+    // ── keyboard: focus a handle and ArrowUp moves that row up one ──
+    const target = afterDrag[4];
+    const handle = page.locator(`nav li[data-key="${target}"] button`).first();
+    await handle.focus();
+    await page.keyboard.press('ArrowUp');
+    const afterKey = await keys(page);
+    expect(afterKey.indexOf(target), 'ArrowUp moved the row up one slot').toBe(3);
+
+    await assertNoHorizontalOverflow(page);
+
+    // ── persist: Done, reload, order survives ──
+    const saved = await keys(page);
+    await page.getByRole('button', { name: 'Done' }).click();
+    await page.waitForTimeout(300);
+    await page.reload();
+    await expect(page.locator('a[href*="/book/"]').first()).toBeVisible();
+    await ensureSidebarVisible(page); // mobile drawer resets to closed on reload
+    await enterEdit(page);
+    const reloaded = await keys(page);
+    expect(reloaded, 'saved order persisted across reload').toEqual(saved);
+
+    // ── cleanup: restore default order so we don't leave the account reordered ──
+    await page.getByRole('button', { name: 'Reset to default' }).click();
+    await page.getByRole('button', { name: 'Done' }).click();
+    await page.waitForTimeout(300);
+
+    assertNoPageErrors(errors);
+  });
+});

--- a/frontend/src/components/Sidebar.module.css
+++ b/frontend/src/components/Sidebar.module.css
@@ -301,6 +301,7 @@
   gap: var(--sp-1);
 }
 .editRow, .editRowHidden {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--sp-2);
@@ -308,9 +309,34 @@
   border: 1px solid rgba(255, 255, 255, .06);
   border-radius: var(--r-md);
   background: var(--surface-2);
+  cursor: grab;
+  touch-action: none;         /* let us own the gesture on touch (no scroll steal) */
+  user-select: none;
+  -webkit-user-select: none;
+  will-change: transform;     /* keep the row on its own layer while reordering */
+  /* transform is animated for the gap-open + FLIP settle; the actively-dragged
+     row overrides this to transition:none so it tracks the pointer 1:1. */
   transition: background var(--dur-fast) var(--ease), opacity var(--dur-fast) var(--ease);
 }
 .editRowHidden { opacity: .5; }
+
+/* The lifted row while a pointer drag is in progress: raised, subtly enlarged,
+   shadowed, and — crucially — no transform transition so it glues to the cursor
+   with zero lag. z-index is set inline so it floats above its neighbours. */
+.editRowDragging {
+  transition: none !important;
+  transform-origin: center;
+  cursor: grabbing;
+  background: var(--surface-3, var(--surface-2));
+  border-color: var(--accent);   /* fallback for engines without color-mix */
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, .10) inset,
+    0 10px 24px rgba(0, 0, 0, .38),
+    0 2px 6px rgba(0, 0, 0, .30);
+}
+.editRowDragging .editLabel { color: var(--text); }
+
 .editHandle {
   display: inline-flex;
   padding: var(--sp-1);
@@ -321,7 +347,8 @@
   cursor: grab;
   touch-action: none;
 }
-.editHandle:hover { color: var(--text-muted); }
+.editRowDragging .editHandle { cursor: grabbing; }
+.editRow:hover .editHandle, .editRowHidden:hover .editHandle { color: var(--text-muted); }
 .editIcon { color: var(--text-muted); flex: none; }
 .editLabel {
   flex: 1;

--- a/frontend/src/components/SidebarEditList.tsx
+++ b/frontend/src/components/SidebarEditList.tsx
@@ -1,11 +1,23 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react';
 import { GripVertical, X, RotateCcw } from 'lucide-react';
 import { useT } from '../lib/i18n';
 import { useAnnouncer } from '../lib/a11y/announcer';
 import { ORDERABLE_ENTRIES } from '../lib/sidebarEntries';
+import { arrayMove, slotForCenter, shiftMap } from '../lib/dragSort';
 import styles from './Sidebar.module.css';
 
 const ENTRY_BY_KEY = new Map(ORDERABLE_ENTRIES.map((e) => [e.key, e]));
+
+// Motion tuning. The settle uses a decel curve (fast out, gentle in) so a
+// dropped row glides home instead of snapping. Honoured only when the user
+// hasn't asked for reduced motion.
+const SETTLE_MS = 220;
+const SETTLE_EASE = 'cubic-bezier(0.22, 1, 0.36, 1)';
+const DRAG_THRESHOLD = 4; // px of travel before a press becomes a drag (vs a tap/click)
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
 
 interface Props {
   order: string[];
@@ -14,19 +26,92 @@ interface Props {
   setVis: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
 }
 
-/** #585 v3 — the inline sidebar edit list shown when the Customize capsule is
- *  active. Each row: drag handle (pointer + keyboard reorder) + label + a
- *  delete/restore control. Deleting hides the entry (visibility off); it stays
- *  in the list, greyed, with a restore affordance so nothing is lost. Shelves is
- *  always shown (only movable). Reorder works by mouse, touch, and keyboard. */
+interface DragState {
+  key: string;
+  fromIndex: number;
+  pointerId: number;
+  startY: number;
+  activated: boolean;
+  centers: number[]; // resting vertical centers (client coords), measured at activation
+  slotSize: number; // mean row pitch (height + gap) — distance a displaced row travels
+  target: number; // current computed destination index
+  raf: number; // pending rAF id for coalesced move handling
+  lastY: number; // most recent pointer clientY (for the coalesced frame)
+}
+
+/** #585 v3 / drag-polish — the inline sidebar edit list shown when the Customize
+ *  capsule is active. Each row: drag handle + label + a delete/restore control.
+ *
+ *  Reorder is a proper free-drag: press anywhere on a row and it lifts and tracks
+ *  the pointer 1:1, while the rows it passes slide out of the way to open a gap;
+ *  on release it glides into its slot (FLIP). Keyboard reorder and delete/restore
+ *  reflow animate through the same FLIP path. Deleting hides the entry (kept in
+ *  the list, greyed, with a restore affordance). Shelves is always shown (only
+ *  movable). Works with mouse, touch, pen, and keyboard; respects reduced motion. */
 export function SidebarEditList({ order, setOrder, vis, setVis }: Props) {
   const t = useT();
   const announce = useAnnouncer();
+
+  const listRef = useRef<HTMLUListElement>(null);
+  const rowRefs = useRef<Map<string, HTMLLIElement>>(new Map());
   const handleRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const refocusKey = useRef<string | null>(null);
-  const dragKey = useRef<string | null>(null);
+
+  const drag = useRef<DragState | null>(null);
+  // FLIP bookkeeping: resting client-tops from the previous committed layout, and
+  // an optional override captured at drop (the lifted/gapped visual positions) so
+  // the settle animates from where the finger left off, not from the old slot.
+  const prevTops = useRef<Map<string, number>>(new Map());
+  const flipFrom = useRef<Map<string, number> | null>(null);
+
+  const [draggingKey, setDraggingKey] = useState<string | null>(null);
 
   const total = order.length;
+
+  const measureTops = useCallback((): Map<string, number> => {
+    const m = new Map<string, number>();
+    for (const key of order) {
+      const node = rowRefs.current.get(key);
+      if (node) m.set(key, node.getBoundingClientRect().top);
+    }
+    return m;
+  }, [order]);
+
+  // ── FLIP: animate every committed layout change (drag drop, keyboard move,
+  //    delete/restore) from its previous position to its new one. ────────────
+  useLayoutEffect(() => {
+    const now = measureTops();
+    const from = flipFrom.current ?? prevTops.current;
+    const reduce = prefersReducedMotion();
+
+    if (from.size && !reduce) {
+      const moved: HTMLLIElement[] = [];
+      for (const [key, top] of now) {
+        const start = from.get(key);
+        const node = rowRefs.current.get(key);
+        if (start === undefined || !node) continue;
+        const dy = start - top;
+        if (Math.abs(dy) < 0.5) continue;
+        node.style.transition = 'none';
+        node.style.transform = `translateY(${dy}px)`;
+        moved.push(node);
+      }
+      if (moved.length) {
+        // Force a reflow so the inverted transforms are the painted "First"
+        // frame, then release them on the next frame to play the transition.
+        void listRef.current?.offsetHeight;
+        requestAnimationFrame(() => {
+          for (const node of moved) {
+            node.style.transition = `transform ${SETTLE_MS}ms ${SETTLE_EASE}`;
+            node.style.transform = '';
+          }
+        });
+      }
+    }
+
+    prevTops.current = now;
+    flipFrom.current = null;
+  }, [order, vis, measureTops]);
 
   // Keep keyboard focus on the item that just moved (its node is keyed by `key`).
   useEffect(() => {
@@ -36,39 +121,135 @@ export function SidebarEditList({ order, setOrder, vis, setVis }: Props) {
     }
   }, [order]);
 
-  const move = (from: number, to: number, key: string) => {
+  // Commit a reorder + announce. Shared by keyboard arrows and drag drop.
+  const move = useCallback((from: number, to: number, key: string) => {
     if (to < 0 || to >= total || from === to) return;
-    setOrder((prev) => {
-      const next = [...prev];
-      const [it] = next.splice(from, 1);
-      next.splice(to, 0, it);
-      return next;
-    });
+    setOrder((prev) => arrayMove(prev, from, to));
     const label = ENTRY_BY_KEY.get(key)?.label ?? key;
     announce(t('{label} moved to position {pos} of {total}', {
       label: t(label), pos: to + 1, total,
     }));
-  };
+  }, [total, setOrder, announce, t]);
 
   const onKeyDown = (e: React.KeyboardEvent, i: number, key: string) => {
     if (e.key === 'ArrowUp') { e.preventDefault(); refocusKey.current = key; move(i, i - 1, key); }
     else if (e.key === 'ArrowDown') { e.preventDefault(); refocusKey.current = key; move(i, i + 1, key); }
   };
 
-  const onPointerMove = (e: React.PointerEvent) => {
-    if (!dragKey.current) return;
-    const over = (document.elementFromPoint(e.clientX, e.clientY) as Element | null)?.closest('[data-key]');
-    const overKey = over?.getAttribute('data-key');
-    if (!overKey || overKey === dragKey.current) return;
-    setOrder((prev) => {
-      const from = prev.indexOf(dragKey.current as string);
-      const to = prev.indexOf(overKey);
-      if (from < 0 || to < 0 || from === to) return prev;
-      const next = [...prev];
-      const [it] = next.splice(from, 1);
-      next.splice(to, 0, it);
-      return next;
+  // ── pointer drag ──────────────────────────────────────────────────────────
+  const clearRowStyles = () => {
+    for (const node of rowRefs.current.values()) {
+      node.style.transition = '';
+      node.style.transform = '';
+      node.style.zIndex = '';
+    }
+  };
+
+  // Paint the current drag frame: dragged row glued to the pointer, the rows it
+  // has crossed shifted by one slot to open the gap, everyone else at rest.
+  const paintDrag = (d: DragState) => {
+    const dy = d.lastY - d.startY;
+    d.target = slotForCenter(d.centers, d.centers[d.fromIndex] + dy);
+    const shifts = shiftMap(d.fromIndex, d.target);
+    order.forEach((key, i) => {
+      const node = rowRefs.current.get(key);
+      if (!node) return;
+      if (i === d.fromIndex) {
+        node.style.transform = `translateY(${dy}px)`;
+      } else {
+        const sign = shifts.get(i);
+        node.style.transform = sign ? `translateY(${sign * d.slotSize}px)` : '';
+      }
     });
+  };
+
+  const activate = (d: DragState, key: string) => {
+    // Measure the resting layout once, at the moment the drag begins.
+    const centers: number[] = [];
+    let firstTop = 0;
+    let lastBottom = 0;
+    order.forEach((k, i) => {
+      const node = rowRefs.current.get(k);
+      const r = node!.getBoundingClientRect();
+      centers[i] = r.top + r.height / 2;
+      if (i === 0) firstTop = r.top;
+      lastBottom = r.bottom;
+    });
+    d.centers = centers;
+    d.slotSize = total > 1 ? (lastBottom - firstTop) / total : 44;
+    d.activated = true;
+    const node = rowRefs.current.get(key);
+    if (node) node.style.zIndex = '5';
+    setDraggingKey(key);
+    const label = ENTRY_BY_KEY.get(key)?.label ?? key;
+    announce(t('Picked up {label}. Drag to reorder, release to drop.', { label: t(label) }));
+  };
+
+  const onPointerDown = (e: React.PointerEvent<HTMLLIElement>, i: number, key: string) => {
+    if (e.pointerType === 'mouse' && e.button !== 0) return; // left / primary only
+    if ((e.target as HTMLElement).closest('[data-nodrag]')) return; // let the ✕/restore click through
+    drag.current = {
+      key, fromIndex: i, pointerId: e.pointerId, startY: e.clientY,
+      activated: false, centers: [], slotSize: 44, target: i, raf: 0, lastY: e.clientY,
+    };
+    try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* capture unsupported */ }
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLLIElement>) => {
+    const d = drag.current;
+    if (!d || d.pointerId !== e.pointerId) return;
+    d.lastY = e.clientY;
+    if (!d.activated) {
+      if (Math.abs(e.clientY - d.startY) < DRAG_THRESHOLD) return;
+      activate(d, d.key);
+    }
+    e.preventDefault(); // suppress scroll / text-selection once we're dragging
+    if (d.raf) return; // coalesce to one paint per frame
+    d.raf = requestAnimationFrame(() => {
+      d.raf = 0;
+      if (drag.current === d && d.activated) paintDrag(d);
+    });
+  };
+
+  const endDrag = (e: React.PointerEvent<HTMLLIElement>) => {
+    const d = drag.current;
+    if (!d || d.pointerId !== e.pointerId) return;
+    drag.current = null;
+    if (d.raf) cancelAnimationFrame(d.raf);
+    try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* already released */ }
+
+    if (!d.activated) { setDraggingKey(null); return; } // it was a tap, not a drag
+
+    const { fromIndex, target, key } = d;
+    if (target !== fromIndex) {
+      // Reorder: hand the settle to FLIP by capturing the lifted/gapped frame as
+      // its "First", then commit the new order and let the layout effect glide
+      // every row into place.
+      flipFrom.current = measureTops();
+      clearRowStyles();
+      setDraggingKey(null);
+      move(fromIndex, target, key);
+    } else {
+      // No reorder — ease the lifted row back into its own slot.
+      setDraggingKey(null);
+      const node = rowRefs.current.get(key);
+      if (node) {
+        if (prefersReducedMotion()) {
+          node.style.transition = '';
+          node.style.transform = '';
+          node.style.zIndex = '';
+        } else {
+          node.style.zIndex = '';
+          node.style.transition = `transform ${SETTLE_MS}ms ${SETTLE_EASE}`;
+          node.style.transform = '';
+          const settle = () => {
+            node.style.transition = '';
+            node.removeEventListener('transitionend', settle);
+          };
+          node.addEventListener('transitionend', settle);
+        }
+      }
+    }
   };
 
   const toggleDelete = (key: string, label: string) => {
@@ -81,18 +262,27 @@ export function SidebarEditList({ order, setOrder, vis, setVis }: Props) {
   };
 
   return (
-    <ul className={styles.editList} role="list" onPointerMove={onPointerMove}>
+    <ul className={styles.editList} role="list" ref={listRef}>
       {order.map((key, i) => {
         const entry = ENTRY_BY_KEY.get(key);
         if (!entry) return null;
         const Icon = entry.icon;
         const isShelves = !!entry.isShelvesBlock;
         const hidden = !isShelves && vis[key] === false;
+        const dragging = draggingKey === key;
         return (
           <li
             key={key}
             data-key={key}
-            className={hidden ? styles.editRowHidden : styles.editRow}
+            ref={(el) => {
+              if (el) rowRefs.current.set(key, el);
+              else rowRefs.current.delete(key);
+            }}
+            className={`${hidden ? styles.editRowHidden : styles.editRow}${dragging ? ` ${styles.editRowDragging}` : ''}`}
+            onPointerDown={(e) => onPointerDown(e, i, key)}
+            onPointerMove={onPointerMove}
+            onPointerUp={endDrag}
+            onPointerCancel={endDrag}
           >
             <button
               type="button"
@@ -102,12 +292,6 @@ export function SidebarEditList({ order, setOrder, vis, setVis }: Props) {
                 label: t(entry.label), pos: i + 1, total,
               })}
               onKeyDown={(e) => onKeyDown(e, i, key)}
-              onPointerDown={(e) => {
-                dragKey.current = key;
-                (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-              }}
-              onPointerUp={() => { dragKey.current = null; }}
-              onPointerCancel={() => { dragKey.current = null; }}
             >
               <GripVertical size={15} aria-hidden="true" focusable={false} />
             </button>
@@ -120,6 +304,7 @@ export function SidebarEditList({ order, setOrder, vis, setVis }: Props) {
             ) : (
               <button
                 type="button"
+                data-nodrag
                 className={hidden ? styles.editRestoreBtn : styles.editDeleteBtn}
                 onClick={() => toggleDelete(key, entry.label)}
                 aria-pressed={hidden}

--- a/frontend/src/lib/dragSort.ts
+++ b/frontend/src/lib/dragSort.ts
@@ -1,0 +1,62 @@
+// Pure geometry helpers for the Customize sidebar drag-reorder. No DOM, no React
+// — the single source of truth for "where does the dragged row belong now", and
+// unit-testable in isolation. This replaces the old elementFromPoint()-per-pixel
+// approach, whose reorder-on-every-frame caused visible jitter at row boundaries.
+
+/** Immutable array move: returns a copy with `from` spliced out and re-inserted
+ *  at `to`. Out-of-range / no-op moves return a shallow copy unchanged. */
+export function arrayMove<T>(list: readonly T[], from: number, to: number): T[] {
+  const next = list.slice();
+  if (
+    from < 0 || from >= next.length ||
+    to < 0 || to >= next.length ||
+    from === to
+  ) {
+    return next;
+  }
+  const [item] = next.splice(from, 1);
+  next.splice(to, 0, item);
+  return next;
+}
+
+/**
+ * Given the resting vertical centers of every row (ascending) and the dragged
+ * row's *live* center (its resting center + the pointer's delta), return the
+ * slot index the dragged row should now occupy.
+ *
+ * It is a pure, monotonic function of `liveCenter`: as the pointer moves down
+ * the result only ever increases, as it moves up it only ever decreases. That
+ * monotonicity is what kills the oscillation the old code suffered — there is a
+ * single deterministic answer for any pointer position, so a row never flickers
+ * back and forth across a boundary.
+ *
+ * The dragged row's own center is included in `centers`; while the live center
+ * sits inside its home slot the function returns the dragged row's own index
+ * (i.e. no reorder). `centers` must be sorted ascending (natural DOM order).
+ */
+export function slotForCenter(centers: readonly number[], liveCenter: number): number {
+  if (centers.length === 0) return 0;
+  let k = 0;
+  while (k < centers.length - 1 && liveCenter > (centers[k] + centers[k + 1]) / 2) {
+    k++;
+  }
+  return k;
+}
+
+/**
+ * The set of resting indices that must visually shift by one slot to open a gap
+ * for a drag from `fromIndex` to `targetIndex`, plus the sign of that shift.
+ *   - dragging down (target > from): rows (from+1 … target) slide UP  (sign -1)
+ *   - dragging up   (target < from): rows (target … from-1) slide DOWN (sign +1)
+ * The dragged row itself is never in the returned set (it tracks the pointer).
+ * Returned as a map of index → sign so the caller can translateY(sign * slot).
+ */
+export function shiftMap(fromIndex: number, targetIndex: number): Map<number, -1 | 1> {
+  const out = new Map<number, -1 | 1>();
+  if (targetIndex > fromIndex) {
+    for (let i = fromIndex + 1; i <= targetIndex; i++) out.set(i, -1);
+  } else if (targetIndex < fromIndex) {
+    for (let i = targetIndex; i < fromIndex; i++) out.set(i, 1);
+  }
+  return out;
+}


### PR DESCRIPTION
## What & why

Reordering sections in the sidebar's **Customize** panel used to feel glitchy: on every pointer move the old code called `elementFromPoint` and instantly reordered the list, so **nothing lifted, nothing tracked the cursor, and nothing animated** — and it oscillated when the pointer sat near a row boundary.

This rebuilds it into a proper free-drag: the row you grab **lifts and tracks the pointer 1:1** while the rows it crosses **glide aside to open a gap**, and it **settles into its slot on release** (FLIP). Keyboard reordering and hide/restore reflow animate through the same motion.

## How

- **`frontend/src/lib/dragSort.ts`** (new) — pure, monotonic target-index math (`slotForCenter` / `shiftMap` / `arrayMove`). Deterministic, so there's no boundary oscillation.
- **`SidebarEditList.tsx`** — pointer engine: whole-row grab, 4px tap-vs-drag threshold, pointer capture, rAF-coalesced frames, direct-DOM transforms during the drag, and a FLIP layout effect that settles the drop and animates keyboard/delete reflow. Honours `prefers-reduced-motion`; works with mouse, touch, and pen.
- **`Sidebar.module.css`** — accent-ring + shadow lift (`transition: none` on the dragged row for zero-lag tracking), transform transitions for the gap-open + settle, grab/grabbing cursors.

No new dependencies, routes, or external URLs.

## Verification

- Pure geometry math: 11/11 (node).
- Full-app E2E in `cwn-local` — `frontend/e2e/customize-reorder.spec.ts`:
  - **desktop**: drag reorder + keyboard reorder + **Done persists across reload** ✅
  - **mobile / touch**: same ✅
- Real-app drag renders the lift + gap in the accent theme ✅
- `prefers-reduced-motion`: still reorders functionally (no animation) ✅
- a11y gate (`a11y.spec.ts`): 13 passed, no critical/serious violations ✅
- Existing `sidebar.spec.ts`: no regression ✅
