### PR TITLE
feat(ui): infinite scrolling on the book lists (adopts #735)

### DIFF
--- a/frontend/e2e/infinite-scroll.spec.ts
+++ b/frontend/e2e/infinite-scroll.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, Page } from '@playwright/test';
+import { collectPageErrors, assertNoPageErrors } from './utils';
+
+/*
+ * Infinite scrolling on the book lists (adopted from community PR #735 by
+ * @kurtlieber). The old lists ended in a "Load more" button; now a sentinel at
+ * the bottom auto-loads the next page as it scrolls into view.
+ *
+ * Driven against the Table view: unlike the Library grid (which floats a
+ * Discover carousel of extra book links above the paginated grid), the Table is
+ * a single paginated list, so every book link on the page is a real row — a
+ * clean count. It's one of the five surfaces the shared hook was wired into.
+ *
+ * This asserts the user-visible contract end-to-end: no "Load more" button
+ * remains, scrolling appends the next page(s) up to the full total, it never
+ * duplicates a book, and the console stays clean.
+ *
+ * Needs more than one page of books. CI's E2E job seeds a single book, so this
+ * skips there; it runs for real against any library with >24 books (the local
+ * dev container is seeded past that). A CI paginated-seed is tracked as a
+ * follow-up to the SPA test-harness gap.
+ */
+
+const PER_PAGE = 24;
+
+async function totalBooks(page: Page): Promise<number> {
+  const res = await page.request.get('/api/v1/books?per_page=1');
+  if (!res.ok()) return 0;
+  const body = await res.json();
+  return body.total ?? 0;
+}
+
+function rowHrefs(page: Page): Promise<string[]> {
+  return page.locator('table a[href*="/book/"]').evaluateAll((els) =>
+    els.map((e) => (e as HTMLAnchorElement).getAttribute('href') || ''),
+  );
+}
+
+test.describe('library infinite scroll', () => {
+  test('scrolling appends pages up to the full total, no button, no dupes', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    await page.goto('/app/table');
+    await expect(page.locator('table a[href*="/book/"]').first()).toBeVisible();
+
+    const total = await totalBooks(page);
+    test.skip(total <= PER_PAGE, `library has ${total} books (≤ one page) — nothing to paginate`);
+
+    // The button-driven affordance is gone; loading is scroll-driven now.
+    await expect(page.getByRole('button', { name: /load more/i })).toHaveCount(0);
+
+    const firstPage = await rowHrefs(page);
+    expect(firstPage.length, 'first render shows exactly one page of rows').toBe(PER_PAGE);
+
+    // Scroll repeatedly; each pass pulls the next page as the sentinel enters
+    // view. Stop when every book is loaded or we stop making progress.
+    let count = firstPage.length;
+    for (let i = 0; i < 8 && count < total; i++) {
+      // Scroll the last row into view so the sentinel below it enters the
+      // viewport, whichever ancestor actually scrolls.
+      await page.locator('table a[href*="/book/"]').last().scrollIntoViewIfNeeded();
+      await expect
+        .poll(async () => (await rowHrefs(page)).length, { timeout: 8_000 })
+        .toBeGreaterThan(count);
+      count = (await rowHrefs(page)).length;
+      // One page at a time — never overshoot the running total by more than a page.
+      expect(count).toBeLessThanOrEqual(total);
+    }
+
+    const finalHrefs = await rowHrefs(page);
+    expect(finalHrefs.length, 'every book loaded after scrolling').toBe(total);
+    expect(new Set(finalHrefs).size, 'no book row is duplicated across pages').toBe(finalHrefs.length);
+
+    assertNoPageErrors(errors);
+  });
+});

--- a/frontend/src/lib/useIntersectionObserver.ts
+++ b/frontend/src/lib/useIntersectionObserver.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+
+interface UseIntersectionObserverProps {
+  onIntersect: () => void;
+  enabled: boolean;
+  threshold?: number;
+  rootMargin?: string;
+}
+
+export function useIntersectionObserver({
+  onIntersect,
+  enabled,
+  threshold = 0.1,
+  rootMargin = '200px',
+}: UseIntersectionObserverProps) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            onIntersect();
+          }
+        });
+      },
+      { threshold, rootMargin }
+    );
+
+    const currentSentinel = sentinelRef.current;
+    if (currentSentinel) {
+      observer.observe(currentSentinel);
+    }
+
+    return () => {
+      if (currentSentinel) {
+        observer.unobserve(currentSentinel);
+      }
+    };
+  }, [enabled, onIntersect, threshold, rootMargin]);
+
+  return sentinelRef;
+}

--- a/frontend/src/pages/AdvancedSearch.tsx
+++ b/frontend/src/pages/AdvancedSearch.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useId } from 'react';
 import { Search as SearchIcon, RotateCcw } from 'lucide-react';
+import { useIntersectionObserver } from '../lib/useIntersectionObserver';
 import { useSearchOptions, useAdvancedSearch, useMe } from '../lib/queries';
 import { MultiSelect } from '../components/MultiSelect';
 import { BookCard } from '../components/BookCard';
@@ -92,6 +93,10 @@ export function AdvancedSearch() {
 
   const total = data?.total ?? 0;
   const hasMore = results.length < total;
+  const sentinelRef = useIntersectionObserver({
+    onIntersect: () => setPage((p) => p + 1),
+    enabled: hasMore && !isFetching,
+  });
   const formatOptions = (options?.formats ?? []).map((f) => ({ id: f, name: f }));
 
   return (
@@ -213,10 +218,8 @@ export function AdvancedSearch() {
                 ))}
               </div>
               {hasMore && (
-                <div className={styles.loadMore}>
-                  <Button variant="ghost" onClick={() => setPage((p) => p + 1)} disabled={isFetching}>
-                    {isFetching ? (<><Spinner size={16} /> {t('Loading…')}</>) : t('Load more')}
-                  </Button>
+                <div ref={sentinelRef} className={styles.loadMore}>
+                  {isFetching && (<><Spinner size={16} /> {t('Loading…')}</>)}
                 </div>
               )}
             </>

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link, useSearch } from 'wouter';
 import { Search, ChevronLeft, SlidersHorizontal, ListChecks, Settings } from 'lucide-react';
+import { useIntersectionObserver } from '../lib/useIntersectionObserver';
 import { BookCard } from '../components/BookCard';
 import { BulkBar } from '../components/BulkBar';
-import { Button } from '../components/Button';
 import { Spinner, SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import { DiscoverSection } from '../components/DiscoverSection';
@@ -278,6 +278,11 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
   const hasMore = allBooks.length < total;
   const isFirstLoad = isLoading && allBooks.length === 0;
 
+  const sentinelRef = useIntersectionObserver({
+    onIntersect: () => setPage((p) => p + 1),
+    enabled: hasMore && !isFetching,
+  });
+
   const heading = isView ? t(VIEW_LABEL[view!]) : filtered ? (entityName ?? '…') : t('Your Library');
   const countLabel =
     total > 0
@@ -450,17 +455,13 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
           </div>
 
           {hasMore && (
-            <div className={styles.loadMore}>
-              <Button variant="ghost" onClick={() => setPage((p) => p + 1)} disabled={isFetching}>
-                {isFetching ? (
-                  <>
-                    <Spinner size={16} />
-                    {t('Loading…')}
-                  </>
-                ) : (
-                  t('Load more')
-                )}
-              </Button>
+            <div ref={sentinelRef} className={styles.loadMore}>
+              {isFetching && (
+                <>
+                  <Spinner size={16} />
+                  {t('Loading…')}
+                </>
+              )}
             </div>
           )}
         </>

--- a/frontend/src/pages/MagicShelfView.tsx
+++ b/frontend/src/pages/MagicShelfView.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link, useLocation } from 'wouter';
+import { useIntersectionObserver } from '../lib/useIntersectionObserver';
 import { ChevronLeft, Copy, Trash2, Pencil } from 'lucide-react';
 import { useMagicShelfBooks, useDeleteMagicShelf, useDuplicateMagicShelf } from '../lib/queries';
 import { BookCard } from '../components/BookCard';
-import { Button } from '../components/Button';
 import { Spinner, SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import { useT } from '../lib/i18n';
@@ -50,6 +50,10 @@ export function MagicShelfView({ id }: { id: string }) {
 
   const total = data.total;
   const hasMore = books.length < total;
+  const sentinelRef = useIntersectionObserver({
+    onIntersect: () => setPage((p) => p + 1),
+    enabled: hasMore && !isFetching,
+  });
 
   return (
     <main className={styles.container}>
@@ -91,10 +95,8 @@ export function MagicShelfView({ id }: { id: string }) {
             ))}
           </div>
           {hasMore && (
-            <div className={styles.loadMore}>
-              <Button variant="ghost" onClick={() => setPage((p) => p + 1)} disabled={isFetching}>
-                {isFetching ? (<><Spinner size={16} /> {t('Loading…')}</>) : t('Load more')}
-              </Button>
+            <div ref={sentinelRef} className={styles.loadMore}>
+              {isFetching && (<><Spinner size={16} /> {t('Loading…')}</>)}
             </div>
           )}
         </>

--- a/frontend/src/pages/Shelf.tsx
+++ b/frontend/src/pages/Shelf.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link, useLocation } from 'wouter';
+import { useIntersectionObserver } from '../lib/useIntersectionObserver';
 import {
   ChevronLeft, Globe, Lock, Pencil, Trash2, Check, X, ArrowUpDown, ArrowUp, ArrowDown, Smartphone,
 } from 'lucide-react';
@@ -7,7 +8,6 @@ import {
   useShelf, useUpdateShelf, useDeleteShelf, useShelfMembership, useReorderShelfBooks, useMe,
 } from '../lib/queries';
 import { BookCard } from '../components/BookCard';
-import { Button } from '../components/Button';
 import { Spinner, SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import type { Book } from '../lib/api';
@@ -78,6 +78,10 @@ export function Shelf({ id }: { id: string }) {
 
   const total = data.total;
   const hasMore = books.length < total;
+  const sentinelRef = useIntersectionObserver({
+    onIntersect: () => setPage((p) => p + 1),
+    enabled: hasMore && !isFetching,
+  });
   const canEdit = data.can_edit;
 
   const startRename = () => {
@@ -260,16 +264,12 @@ export function Shelf({ id }: { id: string }) {
           </div>
 
           {hasMore && (
-            <div className={styles.loadMore}>
-              <Button variant="ghost" onClick={() => setPage((p) => p + 1)} disabled={isFetching}>
-                {isFetching ? (
-                  <>
-                    <Spinner size={16} /> {t('Loading…')}
-                  </>
-                ) : (
-                  t('Load more')
-                )}
-              </Button>
+            <div ref={sentinelRef} className={styles.loadMore}>
+              {isFetching && (
+                <>
+                  <Spinner size={16} /> {t('Loading…')}
+                </>
+              )}
             </div>
           )}
         </>

--- a/frontend/src/pages/Table.tsx
+++ b/frontend/src/pages/Table.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link } from 'wouter';
+import { useIntersectionObserver } from '../lib/useIntersectionObserver';
 import { ArrowUp, ArrowDown, Check, Columns3 } from 'lucide-react';
 import { useBooks } from '../lib/queries';
-import { Button } from '../components/Button';
 import { Spinner, SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import { useT } from '../lib/i18n';
@@ -49,6 +49,10 @@ export function Table() {
 
   const total = data?.total ?? 0;
   const hasMore = rows.length < total;
+  const sentinelRef = useIntersectionObserver({
+    onIntersect: () => setPage((p) => p + 1),
+    enabled: hasMore && !isFetching,
+  });
 
   const onSort = (col: Col) => {
     if (!col.sortAsc) return;
@@ -151,10 +155,8 @@ export function Table() {
             </table>
           </div>
           {hasMore && (
-            <div className={styles.loadMore}>
-              <Button variant="ghost" onClick={() => setPage((p) => p + 1)} disabled={isFetching}>
-                {isFetching ? (<><Spinner size={16} /> {t('Loading…')}</>) : t('Load more')}
-              </Button>
+            <div ref={sentinelRef} className={styles.loadMore}>
+              {isFetching && (<><Spinner size={16} /> {t('Loading…')}</>)}
             </div>
           )}
         </>


### PR DESCRIPTION
Adopts community PR #735 by @kurtlieber, with an e2e test added.

## What
The book lists in the new UI (Library grid, Table, Shelf, Smart Shelf, Advanced Search) now auto-load the next page as you scroll toward the bottom, replacing the manual "Load more" button. A shared `useIntersectionObserver` hook observes a sentinel with a 200px pre-fetch margin; the loading spinner is preserved during fetches.

## Verification
- **e2e** (`frontend/e2e/infinite-scroll.spec.ts`, desktop + mobile): on the Table view, no "Load more" button remains, scrolling appends pages up to the full library total, and no book is duplicated across pages. Verified live 24→41 books with one page-2 fetch.
- Full SPA e2e suite green (59 passed) — no regression in browse / book-detail / sidebar / customize / a11y.
- Console clean; `dedupAppend` guards against duplicate rows.

I evaluated a ref-stabilised rewrite of the observer (to avoid re-subscribing each render) but **dropped it** — removing `onIntersect` from the effect deps regressed the mount-timing that lets the sentinel re-fire while it stays in view, which broke pagination. @kurtlieber's implementation is correct: the `!isFetching` gate plus `dedupAppend` already prevent double-loading and skips.

No new dependency (native IntersectionObserver) / route / external URL.

Credit: @kurtlieber (#735). Closing that PR in favour of this one.