### PR TITLE
docs(readme): note env-supplied Hardcover token leaves admin field blank (#743)

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,8 @@ Without this, CWA may see different client IPs across requests and trigger Sessi
 
 Hardcover then appears in the Fetch Metadata modal.
 
+If you set the token through the `HARDCOVER_TOKEN` environment variable, the **Hardcover API Key** field in the admin UI stays empty — that field only shows a key entered through the UI, and an environment-supplied token is not echoed back into the page. The token still works; Hardcover results appearing in the Fetch Metadata modal confirm it is active.
+
 ### KOReader sync
 
 CWA has built-in KOReader progress sync; no separate kosync server is needed.


### PR DESCRIPTION
## Why
Addresses the confusion in #743 (reported by @KucharczykL): when the Hardcover token is supplied through the `HARDCOVER_TOKEN` environment variable, the **Hardcover API Key** field in Admin → Edit Basic Configuration renders blank, so it looks like the token was not applied — even though metadata operations succeed.

## Root cause (documented, not fixed here)
`cps/templates/config_edit.html:281` binds the field's `value` only to the DB column `config.config_hardcover_token`. An env-supplied token never populates that column, so the field is empty. Every consumer (`cps/metadata_provider/hardcover.py`, `cps/admin.py`, `cps/schedule.py`, `cps/cwa_functions.py`) has a `getenv("HARDCOVER_TOKEN")` fallback, so the token works regardless — the admin field just doesn't reflect it.

## Change
One README sentence in the Hardcover section clarifying that an env-supplied token intentionally does not echo back into the admin field, and that Hardcover results in the Fetch Metadata modal confirm it is active. Pre-empts the same question for the next user.

The code-side fix (a shared token resolver + an "set via env" indicator in the admin field) is scoped separately in `notes/fork-743-hardcover-env-token-design.md` and is a larger `needs-review` change; this doc note ships independently.

## Tier
safe-tier-1 — README-only, 2 insertions, no code. Auto-merges on green CI.