### PR TITLE
docs(install): QNAP + Dockge guides, fix Synology update steps (#527)

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -20,8 +20,10 @@ Pick the guide that matches how you run Docker:
 | **Unraid** (Docker tab) | [unraid.md](unraid.md) |
 | **Portainer** (Stacks) | [portainer.md](portainer.md) |
 | **TrueNAS SCALE** (Apps) | [truenas.md](truenas.md) |
+| **QNAP** (Container Station) | [qnap.md](qnap.md) |
+| **Dockge** (compose stacks) | [dockge.md](dockge.md) |
 | **A terminal / `docker compose`** | [compose.md](compose.md) |
-| QNAP, Dockge, something else | not written yet — see the help links below, we'll walk you through it |
+| Something else | not listed yet — see the help links below, we'll walk you through it |
 
 Every guide covers both a **fresh install** and **switching from stock CWA**, and tells you
 how to **update** later on that platform (on most NAS GUIs a "restart" does **not** pull a new

--- a/docs/install/dockge.md
+++ b/docs/install/dockge.md
@@ -1,0 +1,67 @@
+# Install / switch with Dockge
+
+For [Dockge](https://github.com/louislam/dockge), the compose-file stack manager. Each app is
+a **stack** — a `compose.yaml` Dockge stores on disk and manages from the web UI. Works
+whether you're installing fresh or switching from the standard Calibre-Web-Automated (CWA)
+image.
+
+**Your books, users, settings and the Read checkmarks you've set live in the volumes you bind
+into the container — not in the image — so switching keeps everything and is reversible.**
+
+## Fresh install (new stack)
+
+1. In Dockge, click **+ Compose** (new stack).
+2. **Stack name:** `calibre-web-nextgen`. Paste this into the compose editor:
+
+   ```yaml
+   services:
+     calibre-web-nextgen:
+       image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+       container_name: calibre-web-nextgen
+       environment:
+         - PUID=1000
+         - PGID=1000
+         - TZ=America/New_York
+       volumes:
+         - /opt/stacks/calibre-web-nextgen/config:/config
+         - /opt/stacks/calibre-web-nextgen/library:/calibre-library
+         - /opt/stacks/calibre-web-nextgen/ingest:/cwa-book-ingest
+       ports:
+         - 8083:8083
+       restart: unless-stopped
+   ```
+
+   Replace the three host paths with real folders on the Docker host, and set
+   `PUID`/`PGID`/`TZ` to your user and timezone.
+3. Click **Deploy.** Dockge pulls the image and starts the stack. Open `http://<host>:8083`.
+
+## Switching from CWA
+
+- **If your CWA already runs as a Dockge stack:** open that stack, change the image line to
+  `ghcr.io/new-usemame/calibre-web-nextgen:latest`, keep the same volume binds, then
+  **Deploy** (Dockge re-pulls and recreates).
+- **If your CWA runs outside Dockge** (a plain `docker run`, another compose file, or another
+  GUI): create the stack above, but point the three volumes at the **same host folders** CWA
+  already uses so your library and settings carry over. Stop the old CWA container first so
+  only one app uses the library at a time.
+
+## Updating later
+
+1. Open your `calibre-web-nextgen` stack in Dockge.
+2. Click the stack's **update** control — Dockge shows an update indicator when a newer image
+   is available; use it, or just click **Deploy** again to re-pull and recreate. Dockge pulls
+   the newest `ghcr.io/new-usemame/calibre-web-nextgen:latest` and recreates the container with
+   your data intact.
+
+   *(A plain restart does not pull a new image — you have to re-pull, which Deploy does.)*
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.

--- a/docs/install/qnap.md
+++ b/docs/install/qnap.md
@@ -1,0 +1,80 @@
+# Install / switch on QNAP (Container Station)
+
+For QTS/QuTS with **Container Station 3+** (the "Applications" feature, which runs
+docker-compose files). Works whether you're installing fresh or switching from the standard
+Calibre-Web-Automated (CWA) image.
+
+**Your books, users, settings and the Read checkmarks you've set all live in the folders
+mapped into the container — nothing gets converted or deleted, and you can undo the whole
+thing** by starting your old application again.
+
+## Switching from CWA? Note your current setup first
+
+1. **Container Station → Containers** (or **Applications**), open your existing CWA container →
+   its overview.
+2. Note which QNAP shared folder maps to each of `/config`, `/calibre-library`, and
+   `/cwa-book-ingest` (Container Station shows these under the container's **Storage** /
+   volume settings).
+3. Note the `PUID`, `PGID`, and `TZ` from its **Environment** settings.
+4. **Stop** the old container — but **don't delete it.** A stopped container is your instant
+   undo.
+
+*(Fresh install? Skip the four steps above and just decide which QNAP shared folders you want
+for `/config`, `/calibre-library` and `/cwa-book-ingest`, and your `PUID`/`PGID`.)*
+
+## Create the NextGen application
+
+1. **Container Station → Applications → Create.**
+2. **Application name:** `calibre-web-nextgen`. In the YAML editor, paste the block below and
+   replace the three `/share/...` paths and the `PUID`/`PGID`/`TZ` with your values:
+
+   ```yaml
+   services:
+     calibre-web-nextgen:
+       image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+       container_name: calibre-web-nextgen
+       environment:
+         - PUID=1000
+         - PGID=100
+         - TZ=America/New_York
+       volumes:
+         - /share/Container/calibre/config:/config
+         - /share/Container/calibre/library:/calibre-library
+         - /share/Container/calibre/ingest:/cwa-book-ingest
+       ports:
+         - 8083:8083
+       restart: unless-stopped
+   ```
+
+   Point the three `/share/...` paths at the **same shared folders** your CWA used (if you're
+   switching), so your existing library and settings carry over. To find a QNAP path, browse
+   the folder in **File Station** and read the path at the top.
+3. **Create.** Container Station pulls the image from ghcr.io and starts it. Open
+   `http://<qnap-ip>:8083` and log in with your usual account — your library, users and Read
+   checkmarks are all there.
+
+## Updating later — important
+
+Restarting the container does **not** pull a newer image. To actually update:
+
+1. **Container Station → Applications** → your `calibre-web-nextgen` application → **Stop**.
+2. Open the application's YAML editor and **Recreate** (some QTS versions label this
+   **Update** or **Pull image and recreate**). Container Station re-pulls
+   `ghcr.io/new-usemame/calibre-web-nextgen:latest` and recreates the container with your data
+   intact.
+
+   If your Container Station version has no "recreate/pull" option, delete the **container**
+   first (your data in the shared folders is untouched), then delete the cached
+   `ghcr.io/new-usemame/calibre-web-nextgen:latest` image under **Images**, then **Create** the
+   application again from the same YAML — that forces a fresh pull.
+
+---
+
+**Your setup might differ.** If a step doesn't match what you see on screen, or if
+sync / auto-ingest isn't working after you switch, we'll help you through it:
+
+- **Open an issue** (best for tracking): https://github.com/new-usemame/Calibre-Web-NextGen/issues
+- **Ask on Discord** (faster back-and-forth): https://discord.gg/B8NXZmcp32
+
+Include your platform and a screenshot of the screen you're stuck on, and we'll tell you
+the exact buttons to press.

--- a/docs/install/synology.md
+++ b/docs/install/synology.md
@@ -64,11 +64,17 @@ update NextGen:
 
 1. **Container Manager → Projekt / Project** → your `calibre-web-nextgen` project →
    **Aktion / Action → Stop**.
-2. **Container Manager → Image** → click the `ghcr.io/new-usemame/calibre-web-nextgen:latest`
-   row → **Aktion / Action → Delete**. This only clears the cached app image — if it warns
-   that it's in use, the container is already stopped, so it's safe to confirm. (Your data is
-   in the mounted folders, not here.)
-3. **Container Manager → Projekt / Project** → your project → **Aktion / Action → Build**.
+2. **Container Manager → Container** → select the `calibre-web-nextgen` container →
+   **Aktion / Action → Löschen / Delete**. Do this *before* the next step — an image can't be
+   removed while a container still uses it (even a stopped one), so deleting the image first
+   gives an "in use" error. Deleting the container is safe: your books, users and settings
+   live in the mounted folders, and the project's compose file recreates the container for you
+   in step 4.
+3. **Container Manager → Image** → click the `ghcr.io/new-usemame/calibre-web-nextgen:latest`
+   row → **Aktion / Action → Löschen / Delete**. Now that no container uses it, this succeeds
+   and clears the cached copy so the next build pulls a fresh image. (Your data is in the
+   mounted folders, not here.)
+4. **Container Manager → Projekt / Project** → your project → **Aktion / Action → Build**.
    Container Manager pulls the newest image fresh and recreates the container. Wait about
    30 seconds, then reload the page.
 


### PR DESCRIPTION
## Why
Addresses #527 (step-by-step install/switch guides for NAS & Docker-GUI platforms). Two items were left open in that issue after the first batch (PR #530): the **QNAP Container Station** and **Dockge** guides. This finishes them, and fixes a real defect in the Synology guide.

## What changed (docs-only)
- **`docs/install/qnap.md`** (new) — QNAP Container Station 3+ (Applications/compose): fresh install + switch-from-CWA + update-later + the standard help footer.
- **`docs/install/dockge.md`** (new) — Dockge compose-stack manager: same coverage.
- **`docs/install/synology.md`** — fixed the "Updating later" steps. Real user **uschi1** (#312 / #527) hit an *"image is in use"* error (with a screenshot) following the old steps, and the maintainer confirmed the cause in-thread. Root cause: Docker refuses to delete an image while **any** container references it — even a stopped one. The old guide told users the delete was "safe to confirm" once the container was stopped, which is wrong. The guide now deletes the **container** before the cached image, then rebuilds the project to pull fresh.
- **`docs/install/README.md`** — index now links QNAP + Dockge (removed from the "not written yet" row).

## Verification
- All 7 guides exist; every index link resolves to a real file.
- New guides carry the exact standard help footer (Issues + Discord) and the correct image name `ghcr.io/new-usemame/calibre-web-nextgen:latest`.
- Synology fix traces directly to uschi1's reported error and the maintainer's in-thread explanation (image ref-counting) — a verifiable Docker behavior, not an invented step.
- QNAP/Dockge steps written from official platform docs; per #527 guidance, uncertain fallbacks are marked and the footer invites corrections via issues.

## Tier
`safe-tier-1` — documentation only, no code, no deps. Auto-merges on green CI.