### PR TITLE
Track & display "started reading" date for KOReader/Kobo sync

### DIFF
--- a/cps/api/books.py
+++ b/cps/api/books.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Catalog endpoints for /api/v1."""
+from datetime import timezone
+
 from flask import jsonify, request
 from flask_babel import get_locale
 from sqlalchemy import and_, func
@@ -274,6 +276,8 @@ def book_detail(book_id):
     # sessions have no real id, so they simply read back as not-favorited/hidden.
     favorited = hidden = False
     kosync_progress = None
+    kosync_progress_timestamp = None
+    kosync_progress_created_at = None
     if current_user.is_authenticated and not current_user.is_anonymous:
         uid = int(current_user.id)
         favorited = (ub.session.query(ub.FavoriteBook)
@@ -291,7 +295,12 @@ def book_detail(book_id):
                                   ub.KoboReadingState.book_id == book_id)
                           .first())
             if kobo_state and kobo_state.current_bookmark:
-                kosync_progress = kobo_state.current_bookmark.progress_percent
+                bm = kobo_state.current_bookmark
+                kosync_progress = bm.progress_percent
+                if bm.last_modified:
+                    kosync_progress_timestamp = bm.last_modified.replace(tzinfo=timezone.utc).isoformat()
+                if bm.created_at:
+                    kosync_progress_created_at = bm.created_at.replace(tzinfo=timezone.utc).isoformat()
         except Exception:
             log.debug("Failed to load KOReader progress for book %s", book_id, exc_info=True)
 
@@ -315,6 +324,8 @@ def book_detail(book_id):
         in_progress=in_progress,
     )
     body["kosync_progress"] = kosync_progress
+    body["kosync_progress_timestamp"] = kosync_progress_timestamp
+    body["kosync_progress_created_at"] = kosync_progress_created_at
     return jsonify(body)
 
 

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -1017,9 +1017,18 @@
                                 <div class="meta-chip">
                                     <span class="meta-label">{{ _('KOReader Progress') }}:</span>
                                     <span class="meta-value">{{ kosync_progress|formatfloat(1) }}%</span>
-                                    {% if kosync_progress_timestamp %}
-                                        <span class="meta-value">({{ kosync_progress_timestamp|formatdate }})</span>
-                                    {% endif %}
+                                </div>
+                            {% endif %}
+                            {% if kosync_progress_created_at %}
+                                <div class="meta-chip">
+                                    <span class="meta-label" title="{{ _('When reading progress was first synced') }}">{{ _('Started reading') }}:</span>
+                                    <span class="meta-value">{{ kosync_progress_created_at|formatdate }}</span>
+                                </div>
+                            {% endif %}
+                            {% if kosync_progress_timestamp %}
+                                <div class="meta-chip">
+                                    <span class="meta-label">{{ _('Last synced') }}:</span>
+                                    <span class="meta-value">{{ kosync_progress_timestamp|formatdate }}</span>
                                 </div>
                             {% endif %}
                             {% if cc|length > 0 %}

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -874,6 +874,7 @@ class KoboBookmark(Base):
 
     id = Column(Integer, primary_key=True)
     kobo_reading_state_id = Column(Integer, ForeignKey('kobo_reading_state.id'))
+    created_at = Column(DateTime)
     last_modified = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
     location_source = Column(String)
     location_type = Column(String)
@@ -1104,17 +1105,25 @@ class HardcoverMatchQueue(Base):
         return f'<HardcoverMatchQueue book_id={self.book_id} title="{self.book_title}" reviewed={bool(self.reviewed)}>'
 
 
-# Updates the last_modified timestamp in the KoboReadingState table if any of its children tables are modified.
+# Updates the last_modified timestamp in the KoboReadingState table if any of its children tables are modified,
+# and adds a KoboBookmark's created_at the first time it records progress > 0 ("started reading").
 @event.listens_for(Session, 'before_flush')
 def receive_before_flush(session, flush_context, instances):
+    # Computed lazily on the first Kobo-related change so unrelated flushes don't
+    # pay for a timestamp they never use; reused across the flush once set.
+    ts = None
     for change in itertools.chain(session.new, session.dirty):
         if isinstance(change, (ReadBook, KoboStatistics, KoboBookmark)):
-            if change.kobo_reading_state:
+            if ts is None:
                 ts = (g.kobo_reading_state_lm
                       if has_request_context() and getattr(g, 'kobo_reading_state_lm', None)
                       else datetime.now(timezone.utc))
+            if change.kobo_reading_state:
                 change.kobo_reading_state.last_modified = ts
                 change.kobo_reading_state.priority_timestamp = ts
+            if isinstance(change, KoboBookmark) and not change.created_at and (change.progress_percent or 0) > 0:
+                change.created_at = ts
+
     # Maintain the last_modified_bit for the Shelf table.
     for change in itertools.chain(session.new, session.deleted):
         if isinstance(change, BookShelf):
@@ -1803,6 +1812,8 @@ def _merge_kobo_bookmark(_session, winner, loser):
         loser.current_bookmark = None
         return
     w, l = winner.current_bookmark, loser.current_bookmark
+    if l.created_at and (not w.created_at or l.created_at < w.created_at):
+        w.created_at = l.created_at
     if _loser_wins_lm(l, w):
         for attr in ("location_source", "location_type", "location_value",
                      "progress_percent", "content_source_progress_percent",
@@ -2537,6 +2548,41 @@ def migrate_annotation_decouple_source_target(engine, _session):
         raise
 
 
+def migrate_kobo_bookmark_created_at(engine, _session):
+    """Add the nullable ``created_at`` column to ``kobo_bookmark`` — the
+    "started reading" date, stamped on the first sync with progress > 0.
+    Idempotent.
+
+    Same PRAGMA-guarded shape as `migrate_annotation_device_origin`:
+    query the live SQLite catalog for the column, and treat a duplicate-column
+    error from the ADD COLUMN as a no-op. Nullable column, zero data risk.
+    """
+    with engine.begin() as conn:
+        rows = conn.execute(text(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='kobo_bookmark'"
+        )).fetchall()
+        if not rows:
+            return
+        existing = {
+            row[1] for row in conn.execute(text(
+                "PRAGMA table_info(kobo_bookmark)"
+            )).fetchall()
+        }
+        if "created_at" in existing:
+            return
+        try:
+            conn.execute(text("ALTER TABLE kobo_bookmark ADD COLUMN created_at DATETIME"))
+            log.info("[kobo_bookmark] added created_at column")
+        except exc.OperationalError as e:
+            if "duplicate column" in str(e).lower():
+                log.info(
+                    "[kobo_bookmark] column already present despite "
+                    "PRAGMA check; treating as idempotent"
+                )
+            else:
+                raise
+
+
 def migrate_Database(_session):
     engine = _session.bind
     add_missing_tables(engine, _session)
@@ -2552,6 +2598,7 @@ def migrate_Database(_session):
     migrate_magic_shelf_table(engine, _session)
     migrate_kobo_unique_constraints(engine, _session)
     migrate_kobo_deleted_book(engine, _session)
+    migrate_kobo_bookmark_created_at(engine, _session)
     # Must run before config_sql.load_configuration (it does — ub.init_db
     # precedes config load in cps/__init__.py) so the flipped value is live
     # the same boot.

--- a/cps/web.py
+++ b/cps/web.py
@@ -3628,6 +3628,7 @@ def show_book(book_id):
 
         kosync_progress = None
         kosync_progress_timestamp = None
+        kosync_progress_created_at = None
         if current_user.is_authenticated:
             try:
                 kobo_state = (ub.session.query(ub.KoboReadingState)
@@ -3637,6 +3638,7 @@ def show_book(book_id):
                 if kobo_state and kobo_state.current_bookmark:
                     kosync_progress = kobo_state.current_bookmark.progress_percent
                     kosync_progress_timestamp = kobo_state.current_bookmark.last_modified
+                    kosync_progress_created_at = kobo_state.current_bookmark.created_at
             except Exception as e:
                 log.debug(f"Failed to load KOReader progress for book {book_id}: {e}")
 
@@ -3687,6 +3689,7 @@ def show_book(book_id):
                                      cwa_settings=cwa_settings,
                                      kosync_progress=kosync_progress,
                                      kosync_progress_timestamp=kosync_progress_timestamp,
+                                     kosync_progress_created_at=kosync_progress_created_at,
                                      is_hidden=is_hidden,
                                      is_favorited=is_favorited,
                                      other_users_with_kindle=other_users_with_kindle,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -121,6 +121,12 @@ export interface BookDetail {
   /** KOReader/Kobo synced reading progress as a percentage (0–100), or null when
    *  not synced. */
   kosync_progress: number | null;
+  /** When progress was last synced, as an ISO Date, or null when not synced. */
+  kosync_progress_timestamp: string | null;
+  /** When progress was first synced (the "started reading" date), as a
+   *  ISO date, or null when not synced or for progress that predates
+   *  this field. */
+  kosync_progress_created_at: string | null;
 }
 
 export interface BooksPage {

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -21,18 +21,20 @@ function formatBytes(bytes: number): string {
   return mb >= 0.1 ? `${mb.toFixed(1)} MB` : `${(bytes / 1024).toFixed(0)} KB`;
 }
 
-function formatPubdate(pubdate: string): string {
+function formatDate(date: string, alwaysReturnFullDate = false): string {
   // Try to parse as ISO date — return just the year if it looks like a date
-  const d = new Date(pubdate);
+  const d = new Date(date);
   if (!isNaN(d.getTime())) {
-    // If the time portion is midnight UTC it's likely just a year+date, show full date
-    const year = d.getFullYear();
-    const month = d.getMonth();
-    const day = d.getDate();
-    if (month === 0 && day === 1) return String(year);
+    if (!alwaysReturnFullDate) {
+      // If the time portion is midnight UTC it's likely just a year+date, show full date
+      const year = d.getFullYear();
+      const month = d.getMonth();
+      const day = d.getDate();
+      if (month === 0 && day === 1) return String(year);
+    }
     return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
   }
-  return pubdate;
+  return date;
 }
 
 // Formats the in-browser reader can open. EPUB/KEPUB use the SPA's epub.js
@@ -429,10 +431,24 @@ export function BookDetail() {
                 <dd className={styles.metaValue}>{book.kosync_progress.toFixed(1)}%</dd>
               </>
             )}
+            {book.kosync_progress_created_at !== null && (
+              <>
+                <dt className={styles.metaLabel} title={t('When reading progress was first synced')}>
+                  {t('Started reading')}
+                </dt>
+                <dd className={styles.metaValue}>{formatDate(book.kosync_progress_created_at, true)}</dd>
+              </>
+            )}
+            {book.kosync_progress_timestamp !== null && (
+              <>
+                <dt className={styles.metaLabel}>{t('Last synced')}</dt>
+                <dd className={styles.metaValue}>{formatDate(book.kosync_progress_timestamp, true)}</dd>
+              </>
+            )}
             {book.pubdate && (
               <>
                 <dt className={styles.metaLabel}>{t('Published')}</dt>
-                <dd className={styles.metaValue}>{formatPubdate(book.pubdate)}</dd>
+                <dd className={styles.metaValue}>{formatDate(book.pubdate)}</dd>
               </>
             )}
             {book.languages.length > 0 && (

--- a/tests/unit/test_kobo_bookmark_created_at.py
+++ b/tests/unit/test_kobo_bookmark_created_at.py
@@ -1,0 +1,194 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for the KoboBookmark.created_at field — the "started reading" date.
+
+Covers each piece of the change:
+  * before_flush stamps created_at once, when progress first crosses > 0
+  * the reading-state merge keeps the *earliest* created_at
+  * the detail API surfaces created_at/last_modified and stays None-safe
+  * the schema migration adds the column idempotently
+"""
+import inspect
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import flask
+import pytest
+from sqlalchemy import create_engine, text
+
+
+# --- before_flush: created_at stamping ---------------------------------------
+
+def _session(new=(), dirty=()):
+    return SimpleNamespace(new=list(new), dirty=list(dirty), deleted=[])
+
+
+@pytest.mark.unit
+def test_before_flush_stamps_created_at_on_first_progress():
+    from cps import ub
+    bm = ub.KoboBookmark()
+    bm.progress_percent = 12.5
+    assert bm.created_at is None
+    ub.receive_before_flush(_session(new=[bm]), None, None)
+    assert isinstance(bm.created_at, datetime)
+
+
+@pytest.mark.unit
+def test_before_flush_no_stamp_at_zero_progress():
+    from cps import ub
+    bm = ub.KoboBookmark()
+    bm.progress_percent = 0
+    ub.receive_before_flush(_session(new=[bm]), None, None)
+    assert bm.created_at is None
+
+
+@pytest.mark.unit
+def test_before_flush_does_not_overwrite_existing_created_at():
+    from cps import ub
+    original = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    bm = ub.KoboBookmark()
+    bm.created_at = original
+    bm.progress_percent = 80
+    ub.receive_before_flush(_session(dirty=[bm]), None, None)
+    assert bm.created_at == original
+
+
+# --- reading-state merge: earliest created_at wins ---------------------------
+
+def _bookmark(created_at, last_modified, progress):
+    return SimpleNamespace(
+        created_at=created_at, last_modified=last_modified,
+        progress_percent=progress, content_source_progress_percent=None,
+        location_source=None, location_type=None, location_value=None,
+    )
+
+
+@pytest.mark.unit
+def test_merge_keeps_earliest_created_at_even_when_winner_is_newer():
+    from cps import ub
+    early = datetime(2026, 1, 1)
+    late = datetime(2026, 3, 1)
+    # winner's bookmark is the newer one (higher last_modified) but started later
+    winner = SimpleNamespace(id=1, current_bookmark=_bookmark(late, datetime(2026, 4, 1), 50))
+    loser = SimpleNamespace(id=2, current_bookmark=_bookmark(early, datetime(2026, 2, 1), 30))
+    ub._merge_kobo_bookmark(None, winner, loser)
+    assert winner.current_bookmark.created_at == early
+
+
+@pytest.mark.unit
+def test_merge_fills_created_at_when_winner_has_none():
+    from cps import ub
+    early = datetime(2026, 1, 1)
+    winner = SimpleNamespace(id=1, current_bookmark=_bookmark(None, datetime(2026, 4, 1), 50))
+    loser = SimpleNamespace(id=2, current_bookmark=_bookmark(early, datetime(2026, 2, 1), 30))
+    ub._merge_kobo_bookmark(None, winner, loser)
+    assert winner.current_bookmark.created_at == early
+
+
+@pytest.mark.unit
+def test_merge_keeps_winner_created_at_when_it_is_earlier():
+    from cps import ub
+    early = datetime(2026, 1, 1)
+    winner = SimpleNamespace(id=1, current_bookmark=_bookmark(early, datetime(2026, 4, 1), 50))
+    loser = SimpleNamespace(id=2, current_bookmark=_bookmark(datetime(2026, 3, 1), datetime(2026, 2, 1), 30))
+    ub._merge_kobo_bookmark(None, winner, loser)
+    assert winner.current_bookmark.created_at == early
+
+
+# --- detail API: surfaces timestamps, stays None-safe ------------------------
+
+def _fake_book():
+    return SimpleNamespace(
+        id=7, title="T", series_index="1.0", has_cover=0,
+        authors=[], series=[], data=[], comments=[], tags=[],
+        languages=[], publishers=[], identifiers=[], pubdate=None,
+    )
+
+
+def _call_detail_with_bookmark(bookmark):
+    from cps.api import books as books_mod
+    from cps import ub
+
+    def query_side_effect(model):
+        q = MagicMock()
+        if model is ub.KoboReadingState:
+            q.filter.return_value.first.return_value = SimpleNamespace(current_bookmark=bookmark)
+        else:
+            q.filter.return_value.first.return_value = None
+        return q
+
+    app = flask.Flask(__name__)
+    with app.test_request_context("/api/v1/books/7"):
+        with patch.object(books_mod.calibre_db, "get_book_read_archived",
+                          return_value=(_fake_book(), 0, False)), \
+             patch.object(books_mod.config, "config_read_column", 0, create=True), \
+             patch.object(books_mod, "current_user",
+                          SimpleNamespace(is_authenticated=True, is_anonymous=False, id=1)), \
+             patch.object(books_mod.ub, "session", MagicMock(query=MagicMock(side_effect=query_side_effect))), \
+             patch("cps.api.books.get_locale", return_value="en"), \
+             patch("cps.api.books.isoLanguages.get_language_name", return_value="English"):
+            resp = inspect.unwrap(books_mod.book_detail)(7)
+    return json.loads(resp.get_data(as_text=True))
+
+
+@pytest.mark.unit
+def test_detail_surfaces_timestamps():
+    modified = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+    started = datetime(2026, 1, 1, 8, 0, tzinfo=timezone.utc)
+    data = _call_detail_with_bookmark(SimpleNamespace(
+        progress_percent=45.0, last_modified=modified, created_at=started))
+    assert data["kosync_progress"] == 45.0
+    assert data["kosync_progress_timestamp"] == modified.isoformat()
+    assert data["kosync_progress_created_at"] == started.isoformat()
+
+
+@pytest.mark.unit
+def test_detail_none_safe_when_created_at_missing():
+    """Regression: a pre-migration bookmark has created_at=None. The endpoint
+    must still return progress/timestamp instead of swallowing everything."""
+    modified = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+    data = _call_detail_with_bookmark(SimpleNamespace(
+        progress_percent=45.0, last_modified=modified, created_at=None))
+    assert data["kosync_progress"] == 45.0
+    assert data["kosync_progress_timestamp"] == modified.isoformat()
+    assert data["kosync_progress_created_at"] is None
+
+
+@pytest.mark.unit
+def test_detail_treats_naive_datetimes_as_utc():
+    """DB rows come back naive (SQLite has no tz) but represent UTC wall-clock.
+    The serialized ISO string must carry a +00:00 offset regardless of the
+    server's local timezone, so the naive value is pinned to UTC."""
+    modified = datetime(2026, 3, 1, 12, 0)  # naive, as read back from SQLite
+    started = datetime(2026, 1, 1, 8, 0)
+    data = _call_detail_with_bookmark(SimpleNamespace(
+        progress_percent=45.0, last_modified=modified, created_at=started))
+    assert data["kosync_progress_timestamp"] == modified.replace(tzinfo=timezone.utc).isoformat()
+    assert data["kosync_progress_created_at"] == started.replace(tzinfo=timezone.utc).isoformat()
+
+
+# --- migration: adds the column idempotently ---------------------------------
+
+@pytest.mark.unit
+def test_migration_adds_column_and_is_idempotent():
+    from cps import ub
+    engine = create_engine("sqlite://")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE kobo_bookmark (id INTEGER PRIMARY KEY)"))
+
+    ub.migrate_kobo_bookmark_created_at(engine, None)
+    ub.migrate_kobo_bookmark_created_at(engine, None)  # second run must be a no-op
+
+    with engine.begin() as conn:
+        cols = {row[1] for row in conn.execute(text("PRAGMA table_info(kobo_bookmark)")).fetchall()}
+    assert "created_at" in cols
+
+
+@pytest.mark.unit
+def test_migration_noop_without_table():
+    from cps import ub
+    engine = create_engine("sqlite://")
+    ub.migrate_kobo_bookmark_created_at(engine, None)  # must not raise


### PR DESCRIPTION
## Summary and goal
This PR aims to add tracking and displaying of the first time a KOReader/Kobo sync is received, allowing for an automated tracking of book reading from start to finish: first sync would be when you start, last updated on 100% progress would be when you finished.
This could allow in the future adding a new filter to smart shelves to display for example what you read this year from start to finish, or track statistics like how quick/slow you read something. I think that more data is always better than less data.

### Caveat
`created_at` marks when first sync on server happens: you could sync at 50%, and that first sync becomes your start time. The same goes for users who will sync after this change, first sync will be saved as started.
This is unavoidable without historical data, so I put a tooltip on both frontends where the data is exposed to better explain this.

## Changes
### Backend
#### `ub.py`
- added `created_at` column defaulting to `None`, I thought about defaulting to current date but defaulting to `None` allows populating when progress is actually more than 0%
- updated `receive_before_flush` event to handle inserting timestamp when a `KoboBookmark` record is created or updated and progress is populated and more than 0%
- updated `_merge_kobo_bookmark` to handle the case where loser had an earlier date than winner
- added `migrate_kobo_bookmark_created_at` to handle clean and idempotent (via `PRAGMA` check and duplicated column error) column migration
- added `migrate_kobo_bookmark_created_at` to `migrate_Database` to actually perform migration

#### `books.py`

- added `kosync_progress_timestamp` to response body (was missing in the API and new frontend, was already there in classic frontend)
- added `kosync_progress_created_at` to response body
- both are returned as ISO dates and guarded against `None`, pre-migration rows do not throw unwanted errors
- the stored datetimes are UTC on all paths, but come back naive from SQLite, so I pin `tzinfo=UTC` before `.isoformat()` to keep it correct on non-UTC servers

#### `web.py`
- added `kosync_progress_created_at` to page rendering params

#### `test_kobo_bookmark_created_at.py`
- added unit tests for new changes

### Frontend
#### `detail.html`
- added new chip `Started reading: <formatted_date>` with a clarification tooltip to specify that 'Started reading' means `When reading progress was first synced` and positioned after `KOReader Progress` chip
- moved already present timestamp to a new chip `Last synced: <formatted_date>` for better clarity and to avoid cramming KOReader Progress chip
<img width="1212" height="93" alt="image" src="https://github.com/user-attachments/assets/86bdbdb6-b535-4730-a810-92619f583efd" />

#### `api.ts`
- added `kosync_progress_timestamp` and `kosync_progress_created_at` types as string (ISO date) or null to reflect API changes

#### `BookDetail.tsx`
- renamed `formatPubdate` to `formatDate`, added a param to skip the year-01-01 check defaulting to false, passed as true only when parsing newly added dates
- added new item to metadata table: `Started reading: <formatted_date>` with a clarification tooltip to specify that 'Started reading' means `When reading progress was first synced` and positioned after `KOReader Progress`
- added new item to metadata table: `Last synced: <formatted_date>`, it was missing from this frontend entirely so I added it for feature parity
<img width="474" height="140" alt="image" src="https://github.com/user-attachments/assets/9927ea79-4e77-4865-a1ac-3cd6c30cde3d" />
