### PR TITLE
fix(ui): default the new UI to the readable System font (#641)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ is for things you can see or feel when running the app.
 
 ### Changed
 
+- The new UI now uses the readable System font by default for both headings and body text, instead of the bookish serif some readers found hard to read. If you prefer the old look, "Bookish Serif" is still one click away under Account → UI display/body font (it's now offered for headings too). ([#641](https://github.com/new-usemame/Calibre-Web-NextGen/issues/641))
 - **German interface: 19 strings that showed in English now appear in German.** The OPDS catalog descriptions (for example "Books sorted by series" and "Popular publications from this catalog based on rating") and the duplicate-scan progress messages were untranslated, so German users saw English there while the rest of the UI was translated. Filled in from pending German translations contributed upstream. Thanks to @djalexz85 and @fucx (Calibre-Web-Automated) and @ManuelDrescher (calibre-web).
 - **Ukrainian interface: 141 more strings now appear in Ukrainian.** Error messages, the metadata review queue, the cover/thumbnail cache tools and other panels that previously showed English for Ukrainian users are now translated. Filled in from pending Ukrainian translations contributed upstream. Thanks to @Demelja (Calibre-Web-Automated).
 

--- a/cps/api/account.py
+++ b/cps/api/account.py
@@ -26,7 +26,9 @@ from .serializers import (SIDEBAR_VISIBILITY_BITS, ORDERABLE_SIDEBAR_KEYS,
 # the stacks live in the SPA (frontend/src/lib/fonts.ts). These sets MUST match
 # the keys in that module (UI_BODY_FONTS / UI_DISPLAY_FONTS). "" = theme default.
 ALLOWED_UI_FONT_BODY = frozenset({"", "system-sans", "serif", "mono"})
-ALLOWED_UI_FONT_DISPLAY = frozenset({"", "system-sans", "mono"})
+# #641 — 'serif' is now a valid DISPLAY preset too: once the display default
+# flipped from bookish serif to System sans, serif has to stay reachable here.
+ALLOWED_UI_FONT_DISPLAY = frozenset({"", "system-sans", "serif", "mono"})
 
 
 def _iso(dt):

--- a/frontend/src/lib/fonts.ts
+++ b/frontend/src/lib/fonts.ts
@@ -19,19 +19,21 @@ const SANS = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 
 const SERIF = "'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif";
 const MONO = "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace";
 
-// Body text. Default is the theme's Optima-led sans (tokens.css --font-body).
+// Body text. Default is the theme's System sans (tokens.css --font-body, #641).
 export const UI_BODY_FONTS: FontPreset[] = [
-  { key: '', label: 'Default (Optima / Sans-Serif)', stack: '' },
+  { key: '', label: 'Default (System Sans-Serif)', stack: '' },
   { key: 'system-sans', label: 'System Sans-Serif', stack: SANS },
   { key: 'serif', label: 'Bookish Serif', stack: SERIF },
   { key: 'mono', label: 'Monospace', stack: MONO },
 ];
 
-// Display / headings. Default is already the bookish serif (tokens.css
-// --font-display), so a "serif" preset would be redundant here.
+// Display / headings. Default is the System sans (tokens.css --font-display,
+// #641). 'serif' is offered explicitly so the bookish serif that used to be the
+// display default stays reachable for anyone who preferred it.
 export const UI_DISPLAY_FONTS: FontPreset[] = [
-  { key: '', label: 'Default (Bookish Serif)', stack: '' },
+  { key: '', label: 'Default (System Sans-Serif)', stack: '' },
   { key: 'system-sans', label: 'System Sans-Serif', stack: SANS },
+  { key: 'serif', label: 'Bookish Serif', stack: SERIF },
   { key: 'mono', label: 'Monospace', stack: MONO },
 ];
 

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -43,10 +43,13 @@
   --danger-soft:   rgba(224, 104, 95, 0.14);
   --success:       #6cc08a;
 
-  /* ---- Typography (system stacks with character — bookish serif display,
-          humanist sans body. Upgrade to self-hosted woff2 later.) ---- */
-  --font-display: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
-  --font-body:    Optima, 'Avenir Next', 'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+  /* ---- Typography (#641: the readable System sans is the default for both
+          display and body — it matches the classic UI and what multiple users
+          asked for. The bookish serif and other faces stay one click away in
+          the account font picker; keep these two stacks in step with the
+          `SANS` const in frontend/src/lib/fonts.ts.) ---- */
+  --font-display: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-body:    system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 
   --fs-xs:   0.75rem;   /* 12 */
   --fs-sm:   0.8125rem; /* 13 */

--- a/tests/unit/test_api_v1_account.py
+++ b/tests/unit/test_api_v1_account.py
@@ -251,11 +251,24 @@ def test_profile_update_rejects_unknown_body_font_400():
 
 
 @pytest.mark.unit
-def test_profile_update_display_allowlist_is_stricter_than_body():
-    """'serif' is a valid BODY preset but not a valid DISPLAY preset (the
-    display default is already serif) — the display field must reject it."""
+def test_profile_update_accepts_serif_as_display_641():
+    """#641: once the display default flipped from bookish serif to System sans,
+    'serif' must be a selectable DISPLAY preset so the old face stays reachable —
+    the display field must now ACCEPT it (it used to reject it)."""
     user = _user()
     mod, ctx, *patches = _profile_ctx(user, {"ui_font_display": "serif"})
+    with ctx:
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            resp = inspect.unwrap(mod.update_profile)()
+    assert user.ui_font_display == "serif"
+
+
+@pytest.mark.unit
+def test_profile_update_rejects_unknown_display_font_400():
+    """A value that isn't a known DISPLAY preset key must 400, not be stored —
+    the guard that keeps an arbitrary string out of the --font-display CSS var."""
+    user = _user()
+    mod, ctx, *patches = _profile_ctx(user, {"ui_font_display": "Comic Sans; }"})
     with ctx:
         with patches[0], patches[1], patches[2], patches[3], patches[4]:
             resp = inspect.unwrap(mod.update_profile)()
@@ -316,3 +329,27 @@ def test_font_allowlists_match_frontend_ssot_keys():
 
     assert _keys("UI_BODY_FONTS") == set(ALLOWED_UI_FONT_BODY)
     assert _keys("UI_DISPLAY_FONTS") == set(ALLOWED_UI_FONT_DISPLAY)
+
+
+@pytest.mark.unit
+def test_theme_default_fonts_are_system_sans_641():
+    """#641: users who never touch the font picker get the readable System sans
+    for BOTH display and body. The empty-preference path clears the CSS override
+    and falls back to these tokens.css defaults, so pin them to a system stack —
+    a revert to the old serif/Optima defaults must fail here."""
+    import re
+    from pathlib import Path
+
+    tokens = (Path(__file__).resolve().parents[2]
+              / "frontend" / "src" / "styles" / "tokens.css").read_text()
+
+    def _default(var):
+        m = re.search(rf"--{var}:\s*([^;]+);", tokens)
+        assert m, f"--{var} not found in tokens.css"
+        return m.group(1).strip().lower()
+
+    for var in ("font-display", "font-body"):
+        val = _default(var)
+        assert val.startswith("system-ui"), f"--{var} default is not System sans: {val}"
+        assert "serif" not in val.replace("sans-serif", ""), \
+            f"--{var} default still carries a serif face: {val}"


### PR DESCRIPTION
## Why
The new UI shipped a bookish serif as the default heading font and an Optima-led body stack. On the issue thread (#641) and via an independent in-app feedback-form report (#700), users said the serif is hard to read and asked for the System font the classic UI used. The maintainer agreed on-thread (2026-07-09) to make System the default in both spots — this ships that.

Credit: @droM4X for the "make System the default in both cases" ask; @kurtlieber for the original font-picker work (#701) this builds on.

## Root cause
The theme default lives in two `tokens.css` design tokens (`--font-display` / `--font-body`). A user with no font preference gets those defaults (the SPA clears its CSS override → the token value applies). They were serif / Optima.

## Fix
- `tokens.css`: both `--font-display` and `--font-body` default to the System sans stack.
- **Kept Bookish Serif reachable** (single-source-of-truth consequence): it was never a selectable *display* option because it used to be the display default. Added `serif` to `UI_DISPLAY_FONTS` (frontend) **and** `ALLOWED_UI_FONT_DISPLAY` (backend `cps/api/account.py`) so the old face is one click away under Account → UI display font. Body already offered it.
- Relabeled the `''` presets to "Default (System Sans-Serif)".

## Tests (red → green)
Verified red on the pre-change tree, green after (stashed production files, kept test edits, ran → 2 failed; restored → pass):
- `test_theme_default_fonts_are_system_sans_641` — pins both token defaults to a `system-ui`-led stack (fails on the old serif/Optima defaults).
- `test_profile_update_accepts_serif_as_display_641` — inverts the old "serif rejected for display" test (its premise is gone); plus a new negative test for a bogus display key.
- `test_font_allowlists_match_frontend_ssot_keys` (existing) stays green both ways — frontend keys ↔ backend allowlist remain in lock-step.

Full file: `tests/unit/test_api_v1_account.py` — **26 passed**. `tsc --noEmit` clean. SPA builds.

## Live e2e (cwn-local, patched backend + freshly-built SPA)
- **Default user (no preference), desktop 1280 + mobile 390×844:** computed `--font-display` and `--font-body` both resolve to the System sans stack; no inline override. This is the user-visible ask.
- **Serif still works:** selecting "Bookish Serif" for display persists (`ui_font_display=serif`) and applies (inline override → Iowan serif). Before the backend patch was deployed, the same save returned 400 and did **not** persist — confirming the allowlist genuinely gates the value.
- Both pickers show: Default (System Sans-Serif) · System Sans-Serif · Bookish Serif · Monospace.

## Tier
Fork-original UI change → `needs-review` (operator merges). No new deps / license / external URLs. Blast radius: two CSS default-token values + one dropdown option + backend allowlist entry; no template/route/CSRF surface changed.

Ships fix for #641.