### PR TITLE
fix(ui): shelves no longer blank-screen in the new UI (#784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+
+- **New UI: opening a shelf no longer shows a blank screen.** On v4.1.8, clicking any shelf — a manual shelf or a smart (magic) shelf — in the new UI left the page blank, and refreshing the browser did not recover it. The main book list, authors, series and other pages were unaffected. Rolling back to v4.1.7 was the only workaround. This is fixed; shelves open and list their books again. Thanks to @mrfearless and @Gauva1n for the reports (#784).
+
 ### Changed
 
 - **German interface: 19 strings that showed in English now appear in German.** The OPDS catalog descriptions (for example "Books sorted by series" and "Popular publications from this catalog based on rating") and the duplicate-scan progress messages were untranslated, so German users saw English there while the rest of the UI was translated. Filled in from pending German translations contributed upstream. Thanks to @djalexz85 and @fucx (Calibre-Web-Automated) and @ManuelDrescher (calibre-web).

--- a/frontend/e2e/shelf-render.spec.ts
+++ b/frontend/e2e/shelf-render.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, Page } from '@playwright/test';
+import { collectPageErrors, assertNoPageErrors } from './utils';
+
+/*
+ * #784 regression — selecting a shelf (manual OR magic) in the new UI rendered a
+ * blank screen on v4.1.8; a browser refresh could not recover it.
+ *
+ * Root cause was a React Rules-of-Hooks violation. The infinite-scroll
+ * `useIntersectionObserver` hook (adopted in v4.1.8) was called AFTER the
+ * loading/error early-returns in Shelf.tsx and MagicShelfView.tsx. On the first
+ * (loading) render the guard returned early, before the hook ran; once the data
+ * resolved the guard was skipped and the hook ran — so the hook count jumped
+ * loading→loaded and React threw "Rendered more hooks than during the previous
+ * render", crashing the page to blank. Catalog/Table wired the same hook in
+ * BEFORE their returns and were unaffected, which matched the report (the main
+ * book list worked, only shelves broke).
+ *
+ * The crash is content-independent — it fires as soon as the query resolves past
+ * the guard — so a single-book library (CI's seed) is enough to exercise it.
+ * Each test self-seeds via the REST API and cleans up the shelf it creates.
+ */
+
+async function csrfToken(page: Page): Promise<string> {
+  const res = await page.request.get('/api/v1/auth/csrf');
+  const body = (await res.json()) as { csrf_token: string };
+  return body.csrf_token;
+}
+
+test.describe('#784 shelves render (no Rules-of-Hooks crash)', () => {
+  test('a manual shelf with a book renders instead of blanking', async ({ page }) => {
+    const headers = { 'X-CSRFToken': await csrfToken(page) };
+
+    const booksRes = await page.request.get('/api/v1/books?per_page=1');
+    const books = (await booksRes.json()) as { total: number; items: Array<{ id: number }> };
+    test.skip((books.total ?? 0) < 1, 'no seeded book to shelve');
+    const bookId = books.items[0].id;
+
+    const created = await page.request.post('/api/v1/shelves', {
+      headers,
+      data: { name: `e2e-784-${Date.now()}` },
+    });
+    expect(created.ok(), 'shelf create should succeed').toBeTruthy();
+    const shelfId = ((await created.json()) as { id: number }).id;
+
+    try {
+      const add = await page.request.post(`/api/v1/shelves/${shelfId}/books/${bookId}`, { headers });
+      expect(add.ok(), 'adding the book to the shelf should succeed').toBeTruthy();
+
+      const errors = collectPageErrors(page);
+      await page.goto(`/app/shelf/${shelfId}`);
+
+      // The shelf must render its content (a book card) — not a blank screen.
+      await expect(page.locator('a[href*="/book/"]').first()).toBeVisible();
+      assertNoPageErrors(errors);
+    } finally {
+      await page.request.post(`/api/v1/shelves/${shelfId}/delete`, { headers }).catch(() => {});
+    }
+  });
+
+  test('a magic shelf renders instead of blanking', async ({ page }) => {
+    const headers = { 'X-CSRFToken': await csrfToken(page) };
+
+    const created = await page.request.post('/magicshelf', {
+      headers,
+      data: {
+        name: `e2e-784-magic-${Date.now()}`,
+        icon: '🪄',
+        rules: { condition: 'OR', rules: [{ id: 'title', operator: 'contains', value: 'a' }] },
+      },
+    });
+    expect(created.ok(), 'magic shelf create should succeed').toBeTruthy();
+    const body = (await created.json()) as { success: boolean; shelf_id?: number };
+    expect(body.success, 'magic shelf create should report success').toBeTruthy();
+    const shelfId = body.shelf_id;
+    expect(shelfId, 'magic shelf create should return an id').toBeTruthy();
+
+    try {
+      const errors = collectPageErrors(page);
+      await page.goto(`/app/magic/${shelfId}`);
+
+      // Past the crash point: the smart-shelf shell (its "Library" back link)
+      // renders whether or not the rule matched any books.
+      await expect(page.getByRole('link', { name: /library/i }).first()).toBeVisible();
+      assertNoPageErrors(errors);
+    } finally {
+      await page.request.post(`/magicshelf/${shelfId}/delete`, { headers }).catch(() => {});
+    }
+  });
+});

--- a/frontend/src/pages/MagicShelfView.tsx
+++ b/frontend/src/pages/MagicShelfView.tsx
@@ -40,6 +40,14 @@ export function MagicShelfView({ id }: { id: string }) {
     else setBooks((p) => dedupAppend(p, data.items));
   }, [data, id, isPlaceholderData]);
 
+  // Infinite-scroll sentinel. Called before the conditional early returns below
+  // so the hook order stays stable across the loading→loaded transition; `data`
+  // is undefined on the first render, so guard `enabled` null-safely (#784).
+  const sentinelRef = useIntersectionObserver({
+    onIntersect: () => setPage((p) => p + 1),
+    enabled: !!data && books.length < data.total && !isFetching,
+  });
+
   if (isLoading && !data) return <SpinnerCentered size={40} />;
   if (error || !data) {
     return <main className={styles.container}>
@@ -50,10 +58,6 @@ export function MagicShelfView({ id }: { id: string }) {
 
   const total = data.total;
   const hasMore = books.length < total;
-  const sentinelRef = useIntersectionObserver({
-    onIntersect: () => setPage((p) => p + 1),
-    enabled: hasMore && !isFetching,
-  });
 
   return (
     <main className={styles.container}>

--- a/frontend/src/pages/Shelf.tsx
+++ b/frontend/src/pages/Shelf.tsx
@@ -64,6 +64,17 @@ export function Shelf({ id }: { id: string }) {
     }
   }, [data, id, isPlaceholderData]);
 
+  // Infinite-scroll sentinel. This hook MUST be called before any conditional
+  // early return below — Rules of Hooks require a stable hook order across
+  // renders. `data` is undefined on the first (loading) render and populated on
+  // the next, so `enabled` is guarded null-safely rather than deriving it from
+  // the post-guard `total`/`hasMore` (#784: calling it after the guards made the
+  // hook count jump loading→loaded and crashed the shelf to a blank screen).
+  const sentinelRef = useIntersectionObserver({
+    onIntersect: () => setPage((p) => p + 1),
+    enabled: !!data && books.length < data.total && !isFetching,
+  });
+
   if (isLoading && !data) return <SpinnerCentered size={40} />;
   if (error || !data) {
     return (
@@ -78,10 +89,6 @@ export function Shelf({ id }: { id: string }) {
 
   const total = data.total;
   const hasMore = books.length < total;
-  const sentinelRef = useIntersectionObserver({
-    onIntersect: () => setPage((p) => p + 1),
-    enabled: hasMore && !isFetching,
-  });
   const canEdit = data.can_edit;
 
   const startRename = () => {


### PR DESCRIPTION
## Why
Ships fix for #784. On **v4.1.8**, opening any shelf in the new UI — manual or magic (smart) — rendered a **blank screen**, and a browser refresh could not recover it. Two independent reports: @mrfearless (QNAP docker) and @Gauva1n (docker compose); both had to roll back to v4.1.7. The main book list, authors, series, etc. were unaffected.

## Root cause
v4.1.8 adopted infinite scroll (`useIntersectionObserver`, from community PR #735). In `Shelf.tsx` and `MagicShelfView.tsx` the hook was called **after** the `if (isLoading && !data) return …` / `if (error || !data) return …` early-returns. The hook internally calls `useRef` + `useEffect`, so:

- first (loading) render → guard returns early, **before** the hook runs → N hooks
- data resolves → guard skipped → hook runs → **N+1 hooks**

React then throws **error #310 — "Rendered more hooks than during the previous render"** and unmounts the tree → blank `#root`. `Catalog.tsx` and `Table.tsx` placed the identical hook **before** their returns and never crashed — which is exactly why the reports said the main list worked but shelves didn't.

## Fix
Hoist `useIntersectionObserver` above the early returns in both pages (Rules of Hooks: stable hook order across renders), guarding `enabled` null-safely since `data` is undefined on the first render. This makes the two broken pages structurally identical to the already-working Catalog/Table.

## Validation — live red→green on real infra
Local Docker Desktop is down on the dev box, so the loop was run against **teenyverse** (Linux docker, same class as the QNAP reporter) which runs `:dev` (= main tip, the buggy code):

- **RED** (buggy build): `/app/shelf/<id>` → `#root` empty (0 children, blank), console `Error: Minified React error #310` with the stack going through `useRef` → the Shelf component.
- **Control** (same buggy build): `/app/table` renders fine (24 book links) — proving correct hook placement is unaffected.
- **GREEN** (this fix, built locally and `docker cp`'d into the container): the same shelf now renders its book and title; a magic shelf renders 156 books. No page errors.

Also adds `frontend/e2e/shelf-render.spec.ts` (self-seeds a manual + magic shelf via REST, asserts render + clean console). Note: the e2e job runs on release tags / `:dev` / manual dispatch, not on PRs, so it will exercise this on the release-tag gate. `npm run build` (tsc + vite) is green.

## Blast radius / gate
- Two `.tsx` edits + one e2e spec + CHANGELOG. No new deps, routes, auth/CSRF, or external URLs.
- Broken-first regression in the current release → autonomous-merge gate (CLAUDE.md rule 3); `/security-review` not applicable (no auth/route/subprocess/path surface).

Reported by @mrfearless and @Gauva1n (#784).