### PR TITLE
fix(ui): half-star ratings no longer render a shrunken star (#776)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,15 +23,14 @@ is for things you can see or feel when running the app.
 ### Fixed
 
 - **New UI: opening a shelf no longer shows a blank screen.** On v4.1.8, clicking any shelf — a manual shelf or a smart (magic) shelf — in the new UI left the page blank, and refreshing the browser did not recover it. The main book list, authors, series and other pages were unaffected. Rolling back to v4.1.7 was the only workaround. This is fixed; shelves open and list their books again. Thanks to @mrfearless and @Gauva1n for the reports (#784).
+- **Half-star ratings no longer draw a tiny star floating inside the outline.** In the new UI, a book with a half-star rating (3.5, 4.5, …) showed the fractional star as a shrunken miniature star sitting inside the empty outline on the book page. The partial star now fills cleanly from the left edge. Thanks to @KucharczykL for the report ([#776](https://github.com/new-usemame/Calibre-Web-NextGen/issues/776)).
+- The new UI could keep showing outdated interface translations after you upgraded — for example the French read button reverting to English "Read now" and the "mark as read" toggle showing the wrong wording, even though the fix had already shipped. The interface-text file the new UI loads now refreshes whenever it changes, so an upgrade always shows the current translations (a hard browser refresh clears any that were already cached). ([#615](https://github.com/new-usemame/Calibre-Web-NextGen/issues/615))
 
 ### Changed
 
 - The new UI now uses the readable System font by default for both headings and body text, instead of the bookish serif some readers found hard to read. If you prefer the old look, "Bookish Serif" is still one click away under Account → UI display/body font (it's now offered for headings too). ([#641](https://github.com/new-usemame/Calibre-Web-NextGen/issues/641))
 - **German interface: 19 strings that showed in English now appear in German.** The OPDS catalog descriptions (for example "Books sorted by series" and "Popular publications from this catalog based on rating") and the duplicate-scan progress messages were untranslated, so German users saw English there while the rest of the UI was translated. Filled in from pending German translations contributed upstream. Thanks to @djalexz85 and @fucx (Calibre-Web-Automated) and @ManuelDrescher (calibre-web).
 - **Ukrainian interface: 141 more strings now appear in Ukrainian.** Error messages, the metadata review queue, the cover/thumbnail cache tools and other panels that previously showed English for Ukrainian users are now translated. Filled in from pending Ukrainian translations contributed upstream. Thanks to @Demelja (Calibre-Web-Automated).
-
-### Fixed
-- The new UI could keep showing outdated interface translations after you upgraded — for example the French read button reverting to English "Read now" and the "mark as read" toggle showing the wrong wording, even though the fix had already shipped. The interface-text file the new UI loads now refreshes whenever it changes, so an upgrade always shows the current translations (a hard browser refresh clears any that were already cached). ([#615](https://github.com/new-usemame/Calibre-Web-NextGen/issues/615))
 
 ## [v4.1.8] - 2026-07-10
 

--- a/frontend/src/components/StarRating.module.css
+++ b/frontend/src/components/StarRating.module.css
@@ -29,4 +29,9 @@
 .fill {
   display: block;
   color: var(--accent);
+  /* The global reset caps every svg at max-width: 100%. Inside the fractional
+     clip wrapper that would SCALE the star down to the wrapper's width (a 50%
+     fill became a tiny star floating in the outline, #776) instead of letting
+     overflow:hidden crop it. Restore the full-size glyph so the clip crops. */
+  max-width: none;
 }

--- a/frontend/src/components/StarRating.tsx
+++ b/frontend/src/components/StarRating.tsx
@@ -8,6 +8,9 @@ import styles from './StarRating.module.css';
  *  single labelled image to assistive tech rather than five ambiguous glyphs. */
 export function StarRating({ rating, size = 16 }: { rating: number; size?: number }) {
   const t = useT();
+  // Callers guard against unset ratings, but stay safe if one slips through:
+  // NaN/undefined would otherwise poison the fill math and the aria label.
+  if (!Number.isFinite(rating) || rating <= 0) return null;
   const stars = Math.max(0, Math.min(5, rating / 2));
   const shown = Number.isInteger(stars) ? String(stars) : stars.toFixed(1);
   const label = t('Rated {rating} out of 5', { rating: shown });

--- a/tests/unit/test_776_star_rating_fill.py
+++ b/tests/unit/test_776_star_rating_fill.py
@@ -1,0 +1,68 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for fork issue #776: half-star ratings rendered as a
+tiny star floating inside the outline instead of a half-filled star.
+
+``StarRating`` encodes a fractional fill by wrapping a full-size filled
+star in an ``overflow: hidden`` span whose *width* is the fill percentage.
+The global reset (``frontend/src/styles/global.css``) applies
+``svg { max-width: 100%; }``, so the "full-size" star inside a 50%-wide
+wrapper was *scaled down to 50%* (SVGs shrink to their container under a
+max-width cap, preserving aspect ratio) rather than cropped — every odd
+Calibre rating (1, 3, 5, 7, 9 → x.5 stars) drew a shrunken star.
+
+The fix opts the fill glyph out of the reset (``max-width: none`` on the
+module's ``.fill`` class, which out-specifies the type selector) and makes
+the component defensive against non-finite/unset ratings so a ``NaN`` can
+never reach the width math or the aria label.
+
+Both pins fail on pre-fix code and pass on the branch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPONENT = REPO_ROOT / "frontend" / "src" / "components" / "StarRating.tsx"
+MODULE_CSS = REPO_ROOT / "frontend" / "src" / "components" / "StarRating.module.css"
+GLOBAL_CSS = REPO_ROOT / "frontend" / "src" / "styles" / "global.css"
+
+
+def test_fill_glyph_opts_out_of_global_svg_max_width():
+    """The fill star must not shrink to the clip wrapper's width (#776)."""
+    css = MODULE_CSS.read_text(encoding="utf-8")
+    fill_rule = css.split(".fill {", 1)[1].split("}", 1)[0]
+    assert "max-width: none" in fill_rule, (
+        "StarRating.module.css .fill must set 'max-width: none' — the global "
+        "reset's 'svg { max-width: 100%; }' otherwise scales the fill star "
+        "down to the fractional wrapper width instead of letting "
+        "overflow:hidden crop it (issue #776)."
+    )
+
+
+def test_global_reset_still_caps_svgs():
+    """Guards the premise: if the reset drops the svg cap, revisit the pin."""
+    css = GLOBAL_CSS.read_text(encoding="utf-8")
+    assert "svg { display: block; max-width: 100%; }" in css.replace(
+        "img, picture, ", ""
+    ) or "max-width: 100%" in css, (
+        "global.css no longer caps svg max-width — the .fill override in "
+        "StarRating.module.css may be removable, update test_776 accordingly."
+    )
+
+
+def test_component_guards_non_finite_ratings():
+    """NaN/undefined must never reach the fill-width math or aria label."""
+    src = COMPONENT.read_text(encoding="utf-8")
+    assert "Number.isFinite(rating)" in src, (
+        "StarRating must early-return for non-finite ratings so an unset "
+        "rating can never produce 'width: NaN%' or a 'Rated NaN out of 5' "
+        "label (issue #776)."
+    )
+    guard = src.index("Number.isFinite(rating)")
+    math = src.index("rating / 2")
+    assert guard < math, "The finite-rating guard must run before the fill math."


### PR DESCRIPTION
## Why

Reporter screenshot on #776: a book with a half-star rating drew the fractional star as a tiny star floating inside the empty outline.

## Root cause

`StarRating` encodes fractional fill as a full-size filled star inside an `overflow:hidden` wrapper whose width is the fill percentage. The global reset (`frontend/src/styles/global.css`) applies `svg { max-width: 100%; }`, so the "full-size" star was **scaled down to the wrapper width** (SVGs shrink to fit under a max-width cap, preserving aspect ratio) instead of being cropped. Every odd Calibre rating (1/3/5/7/9 → x.5 stars) hit it.

## Fix

- `StarRating.module.css`: `.fill { max-width: none; }` — the class out-specifies the reset's type selector, so the glyph stays full-size and the wrapper crops it.
- `StarRating.tsx`: early-return for non-finite/unset ratings (defense-in-depth; a NaN would otherwise poison the width math and the aria label with "Rated NaN out of 5").

## Verification

- `tests/unit/test_776_star_rating_fill.py` — red on pre-fix code (2 failures confirmed via stash), green on branch.
- `npm run build` (tsc + vite) passes.
- Visual verification against the local container in the session verification pass (before/after screenshots).

Addresses #776