### PR TITLE
fix(hardcover): HARDCOVER_TOKEN env works everywhere + HARDCOVER_TOKEN_FILE (#743)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **The `HARDCOVER_TOKEN` environment variable now works everywhere.** Setting the Hardcover API token via the environment used to be honored by some features but ignored by others — most visibly, the Fetch Metadata panel told you to "set a Hardcover API key" even though your env token worked, and the admin page gave no hint a token was active. All features now resolve the token the same way, the admin page shows a note when an environment token is in use, and you can keep the secret out of your compose file entirely with the new `HARDCOVER_TOKEN_FILE` (docker-secrets style). Thanks to @KucharczykL for the report ([#743](https://github.com/new-usemame/Calibre-Web-NextGen/issues/743)).
 - **New UI: opening a shelf no longer shows a blank screen.** On v4.1.8, clicking any shelf — a manual shelf or a smart (magic) shelf — in the new UI left the page blank, and refreshing the browser did not recover it. The main book list, authors, series and other pages were unaffected. Rolling back to v4.1.7 was the only workaround. This is fixed; shelves open and list their books again. Thanks to @mrfearless and @Gauva1n for the reports (#784).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -440,7 +440,15 @@ Without this, CWA may see different client IPs across requests and trigger Sessi
 
 Hardcover then appears in the Fetch Metadata modal.
 
-If you set the token through the `HARDCOVER_TOKEN` environment variable, the **Hardcover API Key** field in the admin UI stays empty — that field only shows a key entered through the UI, and an environment-supplied token is not echoed back into the page. The token still works; Hardcover results appearing in the Fetch Metadata modal confirm it is active.
+If you set the token through the `HARDCOVER_TOKEN` environment variable, the **Hardcover API Key** field in the admin UI stays empty — that field only shows a key entered through the UI, and an environment-supplied token is not echoed back into the page. When an environment token is active, the admin page shows a note under the field saying so; a key typed into the field overrides the environment value.
+
+To keep the token out of your compose file entirely, point `HARDCOVER_TOKEN_FILE` at a file containing just the token (docker-secrets style):
+
+```yaml
+   - HARDCOVER_TOKEN_FILE=/run/secrets/hardcover_token
+```
+
+Precedence: UI-configured key → `HARDCOVER_TOKEN` → `HARDCOVER_TOKEN_FILE`.
 
 ### KOReader sync
 

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -241,12 +241,8 @@ def trigger_hardcover_auto_fetch():
     
     try:
         # Check if token is available
-        from os import getenv
-        token_available = bool(
-            getattr(config, "config_hardcover_token", None) or 
-            getenv("HARDCOVER_TOKEN")
-        )
-        
+        token_available = bool(config.resolved_hardcover_token())
+
         if not token_available:
             show_text['text'] = _('Error: No Hardcover token available. Set HARDCOVER_TOKEN environment variable or configure in Basic Configuration.')
             return json.dumps(show_text), 400

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -222,6 +222,22 @@ class _Settings(_Base):
 
 
 # Class holds all application specific settings in calibre-web automated
+def _read_secret_file(path):
+    """Read a docker-secrets-style token file (fork #743).
+
+    Returns the stripped first line, or "" when the variable is unset, the
+    file is missing, or it is unreadable — a broken secret mount must
+    degrade to "no token", never crash config loading.
+    """
+    if not path:
+        return ""
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return fh.readline().strip()
+    except OSError:
+        return ""
+
+
 class ConfigSQL(object):
     # pylint: disable=no-member
     def __init__(self):
@@ -394,6 +410,38 @@ class ConfigSQL(object):
                     and 'secret' not in k.lower():
                 storage[k] = v
         return storage
+
+    def resolved_hardcover_token(self):
+        """Global Hardcover token: the admin-configured value, else the
+        HARDCOVER_TOKEN environment variable, else the file named by
+        HARDCOVER_TOKEN_FILE (docker-secrets style) — fork #743.
+
+        Single source of truth for every global-token consumer (metadata
+        provider, scheduler, auto-fetch task, admin trigger, zero-result
+        classifier). The env value is resolved per call rather than copied
+        into the config row so an admin form save never persists it to the
+        DB and container-level rotation keeps working. A stray "Bearer "
+        prefix (common copy-paste failure) is trimmed. Per-USER tokens are
+        a separate, deliberate concept and are not consulted here.
+        """
+        raw = (
+            self.config_hardcover_token
+            or os.environ.get("HARDCOVER_TOKEN")
+            or _read_secret_file(os.environ.get("HARDCOVER_TOKEN_FILE"))
+            or ""
+        )
+        return raw.replace("Bearer ", "").strip()
+
+    def hardcover_token_from_env(self):
+        """True when the active global token comes from the environment —
+        lets the admin form explain why its field is empty yet Hardcover
+        works (fork #743)."""
+        if (self.config_hardcover_token or "").strip():
+            return False
+        return bool(
+            (os.environ.get("HARDCOVER_TOKEN") or "").strip()
+            or _read_secret_file(os.environ.get("HARDCOVER_TOKEN_FILE"))
+        )
 
     def load(self):
         """Load all configuration values from the underlying storage."""

--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -1062,11 +1062,7 @@ def set_cwa_settings():
         cwa_settings = cwa_db.get_cwa_settings()
 
     # Check if Hardcover token is available
-    from os import getenv
-    hardcover_token_available = bool(
-        getattr(config, "config_hardcover_token", None) or 
-        getenv("HARDCOVER_TOKEN")
-    )
+    hardcover_token_available = bool(config.resolved_hardcover_token())
 
 
     next_scan_run = get_next_duplicate_scan_run(cwa_settings)

--- a/cps/metadata_provider/hardcover.py
+++ b/cps/metadata_provider/hardcover.py
@@ -162,8 +162,7 @@ class Hardcover(Metadata):
         candidate_tokens = []
         for raw in (
             getattr(current_user, "hardcover_token", None),
-            getattr(config, "config_hardcover_token", None),
-            getenv("HARDCOVER_TOKEN"),
+            config.resolved_hardcover_token(),
         ):
             if not raw:
                 continue

--- a/cps/schedule.py
+++ b/cps/schedule.py
@@ -243,17 +243,13 @@ def _schedule_hardcover_auto_fetch(scheduler, timezone_info):
             _sys.path.insert(1, '/app/calibre-web-automated/scripts/')
         from cwa_db import CWA_DB
         from .tasks.auto_hardcover_id import TaskAutoHardcoverID
-        from os import getenv
 
         db = CWA_DB()
         cwa_settings = db.get_cwa_settings()
         
         # Check if enabled and token available
         enabled = bool(cwa_settings.get('hardcover_auto_fetch_enabled', False))
-        token_available = bool(
-            getattr(config, "config_hardcover_token", None) or 
-            getenv("HARDCOVER_TOKEN")
-        )
+        token_available = bool(config.resolved_hardcover_token())
         
         if not enabled or not token_available:
             return

--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -296,7 +296,9 @@ def _classify_empty_provider(provider) -> tuple:
     """
     pid = getattr(provider, "__id__", "")
     if pid == "hardcover":
-        token = getattr(config, "config_hardcover_token", None)
+        # Resolve like the provider itself (DB value or HARDCOVER_TOKEN env,
+        # #743) — an env-supplied token must not trigger the missing-key hint.
+        token = config.resolved_hardcover_token()
         if not token:
             return ("missing_key",
                     "Set a Hardcover API key in Admin → Configuration → "

--- a/cps/tasks/auto_hardcover_id.py
+++ b/cps/tasks/auto_hardcover_id.py
@@ -177,12 +177,8 @@ class TaskAutoHardcoverID(CalibreTask):
             self.calibre_db.session.close()
 
     def _get_hardcover_token(self) -> Optional[str]:
-        """Get Hardcover token from environment or config"""
-        token = (
-            getattr(config, "config_hardcover_token", None)
-            or getenv("HARDCOVER_TOKEN")
-        )
-        return token
+        """Get Hardcover token from config or environment (#743)."""
+        return config.resolved_hardcover_token() or None
 
     def _get_books_without_hardcover_id(self) -> List[int]:
         """

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -280,6 +280,9 @@
         <label for="config_hardcover_token">{{_('Hardcover API Key')}}</label>
         <input type="text" class="form-control" id="config_hardcover_token" name="config_hardcover_token" value="{% if config.config_hardcover_token != None %}{{ config.config_hardcover_token }}{% endif %}" autocomplete="off">
         <div class="help-block">{{_('Free key from https://hardcover.app/account/api — required for Hardcover metadata results.')}}</div>
+        {% if config.hardcover_token_from_env() %}
+        <div class="help-block">{{_('A token from the HARDCOVER_TOKEN environment variable is currently active. It is not shown here; a key entered in this field would override it.')}}</div>
+        {% endif %}
       </div>
     </div>
     <div class="form-group">

--- a/tests/unit/test_479_hardcover_token_fallback.py
+++ b/tests/unit/test_479_hardcover_token_fallback.py
@@ -37,12 +37,22 @@ def _resp(status, data=None):
     return _R()
 
 
+def _cfg(token):
+    """Real ConfigSQL instance so the provider's token resolution (#743's
+    resolved_hardcover_token) is exercised, not a lookalike."""
+    from cps.config_sql import ConfigSQL
+    cfg = ConfigSQL()
+    cfg.config_hardcover_token = token
+    return cfg
+
+
 def test_search_falls_back_to_global_when_user_token_rejected(monkeypatch):
     from cps.metadata_provider import hardcover as hc
 
     monkeypatch.setattr(hc, "current_user", types.SimpleNamespace(hardcover_token="EXPIRED_USER"))
-    monkeypatch.setattr(hc, "config", types.SimpleNamespace(config_hardcover_token="VALID_GLOBAL"))
+    monkeypatch.setattr(hc, "config", _cfg("VALID_GLOBAL"))
     monkeypatch.delenv("HARDCOVER_TOKEN", raising=False)
+    monkeypatch.delenv("HARDCOVER_TOKEN_FILE", raising=False)
 
     calls = []
 
@@ -69,8 +79,9 @@ def test_search_aborts_only_when_every_token_rejected(monkeypatch):
     from cps.metadata_provider import hardcover as hc
 
     monkeypatch.setattr(hc, "current_user", types.SimpleNamespace(hardcover_token="BAD1"))
-    monkeypatch.setattr(hc, "config", types.SimpleNamespace(config_hardcover_token="BAD2"))
+    monkeypatch.setattr(hc, "config", _cfg("BAD2"))
     monkeypatch.delenv("HARDCOVER_TOKEN", raising=False)
+    monkeypatch.delenv("HARDCOVER_TOKEN_FILE", raising=False)
 
     calls = []
 
@@ -94,8 +105,9 @@ def test_token_bearer_prefix_and_whitespace_trimmed(monkeypatch):
     from cps.metadata_provider import hardcover as hc
 
     monkeypatch.setattr(hc, "current_user", types.SimpleNamespace(hardcover_token="  Bearer abc123\n"))
-    monkeypatch.setattr(hc, "config", types.SimpleNamespace(config_hardcover_token=None))
+    monkeypatch.setattr(hc, "config", _cfg(None))
     monkeypatch.delenv("HARDCOVER_TOKEN", raising=False)
+    monkeypatch.delenv("HARDCOVER_TOKEN_FILE", raising=False)
 
     sent = []
 

--- a/tests/unit/test_743_hardcover_env_token.py
+++ b/tests/unit/test_743_hardcover_env_token.py
@@ -1,0 +1,122 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for fork issue #743: the documented ``HARDCOVER_TOKEN``
+environment variable only worked in *some* code paths.
+
+The env var was bolted on as scattered ``... or getenv("HARDCOVER_TOKEN")``
+fallbacks. Consumers that read ``config.config_hardcover_token`` directly
+never saw it — most visibly the Fetch Metadata modal's zero-result
+classifier (``search_metadata.py``), which told users with a working env
+token to "set a Hardcover API key", and the admin form, which offered no
+hint that an environment token was active.
+
+The fix routes every global-token consumer through one resolver,
+``ConfigSQL.resolved_hardcover_token()`` (DB value → HARDCOVER_TOKEN →
+HARDCOVER_TOKEN_FILE, "Bearer "-trimmed), adds the docker-secrets-style
+``HARDCOVER_TOKEN_FILE`` variant the reporter asked for, and surfaces an
+"env token is active" note on the admin form.
+
+The behavioural tests fail on pre-fix code (no resolver existed); the
+source-pins fail if a consumer regresses to reading the raw column.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _bare_config():
+    from cps.config_sql import ConfigSQL
+
+    cfg = ConfigSQL()
+    cfg.config_hardcover_token = None
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("HARDCOVER_TOKEN", raising=False)
+    monkeypatch.delenv("HARDCOVER_TOKEN_FILE", raising=False)
+
+
+def test_env_token_resolves_and_trims_bearer(monkeypatch):
+    cfg = _bare_config()
+    monkeypatch.setenv("HARDCOVER_TOKEN", " Bearer env-tok ")
+    assert cfg.resolved_hardcover_token() == "env-tok"
+    assert cfg.hardcover_token_from_env() is True
+
+
+def test_db_value_wins_over_env(monkeypatch):
+    cfg = _bare_config()
+    cfg.config_hardcover_token = "db-tok"
+    monkeypatch.setenv("HARDCOVER_TOKEN", "env-tok")
+    assert cfg.resolved_hardcover_token() == "db-tok"
+    assert cfg.hardcover_token_from_env() is False
+
+
+def test_token_file_fallback(monkeypatch, tmp_path):
+    cfg = _bare_config()
+    secret = tmp_path / "hardcover_token"
+    secret.write_text("file-tok\n", encoding="utf-8")
+    monkeypatch.setenv("HARDCOVER_TOKEN_FILE", str(secret))
+    assert cfg.resolved_hardcover_token() == "file-tok"
+    assert cfg.hardcover_token_from_env() is True
+
+
+def test_missing_token_file_degrades_to_no_token(monkeypatch, tmp_path):
+    cfg = _bare_config()
+    monkeypatch.setenv("HARDCOVER_TOKEN_FILE", str(tmp_path / "nope"))
+    assert cfg.resolved_hardcover_token() == ""
+    assert cfg.hardcover_token_from_env() is False
+
+
+def test_no_sources_means_empty():
+    cfg = _bare_config()
+    assert cfg.resolved_hardcover_token() == ""
+    assert cfg.hardcover_token_from_env() is False
+
+
+# --- source-pins: consumers must go through the resolver -------------------
+
+_CONSUMERS = [
+    ("cps/search_metadata.py", "the Fetch Metadata zero-result classifier"),
+    ("cps/admin.py", "the manual Hardcover trigger"),
+    ("cps/schedule.py", "the auto-fetch scheduler gate"),
+    ("cps/cwa_functions.py", "the CWA settings page gate"),
+    ("cps/tasks/auto_hardcover_id.py", "the auto-hardcover-id task"),
+    ("cps/metadata_provider/hardcover.py", "the metadata provider"),
+]
+
+
+@pytest.mark.parametrize("rel,what", _CONSUMERS)
+def test_consumer_uses_resolver(rel, what):
+    src = (REPO_ROOT / rel).read_text(encoding="utf-8")
+    assert "resolved_hardcover_token()" in src, (
+        f"{rel} ({what}) must resolve the global Hardcover token through "
+        "config.resolved_hardcover_token() so DB, HARDCOVER_TOKEN and "
+        "HARDCOVER_TOKEN_FILE behave identically everywhere (issue #743)."
+    )
+
+
+def test_classifier_does_not_read_raw_column():
+    src = (REPO_ROOT / "cps/search_metadata.py").read_text(encoding="utf-8")
+    assert 'getattr(config, "config_hardcover_token"' not in src, (
+        "search_metadata.py must not read the raw config column — that is "
+        "exactly the path that ignored env tokens and produced the bogus "
+        "'set a Hardcover API key' hint (issue #743)."
+    )
+
+
+def test_admin_form_mentions_env_token():
+    tpl = (REPO_ROOT / "cps/templates/config_edit.html").read_text(encoding="utf-8")
+    assert "hardcover_token_from_env()" in tpl, (
+        "config_edit.html must tell admins when an environment token is "
+        "active — the silent empty field is what got #743 reported."
+    )


### PR DESCRIPTION
## Why

#743: README documents `HARDCOVER_TOKEN`, but setting it appeared to do nothing — the admin field stays empty (by design, but with no hint), and the Fetch Metadata panel's zero-result classifier read only the DB column, so users with a working env token were told to "set a Hardcover API key".

## Root cause

The env var was implemented as scattered `... or getenv("HARDCOVER_TOKEN")` fallbacks. Consumers reading `config.config_hardcover_token` directly (`search_metadata.py` classifier, admin template) never saw the env token — a single-source-of-truth violation.

## Fix

- `ConfigSQL.resolved_hardcover_token()`: one resolver — DB value → `HARDCOVER_TOKEN` → `HARDCOVER_TOKEN_FILE` (docker-secrets style, new, requested by the reporter), "Bearer "-trimmed. Resolved per call, never persisted to the DB (an admin form save can't capture the secret; rotation keeps working).
- All six global-token consumers rewired through it (classifier, admin trigger, scheduler gate, CWA settings gate, auto-hardcover-id task, metadata provider).
- Admin form now shows a note when an environment token is active.
- README documents the file variant and the precedence order.
- Per-user tokens untouched (separate concept).

## Verification

- `tests/unit/test_743_hardcover_env_token.py`: behavioural (env/file/precedence/missing-file degradation) + source-pins on every consumer — 13 failures on pre-fix code, green on branch.
- `tests/unit/test_479_hardcover_token_fallback.py` upgraded to use a real `ConfigSQL` so the provider's actual resolution path is exercised (was a SimpleNamespace lookalike).
- Targeted sweep: 22 passed (hardcover/search_metadata/schedule/config_sql selection).
- Container verification with `HARDCOVER_TOKEN` set in this session's verification pass.

New template strings go through the standard translation pipeline (auto-extraction on main).

Addresses #743