### PR TITLE
feat(ui): Refresh-library button in the new UI (#780, #665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ is for things you can see or feel when running the app.
 
 ### Added
 
+- **The new UI now has a Refresh library button, so a manual re-scan is one click away again.** The redesigned library page shipped without any equivalent of the classic header's "Refresh Library" action, so after dropping new files into the ingest folder there was no way to trigger a scan from the new UI — the books just didn't appear until the next automatic sweep. The library toolbar now has a refresh button that starts the background scan, shows a status line while it runs, and refreshes the grid so newly-added books show up. Thanks to the reporters (#780, #665). ([#780](https://github.com/new-usemame/Calibre-Web-NextGen/issues/780), [#665](https://github.com/new-usemame/Calibre-Web-NextGen/issues/665))
 - **The new UI's book editor suggests existing tags, authors, series, publishers, and languages as you type again.** When you edit a book's metadata in the redesigned interface, each of these fields now offers a dropdown of values already in your library, so a typo no longer quietly creates a near-duplicate tag (`sci-fi` vs `scifi`) or series. Pick from the list, or keep typing to enter a brand-new value — the classic editor's autocomplete is back. Thanks to @magdalar for the report. ([#741](https://github.com/new-usemame/Calibre-Web-NextGen/issues/741), [#778](https://github.com/new-usemame/Calibre-Web-NextGen/issues/778), [#689](https://github.com/new-usemame/Calibre-Web-NextGen/issues/689))
 
 ### Fixed

--- a/cps/spa_strings.py
+++ b/cps/spa_strings.py
@@ -263,6 +263,13 @@ _("{label} hidden")
 _("{label} restored")
 _("Could not save sidebar. Please try again.")
 
+# #780 / #665 — manual library scan button in the catalog toolbar (Catalog.tsx).
+# The SPA had no equivalent of the classic header's "Refresh Library" action.
+# Deliberately a distinct (lowercase-l) msgid from the classic "Refresh Library"
+# so the button can read in sentence case; anchored so the auto-translation job
+# keeps it across re-extracts.
+_("Refresh library")
+
 
 # ==== BEGIN AUTOGEN (scripts/extract_spa_strings.py --write) ====
 # Auto-anchored SPA-only msgids — every t('literal') in frontend/src that

--- a/frontend/src/pages/Catalog.module.css
+++ b/frontend/src/pages/Catalog.module.css
@@ -298,3 +298,53 @@
   cursor: pointer;
   flex: none;
 }
+
+/* ---- Manual library refresh button (#780 / #665) -------------------------- */
+/* Mirrors the view-settings gear: a 38×38 icon button so it matches the
+   neighbouring toolbar controls and wraps with them on narrow screens. */
+.refreshBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  flex: none;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-3);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease),
+              background var(--dur-fast) var(--ease);
+}
+.refreshBtn:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.refreshBtn:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+
+/* Spin the RefreshCw glyph while a scan is in flight (same cadence as the
+   CoverPicker refresh spinner). */
+.refreshIconSpin {
+  animation: cpspin 1s linear infinite;
+}
+@keyframes cpspin {
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .refreshIconSpin { animation: none; }
+}
+
+/* Inline scan status (aria-live polite). Sits between the toolbar and the grid. */
+.refreshStatus,
+.refreshStatusError {
+  margin: 0 0 var(--sp-4);
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+}
+.refreshStatusError {
+  color: var(--danger);
+}

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Link, useSearch } from 'wouter';
-import { Search, ChevronLeft, SlidersHorizontal, ListChecks, Settings } from 'lucide-react';
+import { Search, ChevronLeft, SlidersHorizontal, ListChecks, Settings, RefreshCw } from 'lucide-react';
 import { useIntersectionObserver } from '../lib/useIntersectionObserver';
 import { BookCard } from '../components/BookCard';
 import { BulkBar } from '../components/BulkBar';
@@ -9,7 +10,7 @@ import { EmptyState } from '../components/EmptyState';
 import { DiscoverSection } from '../components/DiscoverSection';
 import { useBooks, useEntityList, ENTITY_PLURAL, useMe } from '../lib/queries';
 import type { EntityKind, ReadFilter, DiscoveryView } from '../lib/queries';
-import type { Book } from '../lib/api';
+import { apiPost, apiGet, type Book } from '../lib/api';
 import { saveCatalog, loadCatalog } from '../lib/scrollCache';
 import { usePersistentBool } from '../lib/usePersistentBool';
 import { useT } from '../lib/i18n';
@@ -87,8 +88,87 @@ function dedupAppend(prev: Book[], next: Book[]): Book[] {
   return [...merged, ...fresh];
 }
 
+// Manual library scan (fork #780 / #665). The new UI had no equivalent of the
+// classic header's "Refresh Library" button, so users who drop new files into
+// the ingest folder had no way to trigger a re-scan from the SPA. POST
+// /cwa-library-refresh starts a background ingest scan (csrf-exempt, session-
+// authed — note these routes are NOT under /api/v1, so apiPost/apiGet only add
+// the reverse-proxy mount prefix + credentials). We then poll
+// /cwa-library-refresh/messages roughly once a second until the scan posts a
+// result (or the ~2min cap elapses), then invalidate the catalog/discover/about
+// queries so newly-ingested books + counts surface without a manual reload.
+const LIBRARY_REFRESH_POLL_MS = 1000;
+const LIBRARY_REFRESH_MAX_MS = 120000;
+
+function useLibraryRefresh() {
+  const qc = useQueryClient();
+  const [isRefreshing, setRefreshing] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const deadlineRef = useRef(0);
+  const inFlightRef = useRef(false);
+
+  const stop = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    setError(false);
+    setMessage('');
+    try {
+      const data = await apiPost<{ message: string }>('/cwa-library-refresh');
+      setMessage(data.message ?? '');
+      deadlineRef.current = Date.now() + LIBRARY_REFRESH_MAX_MS;
+      // Guard against a double-click leaving two intervals running.
+      stop();
+      timerRef.current = setInterval(async () => {
+        if (inFlightRef.current) return; // skip overlapping polls
+        if (Date.now() >= deadlineRef.current) {
+          stop();
+          setRefreshing(false);
+          return;
+        }
+        inFlightRef.current = true;
+        try {
+          const res = await apiGet<{ messages: string[] }>('/cwa-library-refresh/messages');
+          if (res.messages && res.messages.length > 0) {
+            stop();
+            setMessage(res.messages.join('  '));
+            setRefreshing(false);
+            // Newly scanned books / metadata should now appear in the catalog.
+            void qc.invalidateQueries({ queryKey: ['books'] });
+            void qc.invalidateQueries({ queryKey: ['discover-strip'] });
+            void qc.invalidateQueries({ queryKey: ['about'] });
+          }
+        } catch {
+          // A transient poll failure is rare (the endpoint is an in-memory read);
+          // keep polling until the deadline rather than aborting the scan.
+        } finally {
+          inFlightRef.current = false;
+        }
+      }, LIBRARY_REFRESH_POLL_MS);
+    } catch (err) {
+      stop();
+      setRefreshing(false);
+      setError(true);
+      setMessage(err instanceof Error ? err.message : '');
+    }
+  }, [qc, stop]);
+
+  // Clean up the poll interval if the catalog unmounts mid-scan.
+  useEffect(() => () => stop(), [stop]);
+
+  return { isRefreshing, message, error, refresh };
+}
+
 export function Catalog({ entityKind, entityId, view }: CatalogProps) {
   const t = useT();
+  const libraryRefresh = useLibraryRefresh();
   const filtered = !!entityKind;
   const isView = !!view;
   const isSeries = entityKind === 'series';
@@ -378,6 +458,20 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
           <span className={styles.selectLabel}>{selecting ? t('Done') : t('Select')}</span>
         </button>
 
+        {/* Manual library scan (fork #780 / #665) — the SPA equivalent of the
+            classic header's "Refresh Library" button. Spins while the background
+            ingest scan runs; the result is announced in the status line below. */}
+        <button
+          type="button"
+          className={styles.refreshBtn}
+          onClick={() => { void libraryRefresh.refresh(); }}
+          disabled={libraryRefresh.isRefreshing}
+          title={t('Refresh library')}
+          aria-label={t('Refresh library')}
+        >
+          <RefreshCw size={15} className={libraryRefresh.isRefreshing ? styles.refreshIconSpin : undefined} />
+        </button>
+
         {/* View settings (library landing only) — currently houses the Discover
             section toggle; a natural home for future per-view preferences. */}
         {!hideLibraryControls && (
@@ -410,6 +504,18 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
           </div>
         )}
       </div>
+
+      {/* Library-scan status (aria-live so the "please wait" → "complete"
+          transition is announced, SC 4.1.3). Hidden when idle + empty. */}
+      {(libraryRefresh.isRefreshing || libraryRefresh.message) && (
+        <p
+          className={libraryRefresh.error ? styles.refreshStatusError : styles.refreshStatus}
+          role="status"
+          aria-live="polite"
+        >
+          {libraryRefresh.message}
+        </p>
+      )}
 
       {/* Discover: random picks, library landing only (not while searching). */}
       {!hideLibraryControls && !search && !discoverHidden && (

--- a/tests/unit/test_780_refresh_library_button.py
+++ b/tests/unit/test_780_refresh_library_button.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Source-pin tests for the new-UI "Refresh library" button (#780 / #665).
+
+The redesigned SPA shipped without any equivalent of the classic header's
+"Refresh Library" action, so users who drop new files into the ingest folder
+had no way to trigger a manual re-scan from the new UI (a duplicate cluster:
+#780 and #665 both report the same missing action).
+
+The backend contract already existed (cps/cwa_functions.py):
+  POST /cwa-library-refresh        -> starts a background scan, 200 {message}
+  GET  /cwa-library-refresh/messages -> {messages:[...]} (poll until non-empty)
+
+These tests pin that the library page wires a RefreshCw button to those routes,
+polls the messages endpoint, clears the poll interval (no leaked timer / stray
+invalidate after unmount), exposes the action to screen readers, and keeps the
+new msgid anchored in the catalog so it stays translatable.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CATALOG_TSX = REPO_ROOT / "frontend" / "src" / "pages" / "Catalog.tsx"
+SPA_STRINGS = REPO_ROOT / "cps" / "spa_strings.py"
+
+
+def _catalog() -> str:
+    return CATALOG_TSX.read_text(encoding="utf-8")
+
+
+def _spa_strings() -> str:
+    return SPA_STRINGS.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# (1) RefreshCw icon button wired to the refresh route
+# ---------------------------------------------------------------------------
+
+def test_catalog_imports_refreshcw_icon():
+    src = _catalog()
+    assert re.search(r"\bRefreshCw\b", src), (
+        "Catalog must import + render the lucide RefreshCw icon for the button"
+    )
+
+
+def test_refresh_button_calls_library_refresh_route():
+    src = _catalog()
+    # The POST that kicks off the background scan (csrf-exempt, NOT under /api/v1).
+    assert "/cwa-library-refresh" in src, (
+        "the refresh action must POST to the /cwa-library-refresh contract route"
+    )
+    # The button's onClick must invoke the refresh handler (not be a dead button).
+    assert re.search(r"onClick=\{[^}]*\.refresh\(\)", src), (
+        "the RefreshCw button onClick must call the refresh handler"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (2) Polls the messages endpoint until the scan reports a result
+# ---------------------------------------------------------------------------
+
+def test_polls_messages_endpoint():
+    src = _catalog()
+    assert "/cwa-library-refresh/messages" in src, (
+        "must poll GET /cwa-library-refresh/messages for the scan result"
+    )
+
+
+def test_poll_interval_is_cleared():
+    """A leaked setInterval would keep polling (and invalidate queries) after
+    the catalog unmounts. The poll must be cleared — clearInterval on the stored
+    timer, with the cleanup wired to unmount."""
+    src = _catalog()
+    assert "clearInterval" in src or "AbortController" in src, (
+        "the poll interval must be cleared (clearInterval / AbortController) so "
+        "it can't leak past unmount"
+    )
+    # The clear must run on unmount — an effect returning a cleanup arrow. The
+    # arrow-return-arrow form is specific to the unmount cleanup (the file's
+    # other effects return block bodies), so it pins the wiring without coupling
+    # to a helper name.
+    assert re.search(r"useEffect\(.+?=>\s*\(\)\s*=>", src, re.DOTALL), (
+        "an effect must return a cleanup (arrow-return) wired to component unmount"
+    )
+
+
+def test_poll_is_bounded():
+    """The poll must not run forever if the backend never posts a result."""
+    src = _catalog()
+    assert re.search(r"LIBRARY_REFRESH_MAX_MS\s*=\s*\d{4,6}", src), (
+        "the poll must be bounded by a max-duration cap (no infinite polling)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (3) Accessibility: labelled for screen readers
+# ---------------------------------------------------------------------------
+
+def test_refresh_button_has_translated_aria_label():
+    src = _catalog()
+    # The button must carry both a title tooltip and an aria-label, both via t().
+    assert re.search(r"aria-label=\{t\('Refresh library'\)\}", src), (
+        "the RefreshCw button needs an aria-label of t('Refresh library')"
+    )
+    assert re.search(r"title=\{t\('Refresh library'\)\}", src), (
+        "the RefreshCw button needs a title tooltip of t('Refresh library')"
+    )
+
+
+def test_refresh_status_is_aria_live():
+    """The scan's 'please wait' -> 'complete' transition must be announced
+    (SC 4.1.3 Status Changes) — an aria-live polite region for the refresh line."""
+    src = _catalog()
+    assert 'aria-live="polite"' in src, (
+        "the refresh status line must be an aria-live=\"polite\" region so the "
+        "scan result is announced to assistive tech"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (4) i18n anchor — the new msgid stays extractable into messages.pot
+# ---------------------------------------------------------------------------
+
+def test_refresh_library_msgid_anchored():
+    anchored = _spa_strings()
+    assert re.search(r'_\(\s*"Refresh library"\s*\)', anchored), (
+        "the new 'Refresh library' msgid must be anchored in cps/spa_strings.py "
+        "so pybabel keeps it (it appears only in .tsx, which babel never scans)"
+    )


### PR DESCRIPTION
## Why

#780 and #665 (independent reports): the new UI has no manual "Refresh library" action — in the classic UI it's one click in the header. Users dropping books into the ingest folder had to switch back to classic (or wait for the automatic sweep).

## What

- `RefreshCw` icon button in the catalog toolbar (matches the neighbouring icon buttons; spins + disables while a scan runs; `prefers-reduced-motion` respected).
- Drives the existing backend: `POST /cwa-library-refresh` → poll `/cwa-library-refresh/messages` every 1s (2-minute cap) → show the result in an `aria-live` status line → invalidate the books/discover/about queries so newly-ingested books appear without a reload.
- Poll interval cleared on completion, timeout, unmount, and double-click (no leaks). Transient poll failures keep polling until the cap.
- One new msgid ("Refresh library") anchored in `cps/spa_strings.py` (the #719 extraction gate is green).

## Verification

- `tests/unit/test_780_refresh_library_button.py` — 8 source-pins, all red against pre-change HEAD, green on branch; no regressions in the other Catalog pin suites (32 passed).
- `npm run build` (tsc + vite) clean.
- Live click→scan→result flow exercised against the local container in this session's verification pass.

Implementation drafted by a delegate model from a spec; endpoint contract and query-key wiring independently re-verified before adoption.

Addresses #780. Addresses #665