### PR TITLE
fix(ui): Report-issue link opens the template chooser (#799)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reporting an issue from the new UI's Help menu now opens the bug-report form instead of a blank issue.** The "Report Issue on GitHub" link pointed at the blank-issue URL, so reporters landed on an empty textarea rather than the Bug report / Feature request templates defined in the repo. It now opens the issue-template chooser. Thanks to @auspex for the report ([#799](https://github.com/new-usemame/Calibre-Web-NextGen/issues/799)).
+
 ## [v4.1.9] - 2026-07-11
 
 ### Added

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -20,7 +20,10 @@ interface TopBarProps {
 /** Project support channels surfaced in the Help menu — the fork's own GitHub
  *  tracker + Discord (already shipped in the legacy admin page) + README. */
 const HELP_LINKS = {
-  issue: 'https://github.com/new-usemame/Calibre-Web-NextGen/issues/new',
+  // /issues/new/choose lands on the template picker (Bug report / Feature
+  // request) instead of a blank issue — the chooser lists the forms in
+  // .github/ISSUE_TEMPLATE/ (#799, adopts @chloeroform's #800).
+  issue: 'https://github.com/new-usemame/Calibre-Web-NextGen/issues/new/choose',
   discord: 'https://discord.gg/B8NXZmcp32',
   docs: 'https://github.com/new-usemame/Calibre-Web-NextGen#readme',
 };

--- a/tests/unit/test_799_issue_template_chooser.py
+++ b/tests/unit/test_799_issue_template_chooser.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression pin for fork issue #799: the new UI's Help menu "Report Issue on
+GitHub" link opened the blank-issue form (``/issues/new``) instead of the
+template chooser, so reporters landed on an empty textarea instead of the
+Bug report / Feature request forms defined in ``.github/ISSUE_TEMPLATE/``.
+
+The fix points the link at ``/issues/new/choose`` (adopts @chloeroform's #800).
+This pin keeps the chooser URL in place so a future refactor can't silently
+revert to the bare ``/issues/new`` form.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOPBAR_TSX = REPO_ROOT / "frontend" / "src" / "components" / "TopBar.tsx"
+
+# The bare blank-issue URL (closing quote immediately after `/issues/new`) is
+# the pre-fix target; the chooser URL is `/issues/new/choose`, so this exact
+# literal must not appear once the fix is in.
+_BLANK_ISSUE_URL = "'https://github.com/new-usemame/Calibre-Web-NextGen/issues/new'"
+_CHOOSER_URL = "https://github.com/new-usemame/Calibre-Web-NextGen/issues/new/choose"
+
+
+def test_help_menu_issue_link_uses_template_chooser():
+    src = TOPBAR_TSX.read_text(encoding="utf-8")
+    assert _CHOOSER_URL in src, (
+        "The Help menu's 'Report Issue on GitHub' link must point at the "
+        "template chooser (/issues/new/choose) so reporters get the Bug report "
+        "form, not a blank issue (#799)."
+    )
+    assert _BLANK_ISSUE_URL not in src, (
+        "The bare blank-issue URL (/issues/new with no /choose) must not be "
+        "the Report-Issue target (#799) — it bypasses the issue templates."
+    )


### PR DESCRIPTION
## Symptom

In the new UI, Help menu → "Report Issue on GitHub" opened the **blank-issue** form (`/issues/new`) — an empty textarea — instead of the Bug report / Feature request templates. Reporters had no structure to fill in.

## Fix

Point the link at `https://github.com/new-usemame/Calibre-Web-NextGen/issues/new/choose`, which opens the template picker. The repo ships `bug_report.md` and `feature_request.md` under `.github/ISSUE_TEMPLATE/`, so the chooser now lists both.

One-line change in `frontend/src/components/TopBar.tsx` (`HELP_LINKS.issue`).

Credit: @chloeroform (#800). Addresses #799.

## Verification

- `cd frontend && npx tsc -b` → 0 errors.
- `cd frontend && npm run build` → success (`✓ built`, vite production bundle emitted).
- `python3 -m pytest tests/unit/test_799_issue_template_chooser.py` → 1 passed (source-pin: the chooser URL is present, the bare `/issues/new` literal is gone).
- Confirmed `.github/ISSUE_TEMPLATE/` contains `bug_report.md` + `feature_request.md` (so `/issues/new/choose` surfaces real templates).

## Notes

- No new user-visible string (`Report Issue on GitHub` is already anchored in `cps/spa_strings.py`).
- Builds on `main`; safe-tier-1-adjacent (a URL constant + a source-pin test, no auth/session/route logic).