### PR TITLE
fix(ui): book-card edit pencil is a real link (open in new tab) (#798)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ is for things you can see or feel when running the app.
 ### Fixed
 
 - **Reporting an issue from the new UI's Help menu now opens the bug-report form instead of a blank issue.** The "Report Issue on GitHub" link pointed at the blank-issue URL, so reporters landed on an empty textarea rather than the Bug report / Feature request templates defined in the repo. It now opens the issue-template chooser. Thanks to @auspex for the report ([#799](https://github.com/new-usemame/Calibre-Web-NextGen/issues/799)).
+- **The edit pencil on a book card can now be opened in a new tab.** In the new UI, the hover edit pencil on a book card was a button rather than a real link, so ⌘/ctrl-click (or middle-click) didn't open the editor in a new tab the way real links do — there was no `href` for the browser to open. The pencil is now a true link: a plain click still opens the editor in place (no full page reload), and a modified click opens it in a new tab. Thanks to @chloeroform for the report ([#798](https://github.com/new-usemame/Calibre-Web-NextGen/issues/798)).
 
 ## [v4.1.9] - 2026-07-11
 

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -1,5 +1,5 @@
 import { Check, X, Pencil } from 'lucide-react';
-import { Link, useLocation } from 'wouter';
+import { Link } from 'wouter';
 import type { Book } from '../lib/api';
 import { useT } from '../lib/i18n';
 import { BookCover } from './BookCover';
@@ -41,7 +41,6 @@ export function BookCard({
   const t = useT();
   const authorStr = book.authors.join(', ');
   const seriesIndexLabel = showSeriesIndex ? formatSeriesIndex(book.series_index) : null;
-  const [, navigate] = useLocation();
 
   // Cover + overlay badges. All non-interactive (pointer-events: none via CSS) so
   // the single wrapping control (link or toggle button) is the only tab stop.
@@ -120,14 +119,20 @@ export function BookCard({
         </button>
       )}
       {quickEdit && (
-        <button
-          type="button"
+        <Link
+          href={`/book/${book.id}/edit`}
           className={styles.quickEditBtn}
           aria-label={t('Edit {title}', { title: book.title })}
-          onClick={() => navigate(`/book/${book.id}/edit`)}
+          // The pencil is a SIBLING of the card link (never nested in an <a>),
+          // so a click can't bubble to the card's own navigation — stopPropagation
+          // keeps that invariant explicit if the layout is ever re-nested.
+          // wouter's <Link> runs SPA navigation only on a plain left-click; on
+          // ⌘/ctrl/shift/alt-click it returns early without preventDefault, so the
+          // browser opens the edit page in a new tab natively (#798).
+          onClick={(e) => e.stopPropagation()}
         >
           <Pencil size={13} strokeWidth={2.5} aria-hidden="true" />
-        </button>
+        </Link>
       )}
     </div>
   );

--- a/tests/unit/test_572_quick_edit.py
+++ b/tests/unit/test_572_quick_edit.py
@@ -24,9 +24,10 @@ def test_bookcard_has_quick_edit_affordance():
     src = (_FE / "components" / "BookCard.tsx").read_text()
     # Opt-in prop so shelves/discover rows don't get the control unless asked.
     assert "quickEdit" in src
-    # Navigates straight to the edit route (not the detail page).
+    # Navigates straight to the edit route (not the detail page) — as a real
+    # anchor since #798, so modified clicks (⌘/ctrl) open a new tab natively.
     assert "/edit" in src
-    assert "useLocation" in src or "navigate" in src
+    assert "href={`/book/${book.id}/edit`}" in src
     # A pencil icon, consistent with the detail-page Edit button.
     assert "Pencil" in src
     # Must not appear in multi-select mode: selection is a separate early-return

--- a/tests/unit/test_798_edit_icon_real_link.py
+++ b/tests/unit/test_798_edit_icon_real_link.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression pin for fork issue #798: the hover edit pencil on a book card was
+a ``<button onClick={() => navigate(...)}>`` rather than a real anchor, so
+⌘/ctrl/middle-click (open-in-new-tab) didn't work — there was no ``href`` for
+the browser to open.
+
+The fix renders the pencil as a wouter ``<Link href="/book/:id/edit">``. A plain
+click still does SPA navigation (wouter intercepts only unmodified left-clicks);
+a modified click falls through to the browser, which opens the edit page in a
+new tab natively. BookDetail.tsx and Duplicates.tsx already used ``<Link>`` for
+their edit affordance — this brings the book-card pencil in line.
+
+This pin keeps the pencil an anchor: the ``href`` must be present, and the old
+imperative ``navigate(`/book/.../edit`)`` pattern must stay gone (a button with
+onClick cannot be opened in a new tab).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOOKCARD_TSX = REPO_ROOT / "frontend" / "src" / "components" / "BookCard.tsx"
+
+
+def test_quick_edit_pencil_is_a_real_link():
+    src = BOOKCARD_TSX.read_text(encoding="utf-8")
+    # The edit pencil must navigate via a real <Link href> so modified-clicks
+    # open a new tab (native anchor behaviour), not a button + imperative nav.
+    assert "href={`/book/${book.id}/edit`}" in src, (
+        "BookCard's quick-edit pencil must be a <Link href> to /book/:id/edit "
+        "so cmd/ctrl/middle-click opens the editor in a new tab (#798)."
+    )
+    assert "navigate(`/book/${book.id}/edit`)" not in src, (
+        "BookCard's quick-edit pencil must not use imperative navigate() — a "
+        "<button onClick> cannot be opened in a new tab (#798)."
+    )


### PR DESCRIPTION
## Symptom

In the new UI, the hover edit pencil on a book card couldn't be opened in a new tab. ⌘/ctrl-click (or middle-click) did nothing, because the pencil was a `<button onClick={() => navigate(...)}>` with no `href` — there was no anchor for the browser to open.

## Fix

Render the pencil as a wouter `<Link href="/book/:id/edit">` instead of a button:

- **Plain click** → SPA navigation to the editor (wouter intercepts only unmodified left-clicks), no full page reload — exactly as before.
- **⌘/ctrl/shift/alt-click or middle-click** → wouter returns early without `preventDefault`, so the browser opens the edit page in a new tab natively.

`stopPropagation` on the click preserves the invariant that clicking the pencil never triggers the card's own navigation (the pencil is a *sibling* of the card link, not nested — stopPropagation keeps that explicit if the layout is ever re-nested). Styling, hover/focus, and the `aria-label` are unchanged (the global `a { color: inherit; text-decoration: none }` reset plus the existing `.quickEditBtn` rules make the `<a>` render identically to the old button).

## Audit (not a bolt-on)

- `BookCard.tsx` quick-edit pencil (used by `Catalog.tsx` + `AdvancedSearch.tsx`) — **converted** (this PR).
- `BookDetail.tsx:387` edit button — already a `<Link>`. ✓
- `Duplicates.tsx:66` edit link — already a `<Link>`. ✓
- `BulkBar.tsx:157` "Edit metadata" pencil — a *different* action: it toggles a bulk-edit panel (`setMetaOpen`) for the selected books, it does not navigate to a per-book edit page. Out of scope for "open one book's editor in a new tab".

Addresses #798.

## Verification

- `cd frontend && npx tsc -b` → 0 errors.
- `cd frontend && npm run build` → success (`✓ built in 1.64s`).
- `python3 -m pytest tests/unit/test_798_edit_icon_real_link.py` → 1 passed (source-pin: the `<Link href>` to `/book/:id/edit` is present; the imperative `navigate(\`/book/.../edit\`)` pattern is gone).
- Edit route confirmed against `App.tsx`: `/book/:id/edit` (line 112).
- wouter v3.10.0 `Link` click handler inspected (src/index.js:286-300): returns early on ctrl/meta/alt/shift without `preventDefault` → new-tab behaviour is native.

## Notes

- No new user-visible string (`Edit {title}` is already anchored in `cps/spa_strings.py`).
- No new dependency, no CSS change.