### PR TITLE
feat(ui): publication-date field in the new editor (#689)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+
+- **The new UI's book editor has a Publication date field again.** The redesigned editor shipped without the publication-date field the classic editor has, so the date could only be set from the classic UI. The editor now has a "Published" date input — prefilled from the book's current date, and clearable to reset it. This completes the #689 report alongside the metadata autocomplete that shipped in v4.1.9. ([#689](https://github.com/new-usemame/Calibre-Web-NextGen/issues/689))
+
 ### Fixed
 
 - **Reporting an issue from the new UI's Help menu now opens the bug-report form instead of a blank issue.** The "Report Issue on GitHub" link pointed at the blank-issue URL, so reporters landed on an empty textarea rather than the Bug report / Feature request templates defined in the repo. It now opens the issue-template chooser. Thanks to @auspex for the report ([#799](https://github.com/new-usemame/Calibre-Web-NextGen/issues/799)).

--- a/cps/api/edit.py
+++ b/cps/api/edit.py
@@ -27,7 +27,7 @@ from ..helper import convert_book_format, save_cover, save_cover_from_url, tags_
 # first because they may restructure the book's directory; the rest follow.
 EDITABLE_FIELDS = [
     "title", "authors", "series", "series_index",
-    "tags", "publishers", "languages", "comments", "rating",
+    "tags", "publishers", "languages", "comments", "rating", "pubdate",
 ]
 
 
@@ -67,6 +67,15 @@ def _editable_metadata(book):
         isoLanguages.get_language_name(get_locale(), l.lang_code)
         for l in (getattr(book, "languages", None) or [])
     ]
+    # Publication date — sentinel year <= 101 (Books.DEFAULT_PUBDATE) reads as
+    # "" so the editor's <input type="date"> shows blank for "no pubdate"
+    # (mirrors serialize_book_detail's null mapping, #689).
+    pubdate_raw = getattr(book, "pubdate", None)
+    pubdate = (
+        pubdate_raw.date().isoformat()
+        if pubdate_raw is not None and getattr(pubdate_raw, "year", 0) > 101
+        else ""
+    )
     return {
         "id": book.id,
         "title": book.title or "",
@@ -81,6 +90,8 @@ def _editable_metadata(book):
         "comments": comments[0].text if comments else "",
         # calibre ratings are stored 0-10 (half-stars); expose 0-5.
         "rating": (rating_rows[0].rating / 2) if rating_rows else 0,
+        # Publication date as YYYY-MM-DD (or "" for the default sentinel), #689.
+        "pubdate": pubdate,
         # ISBN/ASIN/etc. — editable as a table in the SPA (fork #580).
         "identifiers": [
             {"type": i.type, "val": i.val}

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -622,6 +622,30 @@ def edit_book_param(param, vals):
             metadata_changed = rating_changed
             log_key = 'rating'
             log_value = vals.get('value', '')
+        elif param == 'pubdate':
+            # Publication date in the redesigned editor (#689). The SPA's
+            # <input type="date"> posts YYYY-MM-DD, but accept the partial
+            # forms (YYYY, YYYY-MM) the classic editor accepts too (#472) via
+            # the shared validator — single source of truth for date parsing.
+            # parse_partial_pubdate raises BEFORE the assignment, so an invalid
+            # value leaves book.pubdate unchanged (rejected, not clobbered —
+            # unlike the classic editor's reset-to-default). Empty clears,
+            # matching the classic editor (reset to the DEFAULT_PUBDATE
+            # sentinel, year 101).
+            pubdate_text = (vals.get('value') or '').strip()
+            try:
+                book.pubdate = parse_partial_pubdate(pubdate_text) if pubdate_text else db.Books.DEFAULT_PUBDATE
+            except ValueError as e:
+                ret = Response(json.dumps({'success': False, 'msg': str(e)}),
+                               mimetype='application/json')
+            else:
+                new_pubdate = (book.pubdate.date().isoformat()
+                               if getattr(book.pubdate, 'year', 0) > 101 else '')
+                ret = Response(json.dumps({'success': True, 'newValue': new_pubdate}),
+                               mimetype='application/json')
+                metadata_changed = True
+                log_key = 'pubdate'
+                log_value = pubdate_text
         elif param == 'is_archived':
             is_archived = change_archived_books(book.id, vals['value'] == "True",
                                                 message="Book {} archive bit set to: {}".format(book.id, vals['value']))

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -249,6 +249,9 @@ export interface BookMetadata {
   languages: string;
   comments: string;
   rating: number;
+  /** Publication date as YYYY-MM-DD, or "" when the book has no pubdate
+   *  (calibre's year-101 DEFAULT_PUBDATE sentinel). Editable in the SPA (#689). */
+  pubdate: string;
   identifiers: { type: string; val: string }[];
   errors?: Record<string, string>;
 }

--- a/frontend/src/pages/EditBook.tsx
+++ b/frontend/src/pages/EditBook.tsx
@@ -27,6 +27,7 @@ interface FormState {
   languages: string;
   rating: string;
   comments: string;
+  pubdate: string;
   identifiers: Ident[];
 }
 
@@ -73,6 +74,7 @@ export function EditBook({ id }: { id: string }) {
       languages: meta.languages,
       rating: meta.rating ? String(meta.rating) : '',
       comments: meta.comments,
+      pubdate: meta.pubdate || '',
       identifiers: (meta.identifiers || []).map((i) => ({ type: i.type, val: i.val })),
     });
   }, [meta]);
@@ -146,6 +148,7 @@ export function EditBook({ id }: { id: string }) {
       languages: form.languages,
       rating: form.rating ? Number(form.rating) : 0,
       comments: form.comments,
+      pubdate: form.pubdate,
       // Drop blank rows; the backend reconciles the rest against existing rows.
       identifiers: form.identifiers
         .map((i) => ({ type: i.type.trim().toLowerCase(), val: i.val.trim() }))
@@ -206,6 +209,11 @@ export function EditBook({ id }: { id: string }) {
           <MetadataTypeahead field="publishers" multi inputClassName={styles.input}
             value={form.publishers} onChange={(v) => set('publishers', v)}
             aria-label={t('Publishers (comma separated)')} />
+        </Field>
+
+        <Field label={t('Published')} error={fieldErrors.pubdate}>
+          <input className={styles.input} type="date" value={form.pubdate}
+            onChange={(e) => set('pubdate', e.target.value)} />
         </Field>
 
         <div className={styles.row}>

--- a/tests/unit/test_689_pubdate_input.py
+++ b/tests/unit/test_689_pubdate_input.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Behavioural test for the publication-date field in the redesigned editor
+(fork #689 remainder): the new UI editor shipped with no pubdate field, so the
+publication date could only be set in the classic editor.
+
+The fix routes ``pubdate`` through ``edit_book_param`` — the canonical
+single-field editor behind the SPA's ``/api/v1/books/<id>/metadata`` POST — so
+it shares the same commit / ``mark_book_modified`` / change-log path as every
+other field, and lists it in ``EDITABLE_FIELDS`` so the endpoint dispatches it.
+
+These tests exercise the pubdate branch directly:
+  * a valid date PERSISTS (book.pubdate is set, success response);
+  * an invalid value is REJECTED — book.pubdate is left UNCHANGED (not clobbered
+    to the default sentinel, which is what the classic editor does);
+  * an empty value CLEARS (resets to Books.DEFAULT_PUBDATE).
+
+Invalid input is surfaced as a per-field error (``success: False``) rather than
+a top-level 4xx — the endpoint returns field-level errors at HTTP 200 so the SPA
+can show them inline and a single bad field doesn't abort an otherwise-valid
+multi-field save. See notes/delegate-fe-batch-REPORT.md for the rationale.
+"""
+import datetime
+import inspect
+import json
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import cps.editbooks as editbooks
+
+# edit_book_param is decorated with @login_required_if_no_ano + @edit_required
+# (auth gating irrelevant to the pubdate branch). inspect.unwrap strips both
+# (they use functools.wraps) so we exercise the real logic without a Flask
+# request context — same approach test_api_v1_edit.py takes for update_metadata.
+_edit_book_param = inspect.unwrap(editbooks.edit_book_param)
+
+
+def _run_pubdate(value, prior=None):
+    """Call edit_book_param('pubdate', ...) against a fake book; return (book, body).
+
+    calibre_db / helper / log are mocked so the branch runs in isolation; db is
+    left real so Books.DEFAULT_PUBDATE is the genuine sentinel.
+    """
+    book = SimpleNamespace(id=5, title="T", authors=[], pubdate=prior)
+    calibre_db = MagicMock()
+    calibre_db.get_book.return_value = book
+    with patch.object(editbooks, "calibre_db", calibre_db), \
+            patch.object(editbooks, "helper"), \
+            patch.object(editbooks, "log"):
+        ret = _edit_book_param("pubdate", {"pk": "5", "value": value})
+    body = json.loads(ret.get_data(as_text=True))
+    return book, body
+
+
+@pytest.mark.unit
+def test_pubdate_is_dispatched_by_the_spa_endpoint():
+    # The endpoint only routes fields listed in EDITABLE_FIELDS; pubdate must be
+    # present or the editor's pubdate payload is silently dropped (#689).
+    from cps.api import edit as edit_api
+    assert "pubdate" in edit_api.EDITABLE_FIELDS
+
+
+@pytest.mark.unit
+def test_pubdate_valid_persists():
+    book, body = _run_pubdate("2020-05-15")
+    assert book.pubdate == datetime.datetime(2020, 5, 15)
+    assert body["success"] is True
+    assert body["newValue"] == "2020-05-15"
+
+
+@pytest.mark.unit
+def test_pubdate_invalid_is_rejected_without_clobber():
+    prior = datetime.datetime(2010, 1, 1)
+    book, body = _run_pubdate("not-a-date", prior=prior)
+    # Rejected, not clobbered: the existing pubdate is untouched.
+    assert book.pubdate == prior
+    assert body["success"] is False
+    assert "publication date" in body["msg"].lower()
+
+
+@pytest.mark.unit
+def test_pubdate_empty_clears_to_default():
+    book, body = _run_pubdate("")
+    assert book.pubdate == editbooks.db.Books.DEFAULT_PUBDATE
+    assert body["success"] is True


### PR DESCRIPTION
## Symptom

The redesigned book editor (`EditBook.tsx`) had **no publication-date field** — only the classic editor let you set it. (#689 remainder; the metadata-autocomplete part of #689 shipped in v4.1.9.)

## API check first

The v1 book-update endpoint (`POST /api/v1/books/<id>/metadata` → `cps/api/edit.py:update_metadata`) did **not** accept `pubdate`: it wasn't in `EDITABLE_FIELDS`, wasn't in the `_editable_metadata` serializer, and `edit_book_param` had no `pubdate` branch. So this required extending the endpoint.

## Fix (minimal, routed through the canonical core)

- **`cps/editbooks.py`**: add a `pubdate` elif branch to `edit_book_param` — the canonical single-field editor the SPA endpoint already dispatches every other field through. It uses the existing `parse_partial_pubdate` validator (accepts `YYYY-MM-DD` from the SPA's `<input type="date">` plus the partial `YYYY`/`YYYY-MM` forms from #472). Gets `mark_book_modified`/commit/change-log for free, matching every other field.
- **`cps/api/edit.py`**: add `"pubdate"` to `EDITABLE_FIELDS` (so the endpoint dispatches it) and to `_editable_metadata` (so the field prefills — `YYYY-MM-DD`, or `""` for the year-101 `DEFAULT_PUBDATE` sentinel, mirroring `serialize_book_detail`).
- **Frontend**: `BookMetadata` type gains `pubdate: string`; `EditBook.tsx` adds a "Published" `<input type="date">`, prefilled from the current value, sent in the save payload. Saving with no change sends the same value back (no clobber).

### Behaviour

- **Valid date** → persists (`book.pubdate` set, success).
- **Invalid input** → **rejected**: `parse_partial_pubdate` raises *before* the assignment, so `book.pubdate` is left **unchanged** (not clobbered to the default — better than the classic editor, which resets it).
- **Empty** → clears to `Books.DEFAULT_PUBDATE` (matches the classic editor).

Addresses #689.

## Delta vs the contract ("invalid 4xx")

The contract suggested "invalid 4xx". The `/api/v1/books/<id>/metadata` endpoint returns **field-level errors at HTTP 200** in an `errors` dict (see `edit.py` — identifiers/languages/rating all behave this way) so the SPA surfaces them inline per-field via `setFieldErrors` and a single bad field doesn't abort an otherwise-valid multi-field save (other fields commit independently). A 4xx on invalid pubdate would diverge from every other field, bypass the SPA's per-field error display, and surface as a generic "Save failed" banner while the rest of the payload silently persisted. Per the contract's "trust the file, adapt, note the delta" recovery, I followed the endpoint's established field-error pattern: invalid pubdate → `errors["pubdate"]` (HTTP 200), `book.pubdate` unchanged. The behavioural test asserts the substance (invalid rejected + pubdate unchanged + error surfaced), not a 4xx.

## Verification

- `cd frontend && npx tsc -b` → 0 errors.
- `cd frontend && npm run build` → success (`✓ built in 1.73s`).
- `python3 -m pytest tests/unit/test_689_pubdate_input.py tests/unit/test_api_v1_edit.py tests/unit/test_editbooks_param_fixes.py tests/unit/test_api_v1_detail.py` → **37 passed** (4 new: dispatch pin + valid-persists + invalid-rejected-without-clobber + empty-clears; 33 existing — no regressions).
- Backend delta ≈ 25 LOC (one `elif` branch + one `EDITABLE_FIELDS` entry + serializer line) — well under the 150-LOC stop threshold.

## Notes

- No new user-visible string (`Published` is already anchored in `cps/spa_strings.py`). No new dependency, no migration, no external URL.