### PR TITLE
fix: identify books in author-sort warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ is for things you can see or feel when running the app.
 ### Fixed
 
 - **Saving a cover for a PDF-only or other non-EPUB/AZW3 book no longer ends with a false enforcement error.** The metadata enforcer now preserves the successful cover save, refreshes the format-independent `metadata.opf` backup, and logs an informational note that only in-file embedding was skipped for the unsupported format (#797).
+- **Author-sort mismatch warnings now identify the affected book and give a repair step that exists.** The warning previously omitted the book ID and title, then told administrators to edit an internal author-sort value through a UI that does not expose it directly. It now names the book and points to editing that book's Authors field or correcting it in Calibre. Thanks to @auspex for the report (#801).
 
 ## [v4.1.9] - 2026-07-11
 

--- a/cps/db.py
+++ b/cps/db.py
@@ -1588,10 +1588,13 @@ class CalibreDB:
                         _AUTHOR_SORT_DRIFT_WARNED.add(auth)
                         log.warning(
                             "Author sort '%s' from Books.author_sort has no "
-                            "match in linked authors. Falling back to "
-                            "Authors.id order for this author. To fix: edit "
-                            "the author in the admin UI so Authors.sort "
-                            "matches.", auth)
+                            "match in linked authors for book %s ('%s'). "
+                            "Falling back to Authors.id order for this "
+                            "author. To repair the mismatch, edit this "
+                            "book's Authors field so its author sort is "
+                            "regenerated, or correct the book in Calibre.",
+                            auth, getattr(book, 'id', 'unknown'),
+                            getattr(book, 'title', 'untitled'))
                     continue
                 authors_ordered.append(ordered)
                 if ordered.id in ids_remaining:

--- a/tests/unit/test_author_sort_drift_log_dedup.py
+++ b/tests/unit/test_author_sort_drift_log_dedup.py
@@ -28,6 +28,7 @@ exercise the actual `order_authors` method, not just AST shape.
 import ast
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -176,6 +177,32 @@ class TestAuthorSortDriftDedupBehavioral:
         ], list_return=True, combined=False)
         assert "Kosztolányi Dezső" in cps_db._AUTHOR_SORT_DRIFT_WARNED
         assert len(cps_db._AUTHOR_SORT_DRIFT_WARNED) == 4
+
+    def test_warning_identifies_affected_book(self, monkeypatch):
+        """The recovery warning must identify the exact book whose
+        ``Books.author_sort`` value drifted so an operator can repair it."""
+        from cps import db as cps_db
+
+        cps_db._AUTHOR_SORT_DRIFT_WARNED.clear()
+        warning = MagicMock()
+        monkeypatch.setattr(cps_db.log, "warning", warning)
+
+        instance = cps_db.CalibreDB.__new__(cps_db.CalibreDB)
+        instance.session = MagicMock()
+        instance.ensure_session = lambda: None
+        book = SimpleNamespace(
+            id=801,
+            title="The Mismatched Book",
+            author_sort="Missing, Author",
+            authors=[SimpleNamespace(id=1, name="Author", sort="Author, Linked")],
+        )
+
+        instance.order_authors([book], list_return=True, combined=False)
+
+        warning.assert_called_once()
+        rendered = warning.call_args.args[0] % warning.call_args.args[1:]
+        assert "801" in rendered
+        assert "The Mismatched Book" in rendered
 
     def test_continue_preserves_other_authors_ordering_for_same_book(self):
         """A book with TWO linked authors — one whose sort is referenced


### PR DESCRIPTION
Author-sort mismatch warnings currently omit the affected book and recommend editing `Authors.sort` through an admin surface that does not directly expose it. This makes an otherwise recoverable data-drift warning unactionable.

This change includes the book ID and title in the warning and points administrators to editing the book's Authors field so the sort regenerates, or correcting the book in Calibre. The behavioral regression test exercises the real mismatch path and asserts that context is logged.

Addresses #801.

Verification:
- RED: `pytest tests/unit/test_author_sort_drift_log_dedup.py -q` — 1 failed, 6 passed; missing book ID in warning.
- GREEN: `pytest tests/unit/test_author_sort_drift_log_dedup.py -q` — 7 passed.
- `git diff --check` — clean.

No new dependencies, licenses, or external service URLs.