### PR TITLE
fix: report unsupported metadata enforcement honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ is for things you can see or feel when running the app.
 - **The new UI's send-to-e-reader dialog now shows your saved e-reader address instead of an empty recipient field.** The recipient box was blank with only a "blank = your e-reader email" hint, so it looked like the address you'd saved in your account had been lost — even though sending still worked. The field is now prefilled with your saved address; type a different one to override it for that send, or clear it to fall back to the saved address. ([#715](https://github.com/new-usemame/Calibre-Web-NextGen/issues/715))
 - **Reporting an issue from the new UI's Help menu now opens the bug-report form instead of a blank issue.** The "Report Issue on GitHub" link pointed at the blank-issue URL, so reporters landed on an empty textarea rather than the Bug report / Feature request templates defined in the repo. It now opens the issue-template chooser. Thanks to @auspex for the report ([#799](https://github.com/new-usemame/Calibre-Web-NextGen/issues/799)).
 - **The edit pencil on a book card can now be opened in a new tab.** In the new UI, the hover edit pencil on a book card was a button rather than a real link, so ⌘/ctrl-click (or middle-click) didn't open the editor in a new tab the way real links do — there was no `href` for the browser to open. The pencil is now a true link: a plain click still opens the editor in place (no full page reload), and a modified click opens it in a new tab. Thanks to @chloeroform for the report ([#798](https://github.com/new-usemame/Calibre-Web-NextGen/issues/798)).
+### Fixed
+
+- **Saving a cover for a PDF-only or other non-EPUB/AZW3 book no longer ends with a false enforcement error.** The metadata enforcer now preserves the successful cover save, refreshes the format-independent `metadata.opf` backup, and logs an informational note that only in-file embedding was skipped for the unsupported format (#797).
 
 ## [v4.1.9] - 2026-07-11
 

--- a/scripts/cover_enforcer.py
+++ b/scripts/cover_enforcer.py
@@ -615,9 +615,46 @@ class Enforcer:
             self._reset_book_dir_ownership(book_dir)
             return book_objects
         else:
-            print(f"[cover-metadata-enforcer]: No supported file formats found in {book_dir}.", flush=True)
-            print("[cover-metadata-enforcer]: *** NOTICE **** Only EPUB & AZW3 formats are currently supported.", flush=True)
+            return self._write_metadata_backup_for_unsupported(book_dir)
+
+    def _write_metadata_backup_for_unsupported(self, book_dir: str) -> list:
+        """Refresh metadata.opf when no format supports in-file embedding.
+
+        Cover saves happen before the metadata-change log reaches this
+        service.  Exporting Calibre's current OPF is format-independent, so
+        PDF/MOBI/etc. books can still persist that backup even though
+        ebook-polish cannot embed the changes into their book files.
+        """
+        sidecars = {"cover.jpg", "metadata.opf"}
+        book_files = [
+            os.path.join(dirpath, filename)
+            for dirpath, _, filenames in os.walk(book_dir)
+            for filename in filenames
+            if filename.lower() not in sidecars
+        ]
+        if not book_files:
+            print(f"[cover-metadata-enforcer] ERROR: No book file found in {book_dir}; metadata.opf was not updated.", flush=True)
             return []
+
+        book = Book(book_dir, book_files[0])
+        try:
+            self.replace_old_metadata(book.old_metadata_path, book.new_metadata_path)
+        finally:
+            self.empty_metadata_temp()
+
+        self._reset_book_dir_ownership(book_dir)
+        print(
+            f"[cover-metadata-enforcer] SUCCESS: Cover saved and metadata.opf updated for "
+            f"'{book.book_title}' ({book.file_format.upper()}).",
+            flush=True,
+        )
+        print(
+            f"[cover-metadata-enforcer] INFO: Metadata embedding into the "
+            f"{book.file_format.upper()} book file was skipped; only EPUB and "
+            "AZW3 support in-file enforcement.",
+            flush=True,
+        )
+        return [book]
 
     @staticmethod
     def _reset_book_dir_ownership(book_dir: str) -> None:

--- a/tests/unit/test_797_cover_enforcer_unsupported_format.py
+++ b/tests/unit/test_797_cover_enforcer_unsupported_format.py
@@ -1,0 +1,38 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression pins for cover/metadata enforcement on unsupported formats."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "cover_enforcer.py"
+
+
+def _method_source(name: str) -> str:
+    source = SCRIPT.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return ast.get_source_segment(source, node) or ""
+    pytest.fail(f"{name} not found in cover_enforcer.py")
+
+
+@pytest.mark.unit
+def test_unsupported_format_writes_opf_and_reports_embedding_skip():
+    """PDF-only books still get their format-independent OPF backup."""
+    helper = _method_source("_write_metadata_backup_for_unsupported")
+    assert "replace_old_metadata" in helper
+    assert "metadata.opf updated" in helper
+    assert "INFO" in helper
+    assert "embedding" in helper.lower()
+
+    enforce_cover = _method_source("enforce_cover")
+    assert "_write_metadata_backup_for_unsupported" in enforce_cover
+    assert "record_failed_enforcement" not in enforce_cover


### PR DESCRIPTION
Saving a cover for a PDF-only or other non-EPUB/AZW3 book currently succeeds, but the metadata enforcer returns an empty result and logs the whole operation as an error. It also skips `metadata.opf`, even though exporting that backup is format-independent.

This change refreshes `metadata.opf` through the same `calibredb export` and copy path already used for supported formats, preserves the successful cover outcome, and emits an INFO message explaining that only in-file embedding was skipped. A true missing-book-file/export failure still returns failure. Ingest behavior is unchanged.

Addresses #797.

Verification:
- RED: `pytest tests/unit/test_797_cover_enforcer_unsupported_format.py -q` — 1 failed; unsupported-format OPF helper absent.
- GREEN: `pytest tests/unit/test_797_cover_enforcer_unsupported_format.py tests/unit/test_cover_enforcer_chown_contract.py -q` — 6 passed.
- `python3 -m py_compile scripts/cover_enforcer.py` — success.
- `git diff --check` — clean.

No new dependencies, licenses, or external service URLs.