### PR TITLE
fix: show classic read checkbox state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ is for things you can see or feel when running the app.
 
 - **Saving a cover for a PDF-only or other non-EPUB/AZW3 book no longer ends with a false enforcement error.** The metadata enforcer now preserves the successful cover save, refreshes the format-independent `metadata.opf` backup, and logs an informational note that only in-file embedding was skipped for the unsupported format (#797).
 - **Author-sort mismatch warnings now identify the affected book and give a repair step that exists.** The warning previously omitted the book ID and title, then told administrators to edit an internal author-sort value through a UI that does not expose it directly. It now names the book and points to editing that book's Authors field or correcting it in Calibre. Thanks to @auspex for the report (#801).
+- **The classic book page's read checkbox now matches the book's actual state.** Unread books previously showed a checked box beside the “Mark As Read” action, while read books showed an empty box. The checkbox is now empty for unread and checked for read; its tooltip continues to describe what clicking will do (#771).
 
 ## [v4.1.9] - 2026-07-11
 

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -678,13 +678,12 @@
                                     {% endif %}
                                     {% if not current_user.is_anonymous %}
                                         {# Read-status icon uses the glyphicon-check / glyphicon-unchecked matched
-                                           pair per fork #319 @droM4X (#2 + #3 of the 2026-05-28 four-item list).
-                                           The icon shows the ACTION the click will perform, matching the button label:
-                                             read_status=False (unread) → label 'Mark As Read'     → icon ☑  glyphicon-check
-                                             read_status=True  (read)   → label 'Mark As Unread'   → icon ☐  glyphicon-unchecked
-                                           Same matched pair is used as a passive STATE indicator on the grid badge
-                                           (index.html) and cover overlay (image.html) — where there's no click context,
-                                           a check means 'this book is read'. The old eye-open / eye-close collided
+                                           pair. The checkbox glyph shows current STATE while the accessible label
+                                           names the action the click will perform:
+                                             read_status=False (unread) → label 'Mark As Read'   → icon ☐
+                                             read_status=True  (read)   → label 'Mark As Unread' → icon ☑
+                                           A check therefore means 'this book is read' consistently with the passive
+                                           grid badge (index.html) and cover overlay (image.html). The old eye icons collided
                                            visually with the hide button (also an eye), which was the SethMilliken
                                            accidental-hide failure mode. Hide button is now gated by the config flag +
                                            placed at the end of the action row — see further down. #}
@@ -693,7 +692,7 @@
                                                 aria-label="{{ entry.read_status and _('Mark As Unread') or _('Mark As Read') }}"
                                                 data-toast-on="{{ _('Marked as read') }}"
                                                 data-toast-off="{{ _('Marked as unread') }}">
-                                            <span id="read-icon" class="glyphicon {{ entry.read_status and 'glyphicon-unchecked' or 'glyphicon-check' }}"></span>
+                                            <span id="read-icon" class="glyphicon {{ entry.read_status and 'glyphicon-check' or 'glyphicon-unchecked' }}"></span>
                                         </button>
                                         {# Favorite / star toggle — fork #27. Always available to signed-in
                                            users (favorites are per-user); flips in place via the form below. #}
@@ -1262,12 +1261,9 @@
                     }
                     var $icon = $("#read-icon");
                     var isRead = $cb.prop("checked");
-                    // Read-status uses the glyphicon-check / glyphicon-unchecked matched
-                    // pair, showing ACTION (fork #319 droM4X). When the book is now read,
-                    // the icon switches to glyphicon-unchecked (next click = mark unread);
-                    // when unread, glyphicon-check (next click = mark read).
-                    $icon.toggleClass("glyphicon-unchecked", isRead)
-                         .toggleClass("glyphicon-check", !isRead);
+                    // Checkbox glyph shows current state; the title names the next action.
+                    $icon.toggleClass("glyphicon-check", isRead)
+                         .toggleClass("glyphicon-unchecked", !isRead);
                     var title = isRead ? $cb.data("checked") : $cb.data("unchecked");
                     $("#toggle-read-btn").attr("title", title).attr("aria-label", title);
                     // Once the user explicitly marks the book read OR unread, the

--- a/tests/unit/test_read_toggle_icon_action_state_319.py
+++ b/tests/unit/test_read_toggle_icon_action_state_319.py
@@ -23,17 +23,14 @@ Two changes pinned here:
    ``glyphicon-unchecked`` (checkbox empty) — both are checkbox-shaped
    so the toggle reads as a single coherent control.
 
-2. **Show ACTION on interactive button, STATE on passive badge.** On
+2. **Show STATE on the interactive checkbox and passive badge.** On
    the detail-page toggle button:
      - `entry.read_status == False` (book is unread) → show
-       ``glyphicon-check`` (the icon for "click to make checked / mark
-       as read"). The button label says "Mark As Read".
+       ``glyphicon-unchecked`` (the book is currently unread). The
+       button label still says "Mark As Read" because labels name actions.
      - `entry.read_status == True` (book is read) → show
-       ``glyphicon-unchecked`` (the icon for "click to make unchecked /
-       mark as unread"). Label says "Mark As Unread".
-   The icon visually previews the action the click will perform. On
-   the passive badges (index grid card, cover overlay) the icon shows
-   STATE — a check means "read" — because there's no action context.
+       ``glyphicon-check`` (the book is currently read). Label says
+       "Mark As Unread". A check consistently means "read" everywhere.
 
 Sweep: detail.html (button + JS), index.html (passive grid badge),
 image.html (passive cover badge), caliBlur.js (caliBlur theme's badge
@@ -74,12 +71,12 @@ def caliblur_js() -> str:
 
 
 # ---------------------------------------------------------------------------
-# Detail-page button — shows ACTION (the state the click will produce).
+# Detail-page button — checkbox glyph shows STATE; label shows ACTION.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestDetailButtonShowsAction:
+class TestDetailButtonShowsState:
     def test_read_icon_uses_check_unchecked_matched_pair(self, detail_html: str):
         """Pin the glyphicon-check / glyphicon-unchecked pair on the
         read-icon span (consistent checkbox-shaped icons)."""
@@ -107,12 +104,8 @@ class TestDetailButtonShowsAction:
             "pushback asked for the matched glyphicon-check pair instead."
         )
 
-    def test_read_icon_shows_action_not_state(self, detail_html: str):
-        """When the book is READ, the icon must show
-        ``glyphicon-unchecked`` (the action: 'click to mark unread').
-        When the book is UNREAD, the icon must show ``glyphicon-check``
-        (the action: 'click to mark read'). The icon visually previews
-        what the click will do, matching the button's label text."""
+    def test_read_icon_shows_state(self, detail_html: str):
+        """A checked box means read and an empty box means unread."""
         m = re.search(
             r'id=["\']read-icon["\'][^>]*class=(["\'])(.+?)\1',
             detail_html,
@@ -121,31 +114,24 @@ class TestDetailButtonShowsAction:
         assert m, "read-icon span not found"
         klass = m.group(2)
         # The Jinja conditional should be:
-        # entry.read_status and 'glyphicon-unchecked' or 'glyphicon-check'
-        # OR equivalent forms that map True→unchecked, False→check.
-        # Pin the inverted-mapping by looking for the read_status-True
-        # arm choosing 'unchecked'.
+        # entry.read_status and 'glyphicon-check' or 'glyphicon-unchecked'
+        # OR equivalent forms that map True→checked, False→unchecked.
         assert re.search(
-            r"read_status\s+and\s+['\"]glyphicon-unchecked['\"]",
+            r"read_status\s+and\s+['\"]glyphicon-check['\"]",
             klass,
         ) or re.search(
-            r"if\s+entry\.read_status\s*%}\s*glyphicon-unchecked",
+            r"if\s+entry\.read_status\s*%}\s*glyphicon-check",
             detail_html,
         ), (
             "When entry.read_status is True (book is READ), read-icon "
-            "must show glyphicon-unchecked — the action is 'mark unread'. "
-            "droM4X #319: 'they should represent the action that will "
-            "happen when clicked'. Got class string: " + repr(klass)
+            "must show glyphicon-check. Got class string: " + repr(klass)
         )
-        # Defensive: the False arm should pick glyphicon-check (the
-        # action 'mark read'). Combined with the True→unchecked above,
-        # this pins the full inversion.
         assert re.search(
-            r"or\s+['\"]glyphicon-check['\"]",
+            r"or\s+['\"]glyphicon-unchecked['\"]",
             klass,
         ), (
             "When entry.read_status is False (book is UNREAD), read-icon "
-            "must show glyphicon-check — the action is 'mark read'."
+            "must show glyphicon-unchecked."
         )
 
     def test_toggle_read_js_handler_uses_check_unchecked(self, detail_html: str):


### PR DESCRIPTION
On the classic book detail page, an unread book currently renders a checked checkbox beside “Mark As Read,” while a read book renders an empty checkbox. The tooltip correctly names the action, but the checkbox itself communicates the opposite current state.

This change makes the checkbox glyph state-representative on initial render and after the AJAX toggle: checked means read, empty means unread. The title and ARIA label continue to name the action that clicking will perform.

Addresses #771.

Verification:
- RED: `pytest tests/unit/test_read_toggle_icon_action_state_319.py -q` — 1 failed, 7 passed; unread/read mapping was inverted.
- GREEN: `pytest tests/unit/test_read_toggle_icon_action_state_319.py tests/unit/test_615_mark_as_read_inversion.py -q` — 14 passed.
- `git diff --check` — clean.

No new dependencies, licenses, external service URLs, or new user-visible strings.