### PR TITLE
feat: add OPDS currently-reading feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ is for things you can see or feel when running the app.
 - **Saving a cover for a PDF-only or other non-EPUB/AZW3 book no longer ends with a false enforcement error.** The metadata enforcer now preserves the successful cover save, refreshes the format-independent `metadata.opf` backup, and logs an informational note that only in-file embedding was skipped for the unsupported format (#797).
 - **Author-sort mismatch warnings now identify the affected book and give a repair step that exists.** The warning previously omitted the book ID and title, then told administrators to edit an internal author-sort value through a UI that does not expose it directly. It now names the book and points to editing that book's Authors field or correcting it in Calibre. Thanks to @auspex for the report (#801).
 - **The classic book page's read checkbox now matches the book's actual state.** Unread books previously showed a checked box beside the “Mark As Read” action, while read books showed an empty box. The checkbox is now empty for unread and checked for read; its tooltip continues to describe what clicking will do (#771).
+- **OPDS readers now have a dedicated “Currently Reading” feed.** The OPDS root previously offered only Read and Unread, forcing in-progress books into the broad not-finished group. Signed-in users can now open a feed containing exactly books in the canonical in-progress state, with the same visibility and selected-shelf restrictions as the rest of their OPDS catalog (#672).
 
 ## [v4.1.9] - 2026-07-11
 

--- a/cps/opds.py
+++ b/cps/opds.py
@@ -139,6 +139,7 @@ OPDS_ROOT_ORDER_DEFAULT = [
     'recent',
     'random',
     'read',
+    'currently_reading',
     'unread',
     'authors',
     'publishers',
@@ -192,6 +193,12 @@ OPDS_ROOT_ENTRY_DEFS = {
         'endpoint': 'opds.feed_read_books',
         'title': N_('Read Books'),
         'description': N_('Read Books'),
+        'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_READ_AND_UNREAD) and not user.is_anonymous,
+    },
+    'currently_reading': {
+        'endpoint': 'opds.feed_currently_reading',
+        'title': N_('Currently Reading'),
+        'description': N_('Books currently being read'),
         'visible': lambda user, __: user.check_visibility(constants.SIDEBAR_READ_AND_UNREAD) and not user.is_anonymous,
     },
     'unread': {
@@ -1085,6 +1092,40 @@ def feed_read_books():
                                            True,
                                            True,
                                            extra_filter=get_opds_book_filter())
+    return render_xml_template('feed.xml', entries=result, pagination=pagination)
+
+
+@opds.route("/opds/currentlyreading")
+@requires_basic_auth_if_no_ano
+def feed_currently_reading():
+    user = auth.current_user()
+    if not (user.check_visibility(constants.SIDEBAR_READ_AND_UNREAD) and not user.is_anonymous):
+        return abort(403)
+
+    in_progress_filter = magic_shelf.build_filter_from_rule({
+        'id': 'read_status',
+        'field': 'read_status',
+        'type': 'integer',
+        'input': 'radio',
+        'operator': 'equal',
+        'value': ub.ReadBook.STATUS_IN_PROGRESS,
+    }, user_id=user.id)
+    if in_progress_filter is None:
+        return abort(500)
+
+    off = request.args.get("offset") or 0
+    result, __, pagination = fill_opds_indexpage(
+        int(off) / int(config.config_books_per_page) + 1,
+        0,
+        db.Books,
+        in_progress_filter,
+        [db.Books.timestamp.desc()],
+        True,
+        config.config_read_column,
+        db.books_series_link,
+        db.Books.id == db.books_series_link.c.book,
+        db.Series,
+    )
     return render_xml_template('feed.xml', entries=result, pagination=pagination)
 
 

--- a/tests/unit/test_672_opds_currently_reading.py
+++ b/tests/unit/test_672_opds_currently_reading.py
@@ -1,0 +1,104 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Behavioral regression coverage for OPDS Currently Reading (#672)."""
+
+from types import SimpleNamespace
+
+import pytest
+from werkzeug.exceptions import Forbidden
+
+from cps import app, constants, db, opds, ub
+
+
+class _User:
+    def __init__(self, *, anonymous=False, visible=True):
+        self.id = 42
+        self.is_anonymous = anonymous
+        self.is_authenticated = not anonymous
+        self._visible = visible
+        self.view_settings = {}
+
+    def check_visibility(self, value):
+        if value == constants.SIDEBAR_READ_AND_UNREAD:
+            return self._visible
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _plain_gettext(monkeypatch):
+    plain_defs = {
+        key: {**entry, "title": key, "description": key}
+        for key, entry in opds.OPDS_ROOT_ENTRY_DEFS.items()
+    }
+    monkeypatch.setattr(opds, "OPDS_ROOT_ENTRY_DEFS", plain_defs)
+    monkeypatch.setattr(opds, "_", lambda value, **_kwargs: value)
+    monkeypatch.setattr(
+        opds,
+        "url_for",
+        lambda endpoint: "/opds/currentlyreading"
+        if endpoint == "opds.feed_currently_reading" else f"/{endpoint}",
+    )
+
+
+@pytest.mark.unit
+def test_root_contains_currently_reading_for_authenticated_visible_user():
+    user = _User()
+    with app.test_request_context("/opds"):
+        entries = opds.get_opds_root_entries(user, allow_anonymous=False)
+    current = next(entry for entry in entries if entry["key"] == "currently_reading")
+    assert current["title"] == "currently_reading"
+    assert current["url"].endswith("/opds/currentlyreading")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("user", [_User(anonymous=True), _User(visible=False)])
+def test_root_hides_currently_reading_when_read_feeds_are_not_visible(user):
+    with app.test_request_context("/opds"):
+        keys = {entry["key"] for entry in opds.get_opds_root_entries(user, allow_anonymous=True)}
+    assert "currently_reading" not in keys
+
+
+@pytest.mark.unit
+def test_feed_uses_canonical_in_progress_filter_and_restricted_fill(monkeypatch):
+    user = _User()
+    sentinel_filter = object()
+    books = [SimpleNamespace(Books=SimpleNamespace(id=7)), SimpleNamespace(Books=SimpleNamespace(id=9))]
+    captured = {}
+
+    def build_filter(rule, user_id=None):
+        captured["rule"] = rule
+        captured["user_id"] = user_id
+        return sentinel_filter
+
+    def fill(*args, **kwargs):
+        captured["fill_args"] = args
+        return books, False, SimpleNamespace(total_count=2)
+
+    monkeypatch.setattr(opds.auth, "current_user", lambda: user)
+    monkeypatch.setattr(opds.magic_shelf, "build_filter_from_rule", build_filter)
+    monkeypatch.setattr(opds, "fill_opds_indexpage", fill)
+    monkeypatch.setattr(opds, "render_xml_template", lambda *_args, **kwargs: kwargs["entries"])
+    monkeypatch.setattr(opds.config, "config_books_per_page", 20, raising=False)
+    monkeypatch.setattr(opds.config, "config_read_column", 0, raising=False)
+
+    with app.test_request_context("/opds/currentlyreading"):
+        result = opds.feed_currently_reading.__wrapped__()
+
+    assert [row.Books.id for row in result] == [7, 9]
+    assert captured["rule"]["value"] == ub.ReadBook.STATUS_IN_PROGRESS
+    assert captured["rule"]["operator"] == "equal"
+    assert captured["user_id"] == user.id
+    assert captured["fill_args"][3] is sentinel_filter
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("user", [_User(anonymous=True), _User(visible=False)])
+def test_feed_rejects_anonymous_or_visibility_restricted_user(monkeypatch, user):
+    monkeypatch.setattr(opds.auth, "current_user", lambda: user)
+    with app.test_request_context("/opds/currentlyreading"):
+        with pytest.raises(Forbidden):
+            opds.feed_currently_reading.__wrapped__()


### PR DESCRIPTION
OPDS clients currently expose only Read and Unread root feeds, so books actively in progress are buried in the broad not-finished group. There is no dedicated way to browse the tri-state reading status already used by Kobo/KOReader sync and the Currently Reading magic-shelf preset.

This adds an authenticated “Currently Reading” root entry and feed. It reuses the canonical magic-shelf `STATUS_IN_PROGRESS` filter rather than treating every not-finished book as current, including the existing custom-read-column exclusion semantics. Results pass through the centralized OPDS page helper, preserving selected-shelf/book visibility restrictions.

Addresses #672.

Verification:
- RED: `pytest tests/unit/test_672_opds_currently_reading.py -q` — 6 failed; root entry and route absent.
- GREEN: `pytest tests/unit/test_672_opds_currently_reading.py tests/unit/test_opds_sync_restrictions.py tests/unit/test_magic_shelf_currently_reading.py tests/unit/test_634_custom_read_column_currently_reading.py -q` — 32 passed.
- `python3 -m py_compile cps/opds.py` — success.
- `git diff --check` — clean.

New OPDS strings use lazy gettext markers. No new dependencies, licenses, or external service URLs.