### PR TITLE
feat(ui): add inline half-star rating selector (#779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ is for things you can see or feel when running the app.
 
 ### Added
 
+- **Book ratings can now be set with an inline five-star control in the new editor.** Click either half of a star for half-star precision, use the arrow keys to adjust in half-star steps, or clear the rating explicitly — no dropdown required. ([#779](https://github.com/new-usemame/Calibre-Web-NextGen/issues/779))
 - **The new UI's book editor has a Publication date field again.** The redesigned editor shipped without the publication-date field the classic editor has, so the date could only be set from the classic UI. The editor now has a "Published" date input — prefilled from the book's current date, and clearable to reset it. This completes the #689 report alongside the metadata autocomplete that shipped in v4.1.9. ([#689](https://github.com/new-usemame/Calibre-Web-NextGen/issues/689))
 
 ### Fixed

--- a/cps/spa_strings.py
+++ b/cps/spa_strings.py
@@ -53,6 +53,8 @@ _("Remove tag {name}")
 # page) and the "More by this author" browse strip that fills the page for
 # sparse books. SPA-only strings (BookDetail.tsx / StarRating.tsx /
 # MoreByAuthor.tsx), anchored so the auto-translation job keeps them.
+_("Clear rating")
+_("Not rated")
 _("Rated {rating} out of 5")
 _("More by {name}")
 

--- a/frontend/src/pages/EditBook.module.css
+++ b/frontend/src/pages/EditBook.module.css
@@ -70,6 +70,12 @@
 .input { width: 100%; }
 .inputNarrow { width: 130px; }
 
+.ratingControl { display: flex; align-items: center; gap: var(--sp-3); min-height: 40px; }
+.ratingStars { display: flex; color: var(--text-faint); cursor: pointer; border-radius: var(--r-sm); }
+.ratingStars:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 3px; }
+.clearRating { min-height: 40px; color: var(--text-muted); text-decoration: underline; }
+.clearRating:disabled { opacity: .45; cursor: default; }
+
 .textarea {
   width: 100%;
   resize: vertical;

--- a/frontend/src/pages/EditBook.tsx
+++ b/frontend/src/pages/EditBook.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useId, cloneElement, isValidElement, type ReactElement } from 'react';
 import { createPortal } from 'react-dom';
 import { Link, useLocation } from 'wouter';
-import { ChevronLeft, Save, Trash2, RefreshCw, Image as ImageIcon, Upload as UploadIcon, ExternalLink, Sparkles, Search, Plus, X, MoreHorizontal } from 'lucide-react';
+import { ChevronLeft, Save, Trash2, RefreshCw, Image as ImageIcon, Upload as UploadIcon, ExternalLink, Sparkles, Search, Plus, X, MoreHorizontal, Star } from 'lucide-react';
 import {
   useBookMetadata, useUpdateMetadata, useBook, useMe, useDeleteFormat, useConvertFormat,
   useSetCover, useMetadataSearch, useAddFormat,
@@ -10,6 +10,7 @@ import { Button } from '../components/Button';
 import { MetadataTypeahead } from '../components/MetadataTypeahead';
 import { Spinner, SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
+import { StarRating } from '../components/StarRating';
 import type { MetadataUpdate, MetaResult } from '../lib/api';
 import { ApiError, resourceUrl } from '../lib/api';
 import { useT } from '../lib/i18n';
@@ -31,7 +32,38 @@ interface FormState {
   identifiers: Ident[];
 }
 
-const RATINGS = ['', '1', '2', '3', '4', '5'];
+function RatingSelector({ value, onChange }: { value: string; onChange: (value: string) => void }) {
+  const t = useT();
+  const rating = Number(value) || 0;
+  const setRating = (next: number) => onChange(next > 0 ? String(Math.max(0.5, Math.min(5, next))) : '');
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    let next: number | null = null;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowUp') next = rating + 0.5;
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') next = rating - 0.5;
+    if (e.key === 'Home') next = 0;
+    if (e.key === 'End') next = 5;
+    if (next !== null) { e.preventDefault(); setRating(next); }
+  };
+  const choose = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    setRating(Math.ceil(((e.clientX - rect.left) / rect.width) * 10) / 2);
+  };
+  return (
+    <div className={styles.ratingControl}>
+      <div className={styles.ratingStars} role="slider" tabIndex={0}
+        aria-label={t('Rating')} aria-valuemin={0} aria-valuemax={5} aria-valuenow={rating}
+        aria-valuetext={rating ? t('Rated {rating} out of 5', { rating }) : t('Not rated')}
+        onKeyDown={onKeyDown} onClick={choose}>
+        {rating ? <StarRating rating={rating * 2} size={26} /> : Array.from({ length: 5 }, (_, i) => (
+          <Star key={i} size={26} aria-hidden="true" focusable={false} />
+        ))}
+      </div>
+      <button type="button" className={styles.clearRating} onClick={() => onChange('')} disabled={!rating}>
+        {t('Clear rating')}
+      </button>
+    </div>
+  );
+}
 
 /** Which fields a fetched result can contribute, in display order. `has` decides
  *  whether the result actually offers the field (so we only show applicable rows),
@@ -223,9 +255,7 @@ export function EditBook({ id }: { id: string }) {
               aria-label={t('Languages (comma separated)')} />
           </Field>
           <Field label={t('Rating')} error={fieldErrors.rating} grow={false}>
-            <select className={styles.inputNarrow} value={form.rating} onChange={(e) => set('rating', e.target.value)}>
-              {RATINGS.map((r) => <option key={r} value={r}>{r ? `${r} ★` : '—'}</option>)}
-            </select>
+            <RatingSelector value={form.rating} onChange={(value) => set('rating', value)} />
           </Field>
         </div>
 

--- a/tests/unit/test_779_inline_rating_selector.py
+++ b/tests/unit/test_779_inline_rating_selector.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.unit
+def test_editor_rating_is_inline_half_star_keyboard_control():
+    src = (ROOT / "frontend/src/pages/EditBook.tsx").read_text()
+    assert "function RatingSelector" in src
+    assert 'role="slider"' in src
+    assert "rating + 0.5" in src and "rating - 0.5" in src
+    assert "Math.ceil" in src and "/ 2" in src
+    assert "<StarRating rating={rating * 2}" in src
+    assert "<select className={styles.inputNarrow} value={form.rating}" not in src
+    assert "Clear rating" in src


### PR DESCRIPTION
The new metadata editor hid ratings in a dropdown and could not express Calibre’s half-star precision. This replaces it with an inline five-star selector that writes the existing 0–5 API value (the backend remains the single conversion point to Calibre’s 0–10 scale).

Click position selects half-star steps, arrow keys adjust by 0.5, Home/End select the endpoints, and a dedicated Clear rating action removes the rating. The control exposes slider value semantics and reuses the corrected fractional StarRating renderer from #776.

Addresses #779.

Verification:
- `.venv/bin/python -m pytest tests/unit/test_779_inline_rating_selector.py tests/unit/test_776_star_rating_fill.py -q` — 4 passed
- `cd frontend && npx tsc -b` — 0 errors
- `npm run build` — success