### PR TITLE
fix(scripts): publish-cwasync-plugin SIGPIPE under pipefail blocks every publish

### DIFF
--- a/scripts/publish-cwasync-plugin.sh
+++ b/scripts/publish-cwasync-plugin.sh
@@ -89,8 +89,11 @@ rsync -a --delete --exclude='.DS_Store' "$SOURCE/" "$tmp/repo/cwasync.koplugin/"
     cd "$tmp/repo"
     rm -f cwasync.koplugin.zip
     zip -qr cwasync.koplugin.zip cwasync.koplugin
-    unzip -Z1 cwasync.koplugin.zip | grep -qx 'cwasync.koplugin/main.lua'
-    unzip -Z1 cwasync.koplugin.zip | grep -qx 'cwasync.koplugin/_meta.lua'
+    # Read the listing once, then match — piping unzip into `grep -q` trips SIGPIPE
+    # under `set -o pipefail` (grep exits on first match, unzip dies 141) and aborts.
+    zip_listing=$(unzip -Z1 cwasync.koplugin.zip)
+    grep -qx 'cwasync.koplugin/main.lua' <<<"$zip_listing"
+    grep -qx 'cwasync.koplugin/_meta.lua' <<<"$zip_listing"
 )
 
 if ((PUBLISH == 0)); then


### PR DESCRIPTION
## Problem
`scripts/publish-cwasync-plugin.sh` (added in #864) aborted with exit 141 and no output on **every** invocation, blocking the first plugin publish (#842). The zip integrity check piped `unzip -Z1` into `grep -qx`: `grep -q` exits on the first match, `unzip` then receives SIGPIPE (141), and `set -o pipefail` + `set -e` propagated that as a fatal failure before the script could dry-run or publish.

## Fix
Read the `unzip -Z1` listing into a variable once, then `grep -qx` the variable — no pipe for grep to close early.

## Evidence (red/green + live)
- **Red:** `bash scripts/publish-cwasync-plugin.sh --tag v4.1.11` → exit **141**, empty output (`bash -x` traced the death to the `unzip … | grep -qx` line).
- **Green:** same command post-fix → exit **0**, prints `DRY RUN: validated v4.1.11` and lists all 11 plugin files.
- **Live end-to-end:** ran `--publish` and the first cwasync plugin release went out successfully → https://github.com/new-usemame/cwasync.koplugin/releases/tag/v4.1.11

Dev/release-ops tooling only — not in the runtime image. No new deps. Addresses #842's publish path.