### PR TITLE
feat(koreader): sync highlights and notes into the canonical library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+
+- KOReader highlights and notes from the open book can now sync into Calibre-Web NextGen, survive concurrent updates from multiple devices, and appear in the existing Highlights list on the book page. ([#699](https://github.com/new-usemame/Calibre-Web-NextGen/issues/699))
+
 ### Changed
 
 - The new in-browser reader now keeps font family, size, margins, line height, and page theme with your account, so your preferred reading layout follows you between browsers and the classic/new interfaces; its appearance panel is touch- and keyboard-accessible on phones and desktops.

--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -808,7 +808,9 @@ def annotations_delete(book_id, annotation_id):
     # the row has none. Idempotent (re-sets hidden=True, skips tombstones).
     try:
         from .services import annotation_sync
-        annotation_sync.dispatch_annotation_deletes([annotation_id], current_user)
+        annotation_sync.dispatch_annotation_deletes(
+            [annotation_id], current_user, book_id=book_id,
+        )
     except Exception as e:  # pragma: no cover - defensive
         log.warning("annotations: delete fan-out failed: %s", e)
     return jsonify({"status": "deleted", "annotation_id": annotation_id}), 200

--- a/cps/progress_syncing/protocols/koreader_annotations.py
+++ b/cps/progress_syncing/protocols/koreader_annotations.py
@@ -78,11 +78,13 @@ def apply_push(annotations, *, user, book, session, commit) -> dict:
             payload, user_id=user.id, book=book, session=session, commit=commit,
         )
         summary[action] = summary.get(action, 0) + 1
-        if row is None:
+        if row is None or action == "skipped":
             continue
         try:
             if action == "deleted":
-                annotation_sync.dispatch_annotation_deletes([row.annotation_id], user)
+                annotation_sync.dispatch_annotation_deletes(
+                    [row.annotation_id], user, book_id=book.id,
+                )
             else:
                 annotation_sync.dispatch_existing_annotation_sync(row, book, user)
         except Exception:  # pragma: no cover - fan-out must never fail the push
@@ -152,6 +154,14 @@ def push_annotations():
     annotations = data.get("annotations")
     if not isinstance(annotations, list):
         return create_sync_response({"error": "invalid_annotations", "message": "annotations must be an array"}, 400)
+    from ...services.annotation_portable import validate_portable_payload
+    for index, payload in enumerate(annotations):
+        error = validate_portable_payload(payload)
+        if error:
+            return create_sync_response({
+                "error": "invalid_annotation",
+                "message": f"annotations[{index}]: {error}",
+            }, 400)
     summary = apply_push(
         annotations, user=user, book=book,
         session=ub.session, commit=ub.session_commit,

--- a/cps/progress_syncing/protocols/koreader_annotations.py
+++ b/cps/progress_syncing/protocols/koreader_annotations.py
@@ -71,7 +71,9 @@ def apply_push(annotations, *, user, book, session, commit) -> dict:
     from ...services import annotation_sync
 
     summary = {"created": 0, "updated": 0, "deleted": 0, "skipped": 0}
-    for payload in (annotations or []):
+    if not isinstance(annotations, list):
+        return summary
+    for payload in annotations:
         row, action = apply_portable(
             payload, user_id=user.id, book=book, session=session, commit=commit,
         )
@@ -129,7 +131,9 @@ def push_annotations():
     if not user:
         return create_sync_response({"error": ERROR_UNAUTHORIZED_USER, "message": "Unauthorized"}, 401)
 
-    data = request.get_json(silent=True) or {}
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return create_sync_response({"error": "invalid_payload", "message": "JSON object required"}, 400)
     document = data.get("document")
     if not is_valid_key_field(document):
         return create_sync_response({"error": ERROR_DOCUMENT_FIELD_MISSING, "message": "Invalid document field"}, 400)
@@ -145,8 +149,11 @@ def push_annotations():
         return create_sync_response({"document": document, "matched": False,
                                      "created": 0, "updated": 0, "deleted": 0, "skipped": 0})
 
+    annotations = data.get("annotations")
+    if not isinstance(annotations, list):
+        return create_sync_response({"error": "invalid_annotations", "message": "annotations must be an array"}, 400)
     summary = apply_push(
-        data.get("annotations"), user=user, book=book,
+        annotations, user=user, book=book,
         session=ub.session, commit=ub.session_commit,
     )
     summary["document"] = document

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -376,7 +376,9 @@ def handle_annotations(entitlement_id):
                 if updated:
                     annotation_sync.dispatch_annotation_sync(updated, book, current_user)
                 if deleted:
-                    annotation_sync.dispatch_annotation_deletes(deleted, current_user)
+                    annotation_sync.dispatch_annotation_deletes(
+                        deleted, current_user, book_id=book.id,
+                    )
         except Exception:
             log.exception("Error processing PATCH annotations")
     # Proxy to Kobo reading services for both GET + PATCH.
@@ -418,4 +420,3 @@ def handle_unknown_reading_service_request(subpath):
     """
     # Proxy to Kobo reading services
     return proxy_to_kobo_reading_services()
-

--- a/cps/services/annotation_portable.py
+++ b/cps/services/annotation_portable.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional, Tuple
 
+from sqlalchemy import exc
+
 _VALID_SOURCES = {"kobo", "webreader", "koreader"}
 
 
@@ -45,6 +47,9 @@ def to_portable(row) -> dict:
         "end_offset": row.end_offset,
         "context_string": row.context_string,
         "chapter_progress": row.chapter_progress,
+        "position_type": row.position_type,
+        "start_xpointer": row.start_xpointer,
+        "end_xpointer": row.end_xpointer,
         "source": row.source,
         "hidden": bool(row.hidden),
         "device_origin_id": row.device_origin_id,
@@ -65,13 +70,17 @@ def apply_portable(payload, *, user_id, book, session, commit) -> Tuple[Optional
     """
     from cps import ub
 
-    annotation_id = payload.get("annotation_id")
-    if not annotation_id:
+    if not isinstance(payload, dict):
         return None, "skipped"
+    annotation_id = payload.get("annotation_id")
+    if not isinstance(annotation_id, str) or not annotation_id.strip():
+        return None, "skipped"
+    annotation_id = annotation_id.strip()
 
     row = (
         session.query(ub.Annotation)
         .filter(ub.Annotation.user_id == user_id,
+                ub.Annotation.book_id == book.id,
                 ub.Annotation.annotation_id == annotation_id)
         .first()
     )
@@ -89,6 +98,15 @@ def apply_portable(payload, *, user_id, book, session, commit) -> Tuple[Optional
     elif payload.get("source") in _VALID_SOURCES:
         row.source = payload.get("source")
 
+    before = None if created else (
+        row.source, row.highlighted_text, row.note_text, row.highlight_color,
+        row.content_id, row.context_string, row.chapter_progress,
+        row.position_type, row.start_xpointer, row.end_xpointer,
+        row.start_container_path, row.start_offset,
+        row.end_container_path, row.end_offset,
+        row.device_origin_id, bool(row.hidden),
+    )
+
     # Content fields (only overwrite when present in the payload).
     if "highlighted_text" in payload:
         row.highlighted_text = payload.get("highlighted_text")
@@ -102,6 +120,14 @@ def apply_portable(payload, *, user_id, book, session, commit) -> Tuple[Optional
         row.context_string = payload.get("context_string")
     if payload.get("chapter_progress") is not None:
         row.chapter_progress = payload.get("chapter_progress")
+
+    if payload.get("position_type") == "koreader_xpointer":
+        start_xpointer = payload.get("start_xpointer")
+        end_xpointer = payload.get("end_xpointer")
+        if isinstance(start_xpointer, str) and start_xpointer:
+            row.position_type = "koreader_xpointer"
+            row.start_xpointer = start_xpointer
+            row.end_xpointer = end_xpointer if isinstance(end_xpointer, str) else None
 
     # Position — build the Kobo-native selector form from the KoboSpan anchor.
     start_span = payload.get("start_kobospan")
@@ -124,6 +150,35 @@ def apply_portable(payload, *, user_id, book, session, commit) -> Tuple[Optional
         row.hidden = False
         action = "created" if created else "updated"
 
+    after = (
+        row.source, row.highlighted_text, row.note_text, row.highlight_color,
+        row.content_id, row.context_string, row.chapter_progress,
+        row.position_type, row.start_xpointer, row.end_xpointer,
+        row.start_container_path, row.start_offset,
+        row.end_container_path, row.end_offset,
+        row.device_origin_id, bool(row.hidden),
+    )
+    if not created and before == after:
+        return row, "skipped"
+
     row.last_synced = _now()
-    commit()
+    try:
+        commit()
+    except exc.IntegrityError:
+        # A parallel device may have inserted the same canonical identity
+        # after our SELECT. Roll back this losing INSERT and replay as an
+        # update; the unique index is the serialization point.
+        session.rollback()
+        winner = (
+            session.query(ub.Annotation)
+            .filter(ub.Annotation.user_id == user_id,
+                    ub.Annotation.book_id == book.id,
+                    ub.Annotation.annotation_id == annotation_id)
+            .one_or_none()
+        )
+        if winner is None:
+            raise
+        return apply_portable(
+            payload, user_id=user_id, book=book, session=session, commit=commit,
+        )
     return row, action

--- a/cps/services/annotation_portable.py
+++ b/cps/services/annotation_portable.py
@@ -28,6 +28,29 @@ from sqlalchemy import exc
 _VALID_SOURCES = {"kobo", "webreader", "koreader"}
 
 
+def validate_portable_payload(payload) -> Optional[str]:
+    """Return a validation error for fields that would make an upsert unsafe."""
+    if not isinstance(payload, dict):
+        return None  # non-object entries are deliberately counted as skipped
+    for field in ("annotation_id", "highlighted_text", "note_text", "color",
+                  "content_id", "context_string", "position_type",
+                  "start_xpointer", "end_xpointer", "device_origin_id"):
+        value = payload.get(field)
+        if value is not None and not isinstance(value, str):
+            return f"{field} must be a string or null"
+    for field in ("start_kobospan", "end_kobospan"):
+        value = payload.get(field)
+        if value is not None and not isinstance(value, str):
+            return f"{field} must be a string or null"
+    for field in ("start_offset", "end_offset"):
+        value = payload.get(field)
+        if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+            return f"{field} must be an integer or null"
+    if "hidden" in payload and not isinstance(payload.get("hidden"), bool):
+        return "hidden must be a boolean"
+    return None
+
+
 def _now():
     return datetime.now(timezone.utc)
 
@@ -60,7 +83,7 @@ def to_portable(row) -> dict:
 def apply_portable(payload, *, user_id, book, session, commit) -> Tuple[Optional[object], str]:
     """Upsert an Annotation from a device-pushed portable dict.
 
-    Find-or-create keyed on ``(user_id, annotation_id)``. New rows take the
+    Find-or-create keyed on ``(user_id, book_id, annotation_id)``. New rows take the
     payload's ``source`` (coerced to ``koreader`` if absent/invalid). Position
     fields are built from the KoboSpan anchors like the web-reader create path.
     ``device_origin_id`` is recorded so the next pull won't echo the row back to
@@ -95,6 +118,10 @@ def apply_portable(payload, *, user_id, book, session, commit) -> Tuple[Optional
         )
         session.add(row)
         created = True
+    elif row.hidden and not payload.get("hidden"):
+        # A complete-list retry has no mutation clock, so it cannot prove an
+        # intentional recreation. Preserve the tombstone and every stored field.
+        return row, "skipped"
     elif payload.get("source") in _VALID_SOURCES:
         row.source = payload.get("source")
 

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -6,7 +6,7 @@ Public API:
   - register_handler(handler): plug in a new target
   - available_targets(): list registered target names
   - dispatch_annotation_sync(payload_annotations, book, user): push every annotation
-  - dispatch_annotation_deletes(deleted_ids, user): delete every annotation
+  - dispatch_annotation_deletes(deleted_ids, user, book_id): delete scoped annotations
 
 The dispatcher owns all DB persistence — Annotation rows + AnnotationSyncTarget
 rows + the status state machine. Handlers are stateless: they make remote
@@ -61,7 +61,7 @@ def _book_uuid(book):
 
 
 def _upsert_annotation(session, payload, book, user):
-    """Find-or-create Annotation row keyed on (user_id, annotation_id).
+    """Find-or-create Annotation row keyed on (user_id, book_id, annotation_id).
 
     Populates content fields AND position fields from the Kobo PATCH payload
     so subsequent CFI computation has everything it needs.  This is the
@@ -76,6 +76,7 @@ def _upsert_annotation(session, payload, book, user):
         session.query(ub.Annotation)
         .filter(
             ub.Annotation.user_id == user.id,
+            ub.Annotation.book_id == book.id,
             ub.Annotation.annotation_id == annotation_id,
         )
         .first()
@@ -244,7 +245,7 @@ def dispatch_existing_annotation_sync(annotation, book, user) -> None:
     ub.session_commit()
 
 
-def dispatch_annotation_deletes(deleted_ids, user) -> None:
+def dispatch_annotation_deletes(deleted_ids, user, book_id=None) -> None:
     """For each annotation_id, transition non-tombstone sync_targets via
     handler.delete AND soft-delete the local Annotation row by setting
     ``hidden=True``.
@@ -258,14 +259,13 @@ def dispatch_annotation_deletes(deleted_ids, user) -> None:
     if not deleted_ids:
         return
     for annotation_id in deleted_ids:
-        ann = (
-            ub.session.query(ub.Annotation)
-            .filter(
-                ub.Annotation.user_id == user.id,
-                ub.Annotation.annotation_id == annotation_id,
-            )
-            .first()
+        query = ub.session.query(ub.Annotation).filter(
+            ub.Annotation.user_id == user.id,
+            ub.Annotation.annotation_id == annotation_id,
         )
+        if book_id is not None:
+            query = query.filter(ub.Annotation.book_id == book_id)
+        ann = query.first()
         if ann is None:
             continue
         # Push delete through any non-tombstone sync targets first.

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -935,6 +935,11 @@ class Annotation(Base):
     pdf_page = Column(Integer, nullable=True)         # 1-indexed PDF page number
     pdf_quad_json = Column(Text, nullable=True)       # JSON: [[x,y,w,h], ...] in PDF user-space coords
     comic_page = Column(Integer, nullable=True)       # 1-indexed comic page (CBR/CBZ)
+    # KOReader's native reflowable locator.  This is intentionally kept
+    # separate from EPUB CFI: KOReader xpointers are engine-private and are
+    # not safe to present to epub.js as CFIs.
+    start_xpointer = Column(Text, nullable=True)
+    end_xpointer = Column(Text, nullable=True)
     # Phase 2 (KOReader bridge) — opaque per-device id of the row a device last
     # wrote/saw for this annotation (e.g. the KoboReader.sqlite Bookmark.BookmarkID
     # the plugin created). Lets the plugin dedup + suppress feedback loops without
@@ -960,10 +965,14 @@ class Annotation(Base):
     __table_args__ = (
         Index('ix_annotation_user_annotation', 'user_id', 'annotation_id'),
         Index('ix_annotation_user_book', 'user_id', 'book_id'),
+        UniqueConstraint(
+            'user_id', 'book_id', 'annotation_id',
+            name='uq_annotation_user_book_annotation',
+        ),
     )
 
     _VALID_SOURCES = {"kobo", "webreader", "koreader"}
-    _VALID_POSITION_TYPES = {"cfi", "pdf_quad", "comic_page"}
+    _VALID_POSITION_TYPES = {"cfi", "pdf_quad", "comic_page", "koreader_xpointer"}
 
     @validates("source")
     def _validate_source(self, _key, value):
@@ -2622,6 +2631,38 @@ def migrate_annotation_device_origin(engine, _session):
                 raise
 
 
+def migrate_annotation_koreader_identity(engine, _session):
+    """Add KOReader-native locator columns and enforce merge identity.
+
+    The unique index makes parallel device pushes converge on one canonical
+    row.  Existing duplicates are not guessed away: aborting the transaction
+    is rollback-safe and leaves an operator-visible data repair requirement.
+    """
+    with engine.begin() as conn:
+        if not conn.execute(text(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='annotation'"
+        )).first():
+            return
+        duplicate = conn.execute(text(
+            "SELECT user_id, book_id, annotation_id, COUNT(*) AS n "
+            "FROM annotation GROUP BY user_id, book_id, annotation_id "
+            "HAVING COUNT(*) > 1 LIMIT 1"
+        )).first()
+        if duplicate:
+            raise RuntimeError(
+                "annotation identity migration found duplicate "
+                f"(user={duplicate[0]}, book={duplicate[1]}, id={duplicate[2]!r})"
+            )
+        existing = {row[1] for row in conn.execute(text("PRAGMA table_info(annotation)"))}
+        for name in ("start_xpointer", "end_xpointer"):
+            if name not in existing:
+                conn.execute(text(f"ALTER TABLE annotation ADD COLUMN {name} TEXT"))
+        conn.execute(text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_annotation_user_book_annotation "
+            "ON annotation(user_id, book_id, annotation_id)"
+        ))
+
+
 def migrate_annotation_decouple_source_target(engine, _session):
     """Decouple annotation origin from sync target.
 
@@ -2790,6 +2831,7 @@ def migrate_Database(_session):
     migrate_annotation_decouple_source_target(engine, _session)
     migrate_annotation_polymorphic_position(engine, _session)
     migrate_annotation_device_origin(engine, _session)
+    migrate_annotation_koreader_identity(engine, _session)
     migrate_book_cover_preview_table(engine, _session)
     migrate_dismissed_duplicate_groups_table(engine, _session)
 

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -2656,7 +2656,11 @@ def migrate_annotation_koreader_identity(engine, _session):
         existing = {row[1] for row in conn.execute(text("PRAGMA table_info(annotation)"))}
         for name in ("start_xpointer", "end_xpointer"):
             if name not in existing:
-                conn.execute(text(f"ALTER TABLE annotation ADD COLUMN {name} TEXT"))
+                try:
+                    conn.execute(text(f"ALTER TABLE annotation ADD COLUMN {name} TEXT"))
+                except exc.OperationalError as e:
+                    if "duplicate column" not in str(e).lower():
+                        raise
         conn.execute(text(
             "CREATE UNIQUE INDEX IF NOT EXISTS uq_annotation_user_book_annotation "
             "ON annotation(user_id, book_id, annotation_id)"

--- a/koreader/plugins/cwasync.koplugin/device_annotations.lua
+++ b/koreader/plugins/cwasync.koplugin/device_annotations.lua
@@ -17,13 +17,14 @@ Provider interface:
 local DeviceAnnotations = {}
 
 local PROVIDERS = {
+    require("koreader_annotations_provider"),
     require("kobo_sqlite_provider"),
-    -- future: require("koreader_sdr_provider"),
 }
 
 -- First provider that reports itself usable on this device, or nil.
-function DeviceAnnotations.getProvider()
+function DeviceAnnotations.getProvider(ui, document_digest)
     for _, p in ipairs(PROVIDERS) do
+        if p.setContext then p.setContext(ui, document_digest) end
         local ok, usable = pcall(p.available)
         if ok and usable then
             return p

--- a/koreader/plugins/cwasync.koplugin/koreader_annotations_provider.lua
+++ b/koreader/plugins/cwasync.koplugin/koreader_annotations_provider.lua
@@ -1,0 +1,74 @@
+-- KOReader-native phase-1 annotation provider.
+--
+-- Reads the active reader's public ReaderAnnotation collection.  It never
+-- parses or writes .sdr files, so KOReader remains the sole owner regardless
+-- of document-relative/central/hash metadata storage mode.
+
+local Json = require("json")
+local md5 = require("ffi/sha2").md5
+
+local KoboProvider = require("kobo_sqlite_provider")
+local Provider = { push_all_local = true, ui = nil, document_digest = nil }
+
+function Provider.setContext(ui, document_digest)
+    Provider.ui = ui
+    Provider.document_digest = document_digest
+end
+
+function Provider.available()
+    return Provider.ui ~= nil
+        and Provider.ui.annotation ~= nil
+        and type(Provider.ui.annotation.annotations) == "table"
+end
+
+local function stableId(annotation)
+    local identity = {
+        Provider.document_digest or "",
+        annotation.datetime or "",
+        annotation.page,
+        annotation.pos0,
+        annotation.pos1,
+    }
+    return "koreader-" .. md5(Json.encode(identity))
+end
+
+local function toPortable(annotation)
+    local rolling = type(annotation.page) == "string"
+    return {
+        annotation_id = stableId(annotation),
+        highlighted_text = annotation.text,
+        note_text = annotation.note,
+        color = annotation.color,
+        source = "koreader",
+        position_type = rolling and "koreader_xpointer" or nil,
+        start_xpointer = rolling and (annotation.pos0 or annotation.page) or nil,
+        end_xpointer = rolling and annotation.pos1 or nil,
+        chapter_progress = nil,
+        hidden = false,
+        device_origin_id = stableId(annotation),
+    }
+end
+
+function Provider.readAll(_volume_id)
+    if not Provider.available() then return {} end
+    local out = {}
+    for _, annotation in ipairs(Provider.ui.annotation.annotations) do
+        -- A page bookmark with neither selected text nor note is not a
+        -- highlight/annotation and stays in KOReader only.
+        if annotation.text or annotation.note then
+            out[#out + 1] = toPortable(annotation)
+        end
+    end
+    return out
+end
+
+function Provider.applyToDevice(portables, volume_id)
+    -- Preserve the already-shipped Kobo/Nickel bridge when KOReader happens
+    -- to run on a Kobo. Other devices remain phase-1 push-only.
+    if KoboProvider.available() then
+        return KoboProvider.applyToDevice(portables, volume_id)
+    end
+    return 0
+end
+
+return Provider

--- a/koreader/plugins/cwasync.koplugin/main.lua
+++ b/koreader/plugins/cwasync.koplugin/main.lua
@@ -403,8 +403,8 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                 separator = true,
             },
             {
-                text = _("Sync highlights (experimental, Kobo only)"),
-                help_text = _([[Writes highlights from the server into your Kobo's database so they show in the stock reader. A backup of KoboReader.sqlite is made before any write. Needs KOReader running on a Kobo.]]),
+                text = _("Sync KOReader highlights"),
+                help_text = _([[Uploads highlights and notes from the open KOReader document to your NextGen library. On Kobo devices, existing server-to-Nickel highlight support remains available.]]),
                 checked_func = function() return self.settings.sync_annotations end,
                 callback = function()
                     self.settings.sync_annotations = not self.settings.sync_annotations
@@ -1473,20 +1473,20 @@ function CWASync:syncAnnotations(interactive)
         return
     end
 
+    local digest = self:getDocumentDigest()
+    if not digest then return end
+
     local DeviceAnnotations = require("device_annotations")
-    local provider = DeviceAnnotations.getProvider()
+    local provider = DeviceAnnotations.getProvider(self.ui, digest)
     if not provider then
         if interactive then
             UIManager:show(InfoMessage:new{
-                text = _("Highlight sync needs KOReader running on a Kobo (KoboReader.sqlite)."),
+                text = _("Highlight sync is unavailable for this document."),
                 timeout = 3,
             })
         end
         return
     end
-
-    local digest = self:getDocumentDigest()
-    if not digest then return end
 
     local CWASyncClient = require("CWASyncClient")
     local client = CWASyncClient:new{
@@ -1512,8 +1512,15 @@ function CWASync:syncAnnotations(interactive)
                 end
             end
 
-            local localList = volume_id and provider.readAll(volume_id) or {}
+            local localList = (provider.push_all_local or volume_id)
+                and provider.readAll(volume_id) or {}
             local diff = SyncLogic.diffAnnotations(localList, remote)
+            if provider.push_all_local then
+                -- Phase 1 native KOReader provider: retries the complete local
+                -- set. Server identity/upsert makes this idempotent and avoids
+                -- trusting incomparable device clocks.
+                diff.send_to_server = localList
+            end
 
             local applied = 0
             if volume_id and #diff.apply_to_device > 0 then

--- a/tests/unit/test_699_koreader_phase1_contract.py
+++ b/tests/unit/test_699_koreader_phase1_contract.py
@@ -1,0 +1,105 @@
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
+from cps.services.annotation_portable import apply_portable
+
+pytestmark = pytest.mark.unit
+
+
+def test_identity_migration_is_idempotent_and_preserves_rows(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'app.db'}", future=True)
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE annotation (
+                id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL,
+                book_id INTEGER NOT NULL, annotation_id VARCHAR NOT NULL
+            )
+        """))
+        conn.execute(text(
+            "INSERT INTO annotation (user_id, book_id, annotation_id) VALUES (1, 2, 'a')"
+        ))
+    ub.migrate_annotation_koreader_identity(engine, None)
+    ub.migrate_annotation_koreader_identity(engine, None)
+    columns = {c["name"] for c in inspect(engine).get_columns("annotation")}
+    assert {"start_xpointer", "end_xpointer"} <= columns
+    with engine.connect() as conn:
+        assert conn.execute(text("SELECT COUNT(*) FROM annotation")).scalar_one() == 1
+        indexes = {r[1] for r in conn.execute(text("PRAGMA index_list(annotation)"))}
+    assert "uq_annotation_user_book_annotation" in indexes
+
+
+def test_identity_migration_rolls_back_on_preexisting_duplicates(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'dups.db'}", future=True)
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE annotation (
+                id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL,
+                book_id INTEGER NOT NULL, annotation_id VARCHAR NOT NULL
+            )
+        """))
+        conn.execute(text(
+            "INSERT INTO annotation (user_id, book_id, annotation_id) VALUES "
+            "(1, 2, 'a'), (1, 2, 'a')"
+        ))
+    with pytest.raises(RuntimeError, match="duplicate"):
+        ub.migrate_annotation_koreader_identity(engine, None)
+    assert "start_xpointer" not in {c["name"] for c in inspect(engine).get_columns("annotation")}
+
+
+def test_two_parallel_devices_merge_without_duplicate_or_integrity_leak(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'race.db'}", future=True,
+        connect_args={"check_same_thread": False, "timeout": 10},
+    )
+    ub.Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, future=True)
+    barrier = Barrier(2)
+    book = SimpleNamespace(id=7, uuid="book")
+
+    def device(text_value):
+        session = Session()
+        first = True
+
+        def commit():
+            nonlocal first
+            if first:
+                first = False
+                barrier.wait(timeout=5)
+            session.commit()
+
+        try:
+            return apply_portable(
+                {"annotation_id": "shared", "highlighted_text": text_value},
+                user_id=3, book=book, session=session, commit=commit,
+            )[1]
+        finally:
+            session.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        actions = list(pool.map(device, ("device-a", "device-b")))
+    with Session() as session:
+        rows = session.query(ub.Annotation).filter_by(
+            user_id=3, book_id=7, annotation_id="shared"
+        ).all()
+        assert len(rows) == 1
+        assert rows[0].highlighted_text in {"device-a", "device-b"}
+    assert "created" in actions
+
+
+def test_plugin_native_provider_and_handshake_are_wired():
+    root = Path(__file__).parents[2]
+    provider = (root / "koreader/plugins/cwasync.koplugin/koreader_annotations_provider.lua").read_text()
+    main = (root / "koreader/plugins/cwasync.koplugin/main.lua").read_text()
+    client = (root / "koreader/plugins/cwasync.koplugin/CWASyncClient.lua").read_text()
+    assert 'ui.annotation.annotations' in provider
+    assert 'position_type = rolling and "koreader_xpointer"' in provider
+    assert "push_all_local = true" in provider
+    assert "client:pull_annotations" in main and "client:push_annotations" in main
+    assert "function CWASyncClient:authorize" in client

--- a/tests/unit/test_699_koreader_phase1_contract.py
+++ b/tests/unit/test_699_koreader_phase1_contract.py
@@ -93,6 +93,37 @@ def test_two_parallel_devices_merge_without_duplicate_or_integrity_leak(tmp_path
     assert "created" in actions
 
 
+def test_two_parallel_devices_with_distinct_highlights_never_clobber(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'distinct.db'}", future=True,
+        connect_args={"check_same_thread": False, "timeout": 10},
+    )
+    ub.Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, future=True)
+    barrier = Barrier(2)
+    book = SimpleNamespace(id=7, uuid="book")
+
+    def device(annotation_id):
+        session = Session()
+        try:
+            barrier.wait(timeout=5)
+            return apply_portable(
+                {"annotation_id": annotation_id, "highlighted_text": annotation_id},
+                user_id=3, book=book, session=session, commit=session.commit,
+            )[1]
+        finally:
+            session.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        actions = list(pool.map(device, ("device-a-highlight", "device-b-highlight")))
+    with Session() as session:
+        rows = session.query(ub.Annotation).filter_by(user_id=3, book_id=7).all()
+        assert {row.annotation_id for row in rows} == {
+            "device-a-highlight", "device-b-highlight",
+        }
+    assert actions == ["created", "created"]
+
+
 def test_plugin_native_provider_and_handshake_are_wired():
     root = Path(__file__).parents[2]
     provider = (root / "koreader/plugins/cwasync.koplugin/koreader_annotations_provider.lua").read_text()

--- a/tests/unit/test_annotation_portable.py
+++ b/tests/unit/test_annotation_portable.py
@@ -171,3 +171,19 @@ def test_same_annotation_id_is_scoped_by_book(session):
     other = SimpleNamespace(id=43, uuid="other")
     apply_portable(payload, user_id=9, book=other, session=session, commit=session.commit)
     assert session.query(ub.Annotation).filter_by(user_id=9, annotation_id="local-1").count() == 2
+
+
+def test_stale_complete_list_retry_cannot_resurrect_tombstone(session):
+    book = _book()
+    payload = {"annotation_id": "deleted", "highlighted_text": "original"}
+    row, _ = apply_portable(payload, user_id=9, book=book, session=session, commit=session.commit)
+    row.hidden = True
+    session.commit()
+
+    row, action = apply_portable(
+        {"annotation_id": "deleted", "highlighted_text": "stale", "hidden": False},
+        user_id=9, book=book, session=session, commit=session.commit,
+    )
+    assert action == "skipped"
+    assert row.hidden is True
+    assert row.highlighted_text == "original"

--- a/tests/unit/test_annotation_portable.py
+++ b/tests/unit/test_annotation_portable.py
@@ -143,3 +143,31 @@ def test_apply_missing_id_skipped(session):
     )
     assert row is None
     assert action == "skipped"
+
+
+def test_apply_wrong_type_skipped(session):
+    row, action = apply_portable(
+        "not-an-object", user_id=9, book=_book(), session=session,
+        commit=session.commit,
+    )
+    assert row is None and action == "skipped"
+
+
+def test_apply_duplicate_is_suppressed(session):
+    payload = {
+        "annotation_id": "same", "highlighted_text": "text",
+        "position_type": "koreader_xpointer",
+        "start_xpointer": "/body/DocFragment[1]", "end_xpointer": "/body/DocFragment[2]",
+    }
+    _, first = apply_portable(payload, user_id=9, book=_book(), session=session, commit=session.commit)
+    _, second = apply_portable(payload, user_id=9, book=_book(), session=session, commit=session.commit)
+    assert (first, second) == ("created", "skipped")
+    assert session.query(ub.Annotation).count() == 1
+
+
+def test_same_annotation_id_is_scoped_by_book(session):
+    payload = {"annotation_id": "local-1", "highlighted_text": "text"}
+    apply_portable(payload, user_id=9, book=_book(), session=session, commit=session.commit)
+    other = SimpleNamespace(id=43, uuid="other")
+    apply_portable(payload, user_id=9, book=other, session=session, commit=session.commit)
+    assert session.query(ub.Annotation).filter_by(user_id=9, annotation_id="local-1").count() == 2

--- a/tests/unit/test_kobo_annotation_sync_h1_schema.py
+++ b/tests/unit/test_kobo_annotation_sync_h1_schema.py
@@ -531,6 +531,7 @@ class TestMigrationPreservesAllUserData:
         ub.migrate_annotation_decouple_source_target(engine, session)
         ub.migrate_annotation_polymorphic_position(engine, session)
         ub.migrate_annotation_device_origin(engine, session)
+        ub.migrate_annotation_koreader_identity(engine, session)
 
         # Fresh session: ORM read must work on every row.
         s2 = session_maker()

--- a/tests/unit/test_koreader_annotations_endpoints.py
+++ b/tests/unit/test_koreader_annotations_endpoints.py
@@ -14,19 +14,24 @@ file pins the testable core:
 
 from __future__ import annotations
 
+import importlib
 import pytest
+from flask import Flask
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 from types import SimpleNamespace
 
 from cps import ub
+from cps import calibre_db
 from cps.services.annotation_sync import (
-    register_handler, reset_registry_for_testing,
+    register_handler, reset_registry_for_testing, dispatch_annotation_deletes,
 )
 from cps.services.annotation_sync.base import AnnotationSyncTargetHandler, SyncResult
 from cps.progress_syncing.protocols.koreader_annotations import (
     build_pull_payload, apply_push,
 )
+annotation_routes = importlib.import_module("cps.progress_syncing.protocols.koreader_annotations")
+kosync_routes = importlib.import_module("cps.progress_syncing.protocols.kosync")
 
 pytestmark = pytest.mark.unit
 
@@ -148,6 +153,25 @@ def test_push_fans_out_to_enabled_target(env):
     assert tgt.target == "stub" and tgt.status == "synced"
 
 
+def test_duplicate_retry_does_not_fan_out_again(env):
+    s, user = env
+    handler = StubHandler()
+    register_handler(handler)
+    payload = {"annotation_id": "fan-once", "highlighted_text": "same"}
+    apply_push([payload], user=user, book=_book(), session=s, commit=s.commit)
+    apply_push([payload], user=user, book=_book(), session=s, commit=s.commit)
+    assert handler.pushes == ["fan-once"]
+
+
+def test_delete_fanout_is_scoped_to_book(env):
+    s, user = env
+    _seed(s, user, "shared", book_id=7)
+    _seed(s, user, "shared", book_id=8)
+    dispatch_annotation_deletes(["shared"], user, book_id=8)
+    assert s.query(ub.Annotation).filter_by(book_id=7, annotation_id="shared").one().hidden is False
+    assert s.query(ub.Annotation).filter_by(book_id=8, annotation_id="shared").one().hidden is True
+
+
 def test_push_skips_rows_without_id(env):
     s, user = env
     summary = apply_push([{"color": "yellow"}], user=user, book=_book(),
@@ -160,3 +184,86 @@ def test_push_rejects_non_array_annotation_collections(env, value):
     s, user = env
     summary = apply_push(value, user=user, book=_book(), session=s, commit=s.commit)
     assert summary == {"created": 0, "updated": 0, "deleted": 0, "skipped": 0}
+
+
+@pytest.fixture
+def wire(env, monkeypatch):
+    """Real Flask routing for KOReader's auth -> push -> pull handshake."""
+    session, user = env
+    book = _book()
+    monkeypatch.setattr(kosync_routes, "is_koreader_sync_enabled", lambda: True)
+    monkeypatch.setattr(kosync_routes, "authenticate_user", lambda: user)
+    monkeypatch.setattr(annotation_routes, "_require_kosync_enabled", lambda: None)
+    monkeypatch.setattr(annotation_routes, "authenticate_user", lambda: user)
+    monkeypatch.setattr(
+        annotation_routes, "get_book_by_checksum",
+        lambda document: (book.id, "EPUB", book.title, "book.epub", "koreader")
+        if document == "digest-699" else (None, None, None, None, None),
+    )
+    monkeypatch.setattr(calibre_db, "get_book", lambda _id: book)
+    app = Flask(__name__)
+    app.register_blueprint(kosync_routes.kosync)
+    return app.test_client(), session
+
+
+def test_exact_koreader_auth_push_pull_conflict_and_duplicate_sequence(wire):
+    client, session = wire
+
+    auth = client.get("/kosync/users/auth")
+    assert auth.status_code == 200
+
+    device_a = {"annotation_id": "device-a-1", "highlighted_text": "alpha",
+                "position_type": "koreader_xpointer", "start_xpointer": "/a"}
+    first = client.put("/kosync/syncs/annotations", json={
+        "document": "digest-699", "annotations": [device_a],
+    })
+    assert first.status_code == 200
+    assert first.get_json()["created"] == 1
+
+    # Device B pulls A, then contributes a distinct highlight.  A is included
+    # again exactly as the phase-1 provider retries its complete local set.
+    pulled_a = client.get("/kosync/syncs/annotations/digest-699")
+    assert {a["annotation_id"] for a in pulled_a.get_json()["annotations"]} == {"device-a-1"}
+    device_b = {"annotation_id": "device-b-1", "highlighted_text": "beta",
+                "position_type": "koreader_xpointer", "start_xpointer": "/b"}
+    merged = client.put("/kosync/syncs/annotations", json={
+        "document": "digest-699", "annotations": [device_a, device_b],
+    })
+    assert merged.status_code == 200
+    assert merged.get_json()["created"] == 1
+    assert merged.get_json()["skipped"] == 1
+
+    final = client.get("/kosync/syncs/annotations/digest-699").get_json()
+    assert final["annotation_count"] == 2
+    assert {a["annotation_id"] for a in final["annotations"]} == {"device-a-1", "device-b-1"}
+    assert session.query(ub.Annotation).count() == 2
+
+
+@pytest.mark.parametrize("payload,error", [
+    (None, "invalid_payload"),
+    ([], "invalid_payload"),
+    ({"document": "digest-699", "annotations": None}, "invalid_annotations"),
+    ({"document": "digest-699", "annotations": "wrong"}, "invalid_annotations"),
+    ({"document": "digest-699", "annotations": {}}, "invalid_annotations"),
+])
+def test_wire_push_rejects_none_empty_and_wrong_types(wire, payload, error):
+    client, _session = wire
+    response = client.put("/kosync/syncs/annotations", json=payload)
+    assert response.status_code == 400
+    assert response.get_json()["error"] == error
+
+
+def test_wire_preflights_entire_batch_before_persisting(wire):
+    client, session = wire
+    response = client.put("/kosync/syncs/annotations", json={
+        "document": "digest-699",
+        "annotations": [
+            {"annotation_id": "must-not-partially-commit", "highlighted_text": "valid"},
+            {"annotation_id": "bad", "start_kobospan": [], "start_offset": "bad"},
+        ],
+    })
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_annotation"
+    assert session.query(ub.Annotation).filter_by(
+        annotation_id="must-not-partially-commit"
+    ).count() == 0

--- a/tests/unit/test_koreader_annotations_endpoints.py
+++ b/tests/unit/test_koreader_annotations_endpoints.py
@@ -153,3 +153,10 @@ def test_push_skips_rows_without_id(env):
     summary = apply_push([{"color": "yellow"}], user=user, book=_book(),
                          session=s, commit=s.commit)
     assert summary["skipped"] == 1
+
+
+@pytest.mark.parametrize("value", [None, "", {}, "wrong"])
+def test_push_rejects_non_array_annotation_collections(env, value):
+    s, user = env
+    summary = apply_push(value, user=user, book=_book(), session=s, commit=s.commit)
+    assert summary == {"created": 0, "updated": 0, "deleted": 0, "skipped": 0}


### PR DESCRIPTION
## What this delivers

- stores KOReader-native highlight/note locators in the canonical per-user annotation model
- adds authenticated kosync pull/push routes keyed by the existing KOReader document checksum
- reads the active KOReader document's public annotation collection and pushes its complete local set idempotently
- preserves the existing Kobo/Nickel annotation provider while keeping non-Kobo phase 1 push-only
- enforces merge-never-clobber semantics for distinct device highlights and tombstone-wins behavior for stale retries
- keeps the existing read-only Highlights list as the phase-1 display surface

Addresses #699.

## Protocol and compatibility

- Handshake: `GET /kosync/users/auth`
- Pull: `GET /kosync/syncs/annotations/<document>`
- Push: `PUT /kosync/syncs/annotations` with `{document, annotations: [...]}`
- Identity: `(user_id, book_id, annotation_id)`
- KOReader locator: `position_type: "koreader_xpointer"`, `start_xpointer`, `end_xpointer` (opaque; not EPUB CFI)
- No new dependencies.

The cwasync plugin changed; its plugin version bumps at the next release tag, per project policy.

These are new authenticated routes. Please run `/security-review` at merge.

## Verification

- 76 focused/adjacent pytest cases passed, including exact auth → push → pull, duplicate suppression, tombstone preservation, malformed batch rollback, parallel same-ID convergence, parallel distinct-ID survival, #633 furthest-position, and filename-checksum contracts.
- Built the Docker image from this branch and ran isolated container `cwn-spB` on host port `8102` (compose project `cwn-spb`; Docker project names are lowercase-only).
- Two parallel HTTP writers each returned `created: 1`; pull and SQLite contained both distinct annotations. Repeated after adversarial fixes; all four live annotations survived.
- A malformed two-item batch returned HTTP 400 and persisted zero rows from its valid first item.
- Session-cookie login loaded `/annotations/2` with all four highlights and excerpts.
- Two cold container restarts preserved rows, xpointer columns, and the unique identity index.
- Log scans after concurrency and restart found no `database is locked`, `IntegrityError`, `OperationalError`, traceback, duplicate-annotation, or migration-error signature.
- Independent Terra adversarial review findings were fixed and regression-tested: cross-book delete scoping, stale tombstone resurrection, skipped duplicate fan-out, partial malformed batch persistence, and concurrent duplicate-column migration handling.

## Deliberately deferred

- Native server-to-KOReader placement on non-Kobo devices remains phase 2; phase 1 does not parse or write `.sdr` sidecars.
- In-reader SPA rendering remains owned by the deferred web-reader slice. The portable API shape is documented in `notes/org/SPB-REPORT.md` for that consumer.
