### PR TITLE
Add opt-in Goodreads and bol.com metadata providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,6 +236,7 @@ frontend/*.js
 frontend/*.d.ts
 cps/static/app/
 .spe-verification/
+.spf-verification/
 
 # Local output from the no-argument wiki generator. The published wiki is
 # rendered into a temporary clone by scripts/sync-wiki.sh.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ is for things you can see or feel when running the app.
 
 ### Added
 
+- **Goodreads and bol.com can now supply book metadata and covers when you opt in, without taking down metadata search when either site blocks or changes its pages.** Both best-effort providers are off by default, use hard request timeouts, and isolate upstream failures so the other enabled sources keep working. ([#303](https://github.com/new-usemame/Calibre-Web-NextGen/issues/303), [#315](https://github.com/new-usemame/Calibre-Web-NextGen/issues/315))
+
+### Added
+
 - Platform-specific install and switch guides now cover Synology, Unraid, Portainer, TrueNAS SCALE, QNAP, Dockge, and Docker Compose, with verified first-run screenshots, safer migration guidance, and matching generated-wiki pages. Contributor documentation now also explains the supported local-development workflow and pull-request quality checks. ([#527](https://github.com/new-usemame/Calibre-Web-NextGen/issues/527), [#843](https://github.com/new-usemame/Calibre-Web-NextGen/issues/843), [#765](https://github.com/new-usemame/Calibre-Web-NextGen/issues/765))
 - Book details and the sortable table now show when each book was added and last modified, restoring metadata that was only visible in the classic interface. ([#878](https://github.com/new-usemame/Calibre-Web-NextGen/issues/878))
 - Libraries that need a standing filter—such as hiding comics by tag—can now save any advanced search as the account's default library view, with the choice following the user across devices and a one-click way to clear it. ([#498](https://github.com/new-usemame/Calibre-Web-NextGen/issues/498))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,7 @@ is for things you can see or feel when running the app.
 
 ### Added
 
-- **Goodreads and bol.com can now supply book metadata and covers when you opt in, without taking down metadata search when either site blocks or changes its pages.** Both best-effort providers are off by default, use hard request timeouts, and isolate upstream failures so the other enabled sources keep working. ([#303](https://github.com/new-usemame/Calibre-Web-NextGen/issues/303), [#315](https://github.com/new-usemame/Calibre-Web-NextGen/issues/315))
-
-### Added
+- **Metadata searches for English and Dutch books can now find Goodreads and bol.com results after you opt in to their clearly labeled best-effort providers.** Both are off by default, require no API key, use hard request timeouts, and leave other enabled sources working if either website blocks a request or changes its pages. ([#303](https://github.com/new-usemame/Calibre-Web-NextGen/issues/303), [#315](https://github.com/new-usemame/Calibre-Web-NextGen/issues/315))
 
 - Platform-specific install and switch guides now cover Synology, Unraid, Portainer, TrueNAS SCALE, QNAP, Dockge, and Docker Compose, with verified first-run screenshots, safer migration guidance, and matching generated-wiki pages. Contributor documentation now also explains the supported local-development workflow and pull-request quality checks. ([#527](https://github.com/new-usemame/Calibre-Web-NextGen/issues/527), [#843](https://github.com/new-usemame/Calibre-Web-NextGen/issues/843), [#765](https://github.com/new-usemame/Calibre-Web-NextGen/issues/765))
 - Book details and the sortable table now show when each book was added and last modified, restoring metadata that was only visible in the classic interface. ([#878](https://github.com/new-usemame/Calibre-Web-NextGen/issues/878))

--- a/cps/metadata_constants.py
+++ b/cps/metadata_constants.py
@@ -22,3 +22,14 @@ DEFAULT_METADATA_PROVIDER_HIERARCHY = ["google", "openlibrary", "ibdb", "dnb", "
 # template fallback literally — the agreement is asserted in
 # tests/unit/test_metadata_autofetch_safety.py.
 DEFAULT_METADATA_PROVIDER_HIERARCHY_JSON = '["google","openlibrary","ibdb","dnb","douban"]'
+
+# Scraper integrations whose upstream markup/anti-bot posture makes them unsuitable
+# as surprise defaults. Users must explicitly opt in through an existing provider
+# toggle; an explicit saved True/False always wins.
+DEFAULT_OFF_METADATA_PROVIDERS = frozenset({"goodreads", "bolcom"})
+
+
+def metadata_provider_enabled(provider_id, enabled_map):
+    return bool(enabled_map.get(
+        provider_id, provider_id not in DEFAULT_OFF_METADATA_PROVIDERS
+    ))

--- a/cps/metadata_helper.py
+++ b/cps/metadata_helper.py
@@ -79,7 +79,8 @@ def fetch_and_apply_metadata(book_id: int, user_enabled: bool = False) -> bool:
         metadata_found = False
         for provider_id in provider_hierarchy:
             # Check if explicitly disabled (default is enabled if not specified)
-            is_enabled = enabled_map.get(provider_id, True)
+            from cps.metadata_constants import metadata_provider_enabled
+            is_enabled = metadata_provider_enabled(provider_id, enabled_map)
             if not is_enabled:
                 log.debug(f"Provider {provider_id} is globally disabled")
                 continue

--- a/cps/metadata_provider/bolcom.py
+++ b/cps/metadata_provider/bolcom.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Best-effort bol.com book metadata scraper (#315).
+
+Maintenance note: bol.com can reject automated traffic and changes page markup.
+Embedded JSON-LD product data is expected to break first, followed by product-link
+selectors. Recorded fixtures detect parser drift; live opt-in searches detect an
+anti-bot change. Every upstream or parsing failure intentionally returns no results.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import List, Optional
+from urllib.parse import quote_plus, urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+from cps import constants, logger
+from cps.services.Metadata import Metadata, MetaRecord, MetaSourceInfo
+
+log = logger.create()
+
+
+class BolCom(Metadata):
+    __name__ = "bol.com (best effort)"
+    __id__ = "bolcom"
+    DESCRIPTION = __name__
+    META_URL = "https://www.bol.com/"
+    SEARCH_URL = "https://www.bol.com/nl/nl/s/?searchtext={}"
+    TIMEOUT = (4, 8)
+    MAX_RESULTS = 3
+    HEADERS = {
+        "User-Agent": constants.USER_AGENT,
+        "Accept": "text/html,application/xhtml+xml",
+        "Accept-Language": "nl-NL,nl;q=0.9,en;q=0.7",
+    }
+
+    def search(self, query: str, generic_cover: str = "", locale: str = "en") -> List[MetaRecord]:
+        if not self.active or not isinstance(query, str) or not query.strip():
+            return []
+        session = requests.Session()
+        session.headers.update(self.HEADERS)
+        try:
+            response = session.get(self.SEARCH_URL.format(quote_plus(query.strip())), timeout=self.TIMEOUT)
+            response.raise_for_status()
+            links = self._parse_search(response.text)
+        except (requests.RequestException, ValueError, TypeError) as exc:
+            log.warning("bol.com search failed: %s", exc)
+            return []
+        records = []
+        for link in links[:self.MAX_RESULTS]:
+            try:
+                response = session.get(link, timeout=self.TIMEOUT)
+                response.raise_for_status()
+                record = self._parse_book(response.text, link, generic_cover)
+                if record:
+                    records.append(record)
+            except (requests.RequestException, ValueError, TypeError) as exc:
+                log.warning("bol.com book fetch failed: %s", exc)
+        return records
+
+    @classmethod
+    def _parse_search(cls, html: object) -> List[str]:
+        if not isinstance(html, str) or not html.strip():
+            return []
+        soup = BeautifulSoup(html, "html.parser")
+        found = []
+        for anchor in soup.select('a[href*="/nl/nl/p/"]'):
+            href = anchor.get("href")
+            if not isinstance(href, str):
+                continue
+            url = urljoin(cls.META_URL, href.split("?")[0])
+            if url not in found:
+                found.append(url)
+        return found
+
+    @classmethod
+    def _parse_book(cls, html: object, url: str, generic_cover: str = "") -> Optional[MetaRecord]:
+        if not isinstance(html, str) or not html.strip():
+            return None
+        soup = BeautifulSoup(html, "html.parser")
+        data = cls._product_json_ld(soup)
+        title = data.get("name") if data else None
+        if not isinstance(title, str) or not title.strip():
+            return None
+        product_id = cls._product_id(url, data)
+        authors = cls._authors(data)
+        record = MetaRecord(
+            id=product_id,
+            title=title.strip(),
+            authors=authors,
+            url=url,
+            source=MetaSourceInfo(cls.__id__, cls.DESCRIPTION, cls.META_URL),
+            cover=cls._image(data.get("image")) or generic_cover,
+        )
+        description = data.get("description")
+        record.description = description if isinstance(description, str) else ""
+        record.publisher = cls._name(data.get("publisher") or data.get("brand"))
+        record.publishedDate = cls._date(data.get("datePublished"))
+        isbn = data.get("isbn") or data.get("gtin13")
+        record.identifiers = {"bol": product_id}
+        if isinstance(isbn, str) and isbn.strip():
+            record.identifiers["isbn"] = re.sub(r"\D", "", isbn)
+        record.tags = cls._tags(data.get("genre") or data.get("category"))
+        rating = data.get("aggregateRating")
+        if isinstance(rating, dict):
+            record.rating = cls._rating(rating.get("ratingValue"))
+        series = data.get("isPartOf")
+        if isinstance(series, dict):
+            record.series = cls._name(series)
+            try:
+                record.series_index = float(series.get("position", 0))
+            except (TypeError, ValueError):
+                pass
+        language = data.get("inLanguage")
+        if isinstance(language, str) and language.strip():
+            record.languages = [language.strip()]
+        return record
+
+    @staticmethod
+    def _product_json_ld(soup: BeautifulSoup) -> dict:
+        for node in soup.select('script[type="application/ld+json"]'):
+            try:
+                payload = json.loads(node.string or "")
+            except (json.JSONDecodeError, TypeError):
+                continue
+            items = payload if isinstance(payload, list) else [payload]
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                candidates = item.get("@graph") if isinstance(item.get("@graph"), list) else [item]
+                for candidate in candidates:
+                    kind = candidate.get("@type") if isinstance(candidate, dict) else None
+                    kinds = kind if isinstance(kind, list) else [kind]
+                    if "Book" in kinds or "Product" in kinds:
+                        return candidate
+        return {}
+
+    @staticmethod
+    def _name(value):
+        if isinstance(value, str):
+            return value.strip() or None
+        if isinstance(value, dict) and isinstance(value.get("name"), str):
+            return value["name"].strip() or None
+        return None
+
+    @classmethod
+    def _authors(cls, data: dict) -> List[str]:
+        value = data.get("author")
+        values = value if isinstance(value, list) else [value]
+        return [name for item in values if (name := cls._name(item))]
+
+    @staticmethod
+    def _image(value):
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return next((item for item in value if isinstance(item, str)), None)
+        if isinstance(value, dict) and isinstance(value.get("url"), str):
+            return value["url"]
+        return None
+
+    @staticmethod
+    def _date(value):
+        return value[:10] if isinstance(value, str) and re.match(r"^\d{4}", value) else None
+
+    @staticmethod
+    def _rating(value):
+        try:
+            return max(0, min(5, round(float(value))))
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _tags(value):
+        values = value if isinstance(value, list) else [value]
+        return [item.strip() for item in values if isinstance(item, str) and item.strip()][:8]
+
+    @staticmethod
+    def _product_id(url: str, data: dict):
+        match = re.search(r"/(\d{8,})/?$", url)
+        return match.group(1) if match else str(data.get("sku") or data.get("gtin13") or url)

--- a/cps/metadata_provider/goodreads.py
+++ b/cps/metadata_provider/goodreads.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Best-effort Goodreads metadata scraper (#303).
+
+Maintenance note: Goodreads has no supported public API. Embedded JSON-LD is
+expected to break after Goodreads changes its page data shape; search-result
+links/selectors are the next likely failure. Detect rot via the recorded parser
+fixtures plus a live opt-in search returning an empty provider row. Network,
+anti-bot, and parse failures deliberately degrade to no results.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Iterable, List, Optional
+from urllib.parse import quote_plus, urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+from cps import constants, logger
+from cps.services.Metadata import Metadata, MetaRecord, MetaSourceInfo
+
+log = logger.create()
+
+
+class Goodreads(Metadata):
+    __name__ = "Goodreads (best effort)"
+    __id__ = "goodreads"
+    DESCRIPTION = __name__
+    META_URL = "https://www.goodreads.com/"
+    SEARCH_URL = "https://www.goodreads.com/search?q={}"
+    TIMEOUT = (4, 8)
+    MAX_RESULTS = 3
+    HEADERS = {
+        "User-Agent": constants.USER_AGENT,
+        "Accept": "text/html,application/xhtml+xml",
+        "Accept-Language": "en-US,en;q=0.8",
+    }
+
+    def search(self, query: str, generic_cover: str = "", locale: str = "en") -> List[MetaRecord]:
+        if not self.active or not isinstance(query, str) or not query.strip():
+            return []
+        session = requests.Session()
+        session.headers.update(self.HEADERS)
+        try:
+            response = session.get(self.SEARCH_URL.format(quote_plus(query.strip())), timeout=self.TIMEOUT)
+            response.raise_for_status()
+            links = self._parse_search(response.text)
+        except (requests.RequestException, ValueError, TypeError) as exc:
+            log.warning("Goodreads search failed: %s", exc)
+            return []
+
+        records = []
+        # Sequential by design: politely avoid parallel page hammering.
+        for link in links[:self.MAX_RESULTS]:
+            try:
+                response = session.get(link, timeout=self.TIMEOUT)
+                response.raise_for_status()
+                record = self._parse_book(response.text, link, generic_cover)
+                if record:
+                    records.append(record)
+            except (requests.RequestException, ValueError, TypeError) as exc:
+                log.warning("Goodreads book fetch failed: %s", exc)
+        return records
+
+    @classmethod
+    def _parse_search(cls, html: object) -> List[str]:
+        if not isinstance(html, str) or not html.strip():
+            return []
+        soup = BeautifulSoup(html, "html.parser")
+        found = []
+        for anchor in soup.select('a[href*="/book/show/"]'):
+            href = anchor.get("href")
+            if not isinstance(href, str):
+                continue
+            url = urljoin(cls.META_URL, href.split("?")[0])
+            if url not in found:
+                found.append(url)
+        return found
+
+    @classmethod
+    def _parse_book(cls, html: object, url: str, generic_cover: str = "") -> Optional[MetaRecord]:
+        if not isinstance(html, str) or not html.strip():
+            return None
+        soup = BeautifulSoup(html, "html.parser")
+        data = cls._book_json_ld(soup)
+        if not data:
+            return None
+        title = data.get("name")
+        if not isinstance(title, str) or not title.strip():
+            return None
+        authors = cls._names(data.get("author"))
+        book_id = cls._book_id(url, data)
+        record = MetaRecord(
+            id=book_id,
+            title=title.strip(),
+            authors=authors,
+            url=url,
+            source=MetaSourceInfo(cls.__id__, cls.DESCRIPTION, cls.META_URL),
+            cover=data.get("image") if isinstance(data.get("image"), str) else generic_cover,
+        )
+        record.description = data.get("description", "") if isinstance(data.get("description"), str) else ""
+        record.publisher = cls._name(data.get("publisher"))
+        record.publishedDate = cls._date(data.get("datePublished"))
+        record.identifiers = cls._identifiers(data, book_id)
+        record.tags = cls._tags(data.get("genre"))
+        aggregate = data.get("aggregateRating")
+        if isinstance(aggregate, dict):
+            record.rating = cls._rating(aggregate.get("ratingValue"))
+        series = data.get("isPartOf")
+        if isinstance(series, dict):
+            record.series = cls._name(series)
+            position = series.get("position")
+            if isinstance(position, (int, float)):
+                record.series_index = position
+            elif isinstance(position, str):
+                try:
+                    record.series_index = float(position)
+                except ValueError:
+                    pass
+        return record
+
+    @staticmethod
+    def _book_json_ld(soup: BeautifulSoup) -> dict:
+        for node in soup.select('script[type="application/ld+json"]'):
+            try:
+                payload = json.loads(node.string or "")
+            except (json.JSONDecodeError, TypeError):
+                continue
+            candidates: Iterable = payload if isinstance(payload, list) else [payload]
+            for item in candidates:
+                if not isinstance(item, dict):
+                    continue
+                graph = item.get("@graph")
+                nested = graph if isinstance(graph, list) else [item]
+                for candidate in nested:
+                    kinds = candidate.get("@type", []) if isinstance(candidate, dict) else []
+                    if isinstance(kinds, str):
+                        kinds = [kinds]
+                    if "Book" in kinds:
+                        return candidate
+        return {}
+
+    @staticmethod
+    def _name(value):
+        if isinstance(value, str):
+            return value.strip() or None
+        if isinstance(value, dict) and isinstance(value.get("name"), str):
+            return value["name"].strip() or None
+        return None
+
+    @classmethod
+    def _names(cls, value) -> List[str]:
+        values = value if isinstance(value, list) else [value]
+        return [name for item in values if (name := cls._name(item))]
+
+    @staticmethod
+    def _date(value):
+        return value[:10] if isinstance(value, str) and re.match(r"^\d{4}", value) else None
+
+    @staticmethod
+    def _rating(value) -> int:
+        try:
+            return max(0, min(5, round(float(value))))
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _tags(value) -> List[str]:
+        values = value if isinstance(value, list) else [value]
+        return [v.strip() for v in values if isinstance(v, str) and v.strip()][:8]
+
+    @staticmethod
+    def _book_id(url: str, data: dict) -> str:
+        match = re.search(r"/book/show/(\d+)", url)
+        return match.group(1) if match else str(data.get("isbn") or url)
+
+    @staticmethod
+    def _identifiers(data: dict, book_id: str) -> dict:
+        result = {"goodreads": book_id}
+        for source, target in (("isbn", "isbn"), ("isbn13", "isbn")):
+            value = data.get(source)
+            if isinstance(value, str) and value.strip():
+                result[target] = re.sub(r"[^0-9Xx]", "", value)
+        return result

--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -159,12 +159,6 @@ PROVIDER_KEY_REGISTRY = {
         "signup": "https://console.cloud.google.com/apis/library/books.googleapis.com",
         "help":   "Enable 'Books API' in any Google Cloud project, then create an API key under Credentials.",
     },
-    "goodreads": {
-        "name":   "Goodreads",
-        "config": "config_goodreads_api_key",
-        "signup": "https://www.goodreads.com/api/keys",
-        "help":   "Goodreads' developer API was discontinued in 2020. Existing keys still work for legacy integrations.",
-    },
 }
 
 
@@ -244,7 +238,9 @@ def metadata_provider():
                 "active": ac,
                 "initial": ac,
                 "id": c.__id__,
-                "globally_enabled": metadata_provider_enabled(c.__id__, global_enabled),
+                # Global omission means available; best-effort defaults are a
+                # per-user/ingest opt-in, not hidden from the SPA toggle list.
+                "globally_enabled": bool(global_enabled.get(c.__id__, True)),
             }
         )
     return make_response(jsonify(provider))
@@ -273,7 +269,7 @@ def metadata_change_active_provider(prov_name):
         # Respect global disablement for preview search as well
         global_enabled = _get_global_provider_enabled_map()
         if provider is not None:
-            if metadata_provider_enabled(provider.__id__, global_enabled):
+            if bool(global_enabled.get(provider.__id__, True)):
                 try:
                     data = provider.search(new_state.get("query", ""))
                 except Exception as exc:
@@ -369,7 +365,7 @@ def metadata_search():
     runnable = {}
     for provider in cl:
         is_active = metadata_provider_enabled(provider.__id__, active)
-        is_global = metadata_provider_enabled(provider.__id__, global_enabled)
+        is_global = bool(global_enabled.get(provider.__id__, True))
         if not is_active or not is_global:
             provider_status.append({
                 "id": provider.__id__,

--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -22,6 +22,7 @@ from cps.services.Metadata import Metadata
 from cps.services.cover_booster import boost_covers
 from . import config, constants, logger, ub, web_server
 from .usermanagement import user_login_required
+from .metadata_constants import metadata_provider_enabled
 
 
 meta = Blueprint("metadata", __name__)
@@ -236,14 +237,14 @@ def metadata_provider():
     global_enabled = _get_global_provider_enabled_map()
     provider = list()
     for c in cl:
-        ac = active.get(c.__id__, True)
+        ac = metadata_provider_enabled(c.__id__, active)
         provider.append(
             {
                 "name": c.__name__,
                 "active": ac,
                 "initial": ac,
                 "id": c.__id__,
-                "globally_enabled": bool(global_enabled.get(c.__id__, True)),
+                "globally_enabled": metadata_provider_enabled(c.__id__, global_enabled),
             }
         )
     return make_response(jsonify(provider))
@@ -272,7 +273,7 @@ def metadata_change_active_provider(prov_name):
         # Respect global disablement for preview search as well
         global_enabled = _get_global_provider_enabled_map()
         if provider is not None:
-            if bool(global_enabled.get(provider.__id__, True)):
+            if metadata_provider_enabled(provider.__id__, global_enabled):
                 try:
                     data = provider.search(new_state.get("query", ""))
                 except Exception as exc:
@@ -367,8 +368,8 @@ def metadata_search():
     # globally). This keeps modal copy stable across reload.
     runnable = {}
     for provider in cl:
-        is_active = active.get(provider.__id__, True)
-        is_global = bool(global_enabled.get(provider.__id__, True))
+        is_active = metadata_provider_enabled(provider.__id__, active)
+        is_global = metadata_provider_enabled(provider.__id__, global_enabled)
         if not is_active or not is_global:
             provider_status.append({
                 "id": provider.__id__,

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -1368,8 +1368,9 @@ document.addEventListener('DOMContentLoaded', function() {
       wrapper.classList.add('provider_enable_item');
 
       const id = `global-provider-${p.id}`;
-      const defaultOff = new Set(['goodreads', 'bolcom']);
-      const checked = (enabledMap.hasOwnProperty(p.id) ? !!enabledMap[p.id] : !defaultOff.has(p.id));
+      // Global omission means available. Best-effort scraper opt-in happens
+      // per user and in ingest; admins may still disable either server-wide.
+      const checked = (enabledMap.hasOwnProperty(p.id) ? !!enabledMap[p.id] : true);
       wrapper.innerHTML = `
         <input type="checkbox" id="${id}" data-provider-id="${p.id}" ${checked ? 'checked' : ''}>
         <label for="${id}" style="margin-left: 8px;">${p.name}</label>

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -1368,7 +1368,8 @@ document.addEventListener('DOMContentLoaded', function() {
       wrapper.classList.add('provider_enable_item');
 
       const id = `global-provider-${p.id}`;
-      const checked = (enabledMap.hasOwnProperty(p.id) ? !!enabledMap[p.id] : true);
+      const defaultOff = new Set(['goodreads', 'bolcom']);
+      const checked = (enabledMap.hasOwnProperty(p.id) ? !!enabledMap[p.id] : !defaultOff.has(p.id));
       wrapper.innerHTML = `
         <input type="checkbox" id="${id}" data-provider-id="${p.id}" ${checked ? 'checked' : ''}>
         <label for="${id}" style="margin-left: 8px;">${p.name}</label>

--- a/tests/fixtures/metadata/bolcom_book.html
+++ b/tests/fixtures/metadata/bolcom_book.html
@@ -1,0 +1,3 @@
+<!doctype html><html><head><script type="application/ld+json">
+{"@context":"https://schema.org","@type":["Product","Book"],"name":"De ontdekking van de hemel","author":[{"@type":"Person","name":"Harry Mulisch"}],"gtin13":"9789023460005","sku":"1001004001234567","image":{"url":"https://media.s-bol.com/example.jpg"},"description":"Een Nederlandse roman.","publisher":{"name":"De Bezige Bij"},"datePublished":"1992-10-01","genre":["Literatuur","Romans"],"aggregateRating":{"ratingValue":4.6},"inLanguage":"nld","isPartOf":{"name":"Meesterwerken","position":2}}
+</script></head><body></body></html>

--- a/tests/fixtures/metadata/bolcom_search.html
+++ b/tests/fixtures/metadata/bolcom_search.html
@@ -1,0 +1,4 @@
+<!doctype html><html><body>
+<a href="/nl/nl/p/de-ontdekking-van-de-hemel/1001004001234567/?referrer=socialshare">De ontdekking</a>
+<a href="/nl/nl/p/de-ontdekking-van-de-hemel/1001004001234567/">duplicate</a>
+</body></html>

--- a/tests/fixtures/metadata/goodreads_book.html
+++ b/tests/fixtures/metadata/goodreads_book.html
@@ -1,0 +1,3 @@
+<!doctype html><html><head><script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Book","name":"The Great Gatsby","author":[{"@type":"Person","name":"F. Scott Fitzgerald"}],"isbn":"9780743273565","image":"https://images.example/gatsby.jpg","description":"A Jazz Age novel.","publisher":{"@type":"Organization","name":"Scribner"},"datePublished":"2004-09-30","genre":["Classics","Fiction"],"aggregateRating":{"ratingValue":"3.93"},"isPartOf":{"@type":"BookSeries","name":"Modern Library","position":"1"}}
+</script></head><body></body></html>

--- a/tests/fixtures/metadata/goodreads_search.html
+++ b/tests/fixtures/metadata/goodreads_search.html
@@ -1,0 +1,4 @@
+<!doctype html><html><body>
+<a class="bookTitle" href="/book/show/4671.The_Great_Gatsby?from_search=true">The Great Gatsby</a>
+<a href="/book/show/4671.The_Great_Gatsby">duplicate</a>
+</body></html>

--- a/tests/unit/test_best_effort_metadata_providers.py
+++ b/tests/unit/test_best_effort_metadata_providers.py
@@ -1,0 +1,89 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Recorded-fixture and failure-contract tests for #303 and #315."""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from cps.metadata_constants import metadata_provider_enabled
+from cps.metadata_provider.bolcom import BolCom
+from cps.metadata_provider.goodreads import Goodreads
+
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "metadata"
+
+
+def fixture(name):
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("provider_id", ["goodreads", "bolcom"])
+def test_best_effort_providers_default_off_but_explicit_choice_wins(provider_id):
+    assert metadata_provider_enabled(provider_id, {}) is False
+    assert metadata_provider_enabled(provider_id, {provider_id: True}) is True
+    assert metadata_provider_enabled(provider_id, {provider_id: False}) is False
+
+
+def test_goodreads_recorded_search_and_book_fixture():
+    links = Goodreads._parse_search(fixture("goodreads_search.html"))
+    assert links == ["https://www.goodreads.com/book/show/4671.The_Great_Gatsby"]
+    record = Goodreads._parse_book(fixture("goodreads_book.html"), links[0], "generic.svg")
+    assert record.title == "The Great Gatsby"
+    assert record.authors == ["F. Scott Fitzgerald"]
+    assert record.identifiers == {"goodreads": "4671", "isbn": "9780743273565"}
+    assert record.cover.endswith("gatsby.jpg")
+    assert record.rating == 4
+    assert record.series == "Modern Library"
+    assert record.series_index == 1.0
+
+
+def test_bolcom_recorded_search_and_book_fixture():
+    links = BolCom._parse_search(fixture("bolcom_search.html"))
+    assert links == ["https://www.bol.com/nl/nl/p/de-ontdekking-van-de-hemel/1001004001234567/"]
+    record = BolCom._parse_book(fixture("bolcom_book.html"), links[0], "generic.svg")
+    assert record.title == "De ontdekking van de hemel"
+    assert record.authors == ["Harry Mulisch"]
+    assert record.identifiers == {"bol": "1001004001234567", "isbn": "9789023460005"}
+    assert record.cover.startswith("https://media.s-bol.com/")
+    assert record.rating == 5
+    assert record.languages == ["nld"]
+
+
+@pytest.mark.parametrize("provider", [Goodreads, BolCom])
+@pytest.mark.parametrize("bad", [None, "", "not html", 7, [], {}])
+def test_malformed_empty_and_wrong_type_pages_are_none_or_empty(provider, bad):
+    assert provider._parse_search(bad) == []
+    assert provider._parse_book(bad, "https://example.invalid/book", "generic.svg") is None
+
+
+@pytest.mark.parametrize("provider", [Goodreads(), BolCom()])
+@pytest.mark.parametrize("query", [None, "", "   ", 123])
+def test_negative_queries_do_not_touch_network(provider, query):
+    with patch("requests.Session.get") as get:
+        assert provider.search(query) == []
+    get.assert_not_called()
+
+
+@pytest.mark.parametrize("provider", [Goodreads(), BolCom()])
+@pytest.mark.parametrize("failure", [requests.ConnectionError("down"), requests.Timeout("slow")])
+def test_network_down_and_timeout_gracefully_return_empty(provider, failure):
+    with patch("requests.Session.get", side_effect=failure):
+        assert provider.search("a real title") == []
+
+
+@pytest.mark.parametrize("provider,search_fixture", [
+    (Goodreads(), "goodreads_search.html"),
+    (BolCom(), "bolcom_search.html"),
+])
+def test_product_fetch_failure_does_not_escape_or_return_partial_garbage(provider, search_fixture):
+    search_response = Mock(text=fixture(search_fixture))
+    search_response.raise_for_status.return_value = None
+    with patch("requests.Session.get", side_effect=[search_response, requests.Timeout("slow")]):
+        assert provider.search("book") == []

--- a/tests/unit/test_best_effort_metadata_providers.py
+++ b/tests/unit/test_best_effort_metadata_providers.py
@@ -31,6 +31,12 @@ def test_best_effort_providers_default_off_but_explicit_choice_wins(provider_id)
     assert metadata_provider_enabled(provider_id, {provider_id: False}) is False
 
 
+def test_goodreads_scraper_does_not_advertise_dead_api_key_signup():
+    source = (Path(__file__).resolve().parents[2] / "cps" / "search_metadata.py").read_text()
+    registry = source.split("PROVIDER_KEY_REGISTRY = {", 1)[1].split("\n}\n", 1)[0]
+    assert '"goodreads"' not in registry
+
+
 def test_goodreads_recorded_search_and_book_fixture():
     links = Goodreads._parse_search(fixture("goodreads_search.html"))
     assert links == ["https://www.goodreads.com/book/show/4671.The_Great_Gatsby"]


### PR DESCRIPTION
Addresses #303 #315

## What changed

- adds opt-in `Goodreads (best effort)` and `bol.com (best effort)` metadata providers, both default OFF
- extracts title, author, identifiers, cover, description, publisher/date, rating, tags, and series/language fields from recorded JSON-LD page shapes
- uses hard connect/read timeouts, sequential product fetches, and provider-local failure handling so a blocked, unavailable, or changed site returns no rows instead of failing the metadata search
- keeps both providers visible in the classic and SPA provider toggles even though their global default is disabled
- uses the key-free bol.com Path A: no account, API key, signup, subscription, or payment is required
- adds a symptom-first changelog entry

## Rule-6 approval and dependency review

The operator approved these new external hosts on 2026-07-13:

- `goodreads.com` / `www.goodreads.com` — Goodreads search and public book pages
- `www.bol.com` — bol.com search and public product pages
- `media.s-bol.com` — bol.com cover images through the existing cover path

No new pip dependency or license change is introduced. `requests` and Beautiful Soup are already
present. The bol.com implementation does not use the alternative API/auth hosts and introduces no
credential or secret. This decision is recorded in `notes/dep-review-315.md` and
`notes/org/OPERATOR-DECISIONS.md` in the project operations ledger.

## Verification

### Deterministic tests

`pytest -q tests/unit/test_best_effort_metadata_providers.py tests/unit/test_metadata_ui_static.py`

- 33 passed
- recorded Goodreads and bol.com search/book fixtures parse expected metadata and covers
- malformed, empty, and wrong-type input returns no record
- empty/invalid queries make no network call
- connection-down and timeout failures return an empty provider result
- product-fetch timeout returns no partial garbage
- default-OFF behavior and explicit ON/OFF choices are covered
- UI/provider-registration visibility is covered

### Isolated live SPA (`cwn-spf`, host port 8106)

Luna drove the real SPA editor against `cwn-spf-app-1`; `cwn-local` / port 8086 were not touched.

| Scenario | Observed result |
|---|---|
| Live `The Great Gatsby` search | `POST /metadata/search` HTTP 200; Goodreads 0 rows; bol.com 0 rows; Open Library, IBDb, DNB, Apple Books, Amazon, ComicVine, Kobo, LitRes, and LubimyCzytac still returned rows |
| Live `De ontdekking van de hemel` search | HTTP 200; bol.com 0 rows with upstream HTTP 403 logged; other enabled providers returned rows |
| Goodreads host redirected to `10.255.255.1` | HTTP 200; Goodreads 0; `ConnectTimeoutError` logged; other providers returned rows; no traceback |
| bol.com host redirected to `10.255.255.1` | HTTP 200; bol.com 0; `ConnectTimeoutError` logged; other providers returned rows; no traceback |
| Toggle persistence | both providers remained ON after panel close/reopen and full page reload |
| Desktop 1440×900 | both best-effort labels visible, switches operable, no clipping or horizontal overflow |
| Mobile 390×844 | both labels visible, switches operable; bol.com OFF→ON round-trip succeeded; no clipping or horizontal overflow |
| Cleanup | all temporary host overrides removed; isolated container remained healthy |

The target sites did not yield live provider rows from this environment: Goodreads returned an empty
best-effort result and bol.com actively returned HTTP 403. Therefore live upstream parsing is not
claimed here. The observed contract is that both opt-in providers participate in a real SPA search,
remain bounded, and degrade without a 500 or loss of other-provider results; recorded fixtures cover
their extraction behavior deterministically.

## Close-out drafts

### #303

Best-effort Goodreads metadata and cover support is now available in this PR. It is clearly labeled,
off by default, and enabled from the book editor's provider switches. With no public API keys issued
by Goodreads, it reads public book pages with hard timeouts; blocks or markup changes return no
Goodreads rows while other sources continue normally. This replaces the earlier decline/backlog
status.

### #315

Best-effort bol.com metadata and cover support is now available in this PR using the key-free website
path. No signup, API key, subscription, or payment is needed. It is clearly labeled, off by default,
and isolates bol.com blocks or markup changes from every other enabled metadata source.
