### PR TITLE
fix(editbooks): reload metadata must apply only what the file carries (#877)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ is for things you can see or feel when running the app.
 - Changing one classic-reader appearance control no longer erases the user's other saved reader settings.
 - The classic book page's favorite star now changes immediately after a click instead of waiting for a reload, because object-shaped action responses no longer crash the shared flash-message handler. ([#880](https://github.com/new-usemame/Calibre-Web-NextGen/issues/880))
 - Smart-shelf moving date windows are now available in the new interface's rule builder—not only the classic builder—with Publication Date and Date Added fields and day-based operators. ([#467](https://github.com/new-usemame/Calibre-Web-NextGen/issues/467))
-- Reload metadata now uses the same format-aware parser as upload, so PDF, FB2, comic, audio, EPUB, and KEPUB files no longer fail through an EPUB-only path; editors can also run it from the new book page. ([#877](https://github.com/new-usemame/Calibre-Web-NextGen/issues/877))
+- Reload metadata now reads PDF, FB2, comic, audio, EPUB, and KEPUB files instead of failing through an EPUB-only path, and applies only the details a file actually contains — a book whose file carries no title or author keeps the title and authors you curated instead of being renamed after its filename. Editors can also run it from the new book page. ([#877](https://github.com/new-usemame/Calibre-Web-NextGen/issues/877))
+- Uploading a PDF now picks up the author recorded inside the file. PDFs without an XMP block — most of them — previously imported as "Unknown" even when the file said who wrote it. ([#877](https://github.com/new-usemame/Calibre-Web-NextGen/issues/877))
 
 ## [v4.1.12] - 2026-07-13
 

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -2389,12 +2389,18 @@ def reload_metadata_from_disk(book_id):
                                path=file_path)), 404
 
     try:
+        # strict=True is the reload contract: apply only what the file
+        # actually carries. Without it, a file with no embedded title (the
+        # norm for PDFs) comes back titled after its own filename and
+        # silently overwrites the curated title — and renames the book's
+        # folder on disk via update_dir_structure below (#877).
         meta = uploader.process(
             file_path,
             chosen_data.name,
             '.' + file_ext,
             rar_executable=config.config_rarfile_location,
-            no_cover=True)
+            no_cover=True,
+            strict=True)
     except Exception as ex:
         log.error_or_exception("reload_metadata: parse failed for %s: %s",
                                file_path, ex)
@@ -2450,12 +2456,14 @@ def reload_metadata_from_disk(book_id):
 
         # Authors — same helper as the edit-book save path
         # (author_sort regeneration, rename handling, orphan
-        # cleanup). 'Unknown' is get_epub_info's missing-creator
-        # sentinel: a file without <dc:creator> must not stomp the
-        # book's real authors.
+        # cleanup). A strict parse reports a file with no creator as an
+        # empty author, so an absent author is simply falsy here. Do not
+        # reintroduce a comparison against the literal 'Unknown': that
+        # sentinel is localised on the upload path, so the guard passed
+        # for every non-English user and stomped their real authors (#877).
         input_authors = None
         author_value = strip_whitespaces(meta.author or '')
-        if author_value and meta.author != 'Unknown':
+        if author_value:
             input_authors, author_change = handle_author_on_edit(
                 book, author_value)
             if author_change:

--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -69,27 +69,72 @@ except ImportError as e:
     use_audio_meta = False
 
 
-def process(tmp_file_path, original_file_name, original_file_extension, rar_executable, no_cover=False):
-    meta = default_meta(tmp_file_path, original_file_name, original_file_extension)
+def process(tmp_file_path, original_file_name, original_file_extension, rar_executable, no_cover=False,
+            strict=False):
+    """Extract embedded metadata from a book file.
+
+    By default this is the UPLOAD contract: a field the file does not
+    carry is guessed — the title from the filename, the author from a
+    localised 'Unknown' placeholder — and a parse failure degrades to
+    those guesses rather than rejecting the upload. That is correct when
+    creating a new book: the filename is the best available description
+    and the user reviews it in the edit form before saving.
+
+    ``strict=True`` is the RELOAD contract: report only what the file
+    actually carries. A missing field comes back empty and a parse
+    failure propagates. Callers refreshing an existing book's metadata
+    must use it — a guess there silently overwrites data a human curated,
+    and a changed title additionally renames the book's folder on disk
+    (fork #877).
+    """
+    # Every format parser falls back to the caller-supplied display name
+    # when the file carries no title of its own (pdf_meta below,
+    # epub.py:126, comic.py:183/203, audio.py:131). Handing them an empty
+    # name is what makes "the file has no title" distinguishable from
+    # "the file is titled after its filename" — with nothing to fall back
+    # to, a parser can only return what it actually read.
+    parse_name = '' if strict else original_file_name
+    meta = default_meta(tmp_file_path, parse_name, original_file_extension)
+    if strict:
+        # default_meta's author is a localised placeholder for the upload
+        # form. Strict callers want "absent", not a placeholder.
+        meta = meta._replace(author='')
     extension_upper = original_file_extension.upper()
     try:
         if ".PDF" == extension_upper:
-            meta = pdf_meta(tmp_file_path, original_file_name, original_file_extension, no_cover)
+            meta = pdf_meta(tmp_file_path, parse_name, original_file_extension, no_cover)
         elif extension_upper in [".KEPUB", ".EPUB"] and use_epub_meta is True:
-            meta = epub.get_epub_info(tmp_file_path, original_file_name, original_file_extension, no_cover)
+            meta = epub.get_epub_info(tmp_file_path, parse_name, original_file_extension, no_cover)
         elif ".FB2" == extension_upper and use_fb2_meta is True:
             meta = fb2.get_fb2_info(tmp_file_path, original_file_extension)
         elif extension_upper in ['.CBZ', '.CBT', '.CBR', ".CB7"]:
             meta = comic.get_comic_info(tmp_file_path,
-                                        original_file_name,
+                                        parse_name,
                                         original_file_extension,
                                         rar_executable,
                                         no_cover)
         elif extension_upper in [".MP3", ".OGG", ".FLAC", ".WAV", ".AAC", ".AIFF", ".ASF", ".MP4",
                                  ".M4A", ".M4B", ".OGV", ".OPUS"] and use_audio_meta:
-            meta = audio.get_audio_file_info(tmp_file_path, original_file_extension, original_file_name, no_cover)
+            meta = audio.get_audio_file_info(tmp_file_path, original_file_extension, parse_name, no_cover)
     except Exception as ex:
+        if strict:
+            raise
         log.warning('cannot parse metadata, using default: %s', ex)
+
+    if strict:
+        # A parser may report a missing field as None; normalise both
+        # fields to a plain empty string so callers can simply test for a
+        # value.
+        title = strip_whitespaces(meta.title or '')
+        author = strip_whitespaces(meta.author or '')
+        # 'Unknown' is the parsers' shared missing-author sentinel
+        # (epub.py:85, pdf_meta below). Normalising it to empty here means
+        # callers test for a value instead of comparing against a magic
+        # string — a comparison that silently fails once the string is
+        # translated.
+        if author.lower() == 'unknown':
+            author = ''
+        return meta._replace(title=title, author=author)
 
     if not strip_whitespaces(meta.title):
         meta = meta._replace(title=original_file_name)
@@ -183,7 +228,13 @@ def pdf_meta(tmp_file_path, original_file_name, original_file_extension, no_cove
         languages = xmp_info['languages']
         publisher = xmp_info['publisher']
     else:
-        author = 'Unknown'
+        # Empty, not 'Unknown': the DocumentInfo fallback below only fills
+        # fields that came back empty, so seeding this with the sentinel
+        # made the PDF's own /Author unreadable whenever it had no XMP
+        # block — which is most PDFs. `title` was always seeded '' here,
+        # which is why titles were read from DocumentInfo and authors
+        # never were (#877).
+        author = ''
         title = ''
         languages = [""]
         publisher = ""

--- a/tests/unit/test_reload_metadata_authors_tags_series_218.py
+++ b/tests/unit/test_reload_metadata_authors_tags_series_218.py
@@ -109,14 +109,32 @@ class TestReloadCoversDeferredFields:
 
 @pytest.mark.unit
 class TestAbsentFieldSafetyGates:
-    def test_author_unknown_sentinel_does_not_stomp(self):
-        """get_epub_info yields the literal 'Unknown' when the file has no
-        <dc:creator>. Passing that through handle_author_on_edit would
-        replace the book's real authors with 'Unknown'."""
+    def test_author_missing_from_the_file_does_not_stomp(self):
+        """A file with no creator must not replace the book's real authors.
+
+        This used to be pinned by grepping for a `meta.author != 'Unknown'`
+        comparison in the route. That pin was satisfied while the guard was
+        broken: 'Unknown' is localised on the upload path, so it arrived as
+        'Inconnu'/'Unbekannt' and the comparison passed for every
+        non-English user, stomping their authors (#877).
+
+        The invariant is now enforced upstream — reload parses with
+        strict=True, which reports a missing author as empty in every
+        locale — so the route needs no magic-string compare at all. This
+        pins that the landmine is not reintroduced; the behaviour itself is
+        covered against real files and real locales in
+        test_reload_metadata_strict_parse_877.py.
+        """
         body = _body()
-        assert re.search(r"meta\.author[^\n]*['\"]Unknown['\"]", body), (
-            "the author reload must exclude the get_epub_info 'Unknown' "
-            "sentinel — a file without <dc:creator> must not stomp authors"
+        assert not re.search(r"meta\.author\s*!=\s*['\"]Unknown['\"]", body), (
+            "reload must not gate authors on the literal 'Unknown': that "
+            "sentinel is translated on the upload path, so the guard silently "
+            "fails for non-English users. A strict parse reports a missing "
+            "author as empty instead."
+        )
+        assert re.search(r"strict\s*=\s*True", body), (
+            "reload must parse with strict=True so a file's absent fields "
+            "come back empty rather than guessed from the filename"
         )
 
     def test_empty_tags_do_not_wipe_curated_tags(self):

--- a/tests/unit/test_reload_metadata_strict_parse_877.py
+++ b/tests/unit/test_reload_metadata_strict_parse_877.py
@@ -261,7 +261,21 @@ def test_strict_parse_propagates_parse_errors(uploader, app_ctx, corrupt_pdf):
     """RED on main: process swallowed the exception and returned
     default_meta, so the route's error handler (editbooks.py:2398-2403)
     became unreachable and an unparseable file reported success while
-    stomping the title."""
+    stomping the title.
+
+    This payload has no cross-reference table, so pypdf raises while
+    constructing PdfReader — before pdf_meta's own try/except around the
+    DocumentInfo read, which swallows metadata-read errors even under
+    strict. Propagation therefore covers files that fail to open, not
+    every conceivable parse failure. A file that opens but has an
+    unreadable DocumentInfo still returns empty fields rather than
+    guesses, so the invariant that matters for #877 — never overwrite
+    curated data with a guess — holds either way; only the error report
+    degrades to a "0 fields updated" success. If a future pypdf defers
+    this failure to metadata access, process() returns instead of
+    raising and this test fails loudly here rather than passing for the
+    wrong reason.
+    """
     with pytest.raises(Exception) as excinfo:
         uploader.process(
             corrupt_pdf, CALIBRE_DATA_STEM, ".pdf", rar_executable=None,
@@ -272,6 +286,12 @@ def test_strict_parse_propagates_parse_errors(uploader, app_ctx, corrupt_pdf):
     assert not (
         isinstance(excinfo.value, TypeError) and "strict" in str(excinfo.value)
     ), f"raised for the wrong reason: {excinfo.value!r}"
+    # Pin that the error is the PDF parse itself. Without this the test
+    # would accept any exception — a missing fixture or a refactor typo
+    # would keep it green while proving nothing about propagation.
+    assert type(excinfo.value).__module__.split(".")[0] == "pypdf", (
+        f"expected the pypdf parse error to propagate, got {excinfo.value!r}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_reload_metadata_strict_parse_877.py
+++ b/tests/unit/test_reload_metadata_strict_parse_877.py
@@ -1,0 +1,324 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Behavioural tests for fork issue #877 (@yodatak): reloading embedded
+metadata from disk must apply only what the file actually carries.
+
+Background: ``uploader.process`` exists for the UPLOAD path, where
+guessing is correct — a brand-new book with no embedded metadata is best
+described by its filename, and the user sees the guess in the edit form
+before it is saved. RELOAD has the opposite contract: it refreshes an
+EXISTING book's curated metadata, so a guess silently overwrites data a
+human entered, and a title change additionally renames the book's folder
+on disk (``helper.update_dir_structure``).
+
+Every parser fabricates a title the same way — ``title = <parsed> or
+original_file_name`` (``pdf`` uploader.py:196-197/211, ``epub`` epub.py:126,
+``comic`` comic.py:183/203, ``audio`` audio.py:131) — and ``process`` then
+adds a second layer of guessing of its own. Neither layer marks the result
+as a guess, so the caller cannot distinguish "the file says this" from
+"we made this up".
+
+``strict=True`` is the reload contract: parse errors propagate, and a
+field the file does not carry comes back empty instead of guessed.
+
+These are behavioural tests against real files and the real parser — the
+pre-existing suite for this route (test_reload_metadata_from_disk_218.py)
+only greps the source, which is why this regression passed CI.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+pypdf = pytest.importorskip("pypdf", reason="pypdf is required to build real PDF fixtures")
+
+
+# The Calibre data-file stem for a book. Calibre names data files
+# "<Title> - <Author>", so a fabricated title is not merely wrong, it is
+# conspicuously wrong: "Foundation" becomes "Foundation - Isaac Asimov".
+CALIBRE_DATA_STEM = "Foundation - Isaac Asimov"
+CURATED_TITLE = "Foundation"
+
+
+@pytest.fixture(scope="module")
+def uploader():
+    """Import cps.uploader inside an app context (it calls gettext at
+    import-adjacent call time)."""
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    scripts = str(REPO_ROOT / "scripts")
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    return importlib.import_module("cps.uploader")
+
+
+@pytest.fixture(scope="module")
+def app_ctx():
+    from flask import Flask
+    from flask_babel import Babel
+
+    app = Flask(__name__)
+    app.config["BABEL_TRANSLATION_DIRECTORIES"] = str(REPO_ROOT / "cps" / "translations")
+    Babel(app)
+    with app.test_request_context():
+        yield app
+
+
+@pytest.fixture(scope="module")
+def pdf_without_title(tmp_path_factory) -> str:
+    """A real PDF carrying no /Title — the common case for scanned or
+    exported PDFs, and the reporter's format."""
+    from pypdf import PdfWriter
+
+    path = tmp_path_factory.mktemp("pdf") / "notitle.pdf"
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    with open(path, "wb") as fh:
+        writer.write(fh)
+    return str(path)
+
+
+@pytest.fixture(scope="module")
+def pdf_with_title(tmp_path_factory) -> str:
+    """A real PDF that does carry /Title and /Author."""
+    from pypdf import PdfWriter
+
+    path = tmp_path_factory.mktemp("pdf") / "withtitle.pdf"
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    writer.add_metadata({"/Title": "The Real Embedded Title", "/Author": "Ursula K. Le Guin"})
+    with open(path, "wb") as fh:
+        writer.write(fh)
+    return str(path)
+
+
+@pytest.fixture(scope="module")
+def corrupt_pdf(tmp_path_factory) -> str:
+    path = tmp_path_factory.mktemp("pdf") / "corrupt.pdf"
+    path.write_bytes(b"%PDF-1.4\nthis is not a parseable pdf at all\n")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# The reported defect: a title-less file stomps the curated title.
+# ---------------------------------------------------------------------------
+
+
+def test_strict_parse_does_not_fabricate_a_title_from_the_filename(
+    uploader, app_ctx, pdf_without_title
+):
+    """RED on main: returns 'Foundation - Isaac Asimov'.
+
+    The file carries no title, so reload must be told that — not handed
+    the filename dressed up as embedded metadata.
+    """
+    meta = uploader.process(
+        pdf_without_title, CALIBRE_DATA_STEM, ".pdf", rar_executable=None,
+        no_cover=True, strict=True,
+    )
+    assert meta.title == "", (
+        f"strict parse fabricated a title from the filename: {meta.title!r}. "
+        "The reload route applies meta.title whenever it differs from the "
+        "book's title, so this silently overwrites the curated title and "
+        "renames the book's folder on disk."
+    )
+
+
+def test_reload_leaves_the_curated_title_alone_when_the_file_has_none(
+    uploader, app_ctx, pdf_without_title
+):
+    """The user-visible outcome, expressed as the route's own guard
+    (editbooks.py:2418) — RED on main, where the guard fires and the
+    curated title is replaced by the filename stem."""
+    meta = uploader.process(
+        pdf_without_title, CALIBRE_DATA_STEM, ".pdf", rar_executable=None,
+        no_cover=True, strict=True,
+    )
+    would_overwrite = bool(meta.title and meta.title != CURATED_TITLE)
+    assert not would_overwrite, (
+        f"reload would overwrite the curated title {CURATED_TITLE!r} with "
+        f"{meta.title!r}"
+    )
+
+
+def test_strict_parse_still_returns_a_real_embedded_title(
+    uploader, app_ctx, pdf_with_title
+):
+    """The fix must not be 'always return empty' — a real embedded title
+    must still reach the book. This is what makes the test above
+    meaningful rather than vacuous."""
+    meta = uploader.process(
+        pdf_with_title, CALIBRE_DATA_STEM, ".pdf", rar_executable=None,
+        no_cover=True, strict=True,
+    )
+    assert meta.title == "The Real Embedded Title"
+
+
+# ---------------------------------------------------------------------------
+# The locale-dependent defect: a translated 'Unknown' defeats the route's
+# missing-author sentinel, so non-English users get their authors stomped.
+# ---------------------------------------------------------------------------
+
+
+def test_strict_parse_missing_author_is_empty_not_a_translated_guess(
+    uploader, app_ctx, pdf_without_title, monkeypatch
+):
+    """RED on main under any non-English locale.
+
+    ``process`` replaced a missing author with ``_('Unknown')``, which is
+    translated ('Inconnu' in French, 'Unbekannt' in German). The reload
+    route guards with ``meta.author != 'Unknown'`` — a literal English
+    string — so the guard passes for every non-English user and
+    ``handle_author_on_edit`` overwrites their real authors.
+
+    Monkeypatching gettext rather than relying on compiled .mo catalogs
+    keeps this deterministic in CI, where the catalogs may not be built.
+    """
+    monkeypatch.setattr(uploader, "_", lambda s: "Inconnu" if s == "Unknown" else s)
+
+    meta = uploader.process(
+        pdf_without_title, CALIBRE_DATA_STEM, ".pdf", rar_executable=None,
+        no_cover=True, strict=True,
+    )
+    assert meta.author == "", (
+        f"strict parse returned a guessed author {meta.author!r}. A "
+        "translated guess defeats the route's `!= 'Unknown'` sentinel and "
+        "overwrites the book's real authors for non-English users."
+    )
+
+
+def test_strict_parse_missing_author_never_reaches_the_route_guard(
+    uploader, app_ctx, pdf_without_title, monkeypatch
+):
+    """The sentinel comparison itself is the landmine. Once a missing
+    author comes back empty, the route needs no magic-string compare at
+    all — an empty author is falsy and skipped in every locale."""
+    monkeypatch.setattr(uploader, "_", lambda s: "Unbekannt" if s == "Unknown" else s)
+
+    meta = uploader.process(
+        pdf_without_title, CALIBRE_DATA_STEM, ".pdf", rar_executable=None,
+        no_cover=True, strict=True,
+    )
+    author_value = (meta.author or "").strip()
+    assert not author_value, "a missing author must be falsy so the route skips it"
+
+
+def test_strict_parse_returns_a_real_embedded_author(uploader, app_ctx, pdf_with_title):
+    """Guards against over-fixing the author path into a constant empty.
+
+    Also covers a second defect this test found: pdf_meta seeded `author`
+    with the 'Unknown' sentinel in its no-XMP branch, while the
+    DocumentInfo fallback only fills fields that are empty. The PDF's own
+    /Author was therefore unreadable for any PDF without an XMP block —
+    most of them — so reload could never update authors from a PDF at all.
+    """
+    meta = uploader.process(
+        pdf_with_title, CALIBRE_DATA_STEM, ".pdf", rar_executable=None,
+        no_cover=True, strict=True,
+    )
+    assert "Le Guin" in meta.author
+
+
+def test_pdf_without_an_author_still_reports_none_rather_than_guessing(
+    uploader, app_ctx, pdf_without_title
+):
+    """The counterpart to the test above: now that DocumentInfo authors
+    are actually read, a PDF that carries no author must still come back
+    empty so reload leaves the curated authors alone."""
+    meta = uploader.process(
+        pdf_without_title, CALIBRE_DATA_STEM, ".pdf", rar_executable=None,
+        no_cover=True, strict=True,
+    )
+    assert meta.author == ""
+
+
+def test_upload_of_a_pdf_now_reads_its_embedded_author(uploader, app_ctx, pdf_with_title):
+    """The pdf_meta fix reaches the upload path too, which is the point:
+    uploading a PDF used to label it 'Unknown' even when the file said
+    who wrote it."""
+    meta = uploader.process(
+        pdf_with_title, CALIBRE_DATA_STEM, ".pdf", rar_executable=None, no_cover=True,
+    )
+    assert "Le Guin" in meta.author
+
+
+# ---------------------------------------------------------------------------
+# Parse failures must surface, not be silently swallowed into a guess.
+# ---------------------------------------------------------------------------
+
+
+def test_strict_parse_propagates_parse_errors(uploader, app_ctx, corrupt_pdf):
+    """RED on main: process swallowed the exception and returned
+    default_meta, so the route's error handler (editbooks.py:2398-2403)
+    became unreachable and an unparseable file reported success while
+    stomping the title."""
+    with pytest.raises(Exception) as excinfo:
+        uploader.process(
+            corrupt_pdf, CALIBRE_DATA_STEM, ".pdf", rar_executable=None,
+            no_cover=True, strict=True,
+        )
+    # Guard against a false green: before the fix this raised TypeError for
+    # the unknown `strict` kwarg, which is not the parse error we mean.
+    assert not (
+        isinstance(excinfo.value, TypeError) and "strict" in str(excinfo.value)
+    ), f"raised for the wrong reason: {excinfo.value!r}"
+
+
+# ---------------------------------------------------------------------------
+# The upload contract must not change. Guessing is correct there.
+# ---------------------------------------------------------------------------
+
+
+def test_upload_path_still_guesses_the_title_from_the_filename(
+    uploader, app_ctx, pdf_without_title
+):
+    """Non-strict is the upload contract: a new book with no embedded
+    title is best described by its filename, and the user reviews the
+    guess in the edit form before saving. This must keep working."""
+    meta = uploader.process(
+        pdf_without_title, CALIBRE_DATA_STEM, ".pdf", rar_executable=None,
+        no_cover=True,
+    )
+    assert meta.title == CALIBRE_DATA_STEM
+
+
+def test_upload_path_still_swallows_parse_errors(uploader, app_ctx, corrupt_pdf):
+    """Non-strict must still degrade to default_meta so an unparseable
+    upload is importable rather than rejected."""
+    meta = uploader.process(
+        corrupt_pdf, CALIBRE_DATA_STEM, ".pdf", rar_executable=None, no_cover=True,
+    )
+    assert meta.title == CALIBRE_DATA_STEM
+
+
+def test_upload_path_still_labels_a_missing_author_unknown(
+    uploader, app_ctx, pdf_without_title, monkeypatch
+):
+    """The upload form shows the user a translated 'Unknown' placeholder.
+    Strict mode must not take that away from the upload path."""
+    monkeypatch.setattr(uploader, "_", lambda s: "Inconnu" if s == "Unknown" else s)
+    meta = uploader.process(
+        pdf_without_title, CALIBRE_DATA_STEM, ".pdf", rar_executable=None,
+        no_cover=True,
+    )
+    assert meta.author == "Inconnu"
+
+
+def test_strict_defaults_to_off_so_existing_callers_are_unchanged(uploader):
+    """Signature pin: strict must be opt-in keyword with a False default,
+    so the upload path keeps its behaviour without being touched."""
+    import inspect
+
+    sig = inspect.signature(uploader.process)
+    assert "strict" in sig.parameters, "process() must expose a strict parameter"
+    assert sig.parameters["strict"].default is False


### PR DESCRIPTION
Fixes a silent data-corruption regression that is on `main` but has **not shipped in any tag**. Caught before the train departs; per the never-retract rule that is the only time it is cheap to fix.

## What a user sees today

Click "Reload metadata from disk" on a PDF that has no embedded title — the norm for scanned or exported PDFs, and exactly what @yodatak reported in #877:

- The curated title is replaced by the Calibre data-file stem: `Foundation` becomes `Foundation - Isaac Asimov`.
- The book's folder is **renamed on disk** (a title change triggers `update_dir_structure`).
- The response says **success**: `Reloaded 1 field(s)`.
- Clicking again compounds it — the data file becomes `Foundation - Isaac Asimov - Isaac Asimov`.
- If your interface is not English, the same click also replaces your **authors**: a French library's `Frank Herbert` becomes `Inconnu`.

No error, no warning, nothing to undo.

## Root cause

A contract mismatch, not a missing guard.

`uploader.process` exists for the **upload** path, where guessing is correct — a new book with no embedded metadata is best described by its filename, and the user reviews the guess in the edit form before saving. **Reload** has the opposite contract: it refreshes a book a human already curated. `b8bdd8526` reused the helper as-is when it made reload format-aware (the right idea — the EPUB-only path was the actual #877 bug).

The trap is that nothing marks a guessed value as guessed. Every parser fabricates a title the same way — `title = <parsed> or original_file_name` (`pdf_meta`, `epub.py:126`, `comic.py:183/203`, `audio.py:131`) — and `process` then guesses a second time on top. The caller cannot distinguish "the file says this" from "we made this up".

The author path failed for a second reason: `process` substituted a **localised** `_('Unknown')`, while the route guarded on the **literal English** `'Unknown'` (`editbooks.py:2457`). The guard passed for every non-English user.

## The fix

A `strict` mode on `process` — the reload contract: *report only what the file actually carries*.

1. **Nothing to fall back to.** Strict passes an empty display name to the parsers. Since every parser's fallback is "use the caller-supplied name", a parser with no name can only return what it read. This is why the fix is structural rather than a PDF special-case — it holds for all formats.
2. **No second guess.** Strict skips `process`'s own filename/`Unknown` substitution.
3. **Parse errors propagate.** They were being swallowed, which made the route's own error handler (`editbooks.py:2398-2403`) unreachable — an unparseable file reported success while stomping the title.
4. **The magic string is deleted, not translated.** Strict normalises the parsers' missing-author sentinel to empty, so the route tests for a value instead of comparing against a string that changes with locale. Re-adding that comparison is now a test failure.

**Upload behaviour is unchanged**, pinned by tests that stay green either way. `strict` defaults to `False`; the upload call site is untouched.

### Second defect, found by the new tests

`pdf_meta` seeded `author` with the `'Unknown'` sentinel in its no-XMP branch, while the DocumentInfo fallback only fills fields that came back **empty**. So a PDF's own `/Author` was **never read** for any PDF without an XMP block — most of them. `title` was seeded `''` in the same branch, which is why titles were read from DocumentInfo and authors never were. Reload could therefore never update authors from a PDF at all, and uploads labelled them `Unknown`. Fixed by mirroring the title path.

## Verification

Red/green, then driven through the **real HTTP route on a live container** — not just unit tests.

**Unit:** 13 behavioural tests against real PDF fixtures and real locales. **10 fail on pristine `main`, all 13 pass here.** The 3 green-on-`main` are the upload-contract pins. 272 adjacent tests pass (`upload`/`uploader`/`editbook`/`metadata`/`epub`/`comic`/`audio`/`reload`).

**End-to-end** — `POST /admin/book/<id>/reload_metadata`, session-cookied, real Calibre library built with `calibredb`:

| Scenario | `origin/main` | This branch |
|---|---|---|
| EN, title-less PDF | 200 `Reloaded 1 field(s)`; `Foundation` → `Foundation - Isaac Asimov`; folder renamed | 200 `no fields updated`; title + folder preserved |
| **FR**, title-less PDF | `Dune` → `Dune - Frank Herbert`; author `Frank Herbert` → **`Inconnu`** | both preserved |
| Repeat clicks | compounds to `Foundation - Isaac Asimov - Isaac Asimov` | inert |
| PDF **with** real metadata, wrong DB title | — | correctly pulls `The Left Hand of Darkness` |

That last row is the discriminating control: the fix is not "always do nothing" — reload still applies genuine embedded metadata. Container logs clean, no new errors.

## Why CI did not catch this

The route's existing coverage (`test_reload_metadata_from_disk_218.py`, `..._authors_tags_series_218.py`) is **source-pins** — regexes over `editbooks.py`. `test_author_unknown_sentinel_does_not_stomp` asserted the presence of the `meta.author != 'Unknown'` comparison, so it was green the entire time that guard was broken for every non-English user. It pinned the code's *shape*, not its *behaviour*.

That test is rewritten here to guard against the landmine returning, and the real invariant is now covered behaviourally against actual files and locales.

## Tier / gate

- **Tier:** `safe-tier-2` boundary — ~45 production LOC, 2 production files (`cps/uploader.py`, `cps/editbooks.py`).
- **No new dependencies, licences, or external URLs** (rule 6 clean).
- **`/security-review` not required** — no auth/session/CSRF, crypto/secrets, subprocess/shell, user-controlled path, or new-route surface. The route and its path handling are untouched; only what gets written to the DB changes.
- **`@greptileai` requested** — data-integrity change on a DB-write path.

Reported by @yodatak (#877).