### PR TITLE
fix: sync KOReader highlight deletions to the server (#905)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+
+- KOReader: deleting a highlight on your device now removes it from Calibre-Web
+  NextGen too. Previously the highlight stayed in the book's highlights list
+  forever, however many times you synced. Reported by @iroQuai (#905). Update the
+  NextGen Progress Sync plugin on your device to pick this up.
+
 ## [v4.1.13] - 2026-07-14
 
 ### Added

--- a/cps/progress_syncing/protocols/koreader_annotations.py
+++ b/cps/progress_syncing/protocols/koreader_annotations.py
@@ -28,6 +28,8 @@ testable logic. See notes/2026-05-25-annotation-two-way-phase1-phase2-DESIGN.md 
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from flask import request
 
 from ... import csrf, logger, ub
@@ -43,6 +45,14 @@ from .kosync import (
 )
 
 log = logger.create()
+
+# Sources a push may declare itself complete for. A device may only reconcile
+# the source it actually owns, so an unknown/spoofed value reaps nothing.
+_REAPABLE_SOURCES = {"koreader"}
+
+
+def _now():
+    return datetime.now(timezone.utc)
 
 
 # ---------------------------------------------------------------------------
@@ -64,9 +74,17 @@ def build_pull_payload(user_id: int, book_id: int, session) -> dict:
     return {"annotations": annotations, "annotation_count": len(annotations)}
 
 
-def apply_push(annotations, *, user, book, session, commit) -> dict:
+def apply_push(annotations, *, user, book, session, commit,
+               complete_for_source=None) -> dict:
     """Upsert each pushed portable annotation, fan out to enabled sync targets,
-    and return a counts summary keyed by action (created/updated/deleted/skipped)."""
+    and return a counts summary keyed by action (created/updated/deleted/skipped).
+
+    ``complete_for_source`` makes the push authoritative for one source: the
+    caller asserts ``annotations`` is the device's COMPLETE live set for this
+    book, so any live row of that source which is absent has been deleted on
+    the device and is reaped (see :func:`_reap_absent`). Left ``None``, the
+    push is treated as partial and nothing is reaped.
+    """
     from ...services.annotation_portable import apply_portable
     from ...services import annotation_sync
 
@@ -89,7 +107,74 @@ def apply_push(annotations, *, user, book, session, commit) -> dict:
                 annotation_sync.dispatch_existing_annotation_sync(row, book, user)
         except Exception:  # pragma: no cover - fan-out must never fail the push
             log.exception("koreader annotation push fan-out failed for %s", row.annotation_id)
+
+    if complete_for_source:
+        summary["deleted"] += _reap_absent(
+            annotations, user=user, book=book, session=session, commit=commit,
+            source=complete_for_source,
+        )
     return summary
+
+
+def _reap_absent(annotations, *, user, book, session, commit, source) -> int:
+    """Soft-delete rows the device no longer has.
+
+    KOReader leaves no tombstone when a highlight is deleted — the entry just
+    disappears from its annotation collection — so a device-side delete reaches
+    us as an omission from a complete push. Reconciling the pushed set against
+    the stored one is the only way to observe it (#905).
+
+    Scoped hard, because reaping is destructive-in-effect:
+      - only this ``(user, book)``;
+      - only rows of ``source`` (a KOReader sync must never reap a Kobo-native
+        or web-reader highlight — those devices push their own complete sets);
+      - only rows that are still live (an already-hidden row is left alone, so
+        the delete fan-out fires once, not on every subsequent sync).
+
+    Soft-deletes rather than deleting: pull deliberately includes hidden rows so
+    other devices can mirror the deletion locally.
+    """
+    from ...services import annotation_sync
+
+    pushed_ids = {
+        payload.get("annotation_id").strip()
+        for payload in annotations
+        if isinstance(payload, dict)
+        and isinstance(payload.get("annotation_id"), str)
+        and payload.get("annotation_id").strip()
+    }
+
+    stale = [
+        row for row in session.query(ub.Annotation).filter(
+            ub.Annotation.user_id == user.id,
+            ub.Annotation.book_id == book.id,
+            ub.Annotation.source == source,
+        ).filter(
+            (ub.Annotation.hidden.is_(None))
+            | (ub.Annotation.hidden == False)  # noqa: E712 — SQLA needs ==
+        ).all()
+        if row.annotation_id not in pushed_ids
+    ]
+    if not stale:
+        return 0
+
+    for row in stale:
+        row.hidden = True
+        row.last_synced = _now()
+    commit()
+
+    for row in stale:
+        try:
+            annotation_sync.dispatch_annotation_deletes(
+                [row.annotation_id], user, book_id=book.id,
+            )
+        except Exception:  # pragma: no cover - fan-out must never fail the push
+            log.exception("koreader annotation reap fan-out failed for %s", row.annotation_id)
+    log.debug(
+        "koreader reap: soft-deleted %d absent %s row(s) for user=%s book=%s",
+        len(stale), source, user.id, book.id,
+    )
+    return len(stale)
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +236,26 @@ def push_annotations():
         return create_sync_response({"document": document, "matched": False,
                                      "created": 0, "updated": 0, "deleted": 0, "skipped": 0})
 
+    # A plugin that pushes its complete local set says so here, which lets the
+    # server observe device-side deletions (they arrive as omissions, never as
+    # tombstones — #905). Absent/false keeps the legacy partial-push semantics,
+    # so an older plugin build reaps nothing.
+    complete_for_source = None
+    if data.get("complete") is True:
+        claimed = data.get("complete_source") or "koreader"
+        if claimed in _REAPABLE_SOURCES:
+            complete_for_source = claimed
+        else:
+            log.warning("koreader push declared complete for unsupported source %r; not reaping", claimed)
+
     annotations = data.get("annotations")
+    # Lua has no empty-list/empty-object distinction, so the plugin's JSON
+    # encoder emits `{}` for "no annotations". A complete push is the one case
+    # where an empty payload is meaningful (the user deleted their last
+    # highlight), so accept it there. A partial push with no array is still a
+    # client bug and still 400s.
+    if complete_for_source and annotations in ({}, None):
+        annotations = []
     if not isinstance(annotations, list):
         return create_sync_response({"error": "invalid_annotations", "message": "annotations must be an array"}, 400)
     from ...services.annotation_portable import validate_portable_payload
@@ -162,11 +266,14 @@ def push_annotations():
                 "error": "invalid_annotation",
                 "message": f"annotations[{index}]: {error}",
             }, 400)
+
     summary = apply_push(
         annotations, user=user, book=book,
         session=ub.session, commit=ub.session_commit,
+        complete_for_source=complete_for_source,
     )
     summary["document"] = document
+    summary["reconciled"] = complete_for_source is not None
     summary["calibre_book_id"] = book_id
     summary["matched"] = True
     return create_sync_response(summary)

--- a/cps/progress_syncing/protocols/koreader_annotations.py
+++ b/cps/progress_syncing/protocols/koreader_annotations.py
@@ -252,9 +252,15 @@ def push_annotations():
     # Lua has no empty-list/empty-object distinction, so the plugin's JSON
     # encoder emits `{}` for "no annotations". A complete push is the one case
     # where an empty payload is meaningful (the user deleted their last
-    # highlight), so accept it there. A partial push with no array is still a
-    # client bug and still 400s.
-    if complete_for_source and annotations in ({}, None):
+    # highlight), so accept that exact shape there.
+    #
+    # `{}` ONLY — a null or missing `annotations` is a malformed request, not an
+    # assertion that the device has none, and reading it as an empty
+    # authoritative set would reap the whole book. That's unrecoverable: a
+    # tombstoned row is deliberately never un-hidden by a later push
+    # (apply_portable preserves tombstones), so the highlights would not come
+    # back even though the device still has them. Malformed still 400s.
+    if complete_for_source and annotations == {}:
         annotations = []
     if not isinstance(annotations, list):
         return create_sync_response({"error": "invalid_annotations", "message": "annotations must be an array"}, 400)

--- a/koreader/plugins/cwasync.koplugin/CWASyncClient.lua
+++ b/koreader/plugins/cwasync.koplugin/CWASyncClient.lua
@@ -229,7 +229,12 @@ function CWASyncClient:pull_annotations(username, password, document, callback)
 end
 
 -- Phase 2: push annotations for a document (device -> server).
-function CWASyncClient:push_annotations(username, password, document, annotations, callback)
+--
+-- ``complete`` marks this as the device's whole live set for the document, which
+-- is what lets the server observe deletions: KOReader keeps no tombstone when a
+-- highlight is removed, so a delete reaches us only as an omission (#905). Only
+-- pass it when the full set was actually read — the server reaps what's absent.
+function CWASyncClient:push_annotations(username, password, document, annotations, complete, callback)
     self.client:reset_middlewares()
     self.client:enable("Format.JSON")
     self.client:enable("GinClient")
@@ -243,6 +248,8 @@ function CWASyncClient:push_annotations(username, password, document, annotation
             return self.client:push_annotations({
                 document = document,
                 annotations = annotations,
+                complete = complete and true or nil,
+                complete_source = complete and "koreader" or nil,
             })
         end)
         if ok then

--- a/koreader/plugins/cwasync.koplugin/_meta.lua
+++ b/koreader/plugins/cwasync.koplugin/_meta.lua
@@ -5,5 +5,5 @@ return {
     name = "cwasync",
     fullname = _("NextGen Progress Sync"),
     description = _([[Synchronizes your reading progress to Calibre-Web NextGen and across your KOReader devices.]]),
-    version = "4.1.11",  -- Updates Manager reads this; keep in lockstep with main.lua and the CWNG release tag
+    version = "4.1.14",  -- Updates Manager reads this; keep in lockstep with main.lua and the CWNG release tag
 }

--- a/koreader/plugins/cwasync.koplugin/main.lua
+++ b/koreader/plugins/cwasync.koplugin/main.lua
@@ -27,7 +27,7 @@ end
 local CWASync = WidgetContainer:extend{
     name = "cwasync",
     title = _("Login to NextGen Server"),
-    version = "4.1.11",  -- Plugin version mirrors CWNG release tag; keep in lockstep with _meta.lua
+    version = "4.1.14",  -- Plugin version mirrors CWNG release tag; keep in lockstep with _meta.lua
 
     push_timestamp = nil,
     pull_timestamp = nil,
@@ -1531,9 +1531,13 @@ function CWASync:syncAnnotations(interactive)
                 end
             end
 
-            if #diff.send_to_server > 0 then
+            -- A complete push lets the server reap what the device deleted, so
+            -- it must still go out when the local set is empty (the user removed
+            -- their last highlight) — otherwise that delete never syncs (#905).
+            local complete = provider.push_all_local and true or false
+            if #diff.send_to_server > 0 or complete then
                 client:push_annotations(self.settings.username, self.settings.password, digest,
-                    diff.send_to_server,
+                    diff.send_to_server, complete,
                     function(ok2, _body2)
                         if interactive then
                             if ok2 then

--- a/tests/unit/test_koreader_annotation_delete_reap.py
+++ b/tests/unit/test_koreader_annotation_delete_reap.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""KOReader device-side deletes — reconciliation of a complete push (#905).
+
+KOReader keeps no tombstone when a highlight is deleted: the entry simply
+disappears from ``ui.annotation.annotations``. The plugin pushes its complete
+local set (``push_all_local = true``), so a device-side delete reaches the
+server as an *omission*, and an upsert-only push cannot tell "deleted" apart
+from "not mentioned in this push" — the row survived forever (the bug @iroQuai
+reported on #699 after v4.1.13).
+
+The fix: a push may declare itself COMPLETE for a source. When it does, the
+server reconciles — any live row for that (user, book, source) whose
+annotation_id is absent from the pushed set is soft-deleted.
+
+These tests pin the reconciliation contract:
+  - a complete push that omits a row tombstones it (the reported bug);
+  - a push WITHOUT the completeness marker reaps nothing (a partial/retried
+    push must never destroy data);
+  - a complete koreader push never reaps kobo/webreader rows (source scoping);
+  - reaping soft-deletes (hidden=True) rather than hard-deleting, so pull still
+    hands the device a tombstone;
+  - the delete fan-out fires for reaped rows;
+  - an already-hidden row is not re-reaped (no duplicate fan-out).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from types import SimpleNamespace
+
+from cps import ub
+from cps.services.annotation_sync import (
+    register_handler, reset_registry_for_testing,
+)
+from cps.services.annotation_sync.base import AnnotationSyncTargetHandler, SyncResult
+from cps.progress_syncing.protocols.koreader_annotations import (
+    build_pull_payload, apply_push,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class StubHandler(AnnotationSyncTargetHandler):
+    target_name = "stub"
+
+    def __init__(self):
+        self.pushes = []
+        self.deletes = []
+
+    def is_enabled(self, user):
+        return True
+
+    def push(self, annotation, book, user, payload=None):
+        self.pushes.append(annotation.annotation_id)
+        return SyncResult(status="synced", target_record_id="r1")
+
+    def delete(self, sync_target, user):
+        self.deletes.append(sync_target.target_record_id)
+        return SyncResult(status="tombstone")
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_registry_for_testing()
+    yield
+    reset_registry_for_testing()
+
+
+@pytest.fixture
+def env(monkeypatch):
+    engine = create_engine("sqlite:///:memory:", future=True)
+    ub.Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine, future=True)()
+    s.execute(text("PRAGMA foreign_keys=ON"))
+    user = ub.User(name="kr", email="kr@e.com", role=0, password="x")
+    s.add(user)
+    s.commit()
+    monkeypatch.setattr(ub, "session", s)
+    monkeypatch.setattr(ub, "session_commit", lambda: s.commit())
+    yield s, user
+
+
+def _book():
+    return SimpleNamespace(id=7, uuid="bk-7", title="Book")
+
+
+def _seed(s, user, aid, *, book_id=7, source="koreader", hidden=False):
+    s.add(ub.Annotation(
+        user_id=user.id, annotation_id=aid, book_id=book_id, source=source,
+        highlighted_text="t", highlight_color="yellow",
+        start_container_path="span#kobo.1.1", start_offset=0,
+        end_container_path="span#kobo.1.1", end_offset=4, hidden=hidden,
+    ))
+    s.commit()
+
+
+def _live_ids(s, user, book_id=7):
+    rows = s.query(ub.Annotation).filter(
+        ub.Annotation.user_id == user.id,
+        ub.Annotation.book_id == book_id,
+    ).all()
+    return {r.annotation_id for r in rows if not r.hidden}
+
+
+# --- the reported bug ------------------------------------------------------
+
+def test_complete_push_omitting_a_row_tombstones_it(env):
+    """The #905 repro: highlight synced, deleted on device, synced again."""
+    s, user = env
+    _seed(s, user, "kept")
+    _seed(s, user, "deleted-on-device")
+
+    # The device now only knows about "kept" — the other was deleted there.
+    summary = apply_push(
+        [{"annotation_id": "kept", "color": "yellow"}],
+        user=user, book=_book(), session=s, commit=s.commit,
+        complete_for_source="koreader",
+    )
+
+    assert _live_ids(s, user) == {"kept"}
+    assert summary["deleted"] == 1
+
+
+def test_reaped_row_is_soft_deleted_not_destroyed(env):
+    """Pull must still hand the device a tombstone, so the row has to survive."""
+    s, user = env
+    _seed(s, user, "gone")
+
+    apply_push([], user=user, book=_book(), session=s, commit=s.commit,
+               complete_for_source="koreader")
+
+    row = s.query(ub.Annotation).filter_by(annotation_id="gone").one()
+    assert row.hidden is True
+    payload = build_pull_payload(user.id, 7, s)
+    tomb = [a for a in payload["annotations"] if a["annotation_id"] == "gone"]
+    assert tomb and tomb[0]["hidden"] is True
+
+
+# --- the guardrails --------------------------------------------------------
+
+def test_push_without_completeness_marker_reaps_nothing(env):
+    """A partial or retried push must never destroy un-mentioned rows."""
+    s, user = env
+    _seed(s, user, "untouched")
+
+    apply_push([{"annotation_id": "other", "color": "red"}],
+               user=user, book=_book(), session=s, commit=s.commit)
+
+    assert "untouched" in _live_ids(s, user)
+
+
+def test_complete_koreader_push_never_reaps_other_sources(env):
+    """A KOReader sync must not delete Kobo-native or web-reader highlights."""
+    s, user = env
+    _seed(s, user, "kobo-row", source="kobo")
+    _seed(s, user, "web-row", source="webreader")
+    _seed(s, user, "koreader-row", source="koreader")
+
+    apply_push([], user=user, book=_book(), session=s, commit=s.commit,
+               complete_for_source="koreader")
+
+    assert _live_ids(s, user) == {"kobo-row", "web-row"}
+
+
+def test_complete_push_does_not_reap_other_books_or_users(env):
+    s, user = env
+    other = ub.User(name="o", email="o@e.com", role=0, password="x")
+    s.add(other); s.commit()
+    _seed(s, user, "other-book", book_id=99)
+    _seed(s, other, "other-user", book_id=7)
+
+    apply_push([], user=user, book=_book(), session=s, commit=s.commit,
+               complete_for_source="koreader")
+
+    assert _live_ids(s, user, book_id=99) == {"other-book"}
+    assert _live_ids(s, other) == {"other-user"}
+
+
+def test_already_hidden_row_is_not_reaped_again(env):
+    """No duplicate fan-out for a row that is already tombstoned."""
+    s, user = env
+    register_handler(StubHandler())
+    _seed(s, user, "already-gone", hidden=True)
+
+    summary = apply_push([], user=user, book=_book(), session=s, commit=s.commit,
+                         complete_for_source="koreader")
+
+    assert summary["deleted"] == 0
+
+
+def test_reaped_row_dispatches_delete_fanout(env):
+    """A reaped row must tell downstream targets (Hardcover) to tombstone too."""
+    s, user = env
+    handler = StubHandler()
+    register_handler(handler)
+    _seed(s, user, "fanout-me")
+    row = s.query(ub.Annotation).filter_by(annotation_id="fanout-me").one()
+    s.add(ub.AnnotationSyncTarget(
+        annotation_id=row.id,  # FK to annotation.id, not the business key
+        target="stub", target_record_id="r1", status="synced",
+    ))
+    s.commit()
+
+    apply_push([], user=user, book=_book(), session=s, commit=s.commit,
+               complete_for_source="koreader")
+
+    assert handler.deletes == ["r1"]
+
+
+# --- over the wire ---------------------------------------------------------
+
+@pytest.fixture
+def wire(env, monkeypatch):
+    """Real Flask routing, so the reap is exercised through the actual PUT the
+    plugin makes (auth + blueprint + JSON shape), not just the callable."""
+    import importlib
+    from flask import Flask
+    from cps import calibre_db
+
+    session, user = env
+    book = _book()
+    annotation_routes = importlib.import_module(
+        "cps.progress_syncing.protocols.koreader_annotations")
+    kosync_routes = importlib.import_module(
+        "cps.progress_syncing.protocols.kosync")
+    monkeypatch.setattr(kosync_routes, "is_koreader_sync_enabled", lambda: True)
+    monkeypatch.setattr(annotation_routes, "_require_kosync_enabled", lambda: None)
+    monkeypatch.setattr(annotation_routes, "authenticate_user", lambda: user)
+    monkeypatch.setattr(
+        annotation_routes, "get_book_by_checksum",
+        lambda document: (book.id, "EPUB", book.title, "book.epub", "koreader")
+        if document == "digest-905" else (None, None, None, None, None),
+    )
+    monkeypatch.setattr(calibre_db, "get_book", lambda _id: book)
+    app = Flask(__name__)
+    app.register_blueprint(kosync_routes.kosync)
+    return app.test_client(), session, user
+
+
+def test_wire_reporter_sequence_highlight_then_delete_then_resync(wire):
+    """@iroQuai's repro on #905, over the real PUT/GET the plugin makes."""
+    client, session, user = wire
+
+    # 1. Highlight on the device, sync -> it shows up in CWNG.
+    first = client.put("/kosync/syncs/annotations", json={
+        "document": "digest-905",
+        "complete": True,
+        "complete_source": "koreader",
+        "annotations": [
+            {"annotation_id": "kr-1", "highlighted_text": "one", "source": "koreader"},
+            {"annotation_id": "kr-2", "highlighted_text": "two", "source": "koreader"},
+        ],
+    })
+    assert first.status_code == 200
+    assert first.get_json()["created"] == 2
+    assert _live_ids(session, user) == {"kr-1", "kr-2"}
+
+    # 2. Delete kr-2 in KOReader, sync again. The device simply stops sending
+    #    it — there is no tombstone to send.
+    second = client.put("/kosync/syncs/annotations", json={
+        "document": "digest-905",
+        "complete": True,
+        "complete_source": "koreader",
+        "annotations": [
+            {"annotation_id": "kr-1", "highlighted_text": "one", "source": "koreader"},
+        ],
+    })
+    assert second.status_code == 200
+    body = second.get_json()
+    assert body["deleted"] == 1
+    assert body["reconciled"] is True
+
+    # 3. CWNG no longer lists it; the device still gets a tombstone on pull.
+    assert _live_ids(session, user) == {"kr-1"}
+    pull = client.get("/kosync/syncs/annotations/digest-905")
+    hidden = {a["annotation_id"]: a["hidden"] for a in pull.get_json()["annotations"]}
+    assert hidden == {"kr-1": False, "kr-2": True}
+
+
+def test_wire_legacy_plugin_push_without_marker_reaps_nothing(wire):
+    """An older plugin build must never lose the user's highlights."""
+    client, session, user = wire
+    _seed(session, user, "pre-existing")
+
+    resp = client.put("/kosync/syncs/annotations", json={
+        "document": "digest-905",
+        "annotations": [{"annotation_id": "kr-new", "highlighted_text": "n"}],
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()["reconciled"] is False
+    assert "pre-existing" in _live_ids(session, user)
+
+
+def test_wire_deleting_the_last_highlight_syncs(wire):
+    """Lua encodes an empty table as {}, and this is the one push where the
+    payload is legitimately empty — it must reap, not 400."""
+    client, session, user = wire
+    _seed(session, user, "the-only-one")
+
+    for empty in ({}, []):
+        resp = client.put("/kosync/syncs/annotations", json={
+            "document": "digest-905",
+            "complete": True,
+            "complete_source": "koreader",
+            "annotations": empty,
+        })
+        assert resp.status_code == 200, resp.get_json()
+    assert _live_ids(session, user) == set()
+
+
+def test_wire_unknown_complete_source_cannot_reap(wire):
+    """A push may only reconcile a source it owns."""
+    client, session, user = wire
+    _seed(session, user, "kobo-row", source="kobo")
+
+    resp = client.put("/kosync/syncs/annotations", json={
+        "document": "digest-905",
+        "complete": True,
+        "complete_source": "kobo",
+        "annotations": [],
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()["reconciled"] is False
+    assert "kobo-row" in _live_ids(session, user)

--- a/tests/unit/test_koreader_annotation_delete_reap.py
+++ b/tests/unit/test_koreader_annotation_delete_reap.py
@@ -325,3 +325,43 @@ def test_wire_unknown_complete_source_cannot_reap(wire):
     assert resp.status_code == 200
     assert resp.get_json()["reconciled"] is False
     assert "kobo-row" in _live_ids(session, user)
+
+
+@pytest.mark.parametrize("annotations", [None, "missing"])
+def test_wire_complete_push_with_malformed_annotations_cannot_reap(wire, annotations):
+    """A null/absent `annotations` is a malformed request, NOT an assertion that
+    the device has none. Reading it as an empty authoritative set would reap the
+    whole book, and a reap is unrecoverable — apply_portable preserves
+    tombstones, so the rows would never come back even though the device still
+    has them. Reject, don't reap.
+    """
+    client, session, user = wire
+    _seed(session, user, "must-survive")
+
+    body = {"document": "digest-905", "complete": True, "complete_source": "koreader"}
+    if annotations is None:
+        body["annotations"] = None       # explicit null
+    # "missing" -> omit the key entirely
+
+    resp = client.put("/kosync/syncs/annotations", json=body)
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "invalid_annotations"
+    assert "must-survive" in _live_ids(session, user)
+
+
+def test_reap_is_not_undone_by_a_later_push(env):
+    """Pins WHY the malformed-payload guard above matters: a tombstone is
+    permanent by design, so a wrong reap can never be walked back."""
+    s, user = env
+    _seed(s, user, "kr-1")
+
+    apply_push([], user=user, book=_book(), session=s, commit=s.commit,
+               complete_for_source="koreader")
+    assert _live_ids(s, user) == set()
+
+    # The device still has it and pushes it again — it stays tombstoned.
+    apply_push([{"annotation_id": "kr-1", "highlighted_text": "t"}],
+               user=user, book=_book(), session=s, commit=s.commit,
+               complete_for_source="koreader")
+    assert _live_ids(s, user) == set()

--- a/tests/unit/test_kosync_plugin_no_book_handling.py
+++ b/tests/unit/test_kosync_plugin_no_book_handling.py
@@ -35,7 +35,7 @@ SYNC_LOGIC_TEST_LUA = PLUGIN_DIR / "tests" / "sync_logic_test.lua"
 # a deliberate forcing function, not a value to read dynamically. Currently
 # 4.1.11 (latest shipped plugin tag; the release train performs future source
 # bumps when a plugin-touching release is tagged).
-EXPECTED_PLUGIN_VERSION = "4.1.11"
+EXPECTED_PLUGIN_VERSION = "4.1.14"
 
 
 def _read(path: Path) -> str:


### PR DESCRIPTION
Ships fix for #905. Reported by @iroQuai on #699 after he verified KOReader highlight sync in v4.1.13.

## Symptom

Delete a highlight in KOReader, sync again, and it stays in the book's highlights list in CWNG — permanently, however many times you sync.

## Root cause

Not a display bug. Every read path (`_load_user_annotations`, `annotations_data`, the `has_annotations` lookup in `web.py`) already filters `hidden` correctly. The row was never marked hidden.

The push protocol was upsert-only:

- `koreader_annotations_provider.lua` sets `push_all_local = true`, and its `readAll()` enumerates `ui.annotation.annotations` — only the highlights that still exist. Every emitted row is hardcoded `hidden = false`.
- Server-side, `apply_portable()` only soft-deletes when a payload carries `hidden: true`.
- KOReader keeps no tombstone when a highlight is deleted; the entry simply disappears from its collection, so the plugin has nothing to build a `hidden: true` payload from.

So a device-side delete arrived as an *omission*, and an upsert-only push can't tell "deleted" from "not mentioned in this push". This also explains the reporter's observation that the count looked right while the list didn't: the count follows the device, the list rendered the un-reaped rows.

## Fix

A push may declare itself complete for a source (`complete: true` + `complete_source`). When it does, the server reconciles the pushed set against the stored one and soft-deletes live rows that are absent.

Reaping is destructive-in-effect, so it's scoped hard:

- only the pushing `(user, book, source)` — a KOReader sync can never reap a Kobo-native or web-reader highlight, since those devices push their own complete sets;
- only rows that are still live, so the delete fan-out fires once rather than on every subsequent sync;
- soft-delete, not delete — pull deliberately includes hidden rows so other devices mirror the deletion locally;
- unknown `complete_source` reaps nothing.

Without the marker nothing is reaped, so an **older plugin build keeps the current semantics and cannot lose data**.

Plugin side: it already pushed its complete local set, so it now says so. It also had to start pushing when that set is empty (`#send_to_server > 0` previously suppressed the request) — otherwise deleting your *last* highlight never synced at all. An empty Lua table JSON-encodes as `{}`, which the route now accepts **only** on a complete push; a partial push with a non-array still 400s, as before.

Plugin version bumped 4.1.11 → 4.1.14 per the lockstep rule (`_meta.lua`, `main.lua`, and the `EXPECTED_PLUGIN_VERSION` pin).

## Validation

Red/green: `tests/unit/test_koreader_annotation_delete_reap.py` (new, 11 tests) fails on `main` and passes here. The one test that passes pre-fix is the `push_without_completeness_marker_reaps_nothing` guardrail, which must stay green throughout.

Behaviour pinned, not shape:

- the reporter's exact sequence over the **real PUT/GET the plugin makes** (Flask routing, not just the callable): highlight → sync → delete on device → sync → gone from CWNG, tombstone still served on pull;
- a push without the marker reaps nothing (legacy plugin safety);
- a complete koreader push never reaps `kobo`/`webreader` rows;
- no cross-book / cross-user reaping;
- reaped rows are soft-deleted, and dispatch the delete fan-out (so Hardcover tombstones too);
- an already-hidden row isn't re-reaped (no duplicate fan-out);
- deleting the last highlight syncs for both `{}` and `[]` payloads;
- an unknown `complete_source` cannot reap.

Full regression sweep: **340 passed** across the annotation/koreader/kosync surface. Two pre-existing tests caught real problems with a first cut of this change and both are now honestly satisfied rather than weakened — the `{}`/`None` rejection contract is preserved for partial pushes, and the plugin-version pin was updated in lockstep.

`luac -p` clean on both edited Lua files.

## Not verified

I can't drive a real KOReader device from CI, so the device-side leg (KOReader actually emitting the new field) is exercised at the HTTP contract the plugin speaks, not on hardware. @iroQuai's re-test after release is the last mile.

## Tier

Fork-original behaviour change touching the sync protocol. No new dependencies, no license changes, no external service URLs.
