### PR TITLE
fix(auth): keep New UI preference through logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ is for things you can see or feel when running the app.
   bookmark state the pages display. This is a server-side fix; no device plugin
   update is required. Reported and carefully re-tested by @uschi1 (#627).
 
+- **Signing out no longer drops a browser that prefers the New UI onto the
+  classic login page.** The anonymous login state now honors the same durable,
+  per-browser interface choice as the signed-in library, while new browsers,
+  non-HTML clients, disabled-SPA instances, and reverse-proxy subpaths keep
+  their existing behavior. Thanks to @iroQuai for reporting the logout gap
+  after the separate #807 login-label fix. ([#908](https://github.com/new-usemame/Calibre-Web-NextGen/issues/908))
+
 - KOReader: deleting a highlight on your device now removes it from Calibre-Web
   NextGen too. Previously the highlight stayed in the book's highlights list
   forever, however many times you synced. Reported by @iroQuai (#905). Update the

--- a/cps/spa.py
+++ b/cps/spa.py
@@ -149,6 +149,18 @@ def preferred_spa_html_request():
     return bool(request.accept_mimetypes.accept_html)
 
 
+def spa_shell_url():
+    """Return the local, prefix-aware URL for the SPA shell.
+
+    ``url_for`` includes ``request.script_root`` verbatim.  That value normally
+    comes from a trusted reverse proxy, but a malformed forwarded prefix such as
+    ``//evil.example`` would turn a redirect into a scheme-relative off-site
+    destination.  Reuse the same strict prefix sanitizer that protects the SPA
+    shell's asset and API URLs, then append the fixed app-owned route.
+    """
+    return f"{_mount_prefix()}/app/"
+
+
 def _render_shell(index_path, prefix):
     """Serve the built index.html adapted to the current mount prefix.
 

--- a/cps/spa.py
+++ b/cps/spa.py
@@ -127,8 +127,6 @@ def classic_index_redirects_to_spa():
     is NOT the SPA's own 'back to classic' marker (``cwng_feedback``), and the
     client wants HTML (not an API/OPDS machine client). Web index only — never
     books_list, authors, OPDS, Kobo, API, or login (#739 design)."""
-    if not spa_available():
-        return False
     if request.args.get("cwng_feedback"):
         return False
     return preferred_spa_html_request()

--- a/cps/spa.py
+++ b/cps/spa.py
@@ -131,6 +131,19 @@ def classic_index_redirects_to_spa():
         return False
     if request.args.get("cwng_feedback"):
         return False
+    return preferred_spa_html_request()
+
+
+def preferred_spa_html_request():
+    """Whether this browser should use the SPA for an HTML surface.
+
+    Unlike :func:`classic_index_redirects_to_spa`, this has no route-specific
+    ``cwng_feedback`` exception, so it can also route the anonymous login page.
+    The destination remains the app-owned SPA shell; callers must never redirect
+    directly to a user-controlled ``next`` value.
+    """
+    if not spa_available():
+        return False
     if request.cookies.get(PREFER_SPA_COOKIE) != "1":
         return False
     return bool(request.accept_mimetypes.accept_html)

--- a/cps/web.py
+++ b/cps/web.py
@@ -1329,7 +1329,7 @@ def index(page):
     # to the new UI rather than silently reverting (and re-nagging). Same
     # web-index-only scope; the helper also gates on SPA available + accepts HTML.
     if spa.classic_index_redirects_to_spa():
-        return redirect(url_for("spa.spa_shell"))
+        return redirect(spa.spa_shell_url())
 
     return render_books_list("newest", sort_param, 1, page)
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -41,7 +41,7 @@ from .helper import check_valid_domain, check_email, check_username, \
     send_registration_mail, check_send_to_ereader, check_read_formats, tags_filters, reset_password, valid_email, \
     edit_book_read_status, valid_password
 from .pagination import Pagination
-from .redirect import get_redirect_location
+from .redirect import get_redirect_location, is_safe_url
 from .cw_babel import get_available_locale
 from .usermanagement import login_required_if_no_ano
 from .kobo_sync_status import remove_synced_book
@@ -2644,6 +2644,20 @@ def render_login(username="", password=""):
 def login():
     if current_user is not None and current_user.is_authenticated:
         return redirect(url_for('web.index'))
+
+    # #908: the UI preference is intentionally per-browser, not per-user, so it
+    # remains readable after logout. Route an anonymous HTML browser into the
+    # SPA's logged-out tree before rendering the Classic login template.
+    if spa.preferred_spa_html_request():
+        destination = url_for("spa.spa_shell")
+        next_url = request.args.get("next", type=str)
+        # Preserve only a relative, same-origin target for the SPA's post-login
+        # resolver. Never redirect to next_url itself: the immediate destination
+        # is always our own /app shell (prefix-aware through url_for).
+        if (next_url and next_url.startswith("/") and not next_url.startswith("//")
+                and "\\" not in next_url and is_safe_url(next_url)):
+            destination = url_for("spa.spa_shell", next=next_url)
+        return redirect(destination)
 
     # Handle OAuth-only authentication mode
     if config.config_login_type == constants.LOGIN_OAUTH:

--- a/cps/web.py
+++ b/cps/web.py
@@ -41,7 +41,7 @@ from .helper import check_valid_domain, check_email, check_username, \
     send_registration_mail, check_send_to_ereader, check_read_formats, tags_filters, reset_password, valid_email, \
     edit_book_read_status, valid_password
 from .pagination import Pagination
-from .redirect import get_redirect_location, is_safe_url
+from .redirect import get_redirect_location
 from .cw_babel import get_available_locale
 from .usermanagement import login_required_if_no_ano
 from .kobo_sync_status import remove_synced_book
@@ -2649,15 +2649,10 @@ def login():
     # remains readable after logout. Route an anonymous HTML browser into the
     # SPA's logged-out tree before rendering the Classic login template.
     if spa.preferred_spa_html_request():
-        destination = url_for("spa.spa_shell")
-        next_url = request.args.get("next", type=str)
-        # Preserve only a relative, same-origin target for the SPA's post-login
-        # resolver. Never redirect to next_url itself: the immediate destination
-        # is always our own /app shell (prefix-aware through url_for).
-        if (next_url and next_url.startswith("/") and not next_url.startswith("//")
-                and "\\" not in next_url and is_safe_url(next_url)):
-            destination = url_for("spa.spa_shell", next=next_url)
-        return redirect(destination)
+        # The destination is fixed and app-owned. spa_shell_url() preserves a
+        # valid reverse-proxy subpath while rejecting hostile forwarded prefixes;
+        # never redirect to the user-controlled ``next`` query parameter.
+        return redirect(spa.spa_shell_url())
 
     # Handle OAuth-only authentication mode
     if config.config_login_type == constants.LOGIN_OAUTH:

--- a/notes/p807-luna-pref-default-final.md
+++ b/notes/p807-luna-pref-default-final.md
@@ -1,0 +1,52 @@
+# CWNG #908 DEFAULT-theme pilot — final evidence
+
+Date: 2026-07-15
+Origin: `http://127.0.0.1:8101` only
+Viewport: `1280x800`
+
+## Scope and attachment
+
+- OBSERVED: The browser actions ran through the existing Playwright/CDP browser context.
+- ASSUMED: The existing context was the operator-specified Chrome CDP endpoint `9234`; no browser was launched or closed, and the endpoint itself was not independently inspected.
+- OBSERVED: No screenshot was taken; no PNG was created.
+- OBSERVED: No code, Docker, GitHub, or repository files were changed other than this report.
+
+## Required recovery and baseline gate
+
+- OBSERVED: In one `browser_run_code` action, `context.clearCookies({ domain: '127.0.0.1' })` was followed immediately by `page.goto('http://127.0.0.1:8101/login')`.
+- OBSERVED: Baseline URL was `http://127.0.0.1:8101/login`.
+- OBSERVED: Classic login form was visible.
+- OBSERVED: `body.className` was `login ` and did not contain a token-blur class/token.
+- OBSERVED computed body styles:
+  - `backgroundColor`: `rgb(242, 242, 242)`
+  - `backgroundImage`: `none`
+  - `filter`: `none`
+  - `backdropFilter`: `none`
+
+## Flow
+
+- OBSERVED: Signed in through the Classic form as `admin`.
+- OBSERVED: Classic page exposed the visible `Switch to New UI` link; it was clicked.
+- OBSERVED: New UI loaded at `http://127.0.0.1:8101/app/`.
+- OBSERVED: Opened `Account: admin`; the visible `Sign out` button was present and clicked.
+
+## Final state
+
+- OBSERVED: Final URL is `http://127.0.0.1:8101/app/`.
+- OBSERVED: Final title is `Sign in · Calibre-Web NextGen`.
+- OBSERVED: New UI sign-in heading, username/password fields, Remember me checkbox, and Sign in button are visible.
+- OBSERVED: `GET /api/v1/auth/me` with same-origin credentials returned HTTP `401` (`ok: false`).
+
+## Cookies (names and attributes only; values intentionally omitted)
+
+- OBSERVED: `cwng_prefer_spa`; domain `127.0.0.1`; path `/`; `httpOnly=false`; `secure=false`; `sameSite=Lax`; persistent expiry present. **Survives final sign-out.**
+- OBSERVED: `session`; domain `127.0.0.1`; path `/`; `httpOnly=true`; `secure=false`; `sameSite=Lax`; persistent expiry present.
+- OBSERVED: `remember_token` is absent.
+
+## Console
+
+- OBSERVED: 2 errors, 0 warnings were reported by the browser console collector.
+- OBSERVED: Errors were `401 (UNAUTHORIZED)` resource failures for `/api/v1/auth/me`.
+- OBSERVED: The login page also emitted the browser advisory that password inputs should have an `autocomplete="current-password"` attribute.
+
+Pilot stopped at the requested final state.

--- a/notes/p807-luna-pref-fixed.md
+++ b/notes/p807-luna-pref-fixed.md
@@ -1,0 +1,39 @@
+# CWNG #908 reporter-flow verification
+
+Status: IN PROGRESS
+
+- Scope: existing shared Chrome at `http://127.0.0.1:9234`; app origin limited to `http://127.0.0.1:8101` and same-origin paths.
+- Constraints: viewport 1280x800; cookies cleared before start; no cookie values recorded; no PNG.
+- Evidence log will label each claim OBSERVED or ASSUMED.
+
+## Initial classic login — OBSERVED
+
+- Existing tab was already at `http://127.0.0.1:8101/login`; viewport set to 1280x800.
+- Cookies were cleared before navigation. After the clean login-page response, cookie metadata showed only `session` (`HttpOnly`, `SameSite=Lax`, path `/`, host `127.0.0.1`); value intentionally omitted.
+- URL: `/login`; title: `Calibre-Web NextGen | Login`.
+- Accessibility surface: Username textbox, Password textbox, checked Remember Me checkbox, Login button.
+- DEFAULT-theme proof: `body.className` was `login  blur`; `body.classList.contains('caliBlur')` was false; computed body `filter`, `backdrop-filter`, and `transform` were all `none`. The `blur` class is therefore not the `caliBlur` body class under test.
+
+## Classic sign-in and New UI — OBSERVED
+
+- `admin` / `admin123` accepted; login redirected to `/` with title `Calibre-Web NextGen | Books (42)`.
+- Classic authenticated accessibility surface exposed `Switch to New UI` linking to `/app/`.
+- Post-sign-in cookie metadata was inspected without values; authentication remained represented by `session` (`HttpOnly`, `SameSite=Lax`, path `/`).
+
+## New UI Account sign-out — OBSERVED
+
+- `/app/` loaded with title `Your Library · Calibre-Web NextGen`; accessibility snapshot showed `Account: admin` and the visible expanded menu with `My account`, `Admin`, `Back to the classic view`, and `Sign out`.
+- The visible New UI `Sign out` button was activated.
+- Immediate and reloaded final URL: `http://127.0.0.1:8101/app/`.
+- Exact final title: `Sign in · Calibre-Web NextGen`.
+- Final accessibility surface: main sign-in form with heading `Sign in`, Username textbox, Password textbox with `Show password` button, checked `Remember me` checkbox, and `Sign in` button. No Account menu or authenticated library controls were present.
+- Preference cookie: absent on the clean initial login page; present after logout as `cwng_prefer_spa`, host `127.0.0.1`, path `/`, `Secure=false`, `HttpOnly=false`, `SameSite=Lax`, with an expiry; value intentionally omitted.
+- Authentication clearance: `remember_token` was present after sign-in (`HttpOnly`, `SameSite=Strict`) and absent after logout. A `session` cookie remained after logout (`HttpOnly`, `SameSite=Lax`), but the post-logout `/app/` surface stayed anonymous after reload and `/api/v1/auth/me` returned observed `401 (UNAUTHORIZED)`; this confirms the remaining session cookie was not an authenticated session.
+- Console: observed one error class, `Failed to load resource: the server responded with a status of 401 (UNAUTHORIZED)` from `/api/v1/auth/me`; the console tool reported no warnings (its severity-inclusive output repeats the error when queried at warning level). No other warning was observed.
+
+## Evidence boundary
+
+- OBSERVED: browser actions, URLs, titles, accessibility snapshots, cookie names/attributes without values, body class/computed styles, and console response/error output described above.
+- ASSUMED: none for the reporter flow conclusion. The meaning of the surviving anonymous `session` cookie is supported by the observed anonymous UI and observed `401` auth probe, not by decoding its value.
+
+Status: COMPLETE

--- a/notes/p807-luna-pref-repro.md
+++ b/notes/p807-luna-pref-repro.md
@@ -1,0 +1,41 @@
+# CWNG #807/#739/#733 — final preference reproduction report
+
+## Scope
+
+- [OBSERVED] Final capture used the existing leased browser at `http://127.0.0.1:8101/login`.
+- [OBSERVED] Viewport was 1280x800.
+- [OBSERVED] No navigation, click, cookie clearing, browser close, code change, GitHub action, or Docker action was performed during this final capture.
+
+## Preceding run facts
+
+- [OBSERVED] The initial classic login after the temporary default-theme override had body class `login` with no body `blur` token.
+- [OBSERVED] The earlier stale note claiming body blur came from a superseded `caliBlur` run and is removed from this report.
+- [OBSERVED] `admin` / `admin123` login succeeded.
+- [OBSERVED] Authenticated New UI at `/app` showed `Your Library`, 42 books, and account `admin`.
+- [OBSERVED] Before logout, cookies included `remember_token`, `cwng_prefer_spa=1` (Path `/`, one-year expiry, HttpOnly false, Secure false, SameSite Lax), and an authenticated session.
+- [OBSERVED] `Account: admin` was opened and the visible `Sign out` control was clicked.
+- [OBSERVED] Logout landed at `http://127.0.0.1:8101/login` with the classic `Calibre-Web NextGen | Login` title.
+
+## Final capture
+
+- [OBSERVED] Accessibility snapshot URL: `http://127.0.0.1:8101/login`.
+- [OBSERVED] Page title: `Calibre-Web NextGen | Login`.
+- [OBSERVED] Visible surface contains the `Login` heading, Username and Password fields, Remember Me checked, and Login button.
+- [OBSERVED] Current cookies are `cwng_prefer_spa` and `session`; raw cookie values are intentionally omitted.
+- [OBSERVED] `cwng_prefer_spa` remains present with Path `/`, HttpOnly false, Secure false, SameSite Lax, and its observed one-year expiry configuration.
+- [OBSERVED] `remember_token` is absent.
+- [OBSERVED] The remaining `session` cookie is not authenticated, as shown by the classic login surface and absence of `remember_token`.
+- [ASSUMED] The remaining session is an anonymous session; this is inferred from the unauthenticated page and cookie set, without decoding its value.
+- [OBSERVED] The preference survived logout: yes.
+- [OBSERVED] Symptom reproduced: yes — logout preserved `cwng_prefer_spa=1` but landed on the classic login surface rather than the New UI login surface.
+
+## Console
+
+- [OBSERVED] Current console collection reported zero errors and zero warnings.
+- [OBSERVED] One verbose browser message reported missing `autocomplete` attributes on login inputs, suggesting `current-password`.
+
+## Evidence boundary
+
+- [OBSERVED] The final page state comes from one accessibility snapshot.
+- [OBSERVED] The final cookie state comes from the requested Playwright context-cookie read, with values excluded here.
+- [OBSERVED] Console state comes from the console collector.

--- a/notes/p807-security-review.md
+++ b/notes/p807-security-review.md
@@ -1,0 +1,66 @@
+# CWNG #908 — Auth/session security review
+
+Re-reviewed current `HEAD` (`cf51774f4`) on 2026-07-15 after the hostile-prefix correction. No production files were changed during this re-review; this re-review updates only this note.
+
+## Gate result
+
+**Clean for the reviewed hostile-prefix redirect gate.**
+
+**OBSERVED:** both redirects in scope now call the same sanitized, app-owned URL constructor:
+
+| Redirect | Current call site | Result with `SCRIPT_NAME=//evil.example` |
+| --- | --- | --- |
+| Preferred classic index | `cps/web.py:1331-1332` | `/app/` |
+| Preferred anonymous login | `cps/web.py:2651-2655` | `/app/` |
+
+`spa.spa_shell_url()` returns `f"{_mount_prefix()}/app/"` at `cps/spa.py:152-161`. `_mount_prefix()` accepts only the strict path-prefix allowlist and returns `""` for an invalid prefix (`cps/spa.py:61-79`). Therefore neither reviewed redirect reflects a hostile prefix or `next` as its destination.
+
+## Change since the prior review
+
+**OBSERVED:** `git diff 55a8e8a4f..cf51774f4` contains two files, 18 additions and 2 deletions:
+
+* `cps/web.py`: the classic-index preferred-UI redirect changed from `url_for("spa.spa_shell")` to `spa.spa_shell_url()` (`cps/web.py:1331-1332`).
+* `tests/unit/test_739_sticky_new_ui.py`: the minimal classic-index wiring was updated to match production and `test_classic_index_redirect_rejects_hostile_proxy_prefix` was added (`tests/unit/test_739_sticky_new_ui.py:227-240`). It asserts a `302` with exactly `Location: /app/` for `SCRIPT_NAME=//evil.example`.
+
+The previous High classic-index scheme-relative redirect is therefore remediated at current HEAD. The new regression test directly exercises the hostile-prefix result; the production call-site equivalence is additionally established by source inspection. The test fixture is a minimal Flask mirror of the index route, so full authenticated classic-index dispatch is **ASSUMED**, not independently end-to-end exercised here.
+
+## Focused regression evidence
+
+**OBSERVED:** ran:
+
+```
+pytest -q tests/unit/test_739_sticky_new_ui.py tests/unit/test_571_reverse_proxy_prefix.py
+```
+
+Result: **44 passed in 0.51s**.
+
+Coverage relevant to this gate includes:
+
+* preferred classic index rejects `//evil.example` (`tests/unit/test_739_sticky_new_ui.py:227-240`);
+* anonymous login rejects four hostile prefixes, including `//evil.example`, `/../evil.example`, whitespace, and quote/script input (`tests/unit/test_739_sticky_new_ui.py:355-375`);
+* anonymous login preserves a valid `/cwa` mount and ignores supplied `next` (`tests/unit/test_739_sticky_new_ui.py:305-334`);
+* reverse-proxy asset/prefix tests cover direct and `X-Script-Name` subpath handling plus malformed-prefix rejection (`tests/unit/test_571_reverse_proxy_prefix.py`).
+
+## Verified flow
+
+| Flow | Evidence |
+| --- | --- |
+| Write | **OBSERVED:** `GET /app` stamps only `cwng_prefer_spa=1`, one-year lifetime, at the sanitized mount path; `Secure` and `SameSite` mirror session configuration; it is deliberately non-HttpOnly. `cps/spa.py:100-113`; session defaults `cps/__init__.py:75-83`. |
+| Preferred classic index | **OBSERVED:** an SPA-enabled HTML request with cookie value exactly `1` uses the sanitized app-owned shell URL. `cps/web.py:1319-1334`; `cps/spa.py:124-161`. |
+| Preferred anonymous login | **OBSERVED:** after the authenticated-user branch, an SPA-enabled HTML request with the cookie uses the same sanitized app-owned shell URL and ignores `next`. `cps/web.py:2643-2655`; `cps/spa.py:137-161`. |
+| Valid proxy mount | **OBSERVED:** a valid `/cwa` prefix yields `/cwa/app/`; focused test coverage is at `tests/unit/test_739_sticky_new_ui.py:305-334`. |
+| Clear | **OBSERVED:** the `cwng_feedback` classic-index path deletes the preference using the same sanitized path helper. `cps/web.py:1323-1326`; `cps/spa.py:116-121`. |
+| Logout / authentication | **OBSERVED:** logout clears local authentication state but not the UI-preference cookie; `/app` remains a shell, and `/api/v1/auth/me` returns 401 when unauthenticated. `cps/logout.py:11-24`; `cps/web.py:2831-2844`; `cps/spa.py:195-206`; `cps/api/auth.py:171-175`. |
+| Legacy `next` paths | **OBSERVED:** post-login and anonymous-browse logout retain the pre-existing `get_redirect_location` validator. `cps/web.py:2605,2837-2844`; `cps/redirect.py:52-57`. Those paths were not changed by `cf51774f4`. |
+
+## Low residual — root-path preference cookie can affect a subpath instance
+
+**OBSERVED:** the preference cookie is host-only and scoped to `_mount_prefix()` or `/` (`cps/spa.py:91-121`). A root-mounted instance therefore writes `Path=/`; a subpath instance reads the same cookie name (`cps/spa.py:137-149`) and deletes only its own mount path (`cps/spa.py:116-121`). Sibling subpaths such as `/a` and `/b` use distinct paths.
+
+**ASSUMED:** under normal browser cookie path matching, a root `Path=/` preference cookie from one CWNG instance on a host is sent to another instance at `/cwa`; the subpath instance can then select the SPA, while clearing only `Path=/cwa` leaves the root cookie. This requires separate instances on the same host at both `/` and a subpath.
+
+Impact remains limited to the non-authentication UI preference: it can select the SPA and make “Back to classic” appear ineffective while the root cookie remains. It does not grant a session or alter authorization.
+
+## Deliberately not claimed
+
+**ASSUMED:** reverse proxies overwrite or strip client-supplied prefix headers before forwarding. The application-level sanitizer protects these two redirect destinations even if that deployment assumption fails; proxy trust boundaries themselves were not deployed or browser-tested in this re-review.

--- a/tests/unit/test_739_sticky_new_ui.py
+++ b/tests/unit/test_739_sticky_new_ui.py
@@ -24,7 +24,6 @@ set_cookie() test-client API, which changed signature across the supported Flask
 range (1.x–3.x).
 """
 import pathlib
-from urllib.parse import parse_qs, urlsplit
 from unittest.mock import MagicMock, patch
 
 import flask
@@ -303,9 +302,9 @@ def test_preferred_spa_login_redirect_preserves_reverse_proxy_subpath(tmp_path):
 
 
 @pytest.mark.unit
-def test_preferred_spa_login_preserves_safe_local_next_under_subpath(tmp_path):
-    """A legitimate post-login target survives the surface handoff, including
-    its reverse-proxy prefix, so the SPA can safely resume it after sign-in."""
+def test_preferred_spa_login_ignores_next_and_preserves_subpath(tmp_path):
+    """The handoff stays on the app-owned shell even when login has a ``next``
+    target; the sanitized reverse-proxy prefix is the only preserved input."""
     app, web_mod, monkey = _login_app(tmp_path)
     try:
         resp = _get_login(
@@ -313,10 +312,8 @@ def test_preferred_spa_login_preserves_safe_local_next_under_subpath(tmp_path):
             headers=_HTML_ACCEPT,
             environ_overrides={**_PREFER_COOKIE, "SCRIPT_NAME": "/cwa"},
         )
-        location = urlsplit(resp.headers["Location"])
         assert resp.status_code == 302
-        assert location.path == "/cwa/app/"
-        assert parse_qs(location.query) == {"next": ["/cwa/admin"]}
+        assert resp.headers["Location"] == "/cwa/app/"
     finally:
         monkey.undo()
 

--- a/tests/unit/test_739_sticky_new_ui.py
+++ b/tests/unit/test_739_sticky_new_ui.py
@@ -24,6 +24,7 @@ set_cookie() test-client API, which changed signature across the supported Flask
 range (1.x–3.x).
 """
 import pathlib
+from urllib.parse import parse_qs, urlsplit
 from unittest.mock import MagicMock, patch
 
 import flask
@@ -237,7 +238,7 @@ def test_preferred_spa_redirects_anonymous_login_to_new_ui(tmp_path):
             environ_overrides=_PREFER_COOKIE,
         )
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "/app"
+        assert resp.headers["Location"] == "/app/"
     finally:
         monkey.undo()
 
@@ -296,7 +297,26 @@ def test_preferred_spa_login_redirect_preserves_reverse_proxy_subpath(tmp_path):
             environ_overrides={**_PREFER_COOKIE, "SCRIPT_NAME": "/cwa"},
         )
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "/cwa/app"
+        assert resp.headers["Location"] == "/cwa/app/"
+    finally:
+        monkey.undo()
+
+
+@pytest.mark.unit
+def test_preferred_spa_login_preserves_safe_local_next_under_subpath(tmp_path):
+    """A legitimate post-login target survives the surface handoff, including
+    its reverse-proxy prefix, so the SPA can safely resume it after sign-in."""
+    app, web_mod, monkey = _login_app(tmp_path)
+    try:
+        resp = _get_login(
+            _client(app), web_mod, "/login?next=%2Fcwa%2Fadmin",
+            headers=_HTML_ACCEPT,
+            environ_overrides={**_PREFER_COOKIE, "SCRIPT_NAME": "/cwa"},
+        )
+        location = urlsplit(resp.headers["Location"])
+        assert resp.status_code == 302
+        assert location.path == "/cwa/app/"
+        assert parse_qs(location.query) == {"next": ["/cwa/admin"]}
     finally:
         monkey.undo()
 
@@ -313,7 +333,7 @@ def test_preferred_spa_login_rejects_off_site_next_destination(tmp_path):
             headers=_HTML_ACCEPT, environ_overrides=_PREFER_COOKIE,
         )
         assert resp.status_code == 302
-        assert resp.headers["Location"] == "/app"
+        assert resp.headers["Location"] == "/app/"
         assert "evil.example" not in resp.headers["Location"]
     finally:
         monkey.undo()

--- a/tests/unit/test_739_sticky_new_ui.py
+++ b/tests/unit/test_739_sticky_new_ui.py
@@ -86,7 +86,7 @@ def _sticky_app(tmp_path):
             spa_mod.clear_prefer_spa_cookie(resp)
             return resp
         if spa_mod.classic_index_redirects_to_spa():
-            return flask.redirect(flask.url_for("spa.spa_shell"))
+            return flask.redirect(spa_mod.spa_shell_url())
         return "CLASSIC HOME"
 
     return app, monkey
@@ -220,6 +220,22 @@ def test_non_html_accept_not_redirected(tmp_path):
             "/", headers={"Accept": "application/json"},
             environ_overrides=_PREFER_COOKIE)
         assert resp.status_code == 200
+    finally:
+        monkey.undo()
+
+
+@pytest.mark.unit
+def test_classic_index_redirect_rejects_hostile_proxy_prefix(tmp_path):
+    """The original #739 redirect shares the same forwarded-prefix boundary as
+    /login and must not turn ``//host`` into a scheme-relative redirect."""
+    app, monkey = _sticky_app(tmp_path)
+    try:
+        resp = _client(app).get(
+            "/", headers=_HTML_ACCEPT,
+            environ_overrides={**_PREFER_COOKIE, "SCRIPT_NAME": "//evil.example"},
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"] == "/app/"
     finally:
         monkey.undo()
 

--- a/tests/unit/test_739_sticky_new_ui.py
+++ b/tests/unit/test_739_sticky_new_ui.py
@@ -24,6 +24,7 @@ set_cookie() test-client API, which changed signature across the supported Flask
 range (1.x–3.x).
 """
 import pathlib
+from unittest.mock import MagicMock, patch
 
 import flask
 import pytest
@@ -89,6 +90,33 @@ def _sticky_app(tmp_path):
         return "CLASSIC HOME"
 
     return app, monkey
+
+
+def _login_app(tmp_path):
+    """App with the real SPA and web blueprints for anonymous /login routing.
+
+    The classic login renderer is patched at its final template boundary so the
+    tests exercise the production ``web.login`` route and all routing decisions
+    without needing a configured user database, OAuth provider, or Jinja tree.
+    """
+    import cps.web as web_mod
+
+    monkey = _seed_bundle(tmp_path)
+    app = flask.Flask(__name__)
+    app.config["SECRET_KEY"] = "test"
+    _mirror_prod_session_config(app)
+    app.register_blueprint(spa_mod.spa)
+    app.register_blueprint(web_mod.web)
+    return app, web_mod, monkey
+
+
+def _get_login(client, web_mod, *args, **kwargs):
+    anonymous = MagicMock()
+    anonymous.is_authenticated = False
+    with patch.object(web_mod, "current_user", anonymous), \
+         patch.object(web_mod, "render_login", return_value="CLASSIC LOGIN"), \
+         patch.object(web_mod.config, "config_login_type", 0, create=True):
+        return client.get(*args, **kwargs)
 
 
 def _client(app):
@@ -192,6 +220,101 @@ def test_non_html_accept_not_redirected(tmp_path):
             "/", headers={"Accept": "application/json"},
             environ_overrides=_PREFER_COOKIE)
         assert resp.status_code == 200
+    finally:
+        monkey.undo()
+
+
+# ---- anonymous login surface ------------------------------------------------
+
+@pytest.mark.unit
+def test_preferred_spa_redirects_anonymous_login_to_new_ui(tmp_path):
+    """After logout, an anonymous HTML browser that still carries the durable
+    preference must enter the SPA's logged-out tree instead of Classic login."""
+    app, web_mod, monkey = _login_app(tmp_path)
+    try:
+        resp = _get_login(
+            _client(app), web_mod, "/login", headers=_HTML_ACCEPT,
+            environ_overrides=_PREFER_COOKIE,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"] == "/app"
+    finally:
+        monkey.undo()
+
+
+@pytest.mark.unit
+def test_login_without_preference_keeps_classic_surface(tmp_path):
+    """A new/no-cookie browser keeps the existing Classic login behavior."""
+    app, web_mod, monkey = _login_app(tmp_path)
+    try:
+        resp = _get_login(_client(app), web_mod, "/login", headers=_HTML_ACCEPT)
+        assert resp.status_code == 200
+        assert resp.get_data(as_text=True) == "CLASSIC LOGIN"
+    finally:
+        monkey.undo()
+
+
+@pytest.mark.unit
+def test_preferred_spa_login_does_not_redirect_non_html_client(tmp_path):
+    """Machine clients carrying a shared browser cookie must not be sent HTML."""
+    app, web_mod, monkey = _login_app(tmp_path)
+    try:
+        resp = _get_login(
+            _client(app), web_mod, "/login",
+            headers={"Accept": "application/json"},
+            environ_overrides=_PREFER_COOKIE,
+        )
+        assert resp.status_code == 200
+        assert resp.get_data(as_text=True) == "CLASSIC LOGIN"
+    finally:
+        monkey.undo()
+
+
+@pytest.mark.unit
+def test_preferred_spa_login_stays_classic_when_spa_disabled(tmp_path):
+    """The preference cannot redirect into a disabled/unavailable SPA shell."""
+    app, web_mod, monkey = _login_app(tmp_path)
+    monkey.setenv("CWNG_SPA", "0")
+    try:
+        resp = _get_login(
+            _client(app), web_mod, "/login", headers=_HTML_ACCEPT,
+            environ_overrides=_PREFER_COOKIE,
+        )
+        assert resp.status_code == 200
+        assert resp.get_data(as_text=True) == "CLASSIC LOGIN"
+    finally:
+        monkey.undo()
+
+
+@pytest.mark.unit
+def test_preferred_spa_login_redirect_preserves_reverse_proxy_subpath(tmp_path):
+    """url_for must keep the mount prefix; a hardcoded /app breaks #571."""
+    app, web_mod, monkey = _login_app(tmp_path)
+    try:
+        resp = _get_login(
+            _client(app), web_mod, "/login", headers=_HTML_ACCEPT,
+            environ_overrides={**_PREFER_COOKIE, "SCRIPT_NAME": "/cwa"},
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"] == "/cwa/app"
+    finally:
+        monkey.undo()
+
+
+@pytest.mark.unit
+def test_preferred_spa_login_rejects_off_site_next_destination(tmp_path):
+    """An attacker-controlled next= must never turn /login -> /app into an
+    external redirect. The fixed SPA destination contains no hostile target."""
+    app, web_mod, monkey = _login_app(tmp_path)
+    try:
+        resp = _get_login(
+            _client(app), web_mod,
+            "/login?next=https%3A%2F%2Fevil.example%2Fsteal",
+            headers=_HTML_ACCEPT, environ_overrides=_PREFER_COOKIE,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"] == "/app"
+        assert "evil.example" not in resp.headers["Location"]
     finally:
         monkey.undo()
 

--- a/tests/unit/test_739_sticky_new_ui.py
+++ b/tests/unit/test_739_sticky_new_ui.py
@@ -339,6 +339,29 @@ def test_preferred_spa_login_rejects_off_site_next_destination(tmp_path):
         monkey.undo()
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize("bad_prefix", [
+    "//evil.example",
+    "/../evil.example",
+    "/a b",
+    '/a"><script>evil</script>',
+])
+def test_preferred_spa_login_rejects_hostile_proxy_prefix(tmp_path, bad_prefix):
+    """A trusted-prefix header still enters request.script_root. The redirect
+    must use the SPA sanitizer rather than letting url_for emit //host/app/."""
+    app, web_mod, monkey = _login_app(tmp_path)
+    try:
+        resp = _get_login(
+            _client(app), web_mod, "/login", headers=_HTML_ACCEPT,
+            environ_overrides={**_PREFER_COOKIE, "SCRIPT_NAME": bad_prefix},
+        )
+        assert resp.status_code == 302
+        assert resp.headers["Location"] == "/app/"
+        assert "evil.example" not in resp.headers["Location"]
+    finally:
+        monkey.undo()
+
+
 # ---- source pins: template gating + web.py wiring ----
 
 @pytest.mark.unit


### PR DESCRIPTION
## Symptom

After a browser chose the New UI, signing out preserved the browser preference but rendered the Classic login page. This made the New UI login surface unreachable through the reporter's normal logout flow.

Ships the fix tracked in #908, reported by @iroQuai in a post-close comment on #807. The OIDC button-label bug originally tracked by #807 remains separately resolved and reporter-confirmed. This also completes the anonymous-login part of the durable preference behavior discussed in #739 and #733.

## Root cause

The durable `cwng_prefer_spa` cookie added for #739 was written by the SPA and read by the authenticated Classic index, but `/login` never consumed it. Once logout cleared authentication, the user row was unavailable by design and the real anonymous login route always fell through to the Classic template.

Failure mode: Class 1, **happy path verified but the real client's full flow wasn't**. The earlier preference fix covered authenticated navigation and fresh tabs, but not the full `login → choose New UI → logout → anonymous login` sequence. Class 5 also contributed: the anonymous/default-state cell was not exercised.

## Fix

- Reuse the per-browser preference on anonymous HTML `/login` requests when the SPA is available.
- Keep no-cookie, non-HTML, SPA-disabled, and already-authenticated behavior unchanged.
- Redirect only to the fixed app-owned SPA shell. `next` never controls this transition.
- Preserve valid reverse-proxy subpaths through the existing strict prefix sanitizer.
- Apply the same sanitized URL constructor to the adjacent #739 Classic-index redirect; security review found its pre-existing `url_for()` call could emit a scheme-relative redirect for a hostile forwarded prefix.

## Verification

- RED on the pre-fix test commit: 3 failed, 11 passed (anonymous preferred login, valid subpath, hostile `next` containment).
- RED on the inherited first implementation before redirect hardening: 4 failed, 15 passed for hostile forwarded prefixes.
- GREEN at PR head: 90 passed across sticky-preference, reverse-proxy, API auth/auth-gate, logout, and SPA-shell suites.
- Full local unit sweep: 3,344 passed, 44 skipped; 96 failures and 72 setup errors remain in known environment/module-stub-dependent areas. No claim that this broad local suite is green.
- Luna, 1280×800, explicit DEFAULT Classic theme: no-cookie `/login` had no `blur` class; login → visible New UI switch → visible Sign out ended on `/app/` New UI Sign in; preference cookie survived; `remember_token` was absent; `/api/v1/auth/me` returned 401.
- Independent auth/session security review: clean for both redirect entry points after hostile-prefix hardening. A low, pre-existing same-host root-instance/subpath-instance preference-cookie overlap remains documented; it is UI-only and cannot authenticate or authorize.

No dependency, schema, route, or external-service changes.
