### PR TITLE
Make the admin default-theme picker real instead of inert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- Admin → Theme no longer says "Settings saved." and then changes nothing. The
+  picker stored its choice in an old numbering the theme system stopped reading,
+  so "Light" always came back dark. It is now the default theme for **new
+  accounts**, it offers every theme (System, Light, Dark, Sepia, High contrast,
+  Midnight) instead of just two, and a "Light" you saved earlier is honoured
+  rather than discarded. Your own theme stays where it belongs, under Account →
+  Theme. Thanks @auspex for reporting it and pushing back when the first fix
+  missed the part you filed about.
+
 - KOReader progress now appears on both classic and new book pages even when
   the book already had a read/unread record before its first matched sync. The
   devices could exchange positions while the web page showed no “KOReader

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -43,6 +43,7 @@ from .gdriveutils import is_gdrive_ready, gdrive_support
 from .render_template import render_title_template, get_sidebar_config
 from .services.worker import WorkerThread
 from .usermanagement import user_login_required
+from .ui_themes import config_theme_code
 from .cw_babel import get_available_translations, get_available_locale, get_user_locale_language
 from . import debug_info
 from .string_helper import strip_whitespaces
@@ -2790,9 +2791,10 @@ def _handle_new_user(to_save, content, languages, translations, kobo_support):
         content.sidebar_view |= constants.DETAIL_RANDOM
 
     content.role = constants.selected_roles(to_save)
-    # Force dark theme (caliBlur = 1) for new users
+    # Seed the account with the instance default theme (Admin -> Theme). The
+    # account owns its theme from here on, via Account -> Theme in the New UI.
     try:
-        content.theme = 1
+        content.theme = config_theme_code(config.config_theme)
     except Exception:
         pass
     try:

--- a/cps/api/admin.py
+++ b/cps/api/admin.py
@@ -18,13 +18,19 @@ from ..cw_babel import get_available_locale
 from ..usermanagement import login_required_if_no_ano
 from ..helper import (valid_email, check_email, check_username, valid_password,
                       generate_password_hash, reset_password)
+from ..ui_themes import ALLOWED_THEME_SLUGS, config_theme_code, config_theme_slug, theme_code
 from ..admin import _delete_user
 
 # UI-configuration fields the SPA admin form can read/write natively. Scoped to
 # the safe, high-traffic display settings — the deep security config (LDAP,
 # OAuth, SMTP, SSL, external binaries) stays on the legacy pages.
+#
+# config_theme is deliberately NOT here: it travels as a slug, not a raw int
+# (see _ui_config_payload / admin_update_config). Sending it as an int is what
+# let the admin form invent its own Light=0/Dark=1 numbering and drift out of
+# sync with ui_themes.THEME_CODES — the #736 bug.
 _UI_CONFIG_INT = ("config_books_per_page", "config_random_books",
-                  "config_authors_max", "config_theme")
+                  "config_authors_max")
 _UI_CONFIG_STR = ("config_calibre_web_title", "config_default_language",
                   "config_default_locale", "config_server_announcement")
 
@@ -129,7 +135,8 @@ def _ui_config_payload():
         "config_books_per_page": config.config_books_per_page,
         "config_random_books": config.config_random_books,
         "config_authors_max": config.config_authors_max,
-        "config_theme": config.config_theme,
+        # A slug from ui_themes (the SSOT the SPA mirrors), never the raw int.
+        "config_theme": config_theme_slug(config.config_theme),
         "config_default_language": config.config_default_language,
         "config_default_locale": config.config_default_locale,
         "config_server_announcement": config.config_server_announcement or "",
@@ -222,6 +229,13 @@ def admin_update_config():
                 setattr(config, key, int(data[key]))
             except (TypeError, ValueError):
                 return _err("invalid_request", "%s must be a number" % key, 400)
+    if "config_theme" in data:
+        # Validated against the SSOT slug set, exactly like the per-account
+        # endpoint (cps/api/account.py), so an unknown theme is rejected loudly
+        # instead of being stored and silently falling back to dark on read.
+        if data["config_theme"] not in ALLOWED_THEME_SLUGS:
+            return _err("invalid_request", "Invalid theme option", 400)
+        config.config_theme = theme_code(data["config_theme"])
     for key in _UI_CONFIG_STR:
         if key in data:
             setattr(config, key, str(data[key] or ""))
@@ -280,7 +294,9 @@ def admin_create_user():
     new_user.allowed_column_value = config.config_allowed_column_value
     new_user.denied_column_value = config.config_denied_column_value
     new_user.sidebar_view = config.config_default_show
-    new_user.theme = 1  # caliBlur dark, matching _handle_new_user
+    # Inherit the instance default theme, matching _handle_new_user. The account
+    # keeps its own copy from here on — Account -> Theme edits User.theme only.
+    new_user.theme = config_theme_code(config.config_theme)
 
     try:
         ub.session.add(new_user)

--- a/cps/api/admin.py
+++ b/cps/api/admin.py
@@ -251,7 +251,7 @@ def admin_update_config():
 def admin_create_user():
     """Create a household/library user. Mirrors cps/admin.py _handle_new_user:
     same validators, same config-derived defaults (role, locale, language,
-    content restrictions, dark theme), so a user created here is indistinguishable
+    content restrictions, theme), so a user created here is indistinguishable
     from one created via the legacy admin page."""
     guard = _require_admin()
     if guard:

--- a/cps/spa_strings.py
+++ b/cps/spa_strings.py
@@ -88,6 +88,8 @@ _("Midnight (AMOLED)")
 _("Match your device’s light or dark setting")
 _("Theme saved.")
 _("Could not save theme.")
+_("Default theme for new accounts")
+_("Applies to accounts created from now on. Everyone picks their own under Account → Theme.")
 
 
 # ============================================================================

--- a/cps/ui_themes.py
+++ b/cps/ui_themes.py
@@ -31,6 +31,12 @@ THEME_CODES = {
 DEFAULT_THEME_CODE = 1        # dark — current behaviour; existing users stay here
 DEFAULT_THEME_SLUG = "dark"
 
+# The deprecated pre-#845 code. In ``User.theme`` it is an unmigrated anomaly and
+# resolves to dark (see ``theme_slug``). In ``config_theme`` it is not an anomaly:
+# it is the value the admin form actively wrote for "Light" right up until #736,
+# so there it still means light and is read back as such (``config_theme_slug``).
+LEGACY_STANDARD_CODE = 0
+
 _SLUG_TO_CODE = {slug: code for code, slug in THEME_CODES.items()}
 
 # The set the account endpoint validates an incoming choice against.
@@ -51,3 +57,27 @@ def theme_code(slug):
     Callers should validate against ALLOWED_THEME_SLUGS first and 400 on a bad
     value; this stays defensive so it can never write a NULL/garbage code."""
     return _SLUG_TO_CODE.get(slug, DEFAULT_THEME_CODE)
+
+
+def config_theme_slug(code):
+    """The server-wide default theme (``config_theme``) as an SPA slug.
+
+    Differs from ``theme_slug`` on exactly one input: the legacy 0. A 0 in
+    ``User.theme`` is an unmigrated row, so ``theme_slug`` resolves it to dark.
+    A 0 in ``config_theme`` is a deliberate admin choice — the pre-#736 admin
+    form offered Light=0 / Dark=1 and stored the raw int — so reading it back as
+    dark would silently discard the admin's saved intent. Read it as light."""
+    try:
+        value = int(code)
+    except (TypeError, ValueError):
+        return DEFAULT_THEME_SLUG
+    if value == LEGACY_STANDARD_CODE:
+        return "light"
+    return theme_slug(value)
+
+
+def config_theme_code(code):
+    """``config_theme`` (raw stored value) -> the int code to seed a new account
+    with. Normalises the legacy 0 through ``config_theme_slug`` so a new account
+    inherits the theme the admin actually chose."""
+    return theme_code(config_theme_slug(code))

--- a/cps/web.py
+++ b/cps/web.py
@@ -44,6 +44,7 @@ from .pagination import Pagination
 from .redirect import get_redirect_location
 from .cw_babel import get_available_locale
 from .usermanagement import login_required_if_no_ano
+from .ui_themes import config_theme_code
 from .kobo_sync_status import remove_synced_book
 from . import magic_shelf
 from .render_template import render_title_template
@@ -2544,9 +2545,13 @@ def register_post():
         content.role = config.config_default_role
         content.locale = config.config_default_locale
         content.sidebar_view = config.config_default_show
-        # Default to configured theme for new self-registered users (fallback to caliBlur=1)
+        # Seed the instance default theme, same as the admin-created paths. Goes
+        # through config_theme_code rather than assigning the raw value: a legacy
+        # config_theme of 0 means light, but a User.theme of 0 reads back as dark,
+        # so a raw copy would hand self-registered users a different theme than
+        # admin-created ones from the same setting (#736).
         try:
-            content.theme = getattr(config, 'config_theme', 1)
+            content.theme = config_theme_code(getattr(config, 'config_theme', None))
         except Exception:
             pass
         try:

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -380,7 +380,8 @@ export interface AdminConfig {
   config_books_per_page: number;
   config_random_books: number;
   config_authors_max: number;
-  config_theme: number;
+  /** ui_themes slug (e.g. "light"), not the legacy int code — see #736. */
+  config_theme: string;
   config_default_language: string;
   config_default_locale: string;
   config_server_announcement: string;

--- a/frontend/src/pages/Admin.module.css
+++ b/frontend/src/pages/Admin.module.css
@@ -76,6 +76,8 @@
 .field select:focus-visible,
 .field textarea:focus-visible { outline: 2px solid var(--accent); outline-offset: 0; }
 
+.fieldHint { margin: 0; color: var(--text-muted); font-size: var(--fs-sm); }
+
 .newActions {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -13,6 +13,7 @@ import { EmptyState } from '../components/EmptyState';
 import type { AdminUser } from '../lib/api';
 import { ApiError, resourceUrl } from '../lib/api';
 import { useT } from '../lib/i18n';
+import { THEMES, DEFAULT_THEME } from '../lib/themes';
 import styles from './Admin.module.css';
 
 // Remaining legacy server-configuration pages — these are the deep, rarely-touched
@@ -328,11 +329,14 @@ function AdminConfigForm() {
       </div>
       <div className={styles.newRow}>
         <label className={styles.field}>
-          <span>{t('Theme')}</span>
-          <select value={String(form.config_theme ?? 1)} onChange={(e) => set('config_theme', e.target.value)}>
-            <option value="0">{t('Light')}</option>
-            <option value="1">{t('Dark')}</option>
+          <span>{t('Default theme for new accounts')}</span>
+          <select value={String(form.config_theme ?? DEFAULT_THEME)}
+            onChange={(e) => set('config_theme', e.target.value)}>
+            {THEMES.map((o) => <option key={o.slug} value={o.slug}>{t(o.label)}</option>)}
           </select>
+          <p className={styles.fieldHint}>
+            {t('Applies to accounts created from now on. Everyone picks their own under Account → Theme.')}
+          </p>
         </label>
         <label className={styles.field}>
           <span>{t('Default interface language')}</span>

--- a/tests/unit/test_api_v1_admin.py
+++ b/tests/unit/test_api_v1_admin.py
@@ -393,6 +393,55 @@ def test_create_user_seeds_theme_from_config(config_theme, expected_code):
     assert created["obj"].theme == expected_code
 
 
+def _ui_config():
+    """A config double for the SPA-editable UI settings admin_update_config writes."""
+    return SimpleNamespace(
+        config_theme=ui_themes.DEFAULT_THEME_CODE,
+        config_books_per_page=20, config_random_books=4, config_authors_max=0,
+        config_calibre_web_title="t", config_default_language="all",
+        config_default_locale="en", config_server_announcement="",
+        save=lambda: None,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("slug, expected_code", [
+    ("light", 2),
+    ("sepia", 3),
+    ("system", 6),
+])
+def test_update_config_stores_a_valid_theme_slug_as_its_code(slug, expected_code):
+    from cps.api import admin as mod
+    cfg = _ui_config()
+    with _ctx("/api/v1/admin/config", body={"config_theme": slug}):
+        with patch.object(mod, "current_user", _admin()), \
+             patch.object(mod, "config", cfg), \
+             patch.object(mod, "get_available_locale", return_value=[]):
+            # The 200 path echoes the config payload, which enumerates locales
+            # through babel; this test is about what gets stored, so stub it.
+            resp = inspect.unwrap(mod.admin_update_config)()
+    assert cfg.config_theme == expected_code
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", ["hot-pink", "", "Light", 0, 2, None, True])
+def test_update_config_rejects_a_theme_that_is_not_a_known_slug(bad):
+    """#736: the raw int is the drift vector — the pre-#736 form POSTed
+    config_theme=0 and the endpoint stored it, which then read back as dark. An
+    unknown value must 400 rather than be stored and silently resolved, so ints
+    (including the legacy 0) are rejected here alongside nonsense slugs.
+    """
+    from cps.api import admin as mod
+    cfg = _ui_config()
+    before = cfg.config_theme
+    with _ctx("/api/v1/admin/config", body={"config_theme": bad}):
+        with patch.object(mod, "current_user", _admin()), \
+             patch.object(mod, "config", cfg):
+            resp = inspect.unwrap(mod.admin_update_config)()
+    assert resp[1] == 400
+    assert cfg.config_theme == before  # nothing stored
+
+
 @pytest.mark.unit
 def test_create_user_duplicate_name_surfaces_400():
     from cps.api import admin as mod

--- a/tests/unit/test_api_v1_admin.py
+++ b/tests/unit/test_api_v1_admin.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from cps import constants
+from cps import ui_themes
 
 
 def _ctx(path, method="POST", body=None):
@@ -237,8 +238,13 @@ def test_delete_user_last_admin_guard_surfaces_as_400():
 
 # ── user creation ─────────────────────────────────────────────────────────────
 
-def _create_config():
-    """A config double carrying the defaults _handle_new_user reads."""
+def _create_config(config_theme=ui_themes.DEFAULT_THEME_CODE):
+    """A config double carrying the defaults _handle_new_user reads.
+
+    ``config_theme`` mirrors the real Settings column: it is the instance default
+    theme a new account is seeded with, so it is a parameter here rather than a
+    constant — the seeding is behaviour worth pinning at more than one value.
+    """
     return SimpleNamespace(
         config_default_role=constants.ROLE_DOWNLOAD,
         config_default_locale="en",
@@ -246,6 +252,7 @@ def _create_config():
         config_default_show=0,
         config_allowed_tags="", config_denied_tags="",
         config_allowed_column_value="", config_denied_column_value="",
+        config_theme=config_theme,
     )
 
 
@@ -314,7 +321,7 @@ def test_create_user_valid_sets_roles_and_commits():
     assert obj.role & constants.ROLE_UPLOAD
     assert obj.role & constants.ROLE_DOWNLOAD
     assert not (obj.role & constants.ROLE_ADMIN)
-    assert obj.theme == 1  # dark default like legacy
+    assert obj.theme == ui_themes.DEFAULT_THEME_CODE  # seeded from config_theme
 
 
 @pytest.mark.unit
@@ -343,6 +350,47 @@ def test_create_user_defaults_role_when_unspecified():
             resp = inspect.unwrap(mod.admin_create_user)()
     assert resp[1] == 201
     assert created["obj"].role == constants.ROLE_DOWNLOAD  # the configured default
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("config_theme, expected_code", [
+    (2, 2),   # admin picked light -> the new account boots light
+    (3, 3),   # a non-legacy theme the pre-#736 form could not even express
+    (0, 2),   # the legacy "Light" the old form wrote raw; honour it as light
+    (99, ui_themes.DEFAULT_THEME_CODE),   # unknown code degrades to dark, never NULL
+])
+def test_create_user_seeds_theme_from_config(config_theme, expected_code):
+    """#736: a new account inherits the instance default theme.
+
+    The old code hardcoded ``theme = 1``, so an admin who set the default to
+    Light still got dark accounts and the setting drove nothing. Pinning this at
+    several values is what makes the test behavioural — an assertion against
+    dark alone stays green if the hardcode ever comes back.
+    """
+    from cps.api import admin as mod
+    mock_ub = MagicMock()
+    created = {}
+
+    class _U:
+        id = 7
+        email = None
+        kindle_mail = None
+
+        def __init__(self):
+            created["obj"] = self
+    mock_ub.User = _U
+
+    with _ctx("/api/v1/admin/users", body={"name": "ada", "password": "S3cret!pw"}):
+        with patch.object(mod, "current_user", _admin()), \
+             patch.object(mod, "ub", mock_ub), \
+             patch.object(mod, "config", _create_config(config_theme=config_theme)), \
+             patch.object(mod, "check_username", side_effect=lambda n: n), \
+             patch.object(mod, "valid_password", side_effect=lambda p: p), \
+             patch.object(mod, "generate_password_hash", side_effect=lambda p: p):
+            resp = inspect.unwrap(mod.admin_create_user)()
+
+    assert resp[1] == 201
+    assert created["obj"].theme == expected_code
 
 
 @pytest.mark.unit

--- a/tests/unit/test_theme_registry.py
+++ b/tests/unit/test_theme_registry.py
@@ -38,11 +38,17 @@ def test_admin_theme_picker_renders_the_shared_registry_not_its_own_numbering():
     the shared registry so it cannot invent a numbering again."""
     admin_source = (REPO_ROOT / "frontend/src/pages/Admin.tsx").read_text(encoding="utf-8")
 
-    theme_select = re.search(
-        r"config_theme.*?</select>", admin_source, re.DOTALL
+    # Anchor on the <select> element itself, not on the first "config_theme"
+    # anywhere in the file — that also appears in the form-state object, from
+    # which a `.*?</select>` run would land on whichever picker happens to come
+    # next in the JSX and assert against the wrong one.
+    theme_selects = [block for block in re.findall(r"<select[\s\S]*?</select>", admin_source)
+                     if "config_theme" in block]
+    assert len(theme_selects) == 1, (
+        "expected exactly one <select> bound to config_theme, found %d — did the "
+        "admin theme picker move or get duplicated?" % len(theme_selects)
     )
-    assert theme_select, "admin theme picker not found — did config_theme move?"
-    block = theme_select.group(0)
+    block = theme_selects[0]
 
     # It must map the shared registry, and hold no hand-written <option> values.
     assert "THEMES.map" in block

--- a/tests/unit/test_theme_registry.py
+++ b/tests/unit/test_theme_registry.py
@@ -4,16 +4,19 @@ from pathlib import Path
 from cps.ui_themes import (
     ALLOWED_THEME_SLUGS,
     DEFAULT_THEME_CODE,
+    LEGACY_STANDARD_CODE,
     THEME_CODES,
+    config_theme_code,
+    config_theme_slug,
     theme_code,
     theme_slug,
 )
 
+REPO_ROOT = Path(__file__).parents[2]
+
 
 def test_backend_theme_registry_matches_frontend():
-    frontend_source = (Path(__file__).parents[2] / "frontend/src/lib/themes.ts").read_text(
-        encoding="utf-8"
-    )
+    frontend_source = (REPO_ROOT / "frontend/src/lib/themes.ts").read_text(encoding="utf-8")
     frontend_slugs = set(re.findall(r"slug:\s*'([^']+)'", frontend_source))
 
     assert frontend_slugs == set(THEME_CODES.values()) == set(ALLOWED_THEME_SLUGS)
@@ -23,3 +26,45 @@ def test_theme_defaults_and_round_trips():
     assert theme_slug(DEFAULT_THEME_CODE) == "dark"
     for slug in ALLOWED_THEME_SLUGS:
         assert theme_slug(theme_code(slug)) == slug
+
+
+def test_admin_theme_picker_renders_the_shared_registry_not_its_own_numbering():
+    """#736: the admin form used to hardcode <option value="0">Light</option> /
+    <option value="1">Dark</option> — its own Light=0/Dark=1 numbering, which
+    matched neither THEME_CODES (1=dark, 2=light) nor the slugs the SPA stores.
+    Picking Light wrote config_theme=0, which reads back as dark, so the form
+    reported "Settings saved." and nothing changed. The picker must render from
+    the shared registry so it cannot invent a numbering again."""
+    admin_source = (REPO_ROOT / "frontend/src/pages/Admin.tsx").read_text(encoding="utf-8")
+
+    theme_select = re.search(
+        r"config_theme.*?</select>", admin_source, re.DOTALL
+    )
+    assert theme_select, "admin theme picker not found — did config_theme move?"
+    block = theme_select.group(0)
+
+    # It must map the shared registry, and hold no hand-written <option> values.
+    assert "THEMES.map" in block
+    assert not re.search(r"<option\s+value=\"\d", block), (
+        "admin theme picker hardcodes numeric option values again: %s" % block
+    )
+
+
+def test_config_theme_reads_the_legacy_light_code_as_light():
+    """A 0 in config_theme is not an unmigrated anomaly like it is in User.theme
+    — it is what the pre-#736 admin form actively stored for "Light". Reading it
+    back as dark would discard the admin's saved choice."""
+    assert config_theme_slug(LEGACY_STANDARD_CODE) == "light"
+    assert theme_slug(LEGACY_STANDARD_CODE) == "dark"  # User.theme keeps its rule
+    assert config_theme_code(LEGACY_STANDARD_CODE) == theme_code("light")
+
+
+def test_config_theme_round_trips_every_supported_theme():
+    for slug in ALLOWED_THEME_SLUGS:
+        assert config_theme_slug(theme_code(slug)) == slug
+
+
+def test_config_theme_falls_back_to_the_default_on_garbage():
+    for junk in (None, "", "nonsense", object()):
+        assert config_theme_slug(junk) == "dark"
+        assert config_theme_code(junk) == DEFAULT_THEME_CODE

--- a/tests/unit/test_theme_registry.py
+++ b/tests/unit/test_theme_registry.py
@@ -1,3 +1,4 @@
+import pytest
 import re
 from pathlib import Path
 
@@ -68,3 +69,40 @@ def test_config_theme_falls_back_to_the_default_on_garbage():
     for junk in (None, "", "nonsense", object()):
         assert config_theme_slug(junk) == "dark"
         assert config_theme_code(junk) == DEFAULT_THEME_CODE
+
+
+# Every place that seeds a new account's theme from the instance default. Adding
+# a create path without adding it here is fine; assigning config_theme raw in one
+# is not — that is the bug this pins.
+THEME_SEEDING_CREATE_PATHS = (
+    ("cps/api/admin.py", "admin_create_user — the New UI admin form"),
+    ("cps/admin.py", "_handle_new_user — the classic admin form"),
+    ("cps/web.py", "register_post — public self-registration"),
+)
+
+
+@pytest.mark.parametrize("path, description", THEME_SEEDING_CREATE_PATHS)
+def test_every_create_path_normalises_config_theme_before_storing_it(path, description):
+    """#736: config_theme and User.theme disagree on exactly one value — 0 means
+    light in config_theme but reads back as dark in User.theme. So a create path
+    that copies config_theme raw gives its users a different theme than the paths
+    that normalise, from the same admin setting.
+
+    register_post did exactly that: the two admin paths were fixed to call
+    config_theme_code() while it kept `content.theme = getattr(config,
+    'config_theme', 1)`, so with an admin-saved Light a self-registered account
+    booted dark and an admin-created one booted light.
+    """
+    source = (REPO_ROOT / path).read_text(encoding="utf-8")
+
+    raw_assignments = re.findall(
+        r"^\s*(?:content|new_user|user)\.theme\s*=\s*(.+)$", source, re.MULTILINE
+    )
+    assert raw_assignments, "no theme seeding found in %s — did it move? (%s)" % (path, description)
+
+    for expr in raw_assignments:
+        assert "config_theme_code(" in expr, (
+            "%s (%s) stores a theme without normalising through config_theme_code(): "
+            "`.theme = %s`. A raw config_theme (legacy 0 = light) becomes a User.theme "
+            "of 0, which reads back as dark." % (path, description, expr.strip())
+        )


### PR DESCRIPTION
## Symptom

@auspex (#736): picked **Admin → Theme → Light → Save**, got "Settings saved.", still dark. Logged out and back in, still dark. *"I know you young folks love dark themes, but when you get to my age, you won't be able to read that... Also, why is this an 'Admin' setting, and not a user setting?"*

@uschi1 (#351, #579) hit the same wall from the other side and spent two days hunting for a control that could never have worked.

Both reporters have stated vision reasons for wanting light. This is not a preference thread.

## Root cause

`frontend/src/pages/Admin.tsx` hardcoded its own theme numbering:

```tsx
<option value="0">{t('Light')}</option>
<option value="1">{t('Dark')}</option>
```

That matches neither `ui_themes.THEME_CODES` (`1=dark, 2=light, …`) nor the slugs the SPA actually stores. Picking Light wrote `config_theme=0`, and `ui_themes` documents `0` as *"no longer written and resolves to the dark default on read"*. So the save genuinely succeeded and the value genuinely meant dark. Hence "Settings saved." plus no change.

`config_theme` was in fact driving **nothing**, three ways over:

1. Classic force-locks the theme on every request (`cps/admin.py:128`, unconditional, deliberate — light is retired there).
2. The SPA renders from `User.theme`, not `config_theme`.
3. Both account-creation paths hardcoded `theme = 1` (`cps/api/admin.py:283`, `cps/admin.py:2793`), ignoring the config.

`tests/unit/test_theme_registry.py` existed to prevent exactly this drift, but only pinned backend ↔ `themes.ts`. `Admin.tsx` invented a third numbering behind its back.

## Fix

Rather than dress up a dead knob (or delete the control and leave admins with no default at all), give it the meaning its own help text already claimed: **the default theme for new accounts**. That also answers @auspex's "why is this an Admin setting?" — it isn't their setting; theirs is Account → Theme.

- **`config_theme` travels as a slug**, validated against `ALLOWED_THEME_SLUGS`, mirroring what `cps/api/account.py` already does. The raw int no longer crosses the wire — that's what let the form invent a numbering. Unknown value now 400s instead of storing-then-silently-falling-back.
- **The picker renders the shared registry** (`THEMES` from `lib/themes.ts`), so it offers all six themes rather than two, and cannot drift again.
- **Both account-creation paths seed from `config_theme`** instead of hardcoding 1.
- **A legacy `config_theme=0` reads as light**, honouring the choice an admin already saved instead of discarding it. `User.theme` keeps its own rule (`0` = unmigrated row → dark), so existing accounts are untouched.

## Red/green evidence

The behavioural red for the bug that actually shipped is the `Admin.tsx` pin. Run against pre-fix `main` vs this branch:

```
PRE-FIX main     found=True THEMES.map=False hardcoded_numeric=True -> TEST FAIL
     offending: ['<option value="0">{t(\'Light\')}</option>', '<option value="1">{t(\'Dark\')}</option>']
POST-FIX branch  found=True THEMES.map=True  hardcoded_numeric=False -> TEST PASS
```

The `ui_themes` tests are red on `main` only as `ImportError` (they cover new API), so I'm not claiming them as behavioural red. On this branch: `6 passed`. `npx tsc --noEmit` clean.

## Verification (completed by the 18:00Z tick)

The tick that opened this left merge gate (b) unmet — no container evidence. That gap is now closed, and closing it turned up two real defects the unit tests had not caught.

**Fast Tests were red.** `admin_create_user` now reads `config.config_theme`, but the api/v1 admin test's config double predated that read, so it raised `AttributeError` on every create test. Blast radius from changing both create paths without updating the fixtures. Fixed, and the stale `assert obj.theme == 1  # dark default like legacy` — which would have stayed green even if the hardcode returned — is replaced by a parametrized pin (light / sepia / legacy-0 / unknown). Restoring `theme = 1` fails 3 of 4.

**A third create path was still drifting.** `register_post` (public self-registration) seeded `content.theme = getattr(config, 'config_theme', 1)` — the raw value. Since a `config_theme` of 0 means light but a `User.theme` of 0 reads back as dark, an admin-saved Light gave self-registered users dark and admin-created users light, from the same setting. That is exactly the drift this PR set out to remove. Now normalised, with all three create paths pinned.

**Live wire contract** — real endpoints on `cwn-local`, session-cookied, not mocks:

| Probe | Result |
|---|---|
| `GET /api/v1/admin/config` | `config_theme = 'dark'` — slug, not int |
| `POST {"config_theme":"light"}` | `200`, DB `config_theme=2`, reads back `'light'` |
| `POST {"config_theme":"hot-pink"}` | `400 invalid_request` "Invalid theme option", DB unchanged |
| `POST {"config_theme":0}` | `400` — the exact payload the pre-#736 form wrote is now rejected |
| `POST /api/v1/admin/users` (default=light) | new row `theme=2`; that account's `/auth/me` serves `theme='light'` |

The last row is the #736 promise end-to-end: an admin picks Light, a new account boots light. Container logs clean; app boots with no circular import from the new `ui_themes` import in `web.py`; probe user and `config_theme` restored afterward.

**Migration question from the original body, now answered:** `config_sql.py:82` is `config_theme = Column(Integer, default=1)`, so 0 is never the schema default — it can only be present if an admin actively chose Light on the old form. Reading it as light honours a real click rather than guessing at a pre-migration value. Teenyverse (a real install) carries `config_theme=1`.

**Not covered:** the classic Jinja create path (`_handle_new_user`) is unit-tested and verified in container Python, but I drove the SPA/API path only. Same helper, low risk — stated rather than implied.

Addresses #736. Related: #351, #579.