### PR TITLE
fix: close release localization and hot-list gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,15 @@ is for things you can see or feel when running the app.
 
 ### Added
 
-- **You can now hide books from your personal library in the new interface without deleting them or affecting anyone else.** Hide/Unhide lives beside Delete on book details, and View settings can reveal clearly marked hidden books whenever you want one back.
+- **You can now hide books from your personal library in the new interface without deleting them or affecting anyone else.** Hide/Unhide lives beside Delete on book details, and View settings can reveal clearly marked hidden books whenever you want one back. The feature is on by default for new installations; upgrades preserve the admin's existing **Allow users to hide books** switch, which is the kill switch to check if Hide is absent.
 
 ### Fixed
+
+- Translated entity pages now say “Show all authors/tags/…” in the signed-in
+  user's language instead of leaking the English route segment, and locale-
+  sensitive search labels now lowercase using the app language rather than the
+  browser's language. Most-downloaded lists also remain usable for libraries
+  large enough to exceed SQLite's single-query parameter limit.
 
 - Brazilian Portuguese users now see more of the New UI in Portuguese,
   including book actions, upload feedback, favorites, and hide/archive status;

--- a/cps/api/books.py
+++ b/cps/api/books.py
@@ -17,6 +17,26 @@ from ..usermanagement import login_required_if_no_ano
 
 log = logger.create()
 
+# SQLite builds vary in their host-parameter ceiling. Stay below even the
+# conservative historical limit when filtering app.db-derived download ids
+# against the separate calibre metadata database.
+_SQLITE_IN_CHUNK = 900
+
+
+def _visible_ids_for_chunk(book_ids):
+    query = calibre_db.generate_linked_query(config.config_read_column, db.Books)
+    return {row[0] for row in query.filter(calibre_db.common_filters())
+            .filter(db.Books.id.in_(book_ids))
+            .with_entities(db.Books.id).all()}
+
+
+def _visible_hot_book_ids(book_ids):
+    """Return visible ids in hotness order without an unbounded SQL ``IN``."""
+    visible = set()
+    for start in range(0, len(book_ids), _SQLITE_IN_CHUNK):
+        visible.update(_visible_ids_for_chunk(book_ids[start:start + _SQLITE_IN_CHUNK]))
+    return [book_id for book_id in book_ids if book_id in visible]
+
 
 def _detail_custom_columns():
     """Classic-parity display definitions, degrading safely if DB metadata is unavailable."""
@@ -286,13 +306,7 @@ def list_books():
                    .order_by(func.count(ub.Downloads.book_id).desc()))]
         # Filter before paginating: otherwise a hidden/restricted book leaves a
         # short page while the header still counts it.
-        visible = set()
-        if all_hot_ids:
-            q = calibre_db.generate_linked_query(config.config_read_column, db.Books)
-            visible = {row[0] for row in q.filter(calibre_db.common_filters())
-                       .filter(db.Books.id.in_(all_hot_ids))
-                       .with_entities(db.Books.id).all()}
-        visible_hot_ids = [book_id for book_id in all_hot_ids if book_id in visible]
+        visible_hot_ids = _visible_hot_book_ids(all_hot_ids)
         total = len(visible_hot_ids)
         hot_ids = visible_hot_ids[off:off + per_page]
         entries = []

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -200,7 +200,7 @@
     <div class="form-group">
       <input type="checkbox" id="config_user_hide_enabled" name="config_user_hide_enabled" {% if config.config_user_hide_enabled %}checked{% endif %}>
       <label for="config_user_hide_enabled">{{_('Allow users to hide books from their personal library')}}</label>
-      <p class="help-block">{{_('Off by default. When enabled, each user gets a hide button on the book detail page that drops the book out of their own index/search/OPDS without affecting other users. Recovery is via the profile page (Hidden Books link).')}}</p>
+      <p class="help-block">{{_('On by default for new installations; an existing saved choice is preserved during upgrades. When enabled, each user gets a hide button on the book detail page that drops the book out of their own index/search/OPDS without affecting other users. Recovery is via the profile page (Hidden Books link).')}}</p>
     </div>
     {% if feature_support['kobo'] %}
     <div class="form-group">

--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -81,7 +81,11 @@ test('edit book: no critical/serious a11y violations', async ({ page }) => {
 
 test('smart shelf builder: no critical/serious a11y violations', async ({ page }) => {
   await page.goto('/app/magic');
-  await expect(page.getByRole('heading', { name: 'New smart shelf' })).toBeVisible();
+  // The signed-in test user may use any supported locale. Identify the route by
+  // structure rather than an English accessible name, and pin its one-landmark
+  // invariant so a nested page-level <main> cannot return.
+  await expect(page.locator('main#main h1')).toBeVisible();
+  await expect(page.locator('main')).toHaveCount(1);
   await axeScan(page, 'smart-shelf-builder');
 });
 

--- a/frontend/e2e/magic-shelf-rule-schema.spec.ts
+++ b/frontend/e2e/magic-shelf-rule-schema.spec.ts
@@ -9,8 +9,8 @@ type RuleSchema = {
 
 const DATE_FIELDS = ['pubdate', 'timestamp'];
 
-async function selectOptions(page: import('@playwright/test').Page, label: string) {
-  return page.getByLabel(label).locator('option').evaluateAll((options) =>
+async function selectOptions(select: import('@playwright/test').Locator) {
+  return select.locator('option').evaluateAll((options) =>
     options.map((option) => ({ value: (option as HTMLOptionElement).value, text: option.textContent?.trim() || '' })),
   );
 }
@@ -20,7 +20,7 @@ test('Classic and New UI consume the canonical rule schema and date rules previe
   const schemaResponse = await request.get('/api/v1/magicshelves/rule-schema');
   expect(schemaResponse.status()).toBe(200);
   const schema = await schemaResponse.json() as RuleSchema;
-  const expectedFields = schema.fields.map(({ id, label }) => ({ value: id, text: label }));
+  const expectedFieldIds = schema.fields.map(({ id }) => id);
 
   for (const fieldId of DATE_FIELDS) {
     const field = schema.fields.find((item) => item.id === fieldId);
@@ -33,13 +33,15 @@ test('Classic and New UI consume the canonical rule schema and date rules previe
   const classicFields = (await classicFilter.locator('option').evaluateAll((options) =>
     options.map((option) => ({ value: (option as HTMLOptionElement).value, text: option.textContent?.trim() || '' })),
   )).filter((option) => option.value !== '-1');
-  expect(classicFields).toEqual(expectedFields);
+  expect(classicFields.map(({ value }) => value)).toEqual(expectedFieldIds);
+  expect(classicFields.every(({ text }) => text.length > 0)).toBe(true);
 
   for (const fieldId of DATE_FIELDS) {
     await classicFilter.selectOption(fieldId);
     const classicOperator = page.locator('#builder .rule-operator-container select').first();
-    await expect(classicOperator).toContainText('In the past N days');
-    await expect(classicOperator).toContainText('Not in the past N days');
+    const classicOperatorValues = (await selectOptions(classicOperator)).map(({ value }) => value);
+    expect(classicOperatorValues).toContain('in_last_days');
+    expect(classicOperatorValues).toContain('not_in_last_days');
     await classicOperator.selectOption('in_last_days');
     await page.locator('#builder .rule-value-container input').first().fill('30');
     const previewResponse = page.waitForResponse((response) =>
@@ -54,16 +56,20 @@ test('Classic and New UI consume the canonical rule schema and date rules previe
   }
 
   await page.goto('/app/magic');
-  await expect(page.getByRole('heading', { name: 'New smart shelf' })).toBeVisible();
-  expect(await selectOptions(page, 'Rule field')).toEqual(expectedFields);
+  await expect(page.locator('main#main h1')).toBeVisible();
+  const spaField = page.locator('main#main select:has(option[value="pubdate"])').first();
+  const spaOperator = page.locator('main#main select:has(option[value="in_last_days"])').first();
+  const spaFields = await selectOptions(spaField);
+  expect(spaFields.map(({ value }) => value)).toEqual(expectedFieldIds);
+  expect(spaFields.every(({ text }) => text.length > 0)).toBe(true);
 
   for (const fieldId of DATE_FIELDS) {
-    await page.getByLabel('Rule field').selectOption(fieldId);
-    await page.getByLabel('Rule operator').selectOption('in_last_days');
+    await spaField.selectOption(fieldId);
+    await spaOperator.selectOption('in_last_days');
     const previewResponse = page.waitForResponse((response) =>
       response.url().includes('/magicshelf/preview') && response.request().method() === 'POST',
     );
-    await page.getByPlaceholder('value').fill('30');
+    await page.locator('main#main input[type="number"]').first().fill('30');
     const response = await previewResponse;
     expect(response.status()).toBe(200);
     const payload = await response.json() as { success: boolean; count: number };

--- a/frontend/src/pages/BrowseList.tsx
+++ b/frontend/src/pages/BrowseList.tsx
@@ -4,7 +4,7 @@ import { LayoutGrid, List, Search } from 'lucide-react';
 import { useEntityList } from '../lib/queries';
 import { SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
-import { useT } from '../lib/i18n';
+import { useI18n } from '../lib/i18n';
 import { usePersistentBool } from '../lib/usePersistentBool';
 import styles from './BrowseList.module.css';
 
@@ -16,10 +16,18 @@ interface BrowseListProps {
 }
 
 export function BrowseList({ plural, title }: BrowseListProps) {
-  const t = useT();
+  const { t, locale } = useI18n();
   const { data, isLoading, error } = useEntityList(plural);
   const [q, setQ] = useState('');
   const [compact, setCompact] = usePersistentBool('cwng:browse-list-compact', false);
+  const translatedItems = useMemo(() => {
+    const translated = t(title);
+    try {
+      return translated.toLocaleLowerCase((locale || 'en').replace('_', '-'));
+    } catch {
+      return translated.toLocaleLowerCase();
+    }
+  }, [locale, t, title]);
 
   const items = useMemo(() => {
     const all = data?.items ?? [];
@@ -51,10 +59,10 @@ export function BrowseList({ plural, title }: BrowseListProps) {
           <input
             type="search"
             className={styles.searchInput}
-            placeholder={t('Filter {items}…', { items: t(title).toLocaleLowerCase() })}
+            placeholder={t('Filter {items}…', { items: translatedItems })}
             value={q}
             onChange={(e) => setQ(e.target.value)}
-            aria-label={t('Filter {items}', { items: t(title).toLocaleLowerCase() })}
+            aria-label={t('Filter {items}', { items: translatedItems })}
           />
         </div>
       )}
@@ -65,8 +73,8 @@ export function BrowseList({ plural, title }: BrowseListProps) {
         <EmptyState message={error instanceof Error ? error.message : t('Failed to load.')} />
       ) : items.length === 0 ? (
         <EmptyState message={q
-          ? t('No matching {items} for "{query}".', { items: t(title).toLocaleLowerCase(), query: q })
-          : t('No {items} yet.', { items: t(title).toLocaleLowerCase() })} />
+          ? t('No matching {items} for "{query}".', { items: translatedItems, query: q })
+          : t('No {items} yet.', { items: translatedItems })} />
       ) : (
         <ul className={compact ? styles.list : styles.grid} role="list">
           {items.map((e) => (

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -63,6 +63,18 @@ const KIND_OPTIONS: Record<EntityKind, { label: string }> = {
   format: { label: 'Format' },
 };
 
+// Human-facing plural labels are deliberately separate from ENTITY_PLURAL:
+// route segments such as "authors" are identifiers, not gettext msgids.
+const KIND_PLURAL_OPTIONS: Record<EntityKind, { label: string }> = {
+  author: { label: 'Authors' },
+  series: { label: 'Series' },
+  tag: { label: 'Tags' },
+  publisher: { label: 'Publishers' },
+  language: { label: 'Languages' },
+  rating: { label: 'Ratings' },
+  format: { label: 'Formats' },
+};
+
 const DENSITY_OPTIONS = [
   { value: 'comfortable', label: 'Comfortable' },
   { value: 'compact', label: 'Compact' },
@@ -460,7 +472,7 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
       {filtered && (
         <Link href={`/${ENTITY_PLURAL[entityKind!]}`} className={styles.back}>
           <ChevronLeft size={16} />
-          {t('Show all {items}', { items: t(ENTITY_PLURAL[entityKind!]) })}
+          {t('Show all {items}', { items: t(KIND_PLURAL_OPTIONS[entityKind!].label) })}
         </Link>
       )}
 

--- a/frontend/src/pages/MagicShelf.tsx
+++ b/frontend/src/pages/MagicShelf.tsx
@@ -156,14 +156,14 @@ export function MagicShelf({ editId }: { editId?: string }) {
   const saving = create.isPending || edit.isPending;
 
   if (schemaQuery.isLoading) {
-    return <main className={styles.container}><h1 className={styles.title}>{t('Loading…')}</h1></main>;
+    return <div className={styles.container}><h1 className={styles.title}>{t('Loading…')}</h1></div>;
   }
   if (schemaQuery.isError || fields.length === 0) {
-    return <main className={styles.container}><p role="alert">{t('Could not load smart-shelf rules.')}</p></main>;
+    return <div className={styles.container}><p role="alert">{t('Could not load smart-shelf rules.')}</p></div>;
   }
 
   return (
-    <main className={styles.container}>
+    <div className={styles.container}>
       <div className={styles.header}>
         <Wand2 size={22} className={styles.headerIcon} aria-hidden="true" focusable={false} />
         <h1 className={styles.title}>{editId ? t('Edit smart shelf') : t('New smart shelf')}</h1>
@@ -244,6 +244,6 @@ export function MagicShelf({ editId }: { editId?: string }) {
         </Button>
         <Button variant="ghost" onClick={onCancel} disabled={saving}>{t('Cancel')}</Button>
       </div>
-    </main>
+    </div>
   );
 }

--- a/tests/unit/test_api_v1_books.py
+++ b/tests/unit/test_api_v1_books.py
@@ -354,3 +354,25 @@ def test_list_books_handles_discovery_filters():
     src = _inspect.getsource(books_mod.list_books)
     for value in ('favorites', 'rated', 'discover', 'hot'):
         assert 'filter_val == "%s"' % value in src, "discovery filter %r missing" % value
+
+
+@pytest.mark.unit
+def test_hot_visibility_filter_chunks_large_libraries_without_losing_order(monkeypatch):
+    """The app and calibre catalogs use separate SQLite sessions, so hot-book
+    ids must cross the boundary in bounded batches rather than one huge IN().
+    """
+    from cps.api import books as books_mod
+
+    ids = list(range(2005))
+    chunks = []
+
+    def visible_even_ids(chunk):
+        chunks.append(list(chunk))
+        return {book_id for book_id in chunk if book_id % 2 == 0}
+
+    monkeypatch.setattr(books_mod, "_visible_ids_for_chunk", visible_even_ids)
+    result = books_mod._visible_hot_book_ids(ids)
+
+    assert [len(chunk) for chunk in chunks] == [900, 900, 205]
+    assert all(len(chunk) <= books_mod._SQLITE_IN_CHUNK for chunk in chunks)
+    assert result == [book_id for book_id in ids if book_id % 2 == 0]

--- a/tests/unit/test_spa_strings_anchored.py
+++ b/tests/unit/test_spa_strings_anchored.py
@@ -177,6 +177,29 @@ def test_magic_shelf_operator_labels_are_translated_at_render_time():
     assert "{o.label}" not in source
 
 
+def test_catalog_back_link_translates_labels_not_route_segments():
+    """Route identifiers (`authors`) are not gettext msgids; the visible back
+    link must use static plural labels (`Authors`) that the extractor can see.
+    """
+    path = os.path.join(extractor.FRONTEND_SRC, "pages", "Catalog.tsx")
+    with open(path, encoding="utf-8") as source_file:
+        source = source_file.read()
+    assert "items: t(ENTITY_PLURAL[entityKind!])" not in source
+    assert "items: t(KIND_PLURAL_OPTIONS[entityKind!].label)" in source
+    keys = extractor.extract_frontend_keys()
+    for label in ("Authors", "Series", "Tags", "Publishers", "Languages", "Ratings", "Formats"):
+        assert label in keys
+
+
+def test_browse_list_lowercases_with_the_app_locale():
+    path = os.path.join(extractor.FRONTEND_SRC, "pages", "BrowseList.tsx")
+    with open(path, encoding="utf-8") as source_file:
+        source = source_file.read()
+    assert "const { t, locale } = useI18n()" in source
+    assert "toLocaleLowerCase((locale || 'en').replace('_', '-'))" in source
+    assert "t(title).toLocaleLowerCase()" not in source
+
+
 def test_locale_change_invalidates_translated_magic_shelf_names():
     queries = os.path.join(extractor.FRONTEND_SRC, "lib", "queries.ts")
     with open(queries, encoding="utf-8") as source_file:


### PR DESCRIPTION
## What users get

- Entity detail pages translate “Show all authors/tags/…” instead of exposing English route identifiers.
- Browse-list case folding follows the signed-in app locale.
- Very large Most Downloaded lists no longer exceed SQLite’s host-parameter ceiling while filtering hidden/restricted books.
- Hide-books admin help and release wording accurately explain new-install defaults, preserved upgrade choices, and the admin kill switch.
- The smart-shelf builder no longer nests a second main landmark, and its release gates work under localized accounts.

## Why this is in the train

A pre-release second opinion exposed these concrete gaps after #926/#927/#911 merged. Each was independently traced on current main and fixed before tagging rather than deferred.

## Gate evidence

- Red/current-main: Catalog passed `ENTITY_PLURAL` route ids to `t()`, BrowseList used browser-locale `toLocaleLowerCase()`, and no bounded hot-id helper existed.
- Focused unit/i18n suite: 96/96 passed.
- Production frontend build: 1,879 modules, green.
- SPA fuzzy gate: zero anchored fuzzy msgids.
- Live desktop+mobile a11y gate: 22 passed, 9 intentional route/environment skips, zero critical/serious violations.
- Live Classic/New UI canonical rule-schema and both date-preview flows: 2/2 passed under a non-English account.
- Hot-list regression feeds 2,005 ids and observes bounded `[900, 900, 205]` batches with original hotness order preserved.
- `git diff --check`: clean.
- No new dependency, license, external service, auth/session/CSRF, crypto/secrets, subprocess/shell, user-controlled path, or route change; `/security-review` is not triggered.