### PR TITLE
Remove redundant chown operations (#874)

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -221,8 +221,8 @@ fi
 #  Set required permissions
 #------------------------------------------------------------------------------------------------------------------------
 
-# In addition to /config and /app/calibre-web-automated, parse required dirs from dirs.json
-declare -a requiredDirs=("/config" "/app/calibre-web-automated" "/calibre-library")
+# Parse required dirs from dirs.json
+declare -a requiredDirs=()
 if [ -f /app/calibre-web-automated/dirs.json ]; then
   while IFS= read -r dir; do
     [ -n "$dir" ] && requiredDirs+=("$dir")


### PR DESCRIPTION
In the "Set required permissions" section, the `run` script attempts to `chown` three directories unnecessarily:

- `/config` is already `chown`ed earlier (L58-L66).
- `/app/calibre-web-automated` does not need to be `chown`ed; only `cps/cache` does, and that is also handled earlier (_ibid_.).
- `/calibre-library` is already covered by `dirs.json` and will therefore be `chown`ed automatically.

As a result, the list of directories requiring an explicit `chown` becomes empty.

Fixes #874.