### PR TITLE
Keep the library page when a default view is saved (#928)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **Setting a default library view turned your library into the search page.** After saving
+  a default view, the library home showed the "Advanced search" form pinned above the books,
+  the page was retitled "Advanced search", and the library heading, its actions and the
+  Discover strip disappeared. Your library now stays your library — it simply shows the
+  books your default view selects, with a note saying so and a "Show all books" link to see
+  everything again. Reported by @chloeroform.
+
 - **Automatic duplicate resolution never ran if you set a cooldown.** Turning on the
   cooldown ("wait N minutes between automatic resolutions") stopped automatic duplicate
   resolution from running at all, and the log reported a wait of about four hours

--- a/cps/spa_strings.py
+++ b/cps/spa_strings.py
@@ -200,6 +200,11 @@ _('Description contains')
 _('Deselect {title}')
 _('Edit metadata')
 _('Edit {title}')
+# #928 — the saved default library view (#498) renders as a filtered library,
+# so the notice strip that explains the subset lives on Catalog.tsx.
+_('Showing your default library view.')
+_('Show all books')
+_('Edit default view')
 _('Failed to load books.')
 _('Failed to open the book.')
 _('Generate')

--- a/frontend/e2e/default-library-view.spec.ts
+++ b/frontend/e2e/default-library-view.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect, Page } from '@playwright/test';
+import { collectPageErrors, assertNoPageErrors } from './utils';
+
+/*
+ * #928 — a saved default library view must still render THE LIBRARY.
+ *
+ * #891 shipped #498 by swapping the whole page component: `/` rendered
+ * <AdvancedSearch> instead of <Catalog> whenever a default filter existed, so
+ * setting one turned the library home into the search page — search form on top,
+ * "Advanced search" title, no library heading/actions, no Discover strip.
+ *
+ * The filter is a VIEW OF THE LIBRARY, not a different page. These specs pin the
+ * library chrome AND that the filter is genuinely applied, so a future refactor
+ * can't satisfy one by dropping the other.
+ *
+ * Locale independence is deliberate: the harness seed's admin has locale=ru, and
+ * an assertion on English copy passes only on the brief pre-i18n render. Each
+ * spec compares the filtered page against the SAME page unfiltered, or matches
+ * digits — never a translated string.
+ */
+
+test.describe.configure({ mode: 'serial' });
+
+/*
+ * Runs in the desktop project only — see the `testIgnore` note in
+ * playwright.config.ts. The default view is ACCOUNT state and every project
+ * shares one seed login, so running this concurrently in two projects has each
+ * one's writes (and the afterEach reset) clobber the other's.
+ */
+
+/** Persist a default library filter the way the Advanced-search page does. */
+async function setDefaultFilter(page: Page, value: unknown) {
+  const status = await page.evaluate(async (filter) => {
+    const csrf = await (await fetch('/api/v1/auth/csrf', { credentials: 'same-origin' })).json();
+    const response = await fetch('/ajax/view', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf.csrf_token },
+      body: JSON.stringify({ catalog: { default_filter: filter } }),
+    });
+    return response.status;
+  }, value);
+  expect(status).toBe(200);
+}
+
+/** The count strip renders localized ("35 books" / "Книг: 35"); the number is the assertion. */
+async function shownCount(page: Page): Promise<number> {
+  const text = await page.getByTestId('catalog-count').textContent();
+  const digits = (text ?? '').match(/\d+/);
+  expect(digits, `no count in "${text}"`).not.toBeNull();
+  return Number(digits![0]);
+}
+
+/** Distinct books rendered in the library grid. Counting `a[href*="/book/"]`
+ *  would be wrong twice over: each card carries two links (cover + title), and
+ *  the Discover strip contributes its own picks. */
+async function gridBookCount(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const root = document.querySelector('[data-testid=catalog-page]');
+    if (!root) return -1;
+    const ids = new Set<string>();
+    for (const link of root.querySelectorAll('a[href*="/book/"]')) {
+      if (link.closest('[data-testid=discover-section]')) continue;
+      const id = link.getAttribute('href')?.match(/\/book\/(\d+)/)?.[1];
+      if (id) ids.add(id);
+    }
+    return ids.size;
+  });
+}
+
+async function libraryTotal(page: Page): Promise<number> {
+  return page.evaluate(async () => {
+    const response = await fetch('/api/v1/books?per_page=1', { credentials: 'same-origin' });
+    return (await response.json()).total as number;
+  });
+}
+
+/** Live ground truth for "how many books does this tag select right now". */
+async function advancedTotal(page: Page, tagId: number): Promise<number> {
+  return page.evaluate(async (id) => {
+    const csrf = await (await fetch('/api/v1/auth/csrf', { credentials: 'same-origin' })).json();
+    const response = await fetch('/api/v1/search/advanced', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf.csrf_token },
+      body: JSON.stringify({ include_tag: [id], per_page: 1 }),
+    });
+    return (await response.json()).total as number;
+  }, tagId);
+}
+
+/** A tag that selects a real, PROPER subset of the library — so "the filter was
+ *  applied" and "the filter was ignored" can't produce the same count. */
+async function subsetTag(page: Page): Promise<{ id: number; total: number } | null> {
+  return page.evaluate(async () => {
+    const csrf = await (await fetch('/api/v1/auth/csrf', { credentials: 'same-origin' })).json();
+    const library = await fetch('/api/v1/books?per_page=1', { credentials: 'same-origin' });
+    const libraryTotal = (await library.json()).total as number;
+
+    const tags = await fetch('/api/v1/tags?per_page=25', { credentials: 'same-origin' });
+    if (!tags.ok) return null;
+    for (const tag of (await tags.json()).items ?? []) {
+      const response = await fetch('/api/v1/search/advanced', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf.csrf_token },
+        body: JSON.stringify({ include_tag: [tag.id], per_page: 1 }),
+      });
+      if (!response.ok) continue;
+      const total = (await response.json()).total as number;
+      if (total > 0 && total < libraryTotal) return { id: tag.id, total };
+    }
+    return null;
+  });
+}
+
+test.afterEach(async ({ page }) => {
+  // Never leave a default filter behind — it would silently reshape every other spec.
+  await page.goto('/app');
+  await setDefaultFilter(page, null);
+});
+
+test('a saved default view keeps the library page (not the search page)', async ({ page }) => {
+  await page.goto('/app');
+  const errors = collectPageErrors(page);
+  await setDefaultFilter(page, null);
+  await page.reload();
+
+  // Control: the library as it looks with no default view. Captured rather than
+  // hardcoded so this holds in any UI language.
+  await expect(page.getByTestId('catalog-page')).toBeVisible();
+  const libraryHeading = await page.locator('h1').textContent();
+  const libraryTitle = await page.title();
+  expect(libraryHeading?.trim()).toBeTruthy();
+
+  await setDefaultFilter(page, { read_status: 'unread' });
+  await page.goto('/app');
+
+  // Still the library: same page component, same heading, same document title.
+  await expect(page.getByTestId('catalog-page')).toBeVisible();
+  await expect(page.locator('h1')).toHaveText(libraryHeading!.trim());
+  await expect(page).toHaveTitle(libraryTitle);
+
+  // Not the search page: its form must not be pinned to the library home.
+  await expect(page.getByTestId('advanced-search-form')).toHaveCount(0);
+
+  // Library actions + the Discover strip are the rest of symptom 2.
+  await expect(page.getByTestId('catalog-view-settings')).toBeVisible();
+  await expect(page.getByTestId('discover-section')).toBeVisible();
+
+  assertNoPageErrors(errors);
+});
+
+test('the saved filter is actually applied to the library listing', async ({ page }) => {
+  await page.goto('/app');
+  const tag = await subsetTag(page);
+  // A skip here would be a silent coverage hole, not a pass: the seed is the
+  // project's own fixture and it HAS multi-book tags. Fail loudly instead.
+  expect(tag, 'seed exposes no tag selecting a proper subset').not.toBeNull();
+
+  await setDefaultFilter(page, { include_tag: [tag!.id] });
+  await page.goto('/app');
+
+  // The count reflects the FILTERED set, not the whole library — and the cards
+  // agree with the count, so "applied" can't be faked by the header alone.
+  // Re-read the expected total at assert time and poll: sibling specs share this
+  // login and mutate the library (hidden-books hides a book), so a total captured
+  // earlier can go stale mid-test. Polling against live ground truth keeps this
+  // a real assertion instead of a race.
+  await expect(page.getByTestId('catalog-count')).toBeVisible();
+  await expect.poll(async () => {
+    const expected = await advancedTotal(page, tag!.id);
+    return await shownCount(page) === expected && await gridBookCount(page) === expected;
+  }, { message: 'library count/cards never matched the filtered total' }).toBe(true);
+});
+
+test('a default view offers a way back to the whole library', async ({ page }) => {
+  await page.goto('/app');
+  const errors = collectPageErrors(page);
+  const total = await libraryTotal(page);
+  // A proven proper subset, so "Show all" demonstrably changes the listing —
+  // a seed where every book is unread would make that assertion vacuous.
+  const tag = await subsetTag(page);
+  expect(tag, 'seed exposes no tag selecting a proper subset').not.toBeNull();
+  await setDefaultFilter(page, { include_tag: [tag!.id] });
+  await page.goto('/app');
+
+  // A filter that silently hides books with no escape is a trap: the user must be
+  // told the view is filtered and be able to see everything.
+  await expect(page.getByTestId('default-filter-notice')).toBeVisible();
+  const showAll = page.getByTestId('default-filter-show-all');
+  await expect(showAll).toBeVisible();
+
+  const filteredCount = await shownCount(page);
+  expect(filteredCount).toBeLessThan(total);
+
+  await showAll.click();
+
+  // Assert RELATIVELY (more books than the filter showed) rather than against a
+  // total captured earlier: sibling specs share this login and can hide a book
+  // mid-test, which would move an absolute target and fail a working feature.
+  await expect(page.getByTestId('default-filter-show-all')).toHaveCount(0);
+  await expect(page.getByTestId('default-filter-notice')).toHaveCount(0);
+  await expect.poll(() => shownCount(page),
+    { message: 'Show all did not widen the listing beyond the filtered set' })
+    .toBeGreaterThan(filteredCount);
+
+  assertNoPageErrors(errors);
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -62,7 +62,12 @@ export default defineConfig({
         storageState: STORAGE,
       },
       dependencies: ['setup'],
-      testIgnore: /subpath\.spec\.ts/,
+      // default-library-view mutates ACCOUNT state (the saved default view) and
+      // every project shares one seed login, so running it here in parallel with
+      // desktop makes each project clobber the other's writes — a race, not a
+      // defect. Desktop owns it until the harness can hand each project its own
+      // account; it passes standalone at 375px.
+      testIgnore: [/subpath\.spec\.ts/, /default-library-view\.spec\.ts/],
     },
 
     // 4. Sub-path reverse proxy (opt-in: set E2E_SUBPATH_URL to the nginx rig).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,8 +44,11 @@ const NativeReader = lazy(() => import('./pages/NativeReader').then((m) => ({ de
 // links resolve to <prefix>/app/… rather than a prefix-less /app/….
 const ROUTER_BASE = BASE_PREFIX + '/app';
 
+// A saved default view (#498) FILTERS the library; it does not replace it with
+// the search page. Swapping the component here cost the library heading, actions
+// and Discover strip and retitled the home page "Advanced search" (#928).
 function Library({ defaultFilter }: { defaultFilter?: AdvancedSearchParams }) {
-  return defaultFilter ? <AdvancedSearch defaultFilter={defaultFilter} /> : <Catalog />;
+  return <Catalog defaultFilter={defaultFilter} />;
 }
 
 function AuthenticatedAuthLanding() {

--- a/frontend/src/components/DiscoverSection.tsx
+++ b/frontend/src/components/DiscoverSection.tsx
@@ -35,7 +35,7 @@ export function DiscoverSection({ onClose }: { onClose: () => void }) {
   if (!isLoading && books.length === 0) return null;
 
   return (
-    <section className={styles.box} aria-label={t('Discover')}>
+    <section className={styles.box} aria-label={t('Discover')} data-testid="discover-section">
       <div className={styles.head}>
         <div className={styles.titleWrap}>
           <span className={styles.sparkle}><Sparkles size={18} aria-hidden="true" focusable={false} /></span>

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -42,6 +42,10 @@ export interface BooksQuery {
   view?: DiscoveryView;
   /** SPA-only escape hatch: include this user's hidden books in Your Library. */
   showHidden?: boolean;
+  /** Off while a saved default view drives the library from the advanced-search
+   *  endpoint instead (#928) — the hook must still be called (hook order), but
+   *  firing it would spend a request whose result is discarded. */
+  enabled?: boolean;
 }
 
 export function useMe() {
@@ -169,7 +173,7 @@ export function useLogout() {
 export function useBooks(q: BooksQuery) {
   const {
     page, perPage = 24, search = '', sort = 'new', readFilter = 'all',
-    entityKind, entityId, view, showHidden = false,
+    entityKind, entityId, view, showHidden = false, enabled = true,
   } = q;
   const params = new URLSearchParams();
   params.set('page', String(page));
@@ -192,6 +196,7 @@ export function useBooks(q: BooksQuery) {
       entityKind ?? '', entityId ?? '', view ?? '', showHidden],
     queryFn: () => apiGet<BooksPage>(`/api/v1/books?${params.toString()}`),
     placeholderData: (prev) => prev,
+    enabled,
   });
 }
 
@@ -881,10 +886,13 @@ export function useSearchOptions() {
 
 /** Run advanced search. `params` is null until the user submits, which keeps the
  *  query disabled (and the results pane empty) on first load. */
-export function useAdvancedSearch(params: AdvancedSearchParams | null, page: number) {
+/** Advanced search. `perPage` defaults to the search page's own page size; the
+ *  library passes its measured grid size when a saved default view drives it
+ *  (#928), so filtered rows fill the grid exactly like unfiltered ones. */
+export function useAdvancedSearch(params: AdvancedSearchParams | null, page: number, perPage = 24) {
   return useQuery<AdvSearchResult>({
-    queryKey: ['adv-search', params, page],
-    queryFn: () => apiPost<AdvSearchResult>('/api/v1/search/advanced', { ...params, page, per_page: 24 }),
+    queryKey: ['adv-search', params, page, perPage],
+    queryFn: () => apiPost<AdvSearchResult>('/api/v1/search/advanced', { ...params, page, per_page: perPage }),
     enabled: params !== null,
     placeholderData: (prev) => prev,
   });

--- a/frontend/src/pages/AdvancedSearch.tsx
+++ b/frontend/src/pages/AdvancedSearch.tsx
@@ -125,7 +125,7 @@ export function AdvancedSearch({ defaultFilter }: { defaultFilter?: AdvancedSear
     <main className={styles.container}>
       <h1 className={styles.title}>{t('Advanced search')}</h1>
 
-      <form className={styles.form} onSubmit={onSubmit}>
+      <form className={styles.form} onSubmit={onSubmit} data-testid="advanced-search-form">
         <div className={styles.grid}>
           <Field label={t('Title')}>
             <input className={styles.input} value={form.title} aria-label={t('Title')}

--- a/frontend/src/pages/Catalog.module.css
+++ b/frontend/src/pages/Catalog.module.css
@@ -29,6 +29,36 @@
   color: var(--accent);
 }
 
+/* Saved default library view (#928): a quiet strip above the library heading —
+   it explains the subset without competing with the page title. Wraps rather
+   than overflowing at 375px, where the label + both actions don't fit a row. */
+.defaultFilterNotice {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--sp-1) var(--sp-2);
+  margin-bottom: var(--sp-3);
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+}
+
+.defaultFilterShowAll,
+.defaultFilterEdit {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font-size: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  transition: color var(--dur-fast) var(--ease);
+}
+
+.defaultFilterShowAll:hover,
+.defaultFilterEdit:hover {
+  color: var(--text);
+}
+
 .header {
   display: flex;
   align-items: baseline;

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -9,9 +9,9 @@ import { BulkBar } from '../components/BulkBar';
 import { Spinner, SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import { DiscoverSection } from '../components/DiscoverSection';
-import { useBooks, useEntityList, ENTITY_PLURAL, useMe, useRenameTag } from '../lib/queries';
+import { useBooks, useAdvancedSearch, useEntityList, ENTITY_PLURAL, useMe, useRenameTag } from '../lib/queries';
 import type { EntityKind, ReadFilter, DiscoveryView } from '../lib/queries';
-import { apiPost, apiGet, ApiError, type Book } from '../lib/api';
+import { apiPost, apiGet, ApiError, type Book, type AdvancedSearchParams } from '../lib/api';
 import { saveCatalog, loadCatalog } from '../lib/scrollCache';
 import { usePersistentBool } from '../lib/usePersistentBool';
 import { usePersistentChoice } from '../lib/usePersistentChoice';
@@ -87,6 +87,12 @@ interface CatalogProps {
   entityId?: string | number;
   /** When set, render a fixed discovery view (hot/discover/rated/favorites/archived). */
   view?: DiscoveryView;
+  /** The user's saved default library view (#498): an advanced-search filter that
+   *  becomes the standing contents of Your Library. It scopes the LIBRARY LISTING
+   *  only — this is still the library page, with its heading, actions and Discover
+   *  strip (#928). Ignored for entity/discovery views and while a search is active,
+   *  which are explicit navigations away from the default view. */
+  defaultFilter?: AdvancedSearchParams;
 }
 
 // Merge a freshly-fetched page into the accumulator: UPSERT existing books by id
@@ -187,12 +193,16 @@ function useLibraryRefresh() {
   return { isRefreshing, message, error, refresh };
 }
 
-export function Catalog({ entityKind, entityId, view }: CatalogProps) {
+export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogProps) {
   const t = useT();
   const announce = useAnnouncer();
   const libraryRefresh = useLibraryRefresh();
   const filtered = !!entityKind;
   const isView = !!view;
+  // "Show all books" — a per-visit escape from the saved default view. A standing
+  // filter that hides books with no way out is a trap; clearing it for good stays
+  // on the Advanced-search page that set it.
+  const [showingAll, setShowingAll] = useState(false);
   const isSeries = entityKind === 'series';
   const renameTag = useRenameTag(entityId ?? '');
   const [renamingTag, setRenamingTag] = useState(false);
@@ -229,6 +239,13 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
   const [search, setSearch] = useState(() => snap?.search ?? '');
   const [sort, setSort] = useState(() => snap?.sort ?? defaultSort);
   const [readFilter, setReadFilter] = useState<ReadFilter>(() => (snap?.readFilter as ReadFilter) ?? 'all');
+
+  // Is the saved default view (#498) driving this listing? It scopes the plain
+  // library only — an entity or discovery view, or a search, is an explicit
+  // navigation out of it, and the saved filter carries no free-text field to
+  // intersect a search with anyway. Declared here because resetKey below is part
+  // of the filter identity.
+  const filterActive = !!defaultFilter && !filtered && !isView && !search && !showingAll;
 
   // Multi-select / bulk mode
   const [selecting, setSelecting] = useState(false);
@@ -311,7 +328,11 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
     };
   }, [settingsOpen]);
 
-  const resetKey = [search, sort, readFilter, entityKind ?? '', entityId ?? '', view ?? '', perPage, showHidden].join('|');
+  // The saved default view is part of the filter identity: turning it on/off (or
+  // saving a different one) changes which books belong here, so the accumulator
+  // must reset rather than append the new set onto the old (#928).
+  const resetKey = [search, sort, readFilter, entityKind ?? '', entityId ?? '', view ?? '', perPage, showHidden,
+    filterActive ? JSON.stringify(defaultFilter) : ''].join('|');
 
   // Any filter change resets paging to the first page — except on the first
   // restored mount, where the rehydrated page must survive (#578).
@@ -375,7 +396,8 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const { data, isLoading, isFetching, isPlaceholderData, error } = useBooks({
+  // Both hooks are always called (hook order is fixed); exactly one is enabled.
+  const booksQuery = useBooks({
     page,
     perPage,
     search,
@@ -385,7 +407,16 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
     entityId,
     view,
     showHidden: !hideLibraryControls && showHidden,
+    enabled: !filterActive,
   });
+  // The read/unread control is an explicit user action, so it overrides the
+  // read_status baked into the saved filter; sort is the library's own.
+  const advParams: AdvancedSearchParams | null = filterActive
+    ? { ...defaultFilter, sort, ...(readFilter !== 'all' ? { read_status: readFilter } : {}) }
+    : null;
+  const advQuery = useAdvancedSearch(advParams, page, perPage);
+  const { data, isLoading, isFetching, isPlaceholderData, error } =
+    filterActive ? advQuery : booksQuery;
 
   // Accumulate pages; replace the accumulator whenever the filter set changes.
   // Skip placeholder data: on a filter change react-query briefly returns the
@@ -468,12 +499,27 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
     : '';
 
   return (
-    <main className={styles.container}>
+    <main className={styles.container} data-testid="catalog-page">
       {filtered && (
         <Link href={`/${ENTITY_PLURAL[entityKind!]}`} className={styles.back}>
           <ChevronLeft size={16} />
           {t('Show all {items}', { items: t(KIND_PLURAL_OPTIONS[entityKind!].label) })}
         </Link>
+      )}
+
+      {/* Say why the library is a subset, and offer the way out. Without this a
+          saved filter is indistinguishable from missing books (#928). */}
+      {filterActive && (
+        <div className={styles.defaultFilterNotice} data-testid="default-filter-notice">
+          <SlidersHorizontal size={15} aria-hidden="true" focusable={false} />
+          <span>{t('Showing your default library view.')}</span>
+          <button type="button" className={styles.defaultFilterShowAll}
+            data-testid="default-filter-show-all"
+            onClick={() => { setShowingAll(true); setPage(1); }}>
+            {t('Show all books')}
+          </button>
+          <Link href="/search" className={styles.defaultFilterEdit}>{t('Edit default view')}</Link>
+        </div>
       )}
 
       <div className={styles.header}>
@@ -502,7 +548,7 @@ export function Catalog({ entityKind, entityId, view }: CatalogProps) {
         )}
         {/* role=status so the result count is announced when filters/search
             change it and when load-more grows it (SC 4.1.3). */}
-        {countLabel && <span className={styles.count} role="status">{countLabel}</span>}
+        {countLabel && <span className={styles.count} role="status" data-testid="catalog-count">{countLabel}</span>}
         {isSeries && (
           <div className={styles.viewToggle} role="group" aria-label={t('Series view')}>
             <button type="button" onClick={() => setSeriesPresentation('grid')}


### PR DESCRIPTION
Reported by @chloeroform in #928, against v4.1.13.

## Why

Setting a default library view turned the library home into the search page. In the reporter's words: the "Advanced search" form is pinned above the books, the page title becomes "Advanced search", and the library title, actions and Discover strip are gone.

## Root cause

The saved default view (#498) is a *filter over the library*, but #891 implemented it by swapping the whole page component:

```tsx
return defaultFilter ? <AdvancedSearch defaultFilter={defaultFilter} /> : <Catalog />;
```

So the page chrome the user lost wasn't styled away — a different page was rendering. Both of the reporter's symptoms are that one line.

## Fix

Render `<Catalog>` with the filter and drive its listing from the advanced-search endpoint. The library keeps its own heading, actions, count and Discover strip; only the listing is scoped.

The filter applies to the plain library only — an entity view, a discovery view, or an active search is an explicit navigation out of it. A notice strip names the subset and offers **Show all books**, because a standing filter that hides books with no way out is indistinguishable from missing books.

## Verification

**Red/green (e2e, real SPA in `cwn-local`).** The first red run was invalid and thrown away: the spec failed on its *control* assertion because `data-testid=catalog-page` is added by this branch, so it proved nothing about the bug. The honest red keeps this branch's instrumentation and mutates only the defect back in (`App.tsx` → the #891 swap):

- **RED (mutant):** control at L131 passes, fails at **L140** — i.e. exactly after a default filter is set, `catalog-page` disappears. That is the reporter's symptom.
- **GREEN (fix):** 3/3 pass desktop; 3/3 pass standalone at 375px (verifying the `testIgnore` comment's claim rather than trusting it).

**Live measurement** through the real `/ajax/view` endpoint, filter `read_status: unread`:

| Reporter symptom | Result |
|---|---|
| Search form pinned to library | `advanced-search-form` absent |
| Page retitled "Advanced search" | title = `Your Library · Calibre-Web NextGen` |
| Title + actions gone | h1 = `Your Library`, actions visible |
| Discover strip gone | visible |

Filter is genuinely applied and discriminating: library 41, unread 35, page shows **35 books** — a proper subset, so the count can't be faked by ignoring the filter.

**i18n.** The three new strings are anchored in `cps/spa_strings.py`; pybabel does not scan `.tsx`. Mutation-tested: removing the anchor block drops all three msgids from `messages.pot` (3 → 0), so without this the auto-translation job would have shipped them untranslatable. This gap was **not** in the original work.

**Typecheck + production build:** clean.

## Not merging yet — one open question

The desktop a11y specs failed (color-contrast, admin/light) with this build staged, but **pass on the container's pristine image SPA**. I could not distinguish the two explanations before my wall-clock limit:

1. this branch regressed a11y, or
2. the image is older than `main` (known drift), so my build carries an already-merged admin-contrast bug the old image lacks — the failures are on `admin`/`book detail`/`account`, pages this diff does not touch.

The deciding test is a **pristine-`main` build staged into the same container**: if a11y fails identically there, it is not this change. Until that runs, merge gate (b) is not met, so this is `needs-review` rather than merged. Flagging rather than merging on an unresolved gate.

## Provenance

Recovered from an autopilot tick that timed out at 12:00Z leaving this work uncommitted on `main` (no branch, no PR). The design is that tick's; the msgid anchors, the mutation-based red/green, and the a11y finding are this tick's.

For #928.