### PR TITLE
release: v4.1.15 changelog and What's New

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+## [v4.1.15] - 2026-07-17
+
 ### Fixed
 
 - **KOReader stopped seeing new versions of the sync plugin.** If you update the

--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -56,6 +56,56 @@ export interface WhatsNewRelease {
 /** Newest release first. The `whats-new-populate` skill prepends here. */
 export const WHATS_NEW: WhatsNewRelease[] = [
   {
+    version: 'v4.1.15',
+    date: '2026-07-17',
+    items: [
+      {
+        title: 'Changing a cover no longer freezes the server for everyone',
+        body: 'Opening the cover picker on one book used to make every other page hang for as long as the slowest metadata source took to answer — up to about twelve seconds — and the Search metadata button on the edit page did the same. Cover and metadata searches now run without holding up anyone else, and the search itself is no slower.',
+        category: 'Library',
+      },
+      {
+        title: 'Books with several authors are readable again',
+        body: 'Authors were joined with a comma, but a name can contain a comma itself, so two authors ran together as “Dumas, Alexandre, Maquet, Auguste” with no way to tell where one person ended. Authors are now separated with “&”, matching the classic interface, Calibre, and the edit box. Tags, languages, and publishers still use commas.',
+        category: 'Library',
+        link: { to: '/', label: 'Open your library' },
+      },
+      {
+        title: 'Your library stays your library after saving a default view',
+        body: 'Saving a default view used to replace the library home with the Advanced search form, retitle the page, and hide the library heading and Discover strip. The library now simply shows the books your default view selects, with a note saying so and a link to show all books again.',
+        category: 'Library',
+        link: { to: '/', label: 'Open your library' },
+      },
+      {
+        title: 'New accounts start with the theme you chose',
+        body: 'Whichever theme an admin picked under Admin → Theme, some new accounts still started on Dark — self-registered accounts on upgraded servers, and every account created by OAuth, LDAP import, or an external login. All seven ways an account can be created now use the theme you configured.',
+        category: 'Admin',
+        link: { to: '/admin', label: 'Open Admin' },
+      },
+      {
+        title: 'Automatic duplicate resolution respects your cooldown',
+        body: 'Setting a cooldown between automatic resolutions stopped duplicate resolution from running at all, and the log counted the wait upward instead of down. Servers east of UTC saw the opposite — the cooldown was ignored entirely. The cooldown you type is now the one that is used, and your existing resolution history is untouched.',
+        category: 'Admin',
+        link: { to: '/duplicates', label: 'Review duplicates' },
+      },
+      {
+        title: 'KOReader offers the current sync plugin again',
+        body: 'Updating the plugin from inside KOReader kept offering the version from 13 July, so three shipped fixes — highlights and notes syncing into your library, highlight deletions reaching the server, and a guard against a device deleting highlights it never had — never arrived on the device. The current plugin is published again, and publishing it is no longer a manual step. Downloading it from your own server’s KOReader page always gave you the current copy.',
+        category: 'Sync',
+      },
+      {
+        title: 'Faster container startup on large libraries',
+        body: 'Every start walked your whole Calibre library twice to set permissions, and re-walked a folder inside /config that was already covered. Each folder is now visited once, which shortens startup the most on large libraries.',
+        category: 'Under the hood',
+      },
+      {
+        title: 'Russian reading progress reads correctly aloud',
+        body: 'Screen readers announced reading progress in Russian as “Прочитано: 45% r”, with a stray letter left over from the English wording. It only ever affected people using a screen reader, since the text is spoken rather than shown. Brazilian Portuguese was already correct.',
+        category: 'Under the hood',
+      },
+    ],
+  },
+  {
     version: 'v4.1.14',
     date: '2026-07-16',
     items: [

--- a/tests/unit/test_cover_picker_gevent_responsiveness.py
+++ b/tests/unit/test_cover_picker_gevent_responsiveness.py
@@ -32,6 +32,11 @@ from pathlib import Path
 
 import pytest
 
+# Without this marker CI's `-m "smoke or unit"` selector deselects every test in
+# this file, so the cover-picker responsiveness regression #955 fixed would not
+# be caught by CI if it came back.
+pytestmark = pytest.mark.unit
+
 gevent = pytest.importorskip("gevent", reason="production WSGI server is gevent")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/tests/unit/test_request_fanout_gevent_responsiveness.py
+++ b/tests/unit/test_request_fanout_gevent_responsiveness.py
@@ -29,6 +29,12 @@ from pathlib import Path
 
 import pytest
 
+# Without this marker CI's `-m "smoke or unit"` selector deselects every test
+# in this file, including the AST guard below that enforces the no-stdlib-
+# concurrent.futures-on-a-request-path invariant. A guard nobody runs is not a
+# guard: a PR reintroducing a hub-blocking executor would merge green.
+pytestmark = pytest.mark.unit
+
 gevent = pytest.importorskip("gevent", reason="production WSGI server is gevent")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
Departs the daily release train. v4.1.14 published 2026-07-16T04:19:34Z; the 20h gate opened at 00:19:34Z and `[Unreleased]` carried eight user-facing fixes.

## What ships

| Fix | PR | Reporter |
|---|---|---|
| "Change cover" no longer freezes the whole server | #955 | @darkmatterpelican |
| Multi-author lists separated with `&` instead of comma | #959 | @chloeroform |
| Saving a default view no longer turns the library into the search page | #928 | @chloeroform |
| Admin's configured theme seeded on all seven account-creation paths | #957 | — |
| Duplicate auto-resolution cooldown honoured (UTC/local mix + discarded value) | #950 | @jdbway |
| KOReader sync plugin published from the release again | #960 | @KucharczykL, @filiporlo |
| Startup walks each library folder once instead of twice | #942 | @chloeroform |
| Russian reader progress no longer announces "Прочитано: 45% r" | #939 | @standhaftsohnsergius |

## Contents

- `CHANGELOG.md` — `[Unreleased]` → `## [v4.1.15] - 2026-07-17` (8 entries, wording unchanged from the entries each PR landed).
- `frontend/src/data/whatsNew.ts` — new `WHATS_NEW[0]` block, 8 items. Must merge **before** the tag: the SPA is baked into the image at build time, so the shipped build's What's New page shows the release that announces it.
- `tests/unit/test_{request_fanout,cover_picker}_gevent_responsiveness.py` — **added `pytestmark = pytest.mark.unit`** (test-only; see gate finding 2 below).

## Adversarial pre-tag gate

Each of the eight PRs was verified in isolation by the tick that merged it, so the gate hunted **composition** risk. Four independent fresh-context refuters, each told to break the release from a distinct lens. Full record: `notes/verify/v4.1.15-pretag-gate.md`.

| Lens | Verdict |
|---|---|
| i18n catalogs (the v4.0.47 silent-`.mo`-drop class) | **CLEAN** |
| KOReader plugin + #960 publish automation | **CLEAN** |
| Concurrency + time (#955 × #950) | **1 finding — fixed here** |
| Auth paths + SPA (#957, #959, #928) | **1 finding — filed as follow-up** |

**Finding 1 (fixed in this PR).** #955's two test files carried no `unit` marker, so CI's `-m "smoke or unit"` selector deselected all 17: `17 collected / 17 deselected / 0 selected`. One of them is the AST guard enforcing that no request path uses stdlib `concurrent.futures` — the exact invariant #955 fixes, and one whose violation freezes the whole app because CWNG runs gevent without `monkey.patch_all()`. The green CI on this release ran none of #955's tests. With the marker the same selector reports **17 passed**. Instance of the wider gap tracked in #958.

**Finding 2 (not a blocker; follow-up filed).** #928 rewrote `Library` to `<Catalog defaultFilter=…>`, so nothing passes `defaultFilter` to `AdvancedSearch` any more and the notice's "Edit default view" link opens a blank form. Real, but a defect in a new secondary affordance rather than a regression of #928's headline fix, and the correct repair needs intent signalling (pre-filling `/search` unconditionally would break every ordinary Advanced Search). Holding seven fixes — including a server-wide freeze affecting every user — to perfect one link is the wrong trade.

**Verified clean and worth stating:** no bot `[skip ci]` translation commit rewrote any translated string in the whole delta (the only msgstr change is #939's own fix); all 28 catalogs pass `msgfmt --check`; #957 touches new-user-only branches and never rewrites an existing user's theme; #959 is display-only with no round-trip parse; the plugin correctly stays at `4.1.14` (v4.1.15 does not touch it, and bumping it would make Updates Manager offer an identical update).

## Verification

- `npx tsc -b` → 0 errors; `npm run build` → green.
- Deep-link routes (`/`, `/admin`, `/duplicates`) verified present in `src/lib/routes.ts`; no per-book `:id` route used without an id.
- CTA labels already anchored in `cps/spa_strings.py` — no new msgids for the auto-translation job to strip.
- No CI-skip marker on the roll commit: the tag points at it, and `[skip ci]` would suppress the tag-push Test Suite run, silently skipping the SPA e2e release gate (v4.1.5 lesson — which this PR tripped on its first push by quoting the token in the commit body, and fixed).

No source version bump needed — `cps/constants.py:182` reads `STABLE_VERSION` from env / `/app/CWA_STABLE_RELEASE`; the release build injects it from the tag name.