### PR TITLE
Stop claiming startup has a marker gate it does not have

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -221,8 +221,11 @@ fi
 #  Set required permissions
 #------------------------------------------------------------------------------------------------------------------------
 
-# The list (floor + dirs.json), the de-duplication, and the app-tree marker gate
-# all live in set_ownership.sh so they can be tested without a container (#874).
+# The list (floor + dirs.json) and the de-duplication live in set_ownership.sh so
+# they can be tested without a container (#874). Every listed tree is walked on
+# every start: a marker gate was built and rejected, because a marker lives in the
+# writable layer and so is absent on exactly the fresh-container start that is
+# expensive (#941 tracks not walking the app tree at all).
 bash /app/calibre-web-automated/scripts/set_ownership.sh
 
 #------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Found while writing the close-out for #874, not by a user report.

## Why

`cwa-init/run` told the next reader this:

```
# The list (floor + dirs.json), the de-duplication, and the app-tree marker gate
# all live in set_ownership.sh so they can be tested without a container (#874).
```

There is no app-tree marker gate. It was built during #942 and **rejected with a measurement**: a marker is kept in the image's writable layer, so it is necessarily absent on exactly the fresh-container start that is expensive (2.54s locally, 26.4s in @chloeroform's log — 1820 entries, each an overlayfs copy-up), and present only for the restart case that already costs 0.034s. Shipping it would have looked like a fix and done nothing for the reported case. The decision is recorded in `CHANGES-vs-upstream.md`; the comment describing the rejected design was not updated with it.

Verified rather than assumed — `set_ownership.sh` has no marker, gate, or skip logic beyond `NETWORK_SHARE_MODE`:

```
$ grep -cEi "marker|gate" scripts/set_ownership.sh
0
```

Every listed tree is `chown -R`'d on every start.

## Blast radius

Zero. This is why it matters anyway: the comment is the only description of the ownership pass a maintainer reads before touching it, and it describes behaviour that does not exist. It already cost something real — writing the #874 close-out, it nearly had me tell the reporter that a design we deliberately rejected had shipped, after we had explicitly promised them that gate. Caught by reading `set_ownership.sh` instead of trusting the comment.

## Fix

Say what the code does, say the gate was rejected and why, and point at #941 for the real remaining question (whether the app tree needs chowning at all — the answer so far is "almost none of it").

## Verification

**The diff is comment-only, proven mechanically rather than by eye:**

```
$ git diff | grep -E "^[+-]" | grep -vE "^[+-]{3}" | grep -vE "^[+-]\s*#"
(no output — every changed line is a comment)
```

**The behaviour the comment now describes is already pinned**, so this needed no new test: `tests/unit/test_set_ownership.py` drives the real bash with a recording `chown` stub — `test_config_and_app_root_are_always_walked` and `test_network_share_mode_still_walks_the_app_tree` are the unconditional-walk pins.

```
$ PYTHONPATH=scripts:. python -m pytest tests/unit/test_set_ownership.py -m "smoke or unit" -q
21 passed in 9.96s
```

The file carries `pytestmark = pytest.mark.unit`, so CI's `-m "smoke or unit"` selects it rather than silently deselecting it (checked deliberately — that is the #958 class, and two releases running have shipped guards that never ran).

## Merge gate

- **(a)** CI green on the head merged.
- **(b)** Stated honestly rather than claimed: there is **no red/green here, and there should not be**. A comment-only change has no behaviour to regress, and a test asserting this prose would be a source-pin on a comment — the coverage theatre this repo rejects. The proportional verification for a zero-blast-radius change is the mechanical comment-only proof plus the 21 existing behaviour tests staying green, both above.
- **(c)** Own AI-authored PR, so no AI-to-AI review. `/security-review` not required, checked mechanically rather than waived: no auth/session/CSRF, crypto/secrets, subprocess, user-controlled path, or new route — the diff executes nothing.
- **(d)** No dependency, license, or external URL.
- **(e)** Evidence in this body, the commit message, and the tick journal.

Tier: docs-in-code. No user-visible change; no changelog entry, since nothing a user can observe moved.
