### PR TITLE
ci: install gettext so the i18n gates actually run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,14 +64,14 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev
-      
+          sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev gettext
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-      
+
       - name: Create test environment structure
         run: |
           sudo mkdir -p /config /books/import /books/ingest /config/processed_books
@@ -232,14 +232,14 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev
-      
+          sudo apt-get install -y libldap2-dev libsasl2-dev libssl-dev gettext
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-      
+
       - name: Build Docker image
         uses: docker/build-push-action@v7
         with:

--- a/tests/unit/test_translations_compile.py
+++ b/tests/unit/test_translations_compile.py
@@ -60,6 +60,34 @@ def test_at_least_one_po_file_present():
 
 
 @pytest.mark.unit
+def test_msgfmt_is_available_when_running_in_ci():
+    """The msgfmt-backed gates are ``skipif``-guarded so a contributor
+    without gettext can still run the suite. That guard is silent by
+    design, and silence is how it failed: the workflow's apt step never
+    installed gettext, so on every CI run all 57 msgfmt-backed gates —
+    28 ``test_po_file_compiles_cleanly`` (the v4.0.47 "does the locale
+    ship at all" check), 28 ``test_po_file_passes_msgfmt_check`` and the
+    #936 red/green in ``test_i18n_format_flags.py`` — reported SKIPPED
+    while the job reported green. Two releases' worth of i18n protection
+    was decoration.
+
+    Skipping is correct on a dev laptop and wrong in CI, so assert the
+    difference instead of leaving it implicit: locally this skips, in CI
+    a missing msgfmt is a hard failure naming the step to fix. Without
+    this, re-adding gettext today does not stop the next runner-image or
+    workflow change from silently retiring the gates again.
+    """
+    if not os.environ.get("CI"):
+        pytest.skip("not CI; msgfmt is optional for local runs (brew install gettext)")
+    assert shutil.which("msgfmt") is not None, (
+        "msgfmt is missing on the CI runner, so every msgfmt-backed i18n gate "
+        "would silently SKIP and the job would still pass green.\n"
+        "Fix: add `gettext` to the 'Install system dependencies' apt-get step "
+        "in .github/workflows/tests.yml (both the Fast and Integration jobs)."
+    )
+
+
+@pytest.mark.unit
 @pytest.mark.skipif(
     shutil.which("msgfmt") is None,
     reason="msgfmt not available on this host (install gettext / brew install gettext)",


### PR DESCRIPTION
## Why

Every msgfmt-backed i18n gate in this repo has been skipped on every CI run, while the job reported green.

`tests.yml` installs `libldap2-dev libsasl2-dev libssl-dev` and never `gettext`. All three gates are `skipif(shutil.which("msgfmt") is None)`. No gettext on the runner means all of them skip silently.

**Observed** on the most recent green `Test Suite` run on `main` (`29550275809`):

| Gate | Result | What it was supposed to protect |
|---|---|---|
| `test_po_file_compiles_cleanly` × 28 | **SKIPPED** | v4.0.47: does the locale ship at all |
| `test_po_file_passes_msgfmt_check` × 28 | **SKIPPED** | #936: is the string it ships correct |
| `test_russian_reader_progress_renders_without_stray_english` | **SKIPPED** | the #936 red/green itself |

57 dead gates. The job still passed.

## Root cause

Not the tests, and not the translations — the runner. `skipif` is the right call for a contributor without gettext, but it is silent by design, so an environment that lacks the binary loses the coverage and nothing says so. CI was that environment from the start. `update-translations.yml` installs gettext; `tests.yml` never did, and that asymmetry is the whole bug.

The cost is concrete. `test_po_file_compiles_cleanly` exists *because* of v4.0.47: `msgfmt` rejected `hu.po`, `compile_translations.sh` kept going by design, and Hungarian users got the English fallback for a full release cycle. Its docstring says it runs "so a .po that would be silently dropped from the image fails a unit test first." It has never run. That protection has been off this whole time, and a malformed `.po` could ship a whole locale to English fallback today with CI green.

The `--check` gate added for #936 and described in `CHANGES-vs-upstream.md` as "enforced in CI" was decoration from the day it landed.

## Fix

1. `gettext` added to the apt step in **both** the Fast and Integration jobs.
2. `test_msgfmt_is_available_when_running_in_ci` — fails loudly when CI lacks msgfmt, skips politely on a dev laptop.

Part 2 is the durable half. Installing gettext fixes today's instance; without the guard, the next runner-image or workflow change retires the gates again just as quietly. Skipping is correct locally and wrong in CI, so that difference is now asserted instead of implied.

## Validation

**Red/green on the new guard**, all three environments:

| Environment | Result |
|---|---|
| `CI=true`, msgfmt off PATH (**exactly `main` today**) | **RED** — fails naming the apt step to fix |
| `CI=true`, gettext installed (this PR) | **GREEN** |
| no `CI`, msgfmt off PATH (dev laptop) | **SKIPPED**, politely |

- **No hidden failures behind the dead guards.** All 88 pre-existing i18n tests pass locally with msgfmt present, so this converts 57 skips into 57 passes rather than surfacing red. The 4 stale oauth failures in #958 are a different dormant-test instance and are not touched here.
- **The new test is selected, not deselected.** Verified it survives CI's `-m "smoke or unit"` filter (`--collect-only` → 1). Shipping this fix behind a deselected test would have repeated the #958 class inside the fix for it.
- 89 passed under the CI marker selector with `CI=true`.
- `tests.yml` parses; `tests.yml` is the only workflow invoking pytest, and both of its apt steps now carry gettext.

**Residual, stated not implied:** local proof used Homebrew gettext on macOS; CI uses Ubuntu's. A version difference could in principle behave differently on some locale. This PR's own CI run is the real proof — if any locale fails there, that is a genuine pre-existing bug this change exposed rather than caused, and it gets its own issue.

## Not done

No `CHANGELOG.md` entry and no `CHANGES-vs-upstream.md` row: nothing a user can observe moved. Same call as #963.

## Tier

CI config + test only. No production code, no new app dependency (the Docker build already requires msgfmt via `compile_translations.sh`, so this makes CI match production), no license change, no external service URL. Not rule-6.

Same family as the dormant-test class in #958 and the CI-deselected gevent guards found by the v4.1.15 pre-tag gate — a guard that exists, is believed, and does not run.