### PR TITLE
release: prepare v4.1.16 changelog and What's New

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+## [v4.1.16] - 2026-07-17
+
 ### Added
 
 - **You can now support CWNG development from the app** — announcements queue in the top banner, and clicking anywhere on the Ko-fi message opens Ko-fi and dismisses it; dismissals are remembered. A Support on Ko-fi link is also available in the Help menu.

--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -56,6 +56,17 @@ export interface WhatsNewRelease {
 /** Newest release first. The `whats-new-populate` skill prepends here. */
 export const WHATS_NEW: WhatsNewRelease[] = [
   {
+    version: 'v4.1.16',
+    date: '2026-07-17',
+    items: [
+      {
+        title: 'Support CWNG without hunting for a link',
+        body: 'The app can now show occasional project announcements in its top banner, starting with a Ko-fi support message. Selecting the message opens Ko-fi and dismisses it, the choice is remembered, and a permanent Support on Ko-fi link now lives in the Help menu.',
+        category: 'Under the hood',
+      },
+    ],
+  },
+  {
     version: 'v4.1.15',
     date: '2026-07-17',
     items: [


### PR DESCRIPTION
Prepares the next immutable release number required by live history. v4.1.14 and v4.1.15 are already published; v4.1.16 is the next valid tag.

The current `[Unreleased]` section contains one reader-visible change since v4.1.15: #934’s announcement queue, Ko-fi banner, and permanent Help-menu support link. This PR moves that entry under v4.1.16 and prepends the matching humanized in-app What’s New card before the tag is cut. No fake deep link is added because the destination is external rather than an SPA route.

Evidence:
- Red/green artifact check: `origin/main` contains 0 v4.1.16 release blocks in both `CHANGELOG.md` and `whatsNew.ts`; this head contains exactly 1 in each.
- `pytest -q tests/unit/test_whats_new_spa.py tests/unit/test_spa_strings_anchored.py --timeout=120`: 50 passed.
- `cd frontend && npm run build`: TypeScript + production Vite build passed, 1,883 modules transformed.
- `git diff --check`: clean.
- Completeness backstop: `git log v4.1.15..origin/main` contains only #934 as reader-visible work; the other commits are CI/docs/translation automation.
- No dependency, license, migration, route, auth/session, secret, subprocess, user-controlled-path, or new-service-URL change in this PR. `/security-review` is not applicable.

Release publication remains blocked until the ≥20-hour train window after v4.1.15 (`2026-07-17T20:49:18Z`).