### PR TITLE
fix(a11y): keep focus after final announcement dismissal

### DIFF
--- a/frontend/e2e/help-banner-kofi.spec.ts
+++ b/frontend/e2e/help-banner-kofi.spec.ts
@@ -158,6 +158,7 @@ test('keyboard activation opens Ko-fi and moves through link then dismiss button
     (window as Window & { __bannerOpenCalls: unknown[][] }).__bannerOpenCalls,
   )).toEqual([[SUPPORT_URL, '_blank', 'noopener,noreferrer']]);
   await expect(page.locator('[data-announcement-id]')).toHaveCount(0);
+  await expect(page.locator('main#main')).toBeFocused();
 });
 
 test('middle-click opens Ko-fi and dismisses the banner', async ({ page }) => {
@@ -190,6 +191,18 @@ test('Ko-fi X dismisses without opening or navigating', async ({ page }) => {
   )).toEqual([]);
   expect(await page.evaluate((key) => localStorage.getItem(key), KOFI_KEY)).toBe('1');
   await expect(page.locator('[data-announcement-id]')).toHaveCount(0);
+});
+
+test('keyboard dismissal of the final announcement moves focus to main', async ({ page }) => {
+  await page.evaluate((key) => localStorage.setItem(key, '1'), HELP_KEY);
+  await page.reload();
+  const dismissButton = page.getByRole('button', { name: 'Dismiss Ko-fi support message' });
+
+  await dismissButton.focus();
+  await page.keyboard.press('Enter');
+
+  await expect(page.locator('[data-announcement-id]')).toHaveCount(0);
+  await expect(page.locator('main#main')).toBeFocused();
 });
 
 test('legacy dismissal keys migrate independently without re-nagging existing users', async ({ page }) => {

--- a/frontend/src/components/AnnouncementBanner.tsx
+++ b/frontend/src/components/AnnouncementBanner.tsx
@@ -113,16 +113,22 @@ export function AnnouncementBanner() {
 
   if (!announcement) return null;
 
-  const dismiss = () => {
+  const dismiss = (restoreKeyboardFocus = false) => {
+    const hasNextAnnouncement = PRIORITIZED_ANNOUNCEMENTS.some(
+      ({ id }) => id !== announcement.id && !dismissedIds.has(id),
+    );
     persistDismissal(announcement.id);
     setDismissedIds((current) => new Set(current).add(announcement.id));
+    if (restoreKeyboardFocus && !hasNextAnnouncement) {
+      requestAnimationFrame(() => document.getElementById('main')?.focus());
+    }
   };
 
   const activate = (event: ReactMouseEvent<HTMLAnchorElement>) => {
     if (announcement.clickAction !== 'open-url-and-dismiss' || !announcement.url) return;
     event.preventDefault();
     window.open(announcement.url, '_blank', 'noopener,noreferrer');
-    dismiss();
+    dismiss(event.detail === 0);
   };
 
   const activateFromAuxClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
@@ -155,7 +161,7 @@ export function AnnouncementBanner() {
       <button
         type="button"
         className={styles.close}
-        onClick={dismiss}
+        onClick={(event) => dismiss(event.detail === 0)}
         aria-label={t(announcement.dismissLabel)}
       >
         <X size={16} aria-hidden="true" focusable={false} />


### PR DESCRIPTION
The second v4.1.16 pre-tag refuter found a keyboard focus-continuity gap in #934: activating the final announcement’s link or dismiss button with the keyboard removed the focused element and left focus on `<body>` on both desktop and mobile. The next Tab still worked, but the visible focus indicator disappeared between actions.

This restores focus to the surviving `main#main` landmark only for keyboard activation (`MouseEvent.detail === 0`) when no queued announcement remains. Pointer activation is unchanged, and dismissing an announcement when another remains keeps focus on the reused dismiss control.

Evidence:
- Red on exact current-main GHCR `:dev` artifact: final keyboard dismissal left `document.activeElement === document.body` at 1280×800 and 375×667.
- Green on this branch over the same running current-main container with the branch SPA bundle: `help-banner-kofi.spec.ts` + `a11y.spec.ts` passed 56, skipped 9 explicit applicability cells, failed 0 across desktop/mobile.
- New regression pins keyboard X dismissal → `main#main`; the existing keyboard full-surface-link test now pins the same focus destination.
- Production `tsc -b && vite build` passed (1,883 modules).
- `git diff --check` passed.
- Accessibility ledger updated with the reusable unmounting-focused-control lesson.
- No dependency, license, external URL, route, auth/session, secret, subprocess, user-controlled-path, or database change. `/security-review` is not applicable.

Pre-tag adversarial finding for the v4.1.16 release; no issue-closing syntax.