### PR TITLE
Reading progress export

### DIFF
--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -19,6 +19,7 @@ Protocol Specification:
         * GET  /kosync/syncs/progress/<document> - Get reading progress
         * PUT  /kosync/syncs/progress - Update reading progress
         * GET  /kosync - Plugin download page
+        * GET  /kosync/export - Bulk export of all progress (non-protocol)
 
 Security:
     - All API endpoints use HTTP Basic Authentication
@@ -46,7 +47,7 @@ from ...kobo import push_reading_state_to_hardcover
 from flask import Blueprint, request, jsonify
 from flask_babel import gettext as _
 from werkzeug.security import check_password_hash
-from sqlalchemy import func, desc
+from sqlalchemy import func, desc, cast, String
 from sqlalchemy.exc import SQLAlchemyError, OperationalError, InvalidRequestError
 
 from ... import logger, ub, csrf, config, constants, services, usermanagement
@@ -749,6 +750,142 @@ def get_progress(document: str):
         return handle_sync_error(KOSyncError(ERROR_INTERNAL, "Database error"))
     except Exception as e:
         log.error(f"get_progress: Unexpected error: {str(e)}")
+        return handle_sync_error(KOSyncError(ERROR_INTERNAL, "Internal server error"))
+
+
+@csrf.exempt
+@kosync.route("/kosync/export", methods=["GET"])
+def export_progress():
+    """
+    Export all the authenticated user's reading progress as JSON, plus book title and authors.
+
+    Not part of the KOReader protocol, it's meant to be a bulk read-only export
+    to feed data into other services.
+    Auth is handled as other KOSync endpoints: HTTP Basic, app passwords supported.
+
+    Because this is not part of the protocol, percentage is exported as stored
+    (0-100) instead of the 0-1 decimal that KOReader expects.
+
+    Entry format:
+        {
+            "calibre_book_id": 42,  # Calibre book id
+            "created_at": "...",    # From Kobo bookmark (reading started), may be null
+            "last_modified": "...", # From the kosync progress timestamp
+            "percentage": 45.67,
+            "title": "...",
+            "authors": [...]        # [] for books without authors
+        }
+
+    Timestamps are UTC, ISO 8601 with explicit offset. Rows that don't resolve
+    to a Calibre library book (checksum-keyed records that never converged after
+    #633, or books since deleted) carry no identifiable metadata and are
+    omitted from the export.
+
+    Returns:
+        200: JSON array of progress entries
+        400: Database or internal error (via handle_sync_error)
+        401: Unauthorized if authentication fails
+        503: KOReader sync disabled
+    """
+    blocked = _require_kosync_enabled()
+    if blocked:
+        return blocked
+
+    user = authenticate_user()
+    if not user:
+        return create_sync_response(
+            {"error": ERROR_UNAUTHORIZED_USER, "message": "Unauthorized"}, 401
+        )
+
+    try:
+        from ... import calibre_db
+        from ...db import Authors, books_authors_link, Books
+
+        progress_rows = (
+            ub.session.query(
+                KOSyncProgress.document,
+                KOSyncProgress.percentage,
+                KOSyncProgress.timestamp,
+                func.min(ub.KoboBookmark.created_at).label("created_at"),
+            )
+            .select_from(KOSyncProgress)
+            .outerjoin(
+                ub.KoboReadingState,
+                (ub.KoboReadingState.user_id == KOSyncProgress.user_id)
+                & (
+                    cast(ub.KoboReadingState.book_id, String) == KOSyncProgress.document
+                ),
+            )
+            .outerjoin(
+                ub.KoboBookmark,
+                ub.KoboBookmark.kobo_reading_state_id == ub.KoboReadingState.id,
+            )
+            .filter(KOSyncProgress.user_id == user.id)
+            .group_by(KOSyncProgress.id)
+            .order_by(KOSyncProgress.timestamp)
+            .all()
+        )
+        if not progress_rows:
+            return jsonify([])
+
+        # Documents are book ids only after #633
+        # older records still carry raw file checksums, which can't be looked up in Calibre.
+        # The length cap keeps an all-digit checksum (rare but possible in hex)
+        # from overflowing SQLite's 64-bit INTEGER in the in_() lookup.
+        book_ids = [
+            int(row.document)
+            for row in progress_rows
+            if row.document.isdecimal() and len(row.document) <= 18
+        ]
+
+        calibre_books = {}
+        if book_ids:
+            calibre_query = (
+                calibre_db.session.query(Books.id, Books.title, Authors.name)
+                .select_from(Books)
+                .outerjoin(books_authors_link, Books.id == books_authors_link.c.book)
+                .outerjoin(Authors, Authors.id == books_authors_link.c.author)
+                .filter(Books.id.in_(book_ids))
+                .order_by(Books.id, Authors.sort)
+                .all()
+            )
+            for book_id, title, author_name in calibre_query:
+                entry = calibre_books.setdefault(
+                    book_id, {"title": title, "authors": []}
+                )
+                if author_name and author_name not in entry["authors"]:
+                    entry["authors"].append(author_name)
+
+        def utc_isoformat(value):
+            return value.replace(tzinfo=timezone.utc).isoformat() if value else None
+
+        result = []
+        for row in progress_rows:
+            book_id = int(row.document) if row.document.isdecimal() else None
+            book = calibre_books.get(book_id)
+            if book is None:
+                # Skips books not found in Calibre, either deleted or still with checksum.
+                # In any case, they won't be identifiable to ingesting service so it's no use to export them.
+                continue
+
+            result.append(
+                {
+                    "calibre_book_id": book_id,
+                    "created_at": utc_isoformat(row.created_at),
+                    "last_modified": utc_isoformat(row.timestamp),
+                    "percentage": row.percentage,
+                    "authors": book["authors"],
+                    "title": book["title"],
+                }
+            )
+
+        return jsonify(result)
+
+    except SQLAlchemyError as e:
+        log.error("export_progress: database error: %s", e)
+        return handle_sync_error(KOSyncError(ERROR_INTERNAL, "Database error"))
+    except Exception as e:
+        log.error("export_progress: unexpected error: %s", e)
         return handle_sync_error(KOSyncError(ERROR_INTERNAL, "Internal server error"))
 
 

--- a/tests/unit/test_kosync_progress_export.py
+++ b/tests/unit/test_kosync_progress_export.py
@@ -1,0 +1,249 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Behaviour tests for ``GET /kosync/export``
+(cps/progress_syncing/protocols/kosync.py).
+
+Runs the endpoint's real SQL against two in-memory SQLite DBs — the app DB
+(``ub.Base``) and the Calibre metadata DB (``cps.db.Base``). They're separate
+databases that can't be SQL-joined, so the endpoint stitches them in Python;
+only the trust boundary (auth + feature gate) is stubbed.
+"""
+
+import sqlite3
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import cps
+from cps import ub
+from cps.progress_syncing.models import KOSyncProgress
+
+pytestmark = pytest.mark.unit
+
+CHECKSUM = "a" * 32  # a KOReader partial-MD5, the shape `document` really holds
+
+
+def _kosync_module():
+    # package __init__ rebinds the ``kosync`` name to the Blueprint; reach past
+    # it to the module via sys.modules
+    import sys
+    import cps.progress_syncing.protocols.kosync  # noqa: F401 — populate sys.modules
+    return sys.modules["cps.progress_syncing.protocols.kosync"]
+
+
+def _calibre_engine():
+    # Calibre tables live under an attached ``calibre`` schema (cps/db.py), so
+    # ATTACH one before create_all; StaticPool keeps the one connection alive.
+    def _creator():
+        conn = sqlite3.connect(":memory:", check_same_thread=False)
+        conn.execute("ATTACH DATABASE ':memory:' AS calibre")
+        return conn
+
+    engine = create_engine("sqlite+pysqlite://", creator=_creator, poolclass=StaticPool)
+    from cps.db import Base
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def _app_engine():
+    engine = create_engine("sqlite://", poolclass=StaticPool)
+    ub.Base.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def env(monkeypatch):
+    # export route wired to real in-memory app + Calibre DBs; mutable
+    # ``user``/``enabled`` let tests flip the caller and the feature gate
+    module = _kosync_module()
+
+    app_session = sessionmaker(bind=_app_engine())()
+    calibre_session = sessionmaker(bind=_calibre_engine())()
+
+    state = SimpleNamespace(
+        user=SimpleNamespace(id=1, name="alice"),
+        enabled=True,
+        app_session=app_session,
+        calibre_session=calibre_session,
+    )
+
+    monkeypatch.setattr(module, "ub", SimpleNamespace(
+        session=app_session, User=ub.User,
+        KoboReadingState=ub.KoboReadingState, KoboBookmark=ub.KoboBookmark))
+    monkeypatch.setattr(module, "is_koreader_sync_enabled", lambda: state.enabled)
+    monkeypatch.setattr(module, "authenticate_user", lambda: state.user)
+    # The export does `from ... import calibre_db`; that resolves cps.calibre_db.
+    monkeypatch.setattr(cps, "calibre_db", SimpleNamespace(session=calibre_session), raising=False)
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(module.kosync)
+    state.client = flask_app.test_client()
+    yield state
+    app_session.close()
+    calibre_session.close()
+
+
+def _seed_progress(session, *, user_id=1, document=CHECKSUM, percentage=45.67,
+                   device="KOReader", device_id="dev1", timestamp=None):
+    row = KOSyncProgress(
+        user_id=user_id, document=document, progress="/body/DocFragment[3]",
+        percentage=percentage, device=device, device_id=device_id,
+        timestamp=timestamp or datetime(2026, 7, 1, 10, 11, 12, tzinfo=timezone.utc),
+    )
+    session.add(row)
+    session.commit()
+    return row
+
+
+def _seed_book(session, *, title, authors):
+    # ``authors`` items are names, or ``(name, sort)`` to pin Authors.sort
+    from cps.db import Books, Authors
+
+    pairs = [(a, a) if isinstance(a, str) else a for a in authors]
+    now = datetime.now(timezone.utc)
+    book = Books(title, title, pairs[0][0], now, now, "1.0", now, "path", 1, [], [])
+    book.authors = [Authors(name, sort) for name, sort in pairs]
+    session.add(book)
+    session.commit()
+    return book
+
+
+def _seed_kobo_bookmark(session, *, user_id, book_id, created_at, last_modified):
+    # reading state + bookmark for (user, book): the export's created_at source
+    state = ub.KoboReadingState(user_id=user_id, book_id=book_id)
+    state.current_bookmark = ub.KoboBookmark(
+        created_at=created_at, last_modified=last_modified)
+    session.add(state)
+    session.commit()
+    return state
+
+
+# ── auth / feature gate (working behaviour) ─────────────────────────────────
+
+def test_unauthenticated_returns_401(env):
+    env.user = None
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 401
+    assert resp.get_json()["error"] == _kosync_module().ERROR_UNAUTHORIZED_USER
+
+
+def test_disabled_sync_is_blocked(env):
+    env.enabled = False
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 503
+
+
+def test_no_progress_returns_empty_json_array(env):
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 200
+    assert resp.mimetype == "application/json"
+    assert resp.get_json() == []
+
+
+# ── the real export ─────────────────────────────────────────────────────────
+
+def test_export_returns_the_users_progress(env):
+    book = _seed_book(env.calibre_session, title="The Dispossessed",
+                      authors=["Ursula K. Le Guin"])
+    _seed_progress(env.app_session, document=str(book.id), percentage=45.67)
+
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body) == 1
+    row = body[0]
+    assert row["calibre_book_id"] == book.id
+    # exported as stored 0–100, not KOReader's 0–1 decimal
+    assert row["percentage"] == pytest.approx(45.67)
+    assert row["title"] == "The Dispossessed"
+    assert row["authors"] == ["Ursula K. Le Guin"]
+
+
+def test_export_includes_started_and_modified_timestamps(env):
+    # created_at is the bookmark's (reading started); last_modified is the
+    # progress row's, NOT the bookmark's (Kobo syncs touch the bookmark alone).
+    book = _seed_book(env.calibre_session, title="Dune", authors=["Frank Herbert"])
+    synced = datetime(2026, 7, 1, 10, 11, 12, tzinfo=timezone.utc)
+    _seed_progress(env.app_session, document=str(book.id), timestamp=synced)
+    started = datetime(2026, 6, 1, 8, 0, 0, tzinfo=timezone.utc)
+    modified = datetime(2026, 7, 1, 9, 30, 0, tzinfo=timezone.utc)
+    _seed_kobo_bookmark(env.app_session, user_id=1, book_id=book.id,
+                        created_at=started, last_modified=modified)
+
+    row = env.client.get("/kosync/export").get_json()[0]
+    # naive UTC in SQLite re-attaches its offset on the way out
+    assert row["created_at"] == started.isoformat()
+    assert row["last_modified"] == synced.isoformat()
+
+
+def test_all_digit_checksum_is_omitted_too(env):
+    # All-digit checksum is decimal-parseable; the length cap keeps its int out
+    # of the in_() bind, which would otherwise overflow SQLite's int64.
+    _seed_progress(env.app_session, document="1" * 32, percentage=5.0)
+
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
+def test_decimal_document_with_no_library_book_is_omitted(env):
+    # Distinct from a checksum: a book id that reaches the Calibre query but
+    # matches nothing (book since deleted) — dropped, not a 500.
+    _seed_progress(env.app_session, document="999", percentage=20.0)
+
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
+def test_book_without_kobo_state_has_null_created_at(env):
+    # No bookmark to source created_at from, but the row still exports.
+    book = _seed_book(env.calibre_session, title="Neuromancer", authors=["William Gibson"])
+    _seed_progress(env.app_session, document=str(book.id))
+
+    row = env.client.get("/kosync/export").get_json()[0]
+    assert row["title"] == "Neuromancer"
+    assert row["created_at"] is None
+    assert row["last_modified"] is not None
+
+
+def test_multiple_authors_listed(env):
+    # ordered by Authors.sort, which inverts display-name order here
+    book = _seed_book(env.calibre_session, title="Co-Authored", authors=[
+        ("Brandon Sanderson", "Sanderson, Brandon"),
+        ("Robin Hobb", "Hobb, Robin")])
+    _seed_progress(env.app_session, document=str(book.id))
+
+    row = env.client.get("/kosync/export").get_json()[0]
+    assert row["authors"] == ["Robin Hobb", "Brandon Sanderson"]
+
+
+def test_resolvable_and_checksum_rows_coexist(env):
+    # Mid-migration (#633): the skip is per-row, so a resolvable row survives
+    # alongside a dropped legacy-checksum one.
+    book = _seed_book(env.calibre_session, title="Snow Crash", authors=["Neal Stephenson"])
+    _seed_progress(env.app_session, document=str(book.id), percentage=30.0)
+    _seed_progress(env.app_session, document="c" * 32, percentage=80.0)
+
+    body = env.client.get("/kosync/export").get_json()
+    assert [r["calibre_book_id"] for r in body] == [book.id]
+    assert body[0]["title"] == "Snow Crash"
+
+
+def test_export_is_scoped_to_authenticated_user(env):
+    mine = _seed_book(env.calibre_session, title="Mine", authors=["A"])
+    theirs = _seed_book(env.calibre_session, title="Theirs", authors=["B"])
+    _seed_progress(env.app_session, user_id=1, document=str(mine.id))
+    _seed_progress(env.app_session, user_id=2, document=str(theirs.id))
+
+    ids = {r["calibre_book_id"] for r in env.client.get("/kosync/export").get_json()}
+    assert ids == {mine.id}  # never another user's rows


### PR DESCRIPTION
## Summary and goal
This PR adds a new KOSync endpoint aimed to export all reading progress of the authenticated user.
The goal is to have a clean way to export your data to be able to feed them into another service.
My personal use case would be to feed this data into another self-hosted service that I use as a unified media tracking.
Being a machine-to-machine endpoint, the authentication is on par with other KOSync endpoints, allowing to use app password if you opt for OIDC providers.

### "Caveat"
Books not found in Calibre DB are skipped and not exported, by my analysis it can happen for two reasons:
- book is deleted from Calibre
- KOSyncProgress id is an old checksum that has not yet been migrated after #633

In my opinion, it is a good thing to not export progress without basic things like book name, it has no practical use if the goal is to be able to ingest it in another service, so both scenarios above are perfectly fine when skipped.


## Implementation
### Changes
#### `kosync.py`
New endpoint lives entirely here, it follows established patterns found across the same file.
Flow:
1. Early error return if KOSync feature is not enabled
2. Early error return for unauthorized users
3. Lazy calibre_db importing (same as other endpoints)
4. Queries current user KOSyncProgress, joins KoboBookmark only for `created_at` (when reading started)
5. Queries calibre_db books using the ids, skipping old checksum based ids not migrated after #633
6. Creates a map of book ids as key and Calibre books as values for a one-pass later enrichment
7. Creates result by formatting and enriching progress query with Calibre data (book name and authors). Books not found in calibre are skipped, as explained in caveat
8. Returns result as JSON

Example output:
```json
[
  {
    "calibre_book_id": 42,  // Calibre book id
    "created_at": "...",    // From KoboBookmark (reading started), null or ISO8601, explicit UTC
    "last_modified": "...", // From the KOSyncProgress timestamp (ISO8601, explicit UTC)
    "percentage": 45.67,
    "title": "...",
    "authors": [...]        // [] for books without authors
  }
  {...}
]
```

#### `test_kosync_progress_export.py`
New test file to cover unit testing for the new endpoint

### Scaling and why no pagination
I thought about implementing pagination, but `kosync_progress` is a single position-per-book.
Even for large collections and reading progress query should be a negligible cost.

### cURL example
```
curl -u 'username:APP_PASSWORD' https://your-cwa-instance/kosync/export
```
