### PR TITLE
test: pin fork immunity to case-variant tag crash (janeczku#3670)

### DIFF
--- a/tests/unit/test_tag_case_variant_jz3670.py
+++ b/tests/unit/test_tag_case_variant_jz3670.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""janeczku/calibre-web#3670: saving a book with tags that differ only by
+letter case (e.g. ``Java, java``) must not raise a database integrity error.
+
+``tags.name`` uses a NOCASE-unique collation and ``books_tags_link`` has a
+composite ``(book, tag)`` primary key, so two case-variant tag strings resolve
+to the same row. A book saved with both variants must collapse to a single tag
+and a single link rather than crashing with
+``UNIQUE constraint failed: tags.name`` (or ...books_tags_link...).
+
+Verified on this fork (2026-07-18): the crash does NOT reproduce here. The
+load-bearing defense is the calibre session's ``autoflush=True`` (see
+``cps/db.py`` ``session_factory``): when ``add_objects`` iterates the second
+case-variant, the autoflush'd lookup sees the tag created for the first variant
+and - because the ``name`` column is ``COLLATE NOCASE`` - resolves both to the
+same row. Disable autoflush and the same payload crashes exactly as reported
+upstream (proven by ``test_autoflush_off_reproduces_upstream_crash`` below).
+
+These tests pin both the user-visible behavior (no crash) and the invariant that
+protects it (autoflush stays on), so a future session-config or ``add_objects``
+refactor can't silently reintroduce the upstream crash.
+"""
+import inspect
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from cps import db
+from cps import editbooks
+
+
+def _engine():
+    engine = create_engine("sqlite://")
+    event.listen(
+        engine,
+        "connect",
+        lambda connection, _record: connection.execute("ATTACH DATABASE ':memory:' AS calibre"),
+    )
+    db.Base.metadata.create_all(engine)
+    return engine
+
+
+def _session(autoflush=True):
+    return sessionmaker(bind=_engine(), autoflush=autoflush)()
+
+
+def _make_book(session, title="Case Test"):
+    now = datetime.now(timezone.utc)
+    book = db.Books(title, title, "Author", now, now, "1.0", now, f"{title}-path", 1, [], [])
+    session.add(book)
+    session.commit()
+    return book
+
+
+@pytest.mark.unit
+def test_control_constraints_bite_when_variants_forced_distinct():
+    """Sanity: the in-memory schema really enforces the crash conditions.
+
+    Inserting two distinct case-variant tag rows must fail on the NOCASE-unique
+    ``tags.name`` constraint, proving the repro exercises the same constraints as
+    a real Calibre metadata.db.
+    """
+    session = _session()
+    try:
+        _make_book(session)
+        session.add(db.Tags("Java"))
+        session.commit()
+        session.add(db.Tags("java"))
+        with pytest.raises(IntegrityError):
+            session.commit()
+    finally:
+        session.rollback()
+        session.close()
+
+
+@pytest.mark.unit
+def test_modify_database_object_tags_case_variants_no_crash():
+    """The exact #3670 payload (``Java, java``) through the real code path.
+
+    ``edit_book_tags`` splits + ``helper.uniq``-dedups (which keeps both case
+    variants) then calls ``modify_database_object``. The fork must collapse the
+    variants to one tag + one link and commit without error.
+    """
+    session = _session()
+    try:
+        book = _make_book(session)
+        changed = editbooks.modify_database_object(
+            ["Java", "java"], book.tags, db.Tags, session, "tags"
+        )
+        session.commit()  # must NOT raise UNIQUE constraint failed
+        assert changed is True
+        assert session.query(db.Tags).count() == 1
+        assert len(book.tags) == 1
+        assert book.tags[0].name in ("Java", "java")
+    finally:
+        session.rollback()
+        session.close()
+
+
+@pytest.mark.unit
+def test_modify_database_object_tags_case_variants_with_preexisting_tag():
+    """Same collision when the lower-case variant already exists globally."""
+    session = _session()
+    try:
+        book = _make_book(session)
+        session.add(db.Tags("java"))  # pre-existing, unlinked
+        session.commit()
+        editbooks.modify_database_object(
+            ["Java", "java"], book.tags, db.Tags, session, "tags"
+        )
+        session.commit()
+        assert session.query(db.Tags).count() == 1
+        assert len(book.tags) == 1
+    finally:
+        session.rollback()
+        session.close()
+
+
+@pytest.mark.unit
+def test_autoflush_off_reproduces_upstream_crash():
+    """Characterize the load-bearing invariant: without autoflush the fork
+    crashes exactly as janeczku#3670 reports. This documents *why* the calibre
+    session must keep ``autoflush=True`` and gives the pin its teeth - flip it
+    off and this expectation, plus the source-pin below, fail loudly.
+    """
+    session = _session(autoflush=False)
+    try:
+        book = _make_book(session)
+        with pytest.raises(IntegrityError) as exc:
+            editbooks.modify_database_object(
+                ["Java", "java"], book.tags, db.Tags, session, "tags"
+            )
+            session.commit()
+        assert "UNIQUE constraint failed" in str(exc.value.orig)
+    finally:
+        session.rollback()
+        session.close()
+
+
+@pytest.mark.unit
+def test_calibre_session_configures_autoflush_on():
+    """Source-pin the invariant that protects the behavior: the calibre session
+    factory must be built with ``autoflush=True``. If a refactor drops it, the
+    #3670 crash returns for real users - catch it here, not in production.
+    """
+    src = inspect.getsource(db.CalibreDB.setup_db)
+    assert "autoflush=True" in src, (
+        "calibre session_factory must keep autoflush=True; without it, saving a "
+        "book with case-variant tags (Java, java) crashes with a UNIQUE "
+        "constraint error (janeczku/calibre-web#3670)."
+    )


### PR DESCRIPTION
## Why

janeczku/calibre-web#3670 reports that saving a book with tags differing only by letter case — e.g. `Java, java` — crashes stock calibre-web with `UNIQUE constraint failed: tags.name` (and, downstream, the `books_tags_link` composite key). Credit: @the3rdsky (janeczku#3670) for the upstream report and fix.

## Verification finding — this fork is already immune

Reproduced the exact payload against our schema (in-memory SQLite built from `db.Base.metadata`, and confirmed constraints match the live `metadata.db`: `tags.name TEXT NOT NULL COLLATE NOCASE UNIQUE`, `books_tags_link UNIQUE(book, tag)`). The crash does **not** occur here.

Root cause of our immunity (traced, not assumed):
- The calibre session is built with `autoflush=True` (`cps/db.py` `CalibreDB.setup_db`).
- `tags.name` is `COLLATE NOCASE`.
- When `add_objects` processes the second case-variant, the autoflush'd lookup sees the tag created for the first variant, and the NOCASE column collation resolves `java` → the existing `Java` row. Both variants collapse to one tag + one link.

Proven load-bearing: with `autoflush=False` the identical payload crashes exactly as upstream (`UNIQUE constraint failed: tags.name`). So the invariant is real and worth guarding.

## What this PR does

Test-only. No production change (none is needed — we're already defended). Adds `tests/unit/test_tag_case_variant_jz3670.py`:
- `test_control_constraints_bite_when_variants_forced_distinct` — sanity: the schema really enforces the crash conditions.
- `test_modify_database_object_tags_case_variants_no_crash` — the real `modify_database_object` path with `["Java","java"]` collapses to one tag + one link.
- `..._with_preexisting_tag` — same when the lower-case variant already exists globally.
- `test_autoflush_off_reproduces_upstream_crash` — characterizes the invariant: disable autoflush and the upstream crash returns.
- `test_calibre_session_configures_autoflush_on` — source-pins `autoflush=True` in `CalibreDB.setup_db`, so a refactor that drops it fails here instead of in production.

## Red/green

Demonstrated locally: flipping `autoflush=True → False` (or dropping it from `setup_db`) makes `test_autoflush_off_reproduces_upstream_crash` describe the crash and `test_calibre_session_configures_autoflush_on` fail — the pin has teeth. All 5 pass on `main` as-is; 24 adjacent editbooks/tag tests stay green.

## Tier / release

Tier: test-only (no user-facing change, no CHANGELOG entry). No new dependencies, no license or external-URL changes, no auth/session/CSRF/migration surface touched.