### PR TITLE
test(api): make hot-list chunking order assertion non-vacuous (#937)

### DIFF
--- a/tests/unit/test_api_v1_books.py
+++ b/tests/unit/test_api_v1_books.py
@@ -360,10 +360,18 @@ def test_list_books_handles_discovery_filters():
 def test_hot_visibility_filter_chunks_large_libraries_without_losing_order(monkeypatch):
     """The app and calibre catalogs use separate SQLite sessions, so hot-book
     ids must cross the boundary in bounded batches rather than one huge IN().
+
+    The input is a *seeded shuffle* — not ``range(2005)`` — so hotness order and
+    ascending order genuinely differ. That is what makes the order assertion
+    real: an implementation that re-sorted the visible set (or returned raw
+    ``set`` iteration order) yields ascending ids and fails here, where an
+    ascending input would have let it pass silently (#937).
     """
+    import random
     from cps.api import books as books_mod
 
     ids = list(range(2005))
+    random.Random(1337).shuffle(ids)
     chunks = []
 
     def visible_even_ids(chunk):
@@ -373,6 +381,12 @@ def test_hot_visibility_filter_chunks_large_libraries_without_losing_order(monke
     monkeypatch.setattr(books_mod, "_visible_ids_for_chunk", visible_even_ids)
     result = books_mod._visible_hot_book_ids(ids)
 
+    # Chunk sizes stay under the SQLite host-parameter ceiling regardless of order.
     assert [len(chunk) for chunk in chunks] == [900, 900, 205]
     assert all(len(chunk) <= books_mod._SQLITE_IN_CHUNK for chunk in chunks)
-    assert result == [book_id for book_id in ids if book_id % 2 == 0]
+    # Hotness (input) order is preserved, not ascending/sorted order.
+    expected = [book_id for book_id in ids if book_id % 2 == 0]
+    assert result == expected
+    # Self-guard: the shuffle must make hotness order differ from sorted order,
+    # or this test would go vacuous again (the exact regression #937 caught).
+    assert expected != sorted(expected)


### PR DESCRIPTION
## Why
Fixes #937. The v4.1.14 pre-tag adversarial gate flagged that `test_hot_visibility_filter_chunks_large_libraries_without_losing_order` guarded nothing: it fed `list(range(2005))` (already ascending) and kept even ids, so the expected value was ascending too. `sorted(visible)` and bare set iteration both produce that same list, so a re-sorting implementation would pass. The chunk-size assertion was sound; the order pin was not.

## Root cause
The property worth protecting is that `_visible_hot_book_ids` (`cps/api/books.py:33-38`) preserves hotness order — it iterates the original `book_ids` and tests membership in the accumulated `visible` set, so chunk boundaries are structurally irrelevant. Nothing would catch that comprehension being swapped for `sorted(visible)`.

## Fix (test-only, no production change)
- Seed-shuffle the input (`random.Random(1337)`) so hotness order and ascending order genuinely differ.
- Keep the `[900, 900, 205]` chunk-size assertions and the `<= _SQLITE_IN_CHUNK` bound.
- Assert the result equals the hotness-ordered filter, and add a self-guard `expected != sorted(expected)` so the test can't silently go vacuous again.

## Validation (red/green)
- **Green** on the current order-preserving implementation.
- **Red** on a temporary `return sorted(visible)` variant (the exact regression the old test missed) — verified locally, then reverted.
- Full `tests/unit/test_api_v1_books.py` — 14 passed.

## Tier
Test-only, non-security, no deps. Autonomous-merge eligible (hard rule 3): first-party, red/green regression coverage, no auth/session/csrf/crypto/subprocess/file-path/new-route surface, no dependency changes.

## Release target
No user-facing change — test hardening only; rides the next train, no changelog entry needed.