### PR TITLE
fix: add border around cover in BookDetail (#987)

### DIFF
--- a/frontend/src/pages/BookDetail.module.css
+++ b/frontend/src/pages/BookDetail.module.css
@@ -44,6 +44,7 @@
   border-radius: var(--r-md);
   box-shadow: var(--cover-shadow);
   display: block;
+  border: thin solid var(--border);
 }
 
 /* "Change cover" affordance overlaid on the cover — discoverable for editors


### PR DESCRIPTION
If a book cover has the same background as the CWNG theme, the image gets "swallowed" by the page. It makes it a bit unaesthetic.

This change adds a very discrete border around the cover, using the already defined `--border` CSS variable.

Fixes #987.