### PR TITLE
feat(kosync): add GET /kosync/export bulk reading-progress export (adopts #978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+
+- **Export all your KOReader reading progress as JSON.** A new read-only endpoint, `GET /kosync/export`, returns every book you have reading progress for — Calibre book id, title, authors, percentage, and when you started and last updated it — so you can feed your progress into another service (for example a unified media tracker). It authenticates the same way as the other KOReader sync endpoints (HTTP Basic, app passwords supported) and only ever returns your own progress, limited to books you're allowed to see. Example: `curl -u 'user:APP_PASSWORD' https://your-instance/kosync/export`. Contributed by @Kyraminol (#978).
+
 ## [v4.1.17] - 2026-07-19
 
 ### Added

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -1053,10 +1053,18 @@ def find_duplicate_books_python(use_title, use_author, use_language, use_series,
 
 
 def get_common_filters(user_id=None, allow_show_archived=False, return_all_languages=False,
-                       allow_show_hidden=False):
+                       allow_show_hidden=False, strict=False):
     """Build common filters using either current_user or a specific user_id.
 
     Falls back to no-op filters if user context is unavailable.
+
+    ``strict`` changes that fallback for the ``user_id`` path: when the user
+    cannot be reloaded or filter construction fails, raise instead of returning
+    a permissive ``true()``. A permissive fallback is fine for a best-effort
+    duplicate scan, but a caller using this as an authorization boundary (e.g.
+    the KOSync export) must fail closed — it should surface an error rather than
+    silently drop every per-user restriction. Existing callers keep the
+    permissive default unchanged.
     """
     try:
         if user_id is None:
@@ -1070,6 +1078,8 @@ def get_common_filters(user_id=None, allow_show_archived=False, return_all_langu
     try:
         user = ub.session.query(ub.User).filter(ub.User.id == int(user_id)).first()
         if not user:
+            if strict:
+                raise ValueError(f"get_common_filters(strict): user {user_id!r} not found")
             return true()
 
         if not allow_show_archived:
@@ -1125,6 +1135,10 @@ def get_common_filters(user_id=None, allow_show_archived=False, return_all_langu
                     pos_content_cc_filter, ~neg_content_cc_filter, archived_filter,
                     hidden_filter)
     except Exception:
+        if strict:
+            # Fail closed for authorization callers: a construction error must
+            # not silently degrade into "no restrictions".
+            raise
         return true()
 
 

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -19,6 +19,7 @@ Protocol Specification:
         * GET  /kosync/syncs/progress/<document> - Get reading progress
         * PUT  /kosync/syncs/progress - Update reading progress
         * GET  /kosync - Plugin download page
+        * GET  /kosync/export - Bulk export of all progress (non-protocol)
 
 Security:
     - All API endpoints use HTTP Basic Authentication
@@ -46,7 +47,7 @@ from ...kobo import push_reading_state_to_hardcover
 from flask import Blueprint, request, jsonify
 from flask_babel import gettext as _
 from werkzeug.security import check_password_hash
-from sqlalchemy import func, desc
+from sqlalchemy import func, desc, cast, String
 from sqlalchemy.exc import SQLAlchemyError, OperationalError, InvalidRequestError
 
 from ... import logger, ub, csrf, config, constants, services, usermanagement
@@ -749,6 +750,165 @@ def get_progress(document: str):
         return handle_sync_error(KOSyncError(ERROR_INTERNAL, "Database error"))
     except Exception as e:
         log.error(f"get_progress: Unexpected error: {str(e)}")
+        return handle_sync_error(KOSyncError(ERROR_INTERNAL, "Internal server error"))
+
+
+def _is_ascii_book_id(document: str) -> bool:
+    """True if ``document`` is a plain ASCII-decimal Calibre book id.
+
+    ``str.isdecimal()`` also accepts non-ASCII digit scripts (e.g. Arabic-Indic)
+    that ``int()`` folds onto the same value, which would let two distinct
+    ``document`` strings alias the same book id. Requiring ASCII digits keeps the
+    parse unambiguous. The length cap keeps an all-digit KOReader checksum from
+    overflowing SQLite's 64-bit INTEGER in the ``in_()`` lookup.
+    """
+    return document.isascii() and document.isdecimal() and len(document) <= 18
+
+
+@csrf.exempt
+@kosync.route("/kosync/export", methods=["GET"])
+def export_progress():
+    """
+    Export all the authenticated user's reading progress as JSON, plus book title and authors.
+
+    Not part of the KOReader protocol, it's meant to be a bulk read-only export
+    to feed data into other services.
+    Auth is handled as other KOSync endpoints: HTTP Basic, app passwords supported.
+
+    Because this is not part of the protocol, percentage is exported as stored
+    (0-100) instead of the 0-1 decimal that KOReader expects.
+
+    Entry format:
+        {
+            "calibre_book_id": 42,  # Calibre book id
+            "created_at": "...",    # From Kobo bookmark (reading started), may be null
+            "last_modified": "...", # From the kosync progress timestamp
+            "percentage": 45.67,
+            "title": "...",
+            "authors": [...]        # [] for books without authors
+        }
+
+    Timestamps are UTC, ISO 8601 with explicit offset. Rows that don't resolve
+    to a Calibre library book (checksum-keyed records that never converged after
+    #633, or books since deleted) carry no identifiable metadata and are
+    omitted from the export.
+
+    Returns:
+        200: JSON array of progress entries
+        400: Database or internal error (via handle_sync_error)
+        401: Unauthorized if authentication fails
+        503: KOReader sync disabled
+    """
+    blocked = _require_kosync_enabled()
+    if blocked:
+        return blocked
+
+    user = authenticate_user()
+    if not user:
+        return create_sync_response(
+            {"error": ERROR_UNAUTHORIZED_USER, "message": "Unauthorized"}, 401
+        )
+
+    try:
+        from ... import calibre_db
+        from ...db import Authors, books_authors_link, Books
+        from ...duplicates import get_common_filters
+
+        progress_rows = (
+            ub.session.query(
+                KOSyncProgress.document,
+                KOSyncProgress.percentage,
+                KOSyncProgress.timestamp,
+                func.min(ub.KoboBookmark.created_at).label("created_at"),
+            )
+            .select_from(KOSyncProgress)
+            .outerjoin(
+                ub.KoboReadingState,
+                (ub.KoboReadingState.user_id == KOSyncProgress.user_id)
+                & (
+                    cast(ub.KoboReadingState.book_id, String) == KOSyncProgress.document
+                ),
+            )
+            .outerjoin(
+                ub.KoboBookmark,
+                ub.KoboBookmark.kobo_reading_state_id == ub.KoboReadingState.id,
+            )
+            .filter(KOSyncProgress.user_id == user.id)
+            .group_by(KOSyncProgress.id)
+            .order_by(KOSyncProgress.timestamp)
+            .all()
+        )
+        if not progress_rows:
+            return jsonify([])
+
+        # Documents are book ids only after #633
+        # older records still carry raw file checksums, which can't be looked up in Calibre.
+        # The length cap keeps an all-digit checksum (rare but possible in hex)
+        # from overflowing SQLite's 64-bit INTEGER in the in_() lookup.
+        book_ids = [
+            int(row.document)
+            for row in progress_rows
+            if _is_ascii_book_id(row.document)
+        ]
+
+        calibre_books = {}
+        if book_ids:
+            # SECURITY: constrain to books THIS user is allowed to see. The
+            # `document` value is attacker-controlled (update_progress stores any
+            # non-empty key verbatim), so without the per-user visibility filter
+            # a restricted account could seed ids 1..N and enumerate the title +
+            # authors of books hidden from it by denied tags, hidden-book, the
+            # restricted custom column, or a language filter. get_common_filters
+            # is the same single-source-of-truth predicate the duplicate scanner
+            # uses off the request context (current_user is not populated on this
+            # Basic-auth path).
+            calibre_query = (
+                calibre_db.session.query(Books.id, Books.title, Authors.name)
+                .select_from(Books)
+                .outerjoin(books_authors_link, Books.id == books_authors_link.c.book)
+                .outerjoin(Authors, Authors.id == books_authors_link.c.author)
+                .filter(Books.id.in_(book_ids))
+                .filter(get_common_filters(user_id=user.id))
+                .order_by(Books.id, Authors.sort)
+                .all()
+            )
+            for book_id, title, author_name in calibre_query:
+                entry = calibre_books.setdefault(
+                    book_id, {"title": title, "authors": []}
+                )
+                if author_name and author_name not in entry["authors"]:
+                    entry["authors"].append(author_name)
+
+        def utc_isoformat(value):
+            return value.replace(tzinfo=timezone.utc).isoformat() if value else None
+
+        result = []
+        for row in progress_rows:
+            book_id = int(row.document) if _is_ascii_book_id(row.document) else None
+            book = calibre_books.get(book_id)
+            if book is None:
+                # Skips books not found in Calibre, either deleted or still with checksum.
+                # In any case, they won't be identifiable to ingesting service so it's no use to export them.
+                continue
+
+            result.append(
+                {
+                    "calibre_book_id": book_id,
+                    "created_at": utc_isoformat(row.created_at),
+                    "last_modified": utc_isoformat(row.timestamp),
+                    "percentage": row.percentage,
+                    "authors": book["authors"],
+                    "title": book["title"],
+                }
+            )
+
+        return jsonify(result)
+
+    except SQLAlchemyError as e:
+        log.error("export_progress: database error: %s", e)
+        return handle_sync_error(KOSyncError(ERROR_INTERNAL, "Database error"))
+    except Exception as e:
+        log.error("export_progress: unexpected error: %s", e)
         return handle_sync_error(KOSyncError(ERROR_INTERNAL, "Internal server error"))
 
 

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -845,11 +845,13 @@ def export_progress():
         # older records still carry raw file checksums, which can't be looked up in Calibre.
         # The length cap keeps an all-digit checksum (rare but possible in hex)
         # from overflowing SQLite's 64-bit INTEGER in the in_() lookup.
-        book_ids = [
+        # Dedup up-front: a user can accumulate many progress rows for the same
+        # id, and duplicate binds needlessly widen the IN() below.
+        book_ids = sorted({
             int(row.document)
             for row in progress_rows
             if _is_ascii_book_id(row.document)
-        ]
+        })
 
         calibre_books = {}
         if book_ids:
@@ -861,23 +863,33 @@ def export_progress():
             # restricted custom column, or a language filter. get_common_filters
             # is the same single-source-of-truth predicate the duplicate scanner
             # uses off the request context (current_user is not populated on this
-            # Basic-auth path).
-            calibre_query = (
-                calibre_db.session.query(Books.id, Books.title, Authors.name)
-                .select_from(Books)
-                .outerjoin(books_authors_link, Books.id == books_authors_link.c.book)
-                .outerjoin(Authors, Authors.id == books_authors_link.c.author)
-                .filter(Books.id.in_(book_ids))
-                .filter(get_common_filters(user_id=user.id))
-                .order_by(Books.id, Authors.sort)
-                .all()
-            )
-            for book_id, title, author_name in calibre_query:
-                entry = calibre_books.setdefault(
-                    book_id, {"title": title, "authors": []}
+            # Basic-auth path). strict=True makes it FAIL CLOSED — if the filter
+            # can't be built we want the enclosing except to return an error,
+            # never a silently-unrestricted dump.
+            visibility_filter = get_common_filters(user_id=user.id, strict=True)
+
+            # Chunk the id lookup so a user with a very large library (or one who
+            # has seeded many numeric progress rows) can't blow past the SQLite
+            # host's bound-parameter limit and 500 the export.
+            _CHUNK = 500
+            for start in range(0, len(book_ids), _CHUNK):
+                chunk = book_ids[start:start + _CHUNK]
+                calibre_query = (
+                    calibre_db.session.query(Books.id, Books.title, Authors.name)
+                    .select_from(Books)
+                    .outerjoin(books_authors_link, Books.id == books_authors_link.c.book)
+                    .outerjoin(Authors, Authors.id == books_authors_link.c.author)
+                    .filter(Books.id.in_(chunk))
+                    .filter(visibility_filter)
+                    .order_by(Books.id, Authors.sort)
+                    .all()
                 )
-                if author_name and author_name not in entry["authors"]:
-                    entry["authors"].append(author_name)
+                for book_id, title, author_name in calibre_query:
+                    entry = calibre_books.setdefault(
+                        book_id, {"title": title, "authors": []}
+                    )
+                    if author_name and author_name not in entry["authors"]:
+                        entry["authors"].append(author_name)
 
         def utc_isoformat(value):
             return value.replace(tzinfo=timezone.utc).isoformat() if value else None

--- a/tests/unit/test_kosync_progress_export.py
+++ b/tests/unit/test_kosync_progress_export.py
@@ -84,6 +84,21 @@ def env(monkeypatch):
     # The export does `from ... import calibre_db`; that resolves cps.calibre_db.
     monkeypatch.setattr(cps, "calibre_db", SimpleNamespace(session=calibre_session), raising=False)
 
+    # The export calls get_common_filters(user_id=..., strict=True), which reads
+    # cps.duplicates' own ub/config globals off the request context. Wire them to
+    # the in-memory app DB and seed a REAL user row (id=1) so every test exercises
+    # the real, fail-closed visibility filter rather than a permissive fallback.
+    import cps.duplicates as dup
+    monkeypatch.setattr(dup, "ub", SimpleNamespace(
+        session=app_session, User=ub.User,
+        ArchivedBook=ub.ArchivedBook, UserHiddenBook=ub.UserHiddenBook))
+    monkeypatch.setattr(dup, "config", SimpleNamespace(config_restricted_column=0))
+    real_user = ub.User()
+    real_user.id = 1
+    real_user.name = "alice"
+    app_session.add(real_user)
+    app_session.commit()
+
     flask_app = Flask(__name__)
     flask_app.register_blueprint(module.kosync)
     state.client = flask_app.test_client()
@@ -258,27 +273,13 @@ def _seed_hidden_book(session, *, user_id, book_id):
     session.commit()
 
 
-def test_export_excludes_books_hidden_from_this_user(env, monkeypatch):
+def test_export_excludes_books_hidden_from_this_user(env):
     # SECURITY REGRESSION (#978 review): `document` is attacker-controlled —
     # update_progress stores any non-empty key verbatim — so the export's
     # Calibre enrichment query MUST apply the user's visibility filter, or a
     # restricted account can seed ids 1..N and enumerate the title + authors of
-    # books it isn't allowed to see. get_common_filters lives in cps.duplicates
-    # and reads that module's ub/db/config globals off the request context
-    # (current_user isn't populated on the Basic-auth path); wire them to the
-    # in-memory app DB and seed a real User + a UserHiddenBook.
-    import cps.duplicates as dup
-    monkeypatch.setattr(dup, "ub", SimpleNamespace(
-        session=env.app_session, User=ub.User,
-        ArchivedBook=ub.ArchivedBook, UserHiddenBook=ub.UserHiddenBook))
-    monkeypatch.setattr(dup, "config", SimpleNamespace(config_restricted_column=0))
-
-    user = ub.User()
-    user.id = 1
-    user.name = "alice"
-    env.app_session.add(user)
-    env.app_session.commit()
-
+    # books it isn't allowed to see. The env fixture already wires cps.duplicates
+    # to the in-memory app DB and seeds the real user; here we just hide one book.
     visible = _seed_book(env.calibre_session, title="Visible", authors=["A"])
     hidden = _seed_book(env.calibre_session, title="Hidden", authors=["B"])
     _seed_progress(env.app_session, document=str(visible.id), percentage=10.0)
@@ -291,6 +292,60 @@ def test_export_excludes_books_hidden_from_this_user(env, monkeypatch):
     assert titles == {"Visible"}          # the hidden book must not leak
     assert hidden.id not in ids
     assert visible.id in ids               # own visible progress still exported
+
+
+def test_visibility_filter_fails_closed_not_open(env, monkeypatch):
+    # SECURITY REGRESSION (#978 second review): get_common_filters defaults to a
+    # permissive true() when it can't build the per-user filter. As an
+    # authorization boundary the export must instead FAIL CLOSED — surface an
+    # error, never a silently-unrestricted dump. Force the filter build to raise
+    # and assert no metadata is returned.
+    import cps.duplicates as dup
+
+    def _boom(*a, **k):
+        raise RuntimeError("simulated visibility-filter failure")
+
+    monkeypatch.setattr(dup, "get_common_filters", _boom)
+
+    book = _seed_book(env.calibre_session, title="Secret", authors=["A"])
+    _seed_progress(env.app_session, document=str(book.id), percentage=10.0)
+
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code != 200          # error, not a 200 dump
+    assert b"Secret" not in resp.data       # no metadata leaked on failure
+
+
+def test_get_common_filters_strict_raises_for_unknown_user(env):
+    # Unit-level pin of the fail-closed contract: strict=True must raise (not
+    # return a permissive filter) when the user can't be reloaded.
+    import cps.duplicates as dup
+
+    # known user (id=1, seeded by the fixture) builds a real filter
+    built = dup.get_common_filters(user_id=1, strict=True)
+    assert built is not None
+    # unknown user under strict must raise, not fall open to true()
+    with pytest.raises(Exception):
+        dup.get_common_filters(user_id=99999, strict=True)
+    # …and without strict it stays permissive (backwards-compatible default)
+    assert dup.get_common_filters(user_id=99999) is not None
+
+
+def test_export_chunks_large_id_set_without_bind_overflow(env):
+    # DoS/robustness (#978 second review): a user with more numeric progress rows
+    # than the SQLite bound-parameter limit must still export — the endpoint
+    # chunks the IN() lookup. Seed >500 books (one chunk) + a few more so the
+    # loop crosses a chunk boundary.
+    n = 550
+    books = [_seed_book(env.calibre_session, title=f"B{i}", authors=[f"Author {i}"])
+             for i in range(n)]
+    for b in books:
+        _seed_progress(env.app_session, document=str(b.id), percentage=1.0)
+
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body) == n                 # every book exported across chunks
+    assert len({r["calibre_book_id"] for r in body}) == n
 
 
 def test_non_ascii_digit_document_is_not_aliased(env):

--- a/tests/unit/test_kosync_progress_export.py
+++ b/tests/unit/test_kosync_progress_export.py
@@ -1,0 +1,308 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Behaviour tests for ``GET /kosync/export``
+(cps/progress_syncing/protocols/kosync.py).
+
+Runs the endpoint's real SQL against two in-memory SQLite DBs — the app DB
+(``ub.Base``) and the Calibre metadata DB (``cps.db.Base``). They're separate
+databases that can't be SQL-joined, so the endpoint stitches them in Python;
+only the trust boundary (auth + feature gate) is stubbed.
+"""
+
+import sqlite3
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import cps
+from cps import ub
+from cps.progress_syncing.models import KOSyncProgress
+
+pytestmark = pytest.mark.unit
+
+CHECKSUM = "a" * 32  # a KOReader partial-MD5, the shape `document` really holds
+
+
+def _kosync_module():
+    # package __init__ rebinds the ``kosync`` name to the Blueprint; reach past
+    # it to the module via sys.modules
+    import sys
+    import cps.progress_syncing.protocols.kosync  # noqa: F401 — populate sys.modules
+    return sys.modules["cps.progress_syncing.protocols.kosync"]
+
+
+def _calibre_engine():
+    # Calibre tables live under an attached ``calibre`` schema (cps/db.py), so
+    # ATTACH one before create_all; StaticPool keeps the one connection alive.
+    def _creator():
+        conn = sqlite3.connect(":memory:", check_same_thread=False)
+        conn.execute("ATTACH DATABASE ':memory:' AS calibre")
+        return conn
+
+    engine = create_engine("sqlite+pysqlite://", creator=_creator, poolclass=StaticPool)
+    from cps.db import Base
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def _app_engine():
+    engine = create_engine("sqlite://", poolclass=StaticPool)
+    ub.Base.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def env(monkeypatch):
+    # export route wired to real in-memory app + Calibre DBs; mutable
+    # ``user``/``enabled`` let tests flip the caller and the feature gate
+    module = _kosync_module()
+
+    app_session = sessionmaker(bind=_app_engine())()
+    calibre_session = sessionmaker(bind=_calibre_engine())()
+
+    state = SimpleNamespace(
+        user=SimpleNamespace(id=1, name="alice"),
+        enabled=True,
+        app_session=app_session,
+        calibre_session=calibre_session,
+    )
+
+    monkeypatch.setattr(module, "ub", SimpleNamespace(
+        session=app_session, User=ub.User,
+        KoboReadingState=ub.KoboReadingState, KoboBookmark=ub.KoboBookmark))
+    monkeypatch.setattr(module, "is_koreader_sync_enabled", lambda: state.enabled)
+    monkeypatch.setattr(module, "authenticate_user", lambda: state.user)
+    # The export does `from ... import calibre_db`; that resolves cps.calibre_db.
+    monkeypatch.setattr(cps, "calibre_db", SimpleNamespace(session=calibre_session), raising=False)
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(module.kosync)
+    state.client = flask_app.test_client()
+    yield state
+    app_session.close()
+    calibre_session.close()
+
+
+def _seed_progress(session, *, user_id=1, document=CHECKSUM, percentage=45.67,
+                   device="KOReader", device_id="dev1", timestamp=None):
+    row = KOSyncProgress(
+        user_id=user_id, document=document, progress="/body/DocFragment[3]",
+        percentage=percentage, device=device, device_id=device_id,
+        timestamp=timestamp or datetime(2026, 7, 1, 10, 11, 12, tzinfo=timezone.utc),
+    )
+    session.add(row)
+    session.commit()
+    return row
+
+
+def _seed_book(session, *, title, authors):
+    # ``authors`` items are names, or ``(name, sort)`` to pin Authors.sort
+    from cps.db import Books, Authors
+
+    pairs = [(a, a) if isinstance(a, str) else a for a in authors]
+    now = datetime.now(timezone.utc)
+    book = Books(title, title, pairs[0][0], now, now, "1.0", now, "path", 1, [], [])
+    book.authors = [Authors(name, sort) for name, sort in pairs]
+    session.add(book)
+    session.commit()
+    return book
+
+
+def _seed_kobo_bookmark(session, *, user_id, book_id, created_at, last_modified):
+    # reading state + bookmark for (user, book): the export's created_at source
+    state = ub.KoboReadingState(user_id=user_id, book_id=book_id)
+    state.current_bookmark = ub.KoboBookmark(
+        created_at=created_at, last_modified=last_modified)
+    session.add(state)
+    session.commit()
+    return state
+
+
+# ── auth / feature gate (working behaviour) ─────────────────────────────────
+
+def test_unauthenticated_returns_401(env):
+    env.user = None
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 401
+    assert resp.get_json()["error"] == _kosync_module().ERROR_UNAUTHORIZED_USER
+
+
+def test_disabled_sync_is_blocked(env):
+    env.enabled = False
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 503
+
+
+def test_no_progress_returns_empty_json_array(env):
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 200
+    assert resp.mimetype == "application/json"
+    assert resp.get_json() == []
+
+
+# ── the real export ─────────────────────────────────────────────────────────
+
+def test_export_returns_the_users_progress(env):
+    book = _seed_book(env.calibre_session, title="The Dispossessed",
+                      authors=["Ursula K. Le Guin"])
+    _seed_progress(env.app_session, document=str(book.id), percentage=45.67)
+
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body) == 1
+    row = body[0]
+    assert row["calibre_book_id"] == book.id
+    # exported as stored 0–100, not KOReader's 0–1 decimal
+    assert row["percentage"] == pytest.approx(45.67)
+    assert row["title"] == "The Dispossessed"
+    assert row["authors"] == ["Ursula K. Le Guin"]
+
+
+def test_export_includes_started_and_modified_timestamps(env):
+    # created_at is the bookmark's (reading started); last_modified is the
+    # progress row's, NOT the bookmark's (Kobo syncs touch the bookmark alone).
+    book = _seed_book(env.calibre_session, title="Dune", authors=["Frank Herbert"])
+    synced = datetime(2026, 7, 1, 10, 11, 12, tzinfo=timezone.utc)
+    _seed_progress(env.app_session, document=str(book.id), timestamp=synced)
+    started = datetime(2026, 6, 1, 8, 0, 0, tzinfo=timezone.utc)
+    modified = datetime(2026, 7, 1, 9, 30, 0, tzinfo=timezone.utc)
+    _seed_kobo_bookmark(env.app_session, user_id=1, book_id=book.id,
+                        created_at=started, last_modified=modified)
+
+    row = env.client.get("/kosync/export").get_json()[0]
+    # naive UTC in SQLite re-attaches its offset on the way out
+    assert row["created_at"] == started.isoformat()
+    assert row["last_modified"] == synced.isoformat()
+
+
+def test_all_digit_checksum_is_omitted_too(env):
+    # All-digit checksum is decimal-parseable; the length cap keeps its int out
+    # of the in_() bind, which would otherwise overflow SQLite's int64.
+    _seed_progress(env.app_session, document="1" * 32, percentage=5.0)
+
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
+def test_decimal_document_with_no_library_book_is_omitted(env):
+    # Distinct from a checksum: a book id that reaches the Calibre query but
+    # matches nothing (book since deleted) — dropped, not a 500.
+    _seed_progress(env.app_session, document="999", percentage=20.0)
+
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
+def test_book_without_kobo_state_has_null_created_at(env):
+    # No bookmark to source created_at from, but the row still exports.
+    book = _seed_book(env.calibre_session, title="Neuromancer", authors=["William Gibson"])
+    _seed_progress(env.app_session, document=str(book.id))
+
+    row = env.client.get("/kosync/export").get_json()[0]
+    assert row["title"] == "Neuromancer"
+    assert row["created_at"] is None
+    assert row["last_modified"] is not None
+
+
+def test_multiple_authors_listed(env):
+    # ordered by Authors.sort, which inverts display-name order here
+    book = _seed_book(env.calibre_session, title="Co-Authored", authors=[
+        ("Brandon Sanderson", "Sanderson, Brandon"),
+        ("Robin Hobb", "Hobb, Robin")])
+    _seed_progress(env.app_session, document=str(book.id))
+
+    row = env.client.get("/kosync/export").get_json()[0]
+    assert row["authors"] == ["Robin Hobb", "Brandon Sanderson"]
+
+
+def test_resolvable_and_checksum_rows_coexist(env):
+    # Mid-migration (#633): the skip is per-row, so a resolvable row survives
+    # alongside a dropped legacy-checksum one.
+    book = _seed_book(env.calibre_session, title="Snow Crash", authors=["Neal Stephenson"])
+    _seed_progress(env.app_session, document=str(book.id), percentage=30.0)
+    _seed_progress(env.app_session, document="c" * 32, percentage=80.0)
+
+    body = env.client.get("/kosync/export").get_json()
+    assert [r["calibre_book_id"] for r in body] == [book.id]
+    assert body[0]["title"] == "Snow Crash"
+
+
+def test_export_is_scoped_to_authenticated_user(env):
+    mine = _seed_book(env.calibre_session, title="Mine", authors=["A"])
+    theirs = _seed_book(env.calibre_session, title="Theirs", authors=["B"])
+    _seed_progress(env.app_session, user_id=1, document=str(mine.id))
+    _seed_progress(env.app_session, user_id=2, document=str(theirs.id))
+
+    ids = {r["calibre_book_id"] for r in env.client.get("/kosync/export").get_json()}
+    assert ids == {mine.id}  # never another user's rows
+
+
+# ── security: per-user library-visibility restriction ───────────────────────
+
+def _seed_hidden_book(session, *, user_id, book_id):
+    # UserHiddenBook is one of the restrictions get_common_filters honours;
+    # it's the cheapest to exercise in-harness (no tags/custom-column config).
+    session.add(ub.UserHiddenBook(user_id=user_id, book_id=book_id))
+    session.commit()
+
+
+def test_export_excludes_books_hidden_from_this_user(env, monkeypatch):
+    # SECURITY REGRESSION (#978 review): `document` is attacker-controlled —
+    # update_progress stores any non-empty key verbatim — so the export's
+    # Calibre enrichment query MUST apply the user's visibility filter, or a
+    # restricted account can seed ids 1..N and enumerate the title + authors of
+    # books it isn't allowed to see. get_common_filters lives in cps.duplicates
+    # and reads that module's ub/db/config globals off the request context
+    # (current_user isn't populated on the Basic-auth path); wire them to the
+    # in-memory app DB and seed a real User + a UserHiddenBook.
+    import cps.duplicates as dup
+    monkeypatch.setattr(dup, "ub", SimpleNamespace(
+        session=env.app_session, User=ub.User,
+        ArchivedBook=ub.ArchivedBook, UserHiddenBook=ub.UserHiddenBook))
+    monkeypatch.setattr(dup, "config", SimpleNamespace(config_restricted_column=0))
+
+    user = ub.User()
+    user.id = 1
+    user.name = "alice"
+    env.app_session.add(user)
+    env.app_session.commit()
+
+    visible = _seed_book(env.calibre_session, title="Visible", authors=["A"])
+    hidden = _seed_book(env.calibre_session, title="Hidden", authors=["B"])
+    _seed_progress(env.app_session, document=str(visible.id), percentage=10.0)
+    _seed_progress(env.app_session, document=str(hidden.id), percentage=20.0)
+    _seed_hidden_book(env.app_session, user_id=1, book_id=hidden.id)
+
+    body = env.client.get("/kosync/export").get_json()
+    titles = {r["title"] for r in body}
+    ids = {r["calibre_book_id"] for r in body}
+    assert titles == {"Visible"}          # the hidden book must not leak
+    assert hidden.id not in ids
+    assert visible.id in ids               # own visible progress still exported
+
+
+def test_non_ascii_digit_document_is_not_aliased(env):
+    # `str.isdecimal()` accepts non-ASCII digits (e.g. Arabic-Indic "١") that
+    # int() folds onto the same value, so a non-ASCII document could alias — and
+    # resolve to — a real book id. Require ASCII digits: seed book id 1, then a
+    # progress row whose document is the Arabic-Indic "1"; it must NOT resolve.
+    book = _seed_book(env.calibre_session, title="One", authors=["A"])
+    assert book.id == 1  # first insert into a fresh in-memory Calibre DB
+    assert int("١") == book.id  # the alias int() would otherwise fold to
+    _seed_progress(env.app_session, document="١", percentage=5.0)
+
+    resp = env.client.get("/kosync/export")
+    assert resp.status_code == 200
+    assert resp.get_json() == []  # ASCII guard drops it instead of resolving to book 1


### PR DESCRIPTION
Adopts @Kyraminol's reading-progress export (#978) — re-created on a `new-usemame` branch so it can go through the autonomous merge gate, with two review fixes applied and regression tests added. Credit: @Kyraminol (#978).

## What it does
A new read-only, HTTP-Basic-authenticated endpoint `GET /kosync/export` returns the caller's KOReader reading progress (Calibre book id, title, authors, percentage, started / last-modified timestamps) as a JSON array, for feeding into another service. Auth matches the sibling KOSync endpoints (app passwords supported); results are scoped to the caller's own progress.

## Review + dispositions
- **Own `/code-review`-quality pass + prior `community-reviewed` disposition:** clean, well-scoped, tests exceed the anti-slop bar (real in-memory app + Calibre DBs, per-row skip coverage, user-scoping, timestamp sourcing).
- **`/security-review` (required — new authenticated route):** found **1 HIGH** — *Authorization Bypass / Metadata Disclosure*. `document` is attacker-controlled (`update_progress` stores any non-empty key verbatim), and the Calibre enrichment query omitted the per-user visibility predicate every other `Books` query applies. A restricted account could `PUT` progress for ids `1..N` then `GET /kosync/export` to enumerate the title/authors of books hidden from it (denied tags, hidden books, restricted custom column, language filter).
  - **FIXED:** the enrichment query now applies `.filter(get_common_filters(user_id=user.id))` — the same per-user visibility SSOT the duplicate scanner uses off the request context (`current_user` isn't populated on the Basic-auth path).
  - **Also hardened (review recommendation):** book-id parsing now requires ASCII digits (`_is_ascii_book_id`), so non-ASCII Unicode digits can't alias onto a real id via `int()`.
  - Dismissed-with-reason by the review and re-confirmed: SQLi (parameterized), int overflow (255-char cap + length guard), cross-user leak (`user_id`-scoped), CSRF-exempt read-only GET (Basic-auth, non-cookie), app-password scope (no scope boundary crossed).

## Tests (red/green demonstrated)
`tests/unit/test_kosync_progress_export.py` runs the endpoint's real SQL against in-memory app + Calibre DBs. 13 tests, all green with the fix.
- Without the endpoint (main): **11 failed**. With it: **11 passed**.
- New security regressions — without the fix: **2 failed** (`test_export_excludes_books_hidden_from_this_user`, `test_non_ascii_digit_document_is_not_aliased`); with the fix: **green**.

## Live verification (isolated container off `calibre-web-nextgen:local`)
- Route registered (not 404); `GET /kosync/export` with no/bad auth → **401**; CSRF-exempt GET (no token) reaches auth, not a CSRF 400.
- Valid admin auth → **200 `[]`** — `get_common_filters(user_id=...)` executes cleanly in real production context (real `app.db` + `config`), no traceback in logs.
- Feature gate honoured (503 when KOReader sync disabled).

No new dependencies, licenses, or external URLs. Not an upstream backport (fork-original community contribution), so no `CHANGES-vs-upstream.md` row.
