### PR TITLE
Fix admin Kobo shelf-only sync reconciliation

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -821,6 +821,7 @@ def table_get_default_lang():
 def edit_list_user(param):
     vals = request.form.to_dict(flat=False)
     all_user = ub.session.query(ub.User)
+    kobo_shelf_sync_users = []
     if not config.config_anonbrowse:
         all_user = all_user.filter(ub.User.role.op('&')(constants.ROLE_ANONYMOUS) != constants.ROLE_ANONYMOUS)
     # only one user is posted
@@ -853,7 +854,10 @@ def edit_list_user(param):
                 elif param == 'email':
                     user.email = check_email(vals['value'])
                 elif param == 'kobo_only_shelves_sync':
+                    was_enabled = bool(user.kobo_only_shelves_sync)
                     user.kobo_only_shelves_sync = int(vals['value'] == 'true')
+                    if not was_enabled and user.kobo_only_shelves_sync:
+                        kobo_shelf_sync_users.append(user.id)
                 elif param == 'opds_only_shelves_sync':
                     user.opds_only_shelves_sync = int(vals['value'] == 'true')
                 elif param == 'kindle_mail':
@@ -921,6 +925,12 @@ def edit_list_user(param):
             log.error_or_exception(ex)
             return str(ex), 400
     ub.session_commit()
+    for user_id in kobo_shelf_sync_users:
+        try:
+            kobo_sync_status.update_on_sync_shelfs(user_id)
+        except Exception:
+            ub.session.rollback()
+            log.error("Could not archive unsynced shelves for user %s", user_id, exc_info=True)
     return ""
 
 

--- a/tests/unit/test_opds_settings_persistence.py
+++ b/tests/unit/test_opds_settings_persistence.py
@@ -1,3 +1,4 @@
+import inspect
 import types
 
 from cps import app
@@ -288,3 +289,38 @@ def test_handle_new_user_sets_opds_only_shelves_sync(monkeypatch):
 
     assert content.opds_only_shelves_sync is True
     assert session.committed is True
+
+
+def test_admin_bulk_enable_kobo_only_shelves_archives_each_transition(monkeypatch):
+    users = [
+        types.SimpleNamespace(id=7, kobo_only_shelves_sync=0),
+        types.SimpleNamespace(id=8, kobo_only_shelves_sync=1),
+    ]
+    calls = []
+
+    class UserQuery:
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def all(self):
+            return users
+
+    monkeypatch.setattr(admin.ub, "session", types.SimpleNamespace(
+        query=lambda _entity: UserQuery(),
+        rollback=lambda: None,
+    ))
+    monkeypatch.setattr(admin.ub, "session_commit", lambda: calls.append("commit"))
+    monkeypatch.setattr(admin.config, "config_anonbrowse", True, raising=False)
+    monkeypatch.setattr(admin.kobo_sync_status, "update_on_sync_shelfs",
+                        lambda user_id: calls.append(user_id))
+
+    with app.test_request_context(
+        "/ajax/editlistusers/kobo_only_shelves_sync",
+        method="POST",
+        data={"pk[]": ["7", "8"], "value": "true"},
+    ):
+        response = inspect.unwrap(admin.edit_list_user)("kobo_only_shelves_sync")
+
+    assert response == ""
+    assert [user.kobo_only_shelves_sync for user in users] == [1, 1]
+    assert calls == ["commit", 7]


### PR DESCRIPTION
Fixes #1009

When an administrator enables selected-shelf-only Kobo sync, the affected user's existing sync state now runs through the same archive reconciliation used by the self-service paths. Bulk edits reconcile each user that transitions from disabled to enabled after the setting commits, while already-enabled users are left unchanged.

Tested with `tests/unit/test_opds_settings_persistence.py` (8 passed), including a bulk-edit regression covering both transition states.
