### PR TITLE
Draft: fix(docker): create symlinks to finalize Calibre installation (#875)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -378,6 +378,10 @@ RUN \
 # Add unrar from unrar stage
 COPY --from=unrar /usr/bin/unrar-ubuntu /usr/bin/unrar
 
+# Complete the Calibre installation so `calibre-binaries-setup` properly
+# detects that it is already installed.
+RUN find /app/calibre -maxdepth 1 -type f -exec ln -s {} /usr/bin \;
+
 # Deliberately NO global CALIBRE_CONFIG_DIRECTORY here. (A misspelled
 # CALIBRE_CONFIG_DIR lived here for a while -- Calibre ignores that name,
 # and setting the real one globally would force user-plugin loading on for


### PR DESCRIPTION
Finalize the manual install of Calibre so `calibre-binaries-setup` does not reinstall it again.

Fixes #875.

---

Draft, since I am not sure this is how you wanted to fix it.

I followed [your advice](https://github.com/new-usemame/Calibre-Web-NextGen/issues/875#issuecomment-4957851706) that "only the symlink setup moves to build".

Testing protocol:

- `docker compose up --build`
- tried various operations (uploading a book, editing it...).

Logs:

```
2026-07-20T08:32:31.841061217Z [calibre-binaries-setup] Starting Calibre binaries setup...
2026-07-20T08:32:31.841065931Z [calibre-binaries-setup] Checking if Calibre is already installed...
[...]
2026-07-20T08:32:32.532970912Z [calibre-binaries-setup] Calibre version check result: calibredb (calibre 9.1)
2026-07-20T08:32:32.533239558Z [calibre-binaries-setup] Skipping setup, Calibre already installed: calibredb (calibre 9.1)
2026-07-20T08:32:32.533250667Z [calibre-binaries-setup] Service completed successfully, exiting...
```