### PR TITLE
feat: reduce /duplicates/status polling

### DIFF
--- a/cps/static/js/duplicate-notifier.js
+++ b/cps/static/js/duplicate-notifier.js
@@ -8,7 +8,7 @@
     
     const STORAGE_KEY = 'cwa_duplicates_notification_shown';
     const LAST_COUNT_KEY = 'cwa_duplicates_last_count';
-    const POLL_INTERVAL_MS = 2500;
+    const POLL_INTERVAL_MS = 60 * 1000;
     const POLL_MAX_ATTEMPTS = 60; // ~2.5 minutes
     
     let currentDuplicateCount = 0;


### PR DESCRIPTION
Related to issue [#1288](https://github.com/crocodilestick/Calibre-Web-Automated/issues/1288) on the original repository. My personal opinion is that polling every 2.5 seconds is too frequent.

This suggests setting it to a minute. As it's subjective, feel free to edit the polling interval to something else.