### PR TITLE
Classic UI: add a way to support the project (both themes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+- **The classic interface now has a way to support the project.** There was no link anywhere in the classic UI — only the new interface had one — so anyone who wanted to chip in had to go looking for it. There is now a "Support Calibre-Web NextGen" entry in the user menu, in both the default and caliBlur themes.
+
 ### Fixed
 
 - **The new UI no longer signs you out when a request doesn't make it through.** Clicking between shelves could spin and then drop you on the sign-in page, and signing back in didn't help for long — "remember me" included. The new UI treated any request that failed to reach the server as proof your session had expired, and it responded by ending the session for real, so one dropped request on a busy or slow server logged you out for good. It now checks whether you're actually still signed in before doing anything, and a request that simply didn't get through is reported as an error instead. Sessions that genuinely have expired still return you to the sign-in page as before. Reported by [@mrfearless](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1067) ([#1067](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1067)).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Latest release](https://img.shields.io/github/v/release/new-usemame/Calibre-Web-NextGen)](https://github.com/new-usemame/Calibre-Web-NextGen/releases/latest)
 [![Container](https://img.shields.io/badge/ghcr.io-calibre--web--nextgen-blue?logo=docker)](https://github.com/new-usemame/Calibre-Web-NextGen/pkgs/container/calibre-web-nextgen)
 [![Open issues](https://img.shields.io/github/issues/new-usemame/Calibre-Web-NextGen)](https://github.com/new-usemame/Calibre-Web-NextGen/issues)
-[![Support monthly on Ko-fi](https://img.shields.io/badge/Ko--fi-Subscribe%20monthly-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/calibrewebnextgen)
+[![Support monthly on Ko-fi](https://img.shields.io/badge/Ko--fi-Subscribe%20monthly-cc7b19?logo=kofi&logoColor=white)](https://ko-fi.com/calibrewebnextgen)
 
 ---
 

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -347,6 +347,8 @@
                     {% if not current_user.is_anonymous %}
                     <li><a id="logout" href="{{url_for('web.logout', next=(request.path + "?" + request.query_string.decode("utf-8")).rstrip("?"))}}"><span class="glyphicon glyphicon-log-out"></span> <span class="hidden-sm">{{_('Logout')}}</span></a></li>
                     {% endif %}
+                    <li role="separator" class="divider"></li>
+                    <li><a id="top_support" href="https://ko-fi.com/calibrewebnextgen" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-heart"></span> <span class="hidden-sm">{{_('Support Calibre-Web NextGen')}}</span></a></li>
                 </ul>
               </li>
               {% endif %}
@@ -376,6 +378,10 @@
               <li><a id="refresh-library" style="cursor: pointer;" data-text="{{_('Refresh Library')}}" onclick="refreshLibrary()"><span class="glyphicon glyphicon-refresh"></span> <span class="hidden-sm">{{_('Refresh Library')}}</span></a></li>
               {% if g.current_theme == 0 %}
               <li><a id="top_user" data-text="{{_('Account')}}" href="{% if not current_user.is_anonymous %}{{url_for('web.profile')}}{% else %}{{url_for('web.login', next=(request.path + "?" + request.query_string.decode("utf-8")).rstrip("?"))}}{% endif %}"><span class="glyphicon glyphicon-user"></span> <span class="hidden-sm">{{current_user.name}}</span></a></li>
+                {# Support link lives in BOTH themes: the caliBlur profile dropdown
+                   renders only when g.current_theme == 1, so a single placement
+                   there would be invisible to everyone on the default theme. #}
+                <li><a id="top_support" data-text="{{_('Support')}}" href="https://ko-fi.com/calibrewebnextgen" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-heart"></span> <span class="hidden-sm">{{_('Support Calibre-Web NextGen')}}</span></a></li>
                 {% if not current_user.is_anonymous %}
                 <li><a id="logout" href="{{url_for('web.logout', next=(request.path + "?" + request.query_string.decode("utf-8")).rstrip("?"))}}"><span class="glyphicon glyphicon-log-out"></span> <span class="hidden-sm">{{_('Logout')}}</span></a></li>
                 {% endif %}

--- a/tests/unit/test_classic_support_link.py
+++ b/tests/unit/test_classic_support_link.py
@@ -1,0 +1,56 @@
+"""The classic UI must offer a way to support the project — in BOTH themes.
+
+The classic layout renders two different user-menu blocks: a profile dropdown
+that only exists when `g.current_theme == 1` (caliBlur), and a flat list of
+items for `g.current_theme == 0` (the default theme). A link added to only one
+of them is invisible to half the users — the recurring trap in this template,
+and the reason cwn-local (which forces caliBlur) can look fine while the
+default theme is missing the feature entirely.
+"""
+import re
+from pathlib import Path
+
+LAYOUT = Path(__file__).resolve().parents[2] / "cps" / "templates" / "layout.html"
+KOFI = "https://ko-fi.com/calibrewebnextgen"
+
+
+def _layout():
+    return LAYOUT.read_text(encoding="utf-8")
+
+
+def test_support_link_present_twice_once_per_theme():
+    src = _layout()
+    assert src.count('id="top_support"') == 2, (
+        "expected one support link in the caliBlur profile dropdown and one in "
+        "the default-theme user menu"
+    )
+
+
+def test_support_link_points_at_the_project_kofi_page():
+    src = _layout()
+    for m in re.finditer(r'id="top_support"[^>]*href="([^"]+)"', src):
+        assert m.group(1) == KOFI, f"support link points at {m.group(1)}"
+
+
+def test_support_link_opens_safely_in_a_new_tab():
+    # target=_blank without rel=noopener lets the opened page reach back via
+    # window.opener; this is an external link so both attributes are required.
+    for tag in re.findall(r'<a id="top_support".*?>', _layout()):
+        assert 'target="_blank"' in tag
+        assert "noopener" in tag and "noreferrer" in tag
+
+
+def test_support_label_is_translatable():
+    # Every user-visible string in this project goes through gettext, or the
+    # msgid never reaches the translators and non-English users see English.
+    for tag in re.findall(r'<a id="top_support".*?</a>', _layout(), re.S):
+        assert "_('Support Calibre-Web NextGen')" in tag
+
+
+def test_default_theme_block_contains_a_support_link():
+    src = _layout()
+    start = src.index("{% if g.current_theme == 0 %}")
+    end = src.index("{% endif %}", src.index('id="logout"', start))
+    assert 'id="top_support"' in src[start:end], (
+        "default-theme (g.current_theme == 0) user menu has no support link"
+    )


### PR DESCRIPTION
## Why

There was no support link anywhere in the classic interface. The Ko-fi link existed only in the React UI — the top bar menu and the dismissible banner — so users still on the classic theme, which is a large share of them, had no way to find it from inside the app at all.

## What changed

A "Support Calibre-Web NextGen" entry in the classic user menu, plus the README badge recoloured from Ko-fi red to the project's own amber (`#cc7b19`, straight from `frontend/src/styles/tokens.css`).

**It is added in both classic themes, deliberately.** `layout.html` renders two different user menus: a profile dropdown that only exists when `g.current_theme == 1` (caliBlur), and a flat item list for `g.current_theme == 0` (default). Putting the link in just the dropdown would have made it invisible to everyone on the default theme — and our local container forces caliBlur, so that failure would not have shown up in testing.

Placement is the user menu rather than a banner or the main nav: discoverable when you go looking, without nagging every reader on someone else's server.

## Verification

 — 5 assertions, red before and green after (2 fail on `main`: the link count and the default-theme block check):
- the link appears exactly twice, once per theme block
- both point at the project Ko-fi page
- both carry `target="_blank"` **with** `rel="noopener noreferrer"` (external link — without it the opened page can reach back through `window.opener`)
- the label goes through `gettext` so translators actually receive it
- the `g.current_theme == 0` block specifically contains a link

i18n: `babel.cfg` extracts `cps/templates/**.*ml`, and the German catalog already carries 76 msgids from `layout.html`, so the new string is on the normal extraction path and the translation job will fill it. `scripts/compile_translations.sh` runs clean at 28/28 locales and `test_translations_compile.py` passes.

Addresses the gap where supporting the project was only discoverable in the new UI.