### PR TITLE
feat: Add identifiers to KOSync export

### DIFF
--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -769,7 +769,8 @@ def _is_ascii_book_id(document: str) -> bool:
 @kosync.route("/kosync/export", methods=["GET"])
 def export_progress():
     """
-    Export all the authenticated user's reading progress as JSON, plus book title and authors.
+    Export all the authenticated user's reading progress as JSON,
+    plus book title, authors and identifiers.
 
     Not part of the KOReader protocol, it's meant to be a bulk read-only export
     to feed data into other services.
@@ -785,7 +786,8 @@ def export_progress():
             "last_modified": "...", # From the kosync progress timestamp
             "percentage": 45.67,
             "title": "...",
-            "authors": [...]        # [] for books without authors
+            "authors": [...],       # [] for books without authors
+            "identifiers": {...},   # {type: value} map, {} when none found
         }
 
     Timestamps are UTC, ISO 8601 with explicit offset. Rows that don't resolve
@@ -811,7 +813,7 @@ def export_progress():
 
     try:
         from ... import calibre_db
-        from ...db import Authors, books_authors_link, Books
+        from ...db import Authors, books_authors_link, Books, Identifiers
         from ...duplicates import get_common_filters
 
         progress_rows = (
@@ -884,12 +886,30 @@ def export_progress():
                     .order_by(Books.id, Authors.sort)
                     .all()
                 )
+                matched_ids = set()
                 for book_id, title, author_name in calibre_query:
+                    matched_ids.add(book_id)
                     entry = calibre_books.setdefault(
-                        book_id, {"title": title, "authors": []}
+                        book_id, {"title": title, "authors": [], "identifiers": {}}
                     )
                     if author_name and author_name not in entry["authors"]:
                         entry["authors"].append(author_name)
+
+                # SECURITY: visibility_filter is not needed since matched_ids
+                # contains already visibility filtered entries only
+                if matched_ids:
+                    identifier_rows = (
+                        calibre_db.session.query(
+                            Identifiers.book, Identifiers.type, Identifiers.val
+                        )
+                        .filter(Identifiers.book.in_(matched_ids))
+                        .all()
+                    )
+                    for book_id, identifier_type, identifier_value in identifier_rows:
+                        if identifier_type and identifier_value:
+                            calibre_books[book_id]["identifiers"][
+                                identifier_type.lower()
+                            ] = identifier_value
 
         def utc_isoformat(value):
             return value.replace(tzinfo=timezone.utc).isoformat() if value else None
@@ -911,6 +931,7 @@ def export_progress():
                     "percentage": row.percentage,
                     "authors": book["authors"],
                     "title": book["title"],
+                    "identifiers": book["identifiers"],
                 }
             )
 

--- a/tests/unit/test_kosync_progress_export.py
+++ b/tests/unit/test_kosync_progress_export.py
@@ -119,9 +119,10 @@ def _seed_progress(session, *, user_id=1, document=CHECKSUM, percentage=45.67,
     return row
 
 
-def _seed_book(session, *, title, authors):
-    # ``authors`` items are names, or ``(name, sort)`` to pin Authors.sort
-    from cps.db import Books, Authors
+def _seed_book(session, *, title, authors, identifiers=None):
+    # ``authors`` items are names, or ``(name, sort)`` to pin Authors.sort;
+    # ``identifiers`` is a {type: value} dict landing in the identifiers table
+    from cps.db import Books, Authors, Identifiers
 
     pairs = [(a, a) if isinstance(a, str) else a for a in authors]
     now = datetime.now(timezone.utc)
@@ -129,6 +130,10 @@ def _seed_book(session, *, title, authors):
     book.authors = [Authors(name, sort) for name, sort in pairs]
     session.add(book)
     session.commit()
+    for id_type, id_val in (identifiers or {}).items():
+        session.add(Identifiers(id_val, id_type, book.id))
+    if identifiers:
+        session.commit()
     return book
 
 
@@ -168,7 +173,8 @@ def test_no_progress_returns_empty_json_array(env):
 
 def test_export_returns_the_users_progress(env):
     book = _seed_book(env.calibre_session, title="The Dispossessed",
-                      authors=["Ursula K. Le Guin"])
+                      authors=["Ursula K. Le Guin"],
+                      identifiers={"isbn": "9780061054884"})
     _seed_progress(env.app_session, document=str(book.id), percentage=45.67)
 
     resp = env.client.get("/kosync/export")
@@ -181,6 +187,7 @@ def test_export_returns_the_users_progress(env):
     assert row["percentage"] == pytest.approx(45.67)
     assert row["title"] == "The Dispossessed"
     assert row["authors"] == ["Ursula K. Le Guin"]
+    assert row["identifiers"] == {"isbn": "9780061054884"}
 
 
 def test_export_includes_started_and_modified_timestamps(env):
@@ -254,6 +261,21 @@ def test_resolvable_and_checksum_rows_coexist(env):
     assert body[0]["title"] == "Snow Crash"
 
 
+def test_identifiers_exported(env):
+    # Every identifier type is exported as a {type: value} map: values verbatim,
+    # type keys lowercased; a book without identifiers exports {}.
+    tagged = _seed_book(env.calibre_session, title="Tagged", authors=["A"],
+                        identifiers={"ISBN": "0-441-56956-0", "Goodreads": "40651883"})
+    bare = _seed_book(env.calibre_session, title="Bare", authors=["B"])
+    _seed_progress(env.app_session, document=str(tagged.id))
+    _seed_progress(env.app_session, document=str(bare.id))
+
+    rows = {r["title"]: r for r in env.client.get("/kosync/export").get_json()}
+    assert rows["Tagged"]["identifiers"] == {
+        "isbn": "0-441-56956-0", "goodreads": "40651883"}
+    assert rows["Bare"]["identifiers"] == {}
+
+
 def test_export_is_scoped_to_authenticated_user(env):
     mine = _seed_book(env.calibre_session, title="Mine", authors=["A"])
     theirs = _seed_book(env.calibre_session, title="Theirs", authors=["B"])
@@ -280,8 +302,10 @@ def test_export_excludes_books_hidden_from_this_user(env):
     # restricted account can seed ids 1..N and enumerate the title + authors of
     # books it isn't allowed to see. The env fixture already wires cps.duplicates
     # to the in-memory app DB and seeds the real user; here we just hide one book.
-    visible = _seed_book(env.calibre_session, title="Visible", authors=["A"])
-    hidden = _seed_book(env.calibre_session, title="Hidden", authors=["B"])
+    visible = _seed_book(env.calibre_session, title="Visible", authors=["A"],
+                         identifiers={"isbn": "9780000000002"})
+    hidden = _seed_book(env.calibre_session, title="Hidden", authors=["B"],
+                        identifiers={"isbn": "9780000000001"})
     _seed_progress(env.app_session, document=str(visible.id), percentage=10.0)
     _seed_progress(env.app_session, document=str(hidden.id), percentage=20.0)
     _seed_hidden_book(env.app_session, user_id=1, book_id=hidden.id)
@@ -292,6 +316,12 @@ def test_export_excludes_books_hidden_from_this_user(env):
     assert titles == {"Visible"}          # the hidden book must not leak
     assert hidden.id not in ids
     assert visible.id in ids               # own visible progress still exported
+    # identifiers are scoped to visibility-matched ids only: the visible book
+    # keeps its own, and the hidden book's identifier must surface on no row.
+    visible_row = next(r for r in body if r["calibre_book_id"] == visible.id)
+    assert visible_row["identifiers"] == {"isbn": "9780000000002"}
+    all_ident_values = {v for r in body for v in r["identifiers"].values()}
+    assert "9780000000001" not in all_ident_values
 
 
 def test_visibility_filter_fails_closed_not_open(env, monkeypatch):


### PR DESCRIPTION
This PR aims to add a new field in the KOSync export route to export book identifiers values verbatim without normalization (keys are normalized to `.lower()` following project usages). Goal is to have more data on export to help ingesting services match the book correctly.
It is achieved by adding a new query to calibre_db using a book_id array from current chunk, filtering only already matched books from previous calibre_db query. `visibility_filter` is not applied in the new query since we use ids of an already filtered query.
I opted for a new query to avoid adding another outer_join that will fan-out n*m entries, new query keeps row count low and scoped.

## Changes
#### `kosync.py`
Flow:
- `"identifiers": {}` added to setdefault
- Query to calibre_db identifiers using current chunk book_ids, filtered by already matched calibre_db books
- Enrich calibre_books metadata with new queried data
- Emit `identifiers` field in `result.append` loop

#### `test_kosync_progress_export.py`
- Added and updated unit tests to reflect new behavior, including a test to  ensure that not-visible ids are not leaked into new query.
