### PR TITLE
Pin the cross-thread session defect behind #1048 (#1121)

### DIFF
--- a/tests/quarantine.py
+++ b/tests/quarantine.py
@@ -46,8 +46,18 @@ _REAL_BUG = (
     "correct and should go green by fixing the lookup, not by changing them. #1109"
 )
 
+_SHARED_SESSION = (
+    "asserts the fix for #1121, not current behaviour: CalibreDB.init_session "
+    "publishes the calling thread's scoped_session onto a shared attribute, so "
+    "a request thread's session is replaced whenever a background task starts "
+    "one. RED by design until the session resolves per-thread. #1121"
+)
+
 #: node id -> why it is skipped. Every reason must name an issue.
 QUARANTINED = {
+    # --- asserts a fix that has not landed yet (1) --------------------------
+    "tests/unit/test_1121_session_is_thread_local.py::test_a_thread_keeps_its_own_session_after_another_thread_starts_one": _SHARED_SESSION,
+
     # --- shim rot: the duplicate-detection module loaders (30) -------------
     "tests/unit/test_duplicate_delete_index_maintenance.py::test_auto_resolve_duplicates_deletes_duplicate_keys_and_refreshes_cache": _SHIM_ROT,
     "tests/unit/test_duplicate_delete_index_maintenance.py::test_delete_book_from_table_format_only_keeps_duplicate_keys_and_invalidates_cache": _SHIM_ROT,

--- a/tests/unit/test_1121_session_is_thread_local.py
+++ b/tests/unit/test_1121_session_is_thread_local.py
@@ -1,0 +1,126 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""#1121 — `calibre_db.session` must be per-thread, and currently is not.
+
+`CalibreDB.session_factory` is a `scoped_session`, which hands each thread its
+own Session. `init_session()` then does `self.session = self.session_factory()`,
+storing that thread's Session on a **single shared attribute** of a
+module-level singleton. Whichever thread called `init_session()` most recently
+publishes its Session there, and the ~270 call sites that read
+`calibre_db.session` all get it — so the thread-locality the wrapper exists to
+provide is discarded by the assignment.
+
+CWNG runs gevent WITHOUT `monkey.patch_all()` (see the AST guard in
+`test_no_stdlib_futures_on_request_path`), so `WorkerThread` is a real OS
+thread. Two genuinely concurrent users of one Session and one SQLite
+connection.
+
+OBSERVED, and what this file pins: a thread's session changes underneath it
+once another thread calls `init_session()`. Proven below.
+
+NOT OBSERVED, and deliberately not asserted here: that this sharing is what
+produces the #1048 traceback (`sqlite3.ProgrammingError: Cannot operate on a
+closed database`, raised from `sqlalchemy/orm/loading.py` `chunks` 161 ms after
+`Manual scan queued`, with `cps/tasks/duplicate_scan.py:325` calling
+`calibre_db.session.close()` at task teardown). Two attempts to reproduce that
+link failed: a Session survives `close()` and simply re-acquires a connection,
+even under NullPool, so the sequential close-then-use path is harmless. The
+reporter's traceback is a cursor being drained, so reproducing it needs a
+genuine mid-fetch interleave — a worker closing while a request thread is
+partway through a large result set. Until someone builds that, the crash
+mechanism stays a hypothesis and should be described as one.
+
+The sharing is a real defect on its own merits regardless: 270 call sites read
+a session that any thread can replace.
+
+This test asserts the CORRECT behaviour, so it is RED until #1121 is fixed and
+is quarantined in `tests/quarantine.py` with that issue reference. It goes green
+on its own once `session` resolves per-thread rather than being assigned to a
+shared attribute.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _isolated_calibredb():
+    """A CalibreDB wired to a throwaway engine, with the real session plumbing."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import scoped_session, sessionmaker
+
+    from cps.db import CalibreDB
+
+    tmp = tempfile.mkdtemp()
+    engine = create_engine(f"sqlite:///{tmp}/probe.db", future=True)
+    CalibreDB.engine = engine
+    CalibreDB.session_factory = scoped_session(
+        sessionmaker(bind=engine, autocommit=False, autoflush=True, future=True))
+    return CalibreDB(), CalibreDB
+
+
+def test_scoped_session_really_does_hand_each_thread_its_own():
+    """Baseline. If this ever fails the premise is wrong, not the code."""
+    _, cls = _isolated_calibredb()
+    seen = {}
+
+    def grab(name):
+        seen[name] = id(cls.session_factory())
+
+    for name in ("a", "b"):
+        t = threading.Thread(target=grab, args=(name,))
+        t.start()
+        t.join()
+
+    assert seen["a"] != seen["b"], (
+        "scoped_session returned the same Session to two threads — the whole "
+        "premise of #1121 depends on it not doing that")
+
+
+def test_a_thread_keeps_its_own_session_after_another_thread_starts_one():
+    """RED until #1121 is fixed.
+
+    The ordering is the point, and it is the real one: a request thread is
+    already working when a background task starts. The worker publishes its
+    Session over the shared attribute, and the request thread's *next* read of
+    `calibre_db.session` silently returns the worker's.
+    """
+    db, _ = _isolated_calibredb()
+    request_ready = threading.Event()
+    worker_done = threading.Event()
+    seen = {}
+
+    def request_thread():
+        db.init_session()
+        seen["request_first"] = id(db.session)
+        request_ready.set()
+        worker_done.wait(5)
+        seen["request_second"] = id(db.session)
+
+    def worker_thread():
+        request_ready.wait(5)
+        db.init_session()
+        seen["worker"] = id(db.session)
+        worker_done.set()
+
+    threads = [threading.Thread(target=request_thread),
+               threading.Thread(target=worker_thread)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(10)
+
+    assert seen["request_first"] != seen["worker"], "the two threads must not share a Session"
+    assert seen["request_second"] == seen["request_first"], (
+        "the request thread's session changed underneath it: it read %s at the "
+        "start and %s after the worker ran, which is the worker's (%s). Every "
+        "one of the ~270 `calibre_db.session` call sites is exposed to this "
+        "(#1121)" % (seen["request_first"], seen["request_second"], seen["worker"]))


### PR DESCRIPTION
Addresses #1121. Test-only — no runtime change.

## What is proven

`CalibreDB.session_factory` is a `scoped_session` (thread-local). `init_session()` then does `self.session = self.session_factory()`, storing the calling thread's Session on a **single shared attribute** of a module-level singleton. The thread-locality is discarded by the assignment, and the ~270 call sites that read `calibre_db.session` all get whichever thread published last.

This matters more here than in a typical Flask app: CWNG runs gevent **without** `monkey.patch_all()`, so `WorkerThread` is a real OS thread — two genuinely concurrent users of one Session.

The test sequences a request thread and a worker deliberately and shows the request thread's session being replaced underneath it:

```
the request thread's session changed underneath it: it read 4524777568 at the
start and 4524777424 after the worker ran, which is the worker's (4524777424)
```

RED by design, quarantined against #1121 per `tests/quarantine.py`. It goes green on its own when `session` resolves per-thread.

## What is NOT proven, and why there is no test claiming it

I could not reproduce the link from this defect to the #1048 traceback (`Cannot operate on a closed database` from `orm/loading.py` `chunks`, 161 ms after `Manual scan queued`, with `duplicate_scan.py:325` calling `calibre_db.session.close()`).

Two attempts failed:

1. The request thread capturing `mine = db.session` — passes, because the worker closes the Session *it* published and a captured reference survives.
2. The request thread re-reading `calibre_db.session` fresh, as real call sites do — also passes, because a SQLAlchemy Session survives `close()` and simply re-acquires a connection, even under `NullPool`.

The reporter's traceback is a cursor being **drained**, so reproducing it needs a genuine mid-fetch interleave — a worker closing while a request thread is partway through a large result set. Until someone builds that, the crash mechanism is a hypothesis.

I wrote that second test, watched it pass, and deleted it rather than ship it with a docstring asserting a mechanism it did not demonstrate. A test that passes for the wrong reason is worse than no test: it reads as coverage.

The sharing is a real defect on its own merits regardless of whether it is #1048's proximate cause.

## Fix direction (not in this PR)

Make `session` resolve through the `scoped_session` registry per call rather than being assigned to a shared attribute. That touches 270 call sites' semantics and deserves its own change with the reproduction above as its gate.

Rule 6: no new dependency, license or external URL.