### PR TITLE
Update the admin affordance spec to the row #1048 shipped

### DIFF
--- a/frontend/e2e/admin-classic-affordance.spec.ts
+++ b/frontend/e2e/admin-classic-affordance.spec.ts
@@ -7,7 +7,17 @@ test('advanced server links disclose the intentional classic-view transition (#9
     .filter({ hasText: 'Opens in classic view' });
   await expect(cards).toHaveCount(8);
 
-  const duplicates = page.getByRole('link', { name: 'Duplicate books' });
-  await expect(duplicates).toHaveAttribute('href', /\/app\/duplicates$/);
-  await expect(duplicates).not.toContainText('Opens in classic view');
+  // #1048 replaced this row. It used to read "Duplicate books" and link to
+  // /app/duplicates — the exact page the sidebar already opens, which is why
+  // @auspex reported the admin entry as doing nothing. From the admin panel the
+  // useful destination is the duplicate-detection *configuration*, so it now
+  // deep-links into the classic settings page and discloses that, like every
+  // other classic destination here.
+  //
+  // This assertion was left pointing at the old row when that shipped, so the
+  // spec has been red ever since — invisible because E2E does not gate PRs
+  // (#953). Updated to the row that actually exists.
+  const duplicates = page.getByRole('link', { name: /Duplicate detection settings/ });
+  await expect(duplicates).toHaveAttribute('href', /cwa-settings#duplicate-detection$/);
+  await expect(duplicates).toContainText('Opens in classic view');
 });


### PR DESCRIPTION
Test-only.

`admin-classic-affordance.spec.ts` still asserts a **"Duplicate books"** row linking to `/app/duplicates`. #1048 deliberately replaced it — that row pointed at the exact page the sidebar already opens, which is precisely what @auspex reported as the admin entry "doing nothing". It now deep-links into the duplicate-detection configuration and discloses the classic-view transition like every other classic destination there.

The assertion was never updated, so the spec has been **red since #1048 merged** — invisible, because `E2E Tests (SPA)` does not gate PRs (#953).

Found while verifying the affordance still works for #1113: the banner and all eight "Opens in classic view" cards pass; only this stale row failed.

```
before: 1 failed   (element(s) not found — "Duplicate books")
after:  2 passed
```

This is a small instance of the #953 cost: a suite that does not gate rots quietly, and the rot is only found by someone running it by hand.