### PR TITLE
Repair search-after-edit, stale on two counts (#1130)

### DIFF
--- a/frontend/e2e/search-after-edit.spec.ts
+++ b/frontend/e2e/search-after-edit.spec.ts
@@ -3,9 +3,21 @@ import { test, expect, type Page } from '@playwright/test';
 type BooksPage = { items: Array<Record<string, unknown>>; total: number };
 
 async function search(page: Page, title: string) {
-  const input = page.getByRole('searchbox', { name: 'Search books' });
+  // Accessible name, not placeholder: #679's WCAG pass renamed this from
+  // "Search books" to "Search the library" on 2026-07-04 and this helper was
+  // not updated, so the spec has been failing on `locator.fill` ever since —
+  // unnoticed, because the e2e suite did not run on PRs until #953.
+  //
+  // Scoped to the searchbox role deliberately: the mobile search *button*
+  // carries the same aria-label, so a name-only lookup matches two elements.
+  const input = page.getByRole('searchbox', { name: 'Search the library' });
   await input.fill(title);
-  await page.waitForTimeout(350); // Catalog debounces the query by 300 ms.
+  // Submit, don't wait. This helper used to fill and sleep 350ms on the basis
+  // that "Catalog debounces the query by 300 ms" — the TopBar search is a
+  // <form onSubmit={onSearch}>, so typing alone issues no request at all and
+  // the wait was sleeping through nothing. Verified against a running instance:
+  // filling the box produced zero /api/v1/books requests.
+  await input.press('Enter');
 }
 
 test('editing removes a restored book from old-title search results', async ({ page }) => {


### PR DESCRIPTION
Part of #1130. Test-only.

Red since **2026-07-04**, unseen because the e2e suite did not run on PRs until #953.

Two independent rots, both the SPA moving underneath the spec:

1. **Accessible name.** It looked up `getByRole('searchbox', { name: 'Search books' })`. #679's WCAG pass renamed it to "Search the library", so `locator.fill` timed out at 45s before reaching a single assertion.
2. **Interaction model.** The helper filled the box and slept 350ms, commented *"Catalog debounces the query by 300 ms"*. The TopBar search is a `<form onSubmit={onSearch}>` — typing issues no request at all, so the wait was sleeping through nothing. It now submits.

```
before: 45s timeout
after:  1.4s green
```

## A bug I did not file

Chasing (2) briefly looked like a real defect: `useBooks` only sends `search` when no view/entity filter is active (`queries.ts:199`), and the TopBar search box is **not** hidden for discovery views — so a user on hot/discover could plausibly type into a live box and have the term silently dropped.

Checked against a running instance before writing it up: typing alone produces zero `/api/v1/books` requests **regardless** of view, so that suppression is unreachable by this path and there is nothing to report. The comment at `queries.ts:199` does overstate its case ("the UI hides the search box when an entity filter is active" — it does not), but that is a doc inaccuracy, not a defect.

Recording it because the near-miss is the point: this is the third stale spec found today, and the temptation with each one is to read the failure as a product bug.

## Triage progress on #1130

Running the failing clusters against a **populated** library splits them cleanly:

| cluster | populated library | verdict |
|---|---|---|
| `sidebar`, `sp2-display-options`, `book-card-actions` | pass | CI fixture inadequacy |
| `search-after-edit` | failed | stale spec — fixed here |
| `magic-shelf-rule-schema` | failed | not fixture; still to triage |

That **refutes** the blanket "it is all fixture inadequacy" hypothesis I put in #1130.