### PR TITLE
Fix the magic-shelf rule-schema race (#1130)

### DIFF
--- a/frontend/e2e/magic-shelf-rule-schema.spec.ts
+++ b/frontend/e2e/magic-shelf-rule-schema.spec.ts
@@ -59,6 +59,15 @@ test('Classic and New UI consume the canonical rule schema and date rules previe
   await expect(page.locator('main#main h1')).toBeVisible();
   const spaField = page.locator('main#main select:has(option[value="pubdate"])').first();
   const spaOperator = page.locator('main#main select:has(option[value="in_last_days"])').first();
+  // Wait for the schema to populate before reading the options. The heading
+  // renders before the rule schema resolves, so `selectOptions` could snapshot
+  // a select holding a single placeholder and compare 1 entry against 18.
+  // Reliably green when this spec runs alone and reliably red in a batch —
+  // i.e. a race that only loses under parallel load, which is exactly what CI
+  // does (`fullyParallel: true`). It was one of the failures in #1130.
+  await expect
+    .poll(async () => (await selectOptions(spaField)).length, { timeout: 15_000 })
+    .toBeGreaterThan(1);
   const spaFields = await selectOptions(spaField);
   expect(spaFields.map(({ value }) => value)).toEqual(expectedFieldIds);
   expect(spaFields.every(({ text }) => text.length > 0)).toBe(true);


### PR DESCRIPTION
Part of #1130. Test-only.

The spec read the field `<select>`'s options as soon as the page heading was visible. The heading renders **before** the rule schema resolves, so it could snapshot a select holding a single placeholder and compare 1 entry against the expected 18.

```
Expected  - 18
Received  +  1
```

Green when run alone, red in a batch — a race that only loses under parallel load, which is exactly what CI does (`fullyParallel: true`).

Polls until the select is populated before reading it.

```
batch before: 10 passed, 1 failed
batch after:  11 passed, 0 failed
```

(Same batch both times: `sidebar sp2-display-options magic-shelf-rule-schema book-card-actions search-after-edit`.)

## This completes the non-fixture half of #1130

| cluster | cause | status |
|---|---|---|
| `sidebar`, `sp2-display-options`, `book-card-actions` | CI fixture too thin | open — needs shelves in the seed |
| `search-after-edit` | stale spec, two rots | fixed (#1131) |
| `magic-shelf-rule-schema` | race under parallel load | fixed here |

Worth noting all three had different causes, and none was a product bug — despite each one presenting as one. The blanket "it is fixture inadequacy" I first wrote into #1130 would have been wrong for two of the three.