### PR TITLE
ci(e2e): seed shelves so the fixture can exercise shelf grouping (#1130)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -493,6 +493,41 @@ jobs:
             exit 1
           fi
 
+      - name: Seed shelves
+        run: |
+          # The library the harness gets had three books and NO shelves, so
+          # every spec asserting shelf grouping failed on the fixture rather
+          # than on anything real (#1130). Reuse the session the ingest poll
+          # above already logged in with.
+          #
+          # Verification fixture only: these shelves exist so the sidebar has
+          # something to group. Nothing here changes product behaviour, and the
+          # e2e job stays advisory on PRs.
+          jar=$(mktemp)
+          csrf=$(curl -s -c "$jar" http://localhost:8083/api/v1/auth/csrf \
+            | python3 -c 'import sys,json;print(json.load(sys.stdin)["csrf_token"])')
+          curl -s -b "$jar" -c "$jar" -X POST http://localhost:8083/api/v1/auth/login \
+            -H 'Content-Type: application/json' -H "X-CSRFToken: $csrf" \
+            -d '{"username":"admin","password":"admin123"}' -o /dev/null
+          csrf=$(curl -s -b "$jar" -c "$jar" http://localhost:8083/api/v1/auth/csrf \
+            | python3 -c 'import sys,json;print(json.load(sys.stdin)["csrf_token"])')
+          for shelf in "Reading now" "To read"; do
+            code=$(curl -s -o /tmp/shelf.json -w '%{http_code}' \
+              -b "$jar" -c "$jar" -X POST http://localhost:8083/api/v1/shelves \
+              -H 'Content-Type: application/json' -H "X-CSRFToken: $csrf" \
+              -d "{\"name\": \"$shelf\"}")
+            echo "  create shelf '$shelf' -> $code"
+            # 409 is fine (already there); anything else is a broken fixture and
+            # should fail loudly rather than resurface as confusing spec failures.
+            if [ "$code" != "201" ] && [ "$code" != "409" ]; then
+              echo "::error::could not create shelf '$shelf' (HTTP $code)"; cat /tmp/shelf.json; exit 1
+            fi
+          done
+          total=$(curl -s -b "$jar" http://localhost:8083/api/v1/shelves \
+            | python3 -c 'import sys,json;d=json.load(sys.stdin);print(len(d.get("items",d if isinstance(d,list) else [])))' 2>/dev/null || echo 0)
+          echo "shelves now: $total"
+          [ "${total:-0}" -ge 1 ] || { echo "::error::no shelves after seeding"; exit 1; }
+
       - name: Install Playwright
         working-directory: frontend
         run: |

--- a/frontend/e2e/card-action-overlap.spec.ts
+++ b/frontend/e2e/card-action-overlap.spec.ts
@@ -16,7 +16,13 @@ import { test, expect } from '@playwright/test';
  * pixel diff would also fire on every unrelated restyle.
  */
 
-const OVERLAP = `() => {
+// IIFE, not a bare arrow function. page.evaluate() given a STRING evaluates it
+// as an expression, so `() => {...}` returns the function itself — which is not
+// serializable, so it arrives as undefined and every assertion dies on
+// "Cannot read properties of undefined". Shipped that way in #1112 and caught
+// by the e2e gate the first time it ran (#953), which is the gate earning its
+// keep on its first outing.
+const OVERLAP = `(() => {
   const labels = [...document.querySelectorAll('*')].filter(
     (e) => typeof e.className === 'string' && /readNow/.test(e.className));
   let checked = 0, worst = 0;
@@ -33,7 +39,7 @@ const OVERLAP = `() => {
     worst = Math.max(worst, Math.round(contentRight - pb.left));
   }
   return { checked, worst };
-}`;
+})()`;
 
 for (const [name, width, height] of [['phone', 360, 760], ['tablet', 768, 1024]] as const) {
   test(`the Edit control never covers the "Read now" label (${name}, #1112)`, async ({ page }) => {

--- a/frontend/e2e/utils.ts
+++ b/frontend/e2e/utils.ts
@@ -32,5 +32,3 @@ export async function assertNoHorizontalOverflow(page: Page) {
   });
   expect(overflow, 'page scrolls horizontally (mobile reflow regression)').toBeLessThanOrEqual(1);
 }
-
-// seed-verification probe — removed before merge.

--- a/frontend/e2e/utils.ts
+++ b/frontend/e2e/utils.ts
@@ -32,3 +32,5 @@ export async function assertNoHorizontalOverflow(page: Page) {
   });
   expect(overflow, 'page scrolls horizontally (mobile reflow regression)').toBeLessThanOrEqual(1);
 }
+
+// seed-verification probe — removed before merge.


### PR DESCRIPTION
Closes the last cluster in #1130. **Fixture only** — no product behaviour changes, and the e2e job stays advisory on PRs, so nothing new blocks a merge.

## Why

The harness library had three books and **no shelves**. Specs asserting shelf grouping therefore failed on the fixture rather than on anything real — `sidebar`, `sp2-display-options` and `book-card-actions` all pass against a populated library and fail in CI.

## What

Creates two shelves over the API, reusing the session the ingest poll already logged in with. `409` is tolerated (already present); anything else fails the step loudly, rather than resurfacing later as confusing spec failures.

Verified the exact curl sequence against a running instance before shipping:

```
csrf ok
login: 200
create shelf -> 201
GET /api/v1/shelves -> {"items":[...]}     ← the shape the count parses
```

(and the probe shelf was deleted again afterwards, so the local container is as it was).

## Verification of the seed itself

A workflow-only PR skips the e2e job, so there is a temporary one-line touch to `frontend/e2e/utils.ts` on this branch purely so the PR runs its own harness with the new seed. Removed before merge. Expect the failure count to drop from the current 19.