### PR TITLE
Make the e2e auth setup work with anonymous browsing enabled

### DIFF
--- a/frontend/e2e/global.setup.ts
+++ b/frontend/e2e/global.setup.ts
@@ -13,9 +13,15 @@ const PASS = process.env.E2E_PASS || 'admin123';
 setup('authenticate', async ({ page }) => {
   fs.mkdirSync('e2e/.auth', { recursive: true });
 
-  // The SPA renders its own login client-side at /app (the bare /login route is
-  // the legacy Jinja page). Go to the SPA shell and drive its login form.
-  await page.goto('/app');
+  // Go to the SPA's login ROUTE, not the shell. /app only shows a login form
+  // when the instance requires auth to browse; with anonymous browsing enabled
+  // (config_anonbrowse=1) it renders the guest library instead, so there is no
+  // username field and every spec in the run dies here on a 45s timeout before
+  // one of them executes. /app/login renders the form in both configurations.
+  //
+  // The bare /login route is the legacy Jinja page and is not what the SPA
+  // specs should be exercising.
+  await page.goto('/app/login');
   await page.locator('input[autocomplete="username"]').fill(USER);
   await page.locator('input[autocomplete="current-password"]').fill(PASS);
   await page.getByRole('button', { name: /sign in/i }).click();


### PR DESCRIPTION
Test harness only.

`global.setup.ts` navigated to `/app` and filled the login form. `/app` only shows that form when the instance **requires auth to browse**. With `config_anonbrowse=1` it renders the guest library instead — no username field, setup times out at 45s, and **every spec in the run reports "did not run"**.

So a single server setting takes out local e2e verification entirely, and does it silently: the failure names `global.setup`, not the config. It cost real time this session before I found the cause.

Observed, not inferred:

```
config_anonbrowse = 1                    (cwn-local app.db)
/app  → inputs: [search]  buttons: [… "Guest" …]     ← no login form
/app/login → inputs: [search, text/username, password/current-password]
```

`/app/login` renders the form in **both** configurations, so the harness stops depending on how the instance under test happens to be configured.

Verified against `cwn-local` with anonymous browsing ON: setup went from a 45s timeout to passing in **1.6s**, and the suite runs.

Rule 6: no new dependency, license or external URL.