### PR TITLE
Stop double-muting the card series line below AA contrast (#1135)

### DIFF
--- a/frontend/src/components/BookCard.module.css
+++ b/frontend/src/components/BookCard.module.css
@@ -107,8 +107,13 @@
  * author line so the title stays the visual anchor; one line, ellipsised. */
 .series {
   font-size: var(--fs-sm);
+  /* No opacity here. --text-muted IS the muted colour (#54606b in light,
+     5.71:1 on the light surface); stacking 0.85 on top blended it to #6e7881
+     and dropped it to 3.99:1, under the 4.5:1 AA floor at this 13px size
+     (#1135). Double-muting an already-muted token is how a value that passes
+     when you read the stylesheet fails when you measure the pixels — static
+     contrast math on the token says 5.71 and never sees it. */
   color: var(--text-muted);
-  opacity: 0.85;
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 1;


### PR DESCRIPTION
Ships fix for #1135.

## Cause

`BookCard.module.css` `.series`:

```css
color: var(--text-muted);   /* light: #54606b → 5.71:1, passes */
opacity: 0.85;              /* → composites to ~#6e7881 → 3.99:1, fails */
```

`--text-muted` **is** the muted colour. Stacking 0.85 on top de-emphasises it a second time and costs 1.7 contrast points, dropping it under the 4.5:1 AA floor at 13px.

axe measured exactly that — contrast 3.98, foreground `#6e7881`. That value appears **nowhere in the source**, which is the tell: it is composited, so static contrast math on the authored token reports 5.71 and never sees the failure. Same class as the runtime-vs-static trap in the a11y notes.

## Correcting my own first reading

I filed #1135 saying the book **detail** page. It is not. `BookDetail`'s `.series` computes to `#59646f` with **no opacity anywhere in its ancestry** (measured on a running instance) and sits at 5.35:1. The failing element is the **card**'s series line, which appears on the detail page via the "More by this author" strip — which is why the scan is labelled book-detail.

## Honest limit on verification

**I could not reproduce the red on demand.** The violation needs a card carrying a series to be on the scanned page, and this library has almost none, so `a11y.spec.ts` passes with or without the fix here. I tried, with the pre-fix bundle restored into the same container, and got green both ways — so I am not claiming a red/green.

What *is* established:

- the arithmetic: `#54606b` → 5.71:1, `#6e7881` → 3.99:1 (computed, matches axe's 3.98)
- the mechanism: an `opacity` on an already-muted token, and the composited result matches what axe measured
- that the detail page's own rule is **not** the culprit (measured, 5.35:1)

Removing a redundant double-mute on a semantic token is worth doing on its own terms regardless of the gate.

Rule 6: no new dependency, license or external URL. One CSS declaration removed.