### PR TITLE
Point three unauthenticated specs at /app/login (anon browsing)

### DIFF
--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -131,7 +131,12 @@ test('reader: TOC traps focus + Escape, named progressbar, no critical/serious',
 test.describe('login (unauthenticated)', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
   test('login: no critical/serious a11y violations', async ({ page }) => {
-    await page.goto('/app');
+    // /app/login, not /app: the shell only renders a login form when the
+    // instance requires auth to browse. With anonymous browsing enabled it
+    // serves the guest library instead, so the username field never appears
+    // and this scan dies on a 45s timeout without auditing anything — the
+    // same trap that took out global.setup.ts until it was fixed.
+    await page.goto('/app/login');
     await page.locator('input[autocomplete="username"]').waitFor({ state: 'visible' });
     await axeScan(page, 'login');
   });

--- a/frontend/e2e/auth-expiry.spec.ts
+++ b/frontend/e2e/auth-expiry.spec.ts
@@ -187,7 +187,11 @@ test.describe('public authentication guards', () => {
       contentType: 'application/json',
       body: JSON.stringify({ error: { code: 'invalid_credentials', message: 'Invalid username or password' } }),
     }));
-    await page.goto('/app');
+    // /app/login: /app only renders the login form when the instance requires
+    // auth to browse. With anonymous browsing on it serves the guest library,
+    // the username field never appears, and this dies on a 45s timeout without
+    // testing the auth guard at all.
+    await page.goto('/app/login');
     await page.locator('input[autocomplete="username"]').fill('wrong');
     await page.locator('input[autocomplete="current-password"]').fill('wrong');
     await page.getByRole('button', { name: /sign in/i }).click();
@@ -205,7 +209,11 @@ test.describe('public authentication guards', () => {
       }
     });
     await page.route('**/api/v1/auth/login', (route) => route.abort());
-    await page.goto('/app');
+    // /app/login: /app only renders the login form when the instance requires
+    // auth to browse. With anonymous browsing on it serves the guest library,
+    // the username field never appears, and this dies on a 45s timeout without
+    // testing the auth guard at all.
+    await page.goto('/app/login');
     await page.locator('input[autocomplete="username"]').fill('offline');
     await page.locator('input[autocomplete="current-password"]').fill('offline');
     await page.getByRole('button', { name: /sign in/i }).click();


### PR DESCRIPTION
Part of #1130. Test-only.

Same trap that took out `global.setup.ts` (#1134): `/app` only renders a login form when the instance **requires** auth to browse. With `config_anonbrowse=1` it serves the guest library, the username field never appears, and the spec dies on a 45s timeout.

## What these were silently not doing

- **`a11y.spec.ts` — "login: no critical/serious a11y violations"** never reached `axeScan`. **The login page has had zero accessibility coverage**, while sitting in the suite looking like a check. It passes in 1.7s once it can actually see the page.
- **`auth-expiry.spec.ts` — both public-authentication guards** ("login 401 remains invalid credentials and does not navigate", "rejected public login fetch does not navigate") never tested the guard. These exist to prove a failed login does **not** bounce the user through `/logout` — worth having actually run.

That is three specs that could only ever report on an instance configured one particular way, and reported nothing on any other.

## Verification

```
24 passed, 0 failed    (auth-expiry + a11y, populated instance, anon browsing ON)
```

The trailing `toHaveURL(/\/app(?:\/|$|\?)/)` assertions still hold — `/app/login` matches.

Rule 6: no new dependency, license or external URL.