### PR TITLE
Open the mobile search toggle before filling the search box (#1130)

### DIFF
--- a/frontend/e2e/search-after-edit.spec.ts
+++ b/frontend/e2e/search-after-edit.spec.ts
@@ -11,6 +11,15 @@ async function search(page: Page, title: string) {
   // Scoped to the searchbox role deliberately: the mobile search *button*
   // carries the same aria-label, so a name-only lookup matches two elements.
   const input = page.getByRole('searchbox', { name: 'Search the library' });
+  // At narrow widths the search field is collapsed behind a toggle button
+  // (TopBar's mobileSearchBtn), so filling it directly times out — this spec
+  // passed on desktop and failed on mobile for that reason alone, testing
+  // nothing at all on phones. The button carries the same accessible name as
+  // the field, hence the explicit role.
+  if (!(await input.isVisible().catch(() => false))) {
+    await page.getByRole('button', { name: 'Search the library' }).first().click();
+    await input.waitFor({ state: 'visible' });
+  }
   await input.fill(title);
   // Submit, don't wait. This helper used to fill and sleep 350ms on the basis
   // that "Catalog debounces the query by 300 ms" — the TopBar search is a


### PR DESCRIPTION
Part of #1130. Test-only.

At narrow widths `TopBar` collapses the search field behind a toggle button (`mobileSearchBtn` / `toggleMobileSearch`), so filling the searchbox directly times out.

This spec **passed on desktop and failed on mobile for that reason alone** — it was running in the mobile project and testing nothing at all there, while looking like viewport coverage. That is the third distinct flavour of "green-or-red for reasons unrelated to the thing under test" found in this suite today.

Opens the toggle when the field is not already visible. The toggle button carries the same accessible name as the field, so the lookup is scoped by role rather than name.

```
mobile   45s timeout -> 600ms green
desktop  unchanged,     1.4s green
```

Rule 6: no new dependency, license or external URL.