### PR TITLE
Repair two mobile specs that were measuring nothing (#1130)

### DIFF
--- a/frontend/e2e/mobile.spec.ts
+++ b/frontend/e2e/mobile.spec.ts
@@ -47,13 +47,27 @@ test.describe('library gear menu at 360px', () => {
     await expect(gear).toBeVisible();
     await gear.click();
 
-    const menu = page.getByRole('menu');
+    // The panel is a plain <div>, not role="menu" — getByRole('menu') has never
+    // matched it, so this spec has been failing on mobile without ever
+    // measuring the geometry it exists to measure (#628: the menu must not
+    // extend past the left viewport edge when the gear wraps).
+    //
+    // Targeted by test id rather than by asserting a role, because which role
+    // this panel SHOULD carry is an open question: the trigger declares
+    // aria-haspopup="true" (i.e. "menu") while the popup has no role at all,
+    // so assistive tech is promised a menu and finds none. Picking between
+    // menu+menuitemcheckbox, dialog, or group is a design decision — tracked
+    // separately rather than guessed at here.
+    const menu = page.getByTestId('catalog-view-settings-menu');
     await expect(menu).toBeVisible();
     const box = (await menu.boundingBox())!;
     expect(box.x, 'menu extends past the left viewport edge (#628)').toBeGreaterThanOrEqual(0);
     expect(box.x + box.width, 'menu extends past the right viewport edge').toBeLessThanOrEqual(360);
 
     // The menu is still functional where it lands: the Discover toggle is clickable.
-    await expect(menu.getByRole('checkbox')).toBeVisible();
+    // .first(): the panel has grown a second toggle since this was written, so
+    // an unscoped checkbox lookup is a strict-mode violation. The assertion
+    // only needs the panel's content to be rendered, not a specific control.
+    await expect(menu.getByRole('checkbox').first()).toBeVisible();
   });
 });

--- a/frontend/e2e/sp2-display-options.spec.ts
+++ b/frontend/e2e/sp2-display-options.spec.ts
@@ -60,6 +60,13 @@ test('book detail exposes imported name, tag disclosure, and semantic progress',
 
 test('Customize panel can restore hidden Table view', async ({ page }) => {
   await page.goto('/app');
+  // The Customize control lives in the sidebar, which is a drawer at mobile
+  // widths — the button exists in the DOM but never becomes visible, so the
+  // click times out at 45s. Open the drawer first when it is there. (Same
+  // shape as the collapsed search field; the suite's sidebar spec already
+  // drives the hamburger this way.)
+  const hamburger = page.getByRole('button', { name: /open navigation/i });
+  if (await hamburger.isVisible().catch(() => false)) await hamburger.click();
   await page.getByRole('button', { name: 'Customize navigation' }).click();
   const table = page.getByRole('checkbox', { name: 'Show Table view' });
   await expect(table).toBeVisible();

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -697,7 +697,7 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
               <Settings size={15} />
             </button>
             {settingsOpen && (
-              <div className={styles.settingsMenu}>
+              <div className={styles.settingsMenu} data-testid="catalog-view-settings-menu">
                 <p className={styles.settingsHead}>{t('View settings')}</p>
                 <label className={styles.settingsItem}>
                   <input


### PR DESCRIPTION
Part of #1130.

## `sp2-display-options` — Customize panel

The Customize control lives in the sidebar, which is a **drawer** at mobile widths. The button is in the DOM but never visible, so the click timed out at 45s. Opens the drawer first, the way the suite's own `sidebar.spec.ts` already does.

```
mobile   45s timeout -> ~610ms green
desktop  unchanged
```

## `mobile.spec.ts` — view-settings geometry

Looked the panel up with `getByRole('menu')`. **The panel is a plain `<div>` with no role**, so that never matched — this spec has never once measured the geometry it exists for (#628: the menu must not extend past the left viewport edge when the gear wraps). Adds a `data-testid` to the panel and targets that.

**Deliberately not asserting a role.** The trigger declares `aria-haspopup="true"` — i.e. *"menu"* — while the popup carries no role at all, so assistive tech is promised a menu and finds none. Whether the right answer is `menu` + `menuitemcheckbox`, `dialog`, or `group` is a design call with real a11y consequences. Filed separately rather than guessed at.

Also scopes a checkbox lookup with `.first()`: the panel has grown a second toggle since the spec was written, which is a strict-mode violation.

## Known and not fixed here

`sp2-display-options` and `mobile.spec.ts` **interfere when run in parallel** — sp2 mutates shared per-user view settings (hiding/showing Table view) while mobile reads the same menu. Each passes alone (609ms, 624ms across two runs); in the pair one loses. Recorded on #1130 rather than papered over.

One product line changed: a `data-testid` on the panel. No behaviour change.