### PR TITLE
Restore hidden books after the run so the suite stops poisoning itself (#1130)

### DIFF
--- a/frontend/e2e/hidden-books.spec.ts
+++ b/frontend/e2e/hidden-books.spec.ts
@@ -3,6 +3,41 @@ import { assertNoHorizontalOverflow, collectPageErrors, assertNoPageErrors } fro
 
 test.describe.configure({ mode: 'serial' });
 
+// Hiding is PERSISTENT per-user state on the server, and these specs hide
+// books. Without a restore, a run that fails part-way — or is interrupted —
+// leaves a book hidden forever, and from then on every spec that counts books
+// sees a library one short. That is not hypothetical: it is exactly how these
+// specs were failing (`Expected: 41, Received: 42`), and the poisoned instance
+// then mis-attributes the failure to whichever spec happens to count next.
+//
+// afterAll, not afterEach: this file is `mode: 'serial'`, so later tests build
+// on state earlier ones establish — unhiding between them breaks the chain.
+// afterAll still runs when a test fails, which is the case that matters.
+test.afterAll(async ({ browser }) => {
+  const page = await browser.newPage();
+  try {
+    const csrf = await page.request.get('/api/v1/auth/csrf')
+      .then((r) => r.json() as Promise<{ csrf_token: string }>)
+      .then((b) => b.csrf_token);
+    const visible = await page.request.get('/api/v1/books?per_page=500')
+      .then((r) => r.json() as Promise<{ items: Array<{ id: number }> }>);
+    const all = await page.request.get('/api/v1/books?per_page=500&show_hidden=1')
+      .then((r) => r.json() as Promise<{ items: Array<{ id: number }> }>);
+    const shown = new Set(visible.items.map((b) => b.id));
+    for (const book of all.items) {
+      if (shown.has(book.id)) continue;
+      await page.request.post(`/api/v1/books/${book.id}/hidden`, {
+        headers: { 'X-CSRFToken': csrf },
+        data: { hidden: false },
+      });
+    }
+  } catch {
+    /* best effort — never fail the run in cleanup, only avoid poisoning the next */
+  } finally {
+    await page.close();
+  }
+});
+
 async function firstBook(page: Page): Promise<{ id: number; title: string } | null> {
   return page.evaluate(async () => {
     const response = await fetch('/api/v1/books?per_page=1');


### PR DESCRIPTION
Part of #1130. Test-only.

## The defect

Hiding is **persistent per-user server state**, and these specs hide books without restoring them. A run that fails part-way — or is interrupted — leaves a book hidden permanently. From then on *every* spec that counts books sees a library one short.

Not hypothetical: the instance I was triaging on had **book 10 hidden from some earlier run**, which is exactly why `hidden-books` was failing:

```
Expected: 41
Received: 42
```

Unhiding it made all six specs pass with no code change.

The nastiest part is the misattribution — the poisoned count surfaces in whichever spec happens to count next, so the failure points away from the spec that caused it. That is a good chunk of why this cluster looked like five unrelated problems.

## Why afterAll, not afterEach

This file is `mode: 'serial'` and later tests build on state earlier ones establish, so unhiding between them breaks the chain — I tried `afterEach` first and one spec went red. `afterAll` still runs when a test fails, which is the case that matters.

Cleanup is best-effort and swallowed: it must never fail a run, only avoid poisoning the next.

## Verification

```
7 passed
instance afterwards: visible=42, total=42   ← nothing left hidden
```

Rule 6: no new dependency, license or external URL.