### PR TITLE
Match the Discover request by its identifying parts, not an exact query (#1130)

### DIFF
--- a/frontend/e2e/discover-upload.spec.ts
+++ b/frontend/e2e/discover-upload.spec.ts
@@ -6,7 +6,15 @@ test.describe('Discover reshuffle', () => {
     let releaseSecond: (() => void) | undefined;
     const secondHeld = new Promise<void>((resolve) => { releaseSecond = resolve; });
 
-    await page.route('**/api/v1/books?filter=discover&per_page=12', async (route) => {
+    // Match on the parts that identify the request, not on an exact query
+    // string. The pattern here was '**/api/v1/books?filter=discover&per_page=12',
+    // which pins BOTH the page size and the parameter order — so it silently
+    // stops matching if either changes, `requests` stays 0, and the spec fails
+    // with "Expected: 2, Received: 0" while looking like a product bug.
+    // Discover's count is configurable (#705), so pinning 12 was never safe.
+    await page.route((url) =>
+      url.pathname === '/api/v1/books' && url.searchParams.get('filter') === 'discover',
+    async (route) => {
       requests += 1;
       if (requests === 2) await secondHeld;
       await route.continue();


### PR DESCRIPTION
Part of #1130. Test-only.

The route pattern was:

```ts
page.route('**/api/v1/books?filter=discover&per_page=12', ...)
```

That pins **both the page size and the parameter order**. Discover's count is configurable (#705), so it was never safe — change it and the matcher silently stops matching, `requests` stays 0, and the spec fails with:

```
Expected: 2
Received: 0
```

which reads like *the product stopped requesting replacement picks*, not like a stale test. That misdirection is the real cost.

Now matches on `pathname === '/api/v1/books'` and `filter=discover`.

```
desktop 751ms green,  mobile 599ms green   (was failing on both)
```

## Same shape elsewhere

`infinite-scroll:55` bails out of its handler unless `page` is exactly `1` or `2`, so it misses a first request that omits the parameter — the mock never engages and the assertions compare mocked expectations against a real library. Diagnosed on #1130, deliberately not bundled here.

Rule 6: no new dependency, license or external URL.