### PR TITLE
Make the read indicator legible: labelled green pill, bottom-left (#1117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Changed
+
+- **The "read" mark on a book cover is now a green "Read" label at the bottom-left, instead of a small tick in the corner.** It was a 22-pixel checkmark circle in the top-right with no wording, which was easy to miss at a glance — the reporter, who reads in the light theme because of their eyesight, pointed out that the classic view's labelled green badge was far easier to spot. It now says what it means, sits where the classic one sits, and gets larger again on phones and tablets. The wording follows your language, so a German library reads "Gelesen" exactly as the classic view does. Reported by [@uschi1](https://github.com/new-usemame/Calibre-Web-NextGen/issues/351) ([#1117](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1117)).
+
+
 ### Fixed
 
 - **Two people using the library at once no longer break each other's pages.** The server kept one working copy of your library data and shared it across every request it was handling. As soon as any one page finished, it closed that copy, so any other page still being built lost the books it had already read and failed. In the log it showed up as `Instance ... is not persistent within this Session`, pointing at whatever the unlucky page happened to be doing at the time, which made it look like a different bug on every occurrence. It got likelier the busier the server was, so it hit big libraries, shared instances and anything running during an import hardest. Each request now keeps its own working copy ([#1150](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1150)).

--- a/frontend/src/components/BookCard.module.css
+++ b/frontend/src/components/BookCard.module.css
@@ -120,29 +120,65 @@
   -webkit-box-orient: vertical;
 }
 
-.readBadge {
+/* Cover badges live in ONE bottom-left row. Previously .readBadge sat at
+   top-right while .hiddenBadge and .seriesBadge both claimed bottom-left —
+   which meant a hidden book in a series view stacked two badges on the same
+   spot. A flex row makes that impossible rather than relying on each badge's
+   comment asserting the others are elsewhere.
+
+   max-width reserves the bottom-right corner for the quick-edit pencil, so
+   the row can never grow under it (the #1112 collision, avoided by
+   construction this time). */
+.badgeRow {
   position: absolute;
-  top: var(--sp-2);
-  right: var(--sp-2);
-  width: 22px;
-  height: 22px;
-  border-radius: var(--r-full);
-  background: var(--accent);
-  color: var(--on-accent);
-  box-shadow: var(--elev-1);
+  bottom: var(--sp-2);
+  left: var(--sp-2);
+  max-width: calc(100% - var(--sp-2) * 2 - 34px);
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
+  gap: var(--sp-1);
+  pointer-events: none;
+}
+
+/* "Read" is the one badge users actively look FOR, and it was the hardest to
+   see: a bare 22px checkmark circle at top-right, no label (#1117, reported by
+   @uschi1, who reads in the light theme because of eyesight and compared it
+   unfavourably with the classic view's labelled green pill).
+
+   So: labelled, larger, bottom-left, green — the classic affordance. The label
+   is the `Read` msgid, which already renders "Gelesen" in German, i.e. exactly
+   the word in the reporter's classic screenshot. Green rather than --accent
+   because "done" reads as green far more universally than amber, and because
+   the amber circle was competing with the accent-coloured hover actions. */
+.readBadge {
+  min-height: 24px;
+  padding: 0 var(--sp-2);
+  border-radius: var(--r-full);
+  /* Fixed green, NOT var(--success). The badge sits on a cover image, so its
+     legibility has to be self-contained — it cannot borrow contrast from the
+     page background the way page text can. --success is theme-aware and flips
+     to a light green (#6cc08a) in dark mode, where white-on-it measures
+     2.20:1: an accessibility regression inside an accessibility fix. This
+     pairing is 5.35:1 in every theme, and the shadow separates it from dark
+     covers. */
+  background: #1f7a44;
+  color: #fff;
+  box-shadow: var(--elev-1);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semi);
+  line-height: 1;
+  white-space: nowrap;
   pointer-events: none;
 }
 
 /* Personal-library state: quiet but explicit when Show hidden books is on.
-   Bottom-left avoids the read badge and the catalog's quick-edit affordance. */
+   Sits in .badgeRow. */
 .hiddenBadge {
-  position: absolute;
-  bottom: var(--sp-2);
-  left: var(--sp-2);
-  min-height: 22px;
+  min-height: 24px;
   padding: 0 var(--sp-2);
   border-radius: var(--r-full);
   background: var(--cover-control-bg);
@@ -158,15 +194,10 @@
   pointer-events: none;
 }
 
-/* Series position (#573): pinned to the bottom-left of the cover so it never
-   collides with the read badge (top-right) or the select/remove controls
-   (top-left). Shown only in a series view. */
+/* Series position (#573). Sits in .badgeRow; shown only in a series view. */
 .seriesBadge {
-  position: absolute;
-  bottom: var(--sp-2);
-  left: var(--sp-2);
-  min-width: 22px;
-  height: 22px;
+  min-width: 24px;
+  height: 24px;
   padding: 0 var(--sp-2);
   border-radius: var(--r-full);
   background: var(--cover-control-bg);
@@ -295,6 +326,10 @@
    trackpad): touch must not lose actions merely because a fine pointer exists. */
 @media (any-hover: none), (any-pointer: coarse) {
   .readNow { min-height: 44px; opacity: 1; }
+  /* Bigger where legibility is worst — a phone held at arm's length is the
+     case the reporter was describing. */
+  .readBadge, .hiddenBadge { min-height: 28px; font-size: var(--fs-sm); }
+  .seriesBadge { min-width: 28px; height: 28px; font-size: var(--fs-sm); }
   /* The pencil grows to a 44px touch target here, so the reserved corner has
      to grow with it or the overlap comes straight back on the exact devices
      where both controls are permanently visible. */

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -64,27 +64,41 @@ export function BookCard({
   const cover = (
     <div className={styles.coverWrap}>
       <BookCover coverUrl={book.cover_url} title={book.title} authors={book.authors} />
-      {book.read && (
-        <span className={styles.readBadge} role="img" aria-label={t('Read')}>
-          <Check size={14} strokeWidth={3} aria-hidden="true" />
-        </span>
-      )}
-      {book.hidden && (
-        <span className={styles.hiddenBadge} role="img" aria-label={t('Hidden')}
-          data-testid="hidden-book-badge">
-          <EyeOff size={12} aria-hidden="true" focusable={false} />
-          {t('Hidden')}
-        </span>
-      )}
-      {seriesIndexLabel && (
-        <span
-          className={styles.seriesBadge}
-          role="img"
-          aria-label={t('Series position {n}', { n: seriesIndexLabel })}
-        >
-          #{seriesIndexLabel}
-        </span>
-      )}
+      {/* One bottom-left row rather than three independently-positioned badges.
+          `hiddenBadge` and `seriesBadge` were BOTH pinned to bottom-left, so a
+          hidden book in a series view stacked them on top of each other; and
+          the read badge moving down here (#1117) would have made a third.
+          A flex row makes overlap impossible by construction instead of by
+          each badge hoping the others are absent. */}
+      <div className={styles.badgeRow}>
+        {/* role=img + aria-label on these badges is the established pattern from
+            the WCAG pass: it announces the badge once, rather than letting the
+            icon and the adjacent text be read as two separate things. Keep it
+            even now that the label is visible. */}
+        {book.read && (
+          <span className={styles.readBadge} role="img" aria-label={t('Read')}
+            data-testid="read-badge">
+            <Check size={13} strokeWidth={3} aria-hidden="true" focusable={false} />
+            {t('Read')}
+          </span>
+        )}
+        {book.hidden && (
+          <span className={styles.hiddenBadge} role="img" aria-label={t('Hidden')}
+            data-testid="hidden-book-badge">
+            <EyeOff size={12} aria-hidden="true" focusable={false} />
+            {t('Hidden')}
+          </span>
+        )}
+        {seriesIndexLabel && (
+          <span
+            className={styles.seriesBadge}
+            role="img"
+            aria-label={t('Series position {n}', { n: seriesIndexLabel })}
+          >
+            #{seriesIndexLabel}
+          </span>
+        )}
+      </div>
       {selectable && (
         <span className={selected ? styles.checkboxOn : styles.checkboxOff} aria-hidden="true">
           {selected && <Check size={14} strokeWidth={3} />}


### PR DESCRIPTION
Ships fix for #1117, from [@uschi1](https://github.com/uschi1)'s report on #351.

> *"The 'read' indicator is better in the classic design; it's easier to spot than just the checkmark in the new UI."*
> *"I wear glasses, and I get along much better with the light design."*

They were right. It was a **22px checkmark circle, top-right, no wording**. The classic view has a **labelled green pill at the bottom-left**. Given the stated reason, "easy to spot" is not a preference here.

## Change

Labelled, larger, bottom-left, green — the classic affordance. The label is the existing `Read` msgid, which already renders **"Gelesen"** in German: literally the word in their screenshot of the classic view. 24px normally; 28px and one size up on coarse pointers, where legibility is worst.

**Grouped into one `.badgeRow` rather than moved to another fixed corner.** `hiddenBadge` and `seriesBadge` were *both* pinned bottom-left, so a hidden book in a series view already stacked two badges on one spot — adding a third would have compounded it. A flex row makes overlap impossible by construction, and reserves the bottom-right corner so it can never grow under the quick-edit pencil (the #1112 collision, avoided structurally this time rather than by a comment asserting the other badges are elsewhere).

## Two things caught while verifying

**`var(--success)` looked right and was wrong.** It is theme-aware and flips to a light green (`#6cc08a`) in dark mode, where white-on-it measures **2.20:1** — an accessibility regression inside an accessibility fix. The badge sits on a *cover image*, so its contrast has to be self-contained rather than borrowed from the page. Pinned to `#1f7a44`: **5.35:1 in all four themes**.

**The rewrite dropped `role="img"`/`aria-label` from `hiddenBadge`.** Unintended — I only meant to touch the read badge. `hidden-books.spec.ts` caught it. Restored on both.

## Verified on a running instance

- contrast measured in light / dark / sepia / high-contrast — `rgb(31,122,68)` on white in all four
- badge renders **inside** the cover bounds (7px in), not floating below it
- series view: both badges present, geometric overlap check clean
- phone (390px): 28px tall, 13px label
- `a11y`, `card-action-overlap`, `book-card-actions`, `hidden-books`, `browse` green. Two batch failures are the known parallel interference tracked on #1130 — both pass in isolation (7 passed / 4 passed).

## Noted, not fixed here

At 390px "Read now" wraps to two lines beside the pencil. That comes from #1112 reserving the corner; visible-but-wrapped beats hidden-under-the-button, but it is not pretty. Separate concern.

Rule 6: no new dependency, license or external URL.