### PR TITLE
Point the pill-wrap comment at the issue it describes

### DIFF
--- a/frontend/src/components/Pill.module.css
+++ b/frontend/src/components/Pill.module.css
@@ -10,7 +10,7 @@
   /* No nowrap: real Calibre libraries carry Library-of-Congress subject
      headings ("France -- History -- Revolution, 1789-1799 -- Fiction") that are
      wider than a phone, and an unbreakable pill pushed the whole book detail
-     page into horizontal scroll (#1130). Normal wrapping still keeps every
+     page into horizontal scroll (#1170). Normal wrapping still keeps every
      pill that fits on one line; anywhere breaks a single oversized token. */
   max-width: 100%;
   overflow-wrap: anywhere;


### PR DESCRIPTION
Comment-only. The rule added in #1171 cited #1130 (the mobile-spec repair issue) where it meant #1170, the report for the overflow it fixes. No behaviour change.