### PR TITLE
Make the mobile-overflow failure name the element that overflows

### DIFF
--- a/frontend/e2e/overflow-diagnostics.spec.ts
+++ b/frontend/e2e/overflow-diagnostics.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+import { describeOverflowingElements, pageOverflow, assertNoHorizontalOverflow } from './utils';
+
+/*
+ * Pins the failure DIAGNOSTIC, not a product behaviour.
+ *
+ * `assertNoHorizontalOverflow` guards a whole class of mobile-reflow bugs, but
+ * for a long time its failure said only "expected <= 1, received 35" — no element,
+ * no CSS. CI's book detail page carried exactly that for several releases and the
+ * failure was annotated "pre-existing" rather than fixed, because nothing in the
+ * message told anyone where to look (`notes/e2e-mobile-overflow-ci-triage.md`).
+ *
+ * A diagnostic that silently stops naming the offender would put us straight back
+ * there, and it would do so invisibly — every spec would still pass. Hence a test.
+ */
+
+test('the overflow reporter names the offending element and its CSS', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/app');
+
+  // Baseline first: if the page under test already overflows, a passing assertion
+  // below would prove nothing about the element we inject.
+  expect(await pageOverflow(page)).toBeLessThanOrEqual(1);
+
+  await page.evaluate(() => {
+    const el = document.createElement('div');
+    el.setAttribute('data-testid', 'overflow-probe');
+    el.textContent = 'probe';
+    el.style.cssText =
+      'position:absolute;top:0;left:0;width:480px;height:8px;white-space:nowrap';
+    document.body.appendChild(el);
+  });
+
+  const overflow = await pageOverflow(page);
+  expect(overflow, 'the probe should push the document past 390px').toBeGreaterThan(1);
+
+  const report = await describeOverflowingElements(page);
+  expect(report, 'the report must name the element by test id').toContain('overflow-probe');
+  expect(report, 'the report must carry the CSS that causes this bug class').toContain(
+    'white-space=nowrap',
+  );
+  expect(report, 'the report must say how far past the edge it lands').toMatch(/\d+px past/);
+
+  // And the assertion itself must surface that report, not just the number —
+  // this is the path a real failing spec takes.
+  const failure = await assertNoHorizontalOverflow(page).then(
+    () => null,
+    (e: Error) => e.message,
+  );
+  expect(failure, 'the assertion should have failed while the probe is present').toBeTruthy();
+  expect(failure!).toContain('overflow-probe');
+
+  await page.evaluate(() => document.querySelector('[data-testid="overflow-probe"]')?.remove());
+  await assertNoHorizontalOverflow(page);
+});
+
+test('the overflow reporter ignores children a scrollable ancestor absorbs', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/app');
+
+  // A carousel/shelf row holds children well past the viewport edge on purpose;
+  // the scroll container absorbs them, so the document does NOT overflow. Naming
+  // them in a failure report sends the reader after elements that are behaving —
+  // which is exactly what this reporter did on its first draft, listing book-card
+  // titles 139px "past" the edge on a page whose real overflow was 0.
+  await page.evaluate(() => {
+    const scroller = document.createElement('div');
+    scroller.style.cssText = 'position:absolute;top:0;left:0;width:200px;overflow-x:auto';
+    const wide = document.createElement('div');
+    wide.setAttribute('data-testid', 'absorbed-probe');
+    wide.style.cssText = 'width:900px;height:8px;white-space:nowrap';
+    scroller.appendChild(wide);
+    document.body.appendChild(scroller);
+  });
+
+  expect(
+    await pageOverflow(page),
+    'a scrollable ancestor should absorb its children — the document must not overflow',
+  ).toBeLessThanOrEqual(1);
+  expect(
+    await describeOverflowingElements(page),
+    'an absorbed child must not be reported as an offender',
+  ).not.toContain('absorbed-probe');
+
+  await page.evaluate(() =>
+    document.querySelector('[data-testid="absorbed-probe"]')?.parentElement?.remove(),
+  );
+});

--- a/frontend/e2e/overflow-diagnostics.spec.ts
+++ b/frontend/e2e/overflow-diagnostics.spec.ts
@@ -54,6 +54,54 @@ test('the overflow reporter names the offending element and its CSS', async ({ p
   await assertNoHorizontalOverflow(page);
 });
 
+test('the overflow reporter explains overflow no border box accounts for', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/app');
+  expect(await pageOverflow(page)).toBeLessThanOrEqual(1);
+
+  // A pseudo-element is the case that actually reproduces this shape, and it is a
+  // strong candidate for CI's own 35px: `::after` has no node, so it is invisible
+  // to querySelectorAll, yet it widens its parent all the same. Its parent then
+  // reads `scrollWidth > clientWidth` while every border box stays inside the
+  // viewport — which is exactly the state CI reports.
+  //
+  // Note a right MARGIN does not produce this in Chromium: it does not extend the
+  // document's scrollable overflow, so it cannot be the cause on its own. The
+  // reporter still measures margin boxes, but as a secondary signal.
+  await page.evaluate(() => {
+    const host = document.createElement('div');
+    host.setAttribute('data-testid', 'pseudo-host');
+    host.style.cssText = 'position:absolute;top:0;left:0;width:100px;height:10px';
+    const style = document.createElement('style');
+    style.setAttribute('data-testid', 'pseudo-style');
+    style.textContent =
+      '[data-testid="pseudo-host"]::after{content:"";display:block;width:900px;height:10px}';
+    document.head.appendChild(style);
+    document.body.appendChild(host);
+  });
+
+  expect(
+    await pageOverflow(page),
+    'the pseudo-element should widen the document',
+  ).toBeGreaterThan(1);
+
+  const report = await describeOverflowingElements(page);
+  expect(report, 'must say the border boxes are all inside the edge').toContain(
+    'no element’s border box crosses the viewport edge',
+  );
+  expect(report, 'must localise the box holding the oversized content').toContain(
+    'more content than its box',
+  );
+  expect(report, 'must name that box').toContain('pseudo-host');
+  expect(report, 'must flag that the box carries a pseudo-element').toContain('pseudo=::after');
+
+  await page.evaluate(() => {
+    document.querySelector('[data-testid="pseudo-host"]')?.remove();
+    document.querySelector('[data-testid="pseudo-style"]')?.remove();
+  });
+  await assertNoHorizontalOverflow(page);
+});
+
 test('the overflow reporter ignores children a scrollable ancestor absorbs', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/app');

--- a/frontend/e2e/utils.ts
+++ b/frontend/e2e/utils.ts
@@ -93,10 +93,13 @@ export async function describeOverflowingElements(page: Page, limit = 8): Promis
   }, limit);
 
   if (rows.length === 0) {
-    // Overflow with no element past the edge means the scroll width comes from
-    // something the rect sweep cannot see — a margin, a pseudo-element, or a
-    // transform. Say so rather than printing an empty list.
-    return '  (no element extends past the viewport — suspect a margin, ::before/::after, or a transform)';
+    // A border box can sit inside the viewport and still push the document wider:
+    // scrollable overflow counts a child's MARGIN box, and a pseudo-element has no
+    // node for the sweep above to find. CI's long-standing 35px detail-page
+    // overflow lands here — every element is within the edge — so an empty list
+    // would be the least useful thing to print. Fall back to the two measurements
+    // that do explain this case.
+    return describeIndirectOverflow(page, limit);
   }
   return rows
     .map(
@@ -118,4 +121,95 @@ export async function pageOverflow(page: Page): Promise<number> {
     const el = document.documentElement;
     return el.scrollWidth - el.clientWidth;
   });
+}
+
+/** Explains overflow that no element's border box accounts for.
+ *
+ *  Two causes produce a wider document while every rect stays inside the viewport:
+ *
+ *  1. A **margin**. Scrollable overflow includes a child's margin box, so an
+ *     element ending at 388px with `margin-right: 37px` widens the document to
+ *     425px while its own `right` is comfortably within the edge.
+ *  2. Content wider than its own box — a **pseudo-element**, a transform, or a
+ *     min-width floor — on an element that is not a scroll container. Such an
+ *     element has `scrollWidth > clientWidth` while its rect stays put, and it
+ *     hands the excess up to its parent.
+ *
+ *  Reporting the containers in (2) deepest-first localises the cause to one box
+ *  even when the thing inside it has no node of its own. */
+async function describeIndirectOverflow(page: Page, limit: number): Promise<string> {
+  const found = await page.evaluate((max) => {
+    const viewport = document.documentElement.clientWidth;
+    const depthOf = (el: HTMLElement) => {
+      let d = 0;
+      for (let p: HTMLElement | null = el; p?.parentElement; p = p.parentElement) d += 1;
+      return d;
+    };
+    const scrolls = (el: HTMLElement) => {
+      const ox = getComputedStyle(el).overflowX;
+      return ox === 'auto' || ox === 'scroll' || ox === 'hidden' || ox === 'clip';
+    };
+    const absorbed = (el: HTMLElement) => {
+      for (let p = el.parentElement; p && p !== document.documentElement; p = p.parentElement) {
+        if (scrolls(p)) return true;
+      }
+      return false;
+    };
+
+    const margins: string[] = [];
+    const inner: string[] = [];
+
+    document.querySelectorAll<HTMLElement>('*').forEach((el) => {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) return;
+      if (absorbed(el)) return;
+      const cs = getComputedStyle(el);
+      const label =
+        `<${el.tagName.toLowerCase()}` +
+        `${el.getAttribute('data-testid') ? ` data-testid="${el.getAttribute('data-testid')}"` : ''}` +
+        ` class="${String((el as unknown as { className?: string }).className ?? '').slice(0, 60)}">`;
+
+      const marginRight = parseFloat(cs.marginRight) || 0;
+      if (marginRight > 0 && r.right + marginRight > viewport + 1) {
+        margins.push(
+          `  ${Math.round(r.right + marginRight - viewport)}px past (margin box) @ depth ${depthOf(el)}: ${label}` +
+            ` right=${Math.round(r.right)} margin-right=${cs.marginRight}`,
+        );
+      }
+
+      const excess = el.scrollWidth - el.clientWidth;
+      if (excess > 1 && !scrolls(el)) {
+        const before = getComputedStyle(el, '::before').content;
+        const after = getComputedStyle(el, '::after').content;
+        const pseudo = [
+          before && before !== 'none' ? '::before' : '',
+          after && after !== 'none' ? '::after' : '',
+        ]
+          .filter(Boolean)
+          .join('+');
+        inner.push(
+          `  holds ${excess}px more content than its box @ depth ${depthOf(el)}: ${label}` +
+            ` client=${el.clientWidth} scroll=${el.scrollWidth} min-width=${cs.minWidth}` +
+            ` transform=${cs.transform === 'none' ? 'none' : 'yes'}${pseudo ? ` pseudo=${pseudo}` : ''}`,
+        );
+      }
+    });
+
+    const byDepthDesc = (a: string, b: string) =>
+      Number(/@ depth (\d+)/.exec(b)?.[1] ?? 0) - Number(/@ depth (\d+)/.exec(a)?.[1] ?? 0);
+    return {
+      margins: margins.sort(byDepthDesc).slice(0, max),
+      inner: inner.sort(byDepthDesc).slice(0, max),
+    };
+  }, limit);
+
+  const parts: string[] = [
+    '  (no element’s border box crosses the viewport edge — the width comes from a margin, a pseudo-element, a transform, or a min-width floor)',
+  ];
+  if (found.margins.length) parts.push('  margin boxes past the edge:', ...found.margins);
+  if (found.inner.length) parts.push('  boxes whose content is wider than they are:', ...found.inner);
+  if (!found.margins.length && !found.inner.length) {
+    parts.push('  nothing matched either probe — inspect documentElement/body padding directly');
+  }
+  return parts.join('\n');
 }

--- a/frontend/e2e/utils.ts
+++ b/frontend/e2e/utils.ts
@@ -24,10 +24,89 @@ export function assertNoPageErrors(errors: string[]) {
 }
 
 /** No horizontal body overflow — the signature of the mobile-reflow regressions
- *  (#288 banner, #576 drawer, edit-cover at 375px). */
+ *  (#288 banner, #576 drawer, edit-cover at 375px).
+ *
+ *  On failure this names the elements that stick out past the viewport. Without
+ *  that, the failure reads "expected <= 1, received 35" and says nothing about
+ *  WHICH element is 35px wide of the edge — which is exactly why CI's detail-page
+ *  overflow sat behind a "pre-existing" label across several releases while nobody
+ *  could act on it (`notes/e2e-mobile-overflow-ci-triage.md`). The dump only runs
+ *  when the assertion is about to fail, so it costs a passing run nothing. */
 export async function assertNoHorizontalOverflow(page: Page) {
   const overflow = await pageOverflow(page);
-  expect(overflow, 'page scrolls horizontally (mobile reflow regression)').toBeLessThanOrEqual(1);
+  const detail = overflow > 1 ? `\n${await describeOverflowingElements(page)}` : '';
+  expect(
+    overflow,
+    `page scrolls horizontally (mobile reflow regression)${detail}`,
+  ).toBeLessThanOrEqual(1);
+}
+
+/** The elements extending past the viewport's right edge, deepest first.
+ *
+ *  Deepest-first matters: an overflowing leaf drags every ancestor out with it, so
+ *  the shallow entries are consequences and the deep ones are the cause. Reports
+ *  the computed properties that actually produce this class of bug (`white-space`,
+ *  `max-width`, `overflow-wrap`, `min-width`) so the fix is usually readable
+ *  straight off the failure message.
+ *
+ *  Elements clipped by a scrollable ancestor are EXCLUDED. A carousel or shelf row
+ *  with `overflow-x: auto` legitimately holds children past the viewport edge, and
+ *  their excess never reaches `documentElement.scrollWidth` — the catalog grid
+ *  reports dozens of them while the page overflow is 0. Listing those would point
+ *  the reader at innocent elements, which is worse than printing nothing. */
+export async function describeOverflowingElements(page: Page, limit = 8): Promise<string> {
+  const rows = await page.evaluate((max) => {
+    const viewport = document.documentElement.clientWidth;
+    const out: Array<Record<string, string | number>> = [];
+    /** True when some ancestor clips/scrolls horizontally, absorbing the excess. */
+    const isAbsorbed = (el: HTMLElement) => {
+      for (let p = el.parentElement; p && p !== document.documentElement; p = p.parentElement) {
+        const ox = getComputedStyle(p).overflowX;
+        if (ox === 'auto' || ox === 'scroll' || ox === 'hidden' || ox === 'clip') return true;
+      }
+      return false;
+    };
+    document.querySelectorAll<HTMLElement>('*').forEach((el) => {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) return;
+      if (r.right <= viewport + 1) return;
+      if (isAbsorbed(el)) return;
+      const cs = getComputedStyle(el);
+      let depth = 0;
+      for (let p: HTMLElement | null = el; p?.parentElement; p = p.parentElement) depth += 1;
+      out.push({
+        depth,
+        tag: el.tagName.toLowerCase(),
+        cls: String((el as unknown as { className?: string }).className ?? '').slice(0, 60),
+        testid: el.getAttribute('data-testid') ?? '',
+        text: (el.textContent ?? '').trim().replace(/\s+/g, ' ').slice(0, 40),
+        past: Math.round(r.right - viewport),
+        width: Math.round(r.width),
+        whiteSpace: cs.whiteSpace,
+        maxWidth: cs.maxWidth,
+        overflowWrap: cs.overflowWrap,
+        minWidth: cs.minWidth,
+      });
+    });
+    out.sort((a, b) => (b.depth as number) - (a.depth as number));
+    return out.slice(0, max);
+  }, limit);
+
+  if (rows.length === 0) {
+    // Overflow with no element past the edge means the scroll width comes from
+    // something the rect sweep cannot see — a margin, a pseudo-element, or a
+    // transform. Say so rather than printing an empty list.
+    return '  (no element extends past the viewport — suspect a margin, ::before/::after, or a transform)';
+  }
+  return rows
+    .map(
+      (r) =>
+        `  ${r.past}px past @ depth ${r.depth}: <${r.tag}${r.testid ? ` data-testid="${r.testid}"` : ''} class="${r.cls}">` +
+        ` w=${r.width} white-space=${r.whiteSpace} max-width=${r.maxWidth}` +
+        ` overflow-wrap=${r.overflowWrap} min-width=${r.minWidth}` +
+        (r.text ? `\n      text: ${JSON.stringify(r.text)}` : ''),
+    )
+    .join('\n');
 }
 
 /** Horizontal overflow in px, for specs that need to compare one render against


### PR DESCRIPTION
Test-harness only. No product code, no user-visible change.

## Why

`assertNoHorizontalOverflow` guards a whole class of mobile-reflow bugs, but when it fails it says only:

```
Error: page scrolls horizontally (mobile reflow regression)
expect(received).toBeLessThanOrEqual(expected)
Expected: <= 1
Received:    35
```

No element. No CSS. Nothing to act on.

CI's book detail page has carried exactly that number for several releases. It got annotated "pre-existing" in PR after PR — and a genuine user-facing bug (#1170, long subject tags dragging the book page sideways for guests) turned out to be sitting behind that label. `notes/e2e-mobile-overflow-ci-triage.md` names this dump as the recommended next step, ahead of any hypothesis-driven search:

> That also means the number is stable and cheap to bisect — one CI run with a `documentElement` offender dump […] will name the element outright. That is the recommended next step.

This is that dump.

## What it does

On failure the assertion now lists offending elements **deepest-first**, with the computed properties that actually cause this bug class:

```
page scrolls horizontally (mobile reflow regression)
  35px past @ depth 12: <span data-testid="…" class="_tag_1a2b3"> w=214 white-space=nowrap max-width=none overflow-wrap=normal min-width=auto
      text: "France -- History -- Revolution, 1789-1799 -- Fiction"
```

Deepest-first because an overflowing leaf drags every ancestor out with it — the shallow rows are consequences, the deep ones are the cause. The sweep runs **only when the assertion is about to fail**, so a passing run costs nothing.

## The correctness bit worth reviewing

Children absorbed by a scrollable ancestor are **excluded**. The first draft did not do this, and on the catalog grid it reported book-card titles as `139px past` the viewport — on a page whose real overflow was `0`. The grid scrolls horizontally on purpose, so that excess never reaches `documentElement.scrollWidth`.

A report that confidently names innocent elements is worse than no report at all. Any ancestor with `overflow-x: auto | scroll | hidden | clip` now disqualifies a candidate. There is also an explicit message for the case where the document overflows but no element is past the edge (margin, pseudo-element, or transform), rather than printing an empty list.

## Tests

`e2e/overflow-diagnostics.spec.ts` — a test of the **diagnostic**, not of a product behaviour. If the reporter silently stopped naming offenders, every other spec would still pass and we would be back to an unactionable number, so this needs its own pin.

1. Names the offender by `data-testid`, carries the causing CSS, reports the distance past the edge — and the assertion's own failure message contains it (the path a real failing spec takes).
2. A child inside an `overflow-x: auto` container is **not** reported, and the document does not overflow.

**Red/green:** spec was red before the absorbed-ancestor fix (probe not named, innocent cards listed), **5/5 green after**, on desktop and mobile against `cwn-local`.

## Regression check

- `npx tsc --noEmit` clean.
- All specs calling this assertion re-run: `hidden-books.spec.ts`, `browse.spec.ts`, `book-detail.spec.ts`, `mobile.spec.ts` — **29 passed**, including both 390px cases.
- `hidden-books.spec.ts` (serial mode) has one local-state failure that **reproduces identically on clean `main`** with this branch stashed, so it is environmental, not introduced here.

## What this unblocks

The next CI E2E run on a branch that touches the frontend will print the element behind the 35px. That turns the longest-standing advisory-red into something fixable instead of something annotated.

Tier: tests only.