### PR TITLE
Turn the SPA e2e gate green by seeding the toggle its magic-link spec needs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -554,6 +554,59 @@ jobs:
           echo "series now: $series_count"
           [ "${series_count:-0}" -ge 1 ] || { echo "::error::no series after seeding"; exit 1; }
 
+      - name: Enable magic-link login (spec fixture)
+        run: |
+          # login-redirect.spec.ts drives a REAL magic-link flow: it POSTs
+          # /api/v1/auth/magic-link/start logged-out and asserts the response is
+          # 2xx. That endpoint is gated on the admin toggle config_remote_login,
+          # which is `default=False` in cps/config_sql.py — so a fresh container
+          # answers 403 magic_link_disabled and the spec fails on the FIXTURE,
+          # not on the product. It failed that way on every branch, including a
+          # CHANGELOG-only one, which is how a permanently-red advisory gate got
+          # normalised. Same class as the missing shelves (#1130) and the missing
+          # series above: a gate that depends on the seed happening to contain
+          # the right shape of data is not a gate.
+          #
+          # sp2-display-options.spec.ts does not need this — it mocks
+          # /auth/config at the network layer and never reaches the endpoint.
+          jar=$(mktemp)
+          csrf=$(curl -s -c "$jar" http://localhost:8083/api/v1/auth/csrf \
+            | python3 -c 'import sys,json;print(json.load(sys.stdin)["csrf_token"])')
+          curl -s -b "$jar" -c "$jar" -X POST http://localhost:8083/api/v1/auth/login \
+            -H 'Content-Type: application/json' -H "X-CSRFToken: $csrf" \
+            -d '{"username":"admin","password":"admin123"}' -o /dev/null
+          csrf=$(curl -s -b "$jar" -c "$jar" http://localhost:8083/api/v1/auth/csrf \
+            | python3 -c 'import sys,json;print(json.load(sys.stdin)["csrf_token"])')
+          code=$(curl -s -o /tmp/sec.json -w '%{http_code}' \
+            -b "$jar" -c "$jar" -X POST http://localhost:8083/api/v1/admin/security \
+            -H 'Content-Type: application/json' -H "X-CSRFToken: $csrf" \
+            -d '{"remote_login": true}')
+          echo "  enable remote_login -> $code"
+          if [ "$code" != "200" ]; then
+            echo "::error::could not enable remote_login (HTTP $code)"; cat /tmp/sec.json; exit 1
+          fi
+          enabled=$(curl -s -b "$jar" http://localhost:8083/api/v1/admin/security \
+            | python3 -c 'import sys,json;print(json.load(sys.stdin).get("remote_login"))')
+          echo "remote_login now: $enabled"
+          [ "$enabled" = "True" ] || { echo "::error::remote_login still $enabled after seeding"; exit 1; }
+
+          # Assert the thing the spec actually depends on, from a LOGGED-OUT
+          # session, so a future regression fails loudly here instead of
+          # resurfacing as a confusing spec failure 15 minutes later.
+          anon=$(mktemp)
+          acsrf=$(curl -s -c "$anon" http://localhost:8083/api/v1/auth/csrf \
+            | python3 -c 'import sys,json;print(json.load(sys.stdin)["csrf_token"])')
+          code=$(curl -s -o /tmp/ml.json -w '%{http_code}' \
+            -b "$anon" -c "$anon" -X POST http://localhost:8083/api/v1/auth/magic-link/start \
+            -H 'Content-Type: application/json' -H "X-CSRFToken: $acsrf")
+          echo "  anonymous magic-link/start -> $code"
+          if [ "$code" != "200" ]; then
+            echo "::error::magic-link/start returns $code for a logged-out client — login-redirect.spec.ts cannot pass"
+            cat /tmp/ml.json; exit 1
+          fi
+          python3 -c 'import json,sys; d=json.load(open("/tmp/ml.json")); sys.exit(0 if d.get("verify_url") else 1)' \
+            || { echo "::error::magic-link/start returned 200 with no verify_url"; cat /tmp/ml.json; exit 1; }
+
       - name: Install Playwright
         working-directory: frontend
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -332,7 +332,13 @@ jobs:
           # busy main does not make every PR look like it touched everything.
           files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"
           echo "$files"
-          if echo "$files" | grep -qE '^(frontend/|cps/static/app/)'; then
+          # tests.yml itself counts: the e2e job's container setup and seed steps
+          # live in this file, so a PR that changes how the harness is fixtured
+          # could not otherwise be validated by the harness. That is how a broken
+          # seed (config_remote_login left at its default False, so every
+          # magic-link spec 403'd) stayed invisible — the fix for a red e2e gate
+          # would not have run the e2e gate.
+          if echo "$files" | grep -qE '^(frontend/|cps/static/app/|\.github/workflows/tests\.yml$)'; then
             echo "frontend=true" >> "$GITHUB_OUTPUT"
           else
             echo "frontend=false" >> "$GITHUB_OUTPUT"

--- a/tests/unit/test_workflow_safety_invariants.py
+++ b/tests/unit/test_workflow_safety_invariants.py
@@ -595,3 +595,84 @@ def test_all_workflows_have_minimum_permissions_block():
         "Workflow(s) with mutating gh calls but no explicit permissions block: "
         f"{offenders}"
     )
+
+
+# ---------------------------------------------------------------------------
+# 6. The SPA e2e job seeds every admin toggle its specs actually exercise.
+#
+# login-redirect.spec.ts drives a REAL magic-link flow: it POSTs
+# /api/v1/auth/magic-link/start from a logged-out page and asserts a 2xx.
+# That endpoint is gated on config_remote_login, which is `default=False`
+# (cps/config_sql.py). A fresh e2e container therefore answered 403
+# magic_link_disabled and the spec failed on the FIXTURE, not the product —
+# on every branch, including a CHANGELOG-only one. A permanently-red
+# advisory gate teaches everyone to ignore it, which is worse than no gate.
+#
+# This pins the seed so the fixture can't silently regress again.
+# ---------------------------------------------------------------------------
+
+
+def _e2e_steps() -> list[dict]:
+    wf = _load(WF_DIR / "tests.yml")
+    job = (wf.get("jobs") or {}).get("e2e-tests") or {}
+    return [s for s in (job.get("steps") or []) if isinstance(s, dict)]
+
+
+def test_e2e_job_enables_remote_login_before_running_the_harness():
+    steps = _e2e_steps()
+    assert steps, "tests.yml has no e2e-tests steps — did the job get renamed?"
+
+    def _index_of(pred) -> int:
+        for i, step in enumerate(steps):
+            if pred(step):
+                return i
+        return -1
+
+    seed_idx = _index_of(
+        lambda s: "remote_login" in (s.get("run") or "")
+        and "/api/v1/admin/security" in (s.get("run") or "")
+    )
+    assert seed_idx >= 0, (
+        "The e2e job never enables config_remote_login. login-redirect.spec.ts "
+        "POSTs /api/v1/auth/magic-link/start logged-out and asserts 2xx, but that "
+        "endpoint 403s ('magic_link_disabled') while the admin toggle is off, and "
+        "the toggle defaults to False on a fresh container. Seed it via "
+        "POST /api/v1/admin/security {\"remote_login\": true} before the harness runs."
+    )
+
+    harness_idx = _index_of(lambda s: "npm run test:e2e" in (s.get("run") or ""))
+    assert harness_idx >= 0, "tests.yml e2e job no longer runs `npm run test:e2e`"
+    assert seed_idx < harness_idx, (
+        "remote_login is enabled AFTER the Playwright harness runs — the specs "
+        "will still see the feature disabled."
+    )
+
+
+def test_e2e_remote_login_seed_fails_loudly_when_the_endpoint_regresses():
+    """The seed must verify the logged-out endpoint, not just flip the toggle.
+
+    Flipping the flag and hoping is how this class of failure hides: the toggle
+    write succeeds, something else breaks the endpoint, and the operator gets 15
+    minutes of confusing spec failures instead of one clear seed error.
+    """
+    steps = _e2e_steps()
+    seed = next(
+        (
+            s
+            for s in steps
+            if "remote_login" in (s.get("run") or "")
+            and "/api/v1/admin/security" in (s.get("run") or "")
+        ),
+        None,
+    )
+    assert seed is not None, "no remote_login seed step (see the test above)"
+    run = seed.get("run") or ""
+
+    assert "/api/v1/auth/magic-link/start" in run, (
+        "The seed enables remote_login but never checks that "
+        "/api/v1/auth/magic-link/start actually answers for a logged-out client. "
+        "Assert it in the seed so a regression fails here, loudly, instead of "
+        "resurfacing as an opaque spec failure later."
+    )
+    assert "::error::" in run, "seed step should emit a GitHub ::error:: annotation on failure"
+    assert "exit 1" in run, "seed step must fail the job when the fixture is broken"

--- a/tests/unit/test_workflow_safety_invariants.py
+++ b/tests/unit/test_workflow_safety_invariants.py
@@ -676,3 +676,28 @@ def test_e2e_remote_login_seed_fails_loudly_when_the_endpoint_regresses():
     )
     assert "::error::" in run, "seed step should emit a GitHub ::error:: annotation on failure"
     assert "exit 1" in run, "seed step must fail the job when the fixture is broken"
+
+
+def test_changed_paths_treats_tests_yml_as_frontend_relevant():
+    """A change to the e2e harness must be able to run the e2e harness.
+
+    The e2e job's container setup and seed steps live in tests.yml. While the
+    detector only matched frontend/ and cps/static/app/, a PR fixing the e2e
+    fixture could not be validated by the e2e job — the fix for a red gate
+    would not run the gate.
+    """
+    wf = _load(WF_DIR / "tests.yml")
+    detect = next(
+        (
+            s
+            for s in ((wf.get("jobs") or {}).get("changed_paths") or {}).get("steps", [])
+            if isinstance(s, dict) and s.get("id") == "detect"
+        ),
+        None,
+    )
+    assert detect is not None, "changed_paths has no `detect` step"
+    run = detect.get("run") or ""
+    assert "workflows/tests" in run.replace("\\", ""), (
+        "changed_paths does not treat .github/workflows/tests.yml as frontend-relevant, "
+        "so a PR that changes the e2e seed/setup will skip the e2e job that it changes."
+    )


### PR DESCRIPTION
## Why

`E2E Tests (SPA)` — Layer 2 of the three-layer verification standard — reported **failure on every branch**, including `release/v4.1.22-recut`, which changed only `CHANGELOG.md` and `whatsNew.ts`. That branch cannot break magic-link auth. The gate was red regardless of the diff.

Two things compounded it: the job is advisory on PRs (`continue-on-error`) and the run still concludes `success` with the job red inside, so rule-3 merge-gate condition (a) "every required check is green" kept passing. #1176 and #1177 merged through a red e2e gate. A permanently-red gate is worse than an absent one — it teaches every reader to ignore it.

## Root cause

One spec, and it is a fixture gap, not a product bug.

`login-redirect.spec.ts:68` drives a **real** magic-link flow: it POSTs `/api/v1/auth/magic-link/start` from a logged-out page and asserts `started.ok()`. That endpoint is gated on the admin toggle `config_remote_login`:

```python
if not bool(getattr(config, "config_remote_login", False)):
    return _err("magic_link_disabled", "Magic-link login is disabled", 403)
```

`config_remote_login = Column(Boolean, default=False)` (`cps/config_sql.py:101`), and nothing in the e2e seed enabled it. So every fresh container answered 403 and the spec failed on the fixture.

This is the same class as the missing shelves (#1130) and the missing series this job already seeds — and exactly what that step's own comment warns about: *"a gate that depends on the seed happening to contain the right shape of data is not a gate."*

`sp2-display-options.spec.ts` passes because it mocks `/auth/config` at the network layer and never reaches the endpoint.

## Fix

Seed the toggle the way the other fixtures are seeded (`POST /api/v1/admin/security {"remote_login": true}`), then **assert the logged-out endpoint actually answers 200 with a `verify_url`**. Flipping the flag and hoping is how this class of failure hides; if something else breaks the endpoint, the seed now fails loudly with one clear error instead of producing opaque spec failures fifteen minutes later.

## Verification

**Live container (`cwn-local`), the real HTTP route — red/green:**

| `remote_login` | `POST /api/v1/auth/magic-link/start` (logged out) |
|---|---|
| `False` (the CI default) | `403` `{"error":{"code":"magic_link_disabled"}}` |
| `True` (this seed) | `200`, `verify_url` + `token` + `qrcode` present |

`cwn-local` was restored to its prior state afterwards.

**Regression tests** — `tests/unit/test_workflow_safety_invariants.py`, two new invariants:
- the e2e job enables `remote_login` **before** `npm run test:e2e` runs
- the seed verifies the logged-out endpoint and fails loudly (`::error::` + `exit 1`)

Red against `main`'s workflow, green here:

```
# main's tests.yml
AssertionError: The e2e job never enables config_remote_login...
2 failed, 11 deselected

# this branch
13 passed
```

## Scope — what this does not fix

The repo-wide red was three distinct failures, not one. Correcting the earlier triage note, which guessed a shared broken fixture: the seed was healthy all along (`shelves now: 2`, `series now: 1`, 3/3 books ingested).

1. **`login-redirect.spec.ts:68`** — fixed here.
2. **`hidden-books.spec.ts:252`** — a real 35px horizontal overflow on the book detail page at 390px, failing on desktop **and** mobile. **#1178 already fixes it**: it fails on the CHANGELOG-only control branch and does not fail on #1178.
3. **`sp1-ux.spec.ts:3`** — flaky, not broken (passes on retry). Left alone; quarantining it would hide a real nav-ordering assertion.

With #1178 merged and this landed, the expected state is a genuinely green e2e run. **Promoting the job to required, and running it on `main`, should happen only after several consecutive green runs** — making a gate mandatory before it has earned it is how it got ignored in the first place.

No dependency, license, or external-URL change (rule 6). No app code changes — CI fixture and tests only, so no CHANGELOG entry (nothing user-facing) and no `CHANGES-vs-upstream.md` row (no upstream divergence).