### PR TITLE
Make the book card's bottom a real row so actions can't cover metadata (#1166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The edit pencil no longer sits on top of a book's series or author line, and "Read now" no longer breaks across two lines on a phone.** The bottom of each book card wasn't a real layout: the pencil floated over the card and room for it was reserved by padding the "Read now" label. That works only while the card is wider than the space being reserved — on a phone in Compact or Dense view the card is around 82–106 pixels and the reservation alone was 60, so the label wrapped, the row grew, and the pencil rode up into the line above it. Books with no readable format had no "Read now" at all, so the pencil landed directly on the series. The two controls now share one row, sized by the browser rather than guessed at, and on the narrowest cards the pencil scales down and the label gives way to its icon instead of being squeezed. Reported by rogovmtlz on Discord, [@iroQuai](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1166) and [@HLRobius](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1166) ([#1166](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1166), [#1112](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1112)).
+
 ## [v4.1.22] - 2026-07-27
 
 ### Changed

--- a/frontend/e2e/card-action-row.spec.ts
+++ b/frontend/e2e/card-action-row.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect } from '@playwright/test';
+
+/*
+ * #1166 — the Edit pencil overlaps the series line, and "Read now" renders
+ * awkwardly, on narrow cards.
+ *
+ * Reported by rogovmtlz (Discord, "the edit button overlaps the series"),
+ * @iroQuai (a Dutch phone screenshot where "Nu lezen" wraps to two lines beside
+ * a 44px pencil) and @HLRobius ("the edit button doesn't resize on mobile with
+ * the different settings", with Comfortable/Compact/Dense screenshots).
+ *
+ * One root cause behind all three: the bottom of the card was not a layout. The
+ * pencil was absolutely positioned against `.wrap` and the space for it was
+ * *reserved* on the label with a fixed `padding-right: calc(44px + sp-2 * 2)`
+ * (#1112). Reservation only works while the card is wider than the thing being
+ * reserved. On a 4-column 375px grid the card is ~80px, the reservation is
+ * 60px, and the label is left ~20px — so it wraps to two lines, the row grows,
+ * and the 44px pencil (bottom: 8px => top at wrap.bottom - 52) rises above the
+ * 44px-tall label band into the series line.
+ *
+ * The fix makes the bottom row a real flex row, so the browser allocates the
+ * space instead of the stylesheet guessing at it. These assertions therefore
+ * pin *construction*, not pixels: a control that lives in normal flow below the
+ * metadata cannot overlap the metadata at any width, density or locale.
+ *
+ * Runs on the mobile/ipad projects, where coarse-pointer rules make both
+ * controls permanently visible — that is the reporters' default state, not a
+ * hover edge case.
+ */
+
+// Dense is the worst case (4 columns at 375px) and is what @HLRobius shot.
+// Set before first paint so the grid never renders at another density.
+const DENSITY_KEY = 'cwng:catalog-density-v1';
+
+const MEASURE = `(() => {
+  const wraps = [...document.querySelectorAll('[class*="wrap"]')]
+    .filter((w) => w.querySelector('[class*="quickEditBtn"]'));
+
+  const overlaps = [];   // pencil sitting on top of card text
+  const wrapped = [];    // "Read now" broken onto a second line
+  const overflow = [];   // action control escaping the card box
+  let checked = 0;
+
+  for (const w of wraps) {
+    const pencil = w.querySelector('[class*="quickEditBtn"]');
+    if (!pencil || getComputedStyle(pencil).opacity === '0') continue;
+    checked++;
+
+    const wb = w.getBoundingClientRect();
+    const pb = pencil.getBoundingClientRect();
+    const title = (w.querySelector('[class*="title"]')?.textContent || '').slice(0, 30);
+
+    // 1. The pencil must not cover title / author / series.
+    for (const sel of ['[class*="title"]', '[class*="author"]', '[data-testid="book-card-series"]']) {
+      const el = w.querySelector(sel);
+      if (!el) continue;
+      const b = el.getBoundingClientRect();
+      const v = Math.min(pb.bottom, b.bottom) - Math.max(pb.top, b.top);
+      const h = Math.min(pb.right, b.right) - Math.max(pb.left, b.left);
+      if (v > 0.5 && h > 0.5) {
+        overlaps.push({ title, on: sel, v: Math.round(v), h: Math.round(h) });
+      }
+    }
+
+    // 2. The "Read now" label must stay on one line. A Range over the text node
+    //    reports one client rect per rendered line, which works whether the
+    //    label is a bare text node (pre-fix) or wrapped in a span (post-fix).
+    const label = w.querySelector('[class*="readNow"]');
+    if (label) {
+      const textNode = [...label.childNodes]
+        .flatMap((n) => (n.nodeType === 3 ? [n] : [...n.childNodes].filter((c) => c.nodeType === 3)))
+        .find((n) => n.textContent && n.textContent.trim().length > 1);
+      if (textNode) {
+        const r = document.createRange();
+        r.selectNodeContents(textNode);
+        const lines = r.getClientRects().length;
+        if (lines > 1) wrapped.push({ title, lines, text: textNode.textContent.trim() });
+      }
+      // 3. Nothing in the action row may spill outside the card.
+      const lb = label.getBoundingClientRect();
+      if (lb.right - wb.right > 1 || wb.left - lb.left > 1) {
+        overflow.push({ title, el: 'readNow', by: Math.round(Math.max(lb.right - wb.right, wb.left - lb.left)) });
+      }
+    }
+    if (pb.right - wb.right > 1 || wb.left - pb.left > 1) {
+      overflow.push({ title, el: 'pencil', by: Math.round(Math.max(pb.right - wb.right, wb.left - pb.left)) });
+    }
+  }
+  return { checked, overlaps, wrapped, overflow };
+})()`;
+
+for (const density of ['dense', 'compact', 'comfortable'] as const) {
+  test(`card actions never cover the metadata (${density} grid, #1166)`, async ({ page }) => {
+    // usePersistentChoice stores the RAW string and ignores anything not in its
+    // allowed list — a JSON-encoded '"dense"' silently falls back to the
+    // default, which would run all three cases at the same density and look
+    // like coverage it isn't.
+    await page.addInitScript(
+      ([key, value]) => window.localStorage.setItem(key, value),
+      [DENSITY_KEY, density] as const,
+    );
+    await page.goto('/app/');
+    await page.waitForLoadState('networkidle');
+    // The grid animates in; measure settled geometry.
+    await page.locator('[class*="quickEditBtn"]').first().waitFor({ state: 'attached' });
+
+    // Fail loudly if the density never applied, rather than passing on a grid
+    // that was never the one under test. Assert the CLASS, not a column count:
+    // the fixed 2/3/4-column layout only exists below the 600px breakpoint, so
+    // a count would make this spec viewport-specific for no benefit.
+    const applied = await page.evaluate(`(() => {
+      const g = [...document.querySelectorAll('[class*="grid"]')]
+        .find((e) => /density_/.test(e.className));
+      return g ? (g.className.match(/density_(\\w+?)_/) || [])[1] || g.className : null;
+    })()`) as string | null;
+    expect(applied, `the ${density} grid did not apply (grid reports "${applied}")`).toBe(density);
+
+    const r = await page.evaluate(MEASURE) as {
+      checked: number;
+      overlaps: { title: string; on: string; v: number; h: number }[];
+      wrapped: { title: string; lines: number; text: string }[];
+      overflow: { title: string; el: string; by: number }[];
+    };
+
+    test.skip(r.checked === 0, 'no card in this seed shows an edit control');
+
+    expect(r.overlaps,
+      `the Edit control sits on top of card text — the reporters' symptom (#1166): ${JSON.stringify(r.overlaps)}`
+    ).toEqual([]);
+
+    expect(r.wrapped,
+      `the "Read now" label wrapped onto a second line because the reserved corner left it almost no width (#1166): ${JSON.stringify(r.wrapped)}`
+    ).toEqual([]);
+
+    expect(r.overflow,
+      `a card action escaped the card box (#1166): ${JSON.stringify(r.overflow)}`
+    ).toEqual([]);
+  });
+}
+
+/*
+ * The pure form of rogovmtlz's "the edit button overlaps the series": a book
+ * with no readable format (a MOBI/AZW3-only library — neither is in
+ * readerTarget's SPA_READABLE or SERVER_READABLE sets) renders no "Read now"
+ * link at all. Before the fix the pencil was absolutely positioned against the
+ * card, so with nothing at the bottom to sit over it landed straight on the
+ * last metadata line.
+ *
+ * The cwn-local seed is all EPUB, so every card has a read target and that
+ * state cannot occur naturally here. Remove the read link from a card and
+ * re-measure instead: it is the same DOM the reporter's library produces, and
+ * it pins the property that actually matters — the pencil's position is not a
+ * function of whether a sibling happens to exist.
+ */
+test('the Edit control stays off the metadata when a book has no readable format (#1166)', async ({ page }) => {
+  await page.addInitScript(
+    ([key, value]) => window.localStorage.setItem(key, value),
+    ['cwng:catalog-density-v1', 'comfortable'] as const,
+  );
+  await page.goto('/app/');
+  await page.waitForLoadState('networkidle');
+  await page.locator('[class*="quickEditBtn"]').first().waitFor({ state: 'attached' });
+
+  const r = await page.evaluate(`(() => {
+    const card = [...document.querySelectorAll('[class*="wrap"]')]
+      .find((w) => w.querySelector('[class*="quickEditBtn"]') && w.querySelector('[class*="readNow"]'));
+    if (!card) return { simulated: false };
+    card.querySelector('[class*="readNow"]').remove();
+
+    const pencil = card.querySelector('[class*="quickEditBtn"]');
+    const pb = pencil.getBoundingClientRect();
+    const hits = [];
+    for (const sel of ['[class*="title"]', '[class*="author"]', '[data-testid="book-card-series"]']) {
+      const el = card.querySelector(sel);
+      if (!el) continue;
+      const b = el.getBoundingClientRect();
+      const v = Math.min(pb.bottom, b.bottom) - Math.max(pb.top, b.top);
+      const h = Math.min(pb.right, b.right) - Math.max(pb.left, b.left);
+      if (v > 0.5 && h > 0.5) hits.push({ on: sel, v: Math.round(v), h: Math.round(h) });
+    }
+    return { simulated: true, hits, pencilVisible: getComputedStyle(pencil).opacity !== '0' || true };
+  })()`) as { simulated: boolean; hits?: { on: string; v: number; h: number }[] };
+
+  test.skip(!r.simulated, 'no card in this seed has both a read link and an edit control');
+
+  expect(r.hits,
+    `with no "Read now" link the Edit control drops onto the card's metadata (#1166): ${JSON.stringify(r.hits)}`
+  ).toEqual([]);
+});

--- a/frontend/e2e/card-action-row.spec.ts
+++ b/frontend/e2e/card-action-row.spec.ts
@@ -169,6 +169,12 @@ test('the Edit control stays off the metadata when a book has no readable format
 
     const pencil = card.querySelector('[class*="quickEditBtn"]');
     const pb = pencil.getBoundingClientRect();
+    const cb = card.getBoundingClientRect();
+    // Alone in the row, the pencil must still sit at the RIGHT edge. A bare
+    // flex row would start-align it, silently moving a control users have
+    // always found bottom-right — and only on the cards this fix targets.
+    const distFromRight = Math.round(cb.right - pb.right);
+    const distFromLeft = Math.round(pb.left - cb.left);
     const hits = [];
     for (const sel of ['[class*="title"]', '[class*="author"]', '[data-testid="book-card-series"]']) {
       const el = card.querySelector(sel);
@@ -178,12 +184,21 @@ test('the Edit control stays off the metadata when a book has no readable format
       const h = Math.min(pb.right, b.right) - Math.max(pb.left, b.left);
       if (v > 0.5 && h > 0.5) hits.push({ on: sel, v: Math.round(v), h: Math.round(h) });
     }
-    return { simulated: true, hits, pencilVisible: getComputedStyle(pencil).opacity !== '0' || true };
-  })()`) as { simulated: boolean; hits?: { on: string; v: number; h: number }[] };
+    return { simulated: true, hits, distFromRight, distFromLeft };
+  })()`) as {
+    simulated: boolean;
+    hits?: { on: string; v: number; h: number }[];
+    distFromRight?: number;
+    distFromLeft?: number;
+  };
 
   test.skip(!r.simulated, 'no card in this seed has both a read link and an edit control');
 
   expect(r.hits,
     `with no "Read now" link the Edit control drops onto the card's metadata (#1166): ${JSON.stringify(r.hits)}`
   ).toEqual([]);
+
+  expect(r.distFromRight!,
+    `the lone Edit control drifted off the right edge (${r.distFromRight}px from right, ${r.distFromLeft}px from left) — it should stay bottom-right (#1166)`
+  ).toBeLessThan(r.distFromLeft!);
 });

--- a/frontend/e2e/card-action-row.spec.ts
+++ b/frontend/e2e/card-action-row.spec.ts
@@ -202,3 +202,44 @@ test('the Edit control stays off the metadata when a book has no readable format
     `the lone Edit control drifted off the right edge (${r.distFromRight}px from right, ${r.distFromLeft}px from left) — it should stay bottom-right (#1166)`
   ).toBeLessThan(r.distFromLeft!);
 });
+
+/*
+ * Letting the row size itself only helps while what it hands each control is
+ * still tappable. `.readNow` used to floor at min-width: 0, so on the narrowest
+ * real screen — 280px, a folded Galaxy Fold — a 4-column dense card is 58px and
+ * the link measured 22px wide, under WCAG 2.2 SC 2.5.8's 24x24 minimum.
+ *
+ * 280px dense is the worst case the app can be put in, which is why it is the
+ * width asserted here: every wider grid clears the floor with room to spare.
+ */
+test('both card actions stay at a tappable size on the narrowest screens (#1166)', async ({ page }) => {
+  await page.addInitScript(
+    ([key, value]) => window.localStorage.setItem(key, value),
+    ['cwng:catalog-density-v1', 'dense'] as const,
+  );
+  await page.setViewportSize({ width: 280, height: 800 });
+  await page.goto('/app/');
+  await page.waitForLoadState('networkidle');
+  await page.locator('[class*="quickEditBtn"]').first().waitFor({ state: 'attached' });
+
+  const r = await page.evaluate(`(() => {
+    const card = [...document.querySelectorAll('[class*="wrap"]')]
+      .find((w) => w.querySelector('[class*="quickEditBtn"]'));
+    if (!card) return { found: false };
+    const cb = card.getBoundingClientRect();
+    const small = [];
+    for (const [name, sel] of [['Read now', '[class*="readNow"]:not([class*="Label"])'], ['Edit', '[class*="quickEditBtn"]']]) {
+      const el = card.querySelector(sel);
+      if (!el || getComputedStyle(el).opacity === '0') continue;
+      const b = el.getBoundingClientRect();
+      if (b.width < 24 || b.height < 24) small.push({ name, w: Math.round(b.width), h: Math.round(b.height) });
+    }
+    return { found: true, cardWidth: Math.round(cb.width), small };
+  })()`) as { found: boolean; cardWidth?: number; small?: { name: string; w: number; h: number }[] };
+
+  test.skip(!r.found, 'no card with an edit control in this seed');
+
+  expect(r.small,
+    `a card action shrank below the 24x24 minimum target size on a ${r.cardWidth}px card (WCAG 2.2 SC 2.5.8, #1166): ${JSON.stringify(r.small)}`
+  ).toEqual([]);
+});

--- a/frontend/e2e/sp1-ux.spec.ts
+++ b/frontend/e2e/sp1-ux.spec.ts
@@ -54,7 +54,11 @@ test('grid keeps details and adds a direct reader action (#653)', async ({ page 
   const readHref = await read.getAttribute('href');
   expect(readHref).toMatch(/\/(read|view)\//);
 
-  const card = read.locator('..');
+  // Resolve the enclosing card by its wrapper rather than by a fixed number of
+  // `..` hops. The read link gained an action-row parent in #1166, and a
+  // parent-depth assumption fails the moment the card's internals move — which
+  // says nothing about whether the card still offers both actions.
+  const card = read.locator('xpath=ancestor::*[contains(@class,"wrap")][1]');
   const details = card.getByRole('link', { name: /^Open details for / });
   await expect(details).toBeVisible();
   await expect(details).toHaveAttribute('href', /\/book\//);

--- a/frontend/src/components/BookCard.module.css
+++ b/frontend/src/components/BookCard.module.css
@@ -1,5 +1,6 @@
-/* Positioning root: the link/toggle button fills it; action buttons overlay it
-   as siblings of that control (never nested inside the <a>). */
+/* Positioning root: the link/toggle button fills it. The remove control and the
+   cover badges overlay it as siblings of that control (never nested inside the
+   <a>); the read + edit actions sit below it in `.actionRow`. */
 .wrap {
   position: relative;
   display: flex;
@@ -133,14 +134,16 @@
    spot. A flex row makes that impossible rather than relying on each badge's
    comment asserting the others are elsewhere.
 
-   max-width reserves the bottom-right corner for the quick-edit pencil, so
-   the row can never grow under it (the #1112 collision, avoided by
-   construction this time). */
+   max-width is now just the cover inset. It used to also reserve 34px at the
+   bottom-right for the quick-edit pencil; since #1166 the pencil sits in the
+   action row below the metadata and cannot reach the cover, so that reservation
+   only shrank the row. On an 82px dense card it left the badges 32px — narrower
+   than the "Read" badge alone, which then wrapped for no reason. */
 .badgeRow {
   position: absolute;
   bottom: var(--sp-2);
   left: var(--sp-2);
-  max-width: calc(100% - var(--sp-2) * 2 - 34px);
+  max-width: calc(100% - var(--sp-2) * 2);
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -258,6 +261,11 @@
    focus-reveal like the remove button, but always reachable via keyboard focus. */
 .quickEditBtn {
   flex: 0 0 auto;
+  /* A card with no readable format has no "Read now" link, so the pencil is
+     alone in the row and would otherwise flex-start to the LEFT edge — moving
+     a control users have always found at bottom-right, on exactly the
+     MOBI/AZW3 cards this fix was meant to help. */
+  margin-left: auto;
   width: 24px;
   height: 24px;
   border-radius: var(--r-full);
@@ -335,7 +343,13 @@
   flex: 0 0 auto;
 }
 
+/* min-width: 0 is load-bearing: a flex item's automatic minimum size is its
+   min-content width, so without this the label refuses to shrink and the
+   parent's overflow:hidden hard-clips it mid-word instead of ellipsising. The
+   gap is widest just above the container-query threshold, where a 44px touch
+   pencil leaves ~85px for a long localized string ("Jetzt lesen", "Nu lezen"). */
 .readNowLabel {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/frontend/src/components/BookCard.module.css
+++ b/frontend/src/components/BookCard.module.css
@@ -5,6 +5,13 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  /* Named query container so the action row can respond to the CARD's width
+     rather than the viewport's (#1166) — the same card renders at 82px in a
+     dense phone grid and at 260px in search results on the same screen.
+     Safe here because every consumer sizes the card from the outside (a grid
+     track, or the rails' explicit 132px/116px `.item`), so nothing depends on
+     the card's contents to establish its own inline size. */
+  container: book-card / inline-size;
 }
 
 /* The single focusable control (a <Link> or a toggle <button>). */
@@ -246,13 +253,11 @@
   border-color: var(--danger);
 }
 
-/* Quick-edit pencil (fork #572): bottom-right so it never overlaps the read
-   badge (top-right) or the remove control (top-left). Hover/focus-reveal like
-   the remove button, but always reachable via keyboard focus. */
+/* Quick-edit pencil (fork #572). Lives in `.actionRow`, in normal flow beside
+   the read link — NOT absolutely positioned over the card (#1166). Hover/
+   focus-reveal like the remove button, but always reachable via keyboard focus. */
 .quickEditBtn {
-  position: absolute;
-  bottom: var(--sp-2);
-  right: var(--sp-2);
+  flex: 0 0 auto;
   width: 24px;
   height: 24px;
   border-radius: var(--r-full);
@@ -281,27 +286,35 @@
   border-color: var(--accent);
 }
 
-/* The pencil floats over the bottom-right corner while .readNow spans the full
-   card width, so a centred label runs underneath it. Measured at 360px in a
-   touch context: 52px of the label sat under the button, clipping the tail of
-   "Read now" (#1112, reported by @Andrew-H2O). On touch it is always visible —
-   the coarse-pointer block below sets both to opacity 1 — so this is the
-   default state on a phone, not a hover edge case.
+/* The card's bottom action row: read link + edit pencil, side by side in normal
+   flow (#1166).
 
-   Reserve the corner rather than moving the label. Left-aligning it (the
-   reporter's suggestion) still collides once the title's button label is long,
-   and it changes the look on desktop where nothing collides. Padding keeps the
-   label centred within the space actually available.
+   This replaces the reserved-corner approach from #1112, where the pencil was
+   absolutely positioned over the bottom-right and `.readNow` carried a fixed
+   `padding-right: calc(44px + sp-2 * 2)` to keep its label clear of it.
+   Reserving space works only while the card is wider than the reservation. On
+   the 4-column 375px grid the card is ~80px and the reservation 60px, leaving
+   the label ~20px: it wrapped to two lines, which grew the row, which pushed
+   the 44px pencil (bottom: 8px, so top at wrap.bottom - 52) up through the
+   44px label band and into the series line above.
 
-   Only applied when the pencil is rendered, so a card without edit permission
-   keeps a truly centred label. */
-.readNowInset {
-  padding-right: calc(24px + var(--sp-2) * 2);
+   A flex row makes the browser allocate the width, so no control can sit on
+   card text at any width, density or locale. Measured at 375px dense before the
+   fix: 8px of the pencil over the series/author line on every card with an edit
+   control; after: 0. */
+.actionRow {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  margin-top: auto;
 }
 
 .readNow {
+  /* Takes the space the pencil does not. min-width: 0 lets it actually shrink
+     inside the flex row instead of forcing the row wider than the card. */
+  flex: 1 1 auto;
+  min-width: 0;
   min-height: 32px;
-  margin-top: auto;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -311,8 +324,20 @@
   font-size: var(--fs-sm);
   font-weight: var(--fw-medium);
   text-decoration: none;
+  /* One line, always. Two-line labels are what grew the row into the metadata. */
+  white-space: nowrap;
+  overflow: hidden;
   opacity: 0;
   transition: opacity var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease);
+}
+
+.readNow svg {
+  flex: 0 0 auto;
+}
+
+.readNowLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .wrap:hover .readNow,
@@ -330,13 +355,34 @@
      case the reporter was describing. */
   .readBadge, .hiddenBadge { min-height: 28px; font-size: var(--fs-sm); }
   .seriesBadge { min-width: 28px; height: 28px; font-size: var(--fs-sm); }
-  /* The pencil grows to a 44px touch target here, so the reserved corner has
-     to grow with it or the overlap comes straight back on the exact devices
-     where both controls are permanently visible. */
-  .readNowInset { padding-right: calc(44px + var(--sp-2) * 2); }
   .removeBtn, .quickEditBtn {
     width: 44px;
     height: 44px;
     opacity: 1;
   }
+}
+
+/* Narrow cards — the Compact and Dense grids, which are 3 and 4 columns on a
+   phone. Measured at 375px: comfortable 164px, compact 106px, dense 82px per
+   card. @HLRobius reported that the edit button "doesn't resize on mobile with
+   the different settings": a 44px control keeps its full size while the card
+   shrinks around it, so by Dense it is most of the card and the read label has
+   nowhere to go.
+
+   Scale the control with the card and drop the label wording, keeping the icon.
+   Queried on the card's own inline size rather than the viewport, because the
+   same BookCard renders in the catalog grid, shelves, search and the
+   "More by author" rail, each with its own column width at any given viewport
+   (the rails are a fixed 132px / 116px regardless of screen).
+
+   32px stays above the 24x24 CSS-px floor in WCAG 2.2 SC 2.5.8 Target Size
+   (Minimum, AA); the row keeps its 44px min-height, so the read link's touch
+   area is unchanged. */
+@container book-card (max-width: 132px) {
+  /* Only a row that also carries the pencil is tight enough to lose the
+     wording. A rail card at the same width has the whole row to itself, and
+     "Read now" fits there — hiding it would be a regression bought with a
+     threshold that has nothing to do with the rail. */
+  .actionRowEdit .readNowLabel { display: none; }
+  .removeBtn, .quickEditBtn { width: 32px; height: 32px; }
 }

--- a/frontend/src/components/BookCard.module.css
+++ b/frontend/src/components/BookCard.module.css
@@ -315,13 +315,21 @@
   align-items: center;
   gap: var(--sp-1);
   margin-top: auto;
+  /* Below ~60px of card the two controls cannot both hold their 24px floor on
+     one line (see .readNow). Wrapping keeps each one tappable instead of
+     shrinking one under the floor or pushing it out of the card. Inert at every
+     realistic width: a 4-column dense grid is 82px at 375px, 68px at 320px. */
+  flex-wrap: wrap;
 }
 
 .readNow {
-  /* Takes the space the pencil does not. min-width: 0 lets it actually shrink
-     inside the flex row instead of forcing the row wider than the card. */
+  /* Takes the space the pencil does not, down to a floor of 24px — WCAG 2.2
+     SC 2.5.8's minimum target size. It used to floor at 0, which let the link
+     shrink without limit: on a 280px screen (Galaxy Fold, folded) a dense card
+     is 58px and the link measured 22px, a target too small to reliably hit.
+     The label keeps its own min-width: 0, so text still ellipsises inside. */
   flex: 1 1 auto;
-  min-width: 0;
+  min-width: 24px;
   min-height: 32px;
   display: flex;
   align-items: center;

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -202,7 +202,7 @@ export function BookCard({
               // browser opens the edit page in a new tab natively (#798).
               onClick={(e) => e.stopPropagation()}
             >
-              <Pencil size={13} strokeWidth={2.5} aria-hidden="true" />
+              <Pencil size={13} strokeWidth={2.5} aria-hidden="true" focusable={false} />
             </Link>
           )}
         </div>

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -140,27 +140,30 @@ export function BookCard({
     );
   }
 
-  // Browse mode: the card is a single link. Action buttons are SIBLINGS of the
-  // link (never nested inside <a> — that's invalid + a second tab stop),
-  // absolutely positioned over the cover by .wrap.
+  // Browse mode: the card is a single link. Action controls are SIBLINGS of the
+  // link (never nested inside <a> — that's invalid + a second tab stop).
+  //
+  // The read + edit controls share one flex row in NORMAL FLOW below the
+  // metadata (#1166). They used to be absolutely positioned over the bottom of
+  // the card, with room for the pencil reserved as fixed padding on the label
+  // (#1112) — which holds only while the card is wider than the reservation. On
+  // a 4-column phone grid the card is ~80px and the reservation 60px, so the
+  // label wrapped to two lines, the row grew, and the 44px pencil rose into the
+  // series line. Reported by rogovmtlz, @iroQuai and @HLRobius.
+  //
+  // A real row lets the browser allocate the space instead of the stylesheet
+  // guessing at it, so a control can no longer land on top of card text at any
+  // width, density or locale — the same "impossible by construction" move the
+  // badge row above makes. `.removeBtn` stays absolute: it belongs to the cover,
+  // not to this row.
+  const hasActionRow = Boolean(readTarget) || quickEdit;
+
   return (
     <div className={styles.wrap} style={style}>
       <Link href={`/book/${book.id}`} className={styles.card} aria-label={t('Open details for {title}', { title: book.title })}>
         {cover}
         {info}
       </Link>
-      {readTarget && (
-        <Link
-          href={readTarget}
-          // Reserve the bottom-right corner only when the pencil is actually
-          // rendered there, so cards without edit permission keep a centred
-          // label (#1112).
-          className={quickEdit ? `${styles.readNow} ${styles.readNowInset}` : styles.readNow}
-          aria-label={t('Read {title}', { title: book.title })}
-        >
-          <BookOpen size={15} aria-hidden="true" focusable={false} /> {t('Read now')}
-        </Link>
-      )}
       {onRemove && (
         <button
           type="button"
@@ -171,21 +174,38 @@ export function BookCard({
           <X size={14} strokeWidth={3} aria-hidden="true" />
         </button>
       )}
-      {quickEdit && (
-        <Link
-          href={`/book/${book.id}/edit`}
-          className={styles.quickEditBtn}
-          aria-label={t('Edit {title}', { title: book.title })}
-          // The pencil is a SIBLING of the card link (never nested in an <a>),
-          // so a click can't bubble to the card's own navigation — stopPropagation
-          // keeps that invariant explicit if the layout is ever re-nested.
-          // wouter's <Link> runs SPA navigation only on a plain left-click; on
-          // ⌘/ctrl/shift/alt-click it returns early without preventDefault, so the
-          // browser opens the edit page in a new tab natively (#798).
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Pencil size={13} strokeWidth={2.5} aria-hidden="true" />
-        </Link>
+      {hasActionRow && (
+        <div className={quickEdit ? `${styles.actionRow} ${styles.actionRowEdit}` : styles.actionRow}>
+          {readTarget && (
+            <Link
+              href={readTarget}
+              className={styles.readNow}
+              aria-label={t('Read {title}', { title: book.title })}
+            >
+              <BookOpen size={15} aria-hidden="true" focusable={false} />
+              {/* The text is a span so a narrow card can drop the wording and
+                  keep the icon, rather than ellipsising it to "R…". The
+                  aria-label above still names the action either way. */}
+              <span className={styles.readNowLabel}>{t('Read now')}</span>
+            </Link>
+          )}
+          {quickEdit && (
+            <Link
+              href={`/book/${book.id}/edit`}
+              className={styles.quickEditBtn}
+              aria-label={t('Edit {title}', { title: book.title })}
+              // The pencil is a SIBLING of the card link (never nested in an <a>),
+              // so a click can't bubble to the card's own navigation — stopPropagation
+              // keeps that invariant explicit if the layout is ever re-nested.
+              // wouter's <Link> runs SPA navigation only on a plain left-click; on
+              // ⌘/ctrl/shift/alt-click it returns early without preventDefault, so the
+              // browser opens the edit page in a new tab natively (#798).
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Pencil size={13} strokeWidth={2.5} aria-hidden="true" />
+            </Link>
+          )}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Fixes the symptom in #1166 (and completes #1112).

## What users reported

Three people, same card, three faces of one bug:

- **rogovmtlz** (Discord, #new-ui-feedback): "the edit button overlaps the series", on both Android and desktop.
- **@iroQuai**: a Dutch phone screenshot where "Nu lezen" is broken onto two lines next to an oversized pencil.
- **@HLRobius**: "the edit button doesn't resize on mobile with the different settings", with Comfortable / Compact / Dense screenshots.

## Root cause

The bottom of the card was not a layout. The pencil was `position: absolute` against `.wrap`, and the room for it was *reserved* by padding the label: `.readNowInset { padding-right: calc(44px + var(--sp-2) * 2) }` (the #1112 fix).

Reserving space works only while the card is wider than the thing being reserved. Measured at 375px:

| Density | Columns | Card width | Reservation |
|---|---|---|---|
| Comfortable | 2 | 164px | 60px |
| Compact | 3 | 106px | 60px |
| Dense | 4 | 82px | 60px |

At Compact and Dense the label is left ~20–46px, so it wraps to two lines. That grows the row, and the 44px pencil (`bottom: 8px`, so its top is at `wrap.bottom - 52`) rises through the 44px label band into the series line above it. Hence "the edit button overlaps the series".

Two consequences fall out of the same cause:

- **No readable format, no overlap protection.** `getPrimaryReadTarget` returns null for MOBI/AZW3, so those cards render no `.readNow` at all. The absolutely-positioned pencil then had nothing to sit over and landed directly on the metadata — every card, any width. That is the pure form of the reported symptom.
- **The control never scaled.** A 44px touch target keeps its size while the card shrinks around it, so by Dense it is most of the card.

Desktop measured clean at 1280px, which is why this looked mobile-only: there the pencil is 24px and `.readNow` is 32px, so it sits flush. The 8px intrusion only appears once the coarse-pointer block takes both to 44px.

## Fix

Put the read link and the pencil in one flex row in normal flow, below the metadata. The browser allocates the width instead of the stylesheet guessing at it, so a control can no longer land on card text at any width, density or locale — the same "impossible by construction" move `.badgeRow` already makes above. `.readNowInset` is deleted; `.removeBtn` stays absolute because it belongs to the cover.

For narrow cards, a container query (on the *card's* inline size, not the viewport — the same card renders at 82px in a dense grid and 260px in search on one screen) scales the controls to 32px and drops the label wording, keeping the icon and its `aria-label`. 32px stays above the 24×24 floor in WCAG 2.2 SC 2.5.8, and the row keeps its 44px min-height so the read link's touch area is unchanged.

The label-hiding is scoped to rows that actually carry a pencil. The Discover / More-by-author rails are a fixed 116px on mobile — under the threshold, but with the row to themselves, so they keep "Read now". Verified below.

## Verification

Red/green against `cwn-local`, driving the real SPA.

**New spec `e2e/card-action-row.spec.ts`** — geometry, not pixels, so it won't fire on unrelated restyles. Four assertions per density (dense/compact/comfortable) plus the no-read-target case:

- the pencil covers no title / author / series
- "Read now" never wraps to a second line
- no action escapes the card box
- with the read link removed, the pencil still clears the metadata

Before (375px, mobile project), 8px of pencil over the series/author line on **every** card with an edit control, in all three densities:

```
dense:       [{"on":"book-card-series","v":8,"h":44}, {"on":"author","v":8,"h":44}, ... 6 cards]
compact:     [... 5 cards]
comfortable: [... 4 cards]
no-read-target: [{"on":"book-card-series","v":8,"h":44}]
```

After: all empty, 6 passed.

The spec asserts the density class actually applied before measuring. `usePersistentChoice` stores a **raw** string and silently falls back on anything else — my first draft seeded it with `JSON.stringify()`, so all three cases ran at the default density and looked like coverage they weren't. The guard makes that failure loud.

**Non-regressions, measured in-browser rather than assumed:**

| Surface | Width | Pencil | "Read now" wording |
|---|---|---|---|
| Catalog, comfortable | 164px | yes | kept ✓ |
| Discover rail | 116px | no | kept ✓ |
| Catalog, dense | 82px | yes | icon only, by design |

**Suite:** `card-action-overlap` (#1112), `book-card-actions` (ipad-touch), `series-on-cards`, `browse`, `entity-page-title`, `sp1-ux` — 29 passed, 0 failed.

`sp1-ux` #653 reached the details link via `read.locator('..')`. The read link gained an action-row parent, so that hop-count assumption broke — it now resolves the card by its wrapper. Confirmed the assertion still holds (the card does still offer both actions); this is a test coupled to old structure, not a behaviour change.

**Pre-existing failures, not from this change.** I baselined them on clean `origin/main` with the same container and they fail identically there:

- `a11y.spec.ts` — `color-contrast [serious]`, 31 nodes, across grid / book detail / edit / admin / **login (unauthenticated)**. Login has no BookCard, which is what makes it clearly unrelated. The a11y gate is red on main; filed separately.
- `cover-upload-refresh.spec.ts` (#989) — times out on baseline too.

Anything else in the first full-suite run (theme, entity-page-title on mobile) passed on a serial re-run — contention, not defects.

## Scope

- Tier: `needs-review` (fork-original, multi-file, UI).
- Rule 6: no new dependency, license, or external URL. Container queries are a CSS feature (Chrome 105+ / Safari 16+ / Firefox 110+), not a package.
- `/security-review`: not triggered — no auth/session/CSRF, crypto, subprocess, user-controlled path, or new route. Layout only.