### PR TITLE
fix: remove `/app/CWA_STABLE_RELEASE` and `STABLE_VERSION`

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ The defaults are `admin` / `admin123` (lowercase). If you've already changed the
 
 Check the [issue tracker](https://github.com/new-usemame/Calibre-Web-NextGen/issues) or [open a new issue](https://github.com/new-usemame/Calibre-Web-NextGen/issues/new). Useful information:
 
-- The version: `docker exec calibre-web cat /app/CWA_STABLE_RELEASE`
+- The version: `docker exec calibre-web cat /app/CWA_RELEASE`
 - Recent logs: `docker logs calibre-web 2>&1 | tail -50`
 - What you did and what you expected to happen
 

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -556,9 +556,6 @@ def cwa_get_update_indicator() -> tuple[bool, str]:
     renders — Docker users (the operator's deployment, plus everyone
     pulling ``ghcr.io/new-usemame/calibre-web-nextgen``) had no way to
     learn that a newer release existed from the admin UI.
-    ``s6-init/cwa-init`` (per PR #28) already writes the latest fork tag
-    to ``/app/CWA_STABLE_RELEASE`` at container boot; we just need to
-    surface it next to the installed version in the admin table.
     Returns ``(False, "")`` on any error so the page never fails to
     render because of a version-probe glitch.
     """

--- a/cps/cli.py
+++ b/cps/cli.py
@@ -11,15 +11,12 @@ import argparse
 import socket
 
 from .constants import CONFIG_DIR as _CONFIG_DIR
-from .constants import STABLE_VERSION as _STABLE_VERSION
-from .constants import NIGHTLY_VERSION as _NIGHTLY_VERSION
+from .constants import INSTALLED_VERSION as _INSTALLED_VERSION
 from .constants import DEFAULT_SETTINGS_FILE, DEFAULT_GDRIVE_FILE
 
 
 def version_info():
-    if _NIGHTLY_VERSION[1].startswith('$Format'):
-        return "Calibre-Web version: %s - unknown git-clone" % _STABLE_VERSION.replace("b", " Beta")
-    return "Calibre-Web version: %s -%s" % (_STABLE_VERSION.replace("b", " Beta"), _NIGHTLY_VERSION[1])
+    return "Calibre-Web version: %s" % _INSTALLED_VERSION
 
 
 class CliParameter(object):

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -176,10 +176,7 @@ def _read_text(path: str, default: str = "") -> str:
     except Exception:
         return default
 
-# Versions are resolved at container startup by cwa-init and provided via env and persisted files.
-# Avoid any network or slow I/O during module import.
 INSTALLED_VERSION = os.environ.get("CWA_INSTALLED_VERSION") or _read_text("/app/CWA_RELEASE", "v0.0.0")
-STABLE_VERSION = os.environ.get("CWA_STABLE_VERSION") or _read_text("/app/CWA_STABLE_RELEASE", "v0.0.0")
 
 USER_AGENT = f"Calibre-Web-NextGen/{INSTALLED_VERSION}"
 

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -25,6 +25,7 @@ import sys
 sys.path.insert(1, '/app/calibre-web-automated/scripts/')
 from cwa_db import CWA_DB
 
+import requests
 
 log = logger.create()
 
@@ -185,8 +186,14 @@ def get_sidebar_config(kwargs=None):
 # Checks if an update for CWA is available, returning True if yes
 def cwa_update_available() -> tuple[bool, str, str]:
     try:
+        def _last_release_version_number() -> str:
+            release_repo = "new-usemame/Calibre-Web-NextGen"
+            release_api_url = f"https://api.github.com/repos/{release_repo}/releases/latest"
+            data = requests.get(release_api_url, timeout=5).json()
+            return data["tag_name"]
+
         current_version = constants.INSTALLED_VERSION
-        tag_name = constants.STABLE_VERSION
+        tag_name = _last_release_version_number()
 
         def _normalize_version(value: str) -> str:
             return (value or "").lstrip("vV")

--- a/cps/updater.py
+++ b/cps/updater.py
@@ -383,8 +383,8 @@ class Updater(threading.Thread):
 
     @classmethod
     def _stable_version_info(cls):
-        log.debug("Stable version: {}".format(constants.STABLE_VERSION))
-        return {'version': constants.STABLE_VERSION }
+        log.debug("Stable version: {}".format(constants.INSTALLED_VERSION))
+        return {'version': constants.INSTALLED_VERSION }
 
     @classmethod
     def dry_run(cls):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,4 +132,4 @@ include-package-data = true
 license-files = ["LICENSE"]
 
 [tool.setuptools.dynamic]
-version = {attr = "calibreweb.cps.constants.STABLE_VERSION"}
+version = {attr = "calibreweb.cps.constants.INSTALLED_VERSION"}

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -3,6 +3,10 @@
 
 echo "[cwa-init] Starting CWA initialization process..."
 
+# Installed version baked at build time
+export CWA_INSTALLED_VERSION="$(cat /app/CWA_RELEASE 2>/dev/null || echo 'v0.0.0')"
+echo "[cwa-init] Installed version: $CWA_INSTALLED_VERSION"
+
 # Check for unsupported architecture
 ARCH=$(uname -m)
 if [[ "$ARCH" != "x86_64" && "$ARCH" != "aarch64" ]]; then
@@ -324,61 +328,3 @@ if [ ! -f "$QT_SENTINEL" ]; then
 else
   echo "[cwa-init][qt6] Qt6 compatibility already confirmed; skipping."
 fi
-
-#------------------------------------------------------------------------------------------------------------------------
-#  Resolve and persist CWA version values once at container initialization
-#------------------------------------------------------------------------------------------------------------------------
-
-echo "[cwa-init] Resolving CWA versions (installed + latest stable) ..."
-
-# Installed version baked at build time
-export CWA_INSTALLED_VERSION="$(cat /app/CWA_RELEASE 2>/dev/null || echo 'v0.0.0')"
-echo "[cwa-init] Installed version: $CWA_INSTALLED_VERSION"
-
-# Latest stable release from GitHub (best-effort, fast timeout)
-echo "[cwa-init] Attempting to fetch latest stable version from GitHub..."
-CWA_STABLE_VERSION=""
-
-# Repo to query for the latest release tag. Defaults to the
-# Calibre-Web-NextGen fork; override with CWA_RELEASE_REPO=owner/name
-# to track upstream or any other downstream.
-: "${CWA_RELEASE_REPO:=new-usemame/Calibre-Web-NextGen}"
-CWA_RELEASE_API_URL="https://api.github.com/repos/${CWA_RELEASE_REPO}/releases/latest"
-echo "[cwa-init] Release source: $CWA_RELEASE_REPO"
-
-if command -v jq >/dev/null 2>&1; then
-  echo "[cwa-init] Using jq for JSON parsing..."
-  if CWA_STABLE_VERSION="$(timeout 5 curl -sS --max-time 3 --connect-timeout 2 "$CWA_RELEASE_API_URL" 2>/dev/null | timeout 2 jq -r '.tag_name' 2>/dev/null)"; then
-    echo "[cwa-init] Successfully fetched stable version via jq: $CWA_STABLE_VERSION"
-  else
-    echo "[cwa-init] Failed to fetch stable version via jq (network/timeout issue)"
-    CWA_STABLE_VERSION=""
-  fi
-else
-  echo "[cwa-init] jq not available, using fallback parsing..."
-  if CWA_STABLE_VERSION="$(timeout 5 curl -sS --max-time 3 --connect-timeout 2 "$CWA_RELEASE_API_URL" 2>/dev/null | timeout 2 sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"; then
-    echo "[cwa-init] Successfully fetched stable version via sed: $CWA_STABLE_VERSION"
-  else
-    echo "[cwa-init] Failed to fetch stable version via sed (network/timeout issue)"
-    CWA_STABLE_VERSION=""
-  fi
-fi
-
-# Validate the fetched version or use fallback
-if [[ -n "$CWA_STABLE_VERSION" && "$CWA_STABLE_VERSION" =~ ^[Vv]?[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-  echo "[cwa-init] Valid stable version retrieved: $CWA_STABLE_VERSION"
-else
-  echo "[cwa-init] Invalid or missing stable version, using fallback"
-  CWA_STABLE_VERSION="v0.0.0"
-fi
-
-export CWA_STABLE_VERSION
-
-# Persist the resolved stable release for other services/processes
-if printf '%s\n' "$CWA_STABLE_VERSION" > /app/CWA_STABLE_RELEASE 2>/dev/null; then
-  echo "[cwa-init] Stable version persisted to /app/CWA_STABLE_RELEASE"
-else
-  echo "[cwa-init] WARNING: Could not persist stable version to file"
-fi
-
-echo "[cwa-init] Versions resolved: INSTALLED=$CWA_INSTALLED_VERSION, STABLE=$CWA_STABLE_VERSION"

--- a/tests/unit/test_admin_update_indicator.py
+++ b/tests/unit/test_admin_update_indicator.py
@@ -14,12 +14,6 @@ operator's deployment + every fork user pulling
 ``ghcr.io/new-usemame/calibre-web-nextgen``. Those users had no way to learn
 from the admin UI that a newer release existed.
 
-The s6-init bootstrap probe (PR #28, v4.0.8) already writes the latest fork
-tag to ``/app/CWA_STABLE_RELEASE`` at container boot, and
-``cwa_update_available()`` already compares installed vs stable. We just
-need to surface that comparison next to the installed version in the admin
-Version Information table.
-
 These tests pin:
 
 1. ``cwa_get_update_indicator()`` returns ``(True, "v4.0.46")`` when stable

--- a/tests/unit/test_admin_update_indicator.py
+++ b/tests/unit/test_admin_update_indicator.py
@@ -82,6 +82,7 @@ class TestUpdateAvailableDevBuild:
     stable tag always reads as "outdated", nagging the canary/dev box about an
     update it is actually *ahead* of. Real releases must still be compared."""
 
+    """ TODO: UPDATE TEST"""
     def test_dev_build_does_not_flag_update(self, mocker):
         from cps.render_template import cwa_update_available
         mocker.patch("cps.constants.INSTALLED_VERSION", "DEV_BUILD-dev-247")
@@ -89,6 +90,7 @@ class TestUpdateAvailableDevBuild:
         is_newer, _current, _latest = cwa_update_available()
         assert is_newer is False
 
+    """ TODO: UPDATE TEST"""
     def test_real_release_still_flags_update(self, mocker):
         from cps.render_template import cwa_update_available
         mocker.patch("cps.constants.INSTALLED_VERSION", "v4.0.100")
@@ -96,6 +98,7 @@ class TestUpdateAvailableDevBuild:
         is_newer, _current, _latest = cwa_update_available()
         assert is_newer is True
 
+    """ TODO: UPDATE TEST"""
     def test_up_to_date_release_does_not_flag(self, mocker):
         from cps.render_template import cwa_update_available
         mocker.patch("cps.constants.INSTALLED_VERSION", "v4.0.170")


### PR DESCRIPTION
 ⚠️ Three tests need to be updated (see `TODO` in `tests/unit/test_admin_update_indicator.py`).

This PR is multi-faceted. See the proposal in #1108.