### PR TITLE
Stop tests/docker/ from shadowing the Docker SDK (restores the integration suite)

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,18 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Marks tests/ as a package so its subdirectories stay namespaced.
+
+Keep this file. Without it, pytest's prepend import mode puts `tests/`
+itself on `sys.path`, which promotes every directory under it to a
+top-level module — and `tests/docker/` then outranks the installed
+Docker SDK, so `import docker` lands here and the SDK's submodules go
+missing. That took out the whole Docker integration suite once already.
+
+Helpers under tests/ are imported as `tests.<module>`; nothing should
+add `tests/` to `sys.path`. `tests/unit/test_tests_tree_import_hygiene.py`
+holds the line.
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def _get_test_uid_gid() -> tuple[str, str]:
 if USE_DOCKER_VOLUMES:
     print("\n🔄 Docker Volume mode enabled (USE_DOCKER_VOLUMES=true)")
     print("   Using Docker volumes instead of bind mounts for DinD compatibility\n")
-    from conftest_volumes import volume_copy, VolumePath
+    from tests.conftest_volumes import volume_copy, VolumePath
 else:
     # Bind mode by default, but support auto-fallback copying via docker cp
     class DockerPath:
@@ -453,10 +453,10 @@ def pytest_configure(config):
 
 TESTS_ROOT = Path(__file__).resolve().parent
 
-if str(TESTS_ROOT) not in sys.path:
-    sys.path.insert(0, str(TESTS_ROOT))
-
-from quarantine import QUARANTINED  # noqa: E402  (needs TESTS_ROOT on sys.path)
+# Imported through the `tests` package, never by bare name: putting TESTS_ROOT
+# on sys.path would make tests/docker/ shadow the installed Docker SDK. See
+# tests/__init__.py.
+from tests.quarantine import QUARANTINED  # noqa: E402
 
 #: Directory under tests/ -> the lane marker its tests belong to.
 LANE_BY_DIRECTORY = {
@@ -855,16 +855,7 @@ def sample_ebook_path(tmp_path) -> Path:
 
     Creates a fresh minimal EPUB for each test function.
     """
-    # Import relative to tests directory
-    import sys
-    from pathlib import Path as PathLib
-
-    # Add tests directory to path if not already there
-    tests_dir = PathLib(__file__).parent
-    if str(tests_dir) not in sys.path:
-        sys.path.insert(0, str(tests_dir))
-
-    from fixtures.generate_synthetic import create_minimal_epub
+    from tests.fixtures.generate_synthetic import create_minimal_epub
 
     epub_path = tmp_path / "test_sample.epub"
     create_minimal_epub(epub_path)
@@ -902,7 +893,7 @@ def library_folder(test_volumes: dict, container_name: str) -> Path:
 
 if USE_DOCKER_VOLUMES:
     # Import volume-based fixtures
-    from conftest_volumes import (
+    from tests.conftest_volumes import (
         test_volumes_dind,
         cwa_container_dind,
         ingest_folder_dind,

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -15,13 +15,12 @@ shared between docker/ and integration/ test directories.
 """
 
 import pytest
-import sys
 from pathlib import Path
 
-# Add parent tests directory to path
+# Never put tests/ on sys.path — tests/docker/ would shadow the installed
+# Docker SDK and testcontainers could no longer import docker.context. See
+# tests/__init__.py.
 _tests_dir = Path(__file__).parent.parent
-if str(_tests_dir) not in sys.path:
-    sys.path.insert(0, str(_tests_dir))
 
 # Import and re-export from parent conftest (avoids circular import)
 import importlib.util

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,7 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Synthetic book fixtures, imported as `tests.fixtures.<module>`."""

--- a/tests/integration/test_ingest_checksums.py
+++ b/tests/integration/test_ingest_checksums.py
@@ -108,7 +108,7 @@ class TestIngestChecksumGeneration:
 
     def test_epub_ingest_generates_checksum(self, cwa_container, ingest_folder, library_folder, test_epub):
         """Test that importing an EPUB generates a checksum."""
-        from conftest import volume_copy, get_db_path
+        from tests.conftest import volume_copy, get_db_path
 
         # Copy test EPUB to ingest folder
         volume_copy(test_epub, ingest_folder / "test.epub")
@@ -138,7 +138,7 @@ class TestIngestChecksumGeneration:
         self, cwa_container, ingest_folder, library_folder, test_mobi
     ):
         """Test that conversion generates checksums for both original and converted formats."""
-        from conftest import volume_copy, get_db_path
+        from tests.conftest import volume_copy, get_db_path
 
         # Enable auto-convert in settings (this might need API call to change settings)
         # For now, assume it's enabled by default or in test config
@@ -171,7 +171,7 @@ class TestIngestChecksumGeneration:
         self, cwa_container, ingest_folder, library_folder, test_epub
     ):
         """Test that books with multiple formats get checksums for each."""
-        from conftest import volume_copy, get_db_path
+        from tests.conftest import volume_copy, get_db_path
         import shutil
 
         # Copy same book with different extensions (simulating multi-format)
@@ -198,7 +198,7 @@ class TestIngestChecksumGeneration:
         self, container_name, ingest_folder, library_folder, test_epub
     ):
         """Test that checksums survive container restart."""
-        from conftest import volume_copy, get_db_path
+        from tests.conftest import volume_copy, get_db_path
         import subprocess
 
         # Ingest a book
@@ -240,7 +240,7 @@ class TestChecksumGenerationEdgeCases:
         self, cwa_container, ingest_folder, library_folder, tmp_path
     ):
         """Test that failed ingests don't leave orphan checksums."""
-        from conftest import volume_copy, get_db_path
+        from tests.conftest import volume_copy, get_db_path
 
         # Create an invalid file that will fail to ingest
         invalid_file = tmp_path / "invalid.epub"
@@ -263,7 +263,7 @@ class TestChecksumGenerationEdgeCases:
         self, cwa_container, ingest_folder, library_folder, test_epub
     ):
         """Test that re-importing a book updates or maintains checksum."""
-        from conftest import volume_copy, get_db_path
+        from tests.conftest import volume_copy, get_db_path
 
         # Import once
         volume_copy(test_epub, ingest_folder / "duplicate1.epub")
@@ -290,7 +290,7 @@ class TestChecksumGenerationEdgeCases:
         self, cwa_container, ingest_folder, library_folder, test_epub
     ):
         """Test that checksum is generated even if metadata fetch fails."""
-        from conftest import volume_copy, get_db_path
+        from tests.conftest import volume_copy, get_db_path
 
         # This test would need to disable metadata fetching or use a book
         # that won't match any metadata providers
@@ -392,7 +392,7 @@ class TestChecksumInitialization:
         self, cwa_container, library_folder
     ):
         """Test that existing books get checksums on first container startup."""
-        from conftest import get_db_path
+        from tests.conftest import get_db_path
 
         # This test assumes container was just started for the first time
         # and the init script ran

--- a/tests/integration/test_ingest_pipeline.py
+++ b/tests/integration/test_ingest_pipeline.py
@@ -21,15 +21,11 @@ from pathlib import Path
 import sqlite3
 import subprocess
 import json
-import sys
 
-# Ensure fixtures directory is importable
-_tests_dir = Path(__file__).parent.parent
-if str(_tests_dir) not in sys.path:
-    sys.path.insert(0, str(_tests_dir))
-
-# Import volume_copy from conftest - works in both modes
-from conftest import volume_copy, get_db_path
+# Import volume_copy from conftest - works in both modes. Qualified through the
+# `tests` package: putting tests/ on sys.path would make tests/docker/ shadow
+# the installed Docker SDK. See tests/__init__.py.
+from tests.conftest import volume_copy, get_db_path
 
 
 @pytest.mark.docker_integration
@@ -101,7 +97,7 @@ class TestBookIngestInContainer:
     
     def test_ingest_multiple_files(self, ingest_folder, library_folder, tmp_path, cwa_container):
         """Test ingesting multiple files at once."""
-        from fixtures.generate_synthetic import create_minimal_epub
+        from tests.fixtures.generate_synthetic import create_minimal_epub
         
         # Create 3 test EPUBs
         test_files = []
@@ -172,7 +168,7 @@ class TestIngestErrorHandling:
     
     def test_ingest_corrupted_file(self, ingest_folder, tmp_path, cwa_container):
         """Test that corrupted files are handled gracefully."""
-        from fixtures.generate_synthetic import create_corrupted_epub
+        from tests.fixtures.generate_synthetic import create_corrupted_epub
         
         # Create corrupted file
         corrupted = tmp_path / "corrupted_test.epub"
@@ -252,7 +248,7 @@ class TestInternationalCharacters:
         - Nordic: åøæ
         - Polish: książka
         """
-        from fixtures.generate_synthetic import create_minimal_epub
+        from tests.fixtures.generate_synthetic import create_minimal_epub
         
         # Create EPUB with international characters in filename
         international_filename = "test_international_äöüß_éèêë_áéíóú_ñ_åøæ_książka.epub"
@@ -507,7 +503,7 @@ class TestAdvancedIngestFeatures:
         
         Users sometimes drag entire folders into the ingest directory.
         """
-        from fixtures.generate_synthetic import create_minimal_epub
+        from tests.fixtures.generate_synthetic import create_minimal_epub
         
         # Create a subdirectory with multiple files
         sub_dir = ingest_folder / "batch_import"
@@ -584,7 +580,7 @@ class TestFilenameHandling:
         """
         Test that empty directories are cleaned up after files are processed.
         """
-        from fixtures.generate_synthetic import create_minimal_epub
+        from tests.fixtures.generate_synthetic import create_minimal_epub
         
         # Create subdirectory with one file
         sub_dir = ingest_folder / "temp_folder"
@@ -649,7 +645,7 @@ class TestIngestStability:
         
         Regression test for memory leaks and resource exhaustion.
         """
-        from fixtures.generate_synthetic import create_minimal_epub
+        from tests.fixtures.generate_synthetic import create_minimal_epub
         
         num_files = 5  # Conservative number for CI
         created_files = []
@@ -696,7 +692,7 @@ class TestIngestStability:
         time.sleep(20)
         
         # Drop a valid file afterwards to verify ingest still works
-        from fixtures.generate_synthetic import create_minimal_epub
+        from tests.fixtures.generate_synthetic import create_minimal_epub
         local_valid_file = tmp_path / "after_zero_byte.epub"
         create_minimal_epub(local_valid_file)
         

--- a/tests/integration/test_simple_ingest.py
+++ b/tests/integration/test_simple_ingest.py
@@ -11,9 +11,9 @@ Simple test to verify basic EPUB ingest works.
 
 import pytest
 import time
-import shutil
 import subprocess
-from pathlib import Path
+
+from tests.conftest import volume_copy
 
 # Drives a real container via the cwa_container fixture, so it belongs to the
 # Integration job, not the Fast Tests gate. It sat at tests/ root with no
@@ -22,66 +22,71 @@ from pathlib import Path
 pytestmark = pytest.mark.docker_integration
 
 
-def test_simple_epub_ingest(cwa_container, ingest_folder, library_folder):
+def test_simple_epub_ingest(cwa_container, ingest_folder, container_name, tmp_path):
     """
     Drop an EPUB and verify it gets processed.
     """
-    print("\n" + "="*80)
+    print("\n" + "=" * 80)
     print("🧪 SIMPLE EPUB INGEST TEST")
-    print("="*80)
-    
+    print("=" * 80)
+
     # Create a minimal EPUB
     from tests.fixtures.generate_synthetic import create_minimal_epub
-    
-    epub_path = Path("/tmp/simple_test.epub")
+
+    epub_path = tmp_path / "simple_test.epub"
     create_minimal_epub(epub_path)
     print(f"✓ Created EPUB: {epub_path} ({epub_path.stat().st_size} bytes)")
-    
-    # Copy to ingest volume using helper
-    ingest_folder.copy_to(epub_path, "simple_test.epub")
-    print(f"✓ Copied to ingest volume")
-    print(f"✓ File exists in ingest folder: {ingest_folder.file_exists('simple_test.epub')}")
-    
+
+    # volume_copy + `/` + .exists() are the pair that work in both bind and
+    # auto-fallback volume mode. This test used to call ingest_folder.copy_to()
+    # / .file_exists(), which only exist on VolumePath — so it could only ever
+    # have passed in volume mode, and AUTO_DOCKER_VOLUMES defaults to False.
+    # Nobody noticed because the test errored at fixture setup instead (#1201).
+    dest_file = ingest_folder / "simple_test.epub"
+    volume_copy(epub_path, dest_file)
+    print(f"✓ Copied into ingest folder: {dest_file}")
+    print(f"✓ File exists in ingest folder: {dest_file.exists()}")
+
     # Check what the container sees
     print("\n🔍 Checking container's view of /cwa-book-ingest:")
     result = subprocess.run(
-        ["docker", "exec", "temp-cwa-test-suite", "ls", "-la", "/cwa-book-ingest"],
+        ["docker", "exec", container_name, "ls", "-la", "/cwa-book-ingest"],
         capture_output=True, text=True
     )
     print(result.stdout)
-    
+
     # Wait and watch
     print("\n⏳ Waiting for file to be processed...")
     for i in range(30):
         time.sleep(2)
-        exists = ingest_folder.file_exists('simple_test.epub')
-        print(f"[{(i+1)*2}s] File still exists: {exists}")
-        
+        exists = dest_file.exists()
+        print(f"[{(i + 1) * 2}s] File still exists: {exists}")
+
         if not exists:
             print("✅ File was consumed!")
             break
-            
+
         # Check container view periodically
         if i % 5 == 0:
             result = subprocess.run(
-                ["docker", "exec", "temp-cwa-test-suite", "ls", "-la", "/cwa-book-ingest"],
+                ["docker", "exec", container_name, "ls", "-la", "/cwa-book-ingest"],
                 capture_output=True, text=True
             )
             print(f"Container view:\n{result.stdout}")
     else:
         print("❌ File still exists after 60 seconds")
-        
+
         # Check container logs
         print("\n📋 Container logs:")
         result = subprocess.run(
-            ["docker", "logs", "--tail", "50", "temp-cwa-test-suite"],
+            ["docker", "logs", "--tail", "50", container_name],
             capture_output=True, text=True
         )
         print(result.stdout)
-        
+
         pytest.fail("File was not processed")
-    
-    print("\n" + "="*80)
+
+    print("\n" + "=" * 80)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_simple_ingest.py
+++ b/tests/integration/test_simple_ingest.py
@@ -31,12 +31,7 @@ def test_simple_epub_ingest(cwa_container, ingest_folder, library_folder):
     print("="*80)
     
     # Create a minimal EPUB
-    import sys
-    tests_dir = Path(__file__).parent
-    if str(tests_dir) not in sys.path:
-        sys.path.insert(0, str(tests_dir))
-    
-    from fixtures.generate_synthetic import create_minimal_epub
+    from tests.fixtures.generate_synthetic import create_minimal_epub
     
     epub_path = Path("/tmp/simple_test.epub")
     create_minimal_epub(epub_path)

--- a/tests/unit/test_ci_test_lanes.py
+++ b/tests/unit/test_ci_test_lanes.py
@@ -37,10 +37,10 @@ import pytest
 #: nothing at all.
 pytestmark = pytest.mark.unit
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 
-from conftest import LANE_BY_DIRECTORY, LANE_MARKERS, lane_for_path  # noqa: E402
-from quarantine import QUARANTINED  # noqa: E402
+from tests.conftest import LANE_BY_DIRECTORY, LANE_MARKERS, lane_for_path  # noqa: E402
+from tests.quarantine import QUARANTINED  # noqa: E402
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
 TESTS = REPO / "tests"

--- a/tests/unit/test_tests_tree_import_hygiene.py
+++ b/tests/unit/test_tests_tree_import_hygiene.py
@@ -1,0 +1,220 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""The tests/ tree must never shadow an installed distribution.
+
+`tests/docker/` is a directory named after a real PyPI distribution
+(`docker`, the Docker SDK). For as long as `tests/` itself sat on
+`sys.path`, every directory under it was importable as a *top-level*
+module, so `import docker` resolved to `tests/docker/__init__.py`
+instead of the SDK. Anything reaching for a submodule then died with a
+misleading `ModuleNotFoundError: No module named 'docker.context'` —
+`import docker` had succeeded, just against the wrong package.
+
+That is what killed the Docker integration suite: testcontainers' compose
+backend imports `docker.context`, so 80 of 118 integration tests errored
+at fixture setup. The job is `continue-on-error` outside tier-2 PRs, so
+the summary still reported green and the breakage stayed invisible.
+
+These tests pin the structural invariant instead of that one collision,
+and they live in the unit lane on purpose — Fast Tests is a hard merge
+gate, so the next name clash fails a PR rather than quietly disabling a
+suite. See #1017 for the related "integration tests don't run" class.
+"""
+
+import ast
+import importlib
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+TESTS_ROOT = Path(__file__).resolve().parent.parent
+REPO_ROOT = TESTS_ROOT.parent
+
+
+def _package_dirs_under_tests():
+    """Directories under tests/ that are importable as a package."""
+    return sorted(
+        p for p in TESTS_ROOT.iterdir()
+        if p.is_dir() and not p.name.startswith((".", "__"))
+    )
+
+
+def test_tests_root_is_not_on_sys_path():
+    """tests/ on sys.path makes every subdirectory a top-level module.
+
+    Helpers under tests/ are imported as `tests.<name>`, which needs only
+    the repo root on sys.path. Putting tests/ itself there is what lets
+    tests/docker/ outrank the installed Docker SDK.
+    """
+    on_path = [entry for entry in sys.path if entry and Path(entry).resolve() == TESTS_ROOT]
+    assert not on_path, (
+        "tests/ is on sys.path (%r), so every directory under it shadows any "
+        "installed distribution of the same name. Import tests/ helpers as "
+        "`from tests.<module> import ...` instead of inserting TESTS_ROOT."
+        % on_path
+    )
+
+
+def test_no_test_directory_shadows_an_installed_distribution():
+    """`import <name>` must never resolve inside the tests/ tree.
+
+    Deliberately one test that loops rather than a parametrised case per
+    directory: the parameter list would be read off the filesystem at
+    collection time, and under `pytest -n auto` any churn in the tree
+    between workers desynchronises collection and aborts the whole run.
+    """
+    shadowed = []
+    for package_dir in _package_dirs_under_tests():
+        spec = importlib.util.find_spec(package_dir.name)
+        if spec is None or not spec.origin:
+            continue  # nothing installed under that name — no collision
+        origin = Path(spec.origin).resolve()
+        if TESTS_ROOT in origin.parents:
+            shadowed.append((package_dir.name, str(origin)))
+
+    assert not shadowed, (
+        "%s resolve inside the tests tree. Any installed distribution of "
+        "those names is now unreachable, and the failure surfaces as a "
+        "misleading ModuleNotFoundError for one of its submodules deep "
+        "inside a dependency." % shadowed
+    )
+
+
+class _InlineNames(ast.NodeTransformer):
+    """Substitute `name -> assigned expression`, one level deep.
+
+    Done on the AST rather than the unparsed text so that a local called
+    `parent` cannot be spliced into an unrelated `.parent` attribute
+    access — an ast.Attribute's `.attr` is not an ast.Name.
+    """
+
+    def __init__(self, assignments):
+        self._assignments = assignments
+
+    def visit_Name(self, node):
+        replacement = self._assignments.get(node.id)
+        return replacement if replacement is not None else node
+
+
+def _sys_path_arguments(tree):
+    """Every expression handed to sys.path.insert/append in a module."""
+    assignments = {
+        node.targets[0].id: node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+    }
+    inline = _InlineNames(assignments)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in ("insert", "append"):
+            continue
+        if ast.unparse(node.func.value) != "sys.path":
+            continue
+        for arg in node.args:
+            # `sys.path.insert(0, str(d))` where `d = Path(__file__).parent`
+            # appears elsewhere in the module resolves to the full expression.
+            resolved = inline.visit(ast.parse(ast.unparse(arg), mode="eval").body)
+            yield node.lineno, ast.unparse(resolved)
+
+
+def _names_the_tests_root(expr, source_file):
+    """Does this sys.path expression resolve to tests/ for this file?"""
+    if "TESTS_ROOT" in expr:
+        return True
+
+    # tests/unit/x.py -> ('unit', 'x.py'): two `.parent` hops, or parents[1].
+    hops = len(source_file.relative_to(TESTS_ROOT).parts)
+
+    base = expr.split("__file__", 1)[-1] if "__file__" in expr else ""
+    if base and base.count(".parent") == hops and "parents" not in base:
+        return True
+
+    match = re.search(r"parents\[(\d+)\]", expr)
+    return bool(match) and int(match.group(1)) == hops - 1
+
+
+def test_no_test_module_puts_the_tests_root_on_sys_path():
+    """Catch the anti-pattern statically, in the lane that gates merges.
+
+    The dynamic checks above only see the lane they run in — which is how
+    an insert in tests/integration/ survived the first pass of this fix.
+    Reading every module in the tree means a reintroduction fails Fast
+    Tests rather than quietly re-shadowing the Docker SDK inside a job
+    that is advisory anyway.
+
+    Resolves one level of local variable, so `d = Path(__file__).parent`
+    followed by `sys.path.insert(0, str(d))` is caught; a more indirect
+    spelling would slip through, and the dynamic checks above remain the
+    backstop for that.
+
+    Adding the repo root or scripts/ to sys.path is fine and common here —
+    only the tests root is the problem.
+    """
+    offenders = []
+    for source_file in sorted(TESTS_ROOT.rglob("*.py")):
+        if "__pycache__" in source_file.parts:
+            continue
+        try:
+            source = source_file.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "sys.path" not in source:
+            continue  # cheap prefilter — parsing every module costs ~19s
+        try:
+            tree = ast.parse(source, filename=str(source_file))
+        except SyntaxError:
+            continue  # not our invariant to enforce
+        offenders += [
+            (str(source_file.relative_to(REPO_ROOT)), lineno, expr)
+            for lineno, expr in _sys_path_arguments(tree)
+            if _names_the_tests_root(expr, source_file)
+        ]
+
+    assert not offenders, (
+        "%s put the tests root on sys.path. That promotes every directory "
+        "under tests/ to a top-level module, so tests/docker/ shadows the "
+        "Docker SDK. Import siblings as `from tests.<module> import ...` "
+        "instead." % offenders
+    )
+
+
+def test_testcontainers_compose_backend_imports():
+    """The exact import the Docker integration fixtures perform.
+
+    tests/conftest.py's `cwa_container` fixture opens with this import; when
+    it raises, every Docker and integration test errors at setup rather than
+    failing, which is how the suite went dark while CI stayed green.
+    """
+    pytest.importorskip(
+        "testcontainers.compose",
+        reason="testcontainers is an integration-lane dependency",
+    )
+    module = importlib.import_module("testcontainers.compose")
+    assert hasattr(module, "DockerCompose")
+
+
+def test_docker_sdk_is_the_installed_distribution():
+    """`import docker` must reach the SDK, not tests/docker/."""
+    docker = pytest.importorskip(
+        "docker", reason="docker SDK arrives with testcontainers"
+    )
+    origin = Path(docker.__file__).resolve()
+    assert TESTS_ROOT not in origin.parents, (
+        "`import docker` resolved to %s — that is tests/docker/, not the "
+        "Docker SDK." % origin
+    )
+    # The submodule testcontainers reaches for, and the one that broke.
+    importlib.import_module("docker.context")


### PR DESCRIPTION
## Why

The Docker integration suite has been returning `37 passed, 1 skipped, 80 errors` — all 80 at fixture setup, all the identical `ModuleNotFoundError: No module named 'docker.context'`. Nothing under `tests/docker/`, and most of `tests/integration/`, had actually exercised a container. The workflow reported **success** anyway, because the job is `continue-on-error` outside `safe-tier-2` PRs.

Two consequences worth stating plainly:

- Merge-gate condition (a) — "every required CI check is green" — was being met by a suite that could not run.
- On a `safe-tier-2` PR the job *is* a hard gate, so tier-2 auto-merge could not fire at all.

Addresses #1201.

## Root cause

`tests/docker/` is a directory named after a real PyPI distribution (`docker`, the Docker SDK) and carries an `__init__.py`, making it a *regular* package. `tests/conftest.py` put `tests/` itself on `sys.path[0]` so it could `from quarantine import QUARANTINED` by bare name. That promotes every directory under `tests/` to a top-level module, so `import docker` resolved to `tests/docker/__init__.py` instead of the SDK.

Observed directly in the pytest harness on `origin/main`:

```
SYSPATH0: .../repo/tests
DOCKER:   .../repo/tests/docker/__init__.py
```

`import docker` then *succeeds*, which is why the error read so strangely — it surfaced deep inside a dependency, as a missing submodule of a package that had loaded fine.

Four modules put the tests root on `sys.path`: `tests/conftest.py` (two sites), `tests/docker/conftest.py`, `tests/integration/test_ingest_pipeline.py`, `tests/unit/test_ci_test_lanes.py`.

`tests/docker/__init__.py` arrived with `c9e07cc08` (2025-12-01, inherited from upstream CWA), so the collision sat latent for months. It only started biting when the unpinned `testcontainers>=3.7.0` in `requirements-dev.txt` rolled forward to 4.15.0, whose compose backend imports `docker.context`. testcontainers 4.14.2 does not, which is why this never showed up on a developer machine.

## Fix

Make `tests/` a real package and import its helpers as `tests.<module>`, so nothing needs the tests root on `sys.path` and no directory under `tests/` can shadow an installed distribution again. That is the whole class, not just the `docker` instance.

- `tests/__init__.py`, `tests/fixtures/__init__.py` — new
- All three `sys.path.insert(<tests root>)` sites removed
- 20 bare-name imports requalified: `from conftest import` → `from tests.conftest import`, same for `quarantine`, `conftest_volumes`, `fixtures.generate_synthetic`

Net −52/+33 lines across the six existing files.

## Reproduction (red)

Under the CI dependency versions (`testcontainers 4.15.0`, `docker 7.2.0`), cwd = repo root:

```
A) sys.path.insert(0, 'tests')   # == origin/main
   ModuleNotFoundError: No module named 'docker.context'

B) tests/ not on sys.path        # == this branch
   import OK; docker -> .../site-packages/docker/__init__.py
```

That is the CI failure reproduced and cleared locally. All 80 CI errors share this one signature — verified, not assumed:

```
$ grep -oE "E +[A-Za-z]+Error: .*" int-main.log | sort | uniq -c
  80 E   ModuleNotFoundError: No module named 'docker.context'
```

## Regression tests

`tests/unit/test_tests_tree_import_hygiene.py` — in the **unit** lane on purpose. Fast Tests is a hard merge gate; the integration job is advisory, so a guard living there could go dark the same way the suite did.

Five tests, red on `origin/main` and green here:

| Test | On `origin/main` |
|---|---|
| `test_tests_root_is_not_on_sys_path` | fails — `tests/` is on `sys.path` |
| `test_no_test_directory_shadows_an_installed_distribution` | fails — `docker` resolves inside the tests tree |
| `test_docker_sdk_is_the_installed_distribution` | fails — resolves to `tests/docker/__init__.py` |
| `test_testcontainers_compose_backend_imports` | the import `cwa_container` opens with |
| `test_no_test_module_puts_the_tests_root_on_sys_path` | static AST scan of every module under `tests/` |

The last one exists because the dynamic checks only see the lane they run in — that gap is real and I hit it: the first pass of this fix left an insert in `tests/integration/test_ingest_pipeline.py` that the unit-lane checks happily passed. The static scan reads the whole tree and catches a reintroduction anywhere. Verified against the pre-fix sources, where it flags all four offenders and correctly leaves `test_simple_ingest.py` alone (that one inserted `tests/integration`, not `tests/`).

It resolves one level of local variable via an AST transform rather than text substitution — an early text-based version spliced a local named `parent` into unrelated `.parent` attribute accesses and produced nonsense.

## Validation

- Fast Tests (smoke + unit), full local run under the CI invocation — see comment below for the final count
- `pytest tests/docker/ tests/integration/ --collect-only` → **118 collected, 0 errors** (was: collection fine, then 80 setup errors)
- One previously-erroring test, `test_kosync_edge_cases.py::test_percentage_at_zero`, now spends 13.6s in fixture setup and reaches an application-level check instead of erroring instantly
- `ruff`: no new findings on the six modified files; the three new files are clean
- `check_spdx_headers.py`: all headers OK
- Packaging: `tests/` is in `.dockerignore` and the image build never runs setuptools, so `tests/__init__.py` cannot reach the shipped artifact

**Honest scope note.** The local venv carries testcontainers 4.14.2, which does not import `docker.context`, so the integration suite does not fail locally on `main` either — the red/green above is against a venv pinned to the CI versions. Whether the 80 CI errors clear in full is CI's to confirm on this PR; every one of them traces to the single import this change fixes.

## Left out deliberately

The other half of why this went unnoticed — a suite that cannot run at all still reporting the workflow green — is filed separately as #1202 rather than widened into this PR. Making `test-summary` distinguish "some tests failed" from "the suite never ran" is a gate-semantics change that deserves its own diff.

**Tier:** `needs-review` (multi-file test-infrastructure change).
