### PR TITLE
docs(README): make the prefix nginx snippet run on stock nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,9 +421,19 @@ instance, with Nginx:
 ```
 location /cwa/ {
     proxy_pass http://calibre-web-automated:8083/;
-    include proxy_params;
+
+    proxy_set_header Host              $http_host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
 }
 ```
+
+The trailing slash on `proxy_pass` matters: it strips `/cwa/` before the request
+reaches CWA. The headers are written out rather than pulled in with
+`include proxy_params;` because that file ships with Debian and Ubuntu's nginx
+package only — the official `nginx` Docker images don't have it, and nginx
+refuses to start when the include is missing.
 
 You must also configure the application with the external URL prefix by setting
 the following environment variable in your Docker compose file:
@@ -433,8 +443,15 @@ environment:
   - PROXY_SCRIPT_NAME=/cwa
 ```
 
+Leave the trailing slash off `PROXY_SCRIPT_NAME` — CWA joins it to each path
+directly, so `/cwa/` would generate doubled-slash URLs.
+
 This ensures that CWA correctly generates URLs when it is served from the
 prefix path instead of the web server root.
+
+For TLS, upload limits, and the larger proxy buffers Kobo sync needs, see
+[`examples/nginx-reverse-proxy.conf`](examples/nginx-reverse-proxy.conf) — the
+settings there apply to a prefixed deployment too.
 
 ### Reverse proxy / Cloudflare Tunnel
 

--- a/tests/unit/test_readme_prefix_proxy_docs.py
+++ b/tests/unit/test_readme_prefix_proxy_docs.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression tests for the README's "Reverse proxy with a prefix" section
+(added in #1152 by @chloeroform, hardened here).
+
+The section tells users to paste an nginx `location` block. As originally
+written it ended with `include proxy_params;`, which is a Debian/Ubuntu
+*package* file — it is not part of upstream nginx and is absent from the
+official `nginx` and `nginx:alpine` Docker images. Verified 2026-07-28:
+
+    $ docker run --rm -v ./nginx.conf:/etc/nginx/nginx.conf:ro nginx:alpine nginx -t
+    nginx: [emerg] open() "/etc/nginx/proxy_params" failed (2: No such file
+    or directory) in /etc/nginx/nginx.conf:8
+    nginx: configuration file /etc/nginx/nginx.conf test failed
+
+nginx does not start at all — so a user who follows the README on a
+containerised nginx (the deployment style the rest of this README assumes)
+takes their whole proxy down, and the failure points at nginx rather than at
+the docs that caused it. The repo's own reference config,
+`examples/nginx-reverse-proxy.conf`, already writes the headers out inline;
+the README now matches it.
+
+These tests pin the portability invariant, not the prose:
+
+* the documented snippet carries the forwarding headers inline
+* it does not depend on a distro-only `include`
+* `PROXY_SCRIPT_NAME` is documented without a trailing slash, because
+  `ReverseProxied.__call__` assigns it straight to `SCRIPT_NAME` and WSGI
+  builds URLs as `SCRIPT_NAME + PATH_INFO` (`cps/reverseproxy.py`)
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README = REPO_ROOT / "README.md"
+
+HEADING = "### Reverse proxy with a prefix"
+
+# Headers Debian's proxy_params provides, which the snippet must supply itself.
+REQUIRED_HEADERS = (
+    "proxy_set_header Host",
+    "proxy_set_header X-Real-IP",
+    "proxy_set_header X-Forwarded-For",
+    "proxy_set_header X-Forwarded-Proto",
+)
+
+
+@pytest.fixture(scope="module")
+def readme() -> str:
+    assert README.exists(), f"README.md is missing at {README}"
+    return README.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def prefix_section(readme: str) -> str:
+    """The body of the prefix section, up to the next same-level heading."""
+    start = readme.find(HEADING)
+    assert start != -1, (
+        f"README no longer contains {HEADING!r}. If the section was renamed, "
+        f"update this test — but the prefix deployment recipe must stay "
+        f"documented somewhere; it is one of the most common support asks."
+    )
+    rest = readme[start + len(HEADING):]
+    end = rest.find("\n### ")
+    return rest if end == -1 else rest[:end]
+
+
+@pytest.fixture(scope="module")
+def nginx_block(prefix_section: str) -> str:
+    """Just the fenced nginx snippet — the part users copy and paste.
+
+    Scoped deliberately: the surrounding prose *names* `include proxy_params;`
+    to explain why it is avoided, so a whole-section substring check would
+    flag the explanation as the defect it warns about.
+    """
+    blocks = re.findall(r"```[a-z]*\n(.*?)```", prefix_section, re.DOTALL)
+    for block in blocks:
+        if "location " in block and "proxy_pass" in block:
+            return block
+    raise AssertionError(
+        "The prefix section must contain a fenced nginx block with a "
+        "`location` + `proxy_pass` pair — that snippet is the recipe."
+    )
+
+
+@pytest.mark.unit
+class TestPrefixProxySnippetIsPortable:
+    def test_snippet_does_not_include_distro_only_proxy_params(self, nginx_block):
+        assert "include proxy_params" not in nginx_block, (
+            "The prefix nginx snippet must not use `include proxy_params;`. "
+            "That file ships only with the Debian/Ubuntu nginx package; the "
+            "official nginx Docker images do not have it and nginx REFUSES TO "
+            "START when an include is missing (emerg, not a warning). Write "
+            "the proxy_set_header lines out inline instead, the way "
+            "examples/nginx-reverse-proxy.conf does."
+        )
+
+    @pytest.mark.parametrize("header", REQUIRED_HEADERS)
+    def test_snippet_sets_forwarding_header_inline(self, nginx_block, header):
+        assert header in nginx_block, (
+            f"The prefix nginx snippet must set `{header}` inline. Without the "
+            f"X-Forwarded-* headers CWA cannot reconstruct external URLs, and "
+            f"without Host the vhost is wrong."
+        )
+
+    def test_proxy_pass_keeps_trailing_slash(self, nginx_block):
+        # `proxy_pass http://host:8083/` (with slash) strips the location
+        # prefix. Without it nginx forwards /cwa/foo and the app, which is
+        # already mounted at SCRIPT_NAME=/cwa, would look for /cwa/cwa/foo.
+        assert re.search(r"proxy_pass\s+http://[^\s;]+/;", nginx_block), (
+            "The documented proxy_pass must end in a trailing slash so nginx "
+            "strips the location prefix before forwarding."
+        )
+
+
+@pytest.mark.unit
+class TestPrefixEnvVarGuidance:
+    def test_script_name_documented_without_trailing_slash(self, prefix_section):
+        values = re.findall(r"PROXY_SCRIPT_NAME=(\S+)", prefix_section)
+        assert values, (
+            "The section must show a concrete PROXY_SCRIPT_NAME=... example; "
+            "it is the half of the recipe that lives on the CWA side."
+        )
+        for value in values:
+            assert not value.endswith("/"), (
+                f"PROXY_SCRIPT_NAME={value} has a trailing slash. "
+                f"ReverseProxied assigns the value straight to SCRIPT_NAME and "
+                f"WSGI builds every URL as SCRIPT_NAME + PATH_INFO, so a "
+                f"trailing slash yields doubled-slash URLs like /cwa//book/1."
+            )
+
+    def test_section_is_linked_from_the_table_of_contents(self, readme):
+        assert "#reverse-proxy-with-a-prefix" in readme, (
+            "The section must stay reachable from the README table of "
+            "contents — it is long-document content users navigate to."
+        )


### PR DESCRIPTION
Follow-up to #1152 (@chloeroform), whose "Reverse proxy with a prefix" section
is a genuinely useful addition — prefix deployments are a recurring support ask
and the README didn't cover them. One line in the snippet doesn't survive the
deployment style the rest of the README assumes.

## Root cause

The snippet ended with `include proxy_params;`. That file ships with the
**Debian/Ubuntu nginx package**; it is not part of upstream nginx and is absent
from the official `nginx` and `nginx:alpine` images. A missing `include` is
`[emerg]`, not a warning — nginx refuses to start at all.

Verified against both official images:

```
$ docker run --rm nginx:alpine   sh -c 'ls /etc/nginx/proxy_params'
ls: /etc/nginx/proxy_params: No such file or directory
$ docker run --rm nginx:latest   sh -c 'ls /etc/nginx/proxy_params'
ls: cannot access '/etc/nginx/proxy_params': No such file or directory

$ docker run --rm -v ./nginx.conf:/etc/nginx/nginx.conf:ro nginx:alpine nginx -t
nginx: [emerg] open() "/etc/nginx/proxy_params" failed (2: No such file or
directory) in /etc/nginx/nginx.conf:8
nginx: configuration file /etc/nginx/nginx.conf test failed
```

So a user who copies the block into a containerised nginx doesn't get a
half-working prefix — they lose the whole proxy, and the error names nginx
rather than the docs that caused it.

## Fix

Write the four forwarding headers out inline. This is already the convention in
this repo: `examples/nginx-reverse-proxy.conf` sets the same headers explicitly
and pulls in no distro files. Also added: why the trailing slash on `proxy_pass`
is required but must be left off `PROXY_SCRIPT_NAME`, and a pointer to the
reference config for TLS, upload limits, and the larger buffers Kobo sync needs.

## Verification

Live prefixed deployment, not a config lint. nginx on the official `nginx:alpine`
image in front of a container running with `PROXY_SCRIPT_NAME=/cwa`, with the
snippet **extracted verbatim from the README** and pointed at that container:

| Path | Result |
|---|---|
| `/cwa/` | 200 |
| `/cwa` (no slash) | 301 → `/cwa/` |
| `/cwa/login` | 200 |
| `/cwa/app/` (SPA) | 200 |
| `/cwa/api/v1/me` | 200 |
| `/cwa/static/css/style.css` | 200 |

Driven through a browser as a logged-in user on both UIs: login POST and session
worked, the SPA loaded the library (43 books), shelves and covers rendered, and
the API resolved at `/cwa/api/v1/*` while the bare `/api/v1/me` correctly 404'd.
A DOM sweep of the classic UI found **0 unprefixed same-origin URLs** and all
**38 page assets returned 200**. No errors in the container log.

The same probe against the pre-fix snippet never reaches the app — nginx does
not start.

## Tests

`tests/unit/test_readme_prefix_proxy_docs.py`, matching the existing
`test_331_308_nginx_buffer_docs.py` pattern. Pins the portability invariant
(headers inline, no distro-only include, `proxy_pass` trailing slash,
`PROXY_SCRIPT_NAME` without one).

Red/green against the README alone:

- pre-fix README → **5 failed**, 3 passed
- post-fix README → **8 passed**

The assertions are scoped to the fenced nginx block rather than the section,
since the surrounding prose now names `include proxy_params;` to explain why
it's avoided — a whole-section check flags the explanation as the defect.

## Notes

- No CHANGELOG entry: docs-only, and the file scopes itself to "things you can
  see or feel when running the app".
- No new dependencies, licenses, or external URLs (rule 6).
- No `/security-review`: touches no auth, session, CSRF, crypto, subprocess,
  user-controlled path, or route.

Tier: safe-tier-1 (`README*` + tests only).