### PR TITLE
`CWA_RELEASE` and `CALIBRE_RELEASE` cleaning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -385,7 +385,7 @@ RUN \
   # STEP 7.5 - ADD files referencing the versions of the installed main packages
   echo "$VERSION" >| /app/CWA_RELEASE && \
   echo "$KEPUBIFY_RELEASE" >| /app/KEPUBIFY_RELEASE && \
-  echo "$CALIBRE_RELEASE" > /CALIBRE_RELEASE
+  echo "$CALIBRE_RELEASE" > /app/CALIBRE_RELEASE
 
 # Add unrar from unrar stage
 COPY --from=unrar /usr/bin/unrar-ubuntu /usr/bin/unrar

--- a/cps/about.py
+++ b/cps/about.py
@@ -15,7 +15,7 @@ import flask
 from flask import redirect, url_for
 from flask_babel import gettext as _
 
-from . import db, calibre_db, converter, uploader, dep_check
+from . import constants, db, calibre_db, converter, uploader, dep_check
 from .render_template import render_title_template
 from .usermanagement import user_login_required
 
@@ -35,13 +35,7 @@ sorted_modules = OrderedDict((sorted(modules.items(), key=lambda x: x[0].casefol
 
 
 def collect_stats():
-    try:
-        with open("/app/CWA_RELEASE", "r") as f:
-            cwa_version = f.read()
-    except Exception:
-        cwa_version = "Unknown"
-
-    _VERSIONS = {'Calibre-Web NextGen': cwa_version}
+    _VERSIONS = {'Calibre-Web NextGen': constants.INSTALLED_VERSION}
     _VERSIONS.update(OrderedDict(
         Python=sys.version,
         Platform='{0[0]} {0[2]} {0[3]} {0[4]} {0[5]}'.format(platform.uname()),

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -535,7 +535,7 @@ def cwa_get_package_versions() -> tuple[str, str, str, str]:
         kepubify_version = "Unknown"
 
     try:
-        with open("/CALIBRE_RELEASE", "r") as f:
+        with open("/app/CALIBRE_RELEASE", "r") as f:
             calibre_version = f.read()
     except Exception:
         calibre_version = "Unknown"

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -529,12 +529,6 @@ def update_thumbnails():
 
 def cwa_get_package_versions() -> tuple[str, str, str, str]:
     try:
-        with open("/app/CWA_RELEASE", "r") as f:
-            cwa_version = f.read()
-    except Exception:
-        cwa_version = "Unknown"
-
-    try:
         with open("/app/KEPUBIFY_RELEASE", "r") as f:
             kepubify_version = f.read()
     except Exception:
@@ -546,7 +540,7 @@ def cwa_get_package_versions() -> tuple[str, str, str, str]:
     except Exception:
         calibre_version = "Unknown"
 
-    return cwa_version, kepubify_version, calibre_version
+    return constants.INSTALLED_VERSION, kepubify_version, calibre_version
 
 
 def cwa_get_update_indicator() -> tuple[bool, str]:

--- a/cps/updater.py
+++ b/cps/updater.py
@@ -57,8 +57,8 @@ def _normalize_tag(tag_name):
 def release_url_for_version(version):
     """GitHub web URL where the release notes for ``version`` can be read.
 
-    ``version`` is the string shown in the admin version table, read
-    verbatim from ``/app/CWA_RELEASE`` — so it may carry surrounding
+    ``version`` is the string shown in the admin version table, stored in
+    constants.INSTALLED_VERSION — so it may carry surrounding
     whitespace, be ``"Unknown"`` when the probe failed, or be a non-release
     marker (``DEV_BUILD-…``) on a dev/canary image. We point at the exact
     release tag only when the string parses as a release tag (``vX.Y.Z`` /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,4 +132,4 @@ include-package-data = true
 license-files = ["LICENSE"]
 
 [tool.setuptools.dynamic]
-version = {attr = "calibreweb.cps.constants.INSTALLED_VERSION"}
+version = {file = "/app/CWA_RELEASE"}

--- a/root/etc/s6-overlay/s6-rc.d/calibre-binaries-setup/run
+++ b/root/etc/s6-overlay/s6-rc.d/calibre-binaries-setup/run
@@ -50,7 +50,7 @@ if [[ ! "$CALIBRE_INSTALLED_TEST" =~ calibredb.*calibre\ [0-9]+\.[0-9]+ ]]; then
         }
     fi
     
-    echo "[calibre-binaries-setup] Installing Calibre version $(cat /CALIBRE_RELEASE 2>/dev/null || echo 'unknown')..."
+    echo "[calibre-binaries-setup] Installing Calibre version $(cat /app/CALIBRE_RELEASE 2>/dev/null || echo 'unknown')..."
     echo "[calibre-binaries-setup] This may take several minutes, please wait..."
 
     # Fork #769: calibre_postinstall's desktop-integration step shells out to

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -26,7 +26,7 @@ done
 
 # Verify essential files exist
 echo "[cwa-init] Verifying essential files..."
-for file in "/app/CWA_RELEASE" "/CALIBRE_RELEASE"; do
+for file in "/app/CWA_RELEASE" "/app/CALIBRE_RELEASE"; do
   if [[ ! -f "$file" ]]; then
     echo "[cwa-init] WARNING: Expected file $file does not exist"
   else


### PR DESCRIPTION
Some additional cleaning that I didn't include in my previous PR:

1. Make sure everyone gets the current version from `cps/constants.py` (SSOT).
2. Move `CALIBRE_RELEASE` (Calibre version number) to `/app` along with CWNG and Kepubify.

Note:
- Some tests need to be adapted.
- Some documentation too.

But it feels like your workflow will take care of this. If not, let me know, this is not a sloppy PR.

For the future:
- `constants.INSTALLED_VERSION` should come `pyproject.toml`...
- ... but we would need to install CWNG as a Python package.
- `/app/CWA_RELEASE` could be removed so we only use the internal Python versioning.