### PR TITLE
docs(release): section v4.1.26, refile the subpath fix, populate What's New

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+## [v4.1.26] - 2026-07-31
+
 ### Changed
 
 - **Ebook conversion and metadata reading now run on Calibre 9.11.0**, up from
@@ -65,15 +67,6 @@ is for things you can see or feel when running the app.
   [@monimkxl-web](https://github.com/new-usemame/Calibre-Web-NextGen/pull/1264)
   ([#1264](https://github.com/new-usemame/Calibre-Web-NextGen/pull/1264)).
 
-### Added
-
-- **The KOReader page now explains how to auto-update the sync plugin.** Visiting
-  `/kosync` only ever described the manual download-and-copy route, so the
-  in-place update path existed but was undiscoverable — the repository to point
-  an update manager at was written down nowhere a user would look. That page and
-  the README now name it, and spell out why the plugin's version can sit behind
-  your server version without anything being wrong.
-
 - **Every CWA settings page 404'd when the app was mounted under a subpath.** If
   you run Calibre-Web NextGen behind a reverse proxy on a prefix that starts the
   same way as its own pages — `/cwa` being the obvious one — then "CWA settings
@@ -91,6 +84,15 @@ is for things you can see or feel when running the app.
   — it used to break every page in a second, separate way. Reported by
   [@chloeroform](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1248)
   ([#1248](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1248)).
+
+### Added
+
+- **The KOReader page now explains how to auto-update the sync plugin.** Visiting
+  `/kosync` only ever described the manual download-and-copy route, so the
+  in-place update path existed but was undiscoverable — the repository to point
+  an update manager at was written down nowhere a user would look. That page and
+  the README now name it, and spell out why the plugin's version can sit behind
+  your server version without anything being wrong.
 
 ## [v4.1.25] - 2026-07-30
 

--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -56,6 +56,40 @@ export interface WhatsNewRelease {
 /** Newest release first. The `whats-new-populate` skill prepends here. */
 export const WHATS_NEW: WhatsNewRelease[] = [
   {
+    version: 'v4.1.26',
+    date: '2026-07-31',
+    items: [
+      {
+        title: 'Conversion and metadata now run on a much newer Calibre',
+        body: 'The engine behind format conversion, metadata reading and the ingest folder moved from Calibre 9.1 to 9.11, so ten releases of fixes land at once. If a book converted badly, arrived with the wrong details, or never made it out of the ingest folder at all, it is worth adding again.',
+        category: 'Library',
+      },
+      {
+        title: 'KOReader finds new versions of the sync plugin again',
+        body: 'If you had pointed an update manager at this project to keep the Progress Sync plugin current, it stopped finding anything after v4.1.16 — nine releases in a row published no plugin file for it to see, so it kept reporting you were up to date while three plugin fixes went out without reaching your device. Releases that change the plugin now attach it automatically, and the KOReader page spells out which repository to point an update manager at.',
+        category: 'Sync',
+        link: { to: '/account', label: 'Manage sync & app passwords' },
+      },
+      {
+        title: 'Settings pages work again behind a reverse proxy on a subpath',
+        body: 'If you reach your library through a prefix that starts with the same letters as one of its own pages — /cwa being the obvious one — then CWA settings, duplicate detection, the statistics dashboard and the library-refresh button all came back as Not Found, while the ordinary Admin links beside them worked. All 37 of those pages and actions are reachable again, and a prefix written with a trailing slash is now accepted too.',
+        category: 'Under the hood',
+      },
+      {
+        title: 'Polish is now the most complete translation the project ships',
+        body: 'With the language set to Polish, the admin screens, metadata editing, upload, shelves, the reader and a long tail of task and error messages still read in English. A further 273 phrases were worse than untranslated: they held unconfirmed guesses, which are dropped when the catalog is built, so English showed while Polish that said something else sat unused in the file. Polish covered 950 of 2,609 phrases and now covers all of them.',
+        category: 'Account',
+        link: { to: '/account', label: 'Open account settings' },
+      },
+      {
+        title: 'German reads in German across several hundred more labels',
+        body: 'With the language set to German, much of the new interface and a long tail of admin, task and error messages still showed in English. German covered 1,584 of 2,609 phrases and now covers 1,891. Two were actively wrong rather than missing — the Email Your Users heading read "edit user", and the warning for sending mail with nobody chosen asked you to select a book rather than a recipient.',
+        category: 'Account',
+        link: { to: '/account', label: 'Open account settings' },
+      },
+    ],
+  },
+  {
     version: 'v4.1.25',
     date: '2026-07-30',
     items: [


### PR DESCRIPTION
Release prep for **v4.1.26**. No product code changes — a changelog correction, the release section, and the in-app feature log.

## Why

The daily release train is due: v4.1.25 published 2026-07-30T06:40Z (~24.6h ago) and `[Unreleased]` is non-empty. Two things had to land before the tag:

- **The `[Unreleased]` block had a bug fix filed as a feature.** The #1248 reverse-proxy entry — "every CWA settings page 404'd when the app was mounted under a subpath", "the prefix is now only removed at a real path boundary" — sat under `### Added`. Release notes are generated from these sections, so v4.1.26 would have announced a 404 fix to users as a new feature. It is now under `### Fixed`. The KOReader auto-update docs entry stays under `### Added`, where it belongs.
- **What's New has to ship inside the image that announces it.** The SPA is baked in at build time, so the data-file edit must merge before the tag is cut, or the release's own What's New page is a release behind.

## What changed

`CHANGELOG.md`
- Moved the #1248 entry from `### Added` to `### Fixed`.
- Opened `## [v4.1.26] - 2026-07-31`, leaving `[Unreleased]` empty above it.

`frontend/src/data/whatsNew.ts`
- Prepended the v4.1.26 block, 5 items, reader-priority order: Calibre 9.11.0 engine upgrade, the KOReader plugin-updater fix, the subpath-proxy restoration, Polish reaching 100%, German +307.
- The plugin-updater fix and its discoverability docs are **one** card. They are two changelog entries but one shipped change (#1253 + #1258), and two adjacent cards both headed "KOReader plugin updates" read as duplication.
- No link on the Calibre or subpath items: per the deep-linking rules, a conversion-engine upgrade has no universal navigable surface and a proxy fix is pure backend. Never fake a destination.

## Completeness

Cross-checked `git log v4.1.25..main` against the changelog. Every user-facing merge is represented: #1261 (Calibre 9.11.0), #1258/#1253 (KOReader plugin auto-update), #1249 (Polish), #1264 (German), #1255/#1248 (reverse-proxy prefix). The remaining commits are CI (#1262), translation-bot syncs, and SHA backfills — internal by the changelog's own bar.

## Verification

- `npx tsc -b` — 0 errors.
- `npm run build` — green, bundle emitted.
- Every `link.to` (`/account`) verified against `SPA_ROUTES` in `frontend/src/lib/routes.ts`. No `:id`-parameterized route used without an id.
- Both CTA labels (`Manage sync & app passwords`, `Open account settings`) already anchored at `cps/spa_strings.py:335,343`, so the auto-translation job cannot strip them on the next re-extract.
- `tests/unit/test_whats_new_spa.py` + `tests/unit/test_615_residual_i18n.py` — **41 passed**.

## Tier

Docs + a pure data file, no logic. Merging under the rule-3 autonomous gate once CI is green; the tag follows immediately after.