### PR TITLE
docs(release): section v4.1.27, add the missing ru entry, populate What's New

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+## [v4.1.27] - 2026-08-02
+
 ### Changed
 
 - **The admin "Version Information" table now reports the Calibre you are
@@ -34,6 +36,15 @@ is for things you can see or feel when running the app.
   tell which one was right. Both now read the same source. As with Calibre, a
   Kepubify that can't be found or can't be run says so rather than showing
   "Unknown". Thanks again to @chloeroform.
+
+- **The Russian interface is complete again — the custom-columns section of the
+  edit-metadata screen now reads in Russian.** Three phrases there were still in
+  English on an otherwise fully Russian page: the "Custom columns" heading, the
+  "Not set" placeholder shown for an empty column, and the hint telling you a
+  field takes comma-separated values. Russian is back to every string
+  translated. Contributed by
+  [@standhaftsohnsergius](https://github.com/standhaftsohnsergius)
+  ([#1269](https://github.com/new-usemame/Calibre-Web-NextGen/pull/1269)).
 
 ### Fixed
 

--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -56,6 +56,46 @@ export interface WhatsNewRelease {
 /** Newest release first. The `whats-new-populate` skill prepends here. */
 export const WHATS_NEW: WhatsNewRelease[] = [
   {
+    version: 'v4.1.27',
+    date: '2026-08-02',
+    items: [
+      {
+        title: 'The duplicates popup no longer names books you already deleted',
+        body: 'If you removed duplicate copies in Calibre itself rather than in the web app, the popup carried on listing them, while the Duplicates page and a fresh scan both correctly said there was nothing left. It now re-checks your library before it appears, so a group whose books are gone drops out and a group that merely lost a copy shows the real remaining count. The sidebar duplicate badge counts the same way, so it was wrong in the same way and is fixed too.',
+        category: 'Library',
+        link: { to: '/duplicates', label: 'Review duplicates' },
+      },
+      {
+        title: 'A duplicate you dismissed stays dismissed',
+        body: 'Dismissals were matched against a label built from the title and author of whichever copy happened to sort first, so editing a book\'s metadata — or importing another copy — quietly changed the label and the duplicate came back on its own. Dismissals now hold on to an identity that metadata edits do not move.',
+        category: 'Library',
+        link: { to: '/duplicates', label: 'Review duplicates' },
+      },
+      {
+        title: 'Marking a book unread now clears the dates and the device position too',
+        body: 'The percentage reset, but "Started reading" and "Last synced" stayed on the page — and "Last synced" jumped forward to the moment you pressed the button, so a book you had just marked unread looked like it had synced seconds ago. The reading position your e-reader holds was left behind as well, which let a Kobo quietly restore the exact spot you had just cleared on its next sync. Books already left in that state by an earlier version display correctly again, with no migration.',
+        category: 'Reading',
+      },
+      {
+        title: 'Editing a book no longer freezes the site for everyone else',
+        body: 'Saving from the edit-metadata screen, or switching on a metadata source, stopped the server answering anyone — not just the tab doing the work — for as long as the cover download or the lookup took, which on a slow host is up to 30 seconds. Both now do their network work off the request handler, so the rest of the site keeps responding. Measured during a 1.5 second cover download, other page loads went from 1 served with a 1.25 second worst case to 201 served with an 18 millisecond worst case.',
+        category: 'Under the hood',
+      },
+      {
+        title: 'The admin version table reports the Calibre and Kepubify you are actually running',
+        body: 'Both rows showed a value stamped into the image when it was built, so if the binaries had been replaced or the converter path pointed somewhere else, the numbers on the page were not the ones in use — and the Statistics page, which read the real binaries, could disagree with no way to tell which was right. Both rows now read the binary itself. One that cannot be found, or cannot be run, now says which of the two it is instead of "Unknown".',
+        category: 'Admin',
+        link: { to: '/admin', label: 'Open Admin' },
+      },
+      {
+        title: 'Russian is complete again on the edit-metadata screen',
+        body: 'Three phrases in the custom-columns section were still in English on an otherwise fully Russian page: the "Custom columns" heading, the "Not set" placeholder shown for an empty column, and the hint telling you a field takes comma-separated values. Russian is back to every string translated.',
+        category: 'Account',
+        link: { to: '/account', label: 'Open account settings' },
+      },
+    ],
+  },
+  {
     version: 'v4.1.26',
     date: '2026-07-31',
     items: [


### PR DESCRIPTION
Release prep for **v4.1.27**. The train is due: 40h since v4.1.26 (>20h) and `[Unreleased]` is non-empty.

## What's in this PR

**CHANGELOG**
- Audited every commit in `v4.1.26..main` against `[Unreleased]`. One user-facing change had no entry: **#1269**, which finished the Russian locale — the `Custom columns` heading, the `Not set` placeholder and the `{field} (comma separated)` hint, all on the new UI's edit-metadata screen. Every prior Russian completion got a credited entry, so this one does too (Changed, crediting @standhaftsohnsergius).
- The remaining undocumented commits are CI or docs — #1098, #1278, #1281, the four SHA backfills, the auto-translation merges — and stay out under the file's own "internal refactors, CI changes and test-only work don't appear here" rule.
- Opened `## [v4.1.27] - 2026-08-02`; `[Unreleased]` left empty.

**What's New** (`frontend/src/data/whatsNew.ts`)
- Prepended the v4.1.27 block: **6 items from the 7 changelog entries.** The Calibre and Kepubify version rows are grouped into one item — same table, same root cause, same fix, same contributor. Everything else is one item each.
- This has to land *before* the tag: the SPA is baked into the image at build time, so the shipped build must already carry the page that announces its own release.

## Verification

| Check | Result |
|---|---|
| `npx tsc -b` | clean, exit 0 |
| `npm run build` | green (6.65s) |
| Deep links resolve | `/duplicates`, `/admin`, `/account` all present in `frontend/src/lib/routes.ts` |
| CTA labels anchored | `Review duplicates`, `Open Admin`, `Open account settings` already in `cps/spa_strings.py` — a re-extract can't strip them |
| No per-book route faked | Marking-unread and the metadata-stall fix have no universal entry point, so they carry no link rather than a wrong one |
| Built assets | `cps/static/app/` is gitignored; only the two source files change |

## Tier

Docs + data-file only, no code paths. Same file set as #1267 (the v4.1.26 release prep). Tests exempt per the docs-only rule; `/security-review` not applicable — nothing touches auth, session, CSRF, crypto, subprocess, file paths or routes.
