### PR TITLE
fix: restore main to green after the #1288 upload gate

### DIFF
--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -6106,6 +6106,7 @@ msgstr "{field} (séparés par des virgules)"
 #: cps/spa_strings.py:958
 msgid "Uploading is not available for your account on this server."
 msgstr ""
+"Le téléversement n'est pas disponible pour votre compte sur ce serveur."
 
 #: cps/tasks_status.py:54
 msgid "Waiting"

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -5987,7 +5987,7 @@ msgstr "{field} (door komma's gescheiden)"
 
 #: cps/spa_strings.py:958
 msgid "Uploading is not available for your account on this server."
-msgstr ""
+msgstr "Uploaden is niet beschikbaar voor je account op deze server."
 
 #: cps/tasks_status.py:54
 msgid "Waiting"

--- a/tests/unit/test_api_v1_upload.py
+++ b/tests/unit/test_api_v1_upload.py
@@ -27,6 +27,25 @@ def _uploader(role_upload=True, anon=False):
                            role_upload=lambda: role_upload, id=1, name="alice")
 
 
+def _cfg(uploading=1):
+    """A config with the admin's "Enable Uploads" switch ON (#1288).
+
+    ``uploads_enabled`` fails closed on an absent ``config_uploading`` (see
+    ``config_sql.uploads_enabled`` — a config object without it is a defect, not
+    consent), so every test below that means to exercise something *past* the
+    switch has to say so explicitly. Without it the endpoint 403s before it ever
+    reaches the no-files, per-file-validation or ingest-writability paths these
+    tests are actually about. The switch itself is pinned in
+    ``test_1288_upload_config_gate.py``.
+
+    Patched per-test rather than read off the module: ``cps.api.upload.config``
+    is a shared object, so leaving it unpatched makes the outcome depend on
+    whatever ran earlier in the same xdist worker.
+    """
+    return SimpleNamespace(config_uploading=uploading,
+                           config_upload_formats="epub,pdf")
+
+
 @pytest.mark.unit
 def test_upload_anonymous_401():
     from cps.api import upload as mod
@@ -50,6 +69,7 @@ def test_upload_no_files_400():
     from cps.api import upload as mod
     with _ctx(files=None):
         with patch.object(mod, "current_user", _uploader()), \
+             patch.object(mod, "config", _cfg()), \
              patch.object(mod, "_ensure_ingest_dir_writable", return_value=None):
             resp = inspect.unwrap(mod.upload_books)()
     assert resp[1] == 400
@@ -68,7 +88,7 @@ def test_upload_valid_file_queued():
              patch("builtins.open", mock_open()) as manifest_open, \
              patch.object(mod, "os") as mock_os, \
              patch.object(mod, "WorkerThread") as worker, \
-             patch.object(mod, "config", SimpleNamespace(config_upload_formats="epub,pdf")):
+             patch.object(mod, "config", _cfg()):
             resp = inspect.unwrap(mod.upload_books)()
     body = json.loads(resp.get_data())
     assert body["queued"] == ["book.epub"]
@@ -85,7 +105,7 @@ def test_upload_invalid_file_reported_not_queued():
              patch.object(mod, "_ensure_ingest_dir_writable", return_value=None), \
              patch.object(mod, "_validate_uploaded_file", return_value=False), \
              patch.object(mod, "WorkerThread") as worker, \
-             patch.object(mod, "config", SimpleNamespace(config_upload_formats="epub,pdf")):
+             patch.object(mod, "config", _cfg()):
             resp = inspect.unwrap(mod.upload_books)()
     body = json.loads(resp.get_data())
     assert body["queued"] == []
@@ -98,6 +118,7 @@ def test_upload_ingest_unwritable_500():
     from cps.api import upload as mod
     with _ctx(files=[(io.BytesIO(b"x"), "a.epub")]):
         with patch.object(mod, "current_user", _uploader()), \
+             patch.object(mod, "config", _cfg()), \
              patch.object(mod, "_ensure_ingest_dir_writable", side_effect=PermissionError("ro")):
             resp = inspect.unwrap(mod.upload_books)()
     assert resp[1] == 500


### PR DESCRIPTION
## Why

`main` has been red since #1295 merged at 06:43Z. That PR was merged with its own CI already failing (`Fast Tests`, `E2E Tests (SPA)`, `Test Suite Summary` all FAILURE at 04:46–04:50Z), so the six failures landed on `main` directly. `auto-revert` then fired and tried to revert the whole #1288 fix — it only failed because the repo blocks Actions from creating PRs.

None of the six are defects in the new upload gate. The gate is correct; its blast radius was not absorbed.

## Root cause

**Four in `tests/unit/test_api_v1_upload.py`.** `config_sql.uploads_enabled()` deliberately fails closed on an absent `config_uploading`. These four tests either patched `cps.api.upload.config` with a `SimpleNamespace` that lacked the attribute, or never patched it, so each request 403'd *before* reaching the no-files / per-file-validation / ingest-writability paths the tests exist to pin:

- `test_upload_no_files_400` — `assert 403 == 400`
- `test_upload_valid_file_queued` — `'tuple' object has no attribute 'get_data'`
- `test_upload_invalid_file_reported_not_queued` — same
- `test_upload_ingest_unwritable_500` — `assert 403 == 500`

The last one **passed on CI and failed locally**: it read whatever the shared module-level `config` happened to hold, so the result depended on what ran earlier in the same xdist worker. A latent ordering flake, now removed.

**Two in `test_615_residual_i18n.py`.** `spa_strings.py` gained `"Uploading is not available for your account on this server."`. `fr` and `nl` are certified-complete locales (`COMPLETE_LOCALES`), so the extracted msgid landed with an empty `msgstr` and tripped the gate.

## Fix

- A shared `_cfg()` helper declares the switch explicitly, per-test, so the four tests exercise what they mean to and no longer depend on module state.
- fr/nl translated using the house terms — fr *téléversement*, nl *uploaden*, informal *je* per that file's own convention (41 `je` vs 0 `uw`).

**No production code changes.** Only a test file and two `.po` files.

## Validation

Same selection, same command:

| | result |
|---|---|
| pristine `origin/main` | **6 failed**, 2 passed |
| this branch | **8 passed** |

Full fast suite (`tests/unit tests/smoke`, `-n 4`): **4827 passed**, 93 skipped, 2 failed — both pre-existing container-path failures (`test_required_directories_exist` asserts `/config`; `test_ingest_batch_dirty` needs a container sqlite path). Both verified failing identically on pristine `origin/main`, and both pass on CI's Linux runners — they were not in CI's failure list.

i18n verified against the **compiled `.mo`**, not just the `.po`:

```
fr: Le téléversement n'est pas disponible pour votre compte sur ce serveur.
nl: Uploaden is niet beschikbaar voor je account op deze server.
```

`msgfmt --check` clean on both; `compile_translations.sh` reports 28/28 locales.

## Not in scope

- **`E2E Tests (SPA)`** was also red on #1295, but for infrastructure reasons — the *Seed books and wait for ingest* step failed with `ingest imported only 0 of 3 seed books` before any spec ran. Unrelated to this change, and skipped on `main` pushes so it does not gate `main` green. Filed separately.
- **No CHANGELOG entry.** The untranslated string was introduced in this same `[Unreleased]` window by #1288, so it never reached a published release; the changelog's own header excludes test-only and CI work.

## Tier

`needs-review` — touches no production code, but spans three files so it is not strictly tier-1. Merging under the CLAUDE.md rule-3 autonomous gate: red/green demonstrated above, no new deps/licenses/URLs, and `/security-review` is not triggered (no auth/session/CSRF, crypto, subprocess, file-path or new-route code changed — the only diff is test fixtures and translation strings).

Addresses the fallout of #1295 / #1288.