### PR TITLE
docs(spa): correct the wrong root cause recorded on the download anchor

### DIFF
--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -403,13 +403,20 @@ export function BookDetail() {
                 href={resourceUrl(fmt.download_url)}
                 className={styles.downloadBtn}
                 download
-                // iOS Safari ignores the `download` hint and the server serves book
-                // files with `Content-Disposition: inline` (needed for byte-range /
-                // in-browser reading), so a same-tab tap navigates the SPA away to a
-                // file the browser can't render — stranding the user on a dead page
-                // until they force-restart (#716). Opening in a new tab preserves the
-                // app tab; desktop browsers still honour `download` and don't spawn a
-                // stray tab. `noopener` keeps the download context from reaching back.
+                // NOTE: the comment that used to sit here said this route serves
+                // `Content-Disposition: inline`. That is wrong, and it sent #717 after
+                // the wrong fix. `download_url` hits cps/helper.py get_download_link,
+                // which sets `attachment`; `inline` is on the reader route `/show/`
+                // (cps/web.py). The download itself works — #716 is that an iOS
+                // standalone Home Screen app has no browser chrome, so a top-level
+                // navigation to an attachment leaves the user with no way back.
+                //
+                // `target` below is therefore inert on this element: per the HTML
+                // "following hyperlinks" algorithm, a present `download` attribute
+                // means the UA downloads and never consults `target`. It is left in
+                // place only because removing it is a behaviour change that needs a
+                // real standalone iOS run to verify, which #716 is still blocked on.
+                // Full diagnosis and the reproduction plan are on issue #716.
                 target="_blank"
                 rel="noopener"
               >


### PR DESCRIPTION
## Why

The comment on the BookDetail download anchor records a root cause that is **factually wrong**, and it is the same wrong premise that sent PR #717 after a fix which did not work. @Arjan61 told us it did not work; we conceded the over-claim and the issue has been open since. Leaving the false statement in the source guarantees the next person re-derives the same fix.

## The false claim, and what is actually true

The comment says book files are served `Content-Disposition: inline`. Verified against this tree:

| Route | Header | Where |
|---|---|---|
| `download_url` (what this anchor points at) | `attachment` | `cps/helper.py` `get_download_link` |
| `/show/<id>/<fmt>` (the reader) | `inline` | `cps/web.py` |

The anchor's `href` is `fmt.download_url` (`cps/api/serializers.py` → `/download/{id}/{fmt}/{name}` → `web.download_link` → `helper.get_download_link`), i.e. the `attachment` path. Confirmed live on `cwn-local` with an iPhone UA: the download URL returns `attachment`, `/show/` returns `inline`.

So the download is not being served inline, and it is not failing. #716 is that an iOS standalone Home Screen app has no browser chrome, so a top-level navigation to an attachment leaves the user with no way back — which is exactly what the reporter's screenshot shows (WebKit's attachment interstitial, correct filename, zero chrome).

## Also recorded

`target` is **inert on this element**: per the HTML "following hyperlinks" algorithm, when `download` is present the UA downloads and never consults `target`. `download` was already there before #717, so that PR's only delta on this flow was a no-op.

The attribute is **left in place**. Removing it is a behaviour change, and #716 is blocked on a real standalone iOS run — replacing one unverified guess with another is how we got here. The comment now says that explicitly.

## Scope

Comment only. Verified mechanically that every changed line is a comment; `npx tsc --noEmit` exits 0. No runtime change, no deps, no test needed because no behaviour changed.

Does not close #716 — that stays open pending the standalone reproduction.