### PR TITLE
docs(changelog): restore the v4.1.27 section deleted by the #1295 squash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ is for things you can see or feel when running the app.
   now enforced on the server and the button is hidden in both views. Uploading
   stays on by default, so nothing changes unless you deliberately turned it off.
 
+## [v4.1.27] - 2026-08-02
+
 ### Changed
 
 - **The admin "Version Information" table now reports the Calibre you are
@@ -802,8 +804,6 @@ is for things you can see or feel when running the app.
 - **Reporting an issue from the new UI's Help menu now opens the bug-report form instead of a blank issue.** The "Report Issue on GitHub" link pointed at the blank-issue URL, so reporters landed on an empty textarea rather than the Bug report / Feature request templates defined in the repo. It now opens the issue-template chooser. Thanks to @auspex for the report ([#799](https://github.com/new-usemame/Calibre-Web-NextGen/issues/799)).
 - **The edit pencil on a book card can now be opened in a new tab.** In the new UI, the hover edit pencil on a book card was a button rather than a real link, so ⌘/ctrl-click (or middle-click) didn't open the editor in a new tab the way real links do — there was no `href` for the browser to open. The pencil is now a true link: a plain click still opens the editor in place (no full page reload), and a modified click opens it in a new tab. Thanks to @chloeroform for the report ([#798](https://github.com/new-usemame/Calibre-Web-NextGen/issues/798)).
 - **Hardcover metadata is fetched again when a book is auto-ingested.** After the v4.1.9 change that centralised how the Hardcover token is read, the automatic fetch that runs on ingest aborted with an internal error and skipped Hardcover — even with a `HARDCOVER_TOKEN` set — while manual "Fetch Metadata" kept working. The token is now read safely in the background ingest process, so a `HARDCOVER_TOKEN` (or `HARDCOVER_TOKEN_FILE`) in the environment is applied during ingest again. Thanks to @ghub3297 and @Glalith121 for the reports ([#819](https://github.com/new-usemame/Calibre-Web-NextGen/issues/819)).
-### Fixed
-
 - **Saving a cover for a PDF-only or other non-EPUB/AZW3 book no longer ends with a false enforcement error.** The metadata enforcer now preserves the successful cover save, refreshes the format-independent `metadata.opf` backup, and logs an informational note that only in-file embedding was skipped for the unsupported format (#797).
 - **Author-sort mismatch warnings now name the affected book and link straight to where you fix it.** The warning previously omitted the book title/ID and pointed at an author-admin screen that doesn't exist, so there was no clear way to act on it. It now names the book and gives the direct edit link (`/admin/book/<id>`): opening that page and re-saving the book's Authors field regenerates its author sort and clears the warning (or you can correct the book in Calibre). Thanks to @auspex for the report (#801).
 - **The classic book page's read checkbox now matches the book's actual state.** Unread books previously showed a checked box beside the “Mark As Read” action, while read books showed an empty box. The checkbox is now empty for unread and checked for read; its tooltip continues to describe what clicking will do (#771).

--- a/tests/unit/test_changelog_release_sections.py
+++ b/tests/unit/test_changelog_release_sections.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Guard the release-section structure of CHANGELOG.md.
+
+Release notes and the in-app What's New page are both generated from this file, so
+its section structure is shipped content, not bookkeeping.
+
+WHAT WENT WRONG (2026-08-02). At release time a commit moves the ``[Unreleased]``
+entries under a new ``## [vX.Y.Z] - DATE`` heading and the tag is cut from that
+commit. Tag ``v4.1.27`` was cut from ``851536e52``, which has the heading. The very
+next commit on main -- ``76ff555a3``, a squash-merge of a PR whose branch was cut
+*before* the sectioning commit -- carried the older CHANGELOG.md wholesale and
+silently deleted the heading again. Git did not conflict: nothing else touched
+those bytes, so the merge was clean and the whole released section simply reverted
+to ``[Unreleased]``.
+
+Nobody noticed for 21 hours. The next release would then have re-announced every
+v4.1.27 fix -- the duplicates popup, the unread dates, the edit-metadata stall --
+to users who already had them, and a published release can never be retracted,
+only superseded.
+
+WHY THIS TEST AND NOT A CONTENT CHECK. The reverted state is still valid markdown
+and every individual entry is still present and correct, so no spell-check,
+lint or link-check can see it. The only visible trace is *structural*: the
+released section's ``### Changed`` / ``### Fixed`` blocks land back inside
+``[Unreleased]``, which already had its own, leaving two headings of the same kind
+in one section. That duplicate is the fingerprint, it is unambiguous, and it needs
+no network or git history to detect.
+
+Deliberately offline. ``sibling test_changelog_entry_integrity.py`` covers the
+single-bullet variant of the same swallow class; the tag-to-section correspondence
+is a separate, wider guard.
+"""
+
+import re
+from pathlib import Path
+
+CHANGELOG = Path(__file__).resolve().parents[2] / "CHANGELOG.md"
+
+VERSION_HEADING = re.compile(r"^## \[(?:v)?(\d+\.\d+\.\d+)\]")
+UNRELEASED_HEADING = re.compile(r"^## \[Unreleased\]", re.IGNORECASE)
+KIND_HEADING = re.compile(r"^### (\w[\w ]*)")
+
+
+def _sections(text):
+    """Split into (heading, [kind, ...]) pairs, one per top-level ``## `` heading."""
+    sections = []
+    current = None
+    for line in text.split("\n"):
+        if line.startswith("## "):
+            if current:
+                sections.append(current)
+            current = (line.rstrip(), [])
+        elif current is not None:
+            match = KIND_HEADING.match(line)
+            if match:
+                current[1].append(match.group(1).strip())
+    if current:
+        sections.append(current)
+    return sections
+
+
+def _text():
+    assert CHANGELOG.is_file(), f"CHANGELOG.md not found at {CHANGELOG}"
+    return CHANGELOG.read_text(encoding="utf-8")
+
+
+def test_no_section_repeats_a_kind_heading():
+    """Two '### Fixed' blocks in one section means a released section was reverted.
+
+    This is the exact fingerprint of the 2026-08-02 regression: the released
+    section's blocks land back inside ``[Unreleased]``, which already had its own.
+    """
+    offenders = []
+    for heading, kinds in _sections(_text()):
+        duplicates = {k for k in kinds if kinds.count(k) > 1}
+        if duplicates:
+            offenders.append(f"  {heading} repeats: {', '.join(sorted(duplicates))}")
+    assert not offenders, (
+        "a CHANGELOG section repeats a '### Kind' heading. This is what a reverted "
+        "release section looks like: a merge carried an older CHANGELOG.md and put "
+        "already-shipped entries back under [Unreleased].\n"
+        "Re-add the missing '## [vX.Y.Z] - DATE' heading above the second block; the "
+        "released tag's copy of the file is the source of truth.\n" + "\n".join(offenders)
+    )
+
+
+def test_version_headings_are_unique():
+    """One heading per version. A duplicate means a section was pasted, not moved."""
+    versions = [
+        VERSION_HEADING.match(h).group(1)
+        for h, _ in _sections(_text())
+        if VERSION_HEADING.match(h)
+    ]
+    duplicates = sorted({v for v in versions if versions.count(v) > 1})
+    assert not duplicates, f"duplicate version heading(s) in CHANGELOG.md: {duplicates}"
+
+
+def test_version_headings_descend():
+    """Newest first. An out-of-order heading means one was inserted at the wrong depth."""
+    versions = [
+        tuple(int(p) for p in VERSION_HEADING.match(h).group(1).split("."))
+        for h, _ in _sections(_text())
+        if VERSION_HEADING.match(h)
+    ]
+    assert versions, "parsed zero version headings out of CHANGELOG.md"
+    out_of_order = [
+        f"{a} appears before {b}"
+        for a, b in zip(versions, versions[1:])
+        if a < b
+    ]
+    assert not out_of_order, (
+        "CHANGELOG version headings must run newest-first:\n  "
+        + "\n  ".join(out_of_order)
+    )
+
+
+def test_unreleased_is_the_first_section_when_present():
+    """[Unreleased] leads the file, so a released section can never be above it."""
+    headings = [h for h, _ in _sections(_text())]
+    unreleased = [i for i, h in enumerate(headings) if UNRELEASED_HEADING.match(h)]
+    if not unreleased:
+        return  # allowed immediately after a release, before the next entry lands
+    assert unreleased == [0], (
+        "[Unreleased] must be the first '## ' section; found it at index "
+        f"{unreleased} of {headings[:4]}"
+    )
+
+
+def test_the_2026_08_02_regression_is_detected():
+    """Pin the detector against the real reverted file so it cannot rot into a no-op.
+
+    Reconstructed from the actual bug: [Unreleased] holding its own '### Fixed'
+    plus the v4.1.27 blocks that lost their heading.
+    """
+    reverted = "\n".join(
+        [
+            "## [Unreleased]",
+            "",
+            "### Fixed",
+            "",
+            "- **Todays fix.** Body.",
+            "",
+            "### Changed",
+            "",
+            "- **A shipped change.** Body.",
+            "",
+            "### Fixed",
+            "",
+            "- **A shipped fix.** Body.",
+            "",
+            "## [v4.1.26] - 2026-07-31",
+            "",
+            "### Fixed",
+            "",
+            "- **Older fix.** Body.",
+            "",
+        ]
+    )
+    unreleased_kinds = _sections(reverted)[0][1]
+    assert unreleased_kinds.count("Fixed") == 2, (
+        "the parser no longer sees the duplicate kind heading, so "
+        "test_no_section_repeats_a_kind_heading would pass vacuously"
+    )
+
+    repaired = reverted.replace(
+        "### Changed", "## [v4.1.27] - 2026-08-02\n\n### Changed", 1
+    )
+    for _, kinds in _sections(repaired):
+        assert len(kinds) == len(set(kinds)), (
+            "the repaired shape must be clean, or the guard would block the fix"
+        )


### PR DESCRIPTION
## Release blocker

`CHANGELOG.md` on main has **no `## [v4.1.27]` section**. It goes `[Unreleased]` straight to `[v4.1.26]`, so all **7 shipped v4.1.27 entries are sitting under `[Unreleased]` again**.

Release notes and the in-app What's New page are both generated from that file, so the next release would have **re-announced every v4.1.27 fix** — the duplicates popup, the unread dates, the edit-metadata stall — to users who already had them. A published release can never be retracted, only superseded.

## Cause

The tag was cut from `851536e52`, which sections the release. The very next commit on main — **`76ff555a3`**, a squash-merge of a PR whose branch predated the sectioning commit — carried the older `CHANGELOG.md` wholesale and deleted the heading again.

Git did not conflict: nothing else touched those bytes, so the merge was clean and a whole released section silently reverted. This is the same swallow class as #1305 (which lost a single bullet), one level up — and `test_changelog_entry_integrity.py` cannot see it, because that guard looks for welded-bullet residue.

Walked every CHANGELOG-touching commit since the tag to identify the culprit:

```
76ff555a3  section=0  <- first commit after the tag
799fcd54a  section=0
ebae7d1d0  section=0
e1d1af2ab  section=0
01d24af39  section=0
ddff6e39c  section=0
```

## Fix

Re-inserts `## [v4.1.27] - 2026-08-02`. The restored section is **byte-identical** to `git show v4.1.27:CHANGELOG.md` (verified by diff).

Also merges v4.1.10's two adjacent `### Fixed` headings — a pre-existing quirk that shipped in that tag, not a revert. All 22 of its entries are unchanged (verified against the tag).

## Regression test

`tests/unit/test_changelog_release_sections.py` — deliberately offline, no git or network:

- no section may repeat a `### Kind` heading — **this is the fingerprint**: the released blocks land back inside `[Unreleased]`, which already has its own
- version headings are unique
- version headings descend newest-first
- `[Unreleased]` leads the file
- a self-pinning test reconstructs the real reverted shape, so the detector cannot rot into a no-op

**Red/green:** reintroducing the exact regression → `1 failed, 4 passed`; restored → `5 passed`. With `test_changelog_entry_integrity.py`: **9 passed**.

## Gate

(a) CI below. (b) red/green above. (c) docs-only, no auth/session/CSRF/crypto/subprocess/path/route surface — `/security-review` not required. (d) no dependency, license or external URL. (e) this body + ledger row `RELEASE-BLOCKER-changelog-v4127-section-missing`.

Broader guards (tag↔section correspondence, a CI diff-level check for removed bullets) are being built separately and will extend this.