### PR TITLE
ci: guard the changelog release structure at the diff and tag level

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          # Changelog integrity compares every canonical-era release tag. A
+          # shallow checkout would silently fall back to only the committed
+          # What's New ledger and exercise less history than normal CI can.
+          fetch-depth: 0
 
       - name: Remove Python bytecode and pycache
         run: |
@@ -367,6 +372,12 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Reject changelog structure lost by a stale PR branch
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/check_changelog_diff.py "$BASE_SHA" "$HEAD_SHA"
 
       - name: Detect
         id: detect

--- a/scripts/check_changelog_diff.py
+++ b/scripts/check_changelog_diff.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Reject pull-request changelog diffs that swallow released structure."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+
+# The canonical file used an en dash through much of v4.0 and a hyphen later.
+# This guard cares about heading identity, not date typography.
+RELEASE_HEADING = re.compile(r"^## \[(v\d+\.\d+\.\d+)\]", re.MULTILINE)
+ENTRY_LEAD = re.compile(r"^- \*\*", re.MULTILINE)
+
+
+def structural_regressions(base: str, proposed: str) -> list[str]:
+    """Return user-facing errors for structure lost from ``base``."""
+    errors: list[str] = []
+
+    base_entries = len(ENTRY_LEAD.findall(base))
+    proposed_entries = len(ENTRY_LEAD.findall(proposed))
+    if proposed_entries < base_entries:
+        errors.append(
+            "CHANGELOG.md loses "
+            f"{base_entries - proposed_entries} top-level '- **' release-note "
+            "bullet(s). Rewrite or move entries instead of deleting them."
+        )
+
+    base_releases = set(RELEASE_HEADING.findall(base))
+    proposed_releases = set(RELEASE_HEADING.findall(proposed))
+    missing_releases = sorted(base_releases - proposed_releases)
+    if missing_releases:
+        errors.append(
+            "CHANGELOG.md removes existing release heading(s): "
+            + ", ".join(missing_releases)
+            + ". A stale branch may have overwritten a release section; rebase "
+            "or merge the current target branch before proceeding."
+        )
+
+    return errors
+
+
+def pull_request_regressions(
+    target: str, branch_point: str, proposed: str
+) -> list[str]:
+    """Check a PR only when that branch actually edited ``CHANGELOG.md``."""
+    if branch_point == proposed:
+        return []
+    return structural_regressions(target, proposed)
+
+
+def _file_at(ref: str) -> str:
+    result = subprocess.run(
+        ["git", "show", f"{ref}:CHANGELOG.md"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or "git show failed"
+        raise RuntimeError(f"cannot read CHANGELOG.md at {ref}: {detail}")
+    return result.stdout
+
+
+def _merge_base(base_ref: str, head_ref: str) -> str:
+    result = subprocess.run(
+        ["git", "merge-base", base_ref, head_ref],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode or not result.stdout.strip():
+        detail = result.stderr.strip() or "git merge-base returned no commit"
+        raise RuntimeError(
+            f"cannot find merge base for {base_ref} and {head_ref}: {detail}"
+        )
+    return result.stdout.strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reject structural CHANGELOG.md loss between two git refs."
+    )
+    parser.add_argument("base_ref")
+    parser.add_argument("head_ref")
+    args = parser.parse_args(argv)
+
+    try:
+        branch_point = _merge_base(args.base_ref, args.head_ref)
+        errors = pull_request_regressions(
+            _file_at(args.base_ref),
+            _file_at(branch_point),
+            _file_at(args.head_ref),
+        )
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if errors:
+        print("CHANGELOG integrity guard failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "CHANGELOG integrity guard passed: "
+        "no PR-authored release structure was lost."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_changelog_diff_guard.py
+++ b/tests/unit/test_changelog_diff_guard.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Pin the PR-level guard against structural CHANGELOG loss."""
+
+from pathlib import Path
+
+from scripts.check_changelog_diff import (
+    pull_request_regressions,
+    structural_regressions,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_missing_release_heading_is_rejected():
+    base = """## [Unreleased]\n\n## [v4.1.27] - 2026-08-02\n\n### Fixed\n- **A fix.**\n"""
+    stale_branch = """## [Unreleased]\n\n### Fixed\n- **A new fix.**\n- **A fix.**\n"""
+    errors = structural_regressions(base, stale_branch)
+    assert any("v4.1.27" in error for error in errors)
+
+
+def test_missing_historical_en_dash_release_heading_is_rejected():
+    base = """## [v4.0.147] – 2026-06-05\n"""
+    errors = structural_regressions(base, "")
+    assert any("v4.0.147" in error for error in errors)
+
+
+def test_net_release_bullet_loss_is_rejected():
+    base = """### Fixed\n- **First fix.**\n- **Second fix.**\n"""
+    swallowed = """### Fixed\n- **First fix now contains both fixes.**\n"""
+    errors = structural_regressions(base, swallowed)
+    assert any("loses 1" in error for error in errors)
+
+
+def test_wording_edits_reordering_and_release_sectioning_are_allowed():
+    base = """## [Unreleased]\n\n### Fixed\n- **First wording.**\n- **Second wording.**\n"""
+    proposed = """## [Unreleased]\n\n## [v4.1.28] - 2026-08-03\n\n### Fixed\n- **Rewritten second wording.**\n- **Rewritten first wording.**\n"""
+    assert structural_regressions(base, proposed) == []
+
+
+def test_stale_pr_that_did_not_edit_changelog_is_allowed():
+    branch_point = """## [Unreleased]\n\n### Fixed\n- **Old fix.**\n"""
+    current_target = branch_point + "\n## [v4.1.27] - 2026-08-02\n"
+    assert pull_request_regressions(current_target, branch_point, branch_point) == []
+
+
+def test_stale_pr_that_did_edit_changelog_must_preserve_current_releases():
+    branch_point = """## [Unreleased]\n\n### Fixed\n- **Old fix.**\n"""
+    current_target = branch_point + "\n## [v4.1.27] - 2026-08-02\n"
+    proposed = branch_point.replace("- **Old fix.**", "- **PR fix.**\n- **Old fix.**")
+    errors = pull_request_regressions(current_target, branch_point, proposed)
+    assert any("v4.1.27" in error for error in errors)
+
+
+def test_pr_ci_invokes_guard_with_complete_git_history():
+    workflow = (ROOT / ".github" / "workflows" / "tests.yml").read_text(encoding="utf-8")
+    fast_tests = workflow.split("  fast-tests:", 1)[1].split("\n  #", 1)[0]
+    changed_paths = workflow.split("  changed_paths:", 1)[1].split("\n  #", 1)[0]
+    assert "fetch-depth: 0" in fast_tests
+    assert "fetch-depth: 0" in changed_paths
+    assert 'python3 scripts/check_changelog_diff.py "$BASE_SHA" "$HEAD_SHA"' in changed_paths

--- a/tests/unit/test_changelog_tag_sections.py
+++ b/tests/unit/test_changelog_tag_sections.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Keep every canonical-era published tag represented in CHANGELOG.md."""
+
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHANGELOG = ROOT / "CHANGELOG.md"
+WHATS_NEW = ROOT / "frontend" / "src" / "data" / "whatsNew.ts"
+CANONICAL_CHANGELOG_FIRST_RELEASE = "v4.0.147"
+
+VERSION = re.compile(r"v\d+\.\d+\.\d+")
+RELEASE_HEADING = re.compile(
+    r"^## \[(v\d+\.\d+\.\d+)\]\s+[-–]\s+\d{4}-\d{2}-\d{2}\s*$",
+    re.MULTILINE,
+)
+WHATS_NEW_VERSION = re.compile(
+    r"^\s*version:\s*'(v\d+\.\d+\.\d+)',\s*$",
+    re.MULTILINE,
+)
+
+
+def _version_tuple(version: str) -> tuple[int, int, int]:
+    return tuple(map(int, version.removeprefix("v").split(".")))
+
+
+def _missing_sections(published: set[str], headings: set[str]) -> list[str]:
+    """Return canonical-era published versions absent from the changelog."""
+    boundary = _version_tuple(CANONICAL_CHANGELOG_FIRST_RELEASE)
+    covered_tags = {
+        version for version in published if _version_tuple(version) >= boundary
+    }
+    return sorted(covered_tags - headings, key=_version_tuple)
+
+
+def _published_versions() -> tuple[set[str], str]:
+    """Use local tags, or the committed public-release ledger offline."""
+    result = subprocess.run(
+        ["git", "tag", "--list", "v*"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    tags = {tag for tag in result.stdout.splitlines() if VERSION.fullmatch(tag)}
+    if tags:
+        return tags, "local git tags"
+
+    assert WHATS_NEW.is_file(), (
+        "cannot determine published releases: no semver git tags are available "
+        f"and the committed ledger is missing at {WHATS_NEW}"
+    )
+    versions = set(WHATS_NEW_VERSION.findall(WHATS_NEW.read_text(encoding="utf-8")))
+    assert versions, (
+        "cannot determine published releases: no semver git tags are available "
+        "and the committed What's New ledger contains no release versions"
+    )
+    return versions, "committed What's New ledger (git tags unavailable)"
+
+
+def test_every_published_version_has_a_changelog_section():
+    text = CHANGELOG.read_text(encoding="utf-8")
+    headings = set(RELEASE_HEADING.findall(text))
+    assert headings, "CHANGELOG.md contains no dated semver release sections"
+    published, source = _published_versions()
+    missing = _missing_sections(published, headings)
+    assert not missing, (
+        f"published release(s) from {source}, at or after the canonical "
+        f"CHANGELOG boundary {CANONICAL_CHANGELOG_FIRST_RELEASE}, have no "
+        "matching dated section: " + ", ".join(missing)
+    )
+
+
+def test_detector_rejects_the_real_missing_tag_section_shape():
+    """Pin the correspondence detector to the v4.1.27 regression."""
+    headings_after_revert = {"v4.1.26", "v4.1.25"}
+    assert _missing_sections({"v4.1.27"}, headings_after_revert) == ["v4.1.27"]
+
+
+def test_tagless_checkout_uses_committed_release_ledger(monkeypatch):
+    """A source archive or offline shallow clone remains strict, never skips."""
+    class NoTags:
+        stdout = ""
+
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: NoTags())
+    versions, source = _published_versions()
+    assert "v4.1.27" in versions
+    assert source == "committed What's New ledger (git tags unavailable)"


### PR DESCRIPTION
## Why

PR #1312 fixed the **data** — the `## [v4.1.27]` section a stale-branch squash silently deleted — and pinned the *residue* offline (no section may repeat a `### Kind` heading, headings unique and descending). This adds the two guards that file deliberately cannot provide.

## What

**1. `scripts/check_changelog_diff.py` + PR CI wiring.** For a PR that actually changed `CHANGELOG.md` relative to its merge base, rejects a net loss of top-level `- **` bullets or removal of any existing `## [vX.Y.Z]` heading.

Verified against the real incident rather than a fixture:

```
$ python3 scripts/check_changelog_diff.py 851536e52 76ff555a3
CHANGELOG integrity guard failed:
- CHANGELOG.md removes existing release heading(s): v4.1.27. A stale branch may have
  overwritten a release section; rebase or merge the current target branch before proceeding.
rc=1
```

And it does **not** fire on the two legitimate cases — a real release sectioning commit (`rc=0`) or a code-only PR (`rc=0`).

**2. `tests/unit/test_changelog_tag_sections.py`.** Cross-checks stable semver tags against dated changelog headings, from the committed `v4.0.147` boundary onward (earlier tags predate the canonical file; backfilling empty headings would manufacture misleading history).

CI now uses `fetch-depth: 0` so tags are deterministically visible. **The offline path does not skip** — it falls back to the committed `frontend/src/data/whatsNew.ts` as a public-release ledger. A guard that skips when it cannot see its inputs is a silent pass, which is the failure class this whole line of work exists to close.

## Proof each guard fails without its code

Every one mutation-tested, red output captured:

| mutation | red |
|---|---|
| tag detector → `return []` | `assert [] == ['v4.1.27']` |
| offline ledger fallback → empty set | `assert 'v4.1.27' in set()` |
| `structural_regressions()` → `return []` | 2 failed (heading-loss, bullet-loss) |
| workflow invocation → `run: "true"` | wiring assertion failed |

## Rejected, with reasons

- **Literal deleted-line matching** — editing a bullet's lead wording deletes a line without losing an entry. Structural counts plus heading-set preservation allow wording edits, reordering and release sectioning while still catching the observed swallows.
- **Comparing every stale PR snapshot to current main** — would block harmless old code-only branches after each release. The merge-base gate activates only when the PR authored a changelog change.
- **Requiring sections for v4.0.0–v4.0.146** — they predate the canonical file.
- **Network access in unit tests.**

## Residual risk (stated, not hidden)

- The diff guard is **PR-only**; a direct main commit can still remove structure. Tag correspondence and #1312's offline tests do run on main pushes.
- Net bullet counting permits replacing one bullet with another; exact text identity would false-positive on legitimate edits. The welded-credit and bold-lead tests cover the common single-entry residue.

## Gate

(a) CI below. (b) mutation-proven red/green above; focused run `15 passed`. Full unit run `3167 passed, 78 skipped`, stopping at the pre-existing `/config/`-read-only failure in `test_ingest_batch_dirty.py`, identical before and after. (c) CI-config + test-only, no auth/session/CSRF/crypto/subprocess/path/route surface. (d) no dependency, license or external URL. (e) this body.