### PR TITLE
chore: update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,25 @@ changelogs
 cwa-wiki
 wiki_images
 .devcontainer
+.editorconfig
+AI_README.md
+CHANGELOG.md
+CHANGES-vs-upstream.md
+CONTRIBUTING.md
+CONTRIBUTORS
+docs
+drafts
+examples
+feedback-server
+GOVERNANCE.md
+greptile.json
+homepage
+kubernetes
+notes
+run_tests.sh
+SECURITY.md
+state
+wiki-src
 
 # Test infrastructure (not needed in production image)
 tests/


### PR DESCRIPTION
The `.dockerignore` file was outdated, and many files were installed in the Docker image doesn't not being at runtime.

This removes many files, reducing the CWNG installation size by approximately 10%.