### PR TITLE
chore: move `cwa_update_notice` to `/config/`

### DIFF
--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -305,12 +305,12 @@ def cwa_update_available() -> tuple[bool, str, str]:
 # Gets the date the last cwa update notification was displayed
 def get_cwa_last_notification() -> str:
     current_date = datetime.now().strftime("%Y-%m-%d")
-    if not os.path.isfile('/app/cwa_update_notice'):
-        with open('/app/cwa_update_notice', 'w') as f:
+    if not os.path.isfile('/config/cwa_update_notice'):
+        with open('/config/cwa_update_notice', 'w') as f:
             f.write(current_date)
         return "0001-01-01"
     else:
-        with open('/app/cwa_update_notice', 'r') as f:
+        with open('/config/cwa_update_notice', 'r') as f:
             last_notification = f.read()
     return last_notification
 
@@ -352,7 +352,7 @@ def cwa_update_notification() -> None:
             flash(message, category="cwa_update")
             print(f"[cwa-update-notification-service] {message}", flush=True)
 
-        with open('/app/cwa_update_notice', 'w') as f:
+        with open('/config/cwa_update_notice', 'w') as f:
             f.write(current_date)
         return
     else:


### PR DESCRIPTION
Last PR cleaning the `/app` directory.

It makes more sense to have `cwa_update_notice` in `/config`, alongside the logs and other files like `cwa_ingest_status`, `cwa_ingest_retry_queue`...