### PR TITLE
fix: pin the update-notice path to one constant and cover it with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,17 @@ is for things you can see or feel when running the app.
   walks Calibre's hidden `.caltrash` folder, so books you deleted are no longer
   processed and reported alongside the ones in your library.
 
+- **The "update available" banner stops re-appearing every time you restart.**
+  The banner is meant to show at most once a day, and it remembered the date it
+  last appeared in a file. That file was kept in a part of the container that
+  gets wiped whenever the container is recreated, which is exactly what happens
+  when you pull a new image. So the reminder forgot itself at the one moment it
+  was most likely to be redundant, and admins saw it again on the next page
+  load. It now lives in your `/config` folder alongside the logs, so the
+  once-a-day promise holds across restarts and upgrades. You may see the banner
+  one extra time on the first start after updating, then it settles.
+  Thanks to @chloeroform for finding and fixing this.
+
 ### Added
 
 - **Reading in your browser now counts towards your reading progress

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -28,6 +28,17 @@ from cwa_db import CWA_DB
 
 log = logger.create()
 
+# Where the "update available" banner remembers the date it last fired, so it
+# can hold itself to once per calendar day.
+#
+# This has to live under /config. That is the declared VOLUME; /app is part of
+# the image and its writable layer is thrown away whenever the container is
+# recreated, which is precisely what a user does when they pull a new image.
+# Keeping the throttle there reset it at the one moment the banner had most
+# likely already been shown (#1333, @chloeroform). Siblings on the same volume:
+# cwa_ingest_status, cwa_ingest_retry_queue, and the logs.
+CWA_UPDATE_NOTICE_PATH = "/config/cwa_update_notice"
+
 
 def _duplicate_setup_notice_dismissed():
     return duplicate_setup_notice_dismissed(getattr(current_user, 'id', 'unknown'))
@@ -305,12 +316,12 @@ def cwa_update_available() -> tuple[bool, str, str]:
 # Gets the date the last cwa update notification was displayed
 def get_cwa_last_notification() -> str:
     current_date = datetime.now().strftime("%Y-%m-%d")
-    if not os.path.isfile('/config/cwa_update_notice'):
-        with open('/config/cwa_update_notice', 'w') as f:
+    if not os.path.isfile(CWA_UPDATE_NOTICE_PATH):
+        with open(CWA_UPDATE_NOTICE_PATH, 'w') as f:
             f.write(current_date)
         return "0001-01-01"
     else:
-        with open('/config/cwa_update_notice', 'r') as f:
+        with open(CWA_UPDATE_NOTICE_PATH, 'r') as f:
             last_notification = f.read()
     return last_notification
 
@@ -352,7 +363,7 @@ def cwa_update_notification() -> None:
             flash(message, category="cwa_update")
             print(f"[cwa-update-notification-service] {message}", flush=True)
 
-        with open('/config/cwa_update_notice', 'w') as f:
+        with open(CWA_UPDATE_NOTICE_PATH, 'w') as f:
             f.write(current_date)
         return
     else:

--- a/tests/unit/test_cwa_update_notice_persistence.py
+++ b/tests/unit/test_cwa_update_notice_persistence.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for where the "update available" banner keeps its throttle.
+
+Background (community PR #1333, @chloeroform): the banner is meant to fire at
+most once per calendar day. It remembers the last-shown date in a file. That
+file used to live at ``/app/cwa_update_notice``.
+
+``/app`` is not a volume — the Dockerfile declares ``VOLUME /config`` and
+nothing else — so anything written under ``/app`` lives in the container's
+writable layer and is destroyed when the container is recreated. Recreating the
+container is exactly what a user does when they pull a new image, which is
+exactly when the update banner is relevant. The throttle therefore reset at the
+worst possible moment and admins got re-nagged on every recreate.
+
+Moving the file to ``/config`` (a declared volume, alongside its siblings
+``cwa_ingest_status``, ``cwa_ingest_retry_queue`` and the logs) makes the
+once-per-day promise actually hold across upgrades.
+
+Pins here:
+
+1. The path is a single module-level constant, not re-hardcoded per call site
+   (four copies of the same literal is how a future edit silently moves one
+   reader and leaves the writer behind).
+2. The path lives under the persistent ``/config`` volume and never under
+   ``/app`` — this is the bug @chloeroform fixed and it must not regress.
+3. First run with no file: the sentinel ``0001-01-01`` is returned so exactly
+   one notification fires, and the file is created carrying today's date.
+4. Subsequent run: the stored date is returned verbatim and not clobbered.
+5. When the stored date is today, the notification path returns early without
+   reaching out to the network for a version check.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../scripts')))
+
+import cps.render_template as rt
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RENDER_PY = REPO_ROOT / "cps" / "render_template.py"
+
+
+def test_notice_path_is_a_single_module_constant():
+    """SSOT: one constant, and no stray hardcoded copies of the filename."""
+    assert hasattr(rt, "CWA_UPDATE_NOTICE_PATH"), (
+        "the update-notice path must be a module-level constant so readers and "
+        "writers cannot drift apart (cf. LOG_ARCHIVE in cps/cwa_functions.py)"
+    )
+
+    source = RENDER_PY.read_text()
+    # The filename should appear exactly once as a path literal: in the constant.
+    literals = re.findall(r"""["'][^"']*cwa_update_notice["']""", source)
+    assert len(literals) == 1, (
+        f"expected the cwa_update_notice path literal exactly once (the constant), "
+        f"found {len(literals)}: {literals}"
+    )
+
+
+def test_notice_lives_on_the_persistent_config_volume_not_app():
+    """The throttle file must survive container recreation.
+
+    ``/app`` is baked into the image and is wiped on recreate; ``/config`` is a
+    declared VOLUME. Writing the throttle to ``/app`` made it reset on every
+    image pull, which is precisely when the update banner matters.
+    """
+    path = rt.CWA_UPDATE_NOTICE_PATH
+
+    assert path.startswith("/config/"), (
+        f"update notice must live on the persistent /config volume, got {path!r}"
+    )
+    assert not path.startswith("/app"), (
+        "regression: the update notice is back on the ephemeral /app layer, so "
+        "the once-per-day throttle resets every time the container is recreated"
+    )
+
+
+def test_first_run_returns_sentinel_and_creates_the_file(tmp_path, monkeypatch):
+    """No file yet: fire exactly one notification, and record today."""
+    notice = tmp_path / "cwa_update_notice"
+    monkeypatch.setattr(rt, "CWA_UPDATE_NOTICE_PATH", str(notice))
+
+    assert not notice.exists()
+
+    result = rt.get_cwa_last_notification()
+
+    # The sentinel is deliberately an impossible date so the caller's
+    # "already notified today?" comparison always fails on a fresh install.
+    assert result == "0001-01-01"
+    assert notice.exists(), "the first call must create the throttle file"
+    assert notice.read_text() == datetime.now().strftime("%Y-%m-%d")
+
+
+def test_existing_file_is_read_back_verbatim_and_not_clobbered(tmp_path, monkeypatch):
+    """A stored date is returned as-is; reading must not rewrite the file."""
+    notice = tmp_path / "cwa_update_notice"
+    notice.write_text("2026-01-15")
+    monkeypatch.setattr(rt, "CWA_UPDATE_NOTICE_PATH", str(notice))
+
+    result = rt.get_cwa_last_notification()
+
+    assert result == "2026-01-15"
+    assert notice.read_text() == "2026-01-15", (
+        "reading the throttle must not overwrite it — otherwise every page "
+        "render resets the once-per-day window"
+    )
+
+
+def test_same_day_notification_short_circuits_before_the_version_check(tmp_path, monkeypatch):
+    """Already notified today: no network round-trip, no second banner."""
+    notice = tmp_path / "cwa_update_notice"
+    notice.write_text(datetime.now().strftime("%Y-%m-%d"))
+    monkeypatch.setattr(rt, "CWA_UPDATE_NOTICE_PATH", str(notice))
+
+    called = {"update_available": 0, "flash": 0}
+
+    class _FakeDB:
+        cwa_settings = {"cwa_update_notifications": True}
+
+    def _fake_update_available():
+        called["update_available"] += 1
+        return True, "v1.0.0", "v9.9.9"
+
+    monkeypatch.setattr(rt, "CWA_DB", lambda: _FakeDB())
+    monkeypatch.setattr(rt, "cwa_update_available", _fake_update_available)
+    monkeypatch.setattr(rt, "flash", lambda *a, **k: called.__setitem__("flash", called["flash"] + 1))
+
+    rt.cwa_update_notification()
+
+    assert called["update_available"] == 0, (
+        "the daily throttle must short-circuit before the upstream version check"
+    )
+    assert called["flash"] == 0, "no second banner on the same calendar day"


### PR DESCRIPTION
Follow-up to #1333 (@chloeroform). That PR moved the update-banner throttle file
off the ephemeral `/app` layer onto the persistent `/config` volume. This picks
up the two things it left behind, which are about the surrounding code rather
than the fix itself.

## Why

**The path was four copies of one string literal**, spread across
`get_cwa_last_notification()` and `cwa_update_notification()`. Nothing pins them
together, so an edit that moves the reader and leaves the writer behind would
land silently and the throttle would simply stop working. `cwa_functions.py`
already solves this for its own paths with a module constant (`LOG_ARCHIVE`), so
this follows the local pattern: `CWA_UPDATE_NOTICE_PATH`.

**The path had no test coverage at all**, which is a fair part of why it sat on
`/app` long enough to matter. The constant is also the seam the tests need — the
inline literals could not be monkeypatched, so there was no way to exercise this
code without writing to the real `/config`.

## Root cause of the original bug, for the record

The Dockerfile declares `VOLUME /config`, `/cwa-book-ingest` and
`/calibre-library`, and nothing else. `/app` is part of the image, so writes
there land in the container's writable layer and are discarded when the container
is recreated. `docker diff` on a running instance shows this directly:
`/app/CWA_STABLE_RELEASE` and the rest sit in the ephemeral layer, while the
`/config` siblings do not appear at all because they are on the bind mount.

Recreating the container is what happens when a user pulls a new image, so the
"once per calendar day" throttle reset at the exact moment the banner was most
likely to be redundant.

## Verification

Red/green, and the reds are red for the right reason:

| Test | Red on | Why it was red |
|---|---|---|
| `..._is_a_single_module_constant` | `main` before and after #1333 | four duplicated literals, no constant |
| `..._persistent_config_volume_not_app` | `main` before #1333 | path was `/app` — this is @chloeroform's fix, pinned |
| `..._first_run_returns_sentinel...` | `main` before this PR | no monkeypatchable seam |
| `..._read_back_verbatim_and_not_clobbered` | `main` before this PR | no monkeypatchable seam |
| `..._short_circuits_before_the_version_check` | `main` before this PR | no monkeypatchable seam |

```
# before: 5 failed in 8.14s
# after:  5 passed in 0.49s
```

Adjacent `render_template` suites still green (39 passed): `test_update_banner_message`,
`test_theme_migration_notification_suppressed`, `test_admin_update_indicator`,
`test_1167_duplicate_notification_revalidates_cache`.

**End to end on `cwn-local`, through the real HTTP path** rather than stopping at
the unit boundary:

1. `docker cp` the change in, enable `cwa_update_notifications`, restart to healthy.
2. Confirm neither `/config/cwa_update_notice` nor `/app/cwa_update_notice` exists.
3. Real cookie-and-CSRF login as an admin (`login_http=302`), then render `/`
   (`page_http=200`).
4. `/config/cwa_update_notice` now exists containing `2026-08-03`;
   `/app/cwa_update_notice` does not exist.
5. The file is present on the **host** at `local-dev/config/cwa_update_notice`,
   which is what makes it survive container recreation, and
   `docker diff cwn-local | grep -c cwa_update_notice` returns `0` — it is not in
   the layer that gets discarded.
6. Second render on the same day leaves mtime unchanged, so the daily throttle
   short-circuits before the version check.

Container settings and the temporary admin role were restored afterwards.

## Review findings dispositioned

Cross-family review (Terra) agreed the `/config` move fixes a real lifecycle bug
rather than being cosmetic, and asked for exactly these two changes. Its other
findings:

- *Atomic writes, locking, content validation* — **declined**. A malformed or
  truncated read costs at most one extra banner and self-heals on the next write,
  and the deployment is already single-writer because of SQLite. Coordination
  machinery here is weight without a payoff.
- *`NETWORK_SHARE_MODE` skips the recursive `chown` of `/config`, so a write can
  fail where `/app` would have succeeded* — **noted, no change**. The failure
  lands in `get_cwa_last_notification()` before the version check and is caught
  by the existing handler in `render_title_template()`, so it degrades to "no
  banner, one log line per admin render" with no network call and no loop. Making
  it fail open would be worse: a banner and a version check on every render.
- *TOCTOU between `isfile()` and `open()`* — pre-existing, same class as the
  above, same handler catches it.

## Tier

`safe-tier-2` in spirit: one production file, path constant only, no behaviour
change. No new dependencies, licences or external URLs.

Credit: @chloeroform (#1333) for the original fix.