### PR TITLE
chore(docker): realign docker-compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   calibre-web-automated:
     # Calibre-Web-NextGen images are published to GHCR by the release CI.
     # Pin to a version tag (e.g. :v4.0.7) for production. Upstream image still pullable
-    # at crocodilestick/calibre-web-automated:latest if you prefer to track upstream.
+    # at ghcr.io/new-usemame/calibre-web-nextgen:latest if you prefer to track upstream.
     image: ghcr.io/new-usemame/calibre-web-nextgen:latest
     container_name: calibre-web-nextgen
     environment:

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -1,8 +1,11 @@
 ---
 services:
   calibre-web-automated:
-    image: crocodilestick/calibre-web-automated:latest
-    container_name: calibre-web-automated
+    # Calibre-Web-NextGen images are published to GHCR by the release CI.
+    # Pin to a version tag (e.g. :v4.0.7) for production. Upstream image still pullable
+    # at ghcr.io/new-usemame/calibre-web-nextgen:latest if you prefer to track upstream.
+    image: ghcr.io/new-usemame/calibre-web-nextgen:latest
+    container_name: calibre-web-nextgen
     environment:
       # Only change these if you know what you're doing
       - PUID=1000
@@ -19,17 +22,21 @@ services:
       - NETWORK_SHARE_MODE=false
       # If you want to force polling mode regardless of share type, set CWA_WATCH_MODE=poll
       # - CWA_WATCH_MODE=poll
+      # If running behind multiple proxies (e.g., Cloudflare Tunnel + reverse proxy), set the total number of proxies
+      # This ensures proper IP detection for session protection and rate limiting (default: 1)
+      # - TRUSTED_PROXY_COUNT=2
       # Skip the automatic library detection/mount at startup. When enabled, the auto-library service will not run.
       # Accepts: true/yes/1 to disable auto-mount (default: false)
       # - DISABLE_LIBRARY_AUTOMOUNT=false
     volumes:
-      # CW users migrating should stop their existing CW instance, make a copy of the config folder, and bind that here to carry over all of their user settings ect.
-      - /path/to/config/folder:/config 
+      # CW users migrating should stop their existing CW instance, make a copy of the config folder, and bind that here to carry over all of their user settings etc.
+      - /path/to/config/folder:/config
       # This is an ingest dir, NOT a library one. Anything added here will be automatically added to your library according to the settings you have configured in CWA Settings page. All files placed here are REMOVED AFTER PROCESSING
       - /path/to/the/folder/you/want/to/use/for/book/ingest:/cwa-book-ingest
       # If you don't have an existing library, CWA will automatically create one at the bind provided here
       - /path/to/your/calibre/library:/calibre-library
       # If you use calibre plugins, you can bind your plugins folder here to have CWA attempt to add them to it's workflow (WIP)
+      # If you are starting with a fresh install, you also need to copy customize.py.json to the Calibre config volume above, in /path/to/config/folder/.config/calibre/customize.py.json, see the README for more info
       - /path/to/your/calibre/plugins/folder:/config/.config/calibre/plugins
 
       # DEV SPECIFIC BINDS


### PR DESCRIPTION
Add missing comments (nothing functional) to `docker-compose.yml.dev` and remove remaining references to the `crocodilestick` Docker repository.

After this PR, the only remaining difference between both files is the "DEV SPECIFIC BINDS" section. Ultimately, we could drop the dev file.