### PR TITLE
fix(reader): stop a book you marked Read from being un-finished by opening it

### DIFF
--- a/cps/services/reading_position.py
+++ b/cps/services/reading_position.py
@@ -121,7 +121,16 @@ def record_web_reader_progress(user, book_id: int, percentage: float) -> bool:
     # check the affected-row count) used by BOTH writers, so the two cannot
     # drift; that is tracked separately rather than half-done here.
     stored = None
+    already_finished = False
     with ub.session.no_autoflush:
+        read_row = (ub.session.query(ub.ReadBook)
+                    .populate_existing()
+                    .filter(ub.ReadBook.user_id == user_id,
+                            ub.ReadBook.book_id == book_id)
+                    .first())
+        already_finished = (read_row is not None
+                            and read_row.read_status == ub.ReadBook.STATUS_FINISHED)
+
         state = (ub.session.query(ub.KoboReadingState)
                  .populate_existing()
                  .filter(ub.KoboReadingState.user_id == user_id,
@@ -130,6 +139,29 @@ def record_web_reader_progress(user, book_id: int, percentage: float) -> bool:
         if state is not None and state.current_bookmark is not None:
             ub.session.refresh(state.current_bookmark)
             stored = state.current_bookmark.progress_percent
+
+    # "Finished" IS the furthest position, so a sample from the browser has
+    # nothing to contribute to a book the user has already marked Read.
+    #
+    # Checking the status is not belt-and-braces on the percentage check below,
+    # it is the only thing that covers this case: ``edit_book_read_status``
+    # creates a *bare* ``ub.KoboBookmark()`` when it marks a book read
+    # (``cps/helper.py``), so ``progress_percent`` is NULL and the comparison
+    # below is skipped entirely. ``update_book_read_status`` would then recompute
+    # the status from the incoming percentage and write it unconditionally, so
+    # simply reopening a finished book downgraded it to IN_PROGRESS, counted a
+    # new reading session, and — via the ``before_flush`` parent bump — pushed
+    # ``StatusInfo: "Reading"`` to the user's Kobo. Destroying state the user set
+    # deliberately is the worst thing this best-effort helper could do.
+    #
+    # The reader-open path already refuses to touch a FINISHED status for the
+    # same reason (``cps/web.py``); this keeps the two consistent. Restarting a
+    # book stays "mark as unread", which clears every carrier and is the
+    # documented way back to 0.
+    if already_finished:
+        log.debug("Web reader position not shared for user %s book %s: "
+                  "the book is already marked finished", user_id, book_id)
+        return False
 
     if stored is not None and percentage <= stored:
         log.debug("Web reader position not advanced for user %s book %s: "

--- a/tests/unit/test_324_web_reader_progress_writeback.py
+++ b/tests/unit/test_324_web_reader_progress_writeback.py
@@ -513,3 +513,116 @@ def test_progress_lookup_does_not_autoflush_the_callers_bookmark():
     savepoint = src.index("with ub.session.begin_nested():")
     assert guard < lookup < savepoint, \
         "the no_autoflush guard must wrap the lookup, which must precede the savepoint"
+
+
+# ── a book the user marked Read must stay Read (regression, v4.1.29 gate) ────
+#
+# The furthest-wins guard compares ``KoboBookmark.progress_percent`` and nothing
+# else, so it is skipped entirely when that column is NULL — and
+# ``helper.edit_book_read_status`` creates a *bare* ``ub.KoboBookmark()`` when it
+# marks a book read (cps/helper.py:803-805), which is exactly that case.
+# ``update_book_read_status`` then recomputes the status from the incoming
+# percentage and writes it unconditionally (kosync.py:448-450), so a 3% sample
+# from simply reopening the book downgraded FINISHED -> IN_PROGRESS, incremented
+# ``times_started_reading``, and — because the ``before_flush`` listener bumps
+# the parent — pushed ``StatusInfo: "Reading"` to the user's Kobo.
+#
+# "Finished" IS the furthest position, so a web-reader sample below 100% has
+# nothing to contribute to a finished book. Restarting one is "mark as unread",
+# which clears every carrier; that is the documented way back to 0.
+
+def _seed_finished(session, user_id, book_id, percent=None):
+    """The graph ``helper.edit_book_read_status`` leaves behind when a user
+    marks a book Read: FINISHED, with a bare bookmark unless a device had
+    already reported a position."""
+    read = ub.ReadBook(user_id=user_id, book_id=book_id,
+                       read_status=ub.ReadBook.STATUS_FINISHED)
+    state = ub.KoboReadingState(user_id=user_id, book_id=book_id)
+    state.current_bookmark = ub.KoboBookmark(progress_percent=percent)
+    read.kobo_reading_state = state
+    session.add(read)
+    session.commit()
+    return read
+
+
+def _read_row(session, user_id, book_id):
+    return (session.query(ub.ReadBook)
+            .filter(ub.ReadBook.user_id == user_id,
+                    ub.ReadBook.book_id == book_id).first())
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("seeded_percent", [None, 40.0],
+                         ids=["bare-bookmark", "device-reported-percent"])
+def test_finished_book_is_not_unfinished_by_browser_reading(monkeypatch, seeded_percent):
+    """Reopening a book you marked Read must not flip it back to Reading.
+
+    Both shapes reach it: the bare bookmark left by marking read, and a real
+    device percentage the browser then reads past.
+    """
+    session = _session()
+    mod = _service(monkeypatch, session)
+    _seed_finished(session, user_id=7, book_id=42, percent=seeded_percent)
+
+    advanced = mod.record_web_reader_progress(SimpleNamespace(id=7), 42, 55.0)
+    session.commit()
+
+    row = _read_row(session, 7, 42)
+    assert row.read_status == ub.ReadBook.STATUS_FINISHED, (
+        "a book the user marked Read was silently un-finished by opening it "
+        "in the web reader; this syncs to the Kobo as StatusInfo=Reading")
+    assert advanced is False
+
+
+@pytest.mark.unit
+def test_finished_book_does_not_count_as_a_new_reading_session(monkeypatch):
+    """``times_started_reading`` is user-visible on the book detail page."""
+    session = _session()
+    mod = _service(monkeypatch, session)
+    _seed_finished(session, user_id=7, book_id=42)
+
+    mod.record_web_reader_progress(SimpleNamespace(id=7), 42, 3.0)
+    session.commit()
+
+    assert (_read_row(session, 7, 42).times_started_reading or 0) == 0
+
+
+@pytest.mark.unit
+def test_finished_book_write_causes_no_kobo_sync_churn(monkeypatch):
+    """A refused write must not dirty the parent, or every page turn re-pushes
+    the whole book to the device."""
+    session = _session()
+    mod = _service(monkeypatch, session)
+    _seed_finished(session, user_id=7, book_id=42, percent=40.0)
+
+    state = (session.query(ub.KoboReadingState)
+             .filter(ub.KoboReadingState.user_id == 7,
+                     ub.KoboReadingState.book_id == 42).first())
+    before = state.last_modified
+
+    mod.record_web_reader_progress(SimpleNamespace(id=7), 42, 55.0)
+    session.commit()
+
+    session.refresh(state)
+    assert state.last_modified == before
+    assert _stored_percent(session, 7, 42) == 40.0
+
+
+@pytest.mark.unit
+def test_unread_and_in_progress_books_still_advance(monkeypatch):
+    """The guard is scoped to FINISHED — the headline feature must still work."""
+    session = _session()
+    mod = _service(monkeypatch, session)
+    for book_id, status in ((42, ub.ReadBook.STATUS_IN_PROGRESS),
+                            (43, ub.ReadBook.STATUS_UNREAD)):
+        read = ub.ReadBook(user_id=7, book_id=book_id, read_status=status)
+        state = ub.KoboReadingState(user_id=7, book_id=book_id)
+        state.current_bookmark = ub.KoboBookmark(progress_percent=None)
+        read.kobo_reading_state = state
+        session.add(read)
+    session.commit()
+
+    for book_id in (42, 43):
+        assert mod.record_web_reader_progress(SimpleNamespace(id=7), book_id, 55.0) is True
+        session.commit()
+        assert _stored_percent(session, 7, book_id) == 55.0


### PR DESCRIPTION
Found by the pre-release refuter loop for v4.1.29, before the tag. Blocks that release.

## Symptom

Mark a book Read. Open it in the web reader — just to check a quote, not to re-read it. The book flips back to **Reading**, "times started reading" increments, and on its next sync your **Kobo un-finishes it too**. Nothing tells you, and marking it Read again is the only way back.

Verified against the shipping code before fixing:

```
BEFORE: read_status = 1 (FINISHED) | progress_percent = None | times_started = 0
accepted = True
AFTER : read_status = 2 | progress_percent = 3.0 | times_started = 1
parent last_modified advanced (=> pushed to Kobo): True
Kobo sync feed would now report StatusInfo = Reading
```

## Root cause

The furthest-wins guard in `record_web_reader_progress` had exactly one input — the stored percentage — and that input is `NULL` on precisely the books this hits:

1. `helper.edit_book_read_status` creates a **bare** `ub.KoboBookmark()` when it marks a book read, so `progress_percent` is `None`.
2. The guard is `if stored is not None and percentage <= stored` — a `None` skips it entirely.
3. `update_book_read_status` then recomputes the status from the incoming percentage and writes it unconditionally (`if old_status != new_status: book_read.read_status = new_status`), so a 3% sample downgrades `FINISHED` → `IN_PROGRESS` and increments `times_started_reading`.
4. The `before_flush` listener in `cps/ub.py` bumps the parent `KoboReadingState`, which is exactly what makes the Kobo feed emit the row.

A second shape reaches it without any `NULL` involved: read to 40% on the device, mark Read, then browse past 40% in the browser. `55 > 40`, so the percentage guard passes and the status is downgraded anyway.

## The fix

Give the guard the input it was missing, rather than special-casing the symptom. **Finished is the furthest position** — a browser sample below 100% has nothing to contribute to a book already marked Read, whatever the percentage column happens to hold. One check covers both shapes.

`cps/web.py`'s reader-open path already refuses to touch a `FINISHED` status for this exact reason; #1316 added a second writer on the same request with no such guard, which defeated it. This makes the two agree instead of having one undo the other. Restarting a book stays "mark as unread", which clears every carrier — the documented way back to 0.

## Why the existing tests didn't catch it

Every fixture in `test_324_web_reader_progress_writeback.py` seeded `STATUS_IN_PROGRESS`. No test ever started from a finished book, so all 42 passed while the bug was live. That's the gap, not the assertions.

## Validation

| | |
|---|---|
| New tests | 5 (both reaching shapes, `times_started_reading`, parent-timestamp churn, and that UNREAD/IN_PROGRESS still advance) |
| Red before | 4 failed |
| Green after | 47 passed |
| Adjacent | 739 passed (kobo, kosync, bookmark, read-status, #627, #683, #1318) |

The independent repro now reports `accepted = False`, status stays `FINISHED`, `times_started = 0`, no parent bump, and the Kobo feed still says `Finished`.

The scoping test is the one that matters for regression risk: `test_unread_and_in_progress_books_still_advance` pins that the headline #1316 feature is untouched for every book that isn't already finished.

No new dependency, license, route or external service URL.