### PR TITLE
test(changelog): a release section with no tag must not accumulate

### DIFF
--- a/tests/unit/test_changelog_tag_sections.py
+++ b/tests/unit/test_changelog_tag_sections.py
@@ -88,3 +88,60 @@ def test_tagless_checkout_uses_committed_release_ledger(monkeypatch):
     versions, source = _published_versions()
     assert "v4.1.27" in versions
     assert source == "committed What's New ledger (git tags unavailable)"
+
+def test_at_most_one_version_section_is_untagged():
+    """A release is sectioned first, then tagged. Only the in-flight one may lack a tag.
+
+    The sibling test above checks tag -> section: every published tag has a
+    changelog section. Nothing checked the REVERSE, and the reverse is where work
+    gets stranded.
+
+    OBSERVED 2026-08-03: `## [v4.1.29] - 2026-08-03` was written with five
+    user-facing entries and `[Unreleased]` emptied, but the tag was deliberately
+    held (a refuter round found a Kobo read-state blocker). That window is normal
+    and short. What is NOT normal is a second release being prepped on top of an
+    abandoned one: the first section then claims a release that never existed, and
+    its entries are announced nowhere, because the next release's notes are built
+    from `[Unreleased]` — which the abandoned prep already emptied.
+
+    Deliberately clock-free. An age-based rule would need a wall-clock and would
+    red every PR during a legitimately long hold, which is how a guard gets muted.
+    "At most one in flight" cannot fire on the normal window and cannot flake.
+    The operational question — *this* release has been held too long — belongs in
+    the autopilot floor, not in a repo unit test.
+    """
+    text = CHANGELOG.read_text(encoding="utf-8")
+    headings = set(RELEASE_HEADING.findall(text))
+    assert headings, "CHANGELOG.md contains no dated semver release sections"
+    published, source = _published_versions()
+    boundary = _version_tuple(CANONICAL_CHANGELOG_FIRST_RELEASE)
+
+    untagged = sorted(
+        (v for v in headings if _version_tuple(v) >= boundary and v not in published),
+        key=_version_tuple,
+    )
+    assert len(untagged) <= 1, (
+        "more than one changelog release section has no published tag "
+        f"(source: {source}): {untagged}.\n"
+        "A sectioned-but-never-tagged release strands its entries: [Unreleased] was "
+        "emptied when it was cut, so the next release's notes cannot mention them. "
+        "Either tag the older one or fold its entries back into [Unreleased]."
+    )
+
+
+def test_the_untagged_detector_catches_two_abandoned_preps():
+    """Non-vacuity: the assertion above is worthless if it cannot count past one."""
+    published = {"v4.1.28"}
+    headings = {"v4.1.28", "v4.1.29", "v4.1.30"}
+    boundary = _version_tuple(CANONICAL_CHANGELOG_FIRST_RELEASE)
+    untagged = sorted(
+        (v for v in headings if _version_tuple(v) >= boundary and v not in published),
+        key=_version_tuple,
+    )
+    assert untagged == ["v4.1.29", "v4.1.30"], untagged
+    assert len(untagged) > 1, "the shape the guard must reject is not being detected"
+
+    # And the normal in-flight window must stay green, or the guard blocks releases.
+    one_in_flight = {"v4.1.28", "v4.1.29"}
+    still = [v for v in one_in_flight if v not in published]
+    assert len(still) <= 1, "a single in-flight prep must not trip the guard"


### PR DESCRIPTION
## The gap

`test_every_published_version_has_a_changelog_section` checks **tag → section**: every published tag has a changelog section. Nothing checked the **reverse**, and the reverse is where work gets stranded.

## Observed today

`## [v4.1.29] - 2026-08-03` was written with **five user-facing entries** and `[Unreleased]` emptied — then the tag was deliberately held, because a refuter round found a Kobo read-state blocker (#1343). That window is normal and the system logged its reasoning each tick.

What is **not** normal is a second release being prepped on top of an abandoned one. The first section then claims a release that never existed, and its entries are announced **nowhere** — the next release's notes are built from `[Unreleased]`, which the abandoned prep already emptied.

That is the class-12 shape: prep is stage 1, tag is stage 2, and until now nothing counted the gap between them. It was signalled only by the actor maintaining it, so if phase-7 stopped narrating or died, the state would sit silently.

## Why clock-free

An age-based rule ("untagged for more than N hours") would need a wall clock and would red **every PR** during a legitimately long hold — which is exactly how a guard gets muted, and a muted guard is worse than none.

**At most one in flight** cannot fire on the normal window and cannot flake. The operational question — *this* release has been held too long — belongs in the autopilot floor, not a repo unit test. Noted separately, not built here.

## Red/green

Injecting a second untagged section into the real CHANGELOG:

```
AssertionError: more than one changelog release section has no published tag
(source: local git tags): ['v4.1.29', 'v4.1.30'].
```

Restored → `5 passed`. Current state (`untagged = ['v4.1.29']`, one in-flight prep) is correctly green.

A companion test pins the detector itself so it cannot rot into a no-op — it asserts the two-abandoned-prep shape is detected **and** that a single in-flight prep stays green, so the guard can never block a normal release.

## Gate

(a) CI below. (b) red/green above. (c) test-only, no auth/session/CSRF/crypto/subprocess/path/route surface. (d) no dependency, license or external URL. (e) this body.