### PR TITLE
docs(release): make the v4.1.29 notes match what actually ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,17 @@ is for things you can see or feel when running the app.
   Read status is also kept in step now if you use a custom column for it.
   Calibre-Web tracks reading in two places — your column, and an internal record
   the Kobo and KOReader sync both write to — and only the column was being
-  updated when you toggled a book. So the "Currently reading" marker and the
-  progress your devices see could drift away from the checkmark on the book, and
-  a book you had marked Read could still be reported to your Kobo as one you
-  were part-way through. Both now follow the same toggle.
+  updated when you toggled a book. So the "Currently reading" marker could drift
+  away from the checkmark on the book, and a book you had marked Read could
+  still be reported to your Kobo as one you were part-way through. Both records
+  now follow the toggle.
 
-- **Japanese and Chinese books now turn the page the right way in the new
+  One limit worth knowing if you use a custom read column: the toggle reaches
+  your Kobo for books it has already synced, but not yet for a book the device
+  has never seen. That gap is tracked on
+  [#1350](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1350).
+
+- **Japanese and Chinese ebooks now turn the page the right way in the new
   reader.** Books that read right-to-left were paged as if they read
   left-to-right: the button to go forward sat on the right of the screen, so
   tapping the side you actually read towards took you backwards a page instead
@@ -45,15 +50,31 @@ is for things you can see or feel when running the app.
   really do for anyone using a screen reader. Books that read left-to-right are
   unchanged.
 
-- **Your reading position is no longer lost without warning when the database
-  is busy.** Both readers save your place constantly — the classic reader on
-  every page turn, the new one every second or so — and if that save failed
-  because something else was writing to the database at that moment, the
-  browser was told it had worked. It hadn't: the position was thrown away, and
-  because the browser thought it was saved, it never tried again. You would
-  come back to the book and find yourself pages behind, with nothing in the log
-  to explain it. Saves that fail now say so, and the reader retries instead of
-  quietly dropping your place.
+  This covers epub. Comics and manga read as CBZ or CBR still page
+  left-to-right — they carry no equivalent marker for reading direction, so that
+  needs its own detection and is tracked on
+  [#1354](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1354).
+
+- **Your reading position survives a busy database instead of being dropped.**
+  Both readers save your place constantly — the classic reader on every page
+  turn, the new one every second or so — and if that save failed because
+  something else was writing to the database at that moment, the browser was
+  told it had worked. It hadn't: the position was thrown away, and because the
+  browser thought it was saved, nothing ever went back for it. You would come
+  back to the book and find yourself pages behind, with nothing in the log to
+  explain it. A save that fails now reports the failure instead of a success,
+  and both readers act on it: the new reader retries a few times, and the
+  classic reader keeps your place locally and sends it the next time you open
+  the book.
+
+  Two honest limits. There is still no on-screen warning when a save fails for
+  good — the new reader announces it to screen readers only
+  ([#1352](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1352)) —
+  and if you close the tab within a few seconds of turning a page, the new
+  reader can still lose that last page turn. Neither is a step back from the
+  previous release; the new reader did not send your position anywhere at all
+  before this one.
+
   The same "said it worked when it didn't" answer turned up in three other
   places, all now fixed: changing an admin password from the command line could
   print "Password for user X changed" and exit successfully when the change had
@@ -115,6 +136,15 @@ is for things you can see or feel when running the app.
   only KOReader understands, so it doesn't pick up browser reading yet — that
   half needs a position translation and is still tracked on
   [#324](https://github.com/new-usemame/Calibre-Web-NextGen/issues/324).
+
+  Worth knowing if your server has several users *and* an admin has pointed
+  Calibre-Web at a custom column for read status: that column belongs to the
+  book rather than to each reader, so one person finishing a book in the
+  browser now shows it as read for everyone. Marking a book read by hand always
+  worked that way on those libraries; what is new is that reading to the end
+  does it too. Ordinary libraries keep read status per person and are
+  unaffected. Discussion of what the right behaviour should be is on
+  [#1351](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1351).
 
 ## [v4.1.28] - 2026-08-02
 

--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -61,18 +61,18 @@ export const WHATS_NEW: WhatsNewRelease[] = [
     items: [
       {
         title: 'Reading in your browser now counts everywhere else',
-        body: 'Until now the web reader kept its position to itself: it could show you how far your Kobo or KOReader had got, but reading a few chapters in the browser left no trace, so your device still thought you were where you left it. The place you reach in the browser now travels the other way too — your Kobo picks it up on its next sync, the progress on the book updates, and finishing a book in the browser marks it read. Flipping back to an earlier chapter never costs you anything: your own place follows you, but the furthest point your device knows about stays put.',
+        body: 'Until now the web reader kept its position to itself: it could show you how far your Kobo or KOReader had got, but reading a few chapters in the browser left no trace, so your device still thought you were where you left it. The place you reach in the browser now travels the other way too — your Kobo picks it up on its next sync, the progress on the book updates, and finishing a book in the browser marks it read. Flipping back to an earlier chapter never costs you anything: your own place follows you, but the furthest point your device knows about stays put. One thing to know if your server has several users and an admin has set a custom column for read status: that column belongs to the book rather than to each reader, so one person finishing a book in the browser shows it as read for everyone. Ordinary libraries keep read status per person and are unaffected.',
         category: 'Sync',
         link: { to: '/', label: 'Open your library' },
       },
       {
-        title: 'Japanese and Chinese books turn the page the right way',
-        body: 'Books that read right to left were paged as if they read left to right, so the button to go forward sat on the right of the screen and tapping the side you actually read towards took you backwards instead of onwards. The arrow keys were reversed in the same way. Forward now sits where it belongs for these books, and the buttons announce what they really do for anyone using a screen reader.',
+        title: 'Japanese and Chinese ebooks turn the page the right way',
+        body: 'Books that read right to left were paged as if they read left to right, so the button to go forward sat on the right of the screen and tapping the side you actually read towards took you backwards instead of onwards. The arrow keys were reversed in the same way. Forward now sits where it belongs for these books, and the buttons announce what they really do for anyone using a screen reader. This covers epub — comics and manga read as CBZ or CBR still page left to right, since they carry no equivalent marker for reading direction.',
         category: 'Reading',
       },
       {
-        title: 'Your place in a book is no longer lost without warning',
-        body: 'Both readers save your position constantly, and if a save failed because something else was writing to the database at that moment, the browser was told it had worked. It had not: the position was thrown away, and because the browser believed it was saved it never tried again, so you would come back to the book pages behind with nothing in the log to explain it. Saves that fail now say so, and the reader retries instead of quietly dropping your place.',
+        title: 'Your place in a book survives a busy database',
+        body: 'Both readers save your position constantly, and if a save failed because something else was writing to the database at that moment, the browser was told it had worked. It had not: the position was thrown away, and because the browser believed it was saved, nothing ever went back for it, so you would come back to the book pages behind with nothing in the log to explain it. A save that fails now reports the failure instead of a success, and both readers act on it — this reader retries a few times, and the classic reader keeps your place locally and sends it the next time you open the book. Two limits remain: there is still no on-screen warning when a save fails for good, and closing the tab within a few seconds of turning a page can still lose that last turn.',
         category: 'Reading',
       },
       {


### PR DESCRIPTION
Output of the v4.1.29 pre-tag adversarial gate (refuter round 3, five independent
fresh-context critics on the composed `v4.1.28..main` delta).

**The code held. Four of the six release-note claims did not.** Since a published release can
never be retracted and its notes are the part users actually read, the claims are corrected
here, before the tag, rather than apologised for after it.

## What each claim said vs what ships

| Note claim | Verified reality |
|---|---|
| "the reader retries" | True of the new reader (single-flight, 4 attempts, real backoff, every retry re-reads the current position). **False of the classic reader** — `persistCfi`'s catch is byte-identical to v4.1.28; it keeps the place locally and re-sends on next open. Both are now described. |
| "Saves that fail now say so" | The only surfacing is an `sr-only` live region; `Reader.tsx:210` states outright the reader has no toast. Now stated as a remaining limit (#1352). |
| "Both now follow the same toggle" | True of the two database carriers, not of the device: a custom-column toggle never reaches a Kobo that hasn't synced that book yet (#1350). |
| "Japanese and Chinese books…" | The epub reader is fixed and verified across desktop/mobile/keyboard/screen-reader with an LTR control. CBZ/CBR comics still page left-to-right (#1354). |

Also newly disclosed: on a custom-read-column install with several users, one person finishing a
book in the browser marks it read for all of them (#1351). The column is book-level, so this
follows from the admin's column choice and any manual toggle always did it — but a new
*implicit* writer of shared state belongs in the notes.

## Not a regression

Worth being explicit, because the list above reads worse than the release is: **nothing found
leaves users worse off than v4.1.28.** Before this release the new reader did not write reading
position back at all, so "can lose the last few seconds on tab close" replaces "never saves."
The `#1340` and `#1318` gaps (#1355, #1357) are pre-existing paths the fix didn't reach.

## What the gate verified as sound

- **Artifact** (fresh image built from the exact head, `FROM scratch` context probe): the
  `.dockerignore` trim loses exactly 118 files, all docs — **zero** `.py`, `.html`, `.po`,
  static asset or s6 script. 28/28 locales compile and land in-image; no locale lost a single
  translated message vs v4.1.28. SPA bundle rebuilt from delta source. No dependency changes
  anywhere (rule 6 clean).
- **RTL**: held on every cell driven, provenance proved by rebuilding the served chunk
  byte-identically at HEAD.
- **Default-state read status**: the mark-unread inversion is genuinely dead, confirmed with a
  pre-fix control that reproduces the old wrong answer.
- **Concurrency**: 160 parallel position saves → 160×204, no lock/`IntegrityError`/
  `MultipleResultsFound`, no stdlib blocking call added to the request path (the
  no-`monkey.patch_all` invariant holds).

## Follow-ups filed

#1350, #1351, #1352, #1353, #1354, #1355, #1356, #1357, plus an e2e-flakiness note on #1349.

## Verification of this change

Content-only: prose in `CHANGELOG.md` and string bodies in `whatsNew.ts`. No behaviour changes,
so there is no red/green test to write — the proportionate checks are `tsc -b` clean and the 66
changelog / whats-new / SPA-msgid guard tests green. The whats-new edit must land before the tag
because the SPA is baked into the image at build time.