### PR TITLE
ci(e2e): stop the book seed losing races with the ingest watcher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -576,10 +576,33 @@ jobs:
           # reader-rtl.spec.ts skips itself when either is missing, so this seed
           # — and the count check below — is what keeps it a real gate rather
           # than a silent pass.
+          # Stage into /tmp and `mv` into the watched folder, rather than
+          # `docker cp`-ing straight into it. The ingest service watches
+          # `close_write`, `moved_to` and `create` (cwa-ingest-service/run), and
+          # a rename into the folder is guaranteed to emit one of them: same
+          # filesystem gives `moved_to`, and a cross-device fallback copy gives
+          # `create` then `close_write`. `docker cp` instead relies on the
+          # daemon's write producing an inotify event inside the container's
+          # mount namespace, which is not guaranteed across storage drivers.
+          #
+          # A missed `close_write` is fatal here rather than merely late,
+          # because handle_event() drops a bare CREATE unless the file has
+          # nlink > 1 and non-zero size (the hardlink path) -- a plain copied-in
+          # file that fires only CREATE is ignored forever, with no log line.
+          # That is exactly the observed signature: watches established, zero
+          # ingest activity, 0 of 5 imported.
+          #
+          # It is nondeterministic, not a standing break: run 30868527022 ran
+          # this same seed and imported 5/5, while 30866805515 imported 0/5
+          # 34 minutes earlier on a diff of two docs files. Harness
+          # determinism, not a product bug -- ingest works on this commit.
+          docker exec -u 0 cwn-e2e mkdir -p /tmp/seed
           for book in alice_in_wonderland christmas_carol metamorphosis test_rtl_vertical test_ltr_horizontal; do
             docker cp "tests/fixtures/sample_books/${book}.epub" \
-              "cwn-e2e:/cwa-book-ingest/${book}.epub"
-            docker exec -u 0 cwn-e2e chown 1000:1000 "/cwa-book-ingest/${book}.epub"
+              "cwn-e2e:/tmp/seed/${book}.epub"
+            docker exec -u 0 cwn-e2e chown 1000:1000 "/tmp/seed/${book}.epub"
+            docker exec -u 0 cwn-e2e mv "/tmp/seed/${book}.epub" \
+              "/cwa-book-ingest/${book}.epub"
           done
           echo "Polling for the imported book via the API..."
           jar=$(mktemp); total=0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -576,26 +576,26 @@ jobs:
           # reader-rtl.spec.ts skips itself when either is missing, so this seed
           # — and the count check below — is what keeps it a real gate rather
           # than a silent pass.
-          # Stage into /tmp and `mv` into the watched folder, rather than
-          # `docker cp`-ing straight into it. The ingest service watches
-          # `close_write`, `moved_to` and `create` (cwa-ingest-service/run), and
-          # a rename into the folder is guaranteed to emit one of them: same
-          # filesystem gives `moved_to`, and a cross-device fallback copy gives
-          # `create` then `close_write`. `docker cp` instead relies on the
-          # daemon's write producing an inotify event inside the container's
-          # mount namespace, which is not guaranteed across storage drivers.
+          # This seed intermittently imported 0 of 5, which reds the gate on
+          # diffs that cannot reach ingest at all. The cause is a startup race,
+          # not the copy mechanism: the previous step waits only for the web app
+          # to answer HTTP, but s6 brings cwa-ingest-service up after it, and
+          # inotifywait reports only events that happen once its watches exist.
+          # cwa-ingest-service/run has no startup scan of the folder, so a book
+          # that lands in that gap is never seen -- watches established, no
+          # ingest activity, 0 of 5. Nothing retries it, because from the
+          # service's point of view nothing ever happened.
           #
-          # A missed `close_write` is fatal here rather than merely late,
-          # because handle_event() drops a bare CREATE unless the file has
-          # nlink > 1 and non-zero size (the hardlink path) -- a plain copied-in
-          # file that fires only CREATE is ignored forever, with no log line.
-          # That is exactly the observed signature: watches established, zero
-          # ingest activity, 0 of 5 imported.
-          #
-          # It is nondeterministic, not a standing break: run 30868527022 ran
-          # this same seed and imported 5/5, while 30866805515 imported 0/5
-          # 34 minutes earlier on a diff of two docs files. Harness
-          # determinism, not a product bug -- ingest works on this commit.
+          # So: wait for the watcher, then keep nudging whatever it still
+          # missed. Ingest deletes each file once it has imported it, so a book
+          # still sitting in the folder is by definition one the watcher never
+          # picked up -- renaming it away and back fires a fresh event for it.
+          # That second half is what makes this deterministic rather than a
+          # narrower race: it recovers a lost event whatever the reason for it.
+          echo "Waiting for the ingest watcher to establish its watches..."
+          timeout 180 bash -c 'until docker logs cwn-e2e 2>&1 | grep -q "\[cwa-ingest-service\] Watching folder:"; do sleep 2; done' \
+            || echo "::warning::ingest watcher banner never appeared; relying on the re-nudge below"
+          sleep 5
           docker exec -u 0 cwn-e2e mkdir -p /tmp/seed
           for book in alice_in_wonderland christmas_carol metamorphosis test_rtl_vertical test_ltr_horizontal; do
             docker cp "tests/fixtures/sample_books/${book}.epub" \
@@ -616,6 +616,17 @@ jobs:
             # Wait for ALL of them: breaking at the first import is what left
             # the library at one book while the step reported success.
             [ "${total:-0}" -ge 5 ] && break
+            # Ingest removes each file once it has imported it, so anything
+            # still sitting in the folder is a book the watcher never saw.
+            # Rename it away and back to fire a fresh event. The intermediate
+            # name is deliberately not a book extension, so only the move back
+            # is acted on. Every 30s, so a lost event costs a little time
+            # rather than the whole run.
+            if [ $((i % 6)) -eq 0 ]; then
+              echo "  re-nudging books the watcher has not picked up yet"
+              docker exec -u 0 cwn-e2e sh -c \
+                'for f in /cwa-book-ingest/*.epub; do [ -e "$f" ] || continue; mv "$f" "$f.renudge" && mv "$f.renudge" "$f"; done' || true
+            fi
             sleep 5
           done
           if [ "${total:-0}" -lt 5 ]; then


### PR DESCRIPTION
The SPA e2e job intermittently fails its seed step with `ingest imported only 0 of 5 seed books`, reddening the gate on diffs that cannot reach ingest at all. PR #1358 — two docs files — was blocked by exactly this.

## Root cause (corrected — my first attempt was wrong)

This PR's first commit assumed the problem was the inotify **event type**: that `docker cp` might land only a bare CREATE, which `handle_event()` drops unless `nlink > 1` and size is non-zero. That reasoning is sound as far as it goes, but it was not the cause. Run [30871476145](https://github.com/new-usemame/Calibre-Web-NextGen/actions/runs/30871476145) ran the rename version and still imported **0 of 5**, which ruled it out.

The real cause is a **startup race**. The preceding step waits only for the web app:

```
timeout 240 bash -c 'until curl -fsS http://localhost:8083/ -o /dev/null; do sleep 5; done'
```

s6 brings `cwa-ingest-service` up *after* the web service, and `inotifywait` reports only events that happen once its watches exist. `cwa-ingest-service/run` has no startup scan of the folder. So a book that lands in the gap between "app answers HTTP" and "watches established" is never seen, and nothing retries it — from the service's point of view nothing ever happened. That is precisely the observed signature: watches established, zero ingest activity, 0 of 5, no `New file detected` line.

It also explains the flakiness. Same step, opposite outcomes 34 minutes apart:

| Run | Result |
|---|---|
| [30868527022](https://github.com/new-usemame/Calibre-Web-NextGen/actions/runs/30868527022) | 5/5, green |
| [30866805515](https://github.com/new-usemame/Calibre-Web-NextGen/actions/runs/30866805515) | 0/5, red |

## Fix

1. **Wait for the watcher** — poll the container log for the service's own `[cwa-ingest-service] Watching folder:` banner before seeding. A warning, not a failure, if it never appears.
2. **Re-nudge what it missed** — while polling, rename any book still sitting in the ingest folder away and back, every 30s. Ingest deletes each file once imported, so a file still present is by definition one the watcher never picked up. The intermediate name is not a book extension, so only the move back is acted on.

Step 2 is what makes this deterministic. Step 1 narrows the race; step 2 recovers a lost event whatever the reason for it, including the event-type case the first commit was aimed at.

The rename-based seeding from the first commit is kept — it is still the better primitive (a rename emits `moved_to` on the same filesystem, or `create` + `close_write` cross-device, both watched) and ownership is set before the move, so ingest never sees a root-owned file it cannot remove.

## Verification

- `yaml.safe_load` parses the workflow; the extracted seed step passes `bash -n`.
- The real check is this PR's own E2E run, which exercises both halves end to end. **Not yet green at the time of writing** — the run is in flight, and this PR should not merge until it is.
- No product code touched, `.github/workflows/tests.yml` only. Rule 6 clean.

## Honest limits

The startup-race diagnosis is inferred from the log signature — banner ordering, absent `New file detected`, and the absence of any startup scan in `cwa-ingest-service/run` — not from instrumenting inotify on the runner directly. The re-nudge is deliberately built to not depend on that diagnosis being exactly right.

Worth noting separately: a real user can hit the same gap. Books already in the ingest folder when the container starts are not imported until something touches them again. That is a product question rather than a harness one, and is not addressed here.