### PR TITLE
fix(templates): apply a triage label so new issues aren't filed unlabeled

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve!
 title: "[bug]"
-labels: ''
+labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea, even a half-formed one. Anything goes.
 title: ""
-labels: feature-request
+labels: enhancement
 assignees: ''
 
 ---


### PR DESCRIPTION
## What users see

Nothing directly — this is repo hygiene. But it is why the follow-up board has stopped being useful for deciding what to work on next, which does reach users.

## The bug

Both issue templates produce **unlabeled** issues, for two different reasons:

| template | `labels:` | what happens |
|---|---|---|
| `bug_report.md` | `''` | no label, ever |
| `feature_request.md` | `feature-request` | **that label does not exist in this repo**, and GitHub silently drops unknown labels — so also no label |

The second is the one worth naming. The template *looked* configured. Nothing warns you that it references a label nobody ever created, so it read as correct while doing nothing.

## Why it matters

78 open issues carry no labels at all, 58 of them older than two days. `gen-followup-board.sh` counts those as `needs triage` breaches, and they are its largest section by a wide margin — burying the handful of rows that mean a real user is waiting (`owe_reply` is 4).

That is the same drowning the board script's own comment describes fixing:

> it was drowning the board: 63 of 65 breach rows were issues in this state or **merely missing a type label**

The state-label half was fixed by the `STATE_LABELS` allowlist. The missing-type-label half was not, because the cause is upstream in the templates.

## The fix

Uses the labels actually in use here — `bug` (43 open issues) and `enhancement` (33) — both of which are in the board's `TRIAGE_LABELS` taxonomy.

## Verification

Regression test at `tests/autopilot/test_issue_template_labels.sh` (workspace suite, so this PR stays docs-only). Red/green confirmed, and red **for the right reason** — each failure names its own distinct cause rather than one masking the other:

```
pre-fix:  FAIL bug_report.md applies no label
          FAIL feature_request.md applies 'feature-request', which is not in TRIAGE_LABELS
          -- 2 passed, 2 failed --
post-fix: -- 4 passed, 0 failed --
```

It reads the taxonomy **out of `gen-followup-board.sh`** rather than duplicating it, so the two cannot drift into a state where the test passes while the board still counts these as untriaged. It checks taxonomy *membership*, not merely that the field is non-empty — a non-empty value naming an unknown label is exactly the bug we had. Both guards are non-vacuity-checked: the suite fails if the taxonomy or the template glob comes back empty.

## Scope

Stops **new** issues arriving untriaged. The existing 78-issue backlog is a separate cleanup, as is labeling the autopilot's own filings (those are created by phase-7, not by a template).

No dependencies, licenses, or external URLs. Two lines of YAML front matter.
