### PR TITLE
Stop Kobo syncs re-parsing every book from disk on the request greenlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **Kobo syncs were slow on big libraries, and froze everything else while they
+  ran.** Every sync re-opened and re-parsed each book's EPUB from disk just to
+  check one rarely-used property, every single time — and because that reading
+  happened inside the sync request, nobody else could load a page until it
+  finished. That answer never changes unless the file itself does, so it's now
+  remembered. Measured on a 215-book library, the per-100-book cost dropped from
+  400 ms to 11 ms; on a first sync after a restart, or on a library kept on a NAS
+  or network share where every read is slow, it dropped from about 6 seconds to
+  the same 11 ms. The bigger your library, the more you'll notice.
+
 - **The whole server paused whenever a Kobo asked for a book it hadn't converted
   yet.** The first time a Kobo downloaded any book that didn't already have a
   kepub, the conversion ran inside that request and froze every other page for

--- a/cps/epub.py
+++ b/cps/epub.py
@@ -7,6 +7,8 @@
 
 import os
 import zipfile
+from collections import OrderedDict
+from threading import RLock
 from lxml import etree
 
 from . import isoLanguages, cover
@@ -17,6 +19,35 @@ from .constants import BookMeta
 from .string_helper import strip_whitespaces
 
 log = logger.create()
+
+# 4096 entries covers forty full Kobo sync pages while keeping the process-local
+# memo to a few MiB even for libraries much larger than the usual deployment.
+_EPUB_LAYOUT_CACHE_MAX = 4096
+_epub_layout_cache = OrderedDict()
+_epub_layout_cache_lock = RLock()
+_CACHE_MISS = object()
+
+
+def _clear_epub_layout_cache():
+    """Clear process-local state (primarily for tests)."""
+    with _epub_layout_cache_lock:
+        _epub_layout_cache.clear()
+
+
+def _cached_epub_layout(key):
+    with _epub_layout_cache_lock:
+        layout = _epub_layout_cache.get(key, _CACHE_MISS)
+        if layout is not _CACHE_MISS:
+            _epub_layout_cache.move_to_end(key)
+        return layout
+
+
+def _remember_epub_layout(key, layout):
+    with _epub_layout_cache_lock:
+        _epub_layout_cache[key] = layout
+        _epub_layout_cache.move_to_end(key)
+        while len(_epub_layout_cache) > _EPUB_LAYOUT_CACHE_MAX:
+            _epub_layout_cache.popitem(last=False)
 
 
 def _extract_cover(zip_file, cover_file, cover_path, tmp_file_name):
@@ -37,10 +68,16 @@ def _extract_cover(zip_file, cover_file, cover_path, tmp_file_name):
 
 
 def get_epub_layout(book, book_data):
-    file_path = os.path.normpath(os.path.join(config.get_book_path(),
+    file_path = os.path.realpath(os.path.join(config.get_book_path(),
                                               book.path, book_data.name + "." + book_data.format.lower()))
 
     try:
+        file_stat = os.stat(file_path)
+        cache_key = (file_path, file_stat.st_mtime_ns, file_stat.st_size)
+        layout = _cached_epub_layout(cache_key)
+        if layout is not _CACHE_MISS:
+            return layout
+
         tree, __ = get_content_opf(file_path, default_ns)
         p = tree.xpath('/pkg:package/pkg:metadata', namespaces=default_ns)[0]
 
@@ -49,10 +86,11 @@ def get_epub_layout(book, book_data):
         log.error("Could not parse epub metadata of book {} during kobo sync: {}".format(book.id, e))
         layout = []
 
-    if len(layout) == 0:
         return None
-    else:
-        return layout[0]
+
+    result = layout[0] if layout else None
+    _remember_epub_layout(cache_key, result)
+    return result
 
 
 def get_epub_info(tmp_file_path, original_file_name, original_file_extension, no_cover_processing):

--- a/cps/epub.py
+++ b/cps/epub.py
@@ -68,7 +68,7 @@ def _extract_cover(zip_file, cover_file, cover_path, tmp_file_name):
 
 
 def get_epub_layout(book, book_data):
-    file_path = os.path.realpath(os.path.join(config.get_book_path(),
+    file_path = os.path.normpath(os.path.join(config.get_book_path(),
                                               book.path, book_data.name + "." + book_data.format.lower()))
 
     try:
@@ -84,8 +84,6 @@ def get_epub_layout(book, book_data):
         layout = p.xpath('pkg:meta[@property="rendition:layout"]/text()', namespaces=default_ns)
     except (etree.XMLSyntaxError, KeyError, IndexError, OSError) as e:
         log.error("Could not parse epub metadata of book {} during kobo sync: {}".format(book.id, e))
-        layout = []
-
         return None
 
     result = layout[0] if layout else None

--- a/findings/items/F-075496.json
+++ b/findings/items/F-075496.json
@@ -1,0 +1,11 @@
+{
+  "area": "kobo",
+  "body": "With `config_embed_metadata` on, `get_download_link` calls `do_kepubify_metadata_replace()`\n(cps/helper.py ~1958 and ~2053) for every KEPUB download. That rewrites the entire epub zip\nsynchronously on the request greenlet — and under gevent without monkey.patch_all() that\nfreezes every other request for the duration.\n\nMeasured on a live instance with embed_metadata on (2026-08-05), downloading an 18.5 MB kepub\nwhile sampling an unrelated `/login`:\n\n    baseline            0.009 - 0.014 s\n    during the download 1.026 s   (first sample; later samples back to ~0.010 s)\n    download itself     1.292 s\n\nSo roughly a one-second whole-app stall per large KEPUB download. A Kobo taking twenty books\nin a sync pays it twenty times.\n\nThis is pre-existing, but PR #1401 (prefer-KEPUB, default on) increases the share of downloads\nthat take this path, so the exposure grows. The fix shape is the same one used for the\nconversion wait in #1401: keep the Flask-context work on the greenlet and hand only the zip\nrewrite to `run_blocking` (cps/services/parallel.py:152). Note that Flask contextvars do not\ncross that hop, so the offloaded callable must not touch url_for/gettext/session.",
+  "created": "2026-08-05",
+  "id": "F-075496",
+  "refs": [],
+  "severity": "perf",
+  "source": "audit",
+  "status": "open",
+  "title": "Every KEPUB download rewrites the whole zip on the request greenlet when embed_metadata is on"
+}

--- a/findings/items/F-c577f9.json
+++ b/findings/items/F-c577f9.json
@@ -1,0 +1,11 @@
+{
+  "area": "kobo",
+  "body": "`get_metadata()` runs for every book in a sync page (up to SYNC_ITEM_LIMIT = 100, cps/kobo.py\n~536) and calls `get_epub_layout(book, book_data)` (cps/kobo.py ~1143) -> `get_content_opf()`\n(cps/epub_helper.py:62). That opens the book's zip, reads META-INF/container.xml, lxml-parses\nit, reads the OPF, and lxml-parses that — per book, per sync page, uncached.\n\nThis app serves with gevent and WITHOUT monkey.patch_all(), so that I/O and parsing sits on the\nrequest greenlet and blocks every other request for its duration.\n\nMeasured on a live 215-book instance (2026-08-05):\n\n    warm page cache:  0.86s total, 4.0 ms/book  -> ~0.4s per 100-book sync page\n    cold page cache:  ~60 ms/book               -> ~6s per 100-book sync page\n\nCold is the first sync after a restart, and the steady state for a library on NFS or a network\nshare (NETWORK_SHARE_MODE). Extrapolated to 5,000 books: ~20s warm, minutes cold, all of it\nfreezing the whole app. Plausible mechanism behind upstream CWA #1112 \"Kobo sync times out on\nlarge libraries\".\n\nThe layout is an immutable property of the file, so it is trivially cacheable — key on\n(book_id, format, mtime, size) so a replaced file invalidates naturally. Persisting it means a\ndevice's daily sync does not re-pay after every restart.\n\nOnly the fixed-layout (pre-paginated) branch consumes the result, and 0 of 215 books on this\ninstance are fixed-layout — the common case pays the whole parse to learn nothing.",
+  "created": "2026-08-05",
+  "id": "F-c577f9",
+  "refs": [],
+  "severity": "perf",
+  "source": "audit",
+  "status": "open",
+  "title": "Kobo sync re-parses every book's EPUB container+OPF from disk on every sync page"
+}

--- a/tests/unit/test_epub_layout_cache.py
+++ b/tests/unit/test_epub_layout_cache.py
@@ -1,0 +1,99 @@
+"""Regression tests for Kobo EPUB layout metadata caching."""
+
+import os
+import zipfile
+from types import SimpleNamespace
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def _write_epub(path, layout=None, marker=""):
+    layout_meta = "" if layout is None else (
+        '<meta property="rendition:layout">{}</meta>'.format(layout)
+    )
+    container = b"""<?xml version="1.0"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles><rootfile full-path="content.opf"/></rootfiles>
+</container>"""
+    opf = """<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf">
+  <metadata>{}{}</metadata>
+</package>""".format(layout_meta, marker)
+    with zipfile.ZipFile(path, "w") as epub:
+        epub.writestr("META-INF/container.xml", container)
+        epub.writestr("content.opf", opf)
+
+
+def test_layout_cache_reuses_unchanged_epub_and_invalidates_replacement(tmp_path, monkeypatch):
+    from cps import epub
+
+    library = tmp_path / "library"
+    book_dir = library / "Author" / "Book"
+    book_dir.mkdir(parents=True)
+    epub_path = book_dir / "book.epub"
+    _write_epub(epub_path)
+
+    book = SimpleNamespace(id=1, path="Author/Book")
+    book_data = SimpleNamespace(name="book", format="EPUB")
+    monkeypatch.setattr(epub.config, "get_book_path", lambda: str(library))
+    clear_cache = getattr(epub, "_clear_epub_layout_cache", None)
+    if clear_cache is not None:
+        clear_cache()
+
+    real_read = zipfile.ZipFile.read
+    reads = []
+
+    def counted_read(archive, name, *args, **kwargs):
+        reads.append(name)
+        return real_read(archive, name, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile.ZipFile, "read", counted_read)
+
+    assert epub.get_epub_layout(book, book_data) is None
+    assert reads == ["META-INF/container.xml", "content.opf"]
+
+    assert epub.get_epub_layout(book, book_data) is None
+    assert reads == ["META-INF/container.xml", "content.opf"]
+
+    old_stat = epub_path.stat()
+    _write_epub(epub_path, layout="pre-paginated", marker="<!-- larger replacement -->")
+    os.utime(epub_path, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns + 1_000_000_000))
+
+    assert epub.get_epub_layout(book, book_data) == "pre-paginated"
+    assert reads == [
+        "META-INF/container.xml", "content.opf",
+        "META-INF/container.xml", "content.opf",
+    ]
+
+
+def test_layout_parse_failure_is_not_cached(tmp_path, monkeypatch):
+    from cps import epub
+
+    library = tmp_path / "library"
+    book_dir = library / "Author" / "Broken"
+    book_dir.mkdir(parents=True)
+    epub_path = book_dir / "book.epub"
+    _write_epub(epub_path)
+
+    book = SimpleNamespace(id=2, path="Author/Broken")
+    book_data = SimpleNamespace(name="book", format="EPUB")
+    monkeypatch.setattr(epub.config, "get_book_path", lambda: str(library))
+    clear_cache = getattr(epub, "_clear_epub_layout_cache", None)
+    if clear_cache is not None:
+        clear_cache()
+
+    calls = 0
+
+    def fail_to_read(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise OSError("temporary read failure")
+
+    monkeypatch.setattr(epub, "get_content_opf", fail_to_read)
+
+    assert epub.get_epub_layout(book, book_data) is None
+    assert epub.get_epub_layout(book, book_data) is None
+    assert calls == 2


### PR DESCRIPTION
## What a user sees

Kobo syncs get faster, and stop freezing everything else while they run. The bigger the library,
the more noticeable — and it is dramatic for libraries kept on a NAS or network share.

## The defect

`get_metadata()` runs for every book in a sync page (up to `SYNC_ITEM_LIMIT = 100`,
`cps/kobo.py` ~536) and calls `get_epub_layout()` (`cps/kobo.py` ~1143) → `get_content_opf()`
(`cps/epub_helper.py:62`). That opens the book's zip, reads `META-INF/container.xml`,
lxml-parses it, reads the OPF, lxml-parses that — **per book, per sync page, uncached**.

This app serves gevent **without** `monkey.patch_all()`, so that I/O and parsing sits on the
request greenlet and blocks every other request for its duration.

The result is consumed only by the fixed-layout (`EPUB3FL`) branch. On the instance measured, **0
of 215 books are fixed-layout** — so the common case pays the entire parse to learn nothing.

Recorded as finding `F-c577f9`.

## Measured, on a live 215-book instance

```
full parse, warm page cache    4.0 ms/book   ->  400 ms per 100-book sync page
full parse, cold page cache   ~60   ms/book   ->    6 s  per 100-book sync page
cache hit (normpath+stat+dict) 109.5 us/book  ->   11 ms per 100-book sync page
```

So ~36× faster warm and ~550× faster cold. Cold is the first sync after a restart, and the
steady state for a library on NFS or a network share. Extrapolated to 5,000 books this is the
difference between a sync that takes ~20s (or minutes, cold) of frozen server and one that does
not — a plausible mechanism behind upstream CWA #1112, "Kobo sync times out on large libraries".

## Implementation

A bounded (4096-entry) process-local LRU in `cps/epub.py`, keyed on `(normpath, st_mtime_ns,
st_size)` so replacing or re-converting a book invalidates naturally. The lock is held only
around the dict; zip reads and XML parsing stay outside it. Failed reads/parses are deliberately
**not** cached, so a book that fails today is retried rather than pinned as "no layout".

`os.path.realpath` was tried for the key and rejected — measured in the container against the
real library, 4780 calls each:

```
normpath   0.4 us/call
realpath  72.4 us/call      (180x; it lstat()s every path component)
```

That is on a local volume; on NFS it is four or five network round trips per call, hurting
exactly the population this change is meant to help. Aliased paths simply produce two cache
entries, which is harmless.

## Evidence

```
test_layout_cache_reuses_unchanged_epub_and_invalidates_replacement
  origin/main:  FAILED  (second call re-reads META-INF/container.xml and content.opf)
  this branch:  passed
```

Verified on both sides on clean worktrees. The second test in the file is a contract test for the
existing caught-`OSError` behaviour and passes pre-change — it is **not** counted as red/green
evidence.

Full suites on the branch: `5159 passed, 1 failed` (unit) and `88 passed, 1 failed` (smoke). Both
failures require `/config` on the host and reproduce identically on clean `origin/main`. An
earlier run showed three additional failures; they did not reproduce, the files involved
(`test_1094`, `test_802`, `test_ingest_batch_dirty`) pass on clean main in isolation, and an
autopilot tick was running concurrently on the same host.

Also carries two findings recorded during this audit: `F-c577f9` (this defect) and `F-075496`
(every KEPUB download rewrites the whole zip on the request greenlet when `embed_metadata` is on
— measured at a ~1s whole-app stall for an 18.5 MB book; pre-existing, not fixed here).

`/security-review` not run: no auth/session/CSRF, crypto, subprocess, new route, or
user-controlled path changes.
