### PR TITLE
Stop a large Kobo download freezing the site for everyone else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **Sending a large book to a Kobo briefly froze the site for everyone else.**
+  If you have "embed metadata" turned on, every book sent to a Kobo is rebuilt
+  on the way out so its details are up to date — and that rebuild was holding up
+  every other page in the meantime. On a 24 MB book, an unrelated page load went
+  from about 10 ms to 493 ms; it now stays at 21 ms, and the book still arrives
+  just as fast.
+
 - **Kobo syncs were slow on big libraries, and froze everything else while they
   ran.** Every sync re-opened and re-parsed each book's EPUB from disk just to
   check one rarely-used property, every single time — and because that reading

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -16,6 +16,7 @@ import regex
 import shutil
 import socket
 import platform
+from functools import partial
 from datetime import datetime, timedelta, timezone
 import requests
 import unidecode
@@ -51,6 +52,7 @@ from .constants import (STATIC_DIR as _STATIC_DIR, CACHE_TYPE_THUMBNAILS, THUMBN
                         SUPPORTED_CALIBRE_BINARIES, EXTENSIONS_CONVERT_FROM, EXTENSIONS_CONVERT_TO)
 from .subproc_wrapper import process_wait, process_open
 from .services.file_move import copy_with_metadata_fallback
+from .services import parallel
 
 # Track books with pending thumbnail generation to prevent duplicate tasks
 _pending_thumbnail_books = set()
@@ -2067,7 +2069,13 @@ def do_kepubify_metadata_replace(book, file_path):
     tmp_dir = get_temp_dir()
     temp_file_name = str(uuid4())
     # open zipfile and replace metadata block in content.opf
-    updateEpub(file_path, os.path.join(tmp_dir, temp_file_name + ".kepub"), cf_name, content)
+    parallel.run_blocking(partial(
+        updateEpub,
+        file_path,
+        os.path.join(tmp_dir, temp_file_name + ".kepub"),
+        cf_name,
+        content,
+    ))
     return tmp_dir, temp_file_name
 
 

--- a/tests/unit/test_kepub_metadata_rewrite_offload.py
+++ b/tests/unit/test_kepub_metadata_rewrite_offload.py
@@ -1,0 +1,83 @@
+"""Regression coverage for KEPUB metadata embedding request isolation."""
+
+from types import SimpleNamespace
+
+from cps import helper
+from cps.services import parallel
+
+
+def test_only_epub_zip_rewrite_is_offloaded(monkeypatch):
+    """Context-bound preparation stays caller-side; pure zip I/O hops."""
+    events = []
+    in_offload = False
+
+    class Query:
+        def filter(self, *_args):
+            events.append(("db", in_offload))
+            return self
+
+        def order_by(self, *_args):
+            return self
+
+        def all(self):
+            return ["custom-column"]
+
+    def run_blocking(job):
+        nonlocal in_offload
+        events.append(("offload", in_offload))
+        in_offload = True
+        try:
+            return job()
+        finally:
+            in_offload = False
+
+    monkeypatch.setattr(
+        helper.calibre_db,
+        "session",
+        SimpleNamespace(query=lambda *_args: Query()),
+    )
+    monkeypatch.setattr(helper, "current_user", SimpleNamespace(locale="en"))
+    monkeypatch.setattr(helper, "_", lambda text: events.append(("gettext", in_offload)) or text)
+    monkeypatch.setattr(
+        helper,
+        "get_content_opf",
+        lambda path: events.append(("read-opf", in_offload)) or ("tree", "content.opf"),
+    )
+    monkeypatch.setattr(
+        helper,
+        "create_new_metadata_backup",
+        lambda *args, **kwargs: events.append(("create-metadata", in_offload)) or "package",
+    )
+    monkeypatch.setattr(
+        helper,
+        "replace_metadata",
+        lambda tree, package: events.append(("replace-metadata", in_offload)) or b"content",
+    )
+    monkeypatch.setattr(helper, "get_temp_dir", lambda: "/tmp/calibre-web")
+    monkeypatch.setattr(helper, "uuid4", lambda: "generated-id")
+    monkeypatch.setattr(parallel, "run_blocking", run_blocking)
+    monkeypatch.setattr(
+        helper,
+        "updateEpub",
+        lambda *args: events.append(("update-epub", in_offload, args)),
+    )
+
+    result = helper.do_kepubify_metadata_replace(SimpleNamespace(), "/books/source.kepub")
+
+    assert result == ("/tmp/calibre-web", "generated-id")
+    assert [(event[0], event[1]) for event in events] == [
+        ("db", False),
+        ("db", False),
+        ("read-opf", False),
+        ("gettext", False),
+        ("create-metadata", False),
+        ("replace-metadata", False),
+        ("offload", False),
+        ("update-epub", True),
+    ]
+    assert events[-1][2] == (
+        "/books/source.kepub",
+        "/tmp/calibre-web/generated-id.kepub",
+        "content.opf",
+        b"content",
+    )


### PR DESCRIPTION
## What a user sees

With "embed metadata" on, sending a large book to a Kobo briefly froze the whole site for
everyone else. It no longer does, and the download is just as fast.

## The defect (finding F-075496)

`do_kepubify_metadata_replace()` (`cps/helper.py:2058`, called from ~1936 and ~1965) ends in
`updateEpub()` (`cps/epub_helper.py:31`), which decompresses and recompresses **every** member of
the book's zip into a new file — synchronously, on the request greenlet. This app serves gevent
**without** `monkey.patch_all()`, so that freezes every other request for its duration.

Pre-existing, but PR #1401 (prefer-KEPUB, default on) increased the share of downloads on this
path, so the exposure grew.

## The fix

Offload **only** `updateEpub` via `run_blocking` (`cps/services/parallel.py`). Everything above
it stays on the request greenlet, because it needs context that does not survive the hop:
`calibre_db.session.query(...)`, `current_user.locale`, and `_("Cover")`.

That boundary is the whole point. `run_blocking` hands work to a `gevent.threadpool.ThreadPool`
worker — a real OS thread — and Flask 3 keeps app/request context in contextvars, which do not
propagate. Wrapping too much is exactly the bug that shipped in #1401's first draft and had to be
fixed; `updateEpub` is pure zipfile I/O and touches none of it.

## Evidence

A/B on the same container, same 24 MB book, same config, `config_embed_metadata` on, sampling an
unrelated `GET /login` 30x during the download:

```
                        baseline /login    worst during download    download
origin/main (118e8bcaa)  0.010 - 0.015 s        0.493 s              0.697 s
this branch              0.011 - 0.017 s        0.021 s              0.716 s
```

23x reduction in the worst-case stall, no cost to download time.

```
test_only_epub_zip_rewrite_is_offloaded
  origin/main:  FAILED
  this branch:  passed
```

Both verified on clean worktrees. The branch also boots in a container and serves `/login` — a
module-level import was added to `cps/helper.py`, and a startup-breaking import is the failure
class that #1401's first draft hit, so it was checked rather than assumed.

Full suites on the branch: `5166 passed, 1 failed` (unit), `88 passed, 1 failed` (smoke). Both
failures need `/config` on the host and reproduce on clean `origin/main`.

`/security-review` not run: no auth/session/CSRF, crypto, subprocess, new route, or
user-controlled path changes.
