### PR TITLE
Fix three ways the KEPUB backfill could break a library permanently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,15 +55,40 @@ is for things you can see or feel when running the app.
   from about 10 ms to 493 ms; it now stays at 21 ms, and the book still arrives
   just as fast.
 
+- **A book could end up permanently broken on your Kobo if the server was
+  restarted at the wrong moment.** While converting a book for Kobo, the new file
+  was written straight into place, so stopping the container mid-write left a
+  half-written book behind — and the next run would accept that half-written file
+  as finished and record it in the library. From then on your Kobo was handed a
+  file it couldn't finish opening, and nothing would ever repair it. Converted
+  books are now written aside and only swapped in once complete and verified as a
+  readable archive, and a damaged file is never accepted as finished.
+
+- **One unreadable or unwritable book could stop every other book being prepared
+  for Kobo — on every restart, forever.** If a single book failed to convert, for
+  instance because the library is mounted read-only, the whole preparation run
+  stopped at that book and started over from scratch at the next restart, getting
+  no further. It now skips what it can't do, reports how many failed, and finishes
+  the rest.
+
+- **Right after updating, books sent to a Kobo could arrive in the wrong format
+  and take 25 seconds each.** The first run after the update prepares your Kobo
+  books in the background, and a download arriving during that window queued up
+  behind the whole job, timed out, and fell back to the plain format. Downloads
+  now go through immediately while that background work is still running.
+
 - **Kobo syncs were slow on big libraries, and froze everything else while they
   ran.** Every sync re-opened and re-parsed each book's EPUB from disk just to
   check one rarely-used property, every single time — and because that reading
   happened inside the sync request, nobody else could load a page until it
   finished. That answer never changes unless the file itself does, so it's now
-  remembered. Measured on a 215-book library, the per-100-book cost dropped from
-  400 ms to 11 ms; on a first sync after a restart, or on a library kept on a NAS
-  or network share where every read is slow, it dropped from about 6 seconds to
-  the same 11 ms. The bigger your library, the more you'll notice.
+  remembered. Measured on a 215-book library on local disk, the per-100-book cost
+  dropped from 400 ms to 11 ms; on a first sync after a restart it dropped from
+  about 6 seconds to the same 11 ms. Two honest caveats: the memory holds 4,096
+  books, and a sync walks the library in order, so libraries larger than that see
+  little benefit on a full sync; and on a NAS or network share each book still
+  costs one small filesystem check, so the saving is real but smaller than the
+  local-disk numbers above.
 
 - **The whole server paused whenever a Kobo asked for a book it hadn't converted
   yet.** The first time a Kobo downloaded any book that didn't already have a

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -2206,15 +2206,24 @@ def get_download_link(book_id, book_format, client):
             and config.config_kobo_prefer_kepub):
         data1 = calibre_db.get_book_format(book.id, "EPUB")
         if data1:
-            log.info("KEPUB not found for book %d; converting on demand", book.id)
-            err = convert_book_format(
-                book.id, config.get_book_path(), 'EPUB', 'KEPUB', None,
-                blocking=True, timeout=25)
-            if not err:
-                data1 = calibre_db.get_book_format(book.id, "KEPUB")
-            else:
-                log.error("On-demand KEPUB conversion failed for book %d: %s", book.id, err)
+            # The worker is single-threaded, so an on-demand conversion cannot
+            # start until the composite startup backfill has finished. Serve
+            # EPUB immediately instead of waiting 25 seconds and enqueuing a
+            # duplicate conversion behind it.
+            from .tasks.kepub_backfill import is_kepub_backfill_pending
+            if is_kepub_backfill_pending():
+                log.info("KEPUB backfill is in flight for book %d; serving EPUB", book.id)
                 book_format = "epub"
+            else:
+                log.info("KEPUB not found for book %d; converting on demand", book.id)
+                err = convert_book_format(
+                    book.id, config.get_book_path(), 'EPUB', 'KEPUB', None,
+                    blocking=True, timeout=25)
+                if not err:
+                    data1 = calibre_db.get_book_format(book.id, "KEPUB")
+                else:
+                    log.error("On-demand KEPUB conversion failed for book %d: %s", book.id, err)
+                    book_format = "epub"
     if not data1:
         log.error("Requested format %s for book id %s not found in database", book_format.upper(), book_id)
         abort(404)

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -8,6 +8,8 @@
 import os
 import re
 import glob
+import tempfile
+import zipfile
 from shutil import copyfile, copyfileobj
 from markupsafe import escape
 from time import time
@@ -29,6 +31,17 @@ from cps.constants import SUPPORTED_CALIBRE_BINARIES
 from cps.string_helper import strip_whitespaces
 
 log = logger.create()
+
+
+def _valid_archive(path, book_format):
+    """Return whether an EPUB-family conversion target is a readable archive."""
+    if book_format.upper() not in ("EPUB", "EPUB3", "KEPUB"):
+        return True
+    try:
+        with zipfile.ZipFile(path) as archive:
+            return bool(archive.infolist()) and archive.testzip() is None
+    except (OSError, zipfile.BadZipFile, zipfile.LargeZipFile):
+        return False
 
 current_milli_time = lambda: int(round(time() * 1000))
 
@@ -120,8 +133,16 @@ class TaskConvert(CalibreTask):
         # check to see if destination format already exists - or if book is in database
         # if it does - mark the conversion task as complete and return a success
         # this will allow to send to E-Reader workflow to continue to work
-        if os.path.isfile(file_path + format_new_ext) or\
-                local_db.get_book_format(self.book_id, self.settings['new_book_format']):
+        target_path = file_path + format_new_ext
+        target_on_disk = os.path.isfile(target_path)
+        target_is_valid = target_on_disk and _valid_archive(
+            target_path, self.settings['new_book_format'])
+        if target_on_disk and not target_is_valid:
+            log.warning("Book id %d has an invalid %s on disk; conversion will replace it",
+                        book_id, format_new_ext)
+
+        if target_is_valid or local_db.get_book_format(
+                self.book_id, self.settings['new_book_format']):
             log.info("Book id %d already converted to %s", book_id, format_new_ext)
             cur_book = local_db.get_book(book_id)
             self.title = cur_book.title
@@ -235,8 +256,24 @@ class TaskConvert(CalibreTask):
         if check == 0:
             converted_file = glob.glob(glob.escape(os.path.splitext(filename)[0]) + "*.kepub.epub")
             if len(converted_file) == 1:
-                copyfile(converted_file[0], (file_path + format_new_ext))
-                os.unlink(converted_file[0])
+                destination = file_path + format_new_ext
+                temp_fd, temp_destination = tempfile.mkstemp(
+                    dir=os.path.dirname(destination),
+                    prefix="." + os.path.basename(destination) + ".",
+                    suffix=".tmp")
+                os.close(temp_fd)
+                try:
+                    copyfile(converted_file[0], temp_destination)
+                    if not _valid_archive(temp_destination, format_new_ext[1:]):
+                        return 1, N_("Kepubify produced an invalid KEPUB archive")
+                    os.replace(temp_destination, destination)
+                finally:
+                    if os.path.exists(temp_destination):
+                        os.unlink(temp_destination)
+                    try:
+                        os.unlink(converted_file[0])
+                    except OSError:
+                        pass
             else:
                 if config.config_embed_metadata and config.config_binariesdir and os.path.isfile(filename):
                     try:

--- a/cps/tasks/kepub_backfill.py
+++ b/cps/tasks/kepub_backfill.py
@@ -119,3 +119,9 @@ def enqueue_startup_kepub_backfill():
     if not config.config_kobo_kepub_backfill_completed:
         return enqueue_kepub_backfill(hidden=True)
     return False
+
+
+def is_kepub_backfill_pending():
+    """Return whether the composite backfill is queued or running."""
+    with _enqueue_lock:
+        return _pending

--- a/cps/tasks/kepub_backfill.py
+++ b/cps/tasks/kepub_backfill.py
@@ -62,20 +62,30 @@ class TaskKepubBackfill(CalibreTask):
                     file_path = os.path.join(config.get_book_path(), book.path, epub.name)
                     settings = {"old_book_format": "EPUB", "new_book_format": "KEPUB"}
                     conversion = TaskConvert(file_path, book_id, "EPUB -> KEPUB", settings, None)
-                    if conversion._convert_ebook_format():
-                        self.converted += 1
-                    else:
+                    try:
+                        converted = conversion._convert_ebook_format()
+                    except Exception as error:
                         self.failed += 1
-                        log.error("KEPUB backfill failed for book %d: %s", book_id, conversion.error)
+                        log.error_or_exception(
+                            "KEPUB backfill failed for book {}: {}".format(book_id, error))
+                    else:
+                        if converted:
+                            self.converted += 1
+                        else:
+                            self.failed += 1
+                            log.error("KEPUB backfill failed for book %d: %s", book_id, conversion.error)
                     self.progress = (index + 1) / total if total else 1
             finally:
                 local_db.session.close()
 
+            # The startup backfill is a bounded migration attempt. Individual
+            # failures remain visible on the task, but must not make every boot
+            # repeat the same bulk conversion against an unwritable library.
+            config.config_kobo_kepub_backfill_completed = True
+            config.save()
             if self.failed:
                 self._handleError(N_(u"%(count)d KEPUB conversion(s) failed", count=self.failed))
                 return
-            config.config_kobo_kepub_backfill_completed = True
-            config.save()
             self._handleSuccess()
         finally:
             with _enqueue_lock:

--- a/findings/items/F-5c2758.json
+++ b/findings/items/F-5c2758.json
@@ -1,0 +1,11 @@
+{
+  "area": "kobo",
+  "body": "The memo added in #1404 (cps/epub.py) caches only successful parses, including the common\n\"no rendition:layout\" result. The `except` path returns None WITHOUT caching (cps/epub.py:85-87).\n\nSo a corrupt or unreadable EPUB re-opens, re-parses and re-logs an error line every time it is\nemitted in a sync page, forever. That is pre-#1404 behaviour for that book so it is not a\nregression, but the cache was the natural place to cap it, and the log spam is unbounded.\n\nFix: cache the failure under the same key. An mtime or size change already invalidates the entry,\nso a repaired file is picked up automatically.\n\nAlso worth recording about that cache, both by design rather than defects:\n- The bound is 4096 entries and a sync walks the library in `(last_modified, id)` order, so a\n  library larger than 4096 books gets close to a 0% hit rate across a full sync. The measured\n  \"400ms -> 11ms per page\" figure is a <=4096-book number. The CHANGELOG was corrected to say so.\n- On NFS/SMB every call still pays one `os.stat` on the greenlet — a network round trip per book\n  — so the win there is real but smaller than the local-disk numbers.",
+  "created": "2026-08-05",
+  "id": "F-5c2758",
+  "refs": [],
+  "severity": "perf",
+  "source": "audit",
+  "status": "open",
+  "title": "EPUB layout cache does not remember failures, so a corrupt book re-parses and re-logs on every sync page"
+}

--- a/findings/items/F-652e6e.json
+++ b/findings/items/F-652e6e.json
@@ -1,0 +1,11 @@
+{
+  "area": "kobo",
+  "body": "`make_request_to_kobo_store` (cps/kobo.py:95-103) issues a bare\n`requests.request(..., timeout=(2, 10))` on the request greenlet. This app serves gevent WITHOUT\nmonkey.patch_all(), and requests/urllib3 socket reads do not yield, so each call parks the hub\nfor up to 2s connect + 10s read — freezing every other request.\n\nReached from `redirect_or_proxy_request` (cps/kobo.py:108-119) for every non-GET request; GETs\nare cheap 307 redirects. Devices generate non-GETs during normal use — reading-state POSTs to\nunimplemented endpoints, preview POSTs and library mutations all land in\n`HandleUnimplementedRequest` (cps/kobo.py:1892-1899).\n\nGated on `config_kobo_proxy`, which defaults off — but it is ON on the maintainer's own\ninstance, and it produces exactly the \"the whole server stalls while my Kobo syncs\" symptom.\n\nMeasured from that instance's container, three calls to https://storeapi.kobo.com:\n\n    connect=0.139s total=0.240s\n    connect=0.021s total=0.125s\n    connect=0.025s total=1.077s\n\nSo 0.1-1.1s of whole-app freeze per proxied call in normal conditions, and up to 12s if the\nstore is slow or unreachable.\n\nFrequency on a real instance is UNKNOWN and could not be established: `HandleUnimplementedRequest`\nlogs at debug and the instance runs at INFO, so the absence of log lines proves nothing. Raising\nthe log level for one sync cycle would settle it.\n\nFix shape: offload via `parallel.run_blocking`, as `cps/search_metadata.py:315` already does for\nthe same class of call. Note that Flask contextvars do not cross that hop, so build the request\narguments on the greenlet and offload only the `requests.request(...)` call itself.",
+  "created": "2026-08-05",
+  "id": "F-652e6e",
+  "refs": [],
+  "severity": "perf",
+  "source": "audit",
+  "status": "open",
+  "title": "Kobo store proxying blocks the request greenlet for up to 12s per non-GET call"
+}

--- a/findings/items/F-a6c145.json
+++ b/findings/items/F-a6c145.json
@@ -1,0 +1,11 @@
+{
+  "area": "kobo",
+  "body": "`config_kobo_cover_padding_enabled` defaults TRUE (cps/config_sql.py:153). The Kobo cover route\n(cps/kobo.py:1839) calls `_serve_padded_cover_if_enabled` -> `pad_path_to_cache` -> `pad_blob`\n(cps/services/cover_preview.py:511-560): Wand decode, mirror/blur composite, JPEG re-encode.\nThat is roughly 100-500ms of C work per miss, on the request greenlet.\n\nThis app serves gevent WITHOUT monkey.patch_all(). Wand releases the GIL, but the hub's own\nthread is the one inside the C call, so no other greenlet runs until it returns.\n\nThe cache is keyed by (book, resolution, source mtime, settings hash) under the thumbnails dir\n(cover_preview.py:736+), so it is cold after container recreation when that dir is not\npersistent, after any cover change, and after any padding-settings change. On the maintainer's\ninstance the preview cache reports empty (`before=0 after=0 evicted=0`), so every cover fetch is\ncurrently a miss.\n\nA first sync of N books is therefore N serialized stalls — several seconds aggregate — during\nwhich the web UI is frozen too.\n\nFix: offload the miss path with `parallel.run_blocking`. The hit path is `send_from_directory`\nand is fine as-is. Build any Flask-context-dependent values before the hop.",
+  "created": "2026-08-05",
+  "id": "F-a6c145",
+  "refs": [],
+  "severity": "perf",
+  "source": "audit",
+  "status": "open",
+  "title": "Kobo cover padding runs ImageMagick on the request greenlet on every cache miss"
+}

--- a/findings/items/F-c96bd6.json
+++ b/findings/items/F-c96bd6.json
@@ -1,0 +1,11 @@
+{
+  "area": "kobo",
+  "body": "`add_synced_books` (cps/kobo_sync_status.py:19-27) does SELECT-count -> INSERT ->\n`ub.session_commit()` and is called inside the per-book loop of the sync handler\n(cps/kobo.py:578). A full 100-book sync page is therefore 100 separate transactions — 100 fsyncs\non app.db — inside one request, on the request greenlet under gevent without monkey.patch_all().\n\nRoughly 100-300ms on local SSD; seconds on sqlite-over-NFS or a busy spinning disk. It fires\nprecisely when syncs are largest: a device's first sync, and the re-emission wave after a bulk\nconversion bumps many books' last_modified.\n\nFix: accumulate the page's book ids and do one bulk insert plus one commit.\n\nRelated, same file: `log.debug(\"...\".format(changed_entries.count()))` at cps/kobo.py:528\nevaluates `count()` — a full COUNT over the joined query — even when debug logging is off,\nbecause the argument is built before the call. Same eager-evaluation pattern at :674 and :697.",
+  "created": "2026-08-05",
+  "id": "F-c96bd6",
+  "refs": [],
+  "severity": "perf",
+  "source": "audit",
+  "status": "open",
+  "title": "Kobo sync commits once per emitted book inside the request"
+}

--- a/tests/unit/test_kobo_prefer_kepub.py
+++ b/tests/unit/test_kobo_prefer_kepub.py
@@ -153,6 +153,54 @@ def test_backfill_is_composite_idempotent_preserves_sync_rows_and_skips_gdrive(m
 
     kepub_backfill.TaskKepubBackfill().run(None)
     kepub_backfill.TaskKepubBackfill().run(None)
+
+
+def test_backfill_continues_after_per_book_oserror_and_completes(monkeypatch):
+    from cps.tasks import kepub_backfill
+
+    class Query:
+        def distinct(self): return self
+        def all(self): return [(1,), (2,)]
+
+    class AppSession:
+        def query(self, *_): return Query()
+        def close(self): pass
+
+    class CalibreDB:
+        def __init__(self, **_): self.session = SimpleNamespace(close=lambda: None)
+        def get_book(self, book_id): return SimpleNamespace(id=book_id, path=str(book_id), title=str(book_id))
+        def get_book_format(self, book_id, fmt):
+            return SimpleNamespace(format=fmt, name="book") if fmt == "EPUB" else None
+
+    attempted = []
+
+    class Conversion:
+        def __init__(self, _path, book_id, *_args): self.book_id, self.error = book_id, None
+        def _convert_ebook_format(self):
+            attempted.append(self.book_id)
+            if self.book_id == 1:
+                raise OSError("read-only library")
+            return "book.kepub"
+
+    saved = []
+    monkeypatch.setattr(kepub_backfill.ub, "get_new_session_instance", AppSession)
+    monkeypatch.setattr(kepub_backfill.db, "CalibreDB", CalibreDB)
+    monkeypatch.setattr(kepub_backfill, "TaskConvert", Conversion)
+    monkeypatch.setattr(kepub_backfill, "get_epub_layout", lambda *_: None)
+    monkeypatch.setattr(kepub_backfill.config, "config_use_google_drive", False, raising=False)
+    monkeypatch.setattr(kepub_backfill.config, "config_kepubifypath", "/bin/kepubify", raising=False)
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_completed", False, raising=False)
+    monkeypatch.setattr(kepub_backfill.config, "get_book_path", lambda: "/books", raising=False)
+    monkeypatch.setattr(kepub_backfill.config, "save", lambda: saved.append(True), raising=False)
+
+    task = kepub_backfill.TaskKepubBackfill()
+    task.run(None)
+
+    assert attempted == [1, 2]
+    assert task.failed == 1
+    assert task.converted == 1
+    assert kepub_backfill.config.config_kobo_kepub_backfill_completed is True
+    assert saved == [True]
     assert conversions == [1]
     assert sync_rows == [(1,), (2,)]
 
@@ -206,6 +254,71 @@ def test_conversion_advances_modified_without_touching_synced_rows(monkeypatch):
     assert book.last_modified > old_modified
     assert synced_rows == [(1, 1), (2, 1)]
     assert len(merged) == 1
+
+
+def test_truncated_kepub_is_not_adopted_as_database_format(monkeypatch, tmp_path):
+    from cps.tasks import convert
+
+    book = SimpleNamespace(id=1, title="Book", path="Author/Book",
+                           data=[SimpleNamespace(name="book")])
+    merged = []
+
+    class Query:
+        def filter(self, *_): return self
+        def one_or_none(self): return None
+
+    class Session:
+        def query(self, *_): return Query()
+        def merge(self, row): merged.append(row)
+        def commit(self): pass
+        def rollback(self): pass
+        def close(self): pass
+
+    class LocalDB:
+        def __init__(self, **_): self.session = Session()
+        def get_book(self, _book_id): return book
+        def get_book_format(self, *_): return None
+
+    file_path = tmp_path / "book"
+    (tmp_path / "book.epub").write_bytes(b"source")
+    (tmp_path / "book.kepub").write_bytes(b"PK truncated")
+
+    monkeypatch.setattr(convert.db, "CalibreDB", LocalDB)
+    monkeypatch.setattr(convert.config, "config_kepubifypath", "/bin/kepubify", raising=False)
+    task = convert.TaskConvert(str(file_path), 1, "convert",
+                               {"old_book_format": "EPUB", "new_book_format": "KEPUB"}, None)
+    conversion_attempted = []
+    monkeypatch.setattr(task, "_convert_kepubify",
+                        lambda *_: (conversion_attempted.append(True) or 1, "failed"))
+
+    assert task._convert_ebook_format() is None
+    assert conversion_attempted == [True]
+    assert merged == []
+
+
+def test_download_serves_epub_immediately_while_backfill_is_in_flight(monkeypatch):
+    import cps.helper as helper
+    from cps.tasks import kepub_backfill
+
+    epub = SimpleNamespace(format="EPUB", name="book", uncompressed_size=10)
+    book = SimpleNamespace(id=7, title="Book", path="Author/Book", authors=[])
+
+    monkeypatch.setattr(helper.calibre_db, "get_filtered_book", lambda *_args, **_kwargs: book)
+    monkeypatch.setattr(helper.calibre_db, "get_book_format",
+                        lambda _book_id, fmt: epub if fmt == "EPUB" else None)
+    monkeypatch.setattr(helper, "convert_book_format",
+                        lambda *_args, **_kwargs: pytest.fail("download blocked on conversion"))
+    monkeypatch.setattr(helper, "do_download_file", lambda *_args: "served")
+    monkeypatch.setattr(helper, "get_valid_filename", lambda value, **_: value)
+    monkeypatch.setattr(helper, "current_user", SimpleNamespace(is_authenticated=False, role_admin=lambda: False))
+    monkeypatch.setattr(helper.config, "config_kepubifypath", "/bin/kepubify", raising=False)
+    monkeypatch.setattr(helper.config, "config_kobo_prefer_kepub", True, raising=False)
+    monkeypatch.setattr(helper.config, "get_book_path", lambda: "/books", raising=False)
+    monkeypatch.setattr(kepub_backfill, "_pending", True)
+
+    app = Flask(__name__)
+    with app.test_request_context("/kobo/token/download/7/kepub"):
+        assert helper.get_download_link(7, "kepub", "kobo") == "served"
 
 
 def test_startup_backfill_task_formats_without_flask_context():

--- a/tests/unit/test_kobo_prefer_kepub.py
+++ b/tests/unit/test_kobo_prefer_kepub.py
@@ -153,6 +153,12 @@ def test_backfill_is_composite_idempotent_preserves_sync_rows_and_skips_gdrive(m
 
     kepub_backfill.TaskKepubBackfill().run(None)
     kepub_backfill.TaskKepubBackfill().run(None)
+    assert conversions == [1]
+    assert sync_rows == [(1,), (2,)]
+
+    monkeypatch.setattr(kepub_backfill.config, "config_use_google_drive", True)
+    monkeypatch.setattr(kepub_backfill.db, "CalibreDB", lambda **_: pytest.fail("gdrive must not open calibre DB"))
+    kepub_backfill.TaskKepubBackfill().run(None)
 
 
 def test_backfill_continues_after_per_book_oserror_and_completes(monkeypatch):
@@ -201,12 +207,6 @@ def test_backfill_continues_after_per_book_oserror_and_completes(monkeypatch):
     assert task.converted == 1
     assert kepub_backfill.config.config_kobo_kepub_backfill_completed is True
     assert saved == [True]
-    assert conversions == [1]
-    assert sync_rows == [(1,), (2,)]
-
-    monkeypatch.setattr(kepub_backfill.config, "config_use_google_drive", True)
-    monkeypatch.setattr(kepub_backfill.db, "CalibreDB", lambda **_: pytest.fail("gdrive must not open calibre DB"))
-    kepub_backfill.TaskKepubBackfill().run(None)
 
 
 def test_conversion_advances_modified_without_touching_synced_rows(monkeypatch):


### PR DESCRIPTION
## Why this exists

An independent audit of the Kobo path found three defects in the KEPUB backfill that shipped in
#1401 this morning. Two cause **permanent** breakage. All three were verified against the tree
before being fixed.

## 1. One I/O error killed the backfill forever

`TaskKepubBackfill.run` had no `try/except` around `conversion._convert_ebook_format()`, and
`_convert_kepubify` copied its output unguarded. A read-only library mount, a full disk, or an NFS
hiccup raised `OSError` out of `run()` into `CalibreTask.start`'s catch-all, so the task died at
the **first** book. `config_kobo_kepub_backfill_completed` is only set on the success path, so
`enqueue_startup_kepub_backfill()` re-enqueued on every boot, forever, dying at the same book.
Read-only `/books` mounts are routine in CWA deployments.

Now: per-book `try/except` that counts the failure and continues, and the completion flag is set
once the loop has run to the end regardless of per-book failures.

Setting the flag even when books failed is deliberate. The alternative — retry the whole bulk
conversion on every boot against a library that cannot be written — is the worse failure, and it
is the one that was reported. Books missed by a failed run are **not** stranded: the on-demand
path in `get_download_link` still converts them the first time a Kobo asks, the task reports its
failure count, and the manual "Convert missing KEPUBs now" button re-runs it.

## 2. A killed backfill could leave a truncated file that was then adopted as valid, forever

`_convert_kepubify` wrote kepubify's output straight onto the final path with `copyfile` — not
temp-then-`os.replace` — so a kill mid-copy left a truncated `.kepub`. On the next run there was
no `Data` row, so `_convert_ebook_format`'s first branch **adopted whatever file was on disk**
into the database with no validation. The corrupt file became a first-class KEPUB row, the
backfill then skipped that book forever, and the device was served a zip that fails partway
through. No self-heal existed.

Pre-existing, but the backfill converts in bulk at startup — exactly when a container is most
likely to be killed — so #1401 made it far likelier to be hit.

Now: output is copied to a sibling temp file, validated as a readable archive, and published with
`os.replace`; and an existing on-disk file is zip-tested before the adoption branch can create a
`Data` row.

Cost of the added validation, measured on a 23 MB kepub: `testzip()` takes **0.127s** against a
~0.7s conversion. It runs on the WorkerThread, never a request greenlet.

## 3. The backfill starved on-demand downloads, so devices got the wrong format for the window

`WorkerThread` is one thread draining one FIFO. The backfill is a single composite task holding
that slot. Meanwhile `get_download_link` enqueued a `TaskConvert` and waited 25s. On the first
boot after upgrade the device asks for kepubs immediately (because `get_metadata` already
advertises them), each download queued behind the entire remaining backfill, timed out, and fell
back to EPUB — with retries queuing still more conversions. ~10–30 minutes for a 215-book synced
set; hours for a large one, during which email, uploads and thumbnails were starved too.

Now: when a backfill is pending or running, the download path serves EPUB immediately instead of
burning 25s and enqueuing duplicate work. Same outcome for the device, no server cost.

## Evidence

```
                                                              origin/main   branch
test_backfill_continues_after_per_book_oserror_and_completes    FAILED      passed
test_truncated_kepub_is_not_adopted_as_database_format          FAILED      passed
test_download_serves_epub_immediately_while_backfill_in_flight  FAILED      passed
```

Verified on a clean detached worktree at `8712226fd`: `3 failed, 8 passed`. All 11 pass on the
branch. The branch also boots in a container and serves `/login` with zero tracebacks.

Full suites: `5169 passed, 1 failed` (unit), `88 passed, 1 failed` (smoke) — both need `/config`
on the host and reproduce on clean `origin/main`.

## Also in this PR

**A correction to the #1404 changelog entry.** It claimed "about 6 seconds to 11 ms" without
qualification. The cache holds 4096 entries and a sync walks the library in `(last_modified, id)`
order, so libraries larger than that get close to a 0% hit rate across a full sync; and on
NFS/SMB every call still pays one `os.stat` per book. The entry now says both. It was still in
`[Unreleased]`, so no published release notes carried the overstatement.

**Four findings recorded** from the same audit, none fixed here:
`F-652e6e` Kobo store proxying blocks the greenlet up to 12s per non-GET call (measured 0.1–1.1s
against the live store); `F-a6c145` cover padding runs ImageMagick on the greenlet per cache miss
(default-on); `F-c96bd6` sync commits once per emitted book (100 fsyncs per page); `F-5c2758` the
layout cache does not remember failures, so a corrupt book re-parses and re-logs forever.

`/security-review` not run: no auth/session/CSRF, crypto, new route, or user-controlled path
changes. The subprocess call is the pre-existing kepubify invocation with library-derived
arguments.
