### PR TITLE
Stop Kobo covers and store-proxy calls freezing the whole site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **Kobo book covers froze the site while they were being prepared.** Covers are
+  padded to your Kobo's screen shape the first time each one is needed, which is
+  a fraction of a second of image work — but it was holding up every other page
+  while it ran, and it happens once per cover, so a device catching up on a
+  shelf-full stacked those pauses back to back. The padding now happens out of
+  the way. This affects anyone with Kobo sync on, since cover padding is on by
+  default; nothing about the covers themselves changes.
+
+- **With "proxy unknown requests to Kobo Store" turned on, your Kobo could stall
+  the site for seconds at a time.** Some of what a Kobo asks for is passed
+  through to Kobo's own servers, and the site sat still waiting for their reply —
+  up to 12 seconds if they were slow to answer, with everyone else's pages
+  waiting too. Measured against the real store, individual calls took anywhere
+  from 0.1 to 1.1 seconds. The waiting now happens out of the way. Only affects
+  you if you turned that setting on; it's off by default.
+
 - **Sending a large book to a Kobo briefly froze the site for everyone else.**
   If you have "embed metadata" turned on, every book sent to a Kobo is rebuilt
   on the way out so its details are up to date — and that rebuild was holding up

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -47,7 +47,7 @@ from .constants import COVER_THUMBNAIL_SMALL, COVER_THUMBNAIL_MEDIUM, COVER_THUM
 from .kobo_cover_cache import build_cover_image_id, normalize_cover_uuid
 from .helper import get_download_link
 from .services import SyncToken as SyncToken, hardcover
-from .services import cover_preview
+from .services import cover_preview, parallel
 from .fs import FileSystem
 from .web import download_required
 from .kobo_auth import requires_kobo_auth, get_auth_token
@@ -92,14 +92,20 @@ def make_request_to_kobo_store(sync_token=None):
     if sync_token:
         sync_token.set_kobo_store_header(outgoing_headers)
 
-    store_response = requests.request(
-        method=request.method,
-        url=get_store_url_for_current_request(),
+    # Flask's request/app context does not propagate to the real OS thread
+    # used by run_blocking. Materialize every request-bound value here, then
+    # offload only requests/urllib3's blocking socket work.
+    method = request.method
+    store_url = get_store_url_for_current_request()
+    body = request.get_data()
+    store_response = parallel.run_blocking(lambda: requests.request(
+        method=method,
+        url=store_url,
         headers=outgoing_headers,
-        data=request.get_data(),
+        data=body,
         allow_redirects=False,
         timeout=(2, 10)
-    )
+    ))
     log.debug("Content: " + str(store_response.content))
     log.debug("StatusCode: " + str(store_response.status_code))
     return store_response

--- a/cps/services/cover_preview.py
+++ b/cps/services/cover_preview.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from .. import logger
+from . import parallel
 
 # gevent-aware thread pool: gevent.threadpool.ThreadPool yields the gevent
 # loop while a worker thread is busy, so other greenlets keep running. The
@@ -706,7 +707,10 @@ def pad_path_to_cache(
         log.warning("cover_preview: cannot read %s: %s", src_path, ex)
         return None
 
-    padded = pad_blob(blob, settings)
+    # This is the cache-miss boundary: pad_blob is pure bytes/settings work,
+    # but Wand's decode/composite/JPEG encode blocks the gevent hub while its
+    # C calls run. File/path/cache decisions stay on the caller greenlet.
+    padded = parallel.run_blocking(lambda: pad_blob(blob, settings))
     if padded is blob:
         # No-op padding: just symlink-equivalent (copy) so the caller can
         # serve from the cache path without branching. Cheap + simple.

--- a/cps/services/cover_preview.py
+++ b/cps/services/cover_preview.py
@@ -31,7 +31,6 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from .. import logger
-from . import parallel
 
 # gevent-aware thread pool: gevent.threadpool.ThreadPool yields the gevent
 # loop while a worker thread is busy, so other greenlets keep running. The
@@ -710,7 +709,7 @@ def pad_path_to_cache(
     # This is the cache-miss boundary: pad_blob is pure bytes/settings work,
     # but Wand's decode/composite/JPEG encode blocks the gevent hub while its
     # C calls run. File/path/cache decisions stay on the caller greenlet.
-    padded = parallel.run_blocking(lambda: pad_blob(blob, settings))
+    padded = _run_in_pool(pad_blob, blob, settings)
     if padded is blob:
         # No-op padding: just symlink-equivalent (copy) so the caller can
         # serve from the cache path without branching. Cheap + simple.

--- a/tests/unit/test_kobo_cover_padding_offload.py
+++ b/tests/unit/test_kobo_cover_padding_offload.py
@@ -1,0 +1,62 @@
+"""Behavioral regression for Kobo cover padding request isolation."""
+
+import threading
+
+from cps.services import cover_preview, parallel
+
+
+def _run_on_real_thread(job):
+    result = []
+    failure = []
+
+    def worker():
+        try:
+            result.append(job())
+        except BaseException as exc:
+            failure.append(exc)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join()
+    if failure:
+        raise failure[0]
+    return result[0]
+
+
+def test_cover_cache_miss_offloads_padding_but_hit_stays_on_caller(monkeypatch, tmp_path):
+    """Wand work hops only on a miss; path/cache work remains caller-side."""
+    caller_thread = threading.get_ident()
+    source = tmp_path / "cover.jpg"
+    source.write_bytes(b"source-cover")
+    cache_dir = tmp_path / "cache"
+    settings = cover_preview.CoverPreviewSettings(
+        enabled=True,
+        target_aspect="kobo_libra_color",
+        fill_mode="edge_mirror",
+        manual_color="#ffffff",
+    )
+    observed = []
+
+    monkeypatch.setattr(cover_preview, "use_IM", True)
+    monkeypatch.setattr(parallel, "run_blocking", _run_on_real_thread)
+
+    def pad_blob(blob, received_settings):
+        observed.append((threading.get_ident(), blob, received_settings))
+        return b"padded-cover"
+
+    monkeypatch.setattr(cover_preview, "pad_blob", pad_blob)
+
+    target = cover_preview.pad_path_to_cache(
+        str(source), str(cache_dir), "padded.jpg", settings,
+    )
+    assert observed == [(observed[0][0], b"source-cover", settings)]
+    assert observed[0][0] != caller_thread
+    assert target == str(cache_dir / "padded.jpg")
+    assert (cache_dir / "padded.jpg").read_bytes() == b"padded-cover"
+
+    observed.clear()
+    hit = cover_preview.pad_path_to_cache(
+        str(source), str(cache_dir), "padded.jpg", settings,
+    )
+    assert hit == target
+    assert observed == []

--- a/tests/unit/test_kobo_cover_padding_offload.py
+++ b/tests/unit/test_kobo_cover_padding_offload.py
@@ -2,7 +2,7 @@
 
 import threading
 
-from cps.services import cover_preview, parallel
+from cps.services import cover_preview
 
 
 def _run_on_real_thread(job):
@@ -36,9 +36,15 @@ def test_cover_cache_miss_offloads_padding_but_hit_stays_on_caller(monkeypatch, 
         manual_color="#ffffff",
     )
     observed = []
+    dispatches = []
 
     monkeypatch.setattr(cover_preview, "use_IM", True)
-    monkeypatch.setattr(parallel, "run_blocking", _run_on_real_thread)
+
+    def run_in_pool(fn, *args):
+        dispatches.append((fn, args))
+        return _run_on_real_thread(lambda: fn(*args))
+
+    monkeypatch.setattr(cover_preview, "_run_in_pool", run_in_pool)
 
     def pad_blob(blob, received_settings):
         observed.append((threading.get_ident(), blob, received_settings))
@@ -51,6 +57,7 @@ def test_cover_cache_miss_offloads_padding_but_hit_stays_on_caller(monkeypatch, 
     )
     assert observed == [(observed[0][0], b"source-cover", settings)]
     assert observed[0][0] != caller_thread
+    assert len(dispatches) == 1
     assert target == str(cache_dir / "padded.jpg")
     assert (cache_dir / "padded.jpg").read_bytes() == b"padded-cover"
 
@@ -60,3 +67,4 @@ def test_cover_cache_miss_offloads_padding_but_hit_stays_on_caller(monkeypatch, 
     )
     assert hit == target
     assert observed == []
+    assert len(dispatches) == 1

--- a/tests/unit/test_kobo_greenlet_offloads.py
+++ b/tests/unit/test_kobo_greenlet_offloads.py
@@ -1,0 +1,65 @@
+"""Behavioral regressions for blocking Kobo request work."""
+
+import threading
+from types import SimpleNamespace
+
+from flask import Flask, request
+from werkzeug.datastructures import Headers
+
+from cps import kobo
+from cps.services import parallel
+
+
+def _run_on_real_thread(job):
+    """Exercise the context boundary used by gevent's native thread pool."""
+    result = []
+    failure = []
+
+    def worker():
+        try:
+            result.append(job())
+        except BaseException as exc:  # surface worker failures to pytest
+            failure.append(exc)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join()
+    if failure:
+        raise failure[0]
+    return result[0]
+
+
+def test_kobo_store_request_prepares_flask_values_before_offload(monkeypatch):
+    """Only requests' blocking I/O runs outside the request greenlet."""
+    caller_thread = threading.get_ident()
+    observed = {}
+    app = Flask(__name__)
+
+    def request_store(**kwargs):
+        observed["worker_thread"] = threading.get_ident()
+        observed["kwargs"] = kwargs
+        return SimpleNamespace(content=b"ok", status_code=200)
+
+    monkeypatch.setattr(parallel, "run_blocking", _run_on_real_thread)
+    monkeypatch.setattr(kobo.requests, "request", request_store)
+
+    with app.test_request_context(
+        "/kobo/token/v1/library/book?foo=bar",
+        method="POST",
+        headers={"X-Kobo-Test": "prepared", "Host": "local.test"},
+        data=b"reading-state",
+    ):
+        observed["context_thread"] = threading.get_ident()
+        response = kobo.make_request_to_kobo_store()
+
+    assert response.status_code == 200
+    assert observed["context_thread"] == caller_thread
+    assert observed["worker_thread"] != caller_thread
+    assert observed["kwargs"] == {
+        "method": "POST",
+        "url": "https://storeapi.kobo.com/v1/library/book?foo=bar",
+        "headers": Headers([("X-Kobo-Test", "prepared"), ("Content-Length", "13")]),
+        "data": b"reading-state",
+        "allow_redirects": False,
+        "timeout": (2, 10),
+    }


### PR DESCRIPTION
## What a user sees

Two more whole-site freezes triggered by a Kobo, both found by an independent audit of the Kobo
path and both recorded as findings before being fixed.

## F-a6c145 — cover padding ran ImageMagick on the request greenlet

`config_kobo_cover_padding_enabled` defaults **True** (`cps/config_sql.py:153`). The Kobo cover
route (`cps/kobo.py:1839`) → `_serve_padded_cover_if_enabled` → `pad_path_to_cache` called
`pad_blob` directly: Wand decode, mirror/blur composite, JPEG re-encode, ~100–500ms of C work per
cache miss. This app serves gevent **without** `monkey.patch_all()`; Wand releases the GIL but the
hub's own thread is inside the C call, so nothing else runs.

The cache is keyed by (book, resolution, source mtime, settings hash), so it is cold after
container recreation, after a cover change, and after any padding-settings change. A device
catching up on a shelf pays that stall once per cover, back to back.

Notably `cover_preview.py` already had the right mechanism — `_run_in_pool` (~line 610), an
8-worker gevent pool with a reentrancy guard, sized and documented for exactly this Wand work, and
already used by `render_preview_data_url` (~line 671). The Kobo route was the one path that
bypassed it. The fix routes `pad_path_to_cache` through the same pool.

(An earlier draft used the general `parallel.run_blocking` pool. That pool is bounded at 16 and
its docstring says it is for *network waits* — it also serves inline cover downloads and metadata
providers. Putting CPU-bound Wand work there would let a burst of cover misses occupy slots that
path needs, and split one module's Wand work across two pools. Corrected before merge.)

## F-652e6e — Kobo store proxying blocked the greenlet for up to 12s

`make_request_to_kobo_store` (`cps/kobo.py:95-103`) issued a bare
`requests.request(..., timeout=(2, 10))` on the request greenlet; requests/urllib3 socket reads do
not yield. Reached from `redirect_or_proxy_request` for every non-GET request — reading-state
POSTs, preview POSTs and library mutations all land in `HandleUnimplementedRequest`.

Measured from a live instance's container against `https://storeapi.kobo.com`, three calls:

```
connect 0.139s / total 0.240s
connect 0.021s / total 0.125s
connect 0.025s / total 1.077s
```

So 0.1–1.1s of whole-app freeze per proxied call in normal conditions, up to 12s if the store is
slow or unreachable. Gated on `config_kobo_proxy` (default off, but on for the reporting user).

Fixed by materializing `method`, the store URL, the headers and the body on the greenlet, then
offloading only `requests.request(...)` via `parallel.run_blocking` — matching the existing
precedent at `cps/search_metadata.py:315`. `run_blocking` is right *here* because this genuinely
is a network wait.

## Why the boundary matters

`run_blocking` and `_run_in_pool` both hand work to a real OS thread, and Flask 3 keeps app and
request context in contextvars, which do not propagate. Anything touching `url_for`, `gettext`,
`session`, `current_user`, `request` or a scoped DB session raises "Working outside of application
context" there. Wrapping too much is exactly the bug that shipped in #1401's first draft and had
to be fixed, so both offloads here wrap only the pure call.

## Evidence

```
                                                                   origin/main   branch
test_kobo_store_request_prepares_flask_values_before_offload         FAILED      passed
test_cover_cache_miss_offloads_padding_but_hit_stays_on_caller       FAILED      passed
```

Verified on a clean detached worktree at `e22c2c61c`. The tests assert the worker and caller
thread identities differ (so the work really left the greenlet) and that a cache **hit** does not
offload at all — behavioural, not source-pins.

The branch also boots in a container and serves `/login` with zero tracebacks.

Full suites: `5171 passed, 1 failed` (unit), `88 passed, 1 failed` (smoke). Both failures need
`/config` on the host and reproduce on clean `origin/main`.

`/security-review` not run: no auth/session/CSRF, crypto, new route, or user-controlled path
changes. The proxied request is the pre-existing call with unchanged arguments.
