### PR TITLE
Stop Kobo syncs committing once per book inside the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **Kobo syncs wrote to the database once per book instead of once per batch.**
+  Each book a Kobo received was recorded in its own separate save, so a sync
+  carrying a hundred books did a hundred separate writes — and everyone else's
+  pages waited behind them. It's now one write per batch. You'll notice it most
+  on a device's first sync and on libraries kept on a NAS, where each write is
+  slow.
+
 - **Kobo book covers froze the site while they were being prepared.** Covers are
   padded to your Kobo's screen shape the first time each one is needed, which is
   a fraction of a second of image work — but it was holding up every other page

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -539,6 +539,7 @@ def HandleSyncRequest():
     # the joined-load query twice per sync request.
     books_list = changed_entries.limit(SYNC_ITEM_LIMIT).all()
     log.debug("Kobo Sync: selected to sync: {}".format(len(books_list)))
+    synced_book_ids = []
     for book in books_list:
         kobo_reading_state = book.KoboReadingState  # None when no record exists yet
         entitlement = {
@@ -581,7 +582,12 @@ def HandleSyncRequest():
             new_books_last_modified = max(date_added, new_books_last_modified)
 
         new_books_last_created = max(ts_created, new_books_last_created)
-        kobo_sync_status.add_synced_books(book.Books.id)
+        synced_book_ids.append(book.Books.id)
+
+    # Persist the whole emitted page before response/token construction.  In
+    # particular, the next request must not observe zero synced rows and reset
+    # its token.  The batch helper also avoids one SQLite fsync per book.
+    kobo_sync_status.add_synced_books_batch(synced_book_ids)
 
     # Magic-shelf sub-cursor: advance to the highest magic-shelf book id
     # emitted this round. magic_shelf_book_ids may be empty when the arm

--- a/cps/kobo_sync_status.py
+++ b/cps/kobo_sync_status.py
@@ -27,6 +27,29 @@ def add_synced_books(book_id):
         ub.session_commit()
 
 
+def add_synced_books_batch(book_ids):
+    """Record one sync page for the current user in a single transaction."""
+    page_book_ids = set(book_ids)
+    if not page_book_ids:
+        return
+
+    user_id = current_user.id
+    present_book_ids = {
+        row.book_id for row in
+        ub.session.query(ub.KoboSyncedBooks.book_id).filter(
+            ub.KoboSyncedBooks.user_id == user_id,
+            ub.KoboSyncedBooks.book_id.in_(page_book_ids),
+        ).all()
+    }
+    missing_book_ids = page_book_ids - present_book_ids
+    if missing_book_ids:
+        ub.session.bulk_save_objects([
+            ub.KoboSyncedBooks(user_id=user_id, book_id=book_id)
+            for book_id in missing_book_ids
+        ])
+    ub.session_commit()
+
+
 def record_book_deletion(book_id, book_uuid, session=None):
     """Record a book hard-deletion as a tombstone for each user who had
     it synced to a Kobo device.

--- a/tests/unit/test_kobo_sync_batch_commits.py
+++ b/tests/unit/test_kobo_sync_batch_commits.py
@@ -1,0 +1,58 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+
+@pytest.mark.unit
+def test_sync_page_uses_one_commit_and_inserts_only_missing_user_book_pairs(monkeypatch):
+    """An N-book page is one transaction and remains user-keyed/idempotent."""
+    from cps import kobo_sync_status, ub
+
+    engine = create_engine("sqlite:///:memory:")
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    session.add_all([
+        ub.KoboSyncedBooks(user_id=7, book_id=2),
+        ub.KoboSyncedBooks(user_id=99, book_id=3),
+    ])
+    session.commit()
+
+    commits = 0
+
+    def commit_once(*_args, **_kwargs):
+        nonlocal commits
+        commits += 1
+        session.commit()
+        return True
+
+    monkeypatch.setattr(kobo_sync_status.ub, "session", session)
+    monkeypatch.setattr(kobo_sync_status.ub, "session_commit", commit_once)
+    monkeypatch.setattr(kobo_sync_status, "current_user", SimpleNamespace(id=7))
+
+    statements = []
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def count_statements(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement.lstrip().split(None, 1)[0].upper())
+
+    # Repeated IDs model defensive page input; book 2 already belongs to this
+    # user, while book 3 currently belongs only to another user.
+    kobo_sync_status.add_synced_books_batch([1, 2, 2, 3, 4])
+
+    assert commits == 1
+    assert statements.count("SELECT") == 1
+    assert statements.count("INSERT") == 1
+    assert {
+        row.book_id
+        for row in session.query(ub.KoboSyncedBooks).filter_by(user_id=7).all()
+    } == {1, 2, 3, 4}
+    assert session.query(ub.KoboSyncedBooks).filter_by(user_id=7, book_id=2).count() == 1
+    assert session.query(ub.KoboSyncedBooks).filter_by(user_id=99, book_id=3).count() == 1
+
+    session.close()
+    engine.dispose()


### PR DESCRIPTION
## What a user sees

A Kobo sync no longer writes to the database once per book, so it stops holding up everyone
else's pages while it runs. Most noticeable on a device's first sync and on libraries kept on a
NAS, where each write is slow.

## The defect (finding F-c96bd6)

`add_synced_books` (`cps/kobo_sync_status.py:19-27`) did SELECT-count → INSERT →
`ub.session_commit()` — one full transaction per book — and its only caller was inside the
per-book sync loop (`cps/kobo.py:584`). A full 100-book sync page was therefore 100 separate
transactions, 100 fsyncs on `app.db`, inside one request, on the request greenlet under gevent
without `monkey.patch_all()`.

Roughly 100–300ms on local SSD; seconds on sqlite-over-NFS or a busy disk. It fires exactly when
syncs are largest: a device's first sync, and the re-emission wave after a bulk conversion bumps
many books' `last_modified`.

## The fix

Collect the page's book ids in the loop; then one existence query scoped to those ids, one bulk
insert of the difference, one commit. `add_synced_books(book_id)` is left intact for any external
caller.

Two constraints the implementation respects:

- `KoboSyncedBooks` carries `UniqueConstraint('user_id', 'book_id')` (`cps/ub.py:776-778`), so
  the insert covers only ids not already present **for this user** — a book synced by another
  user is still inserted for this one.
- The rows are committed before the response and sync token are built, because `cps/kobo.py:266`
  treats "zero synced rows for this user" as "reset the whole sync token" — leaving a page
  uncommitted would trigger a full-library re-sync on the device's next connect.

**A note on placement.** My brief asked for the flush to be somewhere "it cannot be skipped",
implying a `finally`. The implementation puts it immediately after the loop instead, and that is
the better choice: a `finally` would record books as synced even when the page raised and was
never delivered to the device, which then feeds the two-way delete detection
(`cps/kobo.py:306-357`) a false picture of what the device holds. The old per-book commit had
exactly that flaw — rows persisted for a page that never reached the device. Committing on
successful loop completion is strictly more correct.

## Evidence

```
test_sync_page_uses_one_commit_and_inserts_only_missing_user_book_pairs
  origin/main (aaf7c030c):  FAILED
  this branch:              passed
```

Verified on a clean detached worktree. The test counts commits for an N-book page and asserts 1
rather than N, and pins that duplicates are not re-inserted while a book synced by another user
still is — behavioural, not a source-pin.

Full suites: `5172 passed, 1 failed` (unit), `88 passed, 1 failed` (smoke). Both failures need
`/config` on the host and reproduce on clean `origin/main`.

`/security-review` not run: no auth/session/CSRF, crypto, subprocess, new route, or
user-controlled path changes.
