### PR TITLE
chore(findings): promote F-0a2f72 to #1412

### DIFF
--- a/findings/items/F-0a2f72.json
+++ b/findings/items/F-0a2f72.json
@@ -4,9 +4,17 @@
   "created": "2026-08-05",
   "id": "F-0a2f72",
   "origin_issue": 881,
-  "refs": [],
+  "refs": [
+    "#1412"
+  ],
+  "resolution": {
+    "commit": "",
+    "date": "2026-08-06",
+    "note": "promoted to #1412 (reported independently by a user)",
+    "release": ""
+  },
   "severity": "ux",
   "source": "migrated-issue",
-  "status": "open",
+  "status": "resolved",
   "title": "New UI: read/unread + favorite quick-actions on book cards (parity with classic cards)"
 }


### PR DESCRIPTION
Ledger bookkeeping for the issue filed this tick.

`F-0a2f72` (SPA book-card read/favorite quick-actions) is now tracked as #1412, after @chloeroform asked for it independently on #1054 — the documented condition for promoting a finding back to an issue.

Worth noting for the migration record: the finding came from #881, closed as "recorded by a maintenance pass auditing the surrounding code, not reported by anyone hitting it". #881 was split out of #771, which @darkmatterpelican filed. The classification was wrong, so this is the second report rather than the first.

No code change.