### PR TITLE
Point the package's Source Code link at the code, not the downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,16 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **"Source Code" in the package details opened a list of downloads instead of
+  the code.** If you inspect the installed package — `pip show`, a package
+  index, the dependency view — its Source Code link pointed at the releases
+  page, which is already what the Release Management link is for. It now opens
+  the repository. The same details block used to send you to the upstream
+  tracker for bugs in this build; that was repointed here by @chloeroform in
+  [#1298](https://github.com/new-usemame/Calibre-Web-NextGen/pull/1298), and
+  this finishes the last link that was still wrong.
+  ([#1361](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1361))
+
 - **Kobo syncs wrote to the database once per book instead of once per batch.**
   Each book a Kobo received was recorded in its own separate save, so a sync
   carrying a hundred books did a hundred separate writes — and everyone else's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ Homepage = "https://github.com/new-usemame/Calibre-Web-NextGen"
 "Bug Tracker" = "https://github.com/new-usemame/Calibre-Web-NextGen/issues"
 "Release Management" = "https://github.com/new-usemame/Calibre-Web-NextGen/releases"
 Documentation = "https://github.com/new-usemame/Calibre-Web-NextGen/wiki"
-"Source Code" = "https://github.com/new-usemame/Calibre-Web-NextGen/releases"
+"Source Code" = "https://github.com/new-usemame/Calibre-Web-NextGen"
 
 [project.readme]
 file = "README.md"

--- a/tests/unit/test_1361_package_urls_point_here.py
+++ b/tests/unit/test_1361_package_urls_point_here.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Package metadata must route a reader to *our* tracker, not upstream's (#1361).
+
+Anyone who inspects the installed distribution -- ``pip show``, a package
+index, the About page's dependency view -- follows ``[project.urls]``. When
+those pointed at ``crocodilestick/Calibre-Web-Automated`` a user with a bug in
+*our* build was sent to a tracker that cannot act on it.
+
+#1298 repointed them. These tests keep them repointed, and pin the one that
+was still wrong afterwards: ``Source Code`` pointed at the releases page, so
+"take me to the source" landed on a list of tarballs rather than the code.
+"""
+
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+FORK_REPO = "https://github.com/new-usemame/Calibre-Web-NextGen"
+UPSTREAMS = ("crocodilestick/Calibre-Web-Automated", "janeczku/calibre-web")
+
+
+@pytest.fixture(scope="module")
+def urls():
+    if sys.version_info < (3, 11):  # pragma: no cover - CI runs 3.11+
+        pytest.skip("tomllib requires Python 3.11+")
+    with PYPROJECT.open("rb") as handle:
+        data = tomllib.load(handle)
+    return data["project"]["urls"]
+
+
+def test_source_code_points_at_the_repository_not_the_releases_page(urls):
+    """The regression #1298 left behind: Source Code -> /releases."""
+    assert urls["Source Code"] == FORK_REPO, (
+        "'Source Code' must be the repository root. Pointing it at /releases "
+        "sends someone looking for the code to a list of tarballs; "
+        "'Release Management' already covers the releases page."
+    )
+
+
+def test_no_url_sends_a_reader_to_an_upstream_tracker(urls):
+    for key, value in urls.items():
+        for upstream in UPSTREAMS:
+            assert upstream not in value, (
+                f"[project.urls] {key} = {value} points at {upstream}. "
+                "A bug in this build must land on this fork's tracker (#1361)."
+            )
+
+
+def test_bug_tracker_is_this_forks_issue_tracker(urls):
+    assert urls["Bug Tracker"] == f"{FORK_REPO}/issues"
+
+
+def test_every_url_is_under_this_fork(urls):
+    for key, value in urls.items():
+        assert value.startswith(FORK_REPO), f"[project.urls] {key} = {value} leaves the fork"
+
+
+def test_maintainers_do_not_name_upstream(urls):
+    with PYPROJECT.open("rb") as handle:
+        project = tomllib.load(handle)["project"]
+    names = [m.get("name", "") for m in project.get("maintainers", [])]
+    assert names, "maintainers must not be empty -- packaging drops the field silently"
+    for name in names:
+        assert "CrocodileStick" not in name, (
+            "maintainers still credits upstream; a packaged build of this fork "
+            "must not direct correspondence there (#1361)."
+        )


### PR DESCRIPTION
## Why

`#1361` reported that the installed package's metadata routed readers to the upstream tracker. @chloeroform repointed `[project.urls]` in #1298 and that half is on `main` now. One link was still wrong:

```toml
"Release Management" = ".../Calibre-Web-NextGen/releases"
"Source Code"        = ".../Calibre-Web-NextGen/releases"   # <- both point at the same page
```

Someone following "Source Code" from `pip show`, a package index, or the About page's dependency view gets a list of tarballs rather than the code.

## Fix

One line: `Source Code` becomes the repository root. `Release Management` keeps the releases page.

## Reproduction and validation

`tests/unit/test_1361_package_urls_point_here.py`, red before the change, green after:

```
# with Source Code = .../releases
FAILED test_source_code_points_at_the_repository_not_the_releases_page
1 failed, 4 passed

# after
5 passed
```

The other four assertions pin what #1298 established, so a future edit can't quietly reintroduce the original bug: no URL resolves to `crocodilestick/Calibre-Web-Automated` or `janeczku/calibre-web`, `Bug Tracker` is this fork's issues page, every URL stays under the fork, and `maintainers` doesn't credit upstream.

There was no test on `[project.urls]` before this, which is why the slip landed.

## Tier

safe-tier-2 — 1 production line in a single file, no runtime code path, no new dependencies.

Credit: @chloeroform (#1298) for the repoint this completes.