### PR TITLE
Start the container when it is run as a non-root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,20 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **Running the container as a non-root user gave you a container that said it
+  was fine and served nothing.** If you start NextGen with `--user`, or under
+  rootless Podman with `--userns=keep-id`, every service died the moment it
+  tried to switch to its own app user — something an unprivileged process isn't
+  allowed to do. The supervisor restarted them forever, so `docker ps` showed
+  the container **Up** while nothing was listening on the port and the log
+  filled with `Operation not permitted`. NextGen now checks whether it can
+  switch users before trying, and stays as whoever you started it as when it
+  can't. It also stops trying to take ownership of your files in that mode,
+  which produced most of those errors, and says once in the log why. Running
+  normally is unchanged. Diagnosed down to the call sites by @KucharczykL, from
+  nine days of running it under rootless Podman.
+  ([#947](https://github.com/new-usemame/Calibre-Web-NextGen/issues/947))
+
 - **Kobo syncs wrote to the database once per book instead of once per batch.**
   Each book a Kobo received was recorded in its own separate save, so a sync
   carrying a hundred books did a hundred separate writes — and everyone else's

--- a/findings/items/F-5d9298.json
+++ b/findings/items/F-5d9298.json
@@ -1,0 +1,13 @@
+{
+  "area": "container",
+  "body": "Observed while verifying #947 on a live root-path container (the fixed build and\nstock v4.1.29 behave identically, so this is pre-existing, not a regression):\n\n    USER   COMMAND\n    abc    python3 /app/calibre-web-automated/cps.py\n    root   python3 .../scripts/watch_fallback.py --path .../metadata_change_logs\n    root   python3 .../scripts/metadata_change_dispatch.py --watch-folder ...\n\nmetadata-change-detector/run:32 invokes watch_fallback.py with no privilege\ndrop, while the same unit's line 81 (cwa-as-abc inotifywait ..., after #947)\ndoes drop. So the inotify path runs as abc and the polling fallback path runs as\nroot, in the same service, watching the same directory.\n\nTwo consequences: files the fallback path creates under the watch folder land\nowned by root, which the abc-owned services then cannot rewrite; and it is more\nprivilege than the job needs.\n\nDeliberately not folded into #947 -- that issue is the container failing to\nstart at all as non-root, and widening a startup fix into privilege-hygiene\nchanges on a path that works today would have made it riskier than it needed to\nbe. Wants its own change with its own before/after on ingest.",
+  "created": "2026-08-06",
+  "id": "F-5d9298",
+  "refs": [
+    "#947"
+  ],
+  "severity": "correctness",
+  "source": "audit",
+  "status": "open",
+  "title": "metadata-change-detector starts two watchers as root while its sibling drops to abc"
+}

--- a/root/etc/s6-overlay/s6-rc.d/cwa-auto-zipper/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-auto-zipper/run
@@ -47,7 +47,7 @@ do
     # are owned by PUID:PGID. The mismatch breaks host-side cleanup,
     # backup, and rsync workflows for any deployment where PUID isn't 0.
     # See issue #162.
-    s6-setuidgid abc python3 /app/calibre-web-automated/scripts/auto_zip.py
+    cwa-as-abc python3 /app/calibre-web-automated/scripts/auto_zip.py
     if [[ $? == 1 ]]
     then
         echo "[cwa-auto-zipper] Error occurred during script initialisation (see errors above)."

--- a/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
@@ -33,7 +33,7 @@ fi
 echo "[cwa-checksum-backfill] Checking for missing KOReader sync checksums..."
 
 # Run the checksum generation script (fills in missing checksums)
-if s6-setuidgid abc python3 /app/calibre-web-automated/scripts/generate_book_checksums.py --library-path /calibre-library --batch-size 50; then
+if cwa-as-abc python3 /app/calibre-web-automated/scripts/generate_book_checksums.py --library-path /calibre-library --batch-size 50; then
   echo "[cwa-checksum-backfill] Checksum generation/backfill completed successfully"
 else
   echo "[cwa-checksum-backfill] WARNING: Checksum generation encountered errors but continuing..."

--- a/root/etc/s6-overlay/s6-rc.d/cwa-chown-library-migration/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-chown-library-migration/run
@@ -31,6 +31,16 @@ if [ -f "$MARKER" ]; then
     exit 0
 fi
 
+# Started as an arbitrary non-root user: every chown below would fail with
+# EPERM, and there is nothing to align anyway -- files already belong to the uid
+# we are running as. Leave WITHOUT writing the sentinel, so that a later rootful
+# start still performs the real migration. Writing it here would mark the
+# migration done on the one run that could not do any of it. See #947.
+if [ "$(id -u)" != "0" ]; then
+    echo "[cwa-chown-library-migration] running as uid $(id -u) (not root); nothing to align, leaving sentinel unset"
+    exit 0
+fi
+
 if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] \
    || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
     echo "[cwa-chown-library-migration] NETWORK_SHARE_MODE=true — skipping migration"

--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -125,7 +125,7 @@ wait_for_stable_file() {
 
 run_fallback() {
         echo "[cwa-ingest-service] Falling back to polling watcher" >&2
-        s6-setuidgid abc python3 /app/calibre-web-automated/scripts/watch_fallback.py --path "$WATCH_FOLDER" --interval 5 |
+        cwa-as-abc python3 /app/calibre-web-automated/scripts/watch_fallback.py --path "$WATCH_FOLDER" --interval 5 |
         {
                 # Drain anything a previous run left queued (#1360). No startup
                 # sweep here: watch_fallback.py walks the whole tree on its
@@ -282,7 +282,7 @@ run_processor_with_timeout() {
         if [ -n "${CWA_INGEST_PROCESSOR_CMD:-}" ]; then
                 timeout "$safety_timeout" "$CWA_INGEST_PROCESSOR_CMD" "$filepath"
         else
-                timeout "$safety_timeout" s6-setuidgid abc python3 /app/calibre-web-automated/scripts/ingest_processor.py "$filepath"
+                timeout "$safety_timeout" cwa-as-abc python3 /app/calibre-web-automated/scripts/ingest_processor.py "$filepath"
         fi
 }
 
@@ -663,7 +663,7 @@ if [ -n "$(get_stale_temp_interval_from_db)" ]; then
 fi
 
 ( set -o pipefail
-        s6-setuidgid abc inotifywait -m -r --format="%e %w%f" -e close_write -e moved_to -e create "$WATCH_FOLDER" | \
+        cwa-as-abc inotifywait -m -r --format="%e %w%f" -e close_write -e moved_to -e create "$WATCH_FOLDER" | \
         {
                 # Both ends of a pipeline start together, so by the time this
                 # block runs inotifywait is already establishing its watches

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -46,7 +46,16 @@ fi
 mkdir -p /app/calibre-web-automated/cps/cache
 
 # permissions (skip chown on network shares for bind mounts, but still fix /app)
-if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
+#
+# When the container is started as an arbitrary non-root user (`--user`,
+# `--userns=keep-id`), LSIO's init-adduser is skipped, `abc` keeps its
+# build-time 911:1001, and every chown to it fails with EPERM -- one error per
+# file. Nothing here is fatal, but a screenful of "Operation not permitted"
+# reads like a broken container when it is just a uid we were never going to be
+# able to set. Say it once instead. See #947.
+if [ "$(id -u)" != "0" ]; then
+  echo "[cwa-init] running as uid $(id -u) (not root); skipping chown — files keep their current owner"
+elif [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
   echo "[cwa-init] NETWORK_SHARE_MODE=true detected; skipping initial chown of /config"
   chown -R abc:abc /app/calibre-web-automated/cps/cache
 else
@@ -59,7 +68,7 @@ export CALIBRE_DBPATH=/config
 
 if [[ ! -f /config/app.db ]]; then
   echo "First time run, creating app.db..."
-  cd /app/calibre-web-automated && s6-setuidgid abc python3 /app/calibre-web-automated/cps.py -d > /dev/null 2>&1
+  cd /app/calibre-web-automated && cwa-as-abc python3 /app/calibre-web-automated/cps.py -d > /dev/null 2>&1
   # handle app.db updates for kepubify and ext binary path
   # borrowed from crocodilestick because it's a better solution than what i was doing
   sqlite3 /config/app.db <<EOS

--- a/root/etc/s6-overlay/s6-rc.d/cwa-preview-cache-cleanup/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-preview-cache-cleanup/run
@@ -53,7 +53,7 @@ while true; do
     # Run as the abc service user so unlink permissions match what the
     # Flask endpoint wrote (write_to_cache runs in the gunicorn worker
     # which is also abc).
-    s6-setuidgid abc python3 -m cps.services.cover_preview_cache_sweeper \
+    cwa-as-abc python3 -m cps.services.cover_preview_cache_sweeper \
         || echo "[cwa-preview-cache-cleanup] WARNING: sweeper exited non-zero; continuing schedule"
 
     sleep "$SWEEP_INTERVAL_SECONDS"

--- a/root/etc/s6-overlay/s6-rc.d/metadata-change-detector/run
+++ b/root/etc/s6-overlay/s6-rc.d/metadata-change-detector/run
@@ -78,6 +78,6 @@ fi
 
 (
         set -o pipefail
-        s6-setuidgid abc inotifywait -m -e close_write -e moved_to --format '%f' --exclude '^.*\.(swp)$' "$WATCH_FOLDER" |
+        cwa-as-abc inotifywait -m -e close_write -e moved_to --format '%f' --exclude '^.*\.(swp)$' "$WATCH_FOLDER" |
         python3 "$DISPATCHER" --watch-folder "$WATCH_FOLDER"
 ) || run_fallback

--- a/root/etc/s6-overlay/s6-rc.d/svc-calibre-web-automated/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-calibre-web-automated/run
@@ -11,4 +11,4 @@ export CALIBRE_DBPATH=/config
 
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${CWA_PORT_OVERRIDE:-8083}" \
-        cd /app/calibre-web-automated s6-setuidgid abc python3 /app/calibre-web-automated/cps.py
+        cd /app/calibre-web-automated cwa-as-abc python3 /app/calibre-web-automated/cps.py

--- a/root/usr/local/bin/cwa-as-abc
+++ b/root/usr/local/bin/cwa-as-abc
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Run a command as the app user `abc`, but only when we are actually able to.
+#
+# Every long-running service used to end in an unconditional
+# `s6-setuidgid abc <cmd>`. That is correct for the normal case, where PID 1 is
+# root and LSIO's init-adduser has already remapped `abc` to PUID/PGID.
+#
+# It is fatal when the container is started as an arbitrary non-root user
+# (`docker run --user 1000:1000`, `podman --userns=keep-id --user ...`). On that
+# path init-adduser is skipped, so `abc` keeps its build-time 911:1001, and
+# dropping from an unprivileged uid to a *different* uid needs setgroups(),
+# which an unprivileged process may not call:
+#
+#     s6-applyuidgid: fatal: unable to set supplementary group list:
+#     Operation not permitted
+#
+# Every service then crash-loops under the supervisor while the container still
+# reports `Up` -- a healthy-looking container with no web server. Reported with
+# a full diagnosis by @KucharczykL in #947.
+#
+# So: drop privileges when we are root and it means something, and otherwise run
+# the command as whoever we already are. This is a single place on purpose --
+# there were nine call sites, and a guard copied nine times is a guard that
+# eventually differs in one of them.
+set -eu
+
+if [ "$(id -u)" = "0" ]; then
+  exec s6-setuidgid abc "$@"
+fi
+
+exec "$@"

--- a/scripts/set_ownership.sh
+++ b/scripts/set_ownership.sh
@@ -50,6 +50,7 @@ CWA_DIRS_JSON="${CWA_DIRS_JSON:-${CWA_APP_ROOT}/dirs.json}"
 CWA_OWNER_USER="${CWA_OWNER_USER:-abc}"
 CWA_CHOWN="${CWA_CHOWN:-chown}"
 CWA_PYTHON="${CWA_PYTHON:-python3}"
+CWA_UID="${CWA_UID:-$(id -u)}"
 
 log() { echo "[cwa-init] $*"; }
 
@@ -133,6 +134,20 @@ dedupe_paths() {
 main() {
   local -a candidates=("${CWA_CONFIG_ROOT}")
   local dir
+
+  # Started as an arbitrary non-root user (`--user`, `--userns=keep-id`):
+  # nothing below can succeed. LSIO's init-adduser is skipped on that path, so
+  # `abc` keeps its build-time 911:1001, and changing a file's owner to a
+  # different uid needs CAP_CHOWN. Every directory would report EPERM in turn.
+  #
+  # There is also nothing to repair: files under a bind mount already belong to
+  # the uid we are running as. So say it once and skip the walk, rather than
+  # emitting one failure line per directory that reads like a broken container.
+  # See #947.
+  if [ "${CWA_UID}" != "0" ]; then
+    log "running as uid ${CWA_UID} (not root); skipping ownership pass — files keep their current owner"
+    return 0
+  fi
 
   while IFS= read -r dir; do
     [ -n "$dir" ] && candidates+=("$dir")

--- a/tests/unit/test_947_non_root_container_starts.py
+++ b/tests/unit/test_947_non_root_container_starts.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Starting the container as a non-root user must not crash-loop it (#947).
+
+@KucharczykL ran the published image under rootless Podman as an arbitrary
+non-root uid and found every long-running service dying on::
+
+    s6-applyuidgid: fatal: unable to set supplementary group list:
+                    Operation not permitted
+
+Mechanism: on the non-root path LSIO's ``init-adduser`` is skipped, so ``abc``
+keeps its build-time 911:1001, and every service ended in an unconditional
+``s6-setuidgid abc <cmd>``. Dropping from one unprivileged uid to a *different*
+one needs ``setgroups()``, which an unprivileged process may not call.
+
+The failure is quiet, which is the dangerous part: the supervisor keeps
+restarting the services, so the container reports ``Up`` with no web server
+behind it.
+
+These tests pin the fix: every privilege drop goes through ``cwa-as-abc``, which
+drops only when it is root, and both ownership-fixing units check before they
+try. The static scan is the one that fails on the pre-fix tree; the execution
+tests prove the helper actually behaves, in both branches, rather than merely
+existing.
+"""
+
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+S6_ROOT = REPO_ROOT / "root/etc/s6-overlay/s6-rc.d"
+HELPER = REPO_ROOT / "root/usr/local/bin/cwa-as-abc"
+
+# A privilege drop, ignoring occurrences inside a comment.
+UNGUARDED = re.compile(r"^\s*[^#\n]*\bs6-setuidgid\s+abc\b")
+
+
+def _run_scripts():
+    scripts = sorted(S6_ROOT.glob("*/run"))
+    assert scripts, f"no s6 run scripts found under {S6_ROOT}"
+    return scripts
+
+
+def test_no_service_drops_privileges_unconditionally():
+    """The pre-fix state: nine services ending in a bare `s6-setuidgid abc`."""
+    offenders = []
+    for script in _run_scripts():
+        for lineno, line in enumerate(script.read_text().splitlines(), 1):
+            if UNGUARDED.match(line):
+                offenders.append(f"{script.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "These call sites drop to `abc` without checking that we are root. "
+        "Started as a non-root user they fail with EPERM and the service "
+        "crash-loops while the container still reports Up (#947). "
+        "Use `cwa-as-abc` instead:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_every_service_that_needs_the_app_user_uses_the_helper():
+    """Guard against the fix being 'applied' by deleting the drop entirely."""
+    users = [s for s in _run_scripts() if "cwa-as-abc" in s.read_text()]
+    assert len(users) >= 7, (
+        "Expected the privilege drop to survive as `cwa-as-abc` in the services "
+        f"that had it; only {len(users)} reference the helper."
+    )
+
+
+def test_helper_ships_executable():
+    """`cp -R root/* /` preserves mode; a 644 helper breaks every service."""
+    assert HELPER.exists(), f"{HELPER} is missing"
+    mode = HELPER.stat().st_mode
+    assert mode & stat.S_IXUSR and mode & stat.S_IXGRP and mode & stat.S_IXOTH, (
+        f"{HELPER} must be executable by all (is {stat.filemode(mode)}). "
+        "The image copies this tree verbatim, so a non-executable helper "
+        "means every service fails to start."
+    )
+
+
+def test_helper_runs_the_command_directly_when_not_root(tmp_path):
+    """The #947 path. Runs as the (non-root) test user, so this is the real thing."""
+    if os.geteuid() == 0:
+        pytest.skip("test must run unprivileged to exercise the non-root branch")
+
+    marker = tmp_path / "ran"
+    result = subprocess.run(
+        [str(HELPER), "/bin/sh", "-c", f"id -u > {marker}"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, (
+        f"helper failed as a non-root user: rc={result.returncode} "
+        f"stderr={result.stderr!r}. This is exactly the #947 crash."
+    )
+    assert marker.exists(), "helper did not run the command it was given"
+    assert marker.read_text().strip() == str(os.geteuid()), (
+        "command should run as the current user, not some other uid"
+    )
+
+
+def test_helper_still_drops_to_abc_when_root(tmp_path):
+    """The normal path must be unchanged: as root, still `s6-setuidgid abc`.
+
+    Stubs `id` and `s6-setuidgid` on PATH so the root branch is exercised
+    without the test itself needing root.
+    """
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+
+    (stub_dir / "id").write_text("#!/bin/sh\necho 0\n")
+    out = tmp_path / "dropped"
+    (stub_dir / "s6-setuidgid").write_text(f'#!/bin/sh\necho "$@" > {out}\n')
+    for stub in stub_dir.iterdir():
+        stub.chmod(0o755)
+
+    env = dict(os.environ, PATH=f"{stub_dir}:{os.environ['PATH']}")
+    result = subprocess.run(
+        [str(HELPER), "python3", "/app/calibre-web-automated/cps.py"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, f"helper failed on the root path: {result.stderr!r}"
+    assert out.exists(), "as root the helper must chainload s6-setuidgid"
+    assert out.read_text().strip() == "abc python3 /app/calibre-web-automated/cps.py", (
+        "the root path must still drop to `abc` and pass the command through unchanged"
+    )
+
+
+@pytest.mark.parametrize("unit", ["cwa-init", "cwa-chown-library-migration"])
+def test_ownership_units_check_before_chowning(unit):
+    """Both chown paths fail per-file as non-root; each must check first."""
+    body = (S6_ROOT / unit / "run").read_text()
+    assert 'id -u' in body, (
+        f"{unit}/run changes ownership but never checks whether it is root. "
+        "As a non-root user that is one EPERM per file (#947)."
+    )
+
+
+def _run_ownership_pass(tmp_path, uid):
+    """Drive the real scripts/set_ownership.sh with a chown that takes notes."""
+    app_root = tmp_path / "app"
+    config_root = tmp_path / "config"
+    for d in (app_root, config_root):
+        d.mkdir(parents=True, exist_ok=True)
+    (app_root / "dirs.json").write_text('{"calibre_library_dir": "%s"}' % config_root)
+
+    chown_log = tmp_path / "chown.log"
+    chown_stub = tmp_path / "chown-stub"
+    chown_stub.write_text('#!/bin/sh\necho "$@" >> "$CWA_TEST_CHOWN_LOG"\nexit 0\n')
+    chown_stub.chmod(0o755)
+
+    env = dict(
+        os.environ,
+        CWA_APP_ROOT=str(app_root),
+        CWA_CONFIG_ROOT=str(config_root),
+        CWA_DIRS_JSON=str(app_root / "dirs.json"),
+        CWA_OWNER_USER=str(os.getuid()),
+        CWA_CHOWN=str(chown_stub),
+        CWA_TEST_CHOWN_LOG=str(chown_log),
+        CWA_UID=str(uid),
+    )
+    env.pop("NETWORK_SHARE_MODE", None)
+
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts" / "set_ownership.sh")],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+    calls = chown_log.read_text().splitlines() if chown_log.exists() else []
+    return result, calls
+
+
+def test_ownership_pass_skips_itself_entirely_when_not_root(tmp_path):
+    """The noisiest half of #947: one EPERM line per directory, all unavoidable.
+
+    Live evidence from the fixed image: the guarded units went quiet but this
+    pass kept going, because it lives in scripts/set_ownership.sh rather than in
+    the s6 unit -- which the source-level check above does not reach.
+    """
+    result, calls = _run_ownership_pass(tmp_path, uid=1000)
+
+    assert result.returncode == 0, f"the pass must not fail the boot: {result.stderr!r}"
+    assert calls == [], (
+        "set_ownership.sh tried to chown as a non-root user. Every call fails "
+        f"with EPERM and prints a line saying so: {calls}"
+    )
+    assert "not root" in result.stdout, (
+        "skipping silently is its own problem -- say once why nothing was "
+        f"chowned. stdout was: {result.stdout!r}"
+    )
+
+
+def test_ownership_pass_still_walks_when_root(tmp_path):
+    """The guard must not disable the pass on the path everyone actually uses."""
+    result, calls = _run_ownership_pass(tmp_path, uid=0)
+
+    assert result.returncode == 0
+    assert calls, "as root the ownership pass must still walk its directories"
+
+
+def test_non_root_run_does_not_mark_the_chown_migration_done():
+    """A non-root start must not poison the sentinel for a later rootful one."""
+    body = (S6_ROOT / "cwa-chown-library-migration/run").read_text()
+    guard = body.index('id -u')
+    touch = body.index('touch "$MARKER"')
+    assert guard < touch, "the root check must come before the sentinel is written"
+
+    between = body[guard:touch]
+    assert "exit 0" in between, (
+        "the non-root branch must exit before `touch $MARKER`. Writing the "
+        "sentinel on a run that could not chown anything means a later rootful "
+        "start skips the migration for good (#947)."
+    )

--- a/tests/unit/test_s6_service_privilege_drop.py
+++ b/tests/unit/test_s6_service_privilege_drop.py
@@ -10,6 +10,11 @@ cwa-ingest-service, which already drops privileges — were owned by
 PUID:PGID. The mismatch broke host-side cleanup and backup workflows
 for any deployment where PUID isn't 0.
 
+Since #947 the drop is spelled ``cwa-as-abc`` rather than a bare
+``s6-setuidgid abc``, because an unconditional drop is fatal when the
+container itself is started as an unprivileged user. These tests pin the
+drop, not the spelling — see DROP_TO_ABC below.
+
 This test is narrow on purpose: it pins the exact regression the user
 reported. A broader audit of every long-running service is tracked in
 ``notes/s6-privilege-drop-audit.md`` — several services (e.g.
@@ -37,17 +42,55 @@ AUTO_ZIPPER_RUN = (
     / "cwa-auto-zipper"
     / "run"
 )
+AS_ABC_HELPER = REPO_ROOT / "root" / "usr" / "local" / "bin" / "cwa-as-abc"
+
+# Two spellings satisfy issue #162, and both must keep doing so.
+#
+# ``s6-setuidgid abc`` is the original, unconditional drop. ``cwa-as-abc``
+# (added for #947) is a chainloader that performs exactly that drop when the
+# container runs as root — the case #162 was reported in — and skips it only
+# when PID 1 is already an unprivileged uid, where the drop is impossible
+# rather than merely unnecessary. Pinning the literal string instead of the
+# behaviour made this file fail the moment the indirection landed, which is
+# the test being wrong, not the code.
+#
+# test_the_helper_still_performs_the_drop below is what keeps the second
+# spelling honest: if someone hollows out cwa-as-abc, this file fails even
+# though the service scripts never changed.
+DROP_TO_ABC = r"(?:s6-setuidgid\s+abc|cwa-as-abc)"
+
+
+def test_the_helper_still_performs_the_drop():
+    """``cwa-as-abc`` is only an acceptable stand-in for a bare
+    ``s6-setuidgid abc`` for as long as it actually chainloads one when
+    running as root. Without this, gutting the helper would silently
+    un-fix #162 across every service while the pins below stayed green.
+
+    tests/unit/test_947_non_root_container_starts.py executes the helper
+    with a stubbed PATH to prove both branches; this is the cheap source
+    pin that keeps *this* regression file self-contained."""
+    assert AS_ABC_HELPER.exists(), f"missing {AS_ABC_HELPER}"
+    body = AS_ABC_HELPER.read_text()
+    assert re.search(r'id\s+-u', body), (
+        "cwa-as-abc no longer branches on the current uid — it can no "
+        "longer be assumed to drop privileges when root."
+    )
+    assert re.search(r"exec\s+s6-setuidgid\s+abc\s+\"\$@\"", body), (
+        "cwa-as-abc no longer chainloads `s6-setuidgid abc` — the services "
+        "that call it are no longer dropping to the app user, which "
+        "regresses issue #162."
+    )
 
 
 def test_cwa_auto_zipper_invokes_auto_zip_under_s6_setuidgid():
     """Every uncommented invocation of auto_zip.py in the auto-zipper
-    run script must be wrapped by ``s6-setuidgid abc``."""
+    run script must drop privileges to ``abc`` first."""
     assert AUTO_ZIPPER_RUN.exists(), f"missing {AUTO_ZIPPER_RUN}"
     text = AUTO_ZIPPER_RUN.read_text()
     assert "auto_zip.py" in text, "cwa-auto-zipper run script no longer references auto_zip.py"
 
     setuid_pattern = re.compile(
-        r"\bs6-setuidgid\s+abc\b.*python3?\b.*auto_zip\.py"
+        rf"\b{DROP_TO_ABC}\b.*python3?\b.*auto_zip\.py"
     )
     offenders = []
     saw_invocation = False
@@ -65,7 +108,8 @@ def test_cwa_auto_zipper_invokes_auto_zip_under_s6_setuidgid():
         "renamed or rewritten?"
     )
     assert not offenders, (
-        "cwa-auto-zipper invokes auto_zip.py without `s6-setuidgid abc` — "
+        "cwa-auto-zipper invokes auto_zip.py without dropping to `abc` "
+        "(neither `s6-setuidgid abc` nor `cwa-as-abc`) — "
         f"would regress issue #162: {offenders}"
     )
 
@@ -80,10 +124,10 @@ def test_cwa_ingest_service_still_uses_s6_setuidgid_for_python():
     assert run.exists(), f"missing {run}"
     text = run.read_text()
     assert re.search(
-        r"s6-setuidgid\s+abc\s+(?:\S+\s+)*python3?\s+/app/calibre-web-automated/scripts/ingest_processor\.py",
+        rf"{DROP_TO_ABC}\s+(?:\S+\s+)*python3?\s+/app/calibre-web-automated/scripts/ingest_processor\.py",
         text,
     ), (
-        "cwa-ingest-service no longer wraps ingest_processor.py with "
-        "`s6-setuidgid abc`. The structural comparison underlying issue "
+        "cwa-ingest-service no longer drops to `abc` before invoking "
+        "ingest_processor.py. The structural comparison underlying issue "
         "#162 has changed — re-evaluate the auto-zipper fix."
     )

--- a/tests/unit/test_set_ownership.py
+++ b/tests/unit/test_set_ownership.py
@@ -103,6 +103,14 @@ class Harness:
                 "CWA_OWNER_USER": str(os.getuid()),
                 "CWA_CHOWN": str(self.chown),
                 "CWA_TEST_CHOWN_LOG": str(self.chown_log),
+                # In the container this pass runs as root, and since #947 it
+                # skips itself entirely when it is not (nothing it does can
+                # succeed unprivileged). The suite runs as an ordinary user, so
+                # state the uid rather than inheriting the runner's -- otherwise
+                # every test below silently asserts the skip path instead of the
+                # walk it was written for. Non-root behaviour is covered in
+                # tests/unit/test_947_non_root_container_starts.py.
+                "CWA_UID": "0",
             }
         )
         env.pop("NETWORK_SHARE_MODE", None)


### PR DESCRIPTION
## Why

@KucharczykL ran the published image under rootless Podman for nine days and reported, with the call sites already located, that starting it as an arbitrary non-root user produces a container that looks healthy and serves nothing.

Reproduced on plain Docker against `ghcr.io/new-usemame/calibre-web-nextgen:v4.1.29`, `--user 1000:1000`:

```
STATUS:  Up About a minute (health: starting)
curl /login → connection refused (http_code=000)
logs: 76 × "s6-applyuidgid: fatal: unable to set supplementary group list: Operation not permitted"
      [svc-calibre-web-automated] Starting Calibre-Web server on port 8083...   (repeating)
```

## Root cause

On the non-root path LSIO's `init-adduser` is skipped, so `abc` keeps its build-time 911:1001. Every service ended in an unconditional `s6-setuidgid abc <cmd>`, and dropping from one unprivileged uid to a *different* one needs `setgroups()`, which an unprivileged process may not call.

The supervisor restarts each service forever, which is what makes the container report `Up`. Nothing here is a startup error the user can see as one.

## Fix

Nine drops now go through one helper, `root/usr/local/bin/cwa-as-abc`, which drops only when it is root and otherwise runs the command as whoever we already are. One place rather than nine — a guard copied nine times is a guard that eventually differs in one of them.

The three ownership passes get the same check (`cwa-init`, `cwa-chown-library-migration`, `scripts/set_ownership.sh`). As a non-root user they cannot succeed, and there is nothing to repair — files under a bind mount already belong to the uid we are running as — so each says once why it skipped rather than emitting one EPERM per file.

`cwa-chown-library-migration` additionally no longer writes its sentinel on that path. Writing it on the one run that could not chown anything would mark the migration done for good, so a later rootful start would skip it.

## Verification

**Unit** — `tests/unit/test_947_non_root_container_starts.py`, 9 of 10 red on `origin/main`, all 10 green here. The tenth (`test_ownership_pass_still_walks_when_root`) is green on both by design: it pins that the guard doesn't disable the pass everyone actually uses. Not just source scans — the helper is executed in both branches (real non-root, and root via a stubbed `id`/`s6-setuidgid` on PATH), and `set_ownership.sh` is driven with a recording `chown`.

**Live, non-root** (`--user 1000:1000`, same compose shape, before → after):

| | v4.1.29 | fixed |
|---|---|---|
| container | `Up (health: starting)`, never healthy | `Up (healthy)` |
| `GET /login` | connection refused | **200** |
| `Operation not permitted` in log | **76** | **0** |
| `svc-calibre-web-automated` | restarting forever | `up (pid 296) 97s, ready 94s` |
| chown migration sentinel | — | correctly absent |

Log on the fixed build, once each:

```
[cwa-init] running as uid 1000 (not root); skipping chown — files keep their current owner
[cwa-init] running as uid 1000 (not root); skipping ownership pass — files keep their current owner
[cwa-chown-library-migration] running as uid 1000 (not root); nothing to align, leaving sentinel unset
```

**Live, root — the path everyone uses, checked for regression.** Same image, no `--user`: `Up (healthy)`, `/login` 200, `cps.py` still running as `abc`, ownership pass still walks and succeeds on all three directories, zero `fatal`/`Operation not permitted`/`command not found`.

Full suite for the touched area: 33 passed (`test_947_*` + `test_set_ownership.py`).

## One test change worth flagging

`tests/unit/test_set_ownership.py` now pins `CWA_UID=0` in its harness. The suite runs as an ordinary user, so without it every one of those 23 tests would silently start asserting the new skip path instead of the walk each was written for — green, and testing nothing. Non-root behaviour is covered explicitly in the new file instead.

## Not in scope

`metadata-change-detector` starts two processes as root (`watch_fallback.py`, `metadata_change_dispatch.py`) from a line that never had a privilege drop. Confirmed pre-existing — stock v4.1.29 behaves identically — so it is not a regression here. Recorded in the findings ledger rather than fixed under this issue.

## Tier

`needs-review` — 14 files (9 of them one-line call-site swaps), and it changes how every service starts. No new dependencies, no external URLs, no license change. The root path is unchanged by construction (`cwa-as-abc` chainloads the identical `s6-setuidgid abc` argv) and that was verified live rather than argued.

Credit: @KucharczykL (#947) for the diagnosis, the call-site list, and the observation that the container reports `Up` throughout — which is the part that makes this worth fixing rather than documenting.
