### PR TITLE
Catch a stale KOReader plugin version before the tag, not after

### DIFF
--- a/koreader/plugins/cwasync.koplugin/_meta.lua
+++ b/koreader/plugins/cwasync.koplugin/_meta.lua
@@ -5,5 +5,5 @@ return {
     name = "cwasync",
     fullname = _("NextGen Progress Sync"),
     description = _([[Synchronizes your reading progress to Calibre-Web NextGen and across your KOReader devices.]]),
-    version = "4.1.25",  -- Updates Manager reads this; keep in lockstep with main.lua and the CWNG release tag
+    version = "4.1.32",  -- Updates Manager reads this; keep in lockstep with main.lua and the CWNG release tag
 }

--- a/koreader/plugins/cwasync.koplugin/main.lua
+++ b/koreader/plugins/cwasync.koplugin/main.lua
@@ -27,7 +27,7 @@ end
 local CWASync = WidgetContainer:extend{
     name = "cwasync",
     title = _("Login to NextGen Server"),
-    version = "4.1.25",  -- Plugin version mirrors CWNG release tag; keep in lockstep with _meta.lua
+    version = "4.1.32",  -- Plugin version mirrors CWNG release tag; keep in lockstep with _meta.lua
 
     push_timestamp = nil,
     pull_timestamp = nil,

--- a/tests/unit/test_cwasync_plugin_version_bump_gate.py
+++ b/tests/unit/test_cwasync_plugin_version_bump_gate.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""A changed KOReader plugin must declare a version ahead of the last release.
+
+``scripts/publish-cwasync-plugin.sh`` already refuses to publish a plugin whose
+declared version does not equal the tag it is publishing for. That check is
+correct, but it runs from ``plugin-release-publish.yml``, which fires on
+``release: published`` — **after** the tag exists. A published tag cannot be
+retracted, so discovering the mismatch there costs a whole extra version.
+
+That is not hypothetical. #1427 changed the plugin materially (browser-to-KOReader
+progress only works on a device running the new plugin), while ``_meta.lua`` and
+``main.lua`` both still declared ``4.1.25`` — six releases behind. The next tag
+would have published, the plugin job would have failed, and every device would
+have stayed on a plugin that cannot do the thing the release notes announced.
+
+The bump was tracked as prose in a notes file. The publish workflow's own header
+says it exists because "a release step that depends on someone remembering it is
+a step that gets skipped" — this test applies that same reasoning one level up,
+to the bump the publish depends on.
+
+**The invariant, and why it is shaped this way.** A bump is *not* owed on every
+release. The plugin deliberately holds its version while it is unchanged, so
+Updates Manager does not report a phantom update on app tags that never touched
+it (that regression is why ``plugin-release-asset.yml`` was deleted). So the rule
+keys off the source, not the calendar:
+
+* plugin identical to what the newest release tag shipped -> no bump owed, and
+  the declared version must not have run ahead of that tag either.
+* plugin differs -> the next tag owes a publish, so the declared version must
+  already be greater than the newest released version.
+
+"Differs" deliberately ignores the two ``version = "..."`` lines themselves.
+Those lines live inside the directory being compared, so a naive whole-directory
+diff reports "changed" the instant anyone edits the version — which would make
+the second rule above unreachable, and would let a version bumped with no
+accompanying source change satisfy the first. Comparing substance keeps the two
+rules independent of each other.
+
+This compares against the working tree, not ``HEAD``, so an uncommitted plugin
+edit is caught in the same run that makes it.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_RELPATH = "koreader/plugins/cwasync.koplugin"
+PLUGIN = REPO_ROOT / PLUGIN_RELPATH
+
+VERSION_RE = re.compile(r'version\s*=\s*"([0-9]+(?:\.[0-9]+)*)"')
+RELEASE_TAG_RE = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$")
+
+
+def _git(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ("git", "-C", str(REPO_ROOT)) + args,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _declared_version(filename: str) -> str:
+    text = (PLUGIN / filename).read_text(encoding="utf-8")
+    match = VERSION_RE.search(text)
+    assert match is not None, f"{filename} declares no version = \"...\" line"
+    return match.group(1)
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def _release_tags() -> list[str]:
+    result = _git("tag", "--list", "v*")
+    assert result.returncode == 0, f"git tag failed: {result.stderr.strip()}"
+    return [
+        line.strip()
+        for line in result.stdout.splitlines()
+        if RELEASE_TAG_RE.match(line.strip())
+    ]
+
+
+def _without_version_lines(text: str) -> str:
+    """Blank the declared version so it cannot masquerade as a source change."""
+    return VERSION_RE.sub('version = "<pinned>"', text)
+
+
+def _plugin_files_at(tag: str) -> dict[str, str]:
+    result = _git("ls-tree", "-r", "--name-only", tag, "--", PLUGIN_RELPATH)
+    assert result.returncode == 0, (
+        f"git ls-tree failed for {tag}: {result.stderr.strip()}"
+    )
+    files: dict[str, str] = {}
+    for path in result.stdout.split("\n"):
+        path = path.strip()
+        if not path:
+            continue
+        blob = _git("show", f"{tag}:{path}")
+        assert blob.returncode == 0, f"git show failed for {tag}:{path}"
+        files[path] = blob.stdout
+    return files
+
+
+def _plugin_files_now() -> dict[str, str]:
+    return {
+        str(path.relative_to(REPO_ROOT)): path.read_text(
+            encoding="utf-8", errors="replace"
+        )
+        for path in sorted(PLUGIN.rglob("*"))
+        if path.is_file() and path.name != ".DS_Store"
+    }
+
+
+def _plugin_substance_changed_since(tag: str) -> bool:
+    at_tag = _plugin_files_at(tag)
+    now = _plugin_files_now()
+    if set(at_tag) != set(now):
+        return True
+    return any(
+        _without_version_lines(at_tag[path]) != _without_version_lines(now[path])
+        for path in at_tag
+    )
+
+
+def _newest_release_tag() -> str:
+    tags = _release_tags()
+    # Deliberately a hard failure rather than a skip. A skip here would pass
+    # silently the day CI stops fetching tags, which is precisely when the gate
+    # stops protecting anything -- the failure mode this file exists to close.
+    assert tags, (
+        "no vX.Y.Z release tags are present in this checkout, so the plugin "
+        "version gate cannot run. CI's fast-tests job checks out with "
+        "fetch-depth: 0; a local shallow clone needs `git fetch --tags`."
+    )
+    return max(tags, key=lambda tag: _version_key(tag[1:]))
+
+
+def test_meta_and_main_declare_the_same_version() -> None:
+    """The publish script reads both files and requires them to agree."""
+    meta = _declared_version("_meta.lua")
+    main = _declared_version("main.lua")
+    assert meta == main, (
+        f"_meta.lua declares {meta} but main.lua declares {main}. "
+        "publish-cwasync-plugin.sh reads both and refuses a mismatch."
+    )
+
+
+def test_changed_plugin_declares_a_version_ahead_of_the_last_release() -> None:
+    """A plugin that moved since the last tag must already be bumped past it.
+
+    Red before the #1427 bump: the plugin differed from v4.1.31 while declaring
+    4.1.25, so the next tag would have reached the publish workflow's hard error
+    with the tag already immovable.
+    """
+    newest_tag = _newest_release_tag()
+    newest_version = newest_tag[1:]
+    declared = _declared_version("_meta.lua")
+
+    # Working tree vs the tag, so an uncommitted plugin edit counts as a change.
+    if _plugin_substance_changed_since(newest_tag):
+        assert _version_key(declared) > _version_key(newest_version), (
+            f"The plugin has changed since {newest_tag}, so the next release "
+            f"owes the dedicated repository a publish -- but it still declares "
+            f"{declared}. publish-cwasync-plugin.sh will hard-fail on a version "
+            f"that is not the tag, and it runs after the tag is published, "
+            f"which cannot be undone. Bump the version line in both "
+            f"{PLUGIN_RELPATH}/_meta.lua and {PLUGIN_RELPATH}/main.lua to the "
+            f"next release tag before cutting it."
+        )
+    else:
+        assert _version_key(declared) <= _version_key(newest_version), (
+            f"The plugin is identical to the one {newest_tag} shipped, yet it "
+            f"declares {declared} -- ahead of the newest release. Updates "
+            f"Manager compares installed against latest, so a version that ran "
+            f"ahead of its own source offers devices an update that does not "
+            f"exist."
+        )

--- a/tests/unit/test_kosync_plugin_no_book_handling.py
+++ b/tests/unit/test_kosync_plugin_no_book_handling.py
@@ -14,21 +14,16 @@ tests pattern-pin the load-bearing call sites against the main.lua source. A
 regression that drops a no-book guard, removes the bulk-pull entry point, or
 breaks the sync_logic require would trip the test.
 
-Also pins the plugin version string at the CWNG-tag value — per the standing
-versioning rule, plugin-touching releases must update this in lockstep with
-the release tag.
+The plugin version gate that used to live here is now derived, in
+tests/unit/test_cwasync_plugin_version_bump_gate.py.
 """
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
 
-# CI selects with -m "smoke or unit"; without this the whole file is deselected
-# and EXPECTED_PLUGIN_VERSION below — the anchor tying the plugin version to the
-# release tag — never gates anything.
 pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -37,32 +32,22 @@ MAIN_LUA = PLUGIN_DIR / "main.lua"
 SYNC_LOGIC_LUA = PLUGIN_DIR / "sync_logic.lua"
 SYNC_LOGIC_TEST_LUA = PLUGIN_DIR / "tests" / "sync_logic_test.lua"
 
-# Standing rule: plugin version mirrors the CWNG release tag (drop the `v`).
-# Update this in lockstep with main.lua on every plugin-touching release — it is
-# a deliberate forcing function, not a value to read dynamically. Currently
-# 4.1.25 (the release that lets a KOReader highlight deletion reach the server at
-# all: `api.json` declared `deleted`/`delete_source` for the body but not as
-# expected params, so lua-Spore's validate() raised and the push was never built,
-# #920). The bump is load-bearing here: the Updates Manager compares this string
-# to decide whether a device needs the new plugin, so a device-side fix shipped
-# without it would never reach anyone.
-EXPECTED_PLUGIN_VERSION = "4.1.25"
+# The plugin version gate used to live here as EXPECTED_PLUGIN_VERSION, a
+# hand-maintained constant that main.lua had to equal. It is now derived in
+# tests/unit/test_cwasync_plugin_version_bump_gate.py. The constant did not
+# survive contact with the failure it was written for: it pins the version
+# against *itself*, so it only ever caught a unilateral edit to one of the two
+# places, and was silent on the case that actually happened — #1427 changed 280
+# lines of plugin source while version and constant both sat at 4.1.25, six
+# releases behind, with CI green throughout. It also inverted: bumping the
+# version correctly turned CI red until someone edited the test to match, which
+# teaches the opposite of the intended lesson. The replacement reads the release
+# tags and the plugin's own history, so there is nothing left to remember.
 
 
 def _read(path: Path) -> str:
     assert path.exists(), f"missing file: {path}"
     return path.read_text(encoding="utf-8")
-
-
-def test_plugin_version_mirrors_cwng_release_tag():
-    body = _read(MAIN_LUA)
-    match = re.search(r'version\s*=\s*"([^"]+)"\s*,', body)
-    assert match, "main.lua must declare a `version = \"...\"` field"
-    assert match.group(1) == EXPECTED_PLUGIN_VERSION, (
-        f"plugin version must mirror CWNG release tag — expected "
-        f"{EXPECTED_PLUGIN_VERSION!r}, found {match.group(1)!r}. "
-        "If you're updating for a new release, update EXPECTED_PLUGIN_VERSION here too."
-    )
 
 
 def test_main_lua_requires_sync_logic_module():


### PR DESCRIPTION
## Why

The bundled KOReader plugin declares its version in `_meta.lua` and `main.lua`. Both said `4.1.25`, while #1427 (merged `86d9aed8c`) had changed 280 lines of plugin source. The newest release is v4.1.31.

`scripts/publish-cwasync-plugin.sh` refuses to publish a changed plugin whose declared version is not the tag — correct, but it runs from `plugin-release-publish.yml`, which fires on `release: published`. So the next tag would have:

1. published,
2. failed the plugin job on `_meta.lua / main.lua declare 4.1.25 / 4.1.25 instead of 4.1.32`,
3. left every device on a plugin that cannot do the thing the release notes announce — the [Unreleased] entry for #1427 says the feature "needs the updated NextGen Progress Sync plugin on the device",
4. and a published tag cannot be retracted, so the fix would have been another whole version.

## Root cause

Not "someone forgot". There *was* a gate — `test_plugin_version_mirrors_cwng_release_tag` — and it was green throughout.

It pinned `main.lua` against `EXPECTED_PLUGIN_VERSION`, a constant in the test file, with a comment calling it "a deliberate forcing function, not a value to read dynamically". A constant you must remember to edit cannot force you to remember to edit it. Concretely it was:

- **blind to the failure that happened** — it compares the version against itself, so changing plugin *source* while leaving both alone is invisible to it;
- **inverted** — bumping the version correctly turns CI red until the test is edited to match, which teaches contributors that bumping is the mistake;
- **half-scoped** — it only ever read `main.lua`, never `_meta.lua`, though the publish script requires both to agree.

It is the "allowlist duplicated across two places that must match byte-for-byte" shape the repo's own quality bar calls out.

## Fix

Replace the constant with a derived gate (`tests/unit/test_cwasync_plugin_version_bump_gate.py`) that reads the release tags and the plugin's own history:

- plugin substance **moved** since the newest release tag -> declared version must already be **greater** than that tag;
- plugin substance **unchanged** -> declared version must **not** have run ahead of it (a phantom update Updates Manager would offer against source that does not exist).

"Substance" ignores the two `version = "..."` lines themselves. They live inside the compared directory, so a whole-directory diff flips to "changed" the moment anyone edits the version — which made the second rule unreachable dead code in my first draft, caught by A/B case 5 below.

It compares against the **working tree**, so an uncommitted plugin edit trips in the same run that makes it. Missing tags are a hard failure, not a skip — a skip would pass silently the day CI stops fetching tags, which is exactly when the gate stops protecting anything. `fast-tests` checks out with `fetch-depth: 0`.

Then: bump both files to `4.1.32` for the next tag.

## Validation — red/green, A/B'd both branches

| # | State | Expected | Observed |
|---|---|---|---|
| 1 | plugin changed by #1427, version `4.1.25` (as merged) | RED | `assert (4, 1, 25) > (4, 1, 31)` |
| 2 | same, version `4.1.32` | GREEN | 2 passed |
| 3 | version `4.1.31`, equal to newest tag | RED | `assert (4, 1, 31) > (4, 1, 31)` |
| 4 | `_meta.lua` `4.1.33` vs `main.lua` `4.1.32` | RED | `_meta.lua declares 4.1.33 but main.lua declares 4.1.32` |
| 5 | substance unchanged (worktree at v4.1.31), version run ahead to `4.1.32` | RED | `identical to the one v4.1.31 shipped, yet it declares 4.1.32` |
| 6 | substance unchanged, version `4.1.25` — the deliberate hold across non-plugin releases | GREEN | 2 passed |

Cases 5 and 6 ran in a detached worktree at `v4.1.31`. Case 6 is the one that matters for not over-firing: the plugin legitimately holds its version across releases that do not touch it, which is why `plugin-release-asset.yml` was deleted, and the gate must not demand a bump then.

Full local `-m "smoke or unit"`: **5386 passed, 3 failed**. The 3 (`test_required_directories_exist`, `test_enforcer_missing_log_logs_single_info_not_warning_spam`, `test_successful_import_marks_batch_dirty_without_hot_loop_http_calls`) reproduce identically on a clean `origin/main` worktree — pre-existing local-env failures, not this change.

## Scope / gate notes

- No production Python or JS touched: two Lua version literals plus tests.
- Rule 6 clean — no new dependency, license, or external URL.
- No auth/session/CSRF/crypto/subprocess/file-path/new-route surface in production code, so `/security-review` is not triggered. The new test shells out to `git`, but with fixed arguments in test-only code.

Supersedes `notes/RELEASE-BLOCKER-cwasync-plugin-version.md`, which tracked the bump as prose — the same "step someone has to remember" shape that `plugin-release-publish.yml` exists to eliminate.