### PR TITLE
Stop creating a stray metadata.db at the library root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **If your library lives in a sub-folder, NextGen stopped leaving a stray
+  `metadata.db` at the top of it.** Something in the startup checked for a
+  database at the top level of your library folder, and the act of checking
+  created an empty one there. That stray file is what made versions 4.1.20 to
+  4.1.31 refuse to start for some people — 4.1.32 already stopped it breaking
+  startup, and now it isn't created in the first place. Two other things were
+  looking in the same wrong place and now find your real library: the KOReader
+  sync checksum job, which had been failing with "no such table: books" on every
+  restart, and the reading statistics, which had been reading an empty database
+  and reporting nothing. If you already have a stray file, it's safe to delete
+  once you're on this version.
+
 - **Installing from source no longer reports the previous version.** A checkout
   or pip install made from the v4.1.31 or v4.1.32 tag identified itself as one
   release older than it was, so the update check kept offering an update that

--- a/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
@@ -10,13 +10,35 @@
 
 echo "[cwa-checksum-backfill] Waiting for CWA service to be ready..."
 
+dirs_json="${CWA_DIRS_JSON:-/app/calibre-web-automated/dirs.json}"
+library_path="$(python3 - "$dirs_json" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as config_file:
+        configured = json.load(config_file).get("calibre_library_dir")
+    print(configured if isinstance(configured, str) and configured.strip() else "/calibre-library")
+except (OSError, ValueError, TypeError):
+    print("/calibre-library")
+PY
+)"
+metadata_db="${library_path%/}/metadata.db"
+metadata_uri="$(python3 - "$metadata_db" <<'PY'
+import sys
+from pathlib import Path
+
+print(Path(sys.argv[1]).as_uri() + "?mode=ro")
+PY
+)"
+
 # Poll for database schema to be initialized (up to 30 seconds)
 max_attempts=30
 attempt=0
 db_ready=false
 
 while [ $attempt -lt $max_attempts ]; do
-  if sqlite3 /calibre-library/metadata.db "SELECT name FROM sqlite_master WHERE type='table' AND name='book_format_checksums';" 2>/dev/null | grep -q "book_format_checksums"; then
+  if [ -f "$metadata_db" ] && sqlite3 "$metadata_uri" "SELECT name FROM sqlite_master WHERE type='table' AND name='book_format_checksums';" 2>/dev/null | grep -q "book_format_checksums"; then
     echo "[cwa-checksum-backfill] Database schema ready (attempt $((attempt + 1)))"
     db_ready=true
     break
@@ -33,7 +55,7 @@ fi
 echo "[cwa-checksum-backfill] Checking for missing KOReader sync checksums..."
 
 # Run the checksum generation script (fills in missing checksums)
-if cwa-as-abc python3 /app/calibre-web-automated/scripts/generate_book_checksums.py --library-path /calibre-library --batch-size 50; then
+if cwa-as-abc python3 /app/calibre-web-automated/scripts/generate_book_checksums.py --library-path "$library_path" --batch-size 50; then
   echo "[cwa-checksum-backfill] Checksum generation/backfill completed successfully"
 else
   echo "[cwa-checksum-backfill] WARNING: Checksum generation encountered errors but continuing..."

--- a/scripts/cwa_db.py
+++ b/scripts/cwa_db.py
@@ -12,6 +12,7 @@ import re
 from datetime import datetime
 
 from tabulate import tabulate
+from library_paths import connect_calibre_metadata_db
 
 
 # Settings whose stored int value is a real number, not a boolean flag.
@@ -1279,8 +1280,7 @@ class CWA_DB:
             import sqlite3
             
             # Connect to Calibre's metadata.db
-            metadata_db_path = "/calibre-library/metadata.db"
-            metadata_con = sqlite3.connect(metadata_db_path, timeout=10)
+            metadata_con = connect_calibre_metadata_db()
             metadata_cur = metadata_con.cursor()
             
             # Build date filter
@@ -1316,8 +1316,7 @@ class CWA_DB:
             import sqlite3
             
             # Connect to Calibre's metadata.db
-            metadata_db_path = "/calibre-library/metadata.db"
-            metadata_con = sqlite3.connect(metadata_db_path, timeout=10)
+            metadata_con = connect_calibre_metadata_db()
             metadata_cur = metadata_con.cursor()
             
             # Build date filter for current period
@@ -1399,8 +1398,7 @@ class CWA_DB:
             import sqlite3
             
             # Connect to Calibre's metadata.db
-            metadata_db_path = "/calibre-library/metadata.db"
-            metadata_con = sqlite3.connect(metadata_db_path, timeout=10)
+            metadata_con = connect_calibre_metadata_db()
             metadata_cur = metadata_con.cursor()
             
             # Build date filter
@@ -1519,8 +1517,7 @@ class CWA_DB:
             import sqlite3
             
             # Connect to Calibre's metadata.db
-            metadata_db_path = "/calibre-library/metadata.db"
-            metadata_con = sqlite3.connect(metadata_db_path, timeout=10)
+            metadata_con = connect_calibre_metadata_db()
             metadata_cur = metadata_con.cursor()
             
             # Query series with book counts and highest index, ordered by count
@@ -1556,8 +1553,7 @@ class CWA_DB:
             import sqlite3
             
             # Connect to Calibre's metadata.db
-            metadata_db_path = "/calibre-library/metadata.db"
-            metadata_con = sqlite3.connect(metadata_db_path, timeout=10)
+            metadata_con = connect_calibre_metadata_db()
             metadata_cur = metadata_con.cursor()
             
             # Extract year from pubdate and count books
@@ -2034,8 +2030,7 @@ class CWA_DB:
         try:
             import sqlite3
             
-            metadata_db_path = "/calibre-library/metadata.db"
-            metadata_con = sqlite3.connect(metadata_db_path, timeout=10)
+            metadata_con = connect_calibre_metadata_db()
             metadata_cur = metadata_con.cursor()
             
             # Build date filter for books added in time period
@@ -2179,8 +2174,7 @@ class CWA_DB:
                 return []
             
             # Pass 2: Enrich with book titles from metadata.db
-            metadata_db_path = "/calibre-library/metadata.db"
-            metadata_con = sqlite3.connect(metadata_db_path, timeout=10)
+            metadata_con = connect_calibre_metadata_db()
             metadata_cur = metadata_con.cursor()
             
             results = []

--- a/scripts/kindle_epub_fixer.py
+++ b/scripts/kindle_epub_fixer.py
@@ -27,6 +27,7 @@ import pwd
 import grp
 
 from cwa_db import CWA_DB
+from library_paths import get_calibre_metadata_db_path
 
 try:
     from charset_normalizer import from_bytes as _charset_from_bytes
@@ -369,7 +370,10 @@ class EPUBFixer:
     def _get_metadata_db_path(self) -> str:
         """Get the path to metadata.db considering split library configuration."""
         try:
-            con = sqlite3.connect("/config/app.db", timeout=30)
+            app_db = "/config/app.db"
+            if not os.path.isfile(app_db):
+                return get_calibre_metadata_db_path(dirs_json)
+            con = sqlite3.connect(Path(app_db).as_uri() + "?mode=ro", uri=True, timeout=30)
             cur = con.cursor()
             split_library = cur.execute('SELECT config_calibre_split FROM settings;').fetchone()[0]
 
@@ -382,8 +386,8 @@ class EPUBFixer:
                 library_location = get_library_location()
                 return os.path.join(library_location, "metadata.db")
         except Exception:
-            # Fallback to default location
-            return "/calibre-library/metadata.db"
+            # dirs.json is maintained by auto_library and supports nested libraries.
+            return get_calibre_metadata_db_path(dirs_json)
 
     def _recalculate_checksum_after_modification(self, book_id: int, file_format: str, file_path: str) -> None:
         """Calculate and store new checksum after modifying an EPUB file."""
@@ -413,6 +417,8 @@ class EPUBFixer:
 
             # Store in database using centralized manager function
             metadb_path = self._get_metadata_db_path()
+            if not os.path.isfile(metadb_path):
+                return
             con = sqlite3.connect(metadb_path, timeout=30)
 
             try:
@@ -756,7 +762,9 @@ class EPUBFixer:
             
             # Query metadata.db for language
             metadb_path = self._get_metadata_db_path()
-            con = sqlite3.connect(metadb_path, timeout=30)
+            if not os.path.isfile(metadb_path):
+                return None
+            con = sqlite3.connect(Path(metadb_path).as_uri() + "?mode=ro", uri=True, timeout=30)
             cur = con.cursor()
             
             # Get language from books table via languages link table

--- a/scripts/library_paths.py
+++ b/scripts/library_paths.py
@@ -1,0 +1,36 @@
+"""Resolve the active Calibre library without creating database files."""
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+
+DEFAULT_DIRS_JSON = "/app/calibre-web-automated/dirs.json"
+DEFAULT_LIBRARY_DIR = "/calibre-library"
+
+
+def get_calibre_library_dir(dirs_json_path=None):
+    """Return the configured library directory, with the legacy root as fallback."""
+    config_path = dirs_json_path or os.environ.get("CWA_DIRS_JSON", DEFAULT_DIRS_JSON)
+    try:
+        with open(config_path, "r", encoding="utf-8") as config_file:
+            configured = json.load(config_file).get("calibre_library_dir")
+        if isinstance(configured, str) and configured.strip():
+            return configured
+    except (OSError, ValueError, TypeError):
+        pass
+    return DEFAULT_LIBRARY_DIR
+
+
+def get_calibre_metadata_db_path(dirs_json_path=None):
+    """Return the active metadata.db path without touching the filesystem."""
+    return os.path.join(get_calibre_library_dir(dirs_json_path), "metadata.db")
+
+
+def connect_calibre_metadata_db(dirs_json_path=None, timeout=10):
+    """Open the active metadata.db read-only, refusing to create a missing file."""
+    db_path = get_calibre_metadata_db_path(dirs_json_path)
+    if not os.path.isfile(db_path):
+        raise FileNotFoundError(db_path)
+    return sqlite3.connect(Path(db_path).as_uri() + "?mode=ro", uri=True, timeout=timeout)

--- a/tests/unit/test_1436_nested_library_metadata.py
+++ b/tests/unit/test_1436_nested_library_metadata.py
@@ -1,0 +1,121 @@
+"""Regression coverage for nested Calibre libraries (fork issue #1436)."""
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from cwa_db import CWA_DB  # noqa: E402
+import kindle_epub_fixer  # noqa: E402
+
+
+def _nested_library(tmp_path):
+    mount_root = tmp_path / "calibre-library"
+    # URI-significant characters prove the read-only SQLite URI is encoded.
+    library = mount_root / "ebooks #1?"
+    library.mkdir(parents=True)
+    metadata_db = library / "metadata.db"
+    with sqlite3.connect(metadata_db) as connection:
+        connection.execute("CREATE TABLE books (id INTEGER, timestamp TEXT)")
+        connection.execute("INSERT INTO books VALUES (1, '2025-01-02 03:04:05')")
+        connection.execute("CREATE TABLE book_format_checksums (book INTEGER)")
+    dirs_json = tmp_path / "dirs.json"
+    dirs_json.write_text(json.dumps({"calibre_library_dir": str(library)}))
+    return mount_root, library, dirs_json
+
+
+def test_stats_resolve_nested_library_without_creating_root_db(tmp_path, monkeypatch):
+    mount_root, _library, dirs_json = _nested_library(tmp_path)
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_json))
+    real_connect = sqlite3.connect
+
+    # Model /calibre-library with a temporary mount root on both pre-fix and
+    # fixed code. The old hardcoded connect is allowed to exhibit its bug here.
+    def mounted_connect(database, *args, **kwargs):
+        if database == "/calibre-library/metadata.db":
+            database = mount_root / "metadata.db"
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", mounted_connect)
+
+    stats = CWA_DB.__new__(CWA_DB)
+    assert stats.get_library_growth(days=10000) == [("2025-01-02", 1)]
+    assert not (mount_root / "metadata.db").exists()
+
+
+def test_missing_nested_db_degrades_without_creating_root_db(tmp_path, monkeypatch):
+    mount_root = tmp_path / "calibre-library"
+    nested = mount_root / "ebooks"
+    nested.mkdir(parents=True)
+    dirs_json = tmp_path / "dirs.json"
+    dirs_json.write_text(json.dumps({"calibre_library_dir": str(nested)}))
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_json))
+    real_connect = sqlite3.connect
+
+    def mounted_connect(database, *args, **kwargs):
+        if database == "/calibre-library/metadata.db":
+            database = mount_root / "metadata.db"
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", mounted_connect)
+
+    stats = CWA_DB.__new__(CWA_DB)
+    assert stats.get_library_growth() == []
+    assert not (mount_root / "metadata.db").exists()
+    assert not (nested / "metadata.db").exists()
+
+
+def test_kindle_fixer_resolves_nested_library_from_dirs_json(tmp_path, monkeypatch):
+    mount_root, library, dirs_json = _nested_library(tmp_path)
+    monkeypatch.setattr(kindle_epub_fixer, "dirs_json", str(dirs_json))
+
+    fixer = kindle_epub_fixer.EPUBFixer.__new__(kindle_epub_fixer.EPUBFixer)
+    assert fixer._get_metadata_db_path() == str(library / "metadata.db")
+    assert not (mount_root / "metadata.db").exists()
+
+
+def test_checksum_service_polls_and_backfills_nested_library(tmp_path):
+    mount_root, library, dirs_json = _nested_library(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    invocation = tmp_path / "backfill-args"
+    sqlite_invocation = tmp_path / "sqlite-args"
+    wrapper = bin_dir / "cwa-as-abc"
+    wrapper.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$BACKFILL_ARGS"\n')
+    wrapper.chmod(0o755)
+    sqlite_wrapper = bin_dir / "sqlite3"
+    sqlite_wrapper.write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$@" > "$SQLITE_ARGS"\n'
+        'printf "%s\\n" book_format_checksums\n'
+    )
+    sqlite_wrapper.chmod(0o755)
+    env = os.environ.copy()
+    env.update({
+        "CWA_DIRS_JSON": str(dirs_json),
+        "BACKFILL_ARGS": str(invocation),
+        "SQLITE_ARGS": str(sqlite_invocation),
+        "PATH": f"{bin_dir}:{env['PATH']}",
+    })
+
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run")],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=10,
+    )
+
+    assert "Database schema ready (attempt 1)" in result.stdout
+    assert ["--library-path", str(library)] == invocation.read_text().splitlines()[2:4]
+    assert sqlite_invocation.read_text().splitlines()[0] == (
+        (library / "metadata.db").as_uri() + "?mode=ro"
+    )
+    assert not (mount_root / "metadata.db").exists()


### PR DESCRIPTION
Fixes #1436. Reported via #1428 by @sammiq.

**The root cause in #1436's description is wrong** — it blames `make_new_library()`. I reproduced
this on v4.1.32 and it is not that. Corrected on the issue, and this PR fixes the real thing.

## Reproduced on v4.1.32

Real library at `/calibre-library/ebooks/metadata.db`, nothing at the mount root:

```
library root BEFORE startup:  ebooks
library root AFTER  startup:  ebooks  metadata.db   <- 0 bytes, created during startup
```

auto-library correctly finds and mounts `/calibre-library/ebooks` — the stray comes from
somewhere else.

## What creates it

`root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run` polled with

```
sqlite3 /calibre-library/metadata.db "SELECT name FROM sqlite_master WHERE ... 'book_format_checksums';"
```

The `sqlite3` CLI **creates the file when it doesn't exist**. Verified in-container:

```
rm -f /tmp/probe.db; sqlite3 /tmp/probe.db "SELECT ..."; ls -la /tmp/probe.db
-rw-r--r-- 1 root root 0 /tmp/probe.db
```

It ran that in a wait loop up to 30 times against a hardcoded path instead of the configured
library. That stray file is what #1428 then mounted as the library on the next restart.

## Two consequences nobody had noticed

Both measured on the same pair of containers, identical except for this change.

**The KOReader checksum backfill was dying on every boot.** It was handed
`--library-path /calibre-library`, where the only `metadata.db` was the empty stray it had just
created:

```
before:  ERROR: Database error: no such table: books
after:   ✓ All books already have binary checksums!
```

(Only visible with `koreader_sync_enabled=1`; the generator short-circuits before touching the
library otherwise, which is why this stayed hidden.)

**And it cost 30 seconds of startup, every boot:**

```
before:  [cwa-checksum-backfill] WARNING: Database schema not ready after 30s, proceeding anyway...
after:   [cwa-checksum-backfill] Database schema ready (attempt 1)
```

**Seven statistics paths read the wrong database.** `scripts/cwa_db.py` had seven unguarded,
hardcoded, read-write `sqlite3.connect("/calibre-library/metadata.db")` calls. For a nested
library each both created the stray and queried an empty database, so the stats they feed
returned nothing. `scripts/kindle_epub_fixer.py:386` returned the same hardcoded path.

## The fix

A shared `scripts/library_paths.py` resolves the library from `dirs.json`
(`calibre_library_dir`, which auto-library already sets correctly), with the old hardcoded value
only as a last-resort fallback, and opens read-only via `Path(p).as_uri() + "?mode=ro"` after an
`os.path.isfile` guard — so checking can never create. That mirrors `is_calibre_database` in
`scripts/auto_library.py`, which already does exactly this and documents why.

Applied to the s6 unit, all seven `cwa_db.py` sites, and `kindle_epub_fixer.py`.
`cps/admin.py:2543,2563` already guard with `os.path.isfile` and are unchanged.

The s6 unit needed care: the `sqlite3` **CLI** only honours URI filenames if the build enables
them. Verified in the shipped image (SQLite 3.45.1) that `file:...?mode=ro` reads correctly and
creates nothing for a missing file — rather than assuming it.

## Evidence

```
                                                                  origin/main   branch
test_stats_resolve_nested_library_without_creating_root_db          FAILED      passed
test_missing_nested_db_degrades_without_creating_root_db            FAILED      passed
test_kindle_fixer_resolves_nested_library_from_dirs_json            FAILED      passed
test_checksum_service_polls_and_backfills_nested_library            FAILED      passed
```

Verified on a clean detached worktree at `da1fccdea`.

End-to-end in a container on the reporter's layout, with the branch's `scripts/` and s6 unit
mounted into the v4.1.32 image:

```
library root AFTER startup:  ebooks        <- no stray
mounted library:             /calibre-library/ebooks
checksum backfill:           schema ready (attempt 1) -> completed
```

Full suites: `5308 passed, 1 failed` (unit), `88 passed, 1 failed` (smoke). Both failures need
`/config` on the host and reproduce on clean `origin/main`. `shellcheck` passes on the s6 unit.

`/security-review` not run: no auth/session/CSRF, crypto, new route, or user-controlled path
changes; this narrows a hardcoded path and makes database opens read-only.
