### PR TITLE
Import the constant that replaced the hardcoded dirs.json path

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -418,7 +418,25 @@ jobs:
           # tests/docker/ and tests/integration/ are included for the same
           # reason tests.yml counts as frontend-relevant above: a PR that
           # changes a harness must be validated by the harness it changes.
-          if echo "$files" | grep -qE '^(Dockerfile$|[^/]*requirements[^/]*\.txt$|root/|tests/(docker|integration)/|\.github/workflows/tests\.yml$)'; then
+          #   cps/**.py          the application the image exists to run. A
+          #                      pure-Python change can stop the container
+          #                      booting just as dead as a bad Dockerfile,
+          #                      and integration-tests is still the ONLY job
+          #                      that boots it. #1438 removed a hardcoded
+          #                      path in cps/web.py without importing the
+          #                      constant that replaced it: import-time was
+          #                      fine, every unit test was green, and the
+          #                      container went permanently unhealthy. It
+          #                      touched no Dockerfile, carried no tier-2
+          #                      label, so Integration Tests was advisory,
+          #                      went red, and the summary reported success.
+          #                      Scoped to .py on purpose: cps/translations/
+          #                      *.po are tier-1 auto-merge PRs and a broken
+          #                      catalogue is already a hard failure in Fast
+          #                      Tests (test_translations_compile.py), so
+          #                      routing them through a full image build
+          #                      would buy nothing and stall every locale PR.
+          if echo "$files" | grep -qE '^(Dockerfile$|[^/]*requirements[^/]*\.txt$|root/|cps/.*\.py$|tests/(docker|integration)/|\.github/workflows/tests\.yml$)'; then
             echo "build=true" >> "$GITHUB_OUTPUT"
           else
             echo "build=false" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **The container reported itself unhealthy, and the library count showed 0
+  books.** A path cleanup landed a reference to a setting the file never
+  imported, so the lookup that finds your Calibre library raised an error the
+  moment anything called it. Two places call it, and both quietly treat any
+  error as "no library": the `/health` endpoint every Docker, Compose and
+  Kubernetes setup polls started answering "degraded" forever even though the
+  app was serving pages normally, and the book count on the instance rendered
+  0. If your orchestration restarts or refuses to roll out on a failing
+  healthcheck, that is why. Affects the `:dev` channel only — no published
+  release shipped it.
+
 - **The Tags page showed columns of "…" instead of tag names.** The grid was
   sized before the per-row rename and delete buttons existed, so once those
   arrived they took their space out of the tag name itself: in a 1280px-wide

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1286,6 +1286,12 @@ class Thumbnail(Base):
 
 # Add missing tables during migration of database
 def add_missing_tables(engine, _session):
+    # Local import: progress_syncing.models imports Base from this module, so a
+    # module-level import would be circular. Every other table below is defined
+    # in this file; this one is not, and referencing it as a bare global raised
+    # NameError on any app.db missing kosync_progress (a fresh install).
+    from .progress_syncing.models import KOSyncProgress
+
     if not engine.dialect.has_table(engine.connect(), "archived_book"):
         ArchivedBook.__table__.create(bind=engine, checkfirst=True)
     if not engine.dialect.has_table(engine.connect(), "thumbnail"):

--- a/cps/web.py
+++ b/cps/web.py
@@ -31,6 +31,7 @@ from werkzeug.datastructures import Headers
 from werkzeug.security import generate_password_hash, check_password_hash
 
 from . import constants, logger, isoLanguages, services, helper, spa, oauth_auto_redirect
+from .constants import DIRS_JSON
 from . import db, ub, config, app
 from . import calibre_db, kobo_sync_status
 from .services.ereader_send import send_includes_own_address

--- a/findings/items/F-71ff3d.json
+++ b/findings/items/F-71ff3d.json
@@ -1,0 +1,11 @@
+{
+  "area": "web",
+  "body": "`_probe_metadata_db()` and `cwa_get_num_books_in_library()` in `cps/web.py`\nboth wrap their whole body in `except Exception:` and return `False` / `0`.\n\nThose are not error values, they are *valid-looking answers*: \"the database is\ndown\" and \"the library is empty\". So a programming error three lines away is\nreported to the operator as a service problem.\n\nThat is what made #1438 expensive. A missing import raised `NameError` on\nevery call, and instead of a traceback the operator got `/health` answering\n503 `degraded` while listing every service as \"up\" — a self-contradicting\nresponse that reads as an infrastructure fault. The library count rendered 0\nat the same time. Diagnosis took roughly two hours for a one-word omission.\n\nThe imports are fixed (#1459). The swallowing is not, and it will do this to\nthe next caller.\n\nSuggested shape: catch the errors that genuinely mean \"database unavailable\"\n(`sqlite3.Error`, `OSError`) and let everything else propagate, or log the\nexception at ERROR with the traceback before returning the degraded value so\nthe cause is at least visible in the container log. A health endpoint in\nparticular should distinguish \"I checked and it is down\" from \"I could not\nrun the check\".",
+  "created": "2026-08-08",
+  "id": "F-71ff3d",
+  "refs": [],
+  "severity": "correctness",
+  "source": "audit",
+  "status": "open",
+  "title": "Health probe and book count turn any exception into a plausible wrong answer"
+}

--- a/findings/items/F-7ca150.json
+++ b/findings/items/F-7ca150.json
@@ -1,0 +1,11 @@
+{
+  "area": "web",
+  "body": "`_probe_metadata_db()` in `cps/web.py` opens `metadata.db` and runs\n`SELECT 1`.\n\n`SELECT 1` is a constant expression. SQLite answers it without reading a page\nof the database file, and `sqlite3.connect()` is lazy about opening the file\nat all, so the probe can succeed against a database that is missing, corrupt,\ntruncated, or unreadable by the app user. It proves a connection object can be\nconstructed, not that the library is usable.\n\nThat is thin for the thing every Docker, Compose and Kubernetes deployment\npolls to decide whether to route traffic or roll back.\n\n`SELECT 1 FROM books LIMIT 1` would touch a real table and cost essentially\nthe same. Noted while fixing #1438 (#1459), which restored this probe to\nworking but deliberately did not redesign it.",
+  "created": "2026-08-08",
+  "id": "F-7ca150",
+  "refs": [],
+  "severity": "correctness",
+  "source": "audit",
+  "status": "open",
+  "title": "Health check SELECT 1 never reads metadata.db, so a corrupt library probes healthy"
+}

--- a/findings/items/F-f6f411.json
+++ b/findings/items/F-f6f411.json
@@ -1,0 +1,11 @@
+{
+  "area": "testing",
+  "body": "`tests/unit/test_ingest_batch_dirty.py::test_successful_import_marks_batch_dirty_without_hot_loop_http_calls`\nfails identically on `origin/main` and on a feature branch when run locally\n(Python 3.12.7, macOS), while CI's Fast Tests job reports the same suite green\non main.\n\nObserved 2026-08-08 while running the full unit suite before pushing the #1438\nDIRS_JSON fix. A/B'd against a clean `origin/main` worktree to confirm it is\nnot branch-related: `1 failed, 2 passed` in both trees.\n\nSo either the test asserts something about ambient environment state that\nhappens to hold on the CI runner and not on the dev Mac, or CI is not actually\nrunning it. Both are worth knowing: the first makes the local suite noisy\nenough that a real failure gets waved through as \"that one always fails\", and\nthe second means the assertion protects nothing.\n\nNot chased in the DIRS_JSON PR because it is unrelated to that diff and\npre-existing. Next step is to diff the CI invocation against the local one and\ncheck whether the test depends on Python version, a network-adjacent default,\nor an env var the runner sets.",
+  "created": "2026-08-08",
+  "id": "F-f6f411",
+  "refs": [],
+  "severity": "correctness",
+  "source": "audit",
+  "status": "open",
+  "title": "test_ingest_batch_dirty hot-loop test fails locally but is green in CI"
+}

--- a/tests/unit/test_1438_undefined_module_globals.py
+++ b/tests/unit/test_1438_undefined_module_globals.py
@@ -57,27 +57,52 @@ def _iter_code(code):
             yield from _iter_code(const)
 
 
-def _module_bound_names(source, path):
-    """Names the module binds at any scope, discovered statically.
+SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
 
-    Deliberately over-inclusive: every import, def, class, assignment target
-    and ``global`` declaration counts. A false *negative* here just means the
-    sweep stays quiet, so over-inclusion keeps this test from going flaky on
-    dynamic-but-legitimate binding patterns.
+
+def _module_bound_names(source, path):
+    """Names bound in the module's own scope, discovered statically.
+
+    Scope-aware on purpose. An earlier draft counted every ``Store`` anywhere
+    in the file, which meant a local variable inside one function marked that
+    name "bound" for the whole module and hid a genuinely missing global of the
+    same name elsewhere — the exact class this test exists to catch.
+
+    So: recurse through module-level compound statements (``if``/``try``/
+    ``for``/``with`` are still module scope), bind the *name* of a nested def
+    or class but do not descend into its body, and separately honour ``global``
+    declarations anywhere, since a function may legally bind a module global.
     """
     names = set()
+
+    def visit_block(body):
+        for node in body:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    if alias.name == "*":
+                        names.add("*STAR*")
+                    names.add(alias.asname or alias.name.split(".")[0])
+            elif isinstance(node, SCOPE_NODES):
+                # Its name lands in this scope; its body is a different one.
+                names.add(node.name)
+            else:
+                for sub in ast.walk(node):
+                    if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Store):
+                        names.add(sub.id)
+                    elif isinstance(sub, (ast.Import, ast.ImportFrom)):
+                        for alias in sub.names:
+                            if alias.name == "*":
+                                names.add("*STAR*")
+                            names.add(alias.asname or alias.name.split(".")[0])
+                    elif isinstance(sub, SCOPE_NODES):
+                        names.add(sub.name)
+
     tree = ast.parse(source, str(path))
+    visit_block(tree.body)
+
+    # `global X; X = ...` inside any function still binds a module global.
     for node in ast.walk(tree):
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
-            for alias in node.names:
-                if alias.name == "*":
-                    names.add("*STAR*")
-                names.add(alias.asname or alias.name.split(".")[0])
-        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            names.add(node.name)
-        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
-            names.add(node.id)
-        elif isinstance(node, ast.Global):
+        if isinstance(node, ast.Global):
             names.update(node.names)
     return names
 

--- a/tests/unit/test_1438_undefined_module_globals.py
+++ b/tests/unit/test_1438_undefined_module_globals.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""#1438 replaced a hardcoded path with a constant it never imported.
+
+"Remove hardcoded /app paths from cps/" rewrote ``cps/web.py``::
+
+    -    with open('/app/calibre-web-automated/dirs.json', 'r') as f:
+    +    with open(DIRS_JSON, 'r') as f:
+
+without adding ``from .constants import DIRS_JSON``. The name appeared exactly
+once in the file — as a use. Nothing failed at import time, because a global is
+resolved when the line *runs*, so the container booted and served pages.
+
+What it broke was everything downstream of ``cwa_get_library_location()``, and
+both callers bury the failure in a bare ``except``::
+
+    _probe_metadata_db()          -> except Exception: return False
+    cwa_get_num_books_in_library() -> except Exception: return 0
+
+So ``/health`` computed ``db_up=False`` and answered 503 ``degraded`` forever
+while reporting every service "up", the Docker HEALTHCHECK went permanently
+unhealthy, and the library book count rendered 0. The suite that boots the
+container caught it; the summary gate reported that failure as a pass.
+
+Two tests, two altitudes:
+
+* the mechanism, pinned exactly — ``DIRS_JSON`` must resolve as a global in
+  ``cps/web.py``, which is false the moment anyone uses it without importing it;
+* the class, swept repo-wide — no function anywhere in ``cps/`` may reference a
+  module-level global that the module never binds. That is the shape that
+  shipped this bug, and it is invisible to every test that imports a module
+  without calling the specific function that names the missing global.
+"""
+import ast
+import builtins
+import dis
+import os
+import types
+
+import pytest
+
+CPS_ROOT = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))), "cps")
+
+# Always present in a module namespace at runtime, never statically "bound".
+MODULE_DUNDERS = {
+    "__file__", "__name__", "__doc__", "__package__", "__spec__",
+    "__loader__", "__builtins__", "__debug__", "__path__",
+}
+
+
+def _iter_code(code):
+    """Yield ``code`` and every nested code object (functions, comprehensions)."""
+    yield code
+    for const in code.co_consts:
+        if isinstance(const, types.CodeType):
+            yield from _iter_code(const)
+
+
+def _module_bound_names(source, path):
+    """Names the module binds at any scope, discovered statically.
+
+    Deliberately over-inclusive: every import, def, class, assignment target
+    and ``global`` declaration counts. A false *negative* here just means the
+    sweep stays quiet, so over-inclusion keeps this test from going flaky on
+    dynamic-but-legitimate binding patterns.
+    """
+    names = set()
+    tree = ast.parse(source, str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                if alias.name == "*":
+                    names.add("*STAR*")
+                names.add(alias.asname or alias.name.split(".")[0])
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            names.add(node.id)
+        elif isinstance(node, ast.Global):
+            names.update(node.names)
+    return names
+
+
+def _undefined_globals(path):
+    """Return global names ``path`` loads at runtime but never binds.
+
+    Uses ``LOAD_GLOBAL`` from the compiled bytecode rather than an AST name
+    walk, so attribute accesses, locals, parameters and string annotations
+    (a forward reference like ``"ExtractedCover | None"`` is never executed)
+    do not register as uses.
+    """
+    with open(path, encoding="utf-8") as handle:
+        source = handle.read()
+    code = compile(source, str(path), "exec")
+    bound = _module_bound_names(source, path)
+    # A star-import can bind anything; the sweep cannot reason about it.
+    if "*STAR*" in bound:
+        return set()
+    loaded = set()
+    for block in _iter_code(code):
+        for ins in dis.get_instructions(block):
+            if ins.opname == "LOAD_GLOBAL" and isinstance(ins.argval, str):
+                loaded.add(ins.argval)
+    return {
+        name for name in loaded
+        if name not in bound
+        and name not in MODULE_DUNDERS
+        and not hasattr(builtins, name)
+    }
+
+
+def _cps_python_files():
+    for dirpath, _dirnames, filenames in os.walk(CPS_ROOT):
+        for filename in sorted(filenames):
+            if filename.endswith(".py"):
+                yield os.path.join(dirpath, filename)
+
+
+def test_web_module_resolves_dirs_json():
+    """The exact regression: ``DIRS_JSON`` is used in web.py, so it must be bound.
+
+    Red against the #1438 tree, where the constant was referenced but never
+    imported and ``cwa_get_library_location()`` raised ``NameError`` on call.
+    """
+    path = os.path.join(CPS_ROOT, "web.py")
+    with open(path, encoding="utf-8") as handle:
+        source = handle.read()
+
+    assert "DIRS_JSON" in source, (
+        "web.py no longer references DIRS_JSON — if the path lookup moved, move "
+        "this test with it rather than deleting the guard."
+    )
+    assert "DIRS_JSON" not in _undefined_globals(path), (
+        "cps/web.py uses DIRS_JSON without binding it. cwa_get_library_location() "
+        "will raise NameError when called, and both callers swallow it — "
+        "/health reports 'degraded' 503 forever and the library count renders 0. "
+        "Add `from .constants import DIRS_JSON` (the import cps/cwa_functions.py "
+        "already uses)."
+    )
+
+
+def test_library_location_reader_has_no_undefined_globals():
+    """``cwa_get_library_location`` itself must not name an unbound global.
+
+    Narrower than the sweep and independent of it: this stays meaningful even
+    if the repo-wide test is ever scoped down, because this one function is
+    what /health and the book count both route through.
+    """
+    path = os.path.join(CPS_ROOT, "web.py")
+    with open(path, encoding="utf-8") as handle:
+        source = handle.read()
+    tree = ast.parse(source, path)
+    func = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == "cwa_get_library_location"),
+        None,
+    )
+    assert func is not None, "cwa_get_library_location() not found in cps/web.py"
+
+    bound = _module_bound_names(source, path)
+    code = compile(ast.Module(body=[func], type_ignores=[]), path, "exec")
+    used = {
+        ins.argval
+        for block in _iter_code(code)
+        for ins in dis.get_instructions(block)
+        if ins.opname == "LOAD_GLOBAL" and isinstance(ins.argval, str)
+    }
+    missing = sorted(
+        n for n in used
+        if n not in bound and n not in MODULE_DUNDERS and not hasattr(builtins, n)
+    )
+    assert not missing, (
+        f"cwa_get_library_location() references unbound global(s): {missing}. "
+        "Its callers catch bare Exception, so this fails silently as a degraded "
+        "health check and a zero book count rather than as an error."
+    )
+
+
+@pytest.mark.parametrize("path", sorted(_cps_python_files()), ids=lambda p: os.path.relpath(p, CPS_ROOT))
+def test_no_undefined_module_globals(path):
+    """Repo-wide: no module in ``cps/`` may load a global it never binds.
+
+    This is the class, not the instance. A name that only resolves on a code
+    path nobody exercises in unit tests is exactly how #1438 reached a release:
+    import succeeded, the app served traffic, and the failure surfaced as a
+    swallowed exception three layers away from the typo.
+    """
+    missing = sorted(_undefined_globals(path))
+    assert not missing, (
+        f"{os.path.relpath(path, CPS_ROOT)} loads global(s) it never binds: "
+        f"{missing}. Import them, or bind them at module level — a bare "
+        "NameError here surfaces wherever the caller happens to catch Exception."
+    )

--- a/tests/unit/test_workflow_safety_invariants.py
+++ b/tests/unit/test_workflow_safety_invariants.py
@@ -832,14 +832,30 @@ _DETECT_MATRIX = [
     (["tests/integration/test_ingest_flow.py"], "true", "false"),
     # tests.yml houses both harnesses' setup, so it is relevant to both.
     ([".github/workflows/tests.yml"], "true", "true"),
+    # Application Python. This row used to expect "false" on the theory that
+    # only build *definitions* can break the image. #1438 disproved it: a
+    # cleanup in cps/web.py referenced a constant it never imported, which is
+    # invisible at import time, so every unit test passed, the container
+    # booted, and /health then answered 503 forever. Integration Tests caught
+    # it and was advisory, so the summary reported that failure as a pass.
+    # integration-tests is still the only job that boots the container, and
+    # app code can stop it booting as dead as a bad Dockerfile.
+    (["cps/admin.py"], "true", "false"),
+    (["cps/services/cover_picker.py"], "true", "false"),
     # Negative cases — these must NOT pay the ~15-minute Docker build.
-    (["cps/admin.py"], "false", "false"),
     (["README.md"], "false", "false"),
     # The requirements pattern was widened to catch optional-requirements.txt;
     # pin that the widening stays bounded to the repo root, where the image's
     # pip install reads from. A nested one is not a build input.
     (["docs/requirements.txt"], "false", "false"),
+    # The cps/ gate above is scoped to .py deliberately. Locale catalogues are
+    # tier-1 auto-merge PRs and a malformed one already fails Fast Tests via
+    # test_translations_compile.py, so sending them through a full image build
+    # would buy nothing and stall every translation PR behind it. Same for
+    # templates and static assets, which cannot stop the container booting.
     (["cps/translations/de/LC_MESSAGES/messages.po"], "false", "false"),
+    (["cps/templates/index.html"], "false", "false"),
+    (["cps/static/css/style.css"], "false", "false"),
     (["frontend/src/App.tsx"], "false", "true"),
     # Mixed PR: one build-relevant path anywhere in the diff is enough.
     (["README.md", "Dockerfile"], "true", "false"),
@@ -865,8 +881,10 @@ def test_changed_paths_classifies_build_definition_edits(changed, want_build, wa
     )
     assert out["build"] == want_build, (
         f"changed={changed} → build={out['build']!r}, expected {want_build!r}. "
-        "A Dockerfile/requirements/integration-suite edit must run the Docker "
-        "integration job; anything else must not pay for it."
+        "A Dockerfile/requirements/root/integration-suite edit, or any change "
+        "to application Python under cps/, must run the Docker integration "
+        "job — it is the only one that boots the container. Non-Python cps/ "
+        "assets and everything else must not pay for it."
     )
     assert out["frontend"] == want_frontend, (
         f"changed={changed} → frontend={out['frontend']!r}, expected {want_frontend!r}"


### PR DESCRIPTION
## Why

`main` is broken and the `:dev` image with it. The household canary was `unhealthy` for ~2h before this was caught; `/health` answered 503 on every poll while the app served pages normally.

#1438 ("Remove hardcoded /app paths from cps/") rewrote `cps/web.py`:

```diff
-    with open('/app/calibre-web-automated/dirs.json', 'r') as f:
+    with open(DIRS_JSON, 'r') as f:
```

and never added the import. `DIRS_JSON` appeared in the file exactly once — as a use. `grep -c DIRS_JSON cps/web.py` = 1.

## Root cause

A global resolves when the line *runs*, not at import. So the module imported fine, the container booted, pages served — and `cwa_get_library_location()` raised `NameError` the moment anything called it. Both callers bury it:

```python
_probe_metadata_db()           -> except Exception: return False
cwa_get_num_books_in_library() -> except Exception: return 0
```

So `health_check()` computed `db_up=False` and returned `degraded` / 503 **while reporting every service "up"** — the JSON contradicted itself, which is what made it look like a service problem rather than a missing import. Book count rendered 0.

Measured live on the affected build before the fix:

```
cwa_get_library_location -> NameError name 'DIRS_JSON' is not defined
_probe_metadata_db -> False
num_books -> 0
```

## Fix

`from .constants import DIRS_JSON` — the same import `cps/cwa_functions.py:11` already uses for this constant.

**Second, independent instance of the same defect:** `ub.add_missing_tables()` calls `KOSyncProgress.__table__.create(...)` as a bare global, but that class lives in `progress_syncing.models`. Any `app.db` missing the `kosync_progress` table — a fresh install — hit `NameError`. That module imports `Base` from `ub`, so the import must be function-local; `ub.py` already uses that pattern in eight places. Found by the repo-wide sweep below, not by hand.

## Why CI didn't catch it

Integration Tests **did** catch it — it went red on #1438 and has been red on every `main` run since. `Test Suite Summary` reported success anyway.

Integration is a hard gate only for `safe-tier-2` PRs or build-definition PRs (`Dockerfile`, `requirements*.txt`, `root/`). #1438 was a community PR touching 18 `cps/*.py` files: no tier-2 label, no build path, so the suite was **advisory** — it failed, and the summary printed `⚠️ ... (advisory)` and exited 0.

That is the gate that let a container-breaking change into `main` and the dev image. This PR adds `cps/**.py` to the build-gate paths: integration-tests is still the only job that boots the container, and application Python can stop it booting exactly as dead as a bad Dockerfile.

Scoped to `.py` deliberately — `cps/translations/*.po` are tier-1 auto-merge PRs and a broken catalogue is already a hard failure in Fast Tests (`test_translations_compile.py`), so routing locale PRs through a full image build would buy nothing and stall them. Verified truth table:

| changed file | build gate |
|---|---|
| `cps/web.py` | true |
| `cps/services/x.py` | true |
| `cps/translations/de/LC_MESSAGES/messages.po` | false |
| `cps/templates/index.html` | false |
| `README.md` | false |
| `Dockerfile` / `requirements.txt` | true |

## Validation

**Red/green** — `tests/unit/test_1438_undefined_module_globals.py`, two altitudes, matching the `test_1074_guest_read_book_shadowed_import.py` precedent:

- the mechanism, pinned exactly: `DIRS_JSON` must resolve as a global in `web.py`, and `cwa_get_library_location()` must name no unbound global;
- the class, swept repo-wide: no module in `cps/` may `LOAD_GLOBAL` a name it never binds. Uses bytecode rather than an AST name-walk so attributes, locals and string annotations (a forward ref like `"ExtractedCover | None"` is never executed) don't register as uses.

```
against this branch:  196 passed
against main:         4 failed, 192 passed
                      - test_web_module_resolves_dirs_json
                      - test_library_location_reader_has_no_undefined_globals
                      - test_no_undefined_module_globals[web.py]
                      - test_no_undefined_module_globals[ub.py]
```

The sweep found the `ub.py` bug on its own — it fails for two independent reasons on `main`, which is the point of writing it as a class rather than a one-off.

**Live, on the affected build** (teenyverse, `DEV_BUILD-dev-839`, same container, only `web.py` swapped):

```
BEFORE  {"status":"degraded", services all "up"}   HTTP 503   container unhealthy (streak 10)
AFTER   {"status":"ok",       services all "up"}   HTTP 200   container healthy

cwa_get_library_location() -> /calibre-library   (was NameError)
_probe_metadata_db()       -> True               (was False)
cwa_get_num_books_in_library() -> 220            (was 0)
```

An A/B on `cwn-local` was attempted first and discarded as contaminated: that image predates `oauth_auto_redirect`, so `main`'s `web.py` can't import there at all. It was restored to healthy afterwards.

## Blast radius

Swept all 18 production files #1438 touched: `cps/web.py` was the only undefined name it introduced. `kobo_sync_utils.py`, which #1438 deleted, has zero remaining references. Tree-wide, the only other hit was the pre-existing `ub.py` one fixed here; `cover_picker.py:92` is a string forward-reference and correctly not flagged by the bytecode approach.

Credit: @chloeroform (#1438) for the path cleanup this repairs — the direction was right, the constant just needed its import.