### PR TITLE
Ignore bare-metal runtime artifacts so they cannot wedge the tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,18 @@ cps/static/app/
 # Local output from the no-argument wiki generator. The published wiki is
 # rendered into a temporary clone by scripts/sync-wiki.sh.
 wiki-generated/
+
+# Runtime artifacts of a BARE-METAL run from the source checkout. In Docker the
+# app writes these under /config, but running `cps` directly from a clone puts
+# them in the repo root. `.key` is a real secret, so an accidental `git add -A`
+# by a contributor would publish it.
+#
+# This is not hypothetical: on 2026-08-08 an autopilot tick ran the app from the
+# checkout while working on bare-metal path handling, left both files behind, and
+# every subsequent tick aborted at the preflight clean-tree gate — four ticks in a
+# row drained nothing before anyone noticed.
+.key
+app.db
+app.db-journal
+app.db-wal
+app.db-shm


### PR DESCRIPTION
## Symptom

The autopilot stopped draining. Four consecutive ticks — 14:00Z, 16:00Z, 18:00Z, 20:00Z on 2026-08-08 — aborted at the preflight gate with:

```
[3/5] repo/ checkout
  FAIL repo/ has uncommitted changes — investigate before draining
        ?? .key
        ?? app.db
```

Every other check was green, including the full autopilot test suite. A red preflight `exit 4`s the tick **before** phase-7, so no issue was picked, nothing merged, and the release train did not depart, for eight hours.

## Root cause

`.key` (44 bytes, mode 600) and `app.db` (a real application database — `annotation`, `kobo_reading_state`, `kosync_progress`) were written into the repo root at 08:35Z and 08:56Z by a tick that ran the app **bare metal from the source checkout** while working on bare-metal path handling.

Under Docker the app writes these under `/config`. Run directly from a clone, they land in the repo root — and nothing ignored them, so the clean-tree gate saw them forever.

This is a self-locking wedge: the automation created the condition that then disabled the automation, and it fails in a way that looks like a legitimate "someone left work in the tree" warning.

## Fix

Ignore them, plus the SQLite sidecar files that appear with WAL journaling.

`.key` is a **secret**. The security argument stands on its own regardless of the wedge: a contributor running bare metal and typing `git add -A` would publish it.

## Not fixed here

Clearing the two stray files unblocked the tick immediately (`preflight OK`, drainage restarted). This PR only stops it recurring. Whether preflight should distinguish *untracked runtime junk* from *real uncommitted work* — rather than treating both as a full stop — is a separate question worth asking, since the current behaviour turns a stray file into an eight-hour outage.