### PR TITLE
Release bookkeeping for v4.1.33: two changelog gaps and the What's New block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,29 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Changed
+
+- **On a sign-in-with-your-provider-only server, the login page stops asking
+  you to click one button.** If standard login is switched off and exactly one
+  OAuth provider is configured, the login page existed only to be clicked
+  through — it now starts that provider straight away. Add `?local=1` to the
+  login URL if you ever need the plain page back, which is how an admin gets in
+  when the provider itself is down. Cancelling at the provider's consent screen
+  used to hand your browser straight back to it, over and over; that loop is
+  gone too, and it predates this feature. Servers with standard login enabled,
+  or with more than one provider, are unchanged. Contributed by
+  [@lduesing](https://github.com/new-usemame/Calibre-Web-NextGen/pull/1411)
+  ([#1411](https://github.com/new-usemame/Calibre-Web-NextGen/pull/1411)).
+
 ### Fixed
+
+- **More of the interface reads in Traditional Chinese.** Coverage went from
+  619 to 919 translated phrases, and 130 entries that gettext had guessed and
+  marked provisional — provisional entries are dropped when the catalogue is
+  compiled, so they were showing in English — are now confirmed translations.
+  Contributed by
+  [@siuwai1999](https://github.com/new-usemame/Calibre-Web-NextGen/pull/1424)
+  ([#1424](https://github.com/new-usemame/Calibre-Web-NextGen/pull/1424)).
 
 - **Installing outside Docker still lost your settings database, and imports
   died without saying why.** The previous fix moved `app.db` and `dirs.json`

--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -56,6 +56,49 @@ export interface WhatsNewRelease {
 /** Newest release first. The `whats-new-populate` skill prepends here. */
 export const WHATS_NEW: WhatsNewRelease[] = [
   {
+    version: 'v4.1.33',
+    date: '2026-08-08',
+    items: [
+      {
+        title: 'Tag names are readable again',
+        body: 'The Tags page was showing columns of "…" where the names should be: the grid had been sized before the rename and delete buttons existed, so once those arrived they took their space out of the name itself. Rows with those buttons now get a wider column and a long name wraps to a second line before it gets cut. On a 152-tag library, names cut off went from 87% to 9% on desktop and 32% to 8% on a phone. Authors, Series and Publishers keep their layout and gain the same second line.',
+        category: 'Library',
+        link: { to: '/tags', label: 'Browse tags' },
+      },
+      {
+        title: 'Signing in with your provider skips the extra click',
+        body: 'If your server has standard login switched off and exactly one sign-in provider configured, the login page existed only to be clicked through — it now starts that provider straight away. Adding ?local=1 to the login URL brings the plain page back, which is how an admin gets in if the provider itself is down. Cancelling at the provider used to bounce you straight back to it in a loop; that is fixed too.',
+        category: 'Account',
+      },
+      {
+        title: 'Spanish is complete, and Traditional Chinese is much further along',
+        body: 'Spanish now covers all 2,645 phrases in the interface, up from 1,378 — the most complete translation the project ships. Traditional Chinese went from 619 to 919. Both catalogues also had entries that gettext had guessed from a similar English sentence and marked provisional; a provisional entry is dropped when the catalogue is compiled, so those had been rendering in English while a translation sat in the file unused. In Spanish, 196 of them were confirmed or corrected, and a few had reversed the meaning of the original.',
+        category: 'Under the hood',
+        link: { to: '/account', label: 'Open account settings' },
+      },
+      {
+        title: 'A sync client is told when a position is being held back',
+        body: 'Reading positions that exist only as a percentage — the ones the web reader and a Kobo produce — are deliberately withheld from KOReader clients that have not said they can use them, because older plugins would try to jump to a position they cannot resolve and lose your place. From the client\'s side that looked identical to never having synced at all. The server now says what it is holding and how to ask for it, and the sync protocol documentation covers both position formats. Nothing changes for the bundled plugin.',
+        category: 'Sync',
+      },
+      {
+        title: 'Your library folder stops collecting a stray metadata.db',
+        body: 'Something during startup checked for a database at the top of your library folder, and the act of checking created an empty one there. That stray file is what made versions 4.1.20 to 4.1.31 refuse to start for some people. It is no longer created at all, and two things that had been reading it instead of your real library now find the right one: the KOReader checksum job, which had been failing with "no such table: books" on every restart, and your reading statistics, which had been reporting nothing.',
+        category: 'Under the hood',
+      },
+      {
+        title: 'The "help translate this" notice stops coming back',
+        body: 'The app remembered it had shown you that notice by writing a small file into its own program folder — which gets replaced every time you update, so the reminder returned with each new version. It is now kept alongside your settings, where it survives updates.',
+        category: 'Under the hood',
+      },
+      {
+        title: 'Installing from source keeps your database where the app reads it',
+        body: 'If you run NextGen from a checkout or a distro package rather than the Docker image, setup used to write app.db, dirs.json and your CWA settings into a /config folder it created at the top of the filesystem, while the app read from the folder you installed into — so you got a first-run screen and an empty library. All of them now resolve the same way. An install upgrading from one of those builds is told which database it found instead of being handed an empty one, first run no longer prints a chown error that was not an error, and the version no longer reports one release behind. Docker installs are unaffected.',
+        category: 'Under the hood',
+      },
+    ],
+  },
+  {
     version: 'v4.1.32',
     date: '2026-08-07',
     items: [


### PR DESCRIPTION
Release bookkeeping for **v4.1.33**, ahead of the tag. Two parts.

## 1. Two changelog gaps

Both found by the **git completeness backstop**, not by the changelog — which
is the point of that step. Neither had an entry:

- **#1411 — OAuth auto-start** (@lduesing). On a server with standard login
  disabled and exactly one provider configured, the login page now starts that
  provider directly instead of existing to be clicked through. That is a
  behaviour change a user needs told about, and the `?local=1` escape hatch is
  how an admin gets back in when the provider itself is down. It also ends a
  redirect loop on consent-screen cancel that predates the feature.
- **#1424 — Traditional Chinese** (@siuwai1999). Measured against the compiled
  catalogue rather than the diff, because the diff's -434/+316 reads like a
  removal: `msgfmt --statistics` goes from **619 translated / 381 fuzzy /
  1645 untranslated** to **919 / 251 / 1475**. A real +300.

## 2. The in-app What's New block for v4.1.33

Seven items. Grouping follows the skill's rule — the five source-install fixes
(#1462, #1463, the chown non-error, the upgrade-detection stop, and #1474)
are one item, since they are one story to a reader.

**Deliberately left out**: the `/health` degraded + zero-book-count regression.
It existed only on the `:dev` channel and no published release carried it, so
it is not something a user of a released build can have experienced.

Verified:
- `tsc --noEmit --strict` clean on the edited file (it is self-contained, no imports).
- Both `link.to` targets exist in `SPA_ROUTES` — `/tags` and `/account`.
- Both `link.label` strings (`Browse tags`, `Open account settings`) are already
  anchored in `cps/spa_strings.py`, so no new msgid is introduced and the
  auto-translation job cannot strip them.
- `LATEST_WHATS_NEW_VERSION` derives from `WHATS_NEW[0]`, so prepending is what
  lights the Help-menu unread dot on the new build. Not hand-edited.

This must merge **before** the tag — the SPA is baked into the image at build
time, so the shipped build has to contain the page that announces it.
