### PR TITLE
Restore 31 SPA anchors dropped by regenerating the AUTOGEN block

### DIFF
--- a/cps/spa_strings.py
+++ b/cps/spa_strings.py
@@ -385,6 +385,46 @@ _("Could not save sidebar. Please try again.")
 _("Refresh library")
 
 
+# ---- Restored anchors (regression guard) --------------------------------
+# `extract_spa_strings.py --write` regenerates the AUTOGEN block below from
+# what its parser can see in the frontend. Strings it cannot see statically
+# — dynamic keys, values built at runtime — were previously anchored inside
+# that block and were dropped when it was regenerated on 2026-08-09, which
+# obsoleted their msgids and lost the existing fr/ru/de translations (the
+# #615 symptom: an untranslated SPA msgid renders English rather than
+# failing). They live ABOVE the marker so regeneration cannot drop them again.
+_("<")
+_("=")
+_(">")
+_("A one-time full duplicate scan is needed. Run it from CWA settings, then return here.")
+_("Border fill style")
+_("Date Added")
+_("Delete \u201c{name}\u201d? It is removed from {count} book, which is kept.")
+_("Delete \u201c{name}\u201d? It is removed from {count} books, which are kept.")
+_("Delete")
+_("Dismiss Ko-fi support message")
+_("Dismiss help announcement")
+_("Merge")
+_("Open Ko-fi →")
+_("Publication Date")
+_("Saving…")
+_("Support us on Ko-fi!")
+_("These open the full configuration pages. Changes there apply to the whole server.")
+_("\u201c{name}\u201d already exists on {count} book. Merge this tag into it?")
+_("\u201c{name}\u201d already exists on {count} books. Merge this tag into it?")
+_("begins with")
+_("contains")
+_("does not contain")
+_("ends with")
+_("in the past N days")
+_("is not")
+_("is")
+_("not in the past N days")
+_("on or after")
+_("on or before")
+_("≤")
+_("≥")
+
 # ==== BEGIN AUTOGEN (scripts/extract_spa_strings.py --write) ====
 # Auto-anchored SPA-only msgids — every t('literal') and static label
 # property in frontend/src that

--- a/cps/spa_strings.py
+++ b/cps/spa_strings.py
@@ -393,11 +393,19 @@ _("Refresh library")
 # obsoleted their msgids and lost the existing fr/ru/de translations (the
 # #615 symptom: an untranslated SPA msgid renders English rather than
 # failing). They live ABOVE the marker so regeneration cannot drop them again.
+#
+# 30 of the 31 are restored. "Border fill style" is deliberately NOT among them:
+# nothing renders it. The classic cover picker's dropdown is labelled
+# _('Fill style') (cover_picker.html:114) and the SPA's is t('Fill style')
+# (CoverPicker.tsx:205) -- both of which are anchored and translated. The
+# phrase survives only in changelog prose and a test comment, and no locale has
+# ever carried a translation for it. Re-anchoring it puts a msgid nobody can
+# see back into the SPA-chrome catalog, which is what the #615 completeness
+# gate then requires fr and nl to translate. Do not add it back.
 _("<")
 _("=")
 _(">")
 _("A one-time full duplicate scan is needed. Run it from CWA settings, then return here.")
-_("Border fill style")
 _("Date Added")
 _("Delete \u201c{name}\u201d? It is removed from {count} book, which is kept.")
 _("Delete \u201c{name}\u201d? It is removed from {count} books, which are kept.")

--- a/cps/translations/ar/LC_MESSAGES/messages.po
+++ b/cps/translations/ar/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=0 && n%100<=2 ? 4 : 5);\n"
 "Generated-By: Babel 2.15.0\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "الإحصائيات"
 
@@ -142,7 +142,7 @@ msgstr "لا يوجد عمود مخصص رقم %(column)d في قاعدة بيا
 msgid "Edit Users"
 msgstr "تحرير المستخدمين"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "الكل"
@@ -1006,7 +1006,7 @@ msgstr "غير مثبت"
 msgid "Execution permissions missing"
 msgstr "أذونات التنفيذ مفقودة"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr "تعذر العثور على الدليل المحدد"
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1212,7 +1212,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "دور غير صالح"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2012,7 +2012,7 @@ msgstr "الإصدار الحالي"
 msgid "Unread Books"
 msgstr "الكتب غير المقروءة"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2023,7 +2023,7 @@ msgstr "المؤلفون"
 msgid "Books ordered by Author"
 msgstr "الكتب مرتبة حسب المؤلف"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "الناشرون"
@@ -2032,7 +2032,7 @@ msgstr "الناشرون"
 msgid "Books ordered by publisher"
 msgstr "الكتب مرتبة حسب الناشر"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "الفئات"
@@ -2054,7 +2054,7 @@ msgstr "السلاسل"
 msgid "Books ordered by series"
 msgstr "الكتب مرتبة حسب السلسلة"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2064,7 +2064,7 @@ msgstr "اللغات"
 msgid "Books ordered by Languages"
 msgstr "الكتب مرتبة حسب اللغات"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "التقييمات"
@@ -2081,7 +2081,7 @@ msgstr "تنسيقات الملفات"
 msgid "Books ordered by file formats"
 msgstr "الكتب مرتبة حسب تنسيقات الملفات"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "الأرفف"
@@ -2118,7 +2118,7 @@ msgstr "{} نجوم"
 msgid "Search"
 msgstr "بحث"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2142,7 +2142,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "الكتب"
 
@@ -2175,7 +2175,7 @@ msgstr "عرض المقروء وغير المقروء"
 msgid "Show unread"
 msgstr "عرض غير المقروء"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "اكتشف"
 
@@ -2215,7 +2215,7 @@ msgstr "الكتب المؤرشفة"
 msgid "Show Archived Books"
 msgstr "عرض الكتب المؤرشفة"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2231,7 +2231,7 @@ msgstr "قائمة الكتب"
 msgid "Show Books List"
 msgstr "عرض قائمة الكتب"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2933,13 +2933,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "حذف"
 
@@ -3095,8 +3095,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "دمج"
 
@@ -3224,7 +3225,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3660,225 +3662,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "حول"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "أي"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "أرشفة"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "مؤرشف"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3901,1326 +4020,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "تحويل"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "الوصف"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "تنزيل"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "تحرير"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "البريد الإلكتروني"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "تمكين مزامنة Kobo"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "التشفير"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "إخفاء"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "المعرفات"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "اللغة"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "كلمة المرور"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "المنفذ"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "التقدم"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "التقييم"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5229,634 +5338,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "حفظ"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "تحديد"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "الحالة"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "العلامات"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "المهمة"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "المهام"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "المستخدم"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "اسم المستخدم"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "عرض"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9006,10 +9105,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/cs/LC_MESSAGES/messages.po
+++ b/cps/translations/cs/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Statistika"
 
@@ -142,7 +142,7 @@ msgstr "Vlastní sloupec %(column)d neexistuje v databázi"
 msgid "Edit Users"
 msgstr "Uživatel admin"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Vše"
@@ -1000,7 +1000,7 @@ msgstr "není nainstalováno"
 msgid "Execution permissions missing"
 msgstr "Chybí povolení k exekuci"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Zadána neplatná police"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr "Současná verze"
 msgid "Unread Books"
 msgstr "Nepřečtené knihy"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2018,7 +2018,7 @@ msgstr "Autoři"
 msgid "Books ordered by Author"
 msgstr "Knihy seřazené podle autora"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Vydavatelé"
@@ -2027,7 +2027,7 @@ msgstr "Vydavatelé"
 msgid "Books ordered by publisher"
 msgstr "Knihy seřazené podle vydavatele"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Kategorie"
@@ -2049,7 +2049,7 @@ msgstr "Série"
 msgid "Books ordered by series"
 msgstr "Knihy seřazené podle série"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2059,7 +2059,7 @@ msgstr "Jazyky"
 msgid "Books ordered by Languages"
 msgstr "Knihy seřazené podle jazyků"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Hodnocení"
@@ -2076,7 +2076,7 @@ msgstr "Formáty souborů"
 msgid "Books ordered by file formats"
 msgstr "Knihy seřazené podle souboru formátů"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Police"
@@ -2113,7 +2113,7 @@ msgstr ""
 msgid "Search"
 msgstr "Hledat"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2137,7 +2137,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Knihy"
 
@@ -2171,7 +2171,7 @@ msgstr "Zobrazit prečtené a nepřečtené"
 msgid "Show unread"
 msgstr "Zobrazit nepřečtené"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Objevte"
 
@@ -2219,7 +2219,7 @@ msgstr "Archivované knihy"
 msgid "Show Archived Books"
 msgstr "Zobrazit archivované knihy"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2940,13 +2940,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Smazat"
 
@@ -3102,8 +3102,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr ""
 
@@ -3231,7 +3232,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3667,225 +3669,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "O knihovně"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Archivováno"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3908,1326 +4027,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Popis"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Stahovat"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Upravovat"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "E-mail"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Povolit Kobo synchronizaci"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Šifrování"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identifikátory"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Jazyk"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Heslo"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Průběh"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Hodnocení"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5236,634 +5345,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Uložit"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Stav"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Štítky"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Úkol"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Úlohy"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Uživatel"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Přezdívka"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9057,10 +9156,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Loco-Parser: loco_parse_po\n"
 "X-Loco-Source-Locale: de_DE\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Statistiken"
 
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Benutzer bearbeiten"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Alle"
@@ -439,8 +439,8 @@ msgid ""
 "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
 "Correct Path"
 msgstr ""
-"Der angegebene Speicherort für LDAP-CA-Zertifikat, -Zertifikat oder -"
-"Schlüsseldatei ist falsch,Bitte den korrekten Pfad eingeben."
+"Der angegebene Speicherort für LDAP-CA-Zertifikat, -Zertifikat oder "
+"-Schlüsseldatei ist falsch,Bitte den korrekten Pfad eingeben."
 
 #: cps/admin.py:1905 cps/templates/admin.html:57
 msgid "Add New User"
@@ -1056,7 +1056,7 @@ msgstr "nicht installiert"
 msgid "Execution permissions missing"
 msgstr "Ausführberechtigung fehlt"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr "zurück zur Bearbeitung der Metadaten"
 
@@ -1104,7 +1104,7 @@ msgstr "Angegebener Ordner konnte nicht gefunden werden"
 msgid "Could not load a source image to preview."
 msgstr "Konnte kein Quellbild für die Vorschau laden."
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr "Speichern des Covers fehlgeschlagen."
 
@@ -1265,7 +1265,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Ungültige Buchauswahl."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr "Buch wurde nicht gefunden."
 
@@ -2112,7 +2112,7 @@ msgstr "Kürzlich gelesene Bücher"
 msgid "Unread Books"
 msgstr "Ungelesene Bücher"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2124,7 +2124,7 @@ msgstr "Autoren"
 msgid "Books ordered by Author"
 msgstr "Autor des Buches"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Verleger"
@@ -2133,7 +2133,7 @@ msgstr "Verleger"
 msgid "Books ordered by publisher"
 msgstr "Bücher nach Verleger sortiert"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Kategorien"
@@ -2155,7 +2155,7 @@ msgstr "Serien"
 msgid "Books ordered by series"
 msgstr "Bücher nach Serie sortiert"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2166,7 +2166,7 @@ msgstr "Sprachen"
 msgid "Books ordered by Languages"
 msgstr "Bücher pro Seite"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Bewertungen"
@@ -2183,7 +2183,7 @@ msgstr "Dateiformate"
 msgid "Books ordered by file formats"
 msgstr "Bücher nach Dateiformat sortiert"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Regale"
@@ -2219,7 +2219,7 @@ msgstr "{} Sterne"
 msgid "Search"
 msgstr "Suchen"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2246,7 +2246,7 @@ msgstr ""
 "bevor nach Importen und Metadatenänderungen schnelle Duplikatprüfungen "
 "durchgeführt werden können."
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Bücher"
 
@@ -2279,7 +2279,7 @@ msgstr "Zeige Gelesen und Ungelesen"
 msgid "Show unread"
 msgstr "Zeige Ungelesene"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Entdecken"
 
@@ -2319,7 +2319,7 @@ msgstr "Archivierte Bücher"
 msgid "Show Archived Books"
 msgstr "Zeige archivierte Bücher"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr "Favoriten"
 
@@ -2335,7 +2335,7 @@ msgstr "Bücherliste"
 msgid "Show Books List"
 msgstr "Zeige Bücherliste"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "Duplikate"
 
@@ -3049,13 +3049,13 @@ msgstr "Erstellen Sie Ihren Account"
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Löschen"
 
@@ -3215,8 +3215,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Zusammenführen"
 
@@ -3346,7 +3347,8 @@ msgstr "Profil speichern"
 msgid "Saved."
 msgstr "Gespeichert."
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
@@ -3792,227 +3794,346 @@ msgstr "Seitenleiste speichern fehlgeschlgen. Bitte noch einmal probieren."
 msgid "Refresh library"
 msgstr "Bibliothek aktualisieren"
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+"Ein einmaliger Duplikat-Scan wird benötigt. Von CWA-Einstellungen ausführen, "
+"dann hierher zurückkehren."
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr "Hinzugefügt am"
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr "Veröffentlichungsdatum"
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr "beginnt mit"
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr "enthält"
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr "enthält nicht"
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr "endet mit"
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr "in den letzten N Tagen"
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr "ist nicht"
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr "ist"
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr "nicht in den letzten N Tagen"
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr "am oder nach dem"
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr "am oder vor dem"
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr "(Umschlag ersetzen)"
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr "Ein paar zufällige Titel aus deiner Bibliothek"
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Über"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr "Zu Favoriten hinzufügen"
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr "Administratoren-Gruppe"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr "Erweitert"
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr "Erweiterte Suche"
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr "Alle Regale"
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr "Remote-Login (magic link) erlauben"
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "Beliebig"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr "Beliebiges Format"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr "Beliebige Sprache"
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr "Beliebige Serie"
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr "Beliebige Tags/Schlagwörter"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr "Ausgewählte hinzufügen"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Zu allen Markierten hinzufügen (nur gefüllte Felder werden geändert, "
 "bestehende Werte werden überschrieben):"
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr "Hinzufügen..."
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "Archiv"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Archiviert"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr "Auf Discord fragen"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr "Authentifizierung"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr "Authentifizierung und Sicherheit"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr "Autor A-Z"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr "Autor Z-A"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr "Autorisiert - Sie werden angemeldet..."
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr "URL autorisieren"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr "Benutzer automatisch erstellen"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr "Benutzer beim ersten Login automatisch erstellen"
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr "Zurück zur Bibliothek"
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr "Zurück zur klassischen Ansicht"
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr "Grundkonfiguration"
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr "Buch Standard"
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Band {number}"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr "Bücher pro Seite"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr "Massenverarbeitung"
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr "CWA-Einstellungen (ingest, konvertieren)"
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr "Kann Bücher hochladen"
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -4035,1328 +4156,1318 @@ msgstr "Kann Bücher hochladen"
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr "Umbennen abbrechen"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr "Titelbearbeitung abbrechen"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Aufgabe „{task}“ abbrechen"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr "Pfad zur Zertifikatsdatei"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr "Pfad zum Zertifikat"
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr "Cover ändern"
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr "Prüfe..."
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr "Cover auswählen"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr "Coverbild zum Upload auswählen"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr "Bild auswählen..."
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr "Felder auswählen"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr "Theme wählen"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr "Standardeinstellungen zurücksetzen"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr "Auswahl zurücksetzen"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr "Schließe Reader"
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr "Spalten"
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr "Bequem"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr "Kompakt"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr "Konfiguriert"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr "Passwort bestätigen"
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Konvertiere"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr "Vor dem Senden konvertieren"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr "Konvertieren von"
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr "In die Zwischenablage kopiert"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr "Link kopieren"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr "Regal konnte nicht erstellt werden."
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr "Das Regal konnte nicht erstellt werden."
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr "Regal konnte nicht gelöscht werden."
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr "Vorschläge konnten nicht geladen werden."
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr "Duplikate konnten nicht geladen werden."
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr "Highlights konnten nicht geladen werden."
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr "Statistiken konnten nicht geladen werden."
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr "Aufgaben konnten nicht geladen werden."
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr "Laden dieser Textdatei fehlgeschlagen."
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr "Benutzer konnten nicht geladen werden."
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr "Lesen des Comic-Archivs fehlgeschlagen."
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr "Metadaten konnten nicht neu geladen werden."
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr "Regal konnte nicht umbenannt werden."
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr "Passwort zurücksetzen fehlgeschlagen"
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr "Reihenfolge konnte nicht gespeichert werden."
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr "Konnte Reader-Einstellungen nicht speichern."
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr "Konnte Standard-Bibliotheksfilter nicht speichern."
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr "Das Regal konnte nicht gespeichert werden."
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr "Titel konnte nicht gespeichert werden."
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr "Regal konnte nicht aktualisiert werden."
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "Konnte Magic Link nicht starten. Bitte noch einmal probieren."
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr "Cover gesperrt"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr "Cover nicht erreichbar"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr "Cover von den ausgewählten Vorschlägen aktualisiert. "
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr "Erstellen"
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr "Account erstellen"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr "Account erstellen"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr "Erstellen fehlgeschlagen."
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr "Erstelle ein Regal und füge ein Buch hinzu"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr "Erstelle Benutzer"
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr "{name} wurde erstellt."
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr "Erstelle..."
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr "Aktuell"
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr "Aktuelles Cover"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr "Aktuelles Passwort"
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr "Gerade am Lesen"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr "Datenbanks- und Bibliothekspfad"
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr "Hinzugefügt am"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr "Standard Bücher-Sprache"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr "Standard Bibliotheksfilter gespeichert."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr "Bücher entfernen"
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr "Löschen fehlgeschlagen."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "Regal „{name}“ löschen? Dies kann nicht rückgängig gemacht werden."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr "Dieses Regal entfernen? Ihre Bücher bleiben in der Bibliothek."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Benutzer „{name}“ löschen? Seine Regale und Lesedaten werden ebenfalls "
 "entfernt."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "{name} löschen"
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "{name} wurde gelöscht."
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr "Dicht"
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Beschreibung"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr "Aktiviere Standard Passwort Login"
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr "Entdecken — Zufällige Auswahl"
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr "Dokumentation"
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Download"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Editieren"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr "Intelligentes Regal bearbeiten"
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "E-Mail"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Synchronisation mit Kobo aktivieren"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Verschlüsselung"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr "Regale konnten nicht geladen werden."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Filtern: {items}"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Filtern: {items}…"
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr "Gib deinem intelligenten Regal einen Namen."
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr "Hilfe und Support"
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr "Hilfemenü"
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Verstecke"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr "Entdeckungsbereich ausblenden"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr "Beliebt"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr "Beliebt — Am häufigsten heruntergeladen"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr "Symbol"
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "IDs"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr "KOReader-Fortschritt"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Sprache"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "Zuletzt geändert"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr "Mehr laden"
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr "Wird geladen…"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "Als ungelesen markieren"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr "Übereinstimmung"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr "Name"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr "Möchtest du ein Problem melden? Probiere das neue"
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr "Name des neuen Regals"
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr "Name des neuen Regals…"
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr "Neues intelligentes Regal"
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Keine Treffer in {items} für „{query}“."
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr "Noch keine Regale. Erstelle oben eines, um Bücher zu sammeln."
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Noch keine Einträge in {items}."
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Seite {number}"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Passwort"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Fortschritt"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr "Öffentlich"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Bewertung"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr "Lesestatusfilter"
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr "Vom Regal entfernen"
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr "Regel entfernen"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr "Problem auf Discord melden"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr "Problem auf GitHub melden"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5365,635 +5476,625 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Speichern"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Auswahl"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "Senden"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr "Senden fehlgeschlagen."
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Alle in {items} anzeigen"
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr "Auswahl neu mischen"
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr "Intelligente Regale"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr "Sortierreihenfolge"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "Auf Ko-fi unterstützen →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr "Tabellenansicht"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr "Schlagwort"
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Tags"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Aufgabe"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Aufgaben"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 "Dieses Regal ist leer. Füge Bücher über eine beliebige Buchseite hinzu."
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr "Am besten bewertet"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "Entarchivieren"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr "Aktualisierung fehlgeschlagen."
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Benutzer"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Benutzername"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Ansicht"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr "alle Regeln"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr "mindestens eine Regel"
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr "Bücher stimmen überein"
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr "z. B. ungelesene Science-Fiction"
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr "Wert"
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} Buch"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} Bücher"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} Datei für den Import vorgemerkt"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} Datei abgelehnt"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} Dateien für den Import vorgemerkt"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} Dateien abgelehnt"
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} Ergebnis"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} Ergebnisse"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9223,10 +9324,6 @@ msgstr ""
 msgid "Tags/Genres"
 msgstr "Tags/Genres"
 
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
-msgstr "Veröffentlichungsdatum"
-
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identifikatoren (ISBN usw.)"
@@ -12332,46 +12429,6 @@ msgid "Show Read/Unread Section"
 msgstr "Zeige Gelesen/Ungelesen-Abschnitt"
 
 #~ msgid ""
-#~ "A one-time full duplicate scan is needed. Run it from CWA settings, then "
-#~ "return here."
-#~ msgstr ""
-#~ "Ein einmaliger Duplikat-Scan wird benötigt. Von CWA-Einstellungen "
-#~ "ausführen, dann hierher zurückkehren."
-
-#~ msgid "Date Added"
-#~ msgstr "Hinzugefügt am"
-
-#~ msgid "begins with"
-#~ msgstr "beginnt mit"
-
-#~ msgid "contains"
-#~ msgstr "enthält"
-
-#~ msgid "does not contain"
-#~ msgstr "enthält nicht"
-
-#~ msgid "ends with"
-#~ msgstr "endet mit"
-
-#~ msgid "in the past N days"
-#~ msgstr "in den letzten N Tagen"
-
-#~ msgid "is"
-#~ msgstr "ist"
-
-#~ msgid "is not"
-#~ msgstr "ist nicht"
-
-#~ msgid "not in the past N days"
-#~ msgstr "nicht in den letzten N Tagen"
-
-#~ msgid "on or after"
-#~ msgstr "am oder nach dem"
-
-#~ msgid "on or before"
-#~ msgstr "am oder vor dem"
-
-#~ msgid ""
 #~ "Off by default. When enabled, each user gets a hide button on the book "
 #~ "detail page that drops the book out of their own index/search/OPDS "
 #~ "without affecting other users. Recovery is via the profile page (Hidden "
@@ -12559,9 +12616,9 @@ msgstr "Zeige Gelesen/Ungelesen-Abschnitt"
 #~ "        <a href=\"https://github.com/crocodilestick/Calibre-Web-Automated/"
 #~ "wiki/Configuration#database-configuration\">see here</a>!"
 #~ msgstr ""
-#~ "CWA ist so konfiguriert, dass es deine Calibre-Datenbank (<code>metadata."
-#~ "db</code>-Datei) irgendwo in dem Pfad <code>/calibre-library</code> "
-#~ "sucht.\n"
+#~ "CWA ist so konfiguriert, dass es deine Calibre-Datenbank "
+#~ "(<code>metadata.db</code>-Datei) irgendwo in dem Pfad <code>/calibre-"
+#~ "library</code> sucht.\n"
 #~ "        CWA durchsucht automatisch das Verzeichnis, das du auf <code>/"
 #~ "calibre-library</code> in der docker-compose-Datei verbunden hast, um "
 #~ "eine existierende Calibre-\n"

--- a/cps/translations/el/LC_MESSAGES/messages.po
+++ b/cps/translations/el/LC_MESSAGES/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Στατιστικά"
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Χρήστης Διαχειριστής"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Όλα"
@@ -1023,7 +1023,7 @@ msgstr "δεν εγκαταστάθηκε"
 msgid "Execution permissions missing"
 msgstr "Λείπουν άδειες εκτέλεσης"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1070,7 +1070,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1228,7 +1228,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Διευκρινίστηκε μη έγκυρο ράφι"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2048,7 +2048,7 @@ msgstr "Τρέχουσα έκδοση"
 msgid "Unread Books"
 msgstr "Βιβλία που δεν Διαβάστηκαν"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2059,7 +2059,7 @@ msgstr "Συγγραφείς"
 msgid "Books ordered by Author"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά Συγγραφέα"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Εκδότες"
@@ -2068,7 +2068,7 @@ msgstr "Εκδότες"
 msgid "Books ordered by publisher"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά εκδότη"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Κατηγορίες"
@@ -2090,7 +2090,7 @@ msgstr "Σειρές"
 msgid "Books ordered by series"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά σειρές"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2100,7 +2100,7 @@ msgstr "Γλώσσες"
 msgid "Books ordered by Languages"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά Γλώσσες"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Αξιολογήσεις"
@@ -2117,7 +2117,7 @@ msgstr "Μορφές αρχείου"
 msgid "Books ordered by file formats"
 msgstr "Τα βιβλία ταξινομήθηκαν ανά μορφές αρχείου"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Ράφια"
@@ -2154,7 +2154,7 @@ msgstr ""
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2178,7 +2178,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Βιβλία"
 
@@ -2212,7 +2212,7 @@ msgstr "Προβολή διαβασμένων και αδιάβαστων"
 msgid "Show unread"
 msgstr "Προβολή αδιάβαστων"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Ανακάλυψε"
 
@@ -2260,7 +2260,7 @@ msgstr "Αρχειοθετημένα Βιβλία"
 msgid "Show Archived Books"
 msgstr "Προβολή αρχειοθετημένων βιβλίων"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2276,7 +2276,7 @@ msgstr "Λίστα Βιβλίων"
 msgid "Show Books List"
 msgstr "Προβολή Λίστας Βιβλίων"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2409,8 +2409,8 @@ msgstr "Δημιούργησε ένα Ράφι"
 #, fuzzy
 msgid "Sorry you are not allowed to edit this shelf"
 msgstr ""
-"Συγγνώμη αλλά δεν σου επιτρέπεται η αφαίρεση ενός βιβλίου από αυτό το ράφι: "
-"%(sname)s"
+"Συγγνώμη αλλά δεν σου επιτρέπεται η αφαίρεση ενός βιβλίου από αυτό το ράφι: %"
+"(sname)s"
 
 #: cps/shelf.py:374
 msgid "Edit a shelf"
@@ -2985,13 +2985,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Διαγραφή"
 
@@ -3147,8 +3147,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Συγχώνευση"
 
@@ -3276,7 +3277,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3712,225 +3714,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Σχετικά"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Αρχειοθετήθηκε"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3953,1326 +4072,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Κατέβασμα"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Επεξεργασία"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "Διεύθυνση E-mail"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Ενεργοποίηση συγχρονισμού Kobo"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Κρυπτογράφηση"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Αναγνωριστικά"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Γλώσσα"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Κωδικός"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Θύρα"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Πρόοδος"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Αξιολόγηση"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5281,634 +5390,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Κατάσταση"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Ετικέτες"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Εργασία"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Εργασίες"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Χρήστης"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Όνομα Χρήστη"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9122,10 +9221,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/es/LC_MESSAGES/messages.po
+++ b/cps/translations/es/LC_MESSAGES/messages.po
@@ -25,7 +25,7 @@ msgstr ""
 "X-Generator: Poedit 3.8\n"
 
 # "Last-Translator: victorhck <victorhck@mailbox.org>\n"
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Estadísticas"
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Editar usuarios"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Todo"
@@ -1079,7 +1079,7 @@ msgstr "no instalado"
 msgid "Execution permissions missing"
 msgstr "Faltan permisos de ejecución"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr "Volver a editar metadatos"
 
@@ -1125,7 +1125,7 @@ msgstr "No se pudo generar la vista previa del eReader."
 msgid "Could not load a source image to preview."
 msgstr "No se pudo cargar una imagen de origen para previsualizar."
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr "No se pudo guardar la portada."
 
@@ -1294,7 +1294,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Selección de libro no válida."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr "Libro no encontrado."
 
@@ -2134,7 +2134,7 @@ msgstr "Libros que se están leyendo actualmente"
 msgid "Unread Books"
 msgstr "Libros No Leídos"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2145,7 +2145,7 @@ msgstr "Autores"
 msgid "Books ordered by Author"
 msgstr "Libros ordenados por autor"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Editores"
@@ -2154,7 +2154,7 @@ msgstr "Editores"
 msgid "Books ordered by publisher"
 msgstr "Libros ordenados por editor"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Categorías"
@@ -2176,7 +2176,7 @@ msgstr "Series"
 msgid "Books ordered by series"
 msgstr "Libros ordenados por series"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2186,7 +2186,7 @@ msgstr "Idiomas"
 msgid "Books ordered by Languages"
 msgstr "Libros ordenados por Idioma"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Valoraciones"
@@ -2203,7 +2203,7 @@ msgstr "Formatos de archivo"
 msgid "Books ordered by file formats"
 msgstr "Libros ordenados por formato de archivo"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Estanterías"
@@ -2237,7 +2237,7 @@ msgstr "{} Estrellas"
 msgid "Search"
 msgstr "Buscar"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2264,7 +2264,7 @@ msgstr ""
 "ejecutar comprobaciones rápidas de duplicados tras importaciones y cambios "
 "de metadatos. "
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Libros"
 
@@ -2297,7 +2297,7 @@ msgstr "Mostrar Leídos y No Leídos"
 msgid "Show unread"
 msgstr "Mostrar No Leídos"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Descubrir"
 
@@ -2337,7 +2337,7 @@ msgstr "Libros Archivados"
 msgid "Show Archived Books"
 msgstr "Mostrar Libros Archivados"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr "Favoritos"
 
@@ -2353,7 +2353,7 @@ msgstr "Lista de Libros"
 msgid "Show Books List"
 msgstr "Mostrar Lista de Libros"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "Duplicados"
 
@@ -3065,13 +3065,13 @@ msgstr "Crea tu cuenta"
 msgid "Dark theme"
 msgstr "Tema oscuro"
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Borrar"
 
@@ -3230,8 +3230,9 @@ msgstr "Marcar como leído"
 msgid "Mark unread"
 msgstr "Marcar como no leído"
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Fusionar"
 
@@ -3360,7 +3361,8 @@ msgstr "Guardar perfil"
 msgid "Saved."
 msgstr "Guardado."
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr "Guardando…"
 
@@ -3807,31 +3809,153 @@ msgstr "No se pudo guardar la barra lateral. Inténtalo de nuevo."
 msgid "Refresh library"
 msgstr "Actualizar biblioteca"
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr "<"
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr "="
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ">"
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+"Se necesita un escaneo completo único de duplicados. Ejecútalo desde la "
+"configuración de CWA y vuelve aquí."
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr "Fecha de adición"
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr "¿Borrar «{name}»? Se quitará de {count} libro, que se conservará."
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr "¿Borrar «{name}»? Se quitará de {count} libros, que se conservarán."
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr "Descartar mensaje de apoyo a Ko-fi"
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr "Descartar aviso de ayuda"
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr "Abrir Ko-fi →"
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr "Fecha de publicación"
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr "¡Apóyanos en Ko-fi!"
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+"Estos abren las páginas de configuración completas. Los cambios allí se "
+"aplican a todo el servidor."
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr "«{name}» ya existe en {count} libro. ¿Fusionar esta etiqueta con ella?"
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+"«{name}» ya existe en {count} libros. ¿Fusionar esta etiqueta con ella?"
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr "empieza por"
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr "contiene"
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr "no contiene"
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr "termina en"
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr "en los últimos N días"
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr "no es"
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr "es"
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr "no en los últimos N días"
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr "en o después de"
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr "en o antes de"
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr "≤"
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr "≥"
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr "(cambiar portada)"
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr "2:3 (portada de editorial: sin relleno para portadas típicas)"
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr "3:4 (genérico)"
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 "Ya hay un escaneo de duplicados en curso. Esta lista se actualizará cuando "
 "termine."
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr "Una selección aleatoria de tu biblioteca"
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
@@ -3839,173 +3963,173 @@ msgstr ""
 "Se necesita un escaneo completo único de duplicados. Usa «Buscar duplicados» "
 "arriba para ejecutarlo."
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr "Claves de API"
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Acerca de"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr "Configuración de la cuenta"
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Cuenta: {name}"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr "Añadir identificador"
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr "Añadir a favoritos"
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr "Grupo de administración"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr "Búsqueda avanzada"
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr "Todas las estanterías"
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr "Permitir inicio de sesión remoto (enlace mágico)"
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr "Grupos permitidos (separados por comas)"
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "Cualquiera"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr "Cualquier formato"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr "Cualquier idioma"
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr "Cualquier serie"
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr "Cualquier etiqueta"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr "Aplicar seleccionados"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Aplicar a todos los seleccionados (solo cambian los campos rellenados; "
 "sustituye los valores existentes):"
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr "Aplicando…"
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "Archivar"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Archivado"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr "Preguntar en Discord"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr "Autenticación"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr "Autenticación y seguridad"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr "Autor A-Z"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr "Autor Z-A"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr "Autorizado; iniciando sesión…"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr "URL de autorización"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr "Crear usuarios automáticamente"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr "Crear usuarios automáticamente al iniciar sesión por primera vez"
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr "Volver a la biblioteca"
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr "Volver a la vista clásica"
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr "DN base"
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr "Configuración básica"
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr "Predeterminado del libro"
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr "Densidad de libros"
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Libro {number}"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr "Libros por página"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
@@ -4014,27 +4138,27 @@ msgstr ""
 "del dispositivo en su siguiente sincronización. Siguen estando en tu "
 "biblioteca aquí."
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr "Proveedores integrados (déjalo en blanco para desactivar):"
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr "Acciones masivas"
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr "Ruta del certificado CA"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr "Configuración de CWA (ingesta/conversión)"
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr "Puede subir libros"
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -4057,456 +4181,446 @@ msgstr "Puede subir libros"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr "Cancelar cambio de nombre"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr "Cancelar edición del título"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Cancelar {task}"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr "Ruta del archivo de certificado"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr "Ruta del certificado"
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr "Cambiar portada"
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr "Comprobando…"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr "Elegir una portada"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr "Elegir una imagen de portada para subir"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr "Elegir una imagen…"
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr "Elegir campos"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr "Elige tu tema"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr "Quitar valor predeterminado"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr "Quitar selección"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr "ID de cliente"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr "Secreto de cliente"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr "Secreto de cliente (déjalo en blanco para mantenerlo)"
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr "Cerrar lector"
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr "Columnas"
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr "Cómoda"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr "Compacta"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr "Configurado"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr "Confirmar borrado de la etiqueta {name}"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr "Confirmar nueva contraseña"
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Convertir"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr "Convertir antes de enviar"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr "Convertir desde"
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr "Copiar enlace"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr "No se pudo crear la estantería."
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr "No se pudo crear la estantería."
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr "No se pudo borrar la estantería."
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr "No se pudo borrar la etiqueta"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr "No se pudieron cargar los candidatos."
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr "No se pudieron cargar los duplicados."
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr "No se pudieron cargar los subrayados."
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr "No se pudieron cargar las estadísticas."
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr "No se pudieron cargar las tareas."
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr "No se pudo cargar este archivo de texto."
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr "No se pudieron cargar los usuarios."
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr "No se pudo leer este archivo de cómic."
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr "No se pudieron recargar los metadatos"
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr "No se pudo renombrar la estantería."
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr "No se pudo restablecer la contraseña."
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr "No se pudo guardar el orden."
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr "No se pudo guardar la configuración del lector."
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr "No se pudo guardar el filtro de biblioteca predeterminado."
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr "No se pudo guardar la estantería."
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr "No se pudo guardar el título."
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr "No se pudo guardar tu posición de lectura."
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr "No se pudo iniciar el escaneo de duplicados."
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr "No se pudo actualizar la estantería."
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr "No se pudo actualizar la configuración de tu cuenta."
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "No se pudo iniciar un enlace mágico. Inténtalo de nuevo."
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr "Portada bloqueada"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr "Portada no accesible"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr "Portada actualizada a partir del resultado seleccionado."
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr "Crear"
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr "Crear cuenta"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr "Crear una cuenta"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr "Error al crear."
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr "Crear estantería y añadir libro"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr "Crear usuario"
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr "{name} creado."
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr "Creando…"
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr "Actual"
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr "Portada actual"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr "Contraseña actual"
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr "Leyendo actualmente"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr "Color de borde personalizado"
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr "Columnas personalizadas"
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr "Ruta de la base de datos y la biblioteca"
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr "Fecha de añadido"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr "Predeterminada (Sans-Serif del sistema)"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr "Idioma predeterminado del libro"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr "Idioma predeterminado de la interfaz"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr "Filtro de biblioteca predeterminado eliminado."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr "Filtro de biblioteca predeterminado guardado."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr "Roles predeterminados para nuevos usuarios de OAuth:"
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 "Los valores predeterminados están en Administración → Configuración → "
 "Sincronización con Kobo."
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr "Borrar libros"
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr "Error al borrar."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "¿Borrar la estantería «{name}»? Esta acción no se puede deshacer."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr "Borrar etiqueta {name}"
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr "¿Borrar esta estantería inteligente? Tus libros no se ven afectados."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "¿Borrar al usuario «{name}»? También se borran sus estanterías y datos de "
 "lectura."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "Borrar {name}"
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr "¿Borrar «{name}»? Se quitará de {count} libro, que se conservará."
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr "¿Borrar «{name}»? Se quitará de {count} libros, que se conservarán."
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr "Etiqueta {name} borrada"
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "{name} borrado."
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr "Densa"
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Descripción"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr "Desactivar el inicio de sesión estándar con contraseña"
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr "Selección de Descubrir actualizada."
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr "Descubrir - Selección aleatoria"
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr "Descartar"
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr "Descartar este grupo"
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr "Documentación"
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr "Reordenación terminada"
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Descargar"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr "Suelta los archivos aquí, o haz clic para elegirlos"
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr "Libros duplicados"
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr "Configuración de detección de duplicados"
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
@@ -4514,284 +4628,284 @@ msgstr ""
 "Escaneo de duplicados iniciado. Se ejecuta en segundo plano; esta lista se "
 "actualizará cuando termine."
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr "Vista previa en eReader"
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr "Cada tipo (isbn, amazon, google, doi…) puede aparecer una vez."
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr "Desenfoque de borde: borde bokeh suave"
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Espejo de borde: extiende la ilustración (recomendado)"
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Editar"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr "Editar estanterías públicas"
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr "Editar estantería inteligente"
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr "Editar título de {title}"
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr "Servidor de correo (SMTP)"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr "Correo electrónico (opcional)"
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr "Claim de correo electrónico"
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr "Enviarme un restablecimiento por correo"
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr "Configuración de correo guardada."
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Activar la sincronización con Kobo"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Encriptado"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr "Caduca en"
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr "Exponer solo las estanterías seleccionadas a través de OPDS"
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr "Error al cargar las estanterías."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr "Error al cargar."
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr "Favorito"
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr "Marcado como favorito"
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr "Obtener"
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr "Obtener metadatos de la web"
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr "Archivos"
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 "Los archivos se ponen en cola para el proceso de ingesta de la biblioteca y "
 "aparecen una vez importados."
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr "Estilo de relleno"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Filtrar {items}"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Filtrar {items}…"
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr "Familia tipográfica"
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr "Tamaño de fuente"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr "¿Olvidaste tu contraseña?"
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr "Formato en cola; aparecerá una vez procesado."
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr "Formatos"
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr "Formatos — excluir"
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr "Formatos — incluir"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr "Dirección de origen"
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr "Tabla completa de usuarios y restricciones"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr "Generar un enlace nuevo"
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr "Ponle un nombre a tu estantería inteligente."
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr "Ir a tu biblioteca"
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr "Degradado: transición superior/inferior ajustada a la paleta"
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr "Claim de grupo"
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr "Campo de miembros del grupo"
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr "Nombre del grupo"
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr "Filtro de objeto de grupo"
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr "Se permite HTML y se sanea al mostrarlo."
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr "Nombre de la cabecera"
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr "Ayuda y soporte"
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr "Menú de ayuda"
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr "Oculto"
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Ocultar"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr "Ocultar la sección Descubrir"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr "Ocultar campos"
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr "Ocultar contraseña"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr "Subrayado"
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr "Subrayados"
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr "Popular"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr "Popular — Más descargados"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr "Icono"
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr "Tipo de identificador"
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr "Valor del identificador"
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identificadores"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr "Importado como"
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr "En tu libro"
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
@@ -4799,338 +4913,338 @@ msgstr ""
 "La lectura en el navegador admite EPUB por ahora. Usa la descarga o el "
 "lector clásico para otros formatos."
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr "Emisor / URL base"
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr "Puede que se haya movido, o que siga estando en la interfaz clásica."
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr "Progreso de KOReader"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr "Ruta del archivo de clave"
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr "Ruta de la clave"
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264×1680)"
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr "Sincronización con Kobo activada"
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Idioma"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr "Idiomas — incluir"
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "Última modificación"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr "Última sincronización"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr "Configuración de la biblioteca"
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr "Altura de línea"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr "Cargar más"
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr "Cargando"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr "Cargando nueva selección de Descubrir."
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr "Cargando…"
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr "Bloquear portada"
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr "Texto del botón de inicio de sesión"
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr "Método de inicio de sesión"
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr "Iniciar sesión con"
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr "Registros"
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr "Se ve bien"
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr "Baja resolución"
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr "Enlace mágico"
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr "Código QR del enlace mágico"
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr "Hacer privada"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr "Hacer pública"
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr "Hacer esta mi vista de biblioteca predeterminada"
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr "Gestionar el rol de administrador desde el grupo de OAuth"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr "Gestionar estanterías"
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "Marcar como leído"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "Marcar como no leído"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr "Coincidencia"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr "Máx"
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr "Máximo de autores mostrados"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr "Valoración máxima"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr "Filtro de usuarios miembros"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr "Fusionar en {name}"
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr "Fusionado en {name}"
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr "URL de metadatos (autodescubrimiento OIDC)"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr "Mín"
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr "Valoración mínima"
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 "Más opciones de portada (proveedores de búsqueda, vista previa en eReader)"
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr "Más configuración del servidor"
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr "Bajar"
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr "Subir"
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr "Mi cuenta"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr "Nombre"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr "¿Necesitas informar de un problema? Prueba la nueva"
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr "Nuevo"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr "Contraseña nueva"
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr "Nombre de la estantería nueva"
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr "Nombre de la estantería nueva…"
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr "Nueva estantería…"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr "Nueva estantería inteligente"
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr "Usuario nuevo"
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr "Más recientes"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr "Publicación más reciente"
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr "Página siguiente"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr "Ningún libro coincide con esta estantería inteligente por ahora."
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr "Ningún libro coincide con esos criterios."
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr "Aún no se han encontrado candidatos. Prueba otra búsqueda o actualiza."
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr "No se ha encontrado contenido."
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr "No se han encontrado grupos de duplicados."
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr "Sin etiquetas excluidas"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Aún no hay subrayados. Subraya mientras lees, o impórtalos desde un "
 "dispositivo Kobo."
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "No hay {items} que coincidan con «{query}»."
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr "No se han encontrado páginas en este cómic."
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr "Aún no hay estanterías; crea una debajo."
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 "Aún no hay estanterías. Crea una arriba para empezar a coleccionar libros."
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr "Ninguna fuente necesita una clave."
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr "No hay tareas en ejecución."
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Aún no hay {items}."
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr "No configurado"
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr "Sin definir"
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr "Más antiguos"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr "Publicación más antigua"
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
@@ -5138,56 +5252,56 @@ msgstr ""
 "En otro dispositivo donde ya hayas iniciado sesión, escanea este código o "
 "abre el enlace de abajo para autorizar este dispositivo."
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr "Abrir cuenta"
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr "Abrir lector clásico"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr "Abrir navegación"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr "Abrir lector"
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr "Abrir la interfaz clásica"
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr "Abre el enlace de abajo en tu dispositivo con sesión iniciada."
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr "Servidor OpenLDAP"
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr "Se abre en la vista clásica"
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr "Lector de PDF"
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr "Márgenes de página"
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr "Tema de la página"
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Página {number}"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
@@ -5195,17 +5309,17 @@ msgstr ""
 "Las páginas marcadas abajo se abren en la vista clásica. Los cambios allí se "
 "aplican a todo el servidor."
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Contraseña"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr "Contraseña (déjala en blanco para mantenerla)"
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5213,160 +5327,160 @@ msgstr ""
 "Elige una portada de cualquier fuente compatible, pega una URL, sube un "
 "archivo o usa la portada incrustada en el propio libro."
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 "Elemento tomado: {label}. Arrastra para reordenar, suelta para colocarlo."
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Puerto"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr "Preparando tu enlace mágico…"
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr "Página anterior"
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Progreso"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr "Pública"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr "Publicado después de"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr "Publicado antes de"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr "Libros aleatorios mostrados"
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Valoración"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr "Valoración (estrellas)"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr "Estado de lectura"
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr "Filtro de estado de lectura"
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr "Configuración del lector guardada."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr "Apariencia de lectura"
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr "Destinatario(s)"
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr "Host de redirección (URL completa)"
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr "Registrando…"
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr "Recargar"
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr "Recargar metadatos desde el disco"
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr "Recargando…"
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr "Recordarme"
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr "Quitar de favoritos"
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr "Quitar de la estantería"
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr "Quitar subrayado"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr "Quitar identificador"
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr "Quitar regla"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr "Renombrar"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr "Reordenar"
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr "¿Sustituir la portada por esta?"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr "¿Sustituir portada?"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr "Informar de un problema en Discord"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr "Informar de un problema en GitHub"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr "Requerir pertenencia a un grupo"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Restablecer contraseña de {name}"
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5375,31 +5489,31 @@ msgstr ""
 "¿Restablecer la contraseña de {name}? Su contraseña actual dejará de "
 "funcionar y se le enviará una nueva por correo."
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr "Inicio de sesión con cabecera de proxy inverso"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr "Filas por carga"
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr "Tiempo de ejecución"
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr "Servidor SMTP"
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5408,341 +5522,341 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Guardar"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr "Guardar configuración de correo"
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr "Guardar nombre"
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr "Guardar configuración de seguridad"
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr "Guardar configuración"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Guardado. Reinicia el servidor para que los cambios de inicio de sesión "
 "surtan efecto."
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr "Buscar duplicados"
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr "Tareas programadas"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr "Ámbitos (scopes)"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr "Buscar título, autor…"
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr "Buscando en todas las fuentes…"
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr "Buscando…"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr "Configuración de seguridad guardada."
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr "Comprueba cómo se ve cada portada con relleno para tu dispositivo"
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Seleccionar"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr "Seleccionar varios"
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "Enviar"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr "Error al enviar."
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr "Enviar a eReader"
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr "Correo de envío a eReader"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr "Enviando…"
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr "Índice de la serie"
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr "Vista de series"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr "Series — incluir"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr "Servir por HTTPS"
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr "SSL / HTTPS del servidor"
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr "Anuncio del servidor (visible para todos los usuarios)"
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr "Host del servidor"
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr "Cuenta de servicio (DN)"
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr "Contraseña de servicio"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr "Contraseña de servicio (déjala en blanco para mantenerla)"
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 "Define una URL de metadatos para autocompletar los endpoints de abajo, o "
 "introdúcelos manualmente."
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr "Configuración guardada."
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr "Nombre de la estantería"
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr "Estantería no encontrada."
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr "Mostrar la sección Descubrir"
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr "Mostrar los botones «Leer ahora» y «Editar»"
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr "Mostrar vista de tabla"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr "Mostrar las {count} etiquetas"
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Mostrar todos los {items}"
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr "Mostrar libros en el idioma"
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr "Mostrar vistas previas en eReader en cada candidato"
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr "Mostrar menos etiquetas"
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr "Mostrar libros ocultos"
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr "Mostrar contraseña"
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr "Aleatorizar selección"
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr "Iniciar sesión con un enlace mágico"
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr "Cerrar sesión"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr "Iniciando sesión…"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr "Título del sitio"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr "Estantería inteligente no encontrada."
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr "Estanterías inteligentes"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr "Sólido: color medio de la portada"
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr "Sólido: color personalizado"
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr "Sólido: color más frecuente de la portada"
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr "Algunas fuentes necesitan una clave para obtener mejores portadas"
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr "Algo salió mal"
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr "Algo salió mal. Inténtalo de nuevo."
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr "Orden de clasificación"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr "Detalles de la fuente"
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr "Empezado a leer"
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr "Iniciando escaneo…"
 
 # "Last-Translator: victorhck <victorhck@mailbox.org>\n"
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr "Panel de estadísticas"
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Estado"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "Apoyar en Ko-fi →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr "Sincronizar solo mis estanterías seleccionadas"
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr "Sincronizar solo las estanterías seleccionadas con Kobo"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr "Vista de tabla"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr "Etiqueta"
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr "Etiquetas — excluir"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr "Etiquetas — incluir"
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr "Relación de aspecto objetivo"
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Tarea"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Tareas"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr "Detalles técnicos"
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr "Esa URL no es una imagen utilizable."
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr "Este formato se abre en el lector a pantalla completa."
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 "Este enlace mágico ha caducado. Genera uno nuevo para volver a intentarlo."
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr "Esta página no existe aquí."
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
@@ -5750,78 +5864,78 @@ msgstr ""
 "Esta página tuvo un error y no se pudo mostrar. Tu biblioteca está bien; "
 "normalmente basta con recargar."
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 "Esta estantería está vacía. Añade libros desde la página de cualquier libro."
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr "Título A-Z"
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr "Título Z-A"
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr "Título, autor o ISBN"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr "URL del token"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr "Mejor valorados"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr "Confiar en la cabecera de autenticación"
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr "Configuración de interfaz / visualización"
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "Desarchivar"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr "Mostrar de nuevo"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr "Desbloquea la portada de arriba para aplicar una nueva."
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr "Desbloquea la portada para cambiarla"
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr "Sin título"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr "Error al actualizar."
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr "Subir como portada"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr "Subir libros"
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 "La subida de archivos no está disponible para tu cuenta en este servidor."
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5829,70 +5943,70 @@ msgstr ""
 "Úsalas para conectar lectores OPDS o la sincronización de KOReader sin tu "
 "contraseña principal."
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr "Usar esta portada"
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Usuario"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr "Administración de usuarios"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr "Filtro de objeto de usuario"
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr "URL de información de usuario"
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr "Claim de nombre de usuario"
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr "Versiones"
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Vista"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr "Configuración de la vista"
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr "Visor"
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr "Esperando tu autorización…"
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 "Cuando está bloqueada, la obtención de metadatos no sobrescribirá esta "
 "portada."
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr "Cuándo se sincronizó por primera vez el progreso de lectura"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
@@ -5902,159 +6016,148 @@ msgstr ""
 "marcar esta estantería no hace nada por sí solo. Cambia tu cuenta a "
 "sincronización solo por estanterías para que surta efecto."
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr "Tu biblioteca"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr "Tu navegador no puede reproducir este formato de audio."
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr "Tu biblioteca digital personal"
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Se muestra tu dirección de eReader guardada; cámbiala solo para este envío."
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr "todas las reglas"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr "cualquier regla"
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr "libros"
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr "libros coinciden"
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr "copias"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr "eReader"
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr "p. ej. Ciencia ficción sin leer"
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr "Asunto del correo al eReader"
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr "compartido"
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr "hasta"
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr "tipo (isbn, amazon, doi…)"
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr "valor"
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr "tú"
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} libro"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} libros"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} archivo en cola para importar"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} archivo rechazado"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} archivos en cola para importar"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} archivos rechazados"
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} resultado"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} resultados"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "{count} resultados para «{query}»"
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr "{field} (separado por comas)"
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr "{n} encontrado(s)"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "{ok} de {total} fuentes respondieron"
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr "«{name}» ya existe en {count} libro. ¿Fusionar esta etiqueta con ella?"
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-"«{name}» ya existe en {count} libros. ¿Fusionar esta etiqueta con ella?"
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr "…o pega una URL de imagen"
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr "← Volver al libro"
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr "← Volver a iniciar sesión"
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr "← Biblioteca"
 
@@ -9427,10 +9530,6 @@ msgstr ""
 msgid "Tags/Genres"
 msgstr "Etiquetas/Géneros"
 
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
-msgstr "Fecha de publicación"
-
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identificadores (ISBN, etc.)"
@@ -12581,80 +12680,6 @@ msgstr "Exponer las estanterías seleccionadas en OPDS"
 #: cps/templates/user_table.html:158
 msgid "Show Read/Unread Section"
 msgstr "Mostrar Selección Leidos/No Leidos"
-
-#~ msgid "<"
-#~ msgstr "<"
-
-#~ msgid "="
-#~ msgstr "="
-
-#~ msgid ">"
-#~ msgstr ">"
-
-#~ msgid ""
-#~ "A one-time full duplicate scan is needed. Run it from CWA settings, then "
-#~ "return here."
-#~ msgstr ""
-#~ "Se necesita un escaneo completo único de duplicados. Ejecútalo desde la "
-#~ "configuración de CWA y vuelve aquí."
-
-#~ msgid "Date Added"
-#~ msgstr "Fecha de adición"
-
-#~ msgid "Support us on Ko-fi!"
-#~ msgstr "¡Apóyanos en Ko-fi!"
-
-#~ msgid "Open Ko-fi →"
-#~ msgstr "Abrir Ko-fi →"
-
-#~ msgid "Dismiss help announcement"
-#~ msgstr "Descartar aviso de ayuda"
-
-#~ msgid "Dismiss Ko-fi support message"
-#~ msgstr "Descartar mensaje de apoyo a Ko-fi"
-
-#~ msgid ""
-#~ "These open the full configuration pages. Changes there apply to the whole "
-#~ "server."
-#~ msgstr ""
-#~ "Estos abren las páginas de configuración completas. Los cambios allí se "
-#~ "aplican a todo el servidor."
-
-#~ msgid "begins with"
-#~ msgstr "empieza por"
-
-#~ msgid "contains"
-#~ msgstr "contiene"
-
-#~ msgid "does not contain"
-#~ msgstr "no contiene"
-
-#~ msgid "ends with"
-#~ msgstr "termina en"
-
-#~ msgid "in the past N days"
-#~ msgstr "en los últimos N días"
-
-#~ msgid "is"
-#~ msgstr "es"
-
-#~ msgid "is not"
-#~ msgstr "no es"
-
-#~ msgid "not in the past N days"
-#~ msgstr "no en los últimos N días"
-
-#~ msgid "on or after"
-#~ msgstr "en o después de"
-
-#~ msgid "on or before"
-#~ msgstr "en o antes de"
-
-#~ msgid "≤"
-#~ msgstr "≤"
-
-#~ msgid "≥"
-#~ msgstr "≥"
 
 #~ msgid "Sync Kobo read progress to Hardcover (Requires API key per user)"
 #~ msgstr ""

--- a/cps/translations/fi/LC_MESSAGES/messages.po
+++ b/cps/translations/fi/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Tilastot"
 
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Pääkäyttäjä"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Kaikki"
@@ -994,7 +994,7 @@ msgstr "ei asennettu"
 msgid "Execution permissions missing"
 msgstr ""
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1199,7 +1199,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Virheellinen hylly valittu"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgstr "Nykyinen versio"
 msgid "Unread Books"
 msgstr "Lukemattomat kirjat"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2008,7 +2008,7 @@ msgstr "Kirjailijat"
 msgid "Books ordered by Author"
 msgstr "Kirjat kirjailijoittain"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Julkaisijat"
@@ -2017,7 +2017,7 @@ msgstr "Julkaisijat"
 msgid "Books ordered by publisher"
 msgstr "Kirjat julkaisijoittain"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Kategoriat"
@@ -2039,7 +2039,7 @@ msgstr "Sarjat"
 msgid "Books ordered by series"
 msgstr "Kirjat sarjoittain"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2050,7 +2050,7 @@ msgstr "Kielet"
 msgid "Books ordered by Languages"
 msgstr "Kirjat sarjoittain"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Arvostelut"
@@ -2069,7 +2069,7 @@ msgstr "Tiedotomuodot"
 msgid "Books ordered by file formats"
 msgstr "Kirjat sarjoittain"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr ""
@@ -2107,7 +2107,7 @@ msgstr ""
 msgid "Search"
 msgstr "Hae"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2131,7 +2131,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Kirjat"
 
@@ -2165,7 +2165,7 @@ msgstr "Näytä luetut ja lukemattomat"
 msgid "Show unread"
 msgstr "Näyt lukemattomat"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Löydä"
 
@@ -2213,7 +2213,7 @@ msgstr ""
 msgid "Show Archived Books"
 msgstr "Näytä viimeisimmät kirjat"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2936,13 +2936,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Poista"
 
@@ -3098,8 +3098,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr ""
 
@@ -3227,7 +3228,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3663,225 +3665,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Tietoja"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3904,1326 +4023,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Kuvaus"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Lataa"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Muokkaa"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "Sähköposti"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr ""
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Kieli"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Salasana"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Portti"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Edistyminen"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Arvostelu"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5232,634 +5341,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr ""
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Tila"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Tunnisteet"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Tehtävä"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Tehtävät"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Käyttäjä"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Lempinimi"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9040,10 +9139,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -37,7 +37,7 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.8\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Statistiques"
 
@@ -172,7 +172,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Éditer les utilisateurs"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Tout"
@@ -1092,7 +1092,7 @@ msgstr "non installé"
 msgid "Execution permissions missing"
 msgstr "Les permissions d'exécutions manquantes"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr "Retour à l’édition des métadonnées"
 
@@ -1140,7 +1140,7 @@ msgstr "Impossible de trouver le répertoire spécifié"
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr "L’enregistrement de la couverture a échoué."
 
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Sélection de livre invalide."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr "Livre introuvable."
 
@@ -2157,7 +2157,7 @@ msgstr "Version actuelle"
 msgid "Unread Books"
 msgstr "Livres non-lus"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2168,7 +2168,7 @@ msgstr "Auteurs"
 msgid "Books ordered by Author"
 msgstr "Livres classés par auteur"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Éditeurs"
@@ -2177,7 +2177,7 @@ msgstr "Éditeurs"
 msgid "Books ordered by publisher"
 msgstr "Livres classés par éditeur"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Catégories"
@@ -2199,7 +2199,7 @@ msgstr "Séries"
 msgid "Books ordered by series"
 msgstr "Livres classés par série"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2209,7 +2209,7 @@ msgstr "Langues"
 msgid "Books ordered by Languages"
 msgstr "Livres classés par langue"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Évaluations"
@@ -2226,7 +2226,7 @@ msgstr "Formats de fichier"
 msgid "Books ordered by file formats"
 msgstr "Livres classés par formats de fichiers"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Étagères"
@@ -2262,7 +2262,7 @@ msgstr "{} Étoiles"
 msgid "Search"
 msgstr "Chercher"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2286,7 +2286,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Livres"
 
@@ -2319,7 +2319,7 @@ msgstr "Montrer lus et non-lus"
 msgid "Show unread"
 msgstr "Afficher non-lus"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Découvrir"
 
@@ -2359,7 +2359,7 @@ msgstr "Livres archivés"
 msgid "Show Archived Books"
 msgstr "Afficher les livres archivés"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr "Favoris"
 
@@ -2375,7 +2375,7 @@ msgstr "Liste des livres"
 msgid "Show Books List"
 msgstr "Montrer la liste des livres"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "Doubles"
 
@@ -3093,13 +3093,13 @@ msgstr "Créez votre compte"
 msgid "Dark theme"
 msgstr "Thème sombre"
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -3259,8 +3259,9 @@ msgstr "Marquer comme lu"
 msgid "Mark unread"
 msgstr "Marquer comme non lu"
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Fusionner"
 
@@ -3390,7 +3391,8 @@ msgstr "Sauvegarder le profil"
 msgid "Saved."
 msgstr "Sauvegardé."
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr "Enregistrement…"
 
@@ -3838,32 +3840,160 @@ msgstr "Impossible d’enregistrer la barre latérale. Veuillez réessayer."
 msgid "Refresh library"
 msgstr "Actualiser la bibliothèque"
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr "<"
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr "="
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ">"
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+"Une analyse complète des doublons est nécessaire, une seule fois. Lancez-la "
+"depuis les paramètres CWA, puis revenez ici."
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr "Date d’ajout"
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+"Supprimer « {name} » ? Elle sera retirée de {count} livre, qui sera conservé."
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+"Supprimer « {name} » ? Elle sera retirée de {count} livres, qui seront "
+"conservés."
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr "Masquer le message de soutien Ko-fi"
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr "Masquer l’annonce d’aide"
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr "Ouvrir Ko-fi →"
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr "Date de publication"
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr "Soutenez-nous sur Ko-fi !"
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+"Ces liens ouvrent les pages de configuration complètes. Les modifications "
+"qui y sont faites s’appliquent à tout le serveur."
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+"« {name} » existe déjà sur {count} livre. Fusionner cette étiquette avec "
+"celle-ci ?"
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+"« {name} » existe déjà sur {count} livres. Fusionner cette étiquette avec "
+"celle-ci ?"
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr "commence par"
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr "contient"
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr "ne contient pas"
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr "se termine par"
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr "au cours des N derniers jours"
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr "n’est pas"
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr "est"
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr "pas au cours des N derniers jours"
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr "le ou après le"
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr "le ou avant le"
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr "≤"
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr "≥"
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr "(remplacer la couverture)"
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 "2:3 (couverture d’éditeur — aucune marge pour les couvertures courantes)"
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr "3:4 (générique)"
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 "Une recherche de doublons est déjà en cours. Cette liste se mettra à jour "
 "une fois terminée."
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr "Une sélection aléatoire de votre bibliothèque"
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
@@ -3871,173 +4001,173 @@ msgstr ""
 "Une analyse complète des doublons est nécessaire une première fois. Utilisez "
 "« Rechercher les doublons » ci-dessus pour la lancer."
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr "Clés API"
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "À propos"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr "Paramètres du compte"
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Compte : {name}"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr "Ajouter un identifiant"
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr "Ajouter aux favoris"
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr "Groupe administrateur"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr "Avancé"
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr "Recherche avancée"
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr "Toutes les étagères"
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr "Autoriser la connexion à distance (lien magique)"
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr "Groupes autorisés (séparés par des virgules)"
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "Tous"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr "Tous les formats"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr "Toutes les langues"
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr "Toutes les séries"
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr "Toutes les étiquettes"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr "Appliquer la sélection"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Appliquer à toute la sélection (seuls les champs remplis sont modifiés ; les "
 "valeurs existantes sont remplacées) :"
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr "Application…"
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "Archiver"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Archivé"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr "Poser une question sur Discord"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr "Authentification"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr "Authentification et sécurité"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr "Auteur A–Z"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr "Auteur Z–A"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr "Autorisé — connexion en cours…"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr "URL d’autorisation"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr "Créer les utilisateurs automatiquement"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr "Créer les utilisateurs automatiquement à la première connexion"
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr "Retour à la bibliothèque"
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr "Revenir à l’affichage classique"
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr "DN de base"
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr "Configuration de base"
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr "Valeur par défaut du livre"
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr "Densité des livres"
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Livre {number}"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr "Livres par page"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
@@ -4046,27 +4176,27 @@ msgstr ""
 "alors retirés de l’appareil lors de sa prochaine synchronisation. Ils "
 "restent dans votre bibliothèque ici."
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr "Sources intégrées (laisser vide pour désactiver) :"
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr "Actions groupées"
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr "Chemin du certificat d’autorité"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr "Paramètres CWA (import/conversion)"
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr "Peut téléverser des livres"
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -4089,461 +4219,448 @@ msgstr "Peut téléverser des livres"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr "Annuler le renommage"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr "Annuler la modification du titre"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Annuler {task}"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr "Chemin du fichier de certificat"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr "Chemin du certificat"
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr "Changer la couverture"
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr "Vérification…"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr "Choisir une couverture"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr "Choisir une image de couverture à téléverser"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr "Choisir une image…"
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr "Choisir les champs"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr "Choisir votre thème"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr "Effacer la valeur par défaut"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr "Effacer la sélection"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr "Identifiant client"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr "Secret client"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr "Secret client (laisser vide pour conserver)"
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr "Fermer le lecteur"
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr "Colonnes"
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr "Confortable"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr "Compact"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr "Configuré"
 
 # #973 — consolidating tags from the Tag view (merge on rename collision, delete).
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr "Confirmer la suppression de l’étiquette {name}"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr "Confirmer le nouveau mot de passe"
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Convertir"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr "Convertir avant l’envoi"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr "Convertir depuis"
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr "Copié dans le presse-papiers"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr "Copier le lien"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr "Impossible de créer l’étagère."
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr "Impossible de créer l’étagère."
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr "Impossible de supprimer l’étagère."
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr "Impossible de supprimer l’étiquette"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr "Impossible de charger les propositions."
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr "Impossible de charger les doublons."
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr "Impossible de charger les surlignages."
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr "Impossible de charger les statistiques."
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr "Impossible de charger les tâches."
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr "Impossible de charger ce fichier texte."
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr "Impossible de charger les utilisateurs."
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr "Impossible de lire cette archive de bande dessinée."
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr "Impossible de recharger les métadonnées"
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr "Impossible de renommer l’étagère."
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr "Impossible de réinitialiser le mot de passe."
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr "Impossible d’enregistrer l’ordre."
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr "Impossible d’enregistrer les paramètres de lecture."
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr "Impossible d’enregistrer le filtre de bibliothèque par défaut."
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr "Impossible d’enregistrer l’étagère."
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr "Impossible d’enregistrer le titre."
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr "Impossible d’enregistrer votre position de lecture."
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr "Impossible de lancer la recherche de doublons."
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr "Impossible de mettre à jour l’étagère."
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr "Impossible de mettre à jour ce paramètre de votre compte."
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "Impossible de créer un lien magique. Veuillez réessayer."
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr "Couverture verrouillée"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr "Couverture inaccessible"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr "Couverture mise à jour à partir du résultat sélectionné."
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr "Créer"
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr "Créer un compte"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr "Créer un compte"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr "Échec de la création."
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr "Créer l’étagère et y ajouter le livre"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr "Créer un utilisateur"
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr "{name} a été créé."
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr "Création…"
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr "Rogner pour remplir — sans bordure, rogne les bords"
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr "Actuelle"
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr "Couverture actuelle"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr "Mot de passe actuel"
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr "Lecture en cours"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr "Couleur de bordure personnalisée"
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr "Colonnes personnalisées"
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr "Chemin de la base de données et de la bibliothèque"
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr "Date d'ajout"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr "Par défaut (police sans empattement du système)"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr "Langue par défaut des livres"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr "Langue par défaut de l’interface"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr "Filtre de bibliothèque par défaut effacé."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr "Filtre de bibliothèque par défaut enregistré."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr "Rôles par défaut des nouveaux utilisateurs OAuth :"
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 "Les valeurs par défaut se trouvent dans Administration → Configuration → "
 "Synchronisation Kobo."
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr "Supprimer des livres"
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr "Échec de la suppression."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "Supprimer l’étagère « {name} » ? Cette action est irréversible."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr "Supprimer l’étiquette {name}"
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 "Supprimer cette étagère intelligente ? Vos livres ne sont pas affectés."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Supprimer l’utilisateur « {name} » ? Ses étagères et ses données de lecture "
 "seront également supprimées."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "Supprimer {name}"
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-"Supprimer « {name} » ? Elle sera retirée de {count} livre, qui sera conservé."
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-"Supprimer « {name} » ? Elle sera retirée de {count} livres, qui seront "
-"conservés."
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr "Étiquette {name} supprimée"
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "{name} a été supprimé."
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr "Dense"
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Description"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr "Désactiver la connexion par mot de passe classique"
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr "Sélection Découvrir mise à jour."
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr "Découvrir — Sélection aléatoire"
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr "Rejeter"
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr "Ignorer ce groupe"
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr "Documentation"
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr "Réorganisation terminée"
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Télécharger"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr "Déposez les fichiers ici, ou cliquez pour les choisir"
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr "Dupliquer"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr "Livres en double"
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr "Paramètres de détection des doublons"
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
@@ -4551,285 +4668,285 @@ msgstr ""
 "Recherche de doublons lancée. Elle s’exécute en arrière-plan — cette liste "
 "se mettra à jour une fois terminée."
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr "Aperçu sur liseuse"
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 "Chaque type (isbn, amazon, google, doi…) ne peut apparaître qu’une fois."
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr "Flou de bord — bordure bokeh douce"
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Miroir de bord — prolonge l’illustration (recommandé)"
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Éditer"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr "Modifier les étagères publiques"
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr "Modifier l’étagère intelligente"
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr "Modifier le titre de {title}"
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "Adresse mail"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr "Serveur de messagerie (SMTP)"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr "Adresse mail (facultative)"
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr "Revendication d’adresse mail"
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr "M’envoyer un lien de réinitialisation"
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr "Paramètres de messagerie enregistrés."
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Activer la synchronisation Kobo"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Chiffrement"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr "Expire dans"
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr "N’exposer que les étagères sélectionnées via OPDS"
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr "Impossible de charger les étagères."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr "Le chargement a échoué."
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr "Favori"
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr "Ajouté aux favoris"
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr "Récupérer"
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr "Récupérer les métadonnées sur le Web"
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr "Fichiers"
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 "Les fichiers sont mis en file d’attente pour l’import de la bibliothèque et "
 "apparaissent une fois importés."
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr "Style de remplissage"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Filtrer : {items}"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Filtrer : {items}…"
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr "Police"
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr "Taille de police"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr "Mot de passe oublié ?"
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr "Format mis en file d’attente — il apparaîtra une fois traité."
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr "Formats"
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr "Formats — exclure"
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr "Formats — inclure"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr "Adresse de l’expéditeur"
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr "Tableau complet des utilisateurs et restrictions"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr "Générer un nouveau lien"
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr "Donnez un nom à votre étagère intelligente."
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr "Aller à votre bibliothèque"
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr "Dégradé — fondu haut/bas assorti à la palette"
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr "Revendication de groupe"
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr "Champ des membres du groupe"
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr "Nom du groupe"
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr "Filtre d’objet de groupe"
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr "Le HTML est autorisé et nettoyé à l’affichage."
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr "Nom de l’en-tête"
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr "Aide et assistance"
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr "menu Aide"
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr "Masqué"
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Cacher"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr "Masquer la section Découvrir"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr "Masquer les champs"
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr "Masquer le mot de passe"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr "Surligner"
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr "Surlignages"
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr "Populaires"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr "Populaires — Les plus téléchargés"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr "Icône"
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr "Type d’identifiant"
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr "Valeur de l’identifiant"
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identifiants"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr "Importé sous"
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr "Dans votre livre"
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
@@ -4837,342 +4954,342 @@ msgstr ""
 "La lecture dans le navigateur prend actuellement en charge l’EPUB. Utilisez "
 "le téléchargement ou le lecteur classique pour les autres formats."
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr "Émetteur / URL de base"
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 "Elle a peut-être été déplacée, ou se trouve encore dans l’interface "
 "classique."
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr "Avancement KOReader"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr "Chemin du fichier de clé"
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr "Chemin de la clé"
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264×1680)"
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr "Synchronisation Kobo activée"
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Langue"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr "Langues — inclure"
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "Dernière modification"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr "Dernière synchronisation"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr "Paramètres de la bibliothèque"
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr "Interligne"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr "Charger plus"
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr "Chargement…"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr "Chargement d’une nouvelle sélection Découvrir."
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr "Chargement…"
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr "Verrouiller la couverture"
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr "Texte du bouton de connexion"
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr "Méthode de connexion"
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr "Se connecter avec"
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr "Journaux"
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr "Tout est bon"
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr "Basse résolution"
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr "Lien magique"
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr "QR code du lien magique"
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr "Rendre privée"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr "Rendre publique"
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr "Définir comme ma vue de bibliothèque par défaut"
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr "Gérer le rôle administrateur depuis le groupe OAuth"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr "Gérer les étagères"
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "Marquer comme lu"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "Marquer comme non lu"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr "Correspondance"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr "Max."
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr "Nombre maximal d’auteurs affichés"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr "Note maximale"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr "Filtre des utilisateurs membres"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr "Fusionner avec {name}"
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr "Fusionnée avec {name}"
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr "URL de métadonnées (découverte automatique OIDC)"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr "Min."
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr "Note minimale"
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 "Plus d’options de couverture (recherche de sources, aperçu sur liseuse)"
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr "Plus de paramètres du serveur"
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr "Descendre"
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr "Monter"
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr "Mon compte"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr "Nom"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr "Besoin de signaler un problème ? Essayez le nouveau"
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr "Nouveau"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr "Nouveau mot de passe"
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr "Nom de la nouvelle étagère"
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr "Nom de la nouvelle étagère…"
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr "Nouvelle étagère…"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr "Nouvelle étagère intelligente"
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr "Nouvel utilisateur"
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr "Plus récent"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr "Date de publication (décroissant)"
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr "Page suivante"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr "Aucun livre ne correspond à cette étagère intelligente pour le moment."
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr "Aucun livre ne correspond à ces critères."
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 "Aucune proposition pour l’instant. Essayez une autre recherche ou actualisez."
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr "Aucun sommaire trouvé."
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr "Aucun groupe de doublons trouvé."
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr "Aucune étiquette exclue"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Aucun surlignage pour l’instant. Surlignez pendant la lecture, ou importez "
 "depuis un appareil Kobo."
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Aucun résultat dans {items} pour « {query} »."
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr "Aucune page trouvée dans cette bande dessinée."
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr "Aucune étagère pour l’instant — créez-en une ci-dessous."
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 "Aucune étagère pour le moment. Créez-en une ci-dessus pour commencer à "
 "regrouper des livres."
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr "Aucune source ne nécessite de clé."
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr "Aucune tâche en cours."
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Aucun élément dans {items} pour le moment."
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr "Non configuré"
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr "Non défini"
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr "Plus ancien"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr "Date de publication (croissant)"
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
@@ -5180,56 +5297,56 @@ msgstr ""
 "Sur un autre appareil où vous êtes déjà connecté, scannez ce code ou ouvrez "
 "le lien ci-dessous pour autoriser cet appareil."
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr "Ouvrir le compte"
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr "Ouvrir le lecteur classique"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr "Ouvrir la navigation"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr "Ouvrir le lecteur"
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr "Ouvrir l’interface classique"
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr "Ouvrez le lien ci-dessous sur votre appareil connecté."
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr "Serveur OpenLDAP"
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr "S’ouvre dans la vue classique"
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr "Lecteur PDF"
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr "Marges de page"
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr "Thème de la page"
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Page {number}"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
@@ -5237,17 +5354,17 @@ msgstr ""
 "Les pages signalées ci-dessous s’ouvrent dans la vue classique. Les "
 "modifications qui y sont faites s’appliquent à tout le serveur."
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Mot de passe"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr "Mot de passe (laisser vide pour conserver)"
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5256,159 +5373,159 @@ msgstr ""
 "collez une URL, téléversez un fichier, ou utilisez la couverture intégrée au "
 "livre."
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr "{label} saisi. Faites glisser pour réorganiser, relâchez pour déposer."
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr "Préparation de votre lien magique…"
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr "Page précédente"
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Avancement"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr "Publique"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr "Publié après le"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr "Publié avant le"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr "Livres aléatoires affichés"
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Évaluation"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr "Note (étoiles)"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr "Statut de lecture"
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr "Filtre de statut de lecture"
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr "Paramètres de lecture enregistrés."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr "Apparence de lecture"
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr "Destinataire(s)"
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr "Hôte de redirection (URL complète)"
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr "Actualiser"
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr "Inscription…"
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr "Recharger"
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr "Recharger les métadonnées depuis le disque"
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr "Rechargement…"
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr "Se souvenir de moi"
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr "Retirer des favoris"
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr "Retirer de l'étagère"
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr "Supprimer le surlignage"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr "Supprimer l’identifiant"
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr "Supprimer la règle"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr "Renommer"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr "Réorganiser"
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr "Remplacer la couverture par celle-ci ?"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr "Remplacer la couverture ?"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr "Signaler un problème sur Discord"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr "Signaler un problème sur GitHub"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr "Exiger l’appartenance à un groupe"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Réinitialiser le mot de passe de {name}"
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5417,31 +5534,31 @@ msgstr ""
 "Réinitialiser le mot de passe de {name} ? Son mot de passe actuel cessera de "
 "fonctionner et un nouveau lui sera envoyé par courrier électronique."
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr "Connexion par en-tête de proxy inverse"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr "Lignes par chargement"
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr "Durée d’exécution"
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr "Serveur SMTP"
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5450,339 +5567,339 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr "Sauvegarder les paramètres de messagerie"
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr "Sauvegarder le nom"
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr "Sauvegarder les paramètres de sécurité"
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr "Sauvegarder les paramètres"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Sauvegardé. Redémarrez le serveur pour que les modifications de connexion "
 "prennent effet."
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr "Rechercher les doublons"
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr "Tâches planifiées"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr "Portées"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr "Chercher un titre, un auteur…"
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr "Recherche dans toutes les sources…"
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr "Recherche…"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr "Paramètres de sécurité enregistrés."
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr "Voir le rendu de chaque couverture avec marges sur votre appareil"
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Sélectionner"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr "Sélection multiple"
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "Envoyer"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr "Échec de l’envoi."
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr "Envoyer vers la liseuse"
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr "Adresse mail d’envoi vers la liseuse"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr "Envoi…"
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr "Numéro dans la série"
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr "Vue par séries"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr "Séries — inclure"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr "Servir en HTTPS"
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr "SSL / HTTPS du serveur"
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr "Annonce du serveur (visible par tous les utilisateurs)"
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr "Hôte du serveur"
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr "Compte de service (DN)"
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr "Mot de passe du service"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr "Mot de passe du service (laisser vide pour conserver)"
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 "Indiquez une URL de métadonnées pour remplir automatiquement les points "
 "d’accès ci-dessous, ou saisissez-les manuellement."
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr "Paramètres enregistrés."
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr "Nom de l’étagère"
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr "Étagère introuvable."
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr "Afficher la section Découvrir"
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr "Afficher les boutons Lire et Modifier"
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr "Afficher la vue en tableau"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr "Afficher les {count} étiquettes"
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Tout afficher dans {items}"
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr "Afficher les livres dans la langue"
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr "Afficher un aperçu liseuse sur chaque proposition"
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr "Afficher moins d’étiquettes"
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr "Afficher les livres masqués"
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr "Afficher le mot de passe"
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr "Mélanger la sélection"
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr "Se connecter avec un lien magique"
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr "Se déconnecter"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr "Connexion…"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr "Titre du site"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr "Étagère intelligente introuvable."
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr "Étagères intelligentes"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr "Uni : couleur moyenne de la couverture"
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr "Uni : couleur personnalisée"
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr "Uni : couleur dominante de la couverture"
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr "Certaines sources nécessitent une clé pour de meilleures couvertures"
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr "Une erreur s’est produite"
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr "Une erreur s’est produite. Réessayez."
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr "Ordre de tri"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr "Détails de la source"
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr "Lecture commencée"
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr "Démarrage de l’analyse…"
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr "Tableau de bord des statistiques"
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Statut"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr "Étirer pour remplir — sans bordure, légère distorsion"
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "Soutenir sur Ko-fi →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr "Ne synchroniser que les étagères que j’ai sélectionnées"
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr "Ne synchroniser que les étagères sélectionnées vers Kobo"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr "Vue en tableau"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr "Étiquette"
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Étiquettes"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr "Étiquettes — exclure"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr "Étiquettes — inclure"
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr "Format d’image cible"
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Tâche"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Tâches"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr "Détails techniques"
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr "Cette URL ne correspond pas à une image utilisable."
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr "Ce format s’ouvre dans le lecteur plein écran."
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr "Ce lien magique a expiré. Générez-en un nouveau pour réessayer."
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr "Cette page n’existe pas ici."
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
@@ -5790,77 +5907,77 @@ msgstr ""
 "Cette page a rencontré une erreur et n’a pas pu être affichée. Votre "
 "bibliothèque n’est pas affectée — recharger suffit généralement."
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr "Cette étagère est vide. Ajoutez des livres depuis la page d’un livre."
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr "Titre A–Z"
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr "Titre Z–A"
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr "Titre, auteur ou ISBN"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr "URL du jeton"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr "Les mieux notés"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr "Faire confiance à l’en-tête d’authentification"
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr "Configuration de l’interface et de l’affichage"
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "Désarchiver"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr "Afficher"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr "Déverrouillez la couverture ci-dessus pour en appliquer une nouvelle."
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr "Déverrouillez la couverture pour la changer"
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr "Sans titre"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr "Échec de la mise à jour."
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr "Téléverser comme couverture"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr "Téléverser des livres"
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 "Le téléversement n'est pas disponible pour votre compte sur ce serveur."
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5868,70 +5985,70 @@ msgstr ""
 "Utilisez-les pour connecter des lecteurs OPDS ou la synchronisation KOReader "
 "sans votre mot de passe principal."
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr "Utiliser cette couverture"
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Utilisateur"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr "Administration des utilisateurs"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr "Filtre d’objet utilisateur"
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr "URL userinfo"
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr "Revendication de nom d’utilisateur"
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr "Versions"
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Vue"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr "Paramètres d’affichage"
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr "Visionneuse"
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr "En attente de votre autorisation…"
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 "Lorsqu’elle est verrouillée, la récupération des métadonnées ne remplacera "
 "pas cette couverture."
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr "Date de la première synchronisation de la progression de lecture"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
@@ -5941,163 +6058,149 @@ msgstr ""
 "marquer cette étagère n’a donc aucun effet en soi. Basculez votre compte en "
 "synchronisation par étagères uniquement pour que cela prenne effet."
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr "Votre bibliothèque"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr "Votre navigateur ne peut pas lire ce format audio."
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr "Votre bibliothèque numérique personnelle"
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Votre adresse de liseuse enregistrée est affichée — modifiez-la pour cet "
 "envoi uniquement."
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr "toutes les règles"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr "au moins une règle"
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr "livres"
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr "livres correspondent"
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr "exemplaires"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr "liseuse"
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr "ex. Science-fiction non lue"
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr "Objet du message vers la liseuse"
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr "partagé"
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr "à"
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr "type (isbn, amazon, doi…)"
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr "valeur"
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr "vous"
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} livre"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} livres"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} fichier mis en file d’attente pour l’importation"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} fichier rejeté"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} fichiers mis en file d’attente pour l’importation"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} fichiers rejetés"
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} résultat"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} résultats"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "{count} résultats pour « {query} »"
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr "{field} (séparés par des virgules)"
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr "{n} trouvé(s)"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "{ok} sources sur {total} ont répondu"
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-"« {name} » existe déjà sur {count} livre. Fusionner cette étiquette avec "
-"celle-ci ?"
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-"« {name} » existe déjà sur {count} livres. Fusionner cette étiquette avec "
-"celle-ci ?"
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr "…ou collez l’URL d’une image"
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr "← Retour au livre"
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr "← Retour à la connexion"
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr "← Bibliothèque"
 
@@ -9145,9 +9248,9 @@ msgid ""
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
-"Cet outil a été adapté à partir de l'outil <a href=\"https://kindle-epub-fix."
-"netlify.app/\">kindle-epub-fix.netlify.app</a> créé par <a href=\"https://"
-"github.com/innocenat\">innocenat</a>."
+"Cet outil a été adapté à partir de l'outil <a href=\"https://kindle-epub-"
+"fix.netlify.app/\">kindle-epub-fix.netlify.app</a> créé par <a "
+"href=\"https://github.com/innocenat\">innocenat</a>."
 
 #: cps/templates/cwa_settings.html:181
 msgid "Enable KOReader Sync (NextGen Plugin)"
@@ -9350,10 +9453,6 @@ msgstr ""
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
 msgstr "Tags/Genres"
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
-msgstr "Date de publication"
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
 msgid "Identifiers (ISBN, etc.)"
@@ -12477,80 +12576,6 @@ msgstr "Synchroniser les étagères sélectionnées avec Kobo"
 #: cps/templates/user_table.html:158
 msgid "Show Read/Unread Section"
 msgstr "Afficher la section Lu / Non lu"
-
-#~ msgid "<"
-#~ msgstr "<"
-
-#~ msgid "="
-#~ msgstr "="
-
-#~ msgid ">"
-#~ msgstr ">"
-
-#~ msgid ""
-#~ "A one-time full duplicate scan is needed. Run it from CWA settings, then "
-#~ "return here."
-#~ msgstr ""
-#~ "Une analyse complète des doublons est nécessaire, une seule fois. Lancez-"
-#~ "la depuis les paramètres CWA, puis revenez ici."
-
-#~ msgid "Date Added"
-#~ msgstr "Date d’ajout"
-
-#~ msgid "Support us on Ko-fi!"
-#~ msgstr "Soutenez-nous sur Ko-fi !"
-
-#~ msgid "Open Ko-fi →"
-#~ msgstr "Ouvrir Ko-fi →"
-
-#~ msgid "Dismiss help announcement"
-#~ msgstr "Masquer l’annonce d’aide"
-
-#~ msgid "Dismiss Ko-fi support message"
-#~ msgstr "Masquer le message de soutien Ko-fi"
-
-#~ msgid ""
-#~ "These open the full configuration pages. Changes there apply to the whole "
-#~ "server."
-#~ msgstr ""
-#~ "Ces liens ouvrent les pages de configuration complètes. Les modifications "
-#~ "qui y sont faites s’appliquent à tout le serveur."
-
-#~ msgid "begins with"
-#~ msgstr "commence par"
-
-#~ msgid "contains"
-#~ msgstr "contient"
-
-#~ msgid "does not contain"
-#~ msgstr "ne contient pas"
-
-#~ msgid "ends with"
-#~ msgstr "se termine par"
-
-#~ msgid "in the past N days"
-#~ msgstr "au cours des N derniers jours"
-
-#~ msgid "is"
-#~ msgstr "est"
-
-#~ msgid "is not"
-#~ msgstr "n’est pas"
-
-#~ msgid "not in the past N days"
-#~ msgstr "pas au cours des N derniers jours"
-
-#~ msgid "on or after"
-#~ msgstr "le ou après le"
-
-#~ msgid "on or before"
-#~ msgstr "le ou avant le"
-
-#~ msgid "≤"
-#~ msgstr "≤"
-
-#~ msgid "≥"
-#~ msgstr "≥"
 
 #~ msgid "Sync Kobo read progress to Hardcover (Requires API key per user)"
 #~ msgstr ""

--- a/cps/translations/gl/LC_MESSAGES/messages.po
+++ b/cps/translations/gl/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Estatísticas"
 
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Editar Usuarios"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Todo"
@@ -1022,7 +1022,7 @@ msgstr "non instalado"
 msgid "Execution permissions missing"
 msgstr "Faltan permisos de execución"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1227,7 +1227,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Rol non válido"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2046,7 +2046,7 @@ msgstr "Versión actual"
 msgid "Unread Books"
 msgstr "Libros non lidos"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2057,7 +2057,7 @@ msgstr "Autores"
 msgid "Books ordered by Author"
 msgstr "Libros ordeados por autor"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Editores"
@@ -2066,7 +2066,7 @@ msgstr "Editores"
 msgid "Books ordered by publisher"
 msgstr "Libros ordeados por editor"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Categorías"
@@ -2088,7 +2088,7 @@ msgstr "Series"
 msgid "Books ordered by series"
 msgstr "Libros ordeados por series"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2098,7 +2098,7 @@ msgstr "Linguas"
 msgid "Books ordered by Languages"
 msgstr "Libros ordeados por lingua"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Valoracións"
@@ -2115,7 +2115,7 @@ msgstr "Formatos de arquivo"
 msgid "Books ordered by file formats"
 msgstr "Libros ordeados por formato de arquivo"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Andeis"
@@ -2152,7 +2152,7 @@ msgstr "{} Estrelas"
 msgid "Search"
 msgstr "Buscar"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2176,7 +2176,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Libros"
 
@@ -2210,7 +2210,7 @@ msgstr "Mostrar lidos e non lidos"
 msgid "Show unread"
 msgstr "Mostrar non lidos"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Descubrir"
 
@@ -2258,7 +2258,7 @@ msgstr "Libros arquivados"
 msgid "Show Archived Books"
 msgstr "Mostrar libros arquivados"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2274,7 +2274,7 @@ msgstr "Lista de libros"
 msgid "Show Books List"
 msgstr "Mostrar lista de libros"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2978,13 +2978,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Borrar"
 
@@ -3140,8 +3140,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Unir"
 
@@ -3269,7 +3270,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3705,225 +3707,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Acerca de"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Arquivado"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3946,1326 +4065,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Convertir"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Descrición"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Descargar"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Editar"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "Enderezo de correo electrónico"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Activar a sincronización con Kobo"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Cifraxe"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Agochar"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identificadores"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Lingua"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Contrasinal"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Porto"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Progreso"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Valoración"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5274,634 +5383,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Gardar"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Seleccionar"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Estado"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Tarefa"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Tarefas"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Usuario"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Nome de usuario"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Vista"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9111,10 +9210,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/hu/LC_MESSAGES/messages.po
+++ b/cps/translations/hu/LC_MESSAGES/messages.po
@@ -20,7 +20,7 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.9\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Statisztika"
 
@@ -148,7 +148,7 @@ msgstr "A %(column)d egyéni oszlop nem létezik a Calibre adatbázisban"
 msgid "Edit Users"
 msgstr "Felhasználók szerkesztése"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Mind"
@@ -1048,7 +1048,7 @@ msgstr "nincs telepítve"
 msgid "Execution permissions missing"
 msgstr "Hiányzik a futtatási jogosultság"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr "Vissza a metaadatok szerkesztéséhez"
 
@@ -1095,7 +1095,7 @@ msgstr "Nem sikerült létrehozni a Kobo előnézetet."
 msgid "Could not load a source image to preview."
 msgstr "Nem sikerült betölteni a forrásképet az előnézethez."
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr "A borító mentése sikertelen."
 
@@ -1253,7 +1253,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Érvénytelen könyvkijelölés."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr "Könyv nem található."
 
@@ -2074,7 +2074,7 @@ msgstr "Jelenlegi verzió"
 msgid "Unread Books"
 msgstr "Olvasatlan könyvek"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2085,7 +2085,7 @@ msgstr "Szerzők"
 msgid "Books ordered by Author"
 msgstr "Könyvek szerző szerint rendezve"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Kiadók"
@@ -2094,7 +2094,7 @@ msgstr "Kiadók"
 msgid "Books ordered by publisher"
 msgstr "Könyvek kiadók szerint rendezve"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Címkék"
@@ -2116,7 +2116,7 @@ msgstr "Sorozatok"
 msgid "Books ordered by series"
 msgstr "Könyvek sorozat szerint rendezve"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2127,7 +2127,7 @@ msgstr "Nyelvek"
 msgid "Books ordered by Languages"
 msgstr "Könyvek sorozat szerint rendezve"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Értékelések"
@@ -2146,7 +2146,7 @@ msgstr "Fájlformátumok"
 msgid "Books ordered by file formats"
 msgstr "Könyvek sorozat szerint rendezve"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Polcok"
@@ -2182,7 +2182,7 @@ msgstr "{} csillag"
 msgid "Search"
 msgstr "Keresés"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2206,7 +2206,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Könyvek"
 
@@ -2239,7 +2239,7 @@ msgstr "Olvasva/olvasatlan mutatása"
 msgid "Show unread"
 msgstr "Olvasatlan könyvek megjelenítése"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Felfedezés"
 
@@ -2279,7 +2279,7 @@ msgstr "Archivált könyvek"
 msgid "Show Archived Books"
 msgstr "Archivált könyvek mutatása"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr "Kedvencek"
 
@@ -2295,7 +2295,7 @@ msgstr "Könyvek listája"
 msgid "Show Books List"
 msgstr "Könyvek listájának megjelenítése"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "Ismétlődő könyvek"
 
@@ -2998,13 +2998,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Törlés"
 
@@ -3160,8 +3160,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Összevonás"
 
@@ -3289,7 +3290,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr "Mentés…"
 
@@ -3725,225 +3727,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr "Hozzáadás dátuma"
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr "Kiadási dátum"
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr "ezzel kezdődik"
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr "tartalmazza"
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr "nem tartalmazza"
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr "erre végződik"
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr "az elmúlt N napban"
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr "nem egyenlő"
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr "egyenlő"
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr "nem az elmúlt N napban"
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr "ekkor vagy ezután"
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr "ekkor vagy ezelőtt"
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr "3:4 (általános)"
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr "Néhány véletlenszerű könyv a könyvtáradból"
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr "API kulcsok"
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Névjegy"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "Bármelyik"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr "Frissítés…"
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "Archiválás"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Archiválva"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr "Kérdés a Discordon"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr "{number}. könyv"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3966,1139 +4085,1129 @@ msgstr ""
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "{task} megszakítása"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr "Borítócsere"
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr "Kényelmes"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr "Kompakt"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Konvertálás"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr "Nem sikerült létrehozni a polcot."
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr "Nem sikerült létrehozni a polcot."
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr "Nem sikerült törölni a polcot."
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr "Nem sikerült betölteni a statisztikákat."
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr "Nem sikerült betölteni a feladatokat."
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr "Nem sikerült betölteni a felhasználókat."
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr "Nem sikerült átnevezni a polcot."
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr "Nem sikerült menteni a sorrendet."
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr "Nem sikerült menteni a polcot."
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr "Nem sikerült frissíteni a polcot."
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr "Létrehozás"
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr "A létrehozás sikertelen."
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr "{name} létrehozva."
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr "Jelenlegi"
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr "Jelenlegi borító"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr "Hozzáadás dátuma"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr "A törlés sikertelen."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "Törlöd a(z) „{name}” polcot? Ez nem vonható vissza."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Törlöd a(z) „{name}” felhasználót? A polcai és az olvasási adatai is "
 "törlődnek."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "{name} törlése"
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "{name} törölve."
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr "Sűrű"
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Leírás"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr "Felfedezés — Véletlenszerű válogatás"
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr "Elrejtés"
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr "Dokumentáció"
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Letöltés"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr "Elmosott szél — lágy bokeh szegély"
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Tükrözött szél — a grafika kiterjesztése (ajánlott)"
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr "Intelligens polc szerkesztése"
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "E-mail"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Kobo szinkronizáció engedélyezése"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Titkosítás típusa"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr "Nem sikerült betölteni a polcokat."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr "Kitöltés stílusa"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Szűrés: {items}"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Szűrés: {items}…"
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr "Adjon nevet az intelligens polcnak."
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr "Súgó és támogatás"
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr "Súgó menüt"
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Elrejtés"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr "Felfedezés szakasz elrejtése"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr "Népszerű"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr "Népszerű — Legtöbbször letöltött"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr "Ikon"
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Azonosítók"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr "KOReader állapot"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Nyelv"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "Utoljára módosítva"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr "Továbbiak betöltése"
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr "Betöltés…"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr "Betöltés…"
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr "Borító zárolása"
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "Legyen olvasott"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "Legyen olvasatlan"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr "Egyezés"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr "Név"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr "Hibát jelentenél? Próbáld ki az új"
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr "Új"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr "Új polc neve"
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr "Új polc neve…"
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr "Új intelligens polc"
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr "Még nem találhatók jelöltek. Próbáljon más keresést vagy frissítést."
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Nincs találat itt: {items}, erre: „{query}”."
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr "Még nincsenek polcok. Hozz létre egyet fent a könyvek gyűjtéséhez."
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Még nincs elem itt: {items}."
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr "{number}. oldal"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Jelszó"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5106,190 +5215,190 @@ msgstr ""
 "Válassz borítót bármely támogatott forrásból, illessz be egy URL-t, tölts "
 "fel egy fájlt, vagy használd a könyvbe beágyazott borítót."
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Állapot"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr "Nyilvános"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Értékelés"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr "Olvasási állapot szűrő"
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr "Frissítés"
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr "Levétel polcról"
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr "Szabály eltávolítása"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr "Probléma jelentése a Discordon"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr "Probléma jelentése a GitHubon"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5298,634 +5407,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Mentés"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr "Keresés…"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Kiválasztás"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "Küldés"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr "A küldés sikertelen."
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Összes megjelenítése itt: {items}"
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr "Válogatás keverése"
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr "Intelligens polcok"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr "Valami hiba történt. Próbáld újra."
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr "Rendezési sorrend"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Státusz"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "Támogatás a Ko-fi-on →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr "Táblázatos nézet"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr "Címke"
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Címkék"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr "Cél képarány"
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Feladat"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Feladatok"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr "Ez a polc üres. Könyveket bármely könyv oldaláról hozzáadhatsz."
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr "Legjobbra értékeltek"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "Archiválás visszavonása"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr "A frissítés sikertelen."
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr "Feltöltés borítóként"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr "Használja ezt a borítót"
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Felhasználó"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Felhasználónév"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Megtekintés"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr "Zárolás esetén a metaadatok lekérése nem írja felül ezt a borítót."
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr "minden szabály"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr "bármely szabály"
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr "könyv egyezik"
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr "pl. olvasatlan sci-fi"
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr "érték"
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} könyv"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} könyv"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} fájl importálásra vár"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} fájl elutasítva"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} fájl importálásra vár"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} fájl elutasítva"
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} találat"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} találat"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9159,10 +9258,6 @@ msgstr ""
 msgid "Tags/Genres"
 msgstr "Címkék"
 
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
-msgstr "Kiadási dátum"
-
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Azonosítók (ISBN, stb.)"
@@ -12255,39 +12350,6 @@ msgstr "Kiválasztott polcok szinkronizációja Kobo eszközzel"
 msgid "Show Read/Unread Section"
 msgstr "Olvasott/olvasatlan mutatása"
 
-#~ msgid "Date Added"
-#~ msgstr "Hozzáadás dátuma"
-
-#~ msgid "begins with"
-#~ msgstr "ezzel kezdődik"
-
-#~ msgid "contains"
-#~ msgstr "tartalmazza"
-
-#~ msgid "does not contain"
-#~ msgstr "nem tartalmazza"
-
-#~ msgid "ends with"
-#~ msgstr "erre végződik"
-
-#~ msgid "in the past N days"
-#~ msgstr "az elmúlt N napban"
-
-#~ msgid "is"
-#~ msgstr "egyenlő"
-
-#~ msgid "is not"
-#~ msgstr "nem egyenlő"
-
-#~ msgid "not in the past N days"
-#~ msgstr "nem az elmúlt N napban"
-
-#~ msgid "on or after"
-#~ msgstr "ekkor vagy ezután"
-
-#~ msgid "on or before"
-#~ msgstr "ekkor vagy ezelőtt"
-
 #~ msgid ""
 #~ "Off by default. When enabled, each user gets a hide button on the book "
 #~ "detail page that drops the book out of their own index/search/OPDS "
@@ -12479,9 +12541,9 @@ msgstr "Olvasott/olvasatlan mutatása"
 #~ "        <a href=\"https://github.com/crocodilestick/Calibre-Web-Automated/"
 #~ "wiki/Configuration#database-configuration\">see here</a>!"
 #~ msgstr ""
-#~ "A CWA úgy van konfigurálva, hogy a Calibre adatbázisa (a <code>metadata."
-#~ "db</code> fájl) mindig a <code>/calibre-library</code> könyvtáron belül "
-#~ "helyezkedjen el. \n"
+#~ "A CWA úgy van konfigurálva, hogy a Calibre adatbázisa (a "
+#~ "<code>metadata.db</code> fájl) mindig a <code>/calibre-library</code> "
+#~ "könyvtáron belül helyezkedjen el. \n"
 #~ "Induláskor a CWA automatikusan átvizsgálja azt a könyvtárat, amelyet a "
 #~ "docker-compose fájlban a <code>/calibre-library</code> útvonalhoz "
 #~ "rendelt, és meglévő Calibre \n"

--- a/cps/translations/id/LC_MESSAGES/messages.po
+++ b/cps/translations/id/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Statistik"
 
@@ -145,7 +145,7 @@ msgstr "Kolom Kustom No.%(column)d tidak ada di basis data kaliber"
 msgid "Edit Users"
 msgstr "Edit pengguna"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Semua"
@@ -1014,7 +1014,7 @@ msgstr "belum dipasang"
 msgid "Execution permissions missing"
 msgstr "Izin eksekusi hilang"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1219,7 +1219,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Peran tidak valid"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2036,7 +2036,7 @@ msgstr "Versi saat ini"
 msgid "Unread Books"
 msgstr "Buku yang Belum Dibaca"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2047,7 +2047,7 @@ msgstr "Penulis"
 msgid "Books ordered by Author"
 msgstr "Buku yang diurutkan menurut Penulis"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Penerbit"
@@ -2056,7 +2056,7 @@ msgstr "Penerbit"
 msgid "Books ordered by publisher"
 msgstr "Buku yang diurutkan menurut Penerbit"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Kategori"
@@ -2078,7 +2078,7 @@ msgstr "Seri"
 msgid "Books ordered by series"
 msgstr "Buku yang diurutkan menurut Seri"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2088,7 +2088,7 @@ msgstr "Bahasa"
 msgid "Books ordered by Languages"
 msgstr "Buku yang diurutkan menurut Bahasa"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Peringkat"
@@ -2105,7 +2105,7 @@ msgstr "Format berkas"
 msgid "Books ordered by file formats"
 msgstr "Buku yang diurutkan menurut format berkas"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Rak"
@@ -2142,7 +2142,7 @@ msgstr "{}★"
 msgid "Search"
 msgstr "Telusuri"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2166,7 +2166,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Buku"
 
@@ -2200,7 +2200,7 @@ msgstr "Tampilkan sudah dibaca dan belum dibaca"
 msgid "Show unread"
 msgstr "Tampilkan belum dibaca"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Temukan"
 
@@ -2248,7 +2248,7 @@ msgstr "Buku yang Diarsipkan"
 msgid "Show Archived Books"
 msgstr "Tampilkan buku yang diarsipkan"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgstr "Daftar Buku"
 msgid "Show Books List"
 msgstr "Tampilkan Daftar Buku"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2968,13 +2968,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Hapus"
 
@@ -3130,8 +3130,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Gabungkan"
 
@@ -3259,7 +3260,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3695,225 +3697,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Tentang"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Diarsipkan"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3936,1326 +4055,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Batal"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Konversi"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Deskripsi"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Unduh"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Edit"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "Alamat Email"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Aktifkan sinkronisasi Kobo"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Enkripsi"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Sembunyikan"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Pengidentifikasi"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Bahasa"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Kata Sandi"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Kemajuan"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Rating"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5264,634 +5373,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Simpan"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Pilih"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Tag"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Tugas"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Tugas"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Pengguna"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Nama Pengguna"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Tampilan"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9078,10 +9177,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/it/LC_MESSAGES/messages.po
+++ b/cps/translations/it/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 "X-Loco-Parser: loco_parse_po\n"
 "X-Generator: Poedit 3.8\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Statistiche"
 
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Modifica utenti"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Tutti"
@@ -1024,7 +1024,7 @@ msgstr "non installato"
 msgid "Execution permissions missing"
 msgstr "Mancano i permessi di esecuzione"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1072,7 +1072,7 @@ msgstr "Impossibile trovare la cartella specificata"
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1233,7 +1233,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Book ID non valido."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2049,7 +2049,7 @@ msgstr "Versione attuale"
 msgid "Unread Books"
 msgstr "Libri da leggere"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2060,7 +2060,7 @@ msgstr "Autori"
 msgid "Books ordered by Author"
 msgstr "Libri ordinati per autore"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Editori"
@@ -2069,7 +2069,7 @@ msgstr "Editori"
 msgid "Books ordered by publisher"
 msgstr "Libri ordinati per editore"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Categorie"
@@ -2091,7 +2091,7 @@ msgstr "Serie"
 msgid "Books ordered by series"
 msgstr "Libri ordinati per serie"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2101,7 +2101,7 @@ msgstr "Lingue"
 msgid "Books ordered by Languages"
 msgstr "Libri ordinati per lingua"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Valutazioni"
@@ -2118,7 +2118,7 @@ msgstr "Formati di file"
 msgid "Books ordered by file formats"
 msgstr "Libri ordinati per formato di file"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Scaffali"
@@ -2155,7 +2155,7 @@ msgstr "{} stelle"
 msgid "Search"
 msgstr "Cerca"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2179,7 +2179,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Libri"
 
@@ -2212,7 +2212,7 @@ msgstr "Mostra Libri letti e Libri da leggere"
 msgid "Show unread"
 msgstr "Mostra da leggere"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Libri casuali"
 
@@ -2252,7 +2252,7 @@ msgstr "Libri archiviati"
 msgid "Show Archived Books"
 msgstr "Mostra Libri archiviati"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2268,7 +2268,7 @@ msgstr "Elenco libri"
 msgid "Show Books List"
 msgstr "Mostra Elenco libri"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "Duplicati"
 
@@ -2975,13 +2975,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Elimina"
 
@@ -3137,8 +3137,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Unisci"
 
@@ -3266,7 +3267,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3702,225 +3704,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Informazioni su"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "Qualsiasi"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "Archivio"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Archiviato"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3943,1326 +4062,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annulla"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Converti"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Descrizione"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Download"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Modifica"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "E-mail"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Abilita la sincronizzazione Kobo"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Crittografia"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Nascondi"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identificatori"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Lingua"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "Contrassegna come letto"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "Contrassegna come da leggere"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Password"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Porta"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Avanzamento"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Valutazione"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5271,634 +5380,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Salva"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Seleziona"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "Invia"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Stato"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "Sostieni su Ko-fi →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Etichette"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Attività"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Attività"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "Rimuovi dall'archivio"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Utente"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Nome utente"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Visualizza"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9082,10 +9181,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/ja/LC_MESSAGES/messages.po
+++ b/cps/translations/ja/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "統計"
 
@@ -148,7 +148,7 @@ msgstr "カスタムカラムの%(column)d列目がcalibreのDBに存在しま�
 msgid "Edit Users"
 msgstr "ユーザーを編集"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "全て"
@@ -1021,7 +1021,7 @@ msgstr "インストールされていません"
 msgid "Execution permissions missing"
 msgstr "実行権限がありません"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr "指定されたディレクトリが見つかりませんでした"
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "無効な書籍IDです。"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2052,7 +2052,7 @@ msgstr "現在のバージョン"
 msgid "Unread Books"
 msgstr "未読の本"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2063,7 +2063,7 @@ msgstr "著者"
 msgid "Books ordered by Author"
 msgstr "著者名順"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "出版社"
@@ -2072,7 +2072,7 @@ msgstr "出版社"
 msgid "Books ordered by publisher"
 msgstr "出版社順"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "カテゴリ"
@@ -2094,7 +2094,7 @@ msgstr "シリーズ"
 msgid "Books ordered by series"
 msgstr "シリーズ順"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2104,7 +2104,7 @@ msgstr "言語"
 msgid "Books ordered by Languages"
 msgstr "言語順"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "評価"
@@ -2121,7 +2121,7 @@ msgstr "ファイル形式"
 msgid "Books ordered by file formats"
 msgstr "ファイル形式順"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "本棚"
@@ -2158,7 +2158,7 @@ msgstr "星{}"
 msgid "Search"
 msgstr "検索"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2182,7 +2182,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "本"
 
@@ -2215,7 +2215,7 @@ msgstr "既読と未読を表示"
 msgid "Show unread"
 msgstr "未読の本を表示"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "見つける"
 
@@ -2255,7 +2255,7 @@ msgstr "アーカイブされた本"
 msgid "Show Archived Books"
 msgstr "アーカイブされた書籍を表示"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2271,7 +2271,7 @@ msgstr "本の一覧"
 msgid "Show Books List"
 msgstr "本の一覧を表示"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "重複"
 
@@ -2983,13 +2983,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "削除"
 
@@ -3145,8 +3145,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "統合"
 
@@ -3274,7 +3275,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3710,225 +3712,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "このサイトについて"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "すべて"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "アーカイブ"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "アーカイブ済み"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3951,1326 +4070,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "変換"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr "追加日"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "詳細"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr "解除"
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "ダウンロード"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "編集"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "メールアドレス"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Koboの同期を有効にする"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "暗号化"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "非表示"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "識別子"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "言語"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "最終更新"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "既読にする"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "未読にする"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "パスワード"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "ポート番号"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "進捗"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "評価"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5279,634 +5388,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "保存"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "選択"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "送信"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "ステータス"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "Ko-fiで支援する →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "タグ"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "タスク"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "タスク"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "アーカイブ解除"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "ユーザー"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "ユーザー名"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "閲覧"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -8922,8 +9021,8 @@ msgid ""
 "innocenat\">innocenat</a>."
 msgstr ""
 "このツールは<a href=\"https://github.com/innocenat\">innocenat</a>氏が作成し"
-"た<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-fix.netlify."
-"app</a>ツールから移植されました。"
+"た<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-"
+"fix.netlify.app</a>ツールから移植されました。"
 
 #: cps/templates/cwa_settings.html:181
 msgid "Enable KOReader Sync (NextGen Plugin)"
@@ -9120,10 +9219,6 @@ msgstr ""
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
 msgstr "タグ/ジャンル"
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
-msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
 #, fuzzy

--- a/cps/translations/km/LC_MESSAGES/messages.po
+++ b/cps/translations/km/LC_MESSAGES/messages.po
@@ -20,7 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "ស្ថិតិ"
 
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "អ្នកប្រើប្រាស់រដ្ឋបាល"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr "មិនបានតម្លើង"
 msgid "Execution permissions missing"
 msgstr ""
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr ""
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -1983,7 +1983,7 @@ msgstr "លេខ version ដែលបានតម្លើង"
 msgid "Unread Books"
 msgstr "សៀវភៅដែលមិនទាន់បានអាន"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -1995,7 +1995,7 @@ msgstr "អ្នកនិពន្ធ"
 msgid "Books ordered by Author"
 msgstr "អ្នកនិពន្ធ"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr ""
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Books ordered by publisher"
 msgstr ""
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "ប្រភេទនានា"
@@ -2026,7 +2026,7 @@ msgstr "ស៊េរី"
 msgid "Books ordered by series"
 msgstr ""
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2037,7 +2037,7 @@ msgstr "ភាសានានា"
 msgid "Books ordered by Languages"
 msgstr "ចំនួនសៀវភៅក្នុងមួយទំព័រ"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr ""
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "Books ordered by file formats"
 msgstr ""
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr ""
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid "Search"
 msgstr "ស្វែងរក"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2114,7 +2114,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr ""
 
@@ -2148,7 +2148,7 @@ msgstr "បង្ហាញអានរួច និងមិនទាន់អ�
 msgid "Show unread"
 msgstr ""
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "ស្រាវជ្រាវ"
 
@@ -2196,7 +2196,7 @@ msgstr ""
 msgid "Show Archived Books"
 msgstr "បង្ហាញសៀវភៅមកថ្មី"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2212,7 +2212,7 @@ msgstr ""
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2915,13 +2915,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "លុប"
 
@@ -3077,8 +3077,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr ""
 
@@ -3206,7 +3207,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3642,225 +3644,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "អំពី"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3883,1326 +4002,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "ពិពណ៌នា"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "ទាញយក"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "កែប្រែ"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr ""
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr ""
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "ភាសា"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "លេខសម្ងាត់"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "លេខ port"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "ដំណើរការ"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "ការវាយតម្លៃ"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5211,634 +5320,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr ""
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "ស្ថានភាព"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Tag"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "ការងារ"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "កិច្ចការនានា"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "អ្នកប្រើប្រាស់"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "ឈ្មោះហៅក្រៅ"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -8997,10 +9096,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/ko/LC_MESSAGES/messages.po
+++ b/cps/translations/ko/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.7\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "통계"
 
@@ -140,7 +140,7 @@ msgstr "사용자 정의 열 번호 %(column)d이(가) calibre 데이터베이�
 msgid "Edit Users"
 msgstr "사용자 관리"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "모두"
@@ -984,7 +984,7 @@ msgstr "설치되지 않았습니다."
 msgid "Execution permissions missing"
 msgstr "실행 권한이 없습니다."
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1032,7 +1032,7 @@ msgstr "지정된 디렉토리를 찾을 수 없습니다."
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1187,7 +1187,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "잘못된 "
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -1980,7 +1980,7 @@ msgstr "현재 버전"
 msgid "Unread Books"
 msgstr "읽지 않음"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -1991,7 +1991,7 @@ msgstr "저자"
 msgid "Books ordered by Author"
 msgstr "저자별 정렬"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "출판사"
@@ -2000,7 +2000,7 @@ msgstr "출판사"
 msgid "Books ordered by publisher"
 msgstr "출판사별 정렬"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "카테고리"
@@ -2022,7 +2022,7 @@ msgstr "시리즈"
 msgid "Books ordered by series"
 msgstr "시리즈별 정렬"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2032,7 +2032,7 @@ msgstr "언어"
 msgid "Books ordered by Languages"
 msgstr "언어별 정렬"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "평점"
@@ -2049,7 +2049,7 @@ msgstr "파일 형식"
 msgid "Books ordered by file formats"
 msgstr "파일 형식별 정렬"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "서재"
@@ -2086,7 +2086,7 @@ msgstr "{} Stars"
 msgid "Search"
 msgstr "검색"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2110,7 +2110,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "전체"
 
@@ -2143,7 +2143,7 @@ msgstr "읽은 책과 안 읽은 책 보기"
 msgid "Show unread"
 msgstr "읽지 않은 책 보기"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "둘러보기"
 
@@ -2183,7 +2183,7 @@ msgstr "보관함"
 msgid "Show Archived Books"
 msgstr "보관된 책 보기"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2199,7 +2199,7 @@ msgstr "책 목록"
 msgid "Show Books List"
 msgstr "책 목록 보기"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "중복인 책"
 
@@ -2904,13 +2904,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "삭제"
 
@@ -3066,8 +3066,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "병합"
 
@@ -3195,7 +3196,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3631,225 +3633,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "서재 정보"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "모두"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "보관"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "보관됨"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3872,1326 +3991,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "취소"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "변환"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "설명"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "다운로드"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "편집"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "이메일 주소"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Kobo sync 사용"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "보안 연결"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "숨기기"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "식별자"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "언어"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "읽음으로 표시"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "읽지 않음으로 표시"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "비밀번호"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "포트"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "진행률"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "평점"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5200,634 +5309,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "저장"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "선택"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "보내기"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "상태"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "태그"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "작업"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "작업"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "보관 해제"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "사용자"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "사용자 이름"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "보기"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -8974,10 +9073,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
@@ -12155,8 +12250,8 @@ msgstr "읽음/읽지 않음 표시"
 #~ msgstr ""
 #~ "이 경로들은 CWA 내부에서만 사용됩니다. 콜론 왼쪽 경로는 자유롭게 변경가능"
 #~ "하나,\n"
-#~ "        오른쪽 경로는 변경할 이유가 없습니다.<br><br>만약 <code>metadata."
-#~ "db<code> 파일을 나머지 서재와 다른 위치에 두고 싶다면, \n"
+#~ "        오른쪽 경로는 변경할 이유가 없습니다.<br><br>만약 "
+#~ "<code>metadata.db<code> 파일을 나머지 서재와 다른 위치에 두고 싶다면, \n"
 #~ "<b>아래의 ‘책 파일을 서재와 분리하기’ 옵션을 사용하고, 거기에 라이브러리"
 #~ "의 나머지 경로를 입력하십시오.</b>"
 

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -12,8 +12,8 @@ msgstr ""
 "Automated\n"
 "POT-Creation-Date: 2026-07-17 21:21-0400\n"
 "PO-Revision-Date: 2026-04-26 13:31+0200\n"
-"Last-Translator: Michiel Cornelissen <michiel.cornelissen+gitbhun at proton."
-"me>\n"
+"Last-Translator: Michiel Cornelissen <michiel.cornelissen+gitbhun at "
+"proton.me>\n"
 "Language-Team: ed.driesen@telenet.be\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -23,7 +23,7 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.9\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Statistieken"
 
@@ -154,7 +154,7 @@ msgstr "Aangepaste kolom Nr.%(column)d bestaat niet in de Calibre Database"
 msgid "Edit Users"
 msgstr "Bewerken Gebruikers"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Alles"
@@ -1036,7 +1036,7 @@ msgstr "niet geïnstalleerd"
 msgid "Execution permissions missing"
 msgstr "Kan programma niet uitvoeren"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr "Terug naar metagegevens bewerken"
 
@@ -1084,7 +1084,7 @@ msgstr "Kon de opgegeven map niet vinden"
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr "Opslaan van omslag mislukt."
 
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Ongeldige boek selectie"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr "Boek niet gevonden"
 
@@ -2044,7 +2044,7 @@ msgstr "Huidige versie"
 msgid "Unread Books"
 msgstr "Ongelezen boeken"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2055,7 +2055,7 @@ msgstr "Auteurs"
 msgid "Books ordered by Author"
 msgstr "Boeken gesorteerd op auteur"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Uitgevers"
@@ -2064,7 +2064,7 @@ msgstr "Uitgevers"
 msgid "Books ordered by publisher"
 msgstr "Boeken gesorteerd op uitgever"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Categorieën"
@@ -2086,7 +2086,7 @@ msgstr "Boekenreeksen"
 msgid "Books ordered by series"
 msgstr "Boeken gesorteerd op reeks"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2096,7 +2096,7 @@ msgstr "Talen"
 msgid "Books ordered by Languages"
 msgstr "Boeken gesorteerd op taal"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Beoordelingen"
@@ -2113,7 +2113,7 @@ msgstr "Bestandsformaten"
 msgid "Books ordered by file formats"
 msgstr "Boeken gesorteerd op bestandsformaat"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Boekenplanken"
@@ -2149,7 +2149,7 @@ msgstr "{} sterren"
 msgid "Search"
 msgstr "Zoeken"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2173,7 +2173,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Boeken"
 
@@ -2206,7 +2206,7 @@ msgstr "Gelezen/Ongelezen boeken tonen"
 msgid "Show unread"
 msgstr "Ongelezen boeken tonen"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Willekeurige boeken"
 
@@ -2254,7 +2254,7 @@ msgstr "Gearchiveerde boeken"
 msgid "Show Archived Books"
 msgstr "Gearchiveerde boeken tonen"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr "Favorieten"
 
@@ -2270,7 +2270,7 @@ msgstr "Boekenlijst"
 msgid "Show Books List"
 msgstr "Boekenlijst tonen"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "Duplicaten"
 
@@ -2983,13 +2983,13 @@ msgstr "Maak je account aan"
 msgid "Dark theme"
 msgstr "Donker thema"
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Verwijderen"
 
@@ -3149,8 +3149,9 @@ msgstr "Markeren als gelezen"
 msgid "Mark unread"
 msgstr "Markeren als ongelezen"
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Samenvoegen"
 
@@ -3280,7 +3281,8 @@ msgstr "Profiel opslaan"
 msgid "Saved."
 msgstr "Opgeslagen."
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr "Opslaan…"
 
@@ -3723,31 +3725,156 @@ msgstr "Kan zijpaneel niet opslaan. Probeer het opnieuw."
 msgid "Refresh library"
 msgstr "Bibliotheek vernieuwen"
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr "<"
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr "="
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ">"
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+"Een eenmalige volledige duplicaatscan is nodig. Start deze vanuit de CWA-"
+"instellingen en kom daarna hier terug."
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr "Datum toegevoegd"
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+"„{name}” verwijderen? Het wordt van {count} boek verwijderd; het boek blijft "
+"behouden."
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+"„{name}” verwijderen? Het wordt van {count} boeken verwijderd; de boeken "
+"blijven behouden."
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr "Ko-fi-steunbericht sluiten"
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr "Hulpmelding sluiten"
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr "Ko-fi openen →"
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr "Publicatiedatum"
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr "Steun ons op Ko-fi!"
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+"Deze openen de volledige configuratiepagina’s. Wijzigingen daar gelden voor "
+"de hele server."
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr "„{name}” bestaat al op {count} boek. Dit label daarmee samenvoegen?"
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr "„{name}” bestaat al op {count} boeken. Dit label daarmee samenvoegen?"
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr "begint met"
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr "bevat"
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr "bevat niet"
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr "eindigt op"
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr "in de afgelopen N dagen"
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr "is niet"
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr "is"
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr "niet in de afgelopen N dagen"
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr "op of na"
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr "op of voor"
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr "≤"
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr "≥"
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr "(omslag vervangen)"
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr "2:3 (uitgeversomslag — geen opvulling voor standaard omslagen)"
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr "3:4 (algemeen)"
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 "Er is al een duplicatenscan bezig. Deze lijst wordt bijgewerkt zodra deze "
 "klaar is."
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr "Enkele willekeurige keuzes uit je bibliotheek"
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
@@ -3755,173 +3882,173 @@ msgstr ""
 "Er is een eenmalige volledige duplicatenscan nodig. Gebruik hierboven "
 "\"Zoeken naar duplicaten\" om deze uit te voeren."
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr "API-sleutels"
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Informatie"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr "Accountinstellingen"
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Account: {name}"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr "Identificatiecode toevoegen"
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr "Toevoegen aan favorieten"
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr "Beheerdersgroep"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr "Geavanceerd zoeken"
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr "Alle boekenplanken"
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr "Inloggen op afstand (magic link) toestaan"
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr "Toegestane groepen (door komma's gescheiden)"
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "Willekeurig"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr "Elk formaat"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr "Elke taal"
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr "Elke reeks"
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr "Elk label"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr "Geselecteerde toepassen"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Toepassen op alle geselecteerde (alleen ingevulde velden veranderen; "
 "bestaande waarden worden vervangen):"
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr "Toepassen…"
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "Archiveren"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Gearchiveerd"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr "Vraag het in Discord"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr "Authenticatie"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr "Authenticatie & beveiliging"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr "Auteur A–Z"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr "Auteur Z–A"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr "Geautoriseerd — je wordt aangemeld…"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr "Autorisatie-URL"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr "Gebruikers automatisch aanmaken"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr "Gebruikers automatisch aanmaken bij eerste aanmelding"
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr "Terug naar bibliotheek"
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr "Terug naar de klassieke weergave"
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr "Basis DN"
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr "Basisconfiguratie"
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr "Boek standaard"
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr "Boekdichtheid"
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Boek {number}"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr "Aantal boeken per pagina"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
@@ -3930,27 +4057,27 @@ msgstr ""
 "bij de volgende synchronisatie van het apparaat verwijderd. Ze blijven wel "
 "in je bibliotheek hier."
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr "Ingebouwde providers (laat leeg om uit te schakelen):"
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr "Bulkacties"
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr "CA-certificaatpad"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr "CWA-instellingen (importeren/converteren)"
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr "Kan boeken uploaden"
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3973,460 +4100,446 @@ msgstr "Kan boeken uploaden"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr "Hernoemen annuleren"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr "Titelbewerking annuleren"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "{task} annuleren"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr "Bestandspad certificaat"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr "Certificaatpad"
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr "Omslag wijzigen"
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr "Controleren…"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr "Kies een omslag"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr "Kies een omslagafbeelding om te uploaden"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr "Kies een afbeelding…"
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr "Kies velden"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr "Kies je thema"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr "Standaard wissen"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr "Selectie wissen"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr "Client ID"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr "Client geheim"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr "Client geheim (laat leeg om te behouden)"
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr "Lezer sluiten"
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr "Kolommen"
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr "Comfortabel"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr "Compact"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr "Geconfigureerd"
 
 # #973 — consolidating tags from the Tag view (merge on rename collision, delete).
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr "Verwijderen van label {name} bevestigen"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr "Nieuw wachtwoord bevestigen"
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Overzetten"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr "Converteren voor verzenden"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr "Converteren van"
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr "Gekopieerd naar klembord"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr "Link kopiëren"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr "Kan boekenplank niet aanmaken."
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr "Kan de boekenplank niet aanmaken."
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr "Kan boekenplank niet verwijderen."
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr "Kan label niet verwijderen"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr "Kan kandidaten niet laden."
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr "Kan duplicaten niet laden."
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr "Kan markeringen niet laden."
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr "Kan statistieken niet laden."
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr "Kan taken niet laden."
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr "Kan dit tekstbestand niet laden."
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr "Kan gebruikers niet laden."
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr "Kan dit comic-archief niet lezen."
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr "Kan metagegevens niet opnieuw laden"
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr "Kan boekenplank niet hernoemen."
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr "Kan wachtwoord niet herstellen."
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr "Kan volgorde niet opslaan."
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr "Kan lezersinstellingen niet opslaan."
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr "Kan het standaard bibliotheekfilter niet opslaan."
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr "Kan de boekenplank niet opslaan."
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr "Kan titel niet opslaan."
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr "Kan je leespositie niet opslaan."
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr "Kan de duplicatenscan niet starten."
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr "Kan boekenplank niet bijwerken."
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr "Kan je accountinstelling niet bijwerken."
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "Kan geen magic link starten. Probeer het opnieuw."
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr "Omslag vergrendeld"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr "Omslag niet bereikbaar"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr "Omslag bijgewerkt vanuit het geselecteerde resultaat."
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr "Aanmaken"
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr "Account aanmaken"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr "Een account aanmaken"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr "Aanmaken mislukt."
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr "Boekenplank aanmaken en boek toevoegen"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr "Gebruiker aanmaken"
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr "{name} aangemaakt."
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr "Aanmaken…"
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr "Bijsnijden om te vullen — geen rand, snijdt de randen bij"
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr "Huidig"
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr "Huidige omslag"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr "Huidig wachtwoord"
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr "Momenteel aan het lezen"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr "Aangepaste randkleur"
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr "Aangepaste kolommen"
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr "Database- & bibliotheekpad"
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr "Datum toegevoegd"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr "Standaard (systeem sans-serif)"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr "Standaard boekentaal"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr "Standaard interfacetaal"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr "Standaard bibliotheekfilter gewist."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr "Standaard bibliotheekfilter opgeslagen."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr "Standaardrollen voor nieuwe OAuth-gebruikers:"
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr "Standaardwaarden staan onder Beheer → Configuratie → Kobo sync."
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr "Boeken verwijderen"
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr "Verwijderen mislukt."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 "Boekenplank \"{name}\" verwijderen? Dit kan niet ongedaan worden gemaakt."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr "Label {name} verwijderen"
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr "Deze slimme boekenplank verwijderen? Je boeken worden niet beïnvloed."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Gebruiker \"{name}\" verwijderen? Ook hun boekenplanken en leesgegevens "
 "worden verwijderd."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "{name} verwijderen"
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-"„{name}” verwijderen? Het wordt van {count} boek verwijderd; het boek blijft "
-"behouden."
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-"„{name}” verwijderen? Het wordt van {count} boeken verwijderd; de boeken "
-"blijven behouden."
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr "Label {name} verwijderd"
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "{name} verwijderd."
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr "Compact"
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Omschrijving"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr "Standaard wachtwoordlogin uitschakelen"
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr "Verkennen-keuzes bijgewerkt."
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr "Verkennen — Willekeurige keuzes"
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr "Afwijzen"
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr "Deze groep afwijzen"
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr "Documentatie"
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr "Klaar met herschikken"
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Downloaden"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr "Sleep bestanden hierheen, of klik om te kiezen"
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr "Duplicaat"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr "Dubbele boeken"
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr "Instellingen voor duplicatendetectie"
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
@@ -4434,285 +4547,285 @@ msgstr ""
 "Duplicatenscan gestart. De scan wordt op de achtergrond uitgevoerd — deze "
 "lijst wordt bijgewerkt zodra hij klaar is."
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr "E-reader voorbeeld"
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr "Elk type (isbn, amazon, google, doi…) mag één keer voorkomen."
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr "Randvervaging — zachte bokeh-rand"
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Randspiegeling — breid het artwork uit (aanbevolen)"
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Bewerken"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr "Openbare boekenplanken bewerken"
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr "Slimme boekenplank bewerken"
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr "Titel bewerken voor {title}"
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "E-mailadres"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr "E-mail (SMTP)-server"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr "E-mail (optioneel)"
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr "E-mail claim"
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr "Stuur me een herstellink"
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr "E-mailinstellingen opgeslagen."
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Zet Kobo sync aan"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Encryptie"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr "Verloopt over"
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr "Alleen geselecteerde boekenplanken via OPDS tonen"
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr "Boekenplanken laden mislukt."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr "Laden mislukt."
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr "Favoriet"
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr "Aan favorieten toegevoegd"
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr "Ophalen"
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr "Metagegevens van het web ophalen"
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr "Bestanden"
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 "Bestanden staan in de wachtrij voor het importeerproces van de bibliotheek "
 "en verschijnen zodra ze geïmporteerd zijn."
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr "Opvulstijl"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "{items} filteren"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "{items} filteren…"
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr "Lettertypefamilie"
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr "Lettergrootte"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr "Wachtwoord vergeten?"
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 "Formaat in de wachtrij geplaatst — het verschijnt zodra het verwerkt is."
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr "Formaten"
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr "Formaten — uitsluiten"
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr "Formaten — opnemen"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr "Van-adres"
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr "Volledige gebruikerstabel & beperkingen"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr "Genereer een nieuwe link"
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr "Geef je slimme boekenplank een naam."
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr "Ga naar je bibliotheek"
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr "Kleurverloop — op palet afgestemde menging van boven- en onderkant"
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr "Groep claim"
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr "Groepleden veld"
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr "Groepsnaam"
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr "Groep object filter"
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr "HTML is toegestaan en wordt bij weergave opgeschoond."
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr "Header naam"
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr "Hulp & ondersteuning"
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr "Hulpmenu"
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr "Verborgen"
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Verberg"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr "Verkennen-sectie verbergen"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr "Velden verbergen"
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr "Wachtwoord verbergen"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr "Markeren"
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr "Markeringen"
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr "Populair"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr "Populair — Meest gedownload"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr "Pictogram"
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr "Identificatietype"
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr "Identificatiewaarde"
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identificatoren"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr "Geïmporteerd als"
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr "In je boek"
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
@@ -4720,341 +4833,341 @@ msgstr ""
 "Lezen in de browser ondersteunt momenteel EPUB. Gebruik download of de "
 "klassieke lezer voor andere formaten."
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr "Issuer / basis-URL"
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 "Het is misschien verplaatst, of het staat mogelijk nog in de klassieke "
 "interface."
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr "KOReader-voortgang"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr "Pad naar sleutelbestand"
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr "Sleutelpad"
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264×1680)"
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr "Kobo sync aan"
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Taal"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr "Talen — opnemen"
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "Laatst gewijzigd"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr "Laatst gesynchroniseerd"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr "Bibliotheekinstellingen"
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr "Regelhoogte"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr "Meer laden"
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr "Bezig met laden"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr "Nieuwe Verkennen-keuzes worden geladen."
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr "Bezig met laden…"
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr "Omslag vergrendelen"
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr "Tekst van inlogknop"
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr "Inlogmethode"
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr "Inloggen met"
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr "Logboeken"
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr "Ziet er goed uit"
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr "Lage resolutie"
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr "Magische link"
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr "Magische link QR-code"
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr "Privé maken"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr "Openbaar maken"
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr "Dit mijn standaard bibliotheekweergave maken"
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr "Beheerdersrol beheren via OAuth-groep"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr "Boekenplanken beheren"
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "Markeren als gelezen"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "Markeren als ongelezen"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr "Overeenkomst"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr "Max"
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr "Maximaal aantal getoonde auteurs"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr "Maximale beoordeling"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr "Lid gebruiker filter"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr "Samenvoegen met {name}"
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr "Samengevoegd met {name}"
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr "Metadata URL (OIDC automatische detectie)"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr "Min"
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr "Minimale beoordeling"
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr "Meer omslagopties (zoekproviders, e-reader voorbeeld)"
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr "Meer serverconfiguratie"
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr "Naar beneden"
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr "Naar boven"
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr "Mijn account"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr "Naam"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr "Een probleem melden? Probeer de nieuwe"
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr "Nieuw"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr "Nieuw wachtwoord"
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr "Nieuwe boekenplanknaam"
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr "Nieuwe boekenplanknaam…"
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr "Nieuwe boekenplank…"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr "Nieuwe slimme boekenplank"
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr "Nieuwe gebruiker"
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr "Nieuwste"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr "Nieuwst gepubliceerd"
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr "Volgende pagina"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 "Er zijn momenteel geen boeken die overeenkomen met deze slimme boekenplank."
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr "Er zijn geen boeken die aan deze criteria voldoen."
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 "Nog geen kandidaten gevonden. Probeer een andere zoekopdracht of vernieuw."
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr "Geen inhoud gevonden."
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr "Geen duplicaat groepen gevonden."
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr "Geen uitgesloten labels"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Nog geen markeringen. Markeer tijdens het lezen, of importeer van een Kobo-"
 "apparaat."
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Geen overeenkomende {items} voor \"{query}\"."
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr "Geen pagina's gevonden in deze strip."
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr "Nog geen boekenplanken — maak er hieronder een aan."
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 "Nog geen boekenplanken. Maak er hierboven een aan om boeken te verzamelen."
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr "Geen bronnen die een sleutel nodig hebben."
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr "Geen actieve taken."
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Nog geen {items}."
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr "Niet geconfigureerd"
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr "Niet ingesteld"
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr "Oudste"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr "Oudst gepubliceerd"
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
@@ -5062,56 +5175,56 @@ msgstr ""
 "Scan op een ander apparaat waarop je al bent aangemeld deze code of open de "
 "onderstaande link om dit apparaat te autoriseren."
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr "Account openen"
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr "Klassieke lezer openen"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr "Navigatie openen"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr "Lezer openen"
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr "Klassieke interface openen"
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr "Open de onderstaande link op je aangemelde apparaat."
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr "OpenLDAP server"
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr "Opent in klassieke weergave"
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr "PDF-lezer"
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr "Paginamarges"
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr "Paginathema"
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Pagina {number}"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
@@ -5119,17 +5232,17 @@ msgstr ""
 "Hieronder gemarkeerde pagina's openen in de klassieke weergave. Wijzigingen "
 "daar gelden voor de hele server."
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr "Wachtwoord (laat leeg om te behouden)"
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5137,159 +5250,159 @@ msgstr ""
 "Kies een omslag uit elke door ons ondersteunde bron, plak een URL, upload "
 "een bestand, of gebruik de omslag die in het boek zelf is ingesloten."
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr "{label} opgepakt. Sleep om te herschikken, laat los om neer te zetten."
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Poort"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr "Je magische link voorbereiden…"
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr "Vorige pagina"
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Voortgang"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr "Openbaar"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr "Gepubliceerd na"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr "Gepubliceerd voor"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr "Willekeurige boeken getoond"
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Beoordeling"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr "Beoordeling (sterren)"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr "Gelezen/ongelezen status"
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr "Gelezen/ongelezen status filter"
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr "Lezerinstellingen opgeslagen."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr "Leesweergave"
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr "Ontvanger(s)"
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr "Redirect host (volledige URL)"
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr "Verversen"
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr "Registreren…"
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr "Herladen"
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr "Metagegevens vanaf schijf herladen"
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr "Herladen…"
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr "Onthoud mij"
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr "Verwijderen uit favorieten"
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr "Verwijderen van boekenplank"
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr "Markering verwijderen"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr "Identifier verwijderen"
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr "Regel verwijderen"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr "Hernoemen"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr "Herschikken"
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr "Omslag vervangen door deze?"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr "Omslag vervangen?"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr "Probleem melden op Discord"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr "Probleem melden op GitHub"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr "Groepslidmaatschap vereisen"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Wachtwoord herstellen voor {name}"
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5298,31 +5411,31 @@ msgstr ""
 "Wachtwoord herstellen voor {name}? Hun huidige wachtwoord werkt dan niet "
 "meer en er wordt een vervangend wachtwoord gemaild."
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr "Reverse-proxy header aanmelding"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr "Rijen per keer laden"
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr "Uitvoertijd"
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr "SMTP-server"
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5331,339 +5444,339 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Opslaan"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr "E-mailinstellingen opslaan"
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr "Naam opslaan"
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr "Beveiligingsinstellingen opslaan"
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr "Instellingen opslaan"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Opgeslagen. Herstart de server om de aanmeldingswijzigingen door te voeren."
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr "Scan op duplicaten"
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr "Geplande taken"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr "Scopes"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr "Zoeken op titel, auteur…"
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr "Elke bron doorzoeken…"
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr "Zoeken…"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr "Beveiligingsinstellingen opgeslagen."
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr "Bekijk hoe elke omslag eruitziet opgevuld voor je apparaat"
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Selecteer"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr "Meerdere selecteren"
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "Verzenden"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr "Verzenden mislukt."
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr "Versturen naar e-reader"
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr "Verstuur-naar-eReader e-mail"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr "Versturen…"
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr "Reeksindex"
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr "Reeksweergave"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr "Reeks — opnemen"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr "Serveren via HTTPS"
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr "Server SSL / HTTPS"
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr "Serveraankondiging (getoond aan alle gebruikers)"
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr "Server host"
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr "Serviceaccount (DN)"
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr "Servicewachtwoord"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr "Servicewachtwoord (leeg laten om te behouden)"
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 "Stel een metadata-URL in om de onderstaande endpoints automatisch in te "
 "vullen, of voer ze handmatig in."
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr "Instellingen opgeslagen."
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr "Boekenplanknaam"
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr "Boekenplank niet gevonden."
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr "Verkennen-sectie tonen"
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr "Knoppen Nu lezen en bewerken tonen"
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr "Tabelweergave tonen"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr "Alle {count} labels tonen"
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Alle {items} tonen"
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr "Boeken in taal tonen"
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr "E-reader-voorvertoningen tonen bij elke kandidaat"
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr "Minder labels tonen"
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr "Verborgen boeken tonen"
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr "Wachtwoord tonen"
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr "Selectie schudden"
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr "Inloggen met een magic link"
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr "Uitloggen"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr "Inloggen…"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr "Websitetitel"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr "Slimme boekenplank niet gevonden."
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr "Slimme boekenplanken"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr "Effen: gemiddelde kleur van de omslag"
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr "Effen: aangepaste kleur"
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr "Effen: meest voorkomende kleur in de omslag"
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr "Sommige bronnen hebben een sleutel nodig voor betere omslagen"
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr "Er is iets misgegaan"
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr "Er is iets misgegaan. Probeer het opnieuw."
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr "Sorteervolgorde"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr "Brondetails"
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr "Begonnen met lezen"
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr "Scan starten…"
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr "Statistiekendashboard"
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr "Uitrekken om te vullen — geen rand, lichte vervorming"
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "Steunen op Ko-fi →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr "Alleen mijn geselecteerde boekenplanken synchroniseren"
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr "Alleen geselecteerde boekenplanken synchroniseren met Kobo"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr "Tabelweergave"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr "Label"
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Labels"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr "Labels — uitsluiten"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr "Labels — opnemen"
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr "Doel-beeldverhouding"
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Taak"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Taken"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr "Technische details"
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr "Die URL is geen bruikbare afbeelding."
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr "Dit formaat wordt geopend in de lezer op volledig scherm."
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 "Deze magic link is verlopen. Genereer een nieuwe om het opnieuw te proberen."
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr "Deze pagina bestaat hier niet."
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
@@ -5671,77 +5784,77 @@ msgstr ""
 "Deze pagina liep tegen een fout aan en kon niet worden weergegeven. Jouw "
 "bibliotheek is in orde — herladen lost het meestal op."
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 "Deze boekenplank is leeg. Voeg boeken toe vanaf de pagina van een boek."
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr "Titel A–Z"
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr "Titel Z–A"
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr "Titel, auteur of ISBN"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr "Token URL"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr "Best beoordeeld"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr "Authenticatie-header vertrouwen"
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr "UI / weergave-configuratie"
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "Dearchiveren"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr "Zichtbaar maken"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr "Ontgrendel de omslag hierboven om een nieuwe toe te passen."
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr "Ontgrendel de omslag om deze te wijzigen"
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr "Zonder titel"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr "Bijwerken mislukt."
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr "Uploaden als omslag"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr "Boeken uploaden"
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr "Uploaden is niet beschikbaar voor je account op deze server."
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5749,70 +5862,70 @@ msgstr ""
 "Gebruik deze om OPDS-lezers of KOReader-synchronisatie te verbinden zonder "
 "jouw hoofdwachtwoord."
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr "Deze omslag gebruiken"
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Gebruiker"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr "Gebruikersbeheer"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr "Gebruikersobject filter"
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr "Userinfo URL"
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr "Gebruikersnaam claim"
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr "Versies"
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Toon"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr "Weergave-instellingen"
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr "Viewer"
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr "Wachten tot je autoriseert…"
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 "Indien vergrendeld zal het ophalen van metagegevens deze omslag niet "
 "overschrijven."
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr "Wanneer de leesvoortgang voor het eerst is gesynchroniseerd"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
@@ -5823,159 +5936,149 @@ msgstr ""
 "account over naar synchronisatie van alleen boekenplanken om het van kracht "
 "te laten worden."
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr "Jouw bibliotheek"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr "Jouw browser kan dit audioformaat niet afspelen."
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr "Jouw persoonlijke digitale bibliotheek"
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Jouw opgeslagen e-readeradres wordt getoond — wijzig het alleen voor deze "
 "verzending."
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr "alle regels"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr "elke regel"
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr "boeken"
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr "boeken komen overeen"
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr "exemplaren"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr "e-reader"
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr "bijv. Ongelezen sci-fi"
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr "eReader e-mailonderwerp"
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr "gedeeld"
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr "naar"
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr "type (isbn, amazon, doi…)"
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr "waarde"
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr "je"
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} boek"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} boeken"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} bestand in de wachtrij geplaatst voor import"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} bestand afgewezen"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} bestanden in de wachtrij geplaatst voor import"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} bestanden afgewezen"
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} resultaat"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} resultaten"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "{count} resultaten voor \"{query}\""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr "{field} (door komma's gescheiden)"
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr "{n} gevonden"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "{ok} van de {total} bronnen hebben geantwoord"
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr "„{name}” bestaat al op {count} boek. Dit label daarmee samenvoegen?"
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr "„{name}” bestaat al op {count} boeken. Dit label daarmee samenvoegen?"
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr "…of plak een afbeelding-URL"
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr "← Terug naar boek"
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr "← Terug naar inloggen"
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr "← Bibliotheek"
 
@@ -6266,8 +6369,8 @@ msgstr "Kies e-mailadressen:"
 #, fuzzy
 msgid "Success! Book queued for sending to the selected address(es)!"
 msgstr ""
-"Het boek is in de wachtrij geplaatst om te worden verstuurd aan "
-"%(eReadermail)s"
+"Het boek is in de wachtrij geplaatst om te worden verstuurd aan %"
+"(eReadermail)s"
 
 #: cps/web.py:2519
 msgid "Please wait one minute to register next user"
@@ -9142,10 +9245,6 @@ msgstr ""
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
 msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
-msgstr "Publicatiedatum"
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
 #, fuzzy
@@ -12151,80 +12250,6 @@ msgstr "Synchroniseer geselecteerde boekenplanken met Kobo"
 msgid "Show Read/Unread Section"
 msgstr "Toon gelezen/niet gelezen selectie"
 
-#~ msgid "<"
-#~ msgstr "<"
-
-#~ msgid "="
-#~ msgstr "="
-
-#~ msgid ">"
-#~ msgstr ">"
-
-#~ msgid ""
-#~ "A one-time full duplicate scan is needed. Run it from CWA settings, then "
-#~ "return here."
-#~ msgstr ""
-#~ "Een eenmalige volledige duplicaatscan is nodig. Start deze vanuit de CWA-"
-#~ "instellingen en kom daarna hier terug."
-
-#~ msgid "Date Added"
-#~ msgstr "Datum toegevoegd"
-
-#~ msgid "Support us on Ko-fi!"
-#~ msgstr "Steun ons op Ko-fi!"
-
-#~ msgid "Open Ko-fi →"
-#~ msgstr "Ko-fi openen →"
-
-#~ msgid "Dismiss help announcement"
-#~ msgstr "Hulpmelding sluiten"
-
-#~ msgid "Dismiss Ko-fi support message"
-#~ msgstr "Ko-fi-steunbericht sluiten"
-
-#~ msgid ""
-#~ "These open the full configuration pages. Changes there apply to the whole "
-#~ "server."
-#~ msgstr ""
-#~ "Deze openen de volledige configuratiepagina’s. Wijzigingen daar gelden "
-#~ "voor de hele server."
-
-#~ msgid "begins with"
-#~ msgstr "begint met"
-
-#~ msgid "contains"
-#~ msgstr "bevat"
-
-#~ msgid "does not contain"
-#~ msgstr "bevat niet"
-
-#~ msgid "ends with"
-#~ msgstr "eindigt op"
-
-#~ msgid "in the past N days"
-#~ msgstr "in de afgelopen N dagen"
-
-#~ msgid "is"
-#~ msgstr "is"
-
-#~ msgid "is not"
-#~ msgstr "is niet"
-
-#~ msgid "not in the past N days"
-#~ msgstr "niet in de afgelopen N dagen"
-
-#~ msgid "on or after"
-#~ msgstr "op of na"
-
-#~ msgid "on or before"
-#~ msgstr "op of voor"
-
-#~ msgid "≤"
-#~ msgstr "≤"
-
-#~ msgid "≥"
-#~ msgstr "≥"
-
 #, fuzzy
 #~ msgid "Enable Hardcover Auto-Fetch"
 #~ msgstr "Zet Kobo sync aan"
@@ -12395,10 +12420,11 @@ msgstr "Toon gelezen/niet gelezen selectie"
 #~ msgstr ""
 #~ "Deze paden zijn alleen intern voor CWA, je kunt aan de linkerkant naar "
 #~ "hartenlust wijzigen waar ze aan gekoppeld zijn, maar er is geen reden om "
-#~ "de paden aan de rechterkant te wijzigen.<br><br>Als je je <code>metadata."
-#~ "db</code> bestand op een andere locatie wilt dan de rest van je "
-#~ "bibliotheek, gebruik dan de <b>Scheid Boekbestanden van Bibliotheek Optie "
-#~ "hieronder en voer daar het pad naar de rest van de bibliotheek in</b>"
+#~ "de paden aan de rechterkant te wijzigen.<br><br>Als je je "
+#~ "<code>metadata.db</code> bestand op een andere locatie wilt dan de rest "
+#~ "van je bibliotheek, gebruik dan de <b>Scheid Boekbestanden van "
+#~ "Bibliotheek Optie hieronder en voer daar het pad naar de rest van de "
+#~ "bibliotheek in</b>"
 
 #~ msgid "Enable CWA Auto-Convert"
 #~ msgstr "Schakel CWA Auto-Conversie in"

--- a/cps/translations/no/LC_MESSAGES/messages.po
+++ b/cps/translations/no/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Statistikk"
 
@@ -144,7 +144,7 @@ msgstr "Egendefinert kolonnenr.%(column)d finnes ikke i caliber-databasen"
 msgid "Edit Users"
 msgstr "Rediger brukere"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Alle"
@@ -1010,7 +1010,7 @@ msgstr "ikke installert"
 msgid "Execution permissions missing"
 msgstr "Utførelsestillatelser mangler"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Ugyldig rolle"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2037,7 +2037,7 @@ msgstr "Gjeldende versjon"
 msgid "Unread Books"
 msgstr "Uleste bøker"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2049,7 +2049,7 @@ msgstr "Forfattere"
 msgid "Books ordered by Author"
 msgstr "Bøker per side"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Forlag"
@@ -2059,7 +2059,7 @@ msgstr "Forlag"
 msgid "Books ordered by publisher"
 msgstr "Bøker per side"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Kategorier"
@@ -2083,7 +2083,7 @@ msgstr "Serie"
 msgid "Books ordered by series"
 msgstr "Bøker per side"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2094,7 +2094,7 @@ msgstr "Språk"
 msgid "Books ordered by Languages"
 msgstr "Bøker per side"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Vurderinger"
@@ -2113,7 +2113,7 @@ msgstr "Filformater"
 msgid "Books ordered by file formats"
 msgstr "Bøker per side"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr ""
@@ -2150,7 +2150,7 @@ msgstr "{} Stjerner"
 msgid "Search"
 msgstr "Søk"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2174,7 +2174,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Bøker"
 
@@ -2208,7 +2208,7 @@ msgstr "Vis lest og ulest"
 msgid "Show unread"
 msgstr "Vis ulest"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Oppdage"
 
@@ -2256,7 +2256,7 @@ msgstr "Arkiverte bøker"
 msgid "Show Archived Books"
 msgstr "Vis arkiverte bøker"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2272,7 +2272,7 @@ msgstr "Bøker Liste"
 msgid "Show Books List"
 msgstr "Vis bokliste"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2974,13 +2974,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Slett"
 
@@ -3136,8 +3136,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Slå sammen"
 
@@ -3265,7 +3266,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3701,225 +3703,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr ""
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3942,1326 +4061,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Konvertere"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "nedlasting"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Redigere"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr ""
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Aktiver Kobo-synkronisering"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Kryptering"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identifikatorer"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Språk"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Passord"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Havn"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Vurdering"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr ""
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5270,634 +5379,624 @@ msgstr ""
 msgid "Save"
 msgstr "Lagre"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr ""
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Tagger"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr ""
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Oppgaver"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Brukernavn"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9092,10 +9191,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/pl/LC_MESSAGES/messages.po
+++ b/cps/translations/pl/LC_MESSAGES/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.9\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Statystyki"
 
@@ -157,7 +157,7 @@ msgid "Edit Users"
 msgstr "Edytuj Użytkowników"
 
 # ???
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Wszystko"
@@ -1065,7 +1065,7 @@ msgstr "nie zainstalowane"
 msgid "Execution permissions missing"
 msgstr "Brak uprawnień do wykonywania pliku"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr "Wróć do edycji metadanych"
 
@@ -1111,7 +1111,7 @@ msgstr "Nie udało się wyrenderować podglądu na czytniku."
 msgid "Could not load a source image to preview."
 msgstr "Nie udało się wczytać obrazu źródłowego do podglądu."
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr "Nie udało się zapisać okładki."
 
@@ -1270,7 +1270,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Nieprawidłowy wybór książki."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr "Nie znaleziono książki."
 
@@ -2112,7 +2112,7 @@ msgstr "Aktualnie czytane książki"
 msgid "Unread Books"
 msgstr "Nieprzeczytane"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2123,7 +2123,7 @@ msgstr "Autorzy"
 msgid "Books ordered by Author"
 msgstr "Książki sortowane według autorów"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Wydawcy"
@@ -2132,7 +2132,7 @@ msgstr "Wydawcy"
 msgid "Books ordered by publisher"
 msgstr "Książki sortowane według wydawców"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Kategorie"
@@ -2154,7 +2154,7 @@ msgstr "Cykle"
 msgid "Books ordered by series"
 msgstr "Książki sortowane według cyklu"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2164,7 +2164,7 @@ msgstr "Języki"
 msgid "Books ordered by Languages"
 msgstr "Ksiązki sortowane według języka"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Oceny"
@@ -2181,7 +2181,7 @@ msgstr "Formaty plików"
 msgid "Books ordered by file formats"
 msgstr "Ksiązki sortowane według formatu"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Półki"
@@ -2215,7 +2215,7 @@ msgstr "{} Gwiazdek"
 msgid "Search"
 msgstr "Szukaj"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2242,7 +2242,7 @@ msgstr ""
 "importach i zmianach metadanych będzie można uruchamiać szybkie sprawdzanie "
 "duplikatów. "
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Książki"
 
@@ -2275,7 +2275,7 @@ msgstr "Pokaż przeczytane i nieprzeczytane"
 msgid "Show unread"
 msgstr "Pokaż nieprzeczytane"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Odkrywaj"
 
@@ -2315,7 +2315,7 @@ msgstr "Zarchiwizowane książki"
 msgid "Show Archived Books"
 msgstr "Pokaż zarchiwizowane książki"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr "Ulubione"
 
@@ -2331,7 +2331,7 @@ msgstr "Lista książek"
 msgid "Show Books List"
 msgstr "Pokaż listę książek"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "Duplikaty"
 
@@ -3040,13 +3040,13 @@ msgid "Dark theme"
 msgstr "Ciemny motyw"
 
 # ???
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Usuń"
 
@@ -3205,8 +3205,9 @@ msgstr "Oznacz jako przeczytane"
 msgid "Mark unread"
 msgstr "Oznacz jako nieprzeczytane"
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Połącz"
 
@@ -3336,7 +3337,8 @@ msgstr "Zapisz profil"
 msgid "Saved."
 msgstr "Zapisano."
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr "Zapisywanie…"
 
@@ -3784,31 +3786,152 @@ msgstr "Nie udało się zapisać panelu bocznego. Spróbuj ponownie."
 msgid "Refresh library"
 msgstr "Odśwież bibliotekę"
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr "<"
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr "="
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ">"
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+"Wymagane jest jednorazowe pełne skanowanie duplikatów. Uruchom je w "
+"ustawieniach CWA, a następnie wróć tutaj."
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr "Data dodania"
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr "Odrzuć wiadomość o wsparciu na Ko-fi"
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr "Odrzuć ogłoszenie pomocy"
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr "Otwórz Ko-fi →"
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr "Data publikacji"
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr "Wesprzyj nas na Ko-fi!"
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+"Te odnośniki otwierają pełne strony konfiguracji. Zmiany tam wprowadzone "
+"dotyczą całego serwera."
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr "zaczyna się od"
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr "zawiera"
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr "nie zawiera"
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr "kończy się na"
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr "w ciągu ostatnich N dni"
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr "nie jest"
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr "jest"
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr "nie w ciągu ostatnich N dni"
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr "w tym dniu lub później"
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr "w tym dniu lub wcześniej"
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr "≤"
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr "≥"
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr "(zamień okładkę)"
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr "2:3 (okładka wydawcy — bez dopełnienia dla typowych okładek)"
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr "3:4 (ogólny)"
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 "Skanowanie duplikatów jest już uruchomione. Ta lista zaktualizuje się po "
 "jego zakończeniu."
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr "Kilka losowych propozycji z Twojej biblioteki"
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
@@ -3816,173 +3939,173 @@ msgstr ""
 "Wymagane jest jednorazowe pełne skanowanie duplikatów. Użyj powyższego "
 "przycisku “Skanuj w poszukiwaniu duplikatów“, aby je uruchomić."
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr "Klucze API"
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Informacje"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr "Ustawienia konta"
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Konto: {name}"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr "Dodaj identyfikator"
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr "Dodaj do ulubionych"
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr "Grupa administratorów"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr "Zaawansowane"
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr "Wyszukiwanie zaawansowane"
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr "Wszystkie półki"
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr "Zezwól na logowanie zdalne (magic link)"
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr "Dozwolone grupy (oddzielone przecinkami)"
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "Dowolny"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr "Dowolny format"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr "Dowolny język"
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr "Dowolny cykl"
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr "Dowolne tagi"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr "Zastosuj wybrane"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Zastosuj do wszystkich zaznaczonych (zmieniają się tylko wypełnione pola; "
 "zastępuje istniejące wartości):"
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr "Stosowanie…"
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "Archiwizuj"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Zarchiwizowane"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr "Zapytaj na Discordzie"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr "Uwierzytelnianie"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr "Uwierzytelnianie i bezpieczeństwo"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr "Autor A–Z"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr "Autor Z–A"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr "Autoryzowano — logowanie…"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr "Adres URL autoryzacji"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr "Automatyczne tworzenie użytkowników"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr "Automatycznie twórz użytkowników przy pierwszym logowaniu"
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr "Wróć do biblioteki"
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr "Wróć do widoku klasycznego"
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr "Podstawowa DN"
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr "Podstawowa konfiguracja"
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr "Domyślne dla książki"
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr "Zagęszczenie książek"
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Książka {number}"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr "Liczba książek na stronie"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
@@ -3991,27 +4114,27 @@ msgstr ""
 "następnie usunięte z urządzenia przy kolejnej synchronizacji. Pozostają "
 "jednak w Twojej bibliotece tutaj."
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr "Wbudowani dostawcy (pozostaw puste, aby wyłączyć):"
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr "Działania zbiorcze"
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr "Ścieżka certyfikatu CA"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr "Ustawienia CWA (import/konwersja)"
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr "Może przesyłać książki"
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -4034,459 +4157,449 @@ msgstr "Może przesyłać książki"
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr "Anuluj zmianę nazwy"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr "Anuluj edycję tytułu"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Anuluj \"{task}\""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr "Ścieżka pliku certyfikatu"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr "Ścieżka certyfikatu"
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr "Zmień okładkę"
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr "Sprawdzanie…"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr "Wybierz okładkę"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr "Wybierz obraz okładki do przesłania"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr "Wybierz obraz…"
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr "Wybierz pola"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr "Wybierz swój motyw"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr "Wyczyść domyślne"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr "Wyczyść zaznaczenie"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr "Identyfikator klienta"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr "Sekret klienta"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr "Sekret klienta (pozostaw puste, aby zachować)"
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr "Zamknij czytnik"
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr "Kolumny"
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr "Komfortowe"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr "Kompaktowe"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr "Skonfigurowano"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr "Potwierdź nowe hasło"
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Konwertuj"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr "Konwertuj przed wysłaniem"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr "Konwertuj z"
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr "Skopiowano do schowka"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr "Kopiuj link"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr "Nie udało się utworzyć półki."
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr "Nie udało się utworzyć półki."
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr "Nie udało się usunąć półki."
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr "Nie udało się wczytać kandydatów."
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr "Nie udało się wczytać duplikatów."
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr "Nie udało się wczytać zakreśleń."
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr "Nie udało się wczytać statystyk."
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr "Nie udało się wczytać zadań."
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr "Nie udało się wczytać tego pliku tekstowego."
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr "Nie udało się wczytać użytkowników."
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr "Nie udało się odczytać tego archiwum komiksu."
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr "Nie udało się ponownie wczytać metadanych"
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr "Nie udało się zmienić nazwy półki."
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr "Nie udało się zresetować hasła."
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr "Nie udało się zapisać kolejności."
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr "Nie udało się zapisać ustawień czytnika."
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr "Nie udało się zapisać domyślnego filtra biblioteki."
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr "Nie udało się zapisać półki."
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr "Nie udało się zapisać tytułu."
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr "Nie udało się uruchomić skanowania duplikatów."
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr "Nie udało się zaktualizować półki."
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr "Nie udało się zaktualizować ustawienia Twojego konta."
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "Nie udało się utworzyć magic linku. Spróbuj ponownie."
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr "Okładka zablokowana"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr "Okładka niedostępna"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr "Zaktualizowano okładkę na podstawie wybranego wyniku."
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr "Utwórz"
 
 # | msgid "Create a Shelf"
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr "Utwórz konto"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr "Utwórz konto"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr "Tworzenie nie powiodło się."
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr "Utwórz półkę i dodaj książkę"
 
 # | msgid "Create a Shelf"
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr "Utwórz użytkownika"
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr "Utworzono \"{name}\"."
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr "Tworzenie…"
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr "Bieżący"
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr "Bieżąca okładka"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr "Obecne hasło"
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr "Obecnie czytane"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr "Niestandardowy kolor obramowania"
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr "Niestandardowe kolumny"
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr "Ścieżka bazy danych i biblioteki"
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr "Data dodania"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr "Domyślna (systemowa bezszeryfowa)"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr "Domyślny język książek"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr "Domyślny język interfejsu"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr "Wyczyszczono domyślny filtr biblioteki."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr "Zapisano domyślny filtr biblioteki."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr "Domyślne role dla nowych użytkowników OAuth:"
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 "Ustawienia domyślne znajdują się w Panel administratora → Konfiguracja → "
 "Synchronizacja Kobo."
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr "Usuń książki"
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr "Usuwanie nie powiodło się."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "Usunąć półkę \"{name}\"? Tej operacji nie można cofnąć."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr "Usunąć tę inteligentną półkę? Twoje książki nie zostaną naruszone."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Usunąć użytkownika \"{name}\"? Jego półki i dane czytania również zostaną "
 "usunięte."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "Usuń \"{name}\""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "Usunięto \"{name}\"."
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr "Gęste"
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Opis"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr "Wyłącz standardowe logowanie hasłem"
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr "Zaktualizowano propozycje w Odkrywaj."
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr "Odkrywaj — losowe propozycje"
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr "Odrzuć"
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr "Odrzuć tę grupę"
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr "Dokumentacja"
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr "Zakończono zmianę kolejności"
 
 # ???
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Pobieranie"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr "Upuść pliki tutaj lub kliknij, aby wybrać"
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr "Duplikat"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr "Zduplikowane książki"
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr "Ustawienia wykrywania duplikatów"
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
@@ -4494,284 +4607,284 @@ msgstr ""
 "Rozpoczęto skanowanie duplikatów. Działa ono w tle — ta lista zaktualizuje "
 "się po jego zakończeniu."
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr "Podgląd na czytniku e-booków"
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr "Każdy typ (isbn, amazon, google, doi…) może wystąpić tylko raz."
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr "Rozmyta krawędź — miękkie obramowanie bokeh"
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Odbicie krawędzi — rozszerz grafikę (zalecane)"
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Edycja"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr "Edytuj publiczne półki"
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr "Edytuj inteligentną półkę"
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr "Edytuj tytuł \"{title}\""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "E-mail"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr "Serwer e-mail (SMTP)"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr "E-mail (opcjonalnie)"
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr "Roszczenie (claim) e-mail"
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr "Wyślij mi link resetujący"
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr "Ustawienia e-mail zapisane."
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Włącz synchronizację Kobo"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr "Wygasa za"
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr "Udostępniaj przez OPDS tylko wybrane półki"
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr "Nie udało się wczytać półek."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr "Wczytywanie nie powiodło się."
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr "Ulubione"
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr "Dodano do ulubionych"
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr "Pobierz"
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr "Pobierz metadane z internetu"
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr "Pliki"
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 "Pliki zostaną umieszczone w kolejce do przetworzenia i pojawią się po "
 "zaimportowaniu."
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr "Styl wypełnienia"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Filtruj: {items}"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Filtruj: {items}…"
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr "Rodzina czcionek"
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr "Rozmiar czcionki"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr "Nie pamiętasz hasła?"
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr "Format oczekuje w kolejce — pojawi się po przetworzeniu."
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr "Formaty"
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr "Formaty — wyklucz"
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr "Formaty — uwzględnij"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr "Adres nadawcy"
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr "Pełna tabela użytkowników i ograniczenia"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr "Wygeneruj nowy link"
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr "Nadaj nazwę swojej inteligentnej półce."
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr "Przejdź do swojej biblioteki"
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr "Gradient — przejście góra/dół dopasowane do palety"
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr "Roszczenie (claim) grupy"
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr "Pole członków grupy"
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr "Nazwa grupy"
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr "Filtr obiektu grupy"
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr "HTML jest dozwolony i jest oczyszczany przy wyświetlaniu."
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr "Nazwa nagłówka"
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr "Pomoc i wsparcie"
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr "Menu pomocy"
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr "Ukryte"
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Ukryj"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr "Ukryj sekcję Odkrywaj"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr "Ukryj pola"
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr "Ukryj hasło"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr "Zakreślenie"
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr "Zakreślenia"
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr "Popularne"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr "Popularne — najczęściej pobierane"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr "Ikona"
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr "Typ identyfikatora"
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr "Wartość identyfikatora"
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identyfikatory"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr "Zaimportowano jako"
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr "W Twojej książce"
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
@@ -4779,338 +4892,338 @@ msgstr ""
 "Czytanie w przeglądarce obecnie obsługuje format EPUB. W przypadku innych "
 "formatów użyj pobierania lub klasycznego czytnika."
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr "Wystawca / adres bazowy"
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 "Mogła zostać przeniesiona lub nadal znajduje się w klasycznym interfejsie."
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr "Postęp KOReader"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr "Ścieżka pliku klucza"
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr "Ścieżka klucza"
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264×1680)"
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr "Synchronizacja Kobo włączona"
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Język"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr "Języki — uwzględnij"
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "Ostatnio zmodyfikowano"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr "Ostatnio zsynchronizowano"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr "Ustawienia biblioteki"
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr "Wysokość linii"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr "Wczytaj więcej"
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr "Wczytywanie"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr "Wczytywanie nowych propozycji w Odkrywaj."
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr "Wczytywanie…"
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr "Zablokuj okładkę"
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr "Tekst przycisku logowania"
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr "Metoda logowania"
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr "Zaloguj się przez"
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr "Dzienniki"
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr "Wygląda dobrze"
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr "Niska rozdzielczość"
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr "Magic link"
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr "Kod QR magic link"
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr "Ustaw jako prywatną"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr "Ustaw jako publiczną"
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr "Ustaw to jako mój domyślny widok biblioteki"
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr "Zarządzaj rolą administratora na podstawie grupy OAuth"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr "Zarządzaj półkami"
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "Oznacz jako przeczytane"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "Oznacz jako nieprzeczytane"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr "Dopasowanie"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr "Maks."
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr "Maksymalna liczba pokazywanych autorów"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr "Maksymalna ocena"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr "Filtr użytkownika członka"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr "Adres URL metadanych (automatyczne wykrywanie OIDC)"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr "Min."
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr "Minimalna ocena"
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr "Więcej opcji okładek (dostawcy wyszukiwania, podgląd na czytniku)"
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr "Więcej konfiguracji serwera"
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr "Przenieś w dół"
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr "Przenieś w górę"
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr "Moje konto"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr "Nazwa"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr "Chcesz zgłosić problem? Wypróbuj nowy"
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr "Nowe"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr "Nowe hasło"
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr "Nazwa nowej półki"
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr "Nazwa nowej półki…"
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr "Nowa półka…"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr "Nowa inteligentna półka"
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr "Nowy użytkownik"
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr "Najnowsze"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr "Najnowsze wydania"
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr "Następna strona"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr "Żadna książka nie spełnia obecnie kryteriów tej inteligentnej półki."
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr "Żadna książka nie spełnia tych kryteriów."
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 "Nie znaleziono jeszcze kandydatów. Spróbuj innego wyszukiwania lub odśwież."
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr "Nie znaleziono zawartości."
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr "Nie znaleziono grup duplikatów."
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr "Brak wykluczonych tagów"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Brak jeszcze zakreśleń. Zakreślaj podczas czytania lub zaimportuj z "
 "urządzenia Kobo."
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Brak wyników \"{items}\" dla \"{query}\"."
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr "Nie znaleziono stron w tym komiksie."
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr "Brak jeszcze półek — utwórz jedną poniżej."
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr "Brak jeszcze półek. Utwórz jedną powyżej, aby zacząć zbierać książki."
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr "Żadne źródło nie wymaga klucza."
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr "Brak uruchomionych zadań."
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Brak jeszcze \"{items}\"."
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr "Nieskonfigurowane"
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr "Nie ustawiono"
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr "Najstarsze"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr "Najstarsze wydania"
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
@@ -5118,56 +5231,56 @@ msgstr ""
 "Na innym urządzeniu, na którym jesteś już zalogowany, zeskanuj ten kod lub "
 "otwórz poniższy link, aby autoryzować to urządzenie."
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr "Otwórz konto"
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr "Otwórz klasyczny czytnik"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr "Otwórz nawigację"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr "Otwórz czytnik"
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr "Otwórz klasyczny interfejs"
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr "Otwórz poniższy link na zalogowanym urządzeniu."
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr "Serwer OpenLDAP"
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr "Otwiera się w widoku klasycznym"
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr "Czytnik PDF"
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr "Marginesy strony"
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr "Motyw strony"
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Strona {number}"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
@@ -5175,17 +5288,17 @@ msgstr ""
 "Strony oznaczone poniżej otwierają się w widoku klasycznym. Zmiany tam "
 "wprowadzone dotyczą całego serwera."
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Hasło"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr "Hasło (pozostaw puste, aby zachować)"
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5193,161 +5306,161 @@ msgstr ""
 "Wybierz okładkę z dowolnego obsługiwanego źródła, wklej adres URL, prześlij "
 "plik lub użyj okładki osadzonej w samej książce."
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 "Podniesiono \"{label}\". Przeciągnij, aby zmienić kolejność, i puść, aby "
 "upuścić."
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr "Przygotowywanie magic linku…"
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr "Poprzednia strona"
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Postęp"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr "Publiczna"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr "Opublikowano po"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr "Opublikowano przed"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr "Wyświetlana liczba losowych książek"
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Ocena"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr "Ocena (gwiazdki)"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr "Status przeczytania"
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr "Filtr statusu przeczytania"
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr "Ustawienia czytnika zapisane."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr "Wygląd czytania"
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr "Odbiorca(y)"
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr "Host przekierowania (pełny adres URL)"
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr "Odśwież"
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr "Rejestrowanie…"
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr "Odśwież"
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr "Wczytaj ponownie metadane z dysku"
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr "Wczytywanie ponowne…"
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr "Zapamiętaj mnie"
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr "Usuń z ulubionych"
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr "Usuń z półki"
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr "Usuń zakreślenie"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr "Usuń identyfikator"
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr "Usuń regułę"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr "Zmień nazwę"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr "Zmień kolejność"
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr "Zamienić okładkę na tę?"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr "Zamienić okładkę?"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr "Zgłoś problem na Discordzie"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr "Zgłoś problem na GitHubie"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr "Wymagaj przynależności do grupy"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Zresetuj hasło dla \"{name}\""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5356,32 +5469,32 @@ msgstr ""
 "Zresetować hasło dla \"{name}\"? Obecne hasło przestanie działać, a nowe "
 "zostanie wysłane e-mailem."
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr "Logowanie przez nagłówek reverse proxy"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr "Liczba wierszy na wczytanie"
 
 # ???
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr "Czas działania"
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr "Serwer SMTP"
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5390,339 +5503,339 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Zapisz"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr "Zapisz ustawienia e-mail"
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr "Zapisz nazwę"
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr "Zapisz ustawienia bezpieczeństwa"
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr "Zapisz ustawienia"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Zapisano. Uruchom ponownie serwer, aby zmiany logowania zaczęły obowiązywać."
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr "Skanuj w poszukiwaniu duplikatów"
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr "Zadania zaplanowane"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr "Zakresy (scopes)"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr "Szukaj tytułu, autora…"
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr "Przeszukiwanie każdego źródła…"
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr "Wyszukiwanie…"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr "Ustawienia bezpieczeństwa zapisane."
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 "Zobacz, jak każda okładka wygląda z dopełnieniem dla Twojego urządzenia"
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Wybierz"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr "Wybierz wiele"
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "Wyślij"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr "Wysyłanie nie powiodło się."
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr "Wyślij na czytnik e-booków"
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr "E-mail do wysyłania na czytnik e-booków"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr "Wysyłanie…"
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr "Indeks w cyklu"
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr "Widok cykli"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr "Cykle — uwzględnij"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr "Udostępniaj przez HTTPS"
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr "SSL / HTTPS serwera"
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr "Ogłoszenie serwera (widoczne dla wszystkich użytkowników)"
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr "Host serwera"
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr "Konto usługi (DN)"
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr "Hasło usługi"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr "Hasło usługi (pozostaw puste, aby zachować)"
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 "Ustaw adres URL metadanych, aby automatycznie uzupełnić poniższe punkty "
 "końcowe, lub wprowadź je ręcznie."
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr "Ustawienia zapisane."
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr "Nazwa półki"
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr "Nie znaleziono półki."
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr "Pokaż sekcję Odkrywaj"
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr "Pokaż widok tabeli"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr "Pokaż wszystkie tagi ({count})"
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Pokaż wszystkie \"{items}\""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr "Pokaż książki w języku"
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr "Pokaż podgląd na czytniku dla każdego kandydata"
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr "Pokaż mniej tagów"
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr "Pokaż ukryte książki"
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr "Pokaż hasło"
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr "Wymieszaj propozycje"
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr "Zaloguj się za pomocą magic linku"
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr "Wyloguj się"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr "Logowanie…"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr "Tytuł strony"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr "Nie znaleziono inteligentnej półki."
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr "Inteligentne półki"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr "Jednolity: średni kolor okładki"
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr "Jednolity: kolor niestandardowy"
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr "Jednolity: najczęstszy kolor na okładce"
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr "Niektóre źródła wymagają klucza dla lepszych okładek"
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr "Coś poszło nie tak"
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr "Coś poszło nie tak. Spróbuj ponownie."
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr "Kolejność sortowania"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr "Szczegóły źródła"
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr "Rozpoczęto czytanie"
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr "Rozpoczynanie skanowania…"
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr "Panel statystyk"
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "Wesprzyj na Ko-fi →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr "Synchronizuj tylko moje wybrane półki"
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr "Synchronizuj z Kobo tylko wybrane półki"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr "Widok tabeli"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr "Tag"
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Etykiety"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr "Tagi — wyklucz"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr "Tagi — uwzględnij"
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr "Docelowe proporcje obrazu"
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Zadanie"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Zadania"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr "Szczegóły techniczne"
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr "Ten adres URL nie jest prawidłowym obrazem."
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr "Ten format otwiera się w czytniku pełnoekranowym."
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr "Ten magic link wygasł. Wygeneruj nowy, aby spróbować ponownie."
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr "Ta strona tutaj nie istnieje."
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
@@ -5730,76 +5843,76 @@ msgstr ""
 "Na tej stronie wystąpił błąd i nie można jej wyświetlić. Z Twoją biblioteką "
 "wszystko w porządku — ponowne wczytanie zwykle to naprawia."
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr "Ta półka jest pusta. Dodawaj książki ze strony dowolnej książki."
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr "Tytuł A–Z"
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr "Tytuł Z–A"
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr "Tytuł, autor lub ISBN"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr "Adres URL tokenu"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr "Najwyżej oceniane"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr "Ufaj nagłówkowi uwierzytelniania"
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr "Konfiguracja interfejsu / wyświetlania"
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "Przywróć z archiwum"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr "Odkryj"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr "Odblokuj powyższą okładkę, aby zastosować nową."
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr "Odblokuj okładkę, aby ją zmienić"
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr "Bez tytułu"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr "Aktualizacja nie powiodła się."
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr "Prześlij jako okładkę"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr "Prześlij książki"
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5807,68 +5920,68 @@ msgstr ""
 "Użyj ich do łączenia czytników OPDS lub synchronizacji KOReader bez "
 "podawania głównego hasła."
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr "Użyj tej okładki"
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Użytkownik"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr "Administracja użytkownikami"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr "Filtr obiektu użytkownika"
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr "Adres URL informacji o użytkowniku"
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr "Roszczenie (claim) nazwy użytkownika"
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr "Wersje"
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Zobacz"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr "Ustawienia widoku"
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr "Przeglądarka"
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr "Oczekiwanie na autoryzację…"
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr "Gdy okładka jest zablokowana, pobieranie metadanych jej nie nadpisze."
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr "Kiedy postęp czytania został po raz pierwszy zsynchronizowany"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
@@ -5878,159 +5991,149 @@ msgstr ""
 "samo oznaczenie tej półki nic nie zmieni. Przełącz swoje konto na "
 "synchronizację tylko wybranych półek, aby to zadziałało."
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr "Twoja biblioteka"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr "Twoja przeglądarka nie obsługuje odtwarzania tego formatu audio."
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr "Twoja osobista cyfrowa biblioteka"
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Wyświetlany jest zapisany adres czytnika e-booków — zmień go tylko na "
 "potrzeby tej wysyłki."
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr "wszystkie reguły"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr "dowolna reguła"
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr "książki"
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr "pasujące książki"
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr "kopie"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr "czytnik e-booków"
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr "np. Nieprzeczytane sci-fi"
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr "Temat e-maila do czytnika e-booków"
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr "udostępniono"
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr "do"
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr "typ (isbn, amazon, doi…)"
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr "wartość"
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr "Ty"
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} książka"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} książek"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} plik oczekuje w kolejce do importu"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} plik odrzucony"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} plików oczekuje w kolejce do importu"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} plików odrzuconych"
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} wynik"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} wyników"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "{count} wyników dla \"{query}\""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr "{field} (oddzielone przecinkami)"
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr "znaleziono: {n}"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "odpowiedziało źródeł: {ok} z {total}"
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr "…lub wklej adres URL obrazu"
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr "← Wróć do książki"
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr "← Wróć do logowania"
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr "← Biblioteka"
 
@@ -9350,10 +9453,6 @@ msgstr ""
 msgid "Tags/Genres"
 msgstr "Tagi/Gatunki"
 
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
-msgstr "Data publikacji"
-
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
 msgid "Identifiers (ISBN, etc.)"
 msgstr "Identyfikatory (ISBN itd.)"
@@ -9667,8 +9766,8 @@ msgid ""
 "Add these two services to your docker-compose file and run \"docker compose "
 "up -d\". After that you stay up to date automatically — no button to press."
 msgstr ""
-"Dodaj te dwie usługi do pliku docker-compose i uruchom \"docker compose up -"
-"d\". Od tej pory aktualizacje odbywają się automatycznie — bez klikania "
+"Dodaj te dwie usługi do pliku docker-compose i uruchom \"docker compose up "
+"-d\". Od tej pory aktualizacje odbywają się automatycznie — bez klikania "
 "żadnego przycisku."
 
 #: cps/templates/cwa_settings.html:770 cps/templates/update_now_modal.html:36
@@ -12490,80 +12589,6 @@ msgstr "Udostępniaj wybrane półki przez OPDS"
 #: cps/templates/user_table.html:158
 msgid "Show Read/Unread Section"
 msgstr "Pokaż sekcję przeczytane/nieprzeczytane"
-
-#~ msgid "<"
-#~ msgstr "<"
-
-#~ msgid "="
-#~ msgstr "="
-
-#~ msgid ">"
-#~ msgstr ">"
-
-#~ msgid ""
-#~ "A one-time full duplicate scan is needed. Run it from CWA settings, then "
-#~ "return here."
-#~ msgstr ""
-#~ "Wymagane jest jednorazowe pełne skanowanie duplikatów. Uruchom je w "
-#~ "ustawieniach CWA, a następnie wróć tutaj."
-
-#~ msgid "Date Added"
-#~ msgstr "Data dodania"
-
-#~ msgid "Support us on Ko-fi!"
-#~ msgstr "Wesprzyj nas na Ko-fi!"
-
-#~ msgid "Open Ko-fi →"
-#~ msgstr "Otwórz Ko-fi →"
-
-#~ msgid "Dismiss help announcement"
-#~ msgstr "Odrzuć ogłoszenie pomocy"
-
-#~ msgid "Dismiss Ko-fi support message"
-#~ msgstr "Odrzuć wiadomość o wsparciu na Ko-fi"
-
-#~ msgid ""
-#~ "These open the full configuration pages. Changes there apply to the whole "
-#~ "server."
-#~ msgstr ""
-#~ "Te odnośniki otwierają pełne strony konfiguracji. Zmiany tam wprowadzone "
-#~ "dotyczą całego serwera."
-
-#~ msgid "begins with"
-#~ msgstr "zaczyna się od"
-
-#~ msgid "contains"
-#~ msgstr "zawiera"
-
-#~ msgid "does not contain"
-#~ msgstr "nie zawiera"
-
-#~ msgid "ends with"
-#~ msgstr "kończy się na"
-
-#~ msgid "in the past N days"
-#~ msgstr "w ciągu ostatnich N dni"
-
-#~ msgid "is"
-#~ msgstr "jest"
-
-#~ msgid "is not"
-#~ msgstr "nie jest"
-
-#~ msgid "not in the past N days"
-#~ msgstr "nie w ciągu ostatnich N dni"
-
-#~ msgid "on or after"
-#~ msgstr "w tym dniu lub później"
-
-#~ msgid "on or before"
-#~ msgstr "w tym dniu lub wcześniej"
-
-#~ msgid "≤"
-#~ msgstr "≤"
-
-#~ msgid "≥"
-#~ msgstr "≥"
 
 #~ msgid "Sync Kobo read progress to Hardcover (Requires API key per user)"
 #~ msgstr ""

--- a/cps/translations/pt/LC_MESSAGES/messages.po
+++ b/cps/translations/pt/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Estatísticas"
 
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Editar utilizadores"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Tudo"
@@ -1030,7 +1030,7 @@ msgstr "não instalado"
 msgid "Execution permissions missing"
 msgstr "Falta de permissões de execução"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1235,7 +1235,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Função inválida"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2067,7 +2067,7 @@ msgstr "Versão atual"
 msgid "Unread Books"
 msgstr "Livros não lidos"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2078,7 +2078,7 @@ msgstr "Autores"
 msgid "Books ordered by Author"
 msgstr "Livros ordenados por autor"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Editoras"
@@ -2087,7 +2087,7 @@ msgstr "Editoras"
 msgid "Books ordered by publisher"
 msgstr "Livros ordenados por editora"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Categorias"
@@ -2109,7 +2109,7 @@ msgstr "Séries"
 msgid "Books ordered by series"
 msgstr "Livros ordenados por série"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2119,7 +2119,7 @@ msgstr "Idiomas"
 msgid "Books ordered by Languages"
 msgstr "Livros ordenados por idiomas"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Pontuações"
@@ -2136,7 +2136,7 @@ msgstr "Formatos de ficheiro"
 msgid "Books ordered by file formats"
 msgstr "Livros ordenados por formatos de ficheiro"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Estantes"
@@ -2173,7 +2173,7 @@ msgstr "{} Estrelas"
 msgid "Search"
 msgstr "Pesquisar"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2197,7 +2197,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Livros"
 
@@ -2231,7 +2231,7 @@ msgstr "Mostrar lido e não lido"
 msgid "Show unread"
 msgstr "Mostrar Não Lidos"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Descobrir"
 
@@ -2279,7 +2279,7 @@ msgstr "Livros arquivados"
 msgid "Show Archived Books"
 msgstr "Mostrar livros arquivados"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2295,7 +2295,7 @@ msgstr "Lista de livros"
 msgid "Show Books List"
 msgstr "Mostrar lista de livros"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2998,13 +2998,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Apagar"
 
@@ -3160,8 +3160,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Fundir"
 
@@ -3289,7 +3290,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3725,225 +3727,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Sobre"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Arquivado"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3966,1326 +4085,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Converter"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Descrição"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Descarregar"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Editar"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "Endereço de email"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Ativar Kobo sync"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Encriptação"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Esconder"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identificadores"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Idioma"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Senha"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Porta"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Progresso"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Pontuação"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5294,634 +5403,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Guardar"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Selecionar"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Estado"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "Apoiar no Ko-fi →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Tarefa"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Tarefas"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Utilizador"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Nome de utilizador"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Ver"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9138,10 +9237,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/cps/translations/pt_BR/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Estatísticas"
 
@@ -139,7 +139,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Editar Usuários"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Todos"
@@ -1017,7 +1017,7 @@ msgstr "não instalado"
 msgid "Execution permissions missing"
 msgstr "Faltam as permissões de execução"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr "Voltar para edição de metadados"
 
@@ -1063,7 +1063,7 @@ msgstr "Não foi possível renderizar a pré-visualização do e-reader."
 msgid "Could not load a source image to preview."
 msgstr "Não foi possível carregar uma imagem de origem para visualização."
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr "Falha ao salvar a capa"
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Seleção de livro inválida."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr "Livro não encontrado."
 
@@ -2035,7 +2035,7 @@ msgstr "Livros sendo lidos"
 msgid "Unread Books"
 msgstr "Livros Não Lidos"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2046,7 +2046,7 @@ msgstr "Autores"
 msgid "Books ordered by Author"
 msgstr "Livros ordenados por Autor"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Editoras"
@@ -2055,7 +2055,7 @@ msgstr "Editoras"
 msgid "Books ordered by publisher"
 msgstr "Livros ordenados por editora"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Categorias"
@@ -2077,7 +2077,7 @@ msgstr "Séries"
 msgid "Books ordered by series"
 msgstr "Livros ordenados por série"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2087,7 +2087,7 @@ msgstr "Idiomas"
 msgid "Books ordered by Languages"
 msgstr "Livros ordenados por Idiomas"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Avaliações"
@@ -2104,7 +2104,7 @@ msgstr "Formatos de arquivo"
 msgid "Books ordered by file formats"
 msgstr "Livros ordenados por formatos de arquivo"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Estantes"
@@ -2141,7 +2141,7 @@ msgstr "{} Estrelas"
 msgid "Search"
 msgstr "Pesquisar"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2165,7 +2165,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Livros"
 
@@ -2199,7 +2199,7 @@ msgstr "Mostrar lido e não lido"
 msgid "Show unread"
 msgstr "Mostrar Não Lidos"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Descubra"
 
@@ -2247,7 +2247,7 @@ msgstr "Livros Arquivados"
 msgid "Show Archived Books"
 msgstr "Mostrar livros arquivados"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr "Favoritos"
 
@@ -2263,7 +2263,7 @@ msgstr "Lista de Livros"
 msgid "Show Books List"
 msgstr "Mostrar Lista de Livros"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "Duplicados"
 
@@ -2968,13 +2968,13 @@ msgstr "Criar sua conta"
 msgid "Dark theme"
 msgstr "Tema escuro"
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Apagar"
 
@@ -3133,8 +3133,9 @@ msgstr "Marcar como lido"
 msgid "Mark unread"
 msgstr "Marcar como não lido"
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Mesclar"
 
@@ -3262,7 +3263,8 @@ msgstr "Salvar perfil"
 msgid "Saved."
 msgstr "Salvo."
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr "Salvando…"
 
@@ -3703,225 +3705,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr "Atualizar biblioteca"
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr "Incluído em"
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr "Ignorar mensagem de apoio no Ko-fi"
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr "Ignorar anúncio de ajuda"
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr "Abrir o Ko-fi →"
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr "Data de Publicação"
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr "Apoie-nos no Ko-fi!"
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr "começa com"
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr "contém"
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr "não contém"
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr "≤"
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr "≥"
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr "Algumas escolhas aleatórias da sua biblioteca"
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Sobre"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr "Configurações de conta"
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Conta: {name}"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr "Adicionar aos favoritos"
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr "Avançado"
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr "Pesquisa avançada"
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr "Todas as estantes"
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr "Permitir login remoto (link mágico)"
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr "Grupos permitidos (separado por vírgulas)"
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "Qualquer"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr "Qualquer formato"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr "Qualquer idioma"
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr "Qualquer série"
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr "Qualquer tag"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr "Aplicar seleção"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr "Aplicando…"
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "Arquivado"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Arquivado"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr "Perguntar no Discord"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr "Autenticação"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr "Autenticação e segurança"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr "Autor A-Z"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr "Autor Z-A"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr "Autorizado — entrando…"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr "Criar usuários automaticamente no primeiro login"
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr "Voltar para a biblioteca"
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr "Voltar para a visualização clássica"
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr "Configuração básica"
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Livro {number}"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr "Livros por página"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr "Configurações do CWA (ingest/convert)"
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3944,1140 +4063,1130 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr "Cancelar renomeação"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr "Cancelar edição de título"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Cancelar {task}"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr "Alterar capa"
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr "Escolha uma capa"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr "Escolha a imagem da capa para enviar"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr "Escolha uma imagem..."
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr "Escolha seu tema"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr "Limpar seleção"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr "Fechar o leitor"
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr "Colunas"
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr "Confortável"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr "Compacto"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr "Configurado"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr "Confirmar nova senha"
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Converter"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr "Converter antes de enviar"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr "Converter de"
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr "Copiado para a área de transferência"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr "Copiar link"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr "Não foi possível criar a estante."
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr "Não foi possível criar a estante."
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr "Não foi possível excluir a estante."
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr "Não foi possível carregar candidatos."
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr "Não foi possível carregar duplicados."
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr "Não foi possível carregar destaques."
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr "Não foi possível carregar estatísticas."
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr "Não foi possível carregar tarefas."
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr "Não foi possível carregar esse arquivo de texto"
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr "Não foi possível carregar usuários."
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr "Não foi possível ler este arquivo de quadrinhos."
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr "Não foi possível recarregar os metadados"
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr "Não foi possível renomear a estante."
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr "Não foi possível redefinir a senha."
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr "Capa atual"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr "Senha atual"
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr "Leitura atual"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr "Incluído em"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Descrição"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr "Documentação"
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Baixar"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr "Livros duplicados"
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr "Pré-visualização no e-reader"
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Editar"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "Endereço de e-mail"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Ativar Kobo sync"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Criptografia"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr "Favoritar"
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr "Favoritado"
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr "Formatos"
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr "Formatos — excluir"
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr "Formatos — incluir"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr "Vá para a sua biblioteca"
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr "Ajuda e suporte"
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr "Menu de ajuda"
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr "Livro ocultado"
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Esconder"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr "Ocultar campos"
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr "Ocultar senha"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr "Destaque"
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr "Destaques"
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr "Ícone"
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identificadores"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr "Importado como"
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr "No seu livro"
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr "KOReader Progresso"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Idioma"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr "Idiomas — incluir"
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "Última modificação"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr "Última sincronização"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr "Configurações da biblioteca"
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr "Carregar mais"
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr "Carregando"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr "Bloquear capa"
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "Marcar como lido"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "Marcar como não lido"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr "Máx."
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr "Mais configurações do servidor"
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr "Mover para baixo"
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr "Mover para cima"
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr "Minha conta"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr "Nome"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr "Precisa reportar um problema? Experimente o novo"
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr "Novo"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr "Nova senha"
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr "Novo nome da estante"
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr "Novo nome da estante…"
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr "Nova estante…"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr "Nova estante inteligente"
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr "Novo usuário"
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr "Mais recentes"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr "Publicados mais recentemente"
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr "Próxima página"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr "Nenhum livro corresponde a esta estante inteligente no momento."
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr "Nenhum livro corresponde a esses critérios."
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 "Nenhum candidato encontrado ainda. Tente uma pesquisa diferente ou atualize."
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr "Nenhum conteúdo encontrado."
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr "Nenhum grupo duplicado encontrado."
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr "Nenhuma tag excluída"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Nenhum destaque ainda. Destaque enquanto lê ou importe de um dispositivo "
 "Kobo."
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "Nenhum {items} corresponde a \"{query}\"."
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr "Nenhuma página encontrada neste quadrinho."
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr "Ainda não há estantes - crie uma abaixo"
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr "Ainda não há estantes. Crie uma acima para começar a guardar livros."
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr "Nenhuma fonte precisa de uma chave."
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr "Nenhuma tarefa em execução"
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "Ainda não há {items}."
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr "Não configurado"
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr "Mais antigos"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr "Publicados há mais tempo"
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr "Abrir Conta"
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr "Abrir leitor clássico"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr "Abrir navegação"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr "Abrir leitor"
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr "Abrir a interface clássica"
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr "Abra o link abaixo em seu dispositivo conectado."
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr "Servidor OpenLDAP"
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr "Abre na visualização clássica"
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr "Leitor de PDF"
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr "Margens da página"
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr "Tema da página"
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Página {number}"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Senha"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr "Senha (deixe em branco para manter)"
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5085,159 +5194,159 @@ msgstr ""
 "Escolha uma capa de qualquer fonte que suportamos, cole um URL, envie um "
 "arquivo ou use a capa incorporada no próprio livro."
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr "Selecionado {label}. Arraste para reordenar, solte para largar."
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Porta"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr "Preparando seu link mágico..."
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr "Página anterior"
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Progresso"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr "Público"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr "Publicados após"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr "Publicados antes"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr "Mostrando livros aleatórios"
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Avaliação"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr "Avaliação (estrelas)"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr "Status de leitura"
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr "Filtro de status de leitura"
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr "Configurações do leitor salvas."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr "Aparência da leitura"
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr "Destinatário(s)"
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr "Host de redirecionamento (URL completa)"
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr "Registrando…"
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr "Recarregar"
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr "Recarregar metadados do disco"
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr "Recarregando…"
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr "Lembrar de mim"
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr "Remover dos favoritos"
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr "Remover da estante"
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr "Remover destaque"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr "Remover identificador"
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr "Remover regra"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr "Renomear"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr "Reordenar"
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr "Substituir a capa por esta?"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr "Substituir a capa?"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr "Reportar Problema no Discord"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr "Reportar Problema no GitHub"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr "Requerer associação a grupo"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Redefinir senha para {name}"
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5246,31 +5355,31 @@ msgstr ""
 "Redefinir senha para {name}? Sua senha atual deixará de funcionar e uma "
 "substituta será enviada por e-mail."
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr "Login via cabeçalho de proxy reverso"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr "Linhas por carregamento"
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5279,411 +5388,411 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Salvar"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr "Salvar configurações de email"
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr "Salvar nome"
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr "Salvar configurações de segurança"
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr "Salvar configurações"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Salvo. Reinicie o servidor para que as alterações de login tenham efeito."
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr "Tarefas agendadas"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr "Pesquisar título, autor..."
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr "Pesquisando em todas as fontes…"
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr "Pesquisando..."
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr "Configurações de Segurança salvas."
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr "Veja como cada capa parece com espaçamento para o seu dispositivo"
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Selecione"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr "Selecionar vários"
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "Enviar"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr "Enviou falhou."
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr "Enviar para E-Reader"
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr "Enviar para o endereço de e-mail do E-Reader"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr "Enviando..."
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr "Índice da série"
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr "Visualização da série"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr "Série — incluir"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr "Configurações salvas."
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr "Mostrar senha"
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr "Sair"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr "Entrando…"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr "Título do site"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr "Estantes inteligentes"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr "Algumas fontes necessitam de uma chave para obter capas melhores"
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr "Algo deu errado"
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr "Ordem de classificação"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr "Detalhes da fonte"
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr "Início da leitura"
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr "Dashboard de estatísticas"
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Estado"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "Apoiar no Ko-fi →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr "Sincronizar apenas as estantes selecionadas com o Kobo"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr "Visualização em tabela"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr "Tag"
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Tags"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr "Tags — excluir"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr "Tags — incluir"
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Tarefa"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Tarefas"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr "Detalhes técnicos"
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr "Esta URL não é uma imagem utilizável."
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr "Título A–Z"
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr "Título Z–A"
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr "Título, autor ou ISBN"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr "URL do token"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr "Melhores avaliados"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "Desarquivar"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr "Mostrar"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr "Desbloqueie a capa para alterá-la"
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr "Sem título"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr "Atualização falhou."
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr "Enviar como capa"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr "Enviar livros"
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5691,226 +5800,216 @@ msgstr ""
 "Use esta para conectar a leitores OPDS ou sincronizar com KOReader sem a sua "
 "senha principal."
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr "Usar esta capa"
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Usuário"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr "Administração de usuário"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Nome de usuário"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Ver"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr "Visualizar configurações"
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr "Quando bloqueada, a busca de metadados não substituirá esta capa."
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr "Sua Biblioteca"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr "Seu navegador não pode reproduzir este formato de áudio."
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr "Sua biblioteca digital pessoal"
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Seu endereço de e-reader salvo é exibido — mude-o apenas para este envio."
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr "livros"
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr "cópias"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} livro"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} livros"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} arquivo na fila para importação"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} arquivo rejeitado"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} arquivos na fila para importação"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} arquivos rejeitados"
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} resultado"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} resultados"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "{count} resultados para \"{query}\""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr "{n} encontrados"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "{ok} de {total} fontes respondidas"
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr "← Voltar para o livro"
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr "← Voltar para o login"
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr "← Biblioteca"
 
@@ -9110,10 +9209,6 @@ msgstr ""
 msgid "Tags/Genres"
 msgstr ""
 
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
-msgstr "Data de Publicação"
-
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
 #, fuzzy
 msgid "Identifiers (ISBN, etc.)"
@@ -12151,36 +12246,6 @@ msgstr "Sincronizar Estantes Selecionadas com Kobo"
 #, fuzzy
 msgid "Show Read/Unread Section"
 msgstr "Mostrar seção de lidos/não lidos"
-
-#~ msgid "Date Added"
-#~ msgstr "Incluído em"
-
-#~ msgid "Support us on Ko-fi!"
-#~ msgstr "Apoie-nos no Ko-fi!"
-
-#~ msgid "Open Ko-fi →"
-#~ msgstr "Abrir o Ko-fi →"
-
-#~ msgid "Dismiss help announcement"
-#~ msgstr "Ignorar anúncio de ajuda"
-
-#~ msgid "Dismiss Ko-fi support message"
-#~ msgstr "Ignorar mensagem de apoio no Ko-fi"
-
-#~ msgid "begins with"
-#~ msgstr "começa com"
-
-#~ msgid "contains"
-#~ msgstr "contém"
-
-#~ msgid "does not contain"
-#~ msgstr "não contém"
-
-#~ msgid "≤"
-#~ msgstr "≤"
-
-#~ msgid "≥"
-#~ msgstr "≥"
 
 #~ msgid "Sync Kobo read progress to Hardcover (Requires API key per user)"
 #~ msgstr ""

--- a/cps/translations/ru/LC_MESSAGES/messages.po
+++ b/cps/translations/ru/LC_MESSAGES/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 "Generated-By: Babel 2.13.1\n"
 "X-Generator: Poedit 3.9\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Статистика"
 
@@ -153,7 +153,7 @@ msgstr "Пользовательский столбец №%(column)d отсут
 msgid "Edit Users"
 msgstr "Редактировать пользователей"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Все"
@@ -721,8 +721,8 @@ msgid ""
 "https://your-domain.com)"
 msgstr ""
 "В поле «Хост перенаправления OAuth» не следует указывать путь. Используйте "
-"только базовый URL (например, [https://your-domain.com](https://your-domain."
-"com))"
+"только базовый URL (например, [https://your-domain.com](https://your-"
+"domain.com))"
 
 #: cps/admin.py:2802
 msgid "Password length has to be between 1 and 40"
@@ -1061,7 +1061,7 @@ msgstr "не установлено"
 msgid "Execution permissions missing"
 msgstr "Отсутствуют права на выполнение"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr "Вернуться к редактированию метаданных"
 
@@ -1110,7 +1110,7 @@ msgid "Could not load a source image to preview."
 msgstr ""
 "Не удалось загрузить исходное изображение для предварительного просмотра."
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr "Ошибка сохранения обложки."
 
@@ -1275,7 +1275,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Неверный выбор книги."
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr "Книга не найдена."
 
@@ -2107,7 +2107,7 @@ msgstr "Книги, читаемые сейчас"
 msgid "Unread Books"
 msgstr "Непрочитанные книги"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2118,7 +2118,7 @@ msgstr "Авторы"
 msgid "Books ordered by Author"
 msgstr "Книги, упорядоченные по автору"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Издатели"
@@ -2127,7 +2127,7 @@ msgstr "Издатели"
 msgid "Books ordered by publisher"
 msgstr "Книги, упорядоченные по издателю"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Категории"
@@ -2149,7 +2149,7 @@ msgstr "Серии"
 msgid "Books ordered by series"
 msgstr "Книги, упорядоченные по серии"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2159,7 +2159,7 @@ msgstr "Языки"
 msgid "Books ordered by Languages"
 msgstr "Книги, упорядоченные по языкам"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Рейтинги"
@@ -2176,7 +2176,7 @@ msgstr "Форматы файлов"
 msgid "Books ordered by file formats"
 msgstr "Книги, упорядоченные по форматам файлов"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Полки"
@@ -2210,7 +2210,7 @@ msgstr "{} звёзд"
 msgid "Search"
 msgstr "Поиск"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2237,7 +2237,7 @@ msgstr ""
 "прежде чем можно будет выполнять быструю проверку после импорта и изменения "
 "метаданных. "
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Книги"
 
@@ -2270,7 +2270,7 @@ msgstr "Показать прочитанные и непрочитанные"
 msgid "Show unread"
 msgstr "Показать непрочитанные"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Интересное"
 
@@ -2310,7 +2310,7 @@ msgstr "Архивированные книги"
 msgid "Show Archived Books"
 msgstr "Показать архивированные книги"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr "Избранное"
 
@@ -2326,7 +2326,7 @@ msgstr "Список книг"
 msgid "Show Books List"
 msgstr "Показать список книг"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "Дубликаты"
 
@@ -3031,13 +3031,13 @@ msgstr "Создать аккаунт"
 msgid "Dark theme"
 msgstr "Тёмная тема"
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Удалить"
 
@@ -3195,8 +3195,9 @@ msgstr "Пометить как прочитанное"
 msgid "Mark unread"
 msgstr "Пометить как непрочитанное"
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Объединить"
 
@@ -3326,7 +3327,8 @@ msgstr "Сохранить профиль"
 msgid "Saved."
 msgstr "Сохранено."
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr "Сохранение…"
 
@@ -3771,30 +3773,153 @@ msgstr "Не удалось сохранить боковую панель. По
 msgid "Refresh library"
 msgstr "Обновить библиотеку"
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr "<"
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr "="
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ">"
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+"Необходим однократный полный поиск дубликатов. Запустите его в настройках "
+"CWA, а затем вернитесь сюда."
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr "Дата добавления"
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+"Удалить «{name}»? Он будет удалён из {count} книги, сама книга останется."
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+"Удалить «{name}»? Он будет удалён из {count} книг, сами книги останутся."
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr "Скрыть сообщение о поддержке на Ko-fi"
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr "Скрыть справочное объявление"
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr "Открыть Ko-fi →"
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr "Дата публикации"
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr "Поддержите нас на Ko-fi!"
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+"Открывает полные страницы настроек. Внесенные там изменения применятся ко "
+"всему серверу."
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr "«{name}» уже существует для {count} книги. Объединить этот тег с ним?"
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr "«{name}» уже существует для {count} книг. Объединить этот тег с ним?"
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr "начинается с"
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr "содержит"
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr "не содержит"
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr "заканчивается на"
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr "за последние N дней"
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr "не равно"
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr "равно"
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr "не за последние N дней"
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr "в эту дату или позже"
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr "в эту дату или раньше"
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr "≤"
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr "≥"
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr "(заменить обложку)"
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr "2:3 (обложка издательства, без отступов для стандартных обложек)"
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr "3:4 (стандартный)"
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 "Поиск дубликатов уже выполняется. Этот список обновится после завершения."
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr "Несколько случайных книг из вашей библиотеки"
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
@@ -3802,173 +3927,173 @@ msgstr ""
 "Необходим однократный полный поиск дубликатов. Используйте кнопку «Поиск "
 "дубликатов» выше, чтобы запустить его."
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr "Ключи API"
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "О программе"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr "Настройки аккаунта"
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr "Учётная запись: {name}"
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr "Добавить идентификатор"
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr "Добавить в избранное"
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr "Группа администраторов"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr "Дополнительно"
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr "Расширенный поиск"
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr "Все полки"
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr "Разрешить удаленный вход (по волшебной ссылке)"
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr "Разрешённые группы (через запятую)"
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "Любой"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr "Любой формат"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr "Любой язык"
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr "Любая серия"
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr "Любые теги"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr "Применить выбранные"
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 "Применить ко всем выбранным (изменятся только заполненные поля; текущие "
 "значения будут заменены):"
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr "Применение…"
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "Архив"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "В архиве"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr "Спросить в Discord"
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr "Авторизация"
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr "Авторизация и безопасность"
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr "Автор А–Я"
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr "Автор Я–А"
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr "Авторизация успешна — выполняем вход…"
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr "URL авторизации"
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr "Автоматически создавать пользователей"
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr "Автоматически создавать пользователей при первом входе"
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr "Вернуться в библиотеку"
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr "Вернуться к классическому виду"
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr "Base DN"
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr "Основные настройки"
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr "По умолчанию для книги"
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr "Плотность отображения книг"
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr "Книга {number}"
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr "Книг на странице"
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
@@ -3977,27 +4102,27 @@ msgstr ""
 "устройства при следующей синхронизации. Здесь, в вашей библиотеке, они "
 "останутся."
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr "Встроенные провайдеры (оставьте пустым, чтобы отключить):"
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr "Массовые действия"
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr "Путь к CA-сертификату"
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr "Настройки CWA (импорт/конвертация)"
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr "Можно загружать книги"
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -4020,458 +4145,446 @@ msgstr "Можно загружать книги"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr "Отменить переименование"
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr "Отменить редактирование названия"
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr "Отменить задачу «{task}»"
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr "Путь к файлу сертификата"
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr "Путь к сертификату"
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr "Изменить обложку"
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr "Проверка…"
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr "Выбрать обложку"
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr "Выберите изображение обложки для загрузки"
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr "Выберите изображение…"
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr "Выбрать поля"
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr "Выберите тему оформления"
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr "Сбросить значение по умолчанию"
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr "Снять выделение"
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr "ID клиента"
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr "Секрет клиента"
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr "Секретный ключ клиента (оставьте пустым, чтобы сохранить текущий)"
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr "Закрыть читалку"
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr "Колонки"
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr "Комфортно"
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr "Компактно"
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr "Настроено"
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr "Подтвердите удаление тега {name}"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr "Подтвердите новый пароль"
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Конвертировать"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr "Конвертировать перед отправкой"
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr "Конвертировать из"
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr "Скопировано в буфер обмена"
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr "Скопировать ссылку"
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr "Не удалось создать полку."
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr "Не удалось создать полку."
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr "Не удалось удалить полку."
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr "Не удалось удалить тег"
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr "Не удалось загрузить кандидатов."
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr "Не удалось загрузить дубликаты."
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr "Не удалось загрузить выделения."
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr "Не удалось загрузить статистику."
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr "Не удалось загрузить задачи."
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr "Не удалось загрузить этот текстовый файл."
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr "Не удалось загрузить пользователей."
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr "Не удалось прочитать этот архив комикса."
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr "Не удалось перезагрузить метаданные"
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr "Не удалось переименовать полку."
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr "Не удалось сбросить пароль."
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr "Не удалось сохранить порядок."
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr "Не удалось сохранить настройки читалки."
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr "Не удалось сохранить фильтр библиотеки по умолчанию."
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr "Не удалось сохранить полку."
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr "Не удалось сохранить название."
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr "Не удалось сохранить вашу позицию чтения."
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr "Не удалось запустить поиск дубликатов."
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr "Не удалось обновить полку."
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr "Не удалось обновить настройку аккаунта."
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr "Не удалось создать волшебную ссылку. Пожалуйста, попробуйте ещё раз."
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr "Обложка заблокирована"
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr "Обложка недоступна"
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr "Обложка обновлена из выбранного результата."
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr "Создать"
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr "Создать учётную запись"
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr "Создать учётную запись"
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr "Не удалось создать."
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr "Создать полку и добавить книгу"
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr "Создать пользователя"
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr "Создано: {name}."
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr "Создание…"
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr "Текущий"
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr "Текущая обложка"
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr "Текущий пароль"
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr "Читаю сейчас"
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr "Пользовательский цвет рамки"
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr "Пользовательские колонки"
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr "База данных и путь к библиотеке"
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr "Дата добавления"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr "По умолчанию (Системный без засечек)"
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr "Язык книг по умолчанию"
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr "Язык интерфейса по умолчанию"
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr "Фильтр библиотеки по умолчанию сброшен."
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr "Фильтр библиотеки по умолчанию сохранен."
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr "Роли по умолчанию для новых пользователей OAuth:"
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 "Настройки по умолчанию находятся в меню Администрирование → Конфигурация → "
 "Синхронизация Kobo."
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr "Удалить книги"
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr "Не удалось удалить."
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr "Удалить полку «{name}»? Это действие нельзя отменить."
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr "Удалить тег {name}"
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr "Удалить эту смарт-полку? Это не повлияет на ваши книги."
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 "Удалить пользователя «{name}»? Его полки и данные о чтении также будут "
 "удалены."
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr "Удалить {name}"
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-"Удалить «{name}»? Он будет удалён из {count} книги, сама книга останется."
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-"Удалить «{name}»? Он будет удалён из {count} книг, сами книги останутся."
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr "Тег {name} удалён"
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr "Удалено: {name}."
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr "Плотно"
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Описание"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr "Отключить стандартный вход по паролю"
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr "Подборки в «Обзоре» обновлены."
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr "Открытия — Случайная подборка"
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr "Скрыть"
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr "Пропустить эту группу"
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr "Документация"
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr "Сортировка завершена"
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Скачать"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr "Перетащите файлы сюда или нажмите, чтобы выбрать"
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr "Дубликат"
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr "Дубликаты книг"
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr "Настройки поиска дубликатов"
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
@@ -4479,285 +4592,285 @@ msgstr ""
 "Поиск дубликатов запущен. Он выполняется в фоновом режиме — этот список "
 "обновится после завершения."
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr "Предварительный просмотр для eReader"
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 "Каждый тип (isbn, amazon, google, doi...) может использоваться только один "
 "раз."
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr "Размытие краев - мягкая рамка с эффектом боке"
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr "Зеркальные края - расширение обложки (рекомендуется)"
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Редактировать"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr "Редактировать общедоступные полки"
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr "Редактировать смарт-полку"
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr "Редактировать название для «{title}»"
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "Email"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr "Сервер электронной почты (SMTP)"
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr "Email (необязательно)"
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr "Атрибут email (Claim)"
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr "Отправить мне письмо для сброса"
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr "Настройки электронной почты сохранены."
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Включить синхронизацию с Kobo"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Шифрование"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr "Истекает через"
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr "Показывать по OPDS только выбранные полки"
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr "Не удалось загрузить полки."
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr "Не удалось загрузить."
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr "Избранное"
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr "В избранном"
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr "Получить"
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr "Загрузить метаданные из сети"
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr "Файлы"
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 "Файлы добавлены в очередь на обработку и появятся в библиотеке после импорта."
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr "Стиль заливки"
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr "Фильтр: {items}"
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr "Фильтр: {items}…"
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr "Семейство шрифтов"
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr "Размер шрифта"
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr "Забыли пароль?"
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr "Формат добавлен в очередь — он появится после обработки."
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr "Форматы"
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr "Форматы — исключить"
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr "Форматы — включить"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr "Адрес отправителя"
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr "Полная таблица пользователей и ограничений"
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr "Создать новую ссылку"
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr "Введите название для смарт-полки."
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr "Перейти в вашу библиотеку"
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr "Градиент - подобранный по палитре переход (верх/низ)"
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr "Атрибут группы (Claim)"
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr "Поле участников группы"
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr "Имя группы"
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr "Фильтр объектов группы"
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr "HTML-теги разрешены и очищаются от вредоносного кода при отображении."
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr "Имя заголовка"
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr "Помощь и поддержка"
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr "Меню справки"
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr "Скрыто"
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Скрыть"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr "Скрыть раздел «Обзор»"
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr "Скрыть поля"
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr "Скрыть пароль"
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr "Выделение"
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr "Выделения"
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr "Популярное"
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr "Популярное — Самые скачиваемые"
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr "Иконка"
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr "Тип идентификатора"
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr "Значение идентификатора"
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Идентификаторы"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr "Импортировано как"
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr "В вашей книге"
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
@@ -4765,342 +4878,342 @@ msgstr ""
 "Встроенная читалка пока поддерживает только EPUB. Для других форматов "
 "скачайте файл или используйте классическую читалку."
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr "Издатель / базовый URL"
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 "Возможно, этот элемент был перемещен или всё ещё находится в классическом "
 "интерфейсе."
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr "Прогресс KOReader"
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr "Путь к файлу ключа"
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr "Путь к ключу"
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr "Kobo Libra Color / Libra 2 (1264×1680)"
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr "Синхронизация Kobo включена"
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Язык"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr "Языки — включить"
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "Последнее изменение"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr "Последняя синхронизация"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr "Настройки библиотеки"
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr "Межстрочный интервал"
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr "Загрузить ещё"
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr "Загрузка"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr "Загрузка новых подборок в «Обзоре»."
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr "Загрузка…"
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr "Заблокировать обложку"
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr "Текст кнопки входа"
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr "Метод входа"
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr "Войти через"
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr "Журналы"
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr "Выглядит отлично"
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr "Низкое разрешение"
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr "Волшебная ссылка"
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr "QR-код волшебной ссылки"
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr "Сделать приватным"
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr "Сделать общедоступным"
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr "Использовать как вид библиотеки по умолчанию"
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr "Управление ролью администратора через группу OAuth"
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr "Управление полками"
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "Пометить как прочитанное"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "Пометить как непрочитанное"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr "Сопоставить"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr "Максимально"
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr "Максимальное количество отображаемых авторов"
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr "Максимальная оценка"
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr "Фильтр пользователей-участников"
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr "Объединить с {name}"
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr "Объединено с {name}"
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr "URL метаданных (автообнаружение OIDC)"
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr "Минимально"
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr "Минимальная оценка"
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 "Дополнительные параметры обложки (поиск по провайдерам, предпросмотр для "
 "читалки)"
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr "Дополнительные настройки сервера"
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr "Переместить вниз"
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr "Переместить вверх"
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr "Мой аккаунт"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr "Название"
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr "Нужно сообщить о проблеме? Попробуйте новый"
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr "Новый"
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr "Новый пароль"
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr "Название новой полки"
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr "Название новой полки…"
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr "Новая полка…"
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr "Новая смарт-полка"
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr "Новый пользователь"
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr "Сначала новые"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr "Сначала недавно изданные"
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr "Следующая страница"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr "Сейчас нет книг, подходящих для этой смарт-полки."
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr "Нет книг, соответствующих этим критериям."
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 "Возможные варианты пока не найдены. Попробуйте другой поиск или обновите "
 "страницу."
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr "Оглавление не найдено."
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr "Группы дубликатов не найдены."
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr "Нет исключённых тегов"
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 "Пока нет выделений. Выделяйте текст при чтении или импортируйте с устройства "
 "Kobo."
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr "В разделе «{items}» нет совпадений по запросу «{query}»."
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr "В этом комиксе не найдены страницы."
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr "Полок пока нет — создайте первую ниже."
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr "Полок пока нет. Создайте полку выше, чтобы начать собирать книги."
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr "Ни для одного источника не требуется ключ."
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr "Нет запущенных задач."
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr "В разделе «{items}» пока ничего нет."
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr "Не настроено"
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr "Не задано"
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr "Сначала старые"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr "Сначала давно изданные"
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
@@ -5108,56 +5221,56 @@ msgstr ""
 "На другом устройстве, где вы уже выполнили вход, отсканируйте этот код или "
 "откройте ссылку ниже, чтобы авторизовать это устройство."
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr "Открыть аккаунт"
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr "Открыть классическую читалку"
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr "Открыть навигацию"
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr "Открыть читалку"
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr "Открыть классический интерфейс"
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr "Откройте ссылку ниже на авторизованном устройстве."
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr "Сервер OpenLDAP"
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr "Открывается в классическом интерфейсе"
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr "PDF-читалка"
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr "Поля страницы"
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr "Тема страницы"
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr "Страница {number}"
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
@@ -5165,17 +5278,17 @@ msgstr ""
 "Отмеченные ниже страницы открываются в классическом интерфейсе. Внесённые "
 "там изменения применятся ко всему серверу."
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Пароль"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr "Пароль (оставьте пустым, чтобы не менять)"
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
@@ -5183,161 +5296,161 @@ msgstr ""
 "Выберите обложку из любого поддерживаемого источника, вставьте URL-адрес, "
 "загрузите файл или используйте обложку, встроенную в саму книгу."
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 "Захвачен элемент {label}. Перетащите для сортировки, отпустите для "
 "перемещения."
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Порт"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr "Подготавливаем волшебную ссылку…"
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr "Предыдущая страница"
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Прогресс"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr "Общедоступный"
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr "Опубликовано после"
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr "Опубликовано до"
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr "Показаны случайные книги"
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr "Рейтинг (звёзды)"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr "Статус прочтения"
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr "Фильтр по статусу прочтения"
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr "Настройки читалки сохранены."
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr "Внешний вид читалки"
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr "Получатели"
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr "Хост для перенаправления (полный URL)"
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr "Обновить"
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr "Регистрация…"
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr "Перезагрузить"
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr "Перезагрузить метаданные с диска"
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr "Перезагрузка…"
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr "Запомнить меня"
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr "Удалить из избранного"
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr "Удалить с полки"
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr "Удалить выделение"
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr "Удалить идентификатор"
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr "Удалить правило"
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr "Переименовать"
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr "Изменить порядок"
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr "Заменить обложку этим вариантом?"
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr "Заменить обложку?"
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr "Сообщить о проблеме в Discord"
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr "Сообщить о проблеме на GitHub"
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr "Требовать членство в группе"
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr "Сбросить пароль для {name}"
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
@@ -5346,31 +5459,31 @@ msgstr ""
 "Сбросить пароль для пользователя {name}? Текущий пароль перестанет работать, "
 "а новый будет отправлен по электронной почте."
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr "Вход по заголовку обратного прокси"
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr "Строк при подгрузке"
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr "Время выполнения"
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr "SMTP-сервер"
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5379,343 +5492,343 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Сохранить"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr "Сохранить настройки почты"
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr "Сохранить название"
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr "Сохранить настройки безопасности"
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr "Сохранить настройки"
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 "Сохранено. Перезапустите сервер, чтобы изменения настроек входа вступили в "
 "силу."
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr "Поиск дубликатов"
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr "Запланированные задачи"
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr "Области доступа (Scopes)"
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr "Поиск по названию, автору…"
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr "Поиск по всем источникам…"
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr "Поиск…"
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr "Настройки безопасности сохранены."
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr "Посмотреть, как каждая обложка выглядит с полями для вашего устройства"
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Выбрать"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr "Выбрать несколько"
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "Отправить"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr "Не удалось отправить."
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr "Отправить на читалку"
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr "Email для отправки на читалку"
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr "Отправка…"
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr "Номер в серии"
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr "Просмотр серий"
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr "Серии — включить"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr "Обслуживать по HTTPS"
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr "SSL / HTTPS сервера"
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr "Объявление сервера (показывается всем пользователям)"
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr "Хост сервера"
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr "Сервисный аккаунт (DN)"
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr "Сервисный пароль"
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr "Пароль сервисной учетной записи (оставьте пустым, чтобы не менять)"
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 "Укажите URL метаданных для автозаполнения адресов (endpoints) ниже или "
 "введите их вручную."
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr "Настройки сохранены."
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr "Название полки"
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr "Полка не найдена."
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr "Показывать раздел «Обзор»"
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr "Показать табличный вид"
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr "Показать все теги ({count})"
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr "Показать все: {items}"
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr "Показывать книги на языке"
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr "Показывать превью для читалки для каждого кандидата"
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr "Показать меньше тегов"
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr "Показать скрытые книги"
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr "Показать пароль"
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr "Перемешать подборку"
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr "Войти по волшебной ссылке"
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr "Выйти"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr "Выполняется вход…"
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr "Название сайта"
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr "Смарт-полка не найдена."
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr "Смарт-полки"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr "Сплошная заливка: средний цвет обложки"
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr "Сплошная заливка: свой цвет"
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr "Сплошная заливка: преобладающий цвет обложки"
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 "Некоторым источникам требуется ключ (API key) для загрузки обложек лучшего "
 "качества"
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr "Что-то пошло не так"
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr "Что-то пошло не так. Попробуйте снова."
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr "Порядок сортировки"
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr "Сведения об источнике"
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr "Начато чтение"
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr "Запуск поиска…"
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr "Панель статистики"
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Статус"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "Поддержать на Ko-fi →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr "Синхронизировать только выбранные полки"
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr "Синхронизировать с Kobo только книги из выбранных полок"
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr "Табличный вид"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr "Тег"
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Теги"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr "Теги — исключить"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr "Теги — включить"
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr "Целевое соотношение сторон"
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Задание"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Задания"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr "Технические подробности"
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr "По этому URL нет подходящего изображения."
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr "Этот формат открывается в режиме полноэкранного чтения."
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 "Срок действия этой волшебной ссылки истек. Создайте новую, чтобы повторить "
 "попытку."
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr "Такой страницы не существует."
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
@@ -5723,76 +5836,76 @@ msgstr ""
 "На этой странице произошла ошибка, и её не удалось отобразить. С вашей "
 "библиотекой всё в порядке — обычно помогает перезагрузка страницы."
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr "Эта полка пуста. Добавьте книги со страницы любой книги."
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr "Название А–Я"
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr "Название Я–А"
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr "Название, автор или ISBN"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr "URL токена"
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr "Лучшие по рейтингу"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr "Доверять заголовку аутентификации"
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr "Настройки интерфейса и отображения"
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "Разархивировать"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr "Показать"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr "Разблокируйте обложку выше, чтобы установить новую."
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr "Разблокируйте обложку, чтобы изменить её"
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr "Без названия"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr "Не удалось обновить."
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr "Загрузить как обложку"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr "Загрузить книги"
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr "Загрузка недоступна для вашего аккаунта на этом сервере."
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
@@ -5800,68 +5913,68 @@ msgstr ""
 "Используйте эти данные для подключения OPDS-читалок или синхронизации "
 "KOReader без ввода основного пароля."
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr "Использовать эту обложку"
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Пользователь"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr "Управление пользователями"
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr "Фильтр объектов пользователей"
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr "URL информации о пользователе"
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr "Атрибут имени пользователя (Claim)"
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr "Версии"
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Просмотр"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr "Настройки отображения"
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr "Читалка"
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr "Ожидаем вашей авторизации…"
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr "Когда заблокировано, получение метаданных не перезапишет эту обложку."
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr "Когда прогресс чтения был синхронизирован впервые"
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
@@ -5871,159 +5984,149 @@ msgstr ""
 "этой полки сам по себе ничего не изменит. Переключите аккаунт в режим "
 "синхронизации только выбранных полок, чтобы настройка вступила в силу."
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr "Ваша библиотека"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr "Ваш браузер не может воспроизвести этот аудиоформат."
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr "Ваша личная цифровая библиотека"
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 "Отображается сохранённый адрес вашей читалки — измените его только для этой "
 "отправки."
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr "все правила"
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr "любое правило"
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr "книги"
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr "подходящих книг"
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr "копии"
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr "читалка"
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr "напр., Непрочитанная научная фантастика"
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr "Тема письма для читалки"
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr "общие"
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr "до"
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr "тип (isbn, amazon, doi...)"
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr "значение"
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr "вы"
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr "Книг: {count}"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr "Книг: {count}"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr "{count} файл поставлен в очередь на импорт"
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr "{count} файл отклонён"
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr "{count} файлов поставлено в очередь на импорт"
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr "{count} файлов отклонено"
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr "{count} результат"
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr "{count} результатов"
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr "Результатов для «{query}»: {count}"
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr "{field} (через запятую)"
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr "{n} найдено"
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr "Получен ответ {ok} из {total} источников"
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr "«{name}» уже существует для {count} книги. Объединить этот тег с ним?"
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr "«{name}» уже существует для {count} книг. Объединить этот тег с ним?"
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr "...или вставьте URL изображения"
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr "← Вернуться к книге"
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr "← Вернуться ко входу"
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr "← Библиотека"
 
@@ -8160,9 +8263,9 @@ msgid ""
 msgstr ""
 "Необязательно. Без ключа для Google Books действует ограничение около 1000 "
 "запросов на IP-адрес в день, которое легко исчерпать на общих серверах "
-"(ошибка HTTP 429). Бесплатный ключ можно получить на [https://console.cloud."
-"google.com](https://console.cloud.google.com) — включите «Books API» и "
-"создайте API-ключ."
+"(ошибка HTTP 429). Бесплатный ключ можно получить на [https://"
+"console.cloud.google.com](https://console.cloud.google.com) — включите "
+"«Books API» и создайте API-ключ."
 
 #: cps/templates/config_edit.html:325
 msgid "Allow Reverse Proxy Authentication"
@@ -9136,9 +9239,9 @@ msgid ""
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
-"Этот инструмент был адаптирован из утилиты <a href=\"https://kindle-epub-fix."
-"netlify.app/\">kindle-epub-fix.netlify.app</a>, созданной <a href=\"https://"
-"github.com/innocenat\">innocenat</a>."
+"Этот инструмент был адаптирован из утилиты <a href=\"https://kindle-epub-"
+"fix.netlify.app/\">kindle-epub-fix.netlify.app</a>, созданной <a "
+"href=\"https://github.com/innocenat\">innocenat</a>."
 
 #: cps/templates/cwa_settings.html:181
 msgid "Enable KOReader Sync (NextGen Plugin)"
@@ -9161,9 +9264,9 @@ msgid ""
 "container after disabling."
 msgstr ""
 "Примечание: Включение этой опции запускает службу фонового вычисления "
-"контрольных сумм при старте, что может временно заблокировать файл metadata."
-"db. Чтобы остановить запущенный процесс, отключите опцию и перезапустите "
-"контейнер."
+"контрольных сумм при старте, что может временно заблокировать файл "
+"metadata.db. Чтобы остановить запущенный процесс, отключите опцию и "
+"перезапустите контейнер."
 
 #: cps/templates/cwa_settings.html:192
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
@@ -9347,10 +9450,6 @@ msgstr ""
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
 msgstr "Теги/Жанры"
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
-msgstr "Дата публикации"
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
 msgid "Identifiers (ISBN, etc.)"
@@ -12488,80 +12587,6 @@ msgstr "Показывать выбранные полки в OPDS"
 msgid "Show Read/Unread Section"
 msgstr "Показать раздел прочитанного/непрочитанного"
 
-#~ msgid "<"
-#~ msgstr "<"
-
-#~ msgid "="
-#~ msgstr "="
-
-#~ msgid ">"
-#~ msgstr ">"
-
-#~ msgid ""
-#~ "A one-time full duplicate scan is needed. Run it from CWA settings, then "
-#~ "return here."
-#~ msgstr ""
-#~ "Необходим однократный полный поиск дубликатов. Запустите его в настройках "
-#~ "CWA, а затем вернитесь сюда."
-
-#~ msgid "Date Added"
-#~ msgstr "Дата добавления"
-
-#~ msgid "Support us on Ko-fi!"
-#~ msgstr "Поддержите нас на Ko-fi!"
-
-#~ msgid "Open Ko-fi →"
-#~ msgstr "Открыть Ko-fi →"
-
-#~ msgid "Dismiss help announcement"
-#~ msgstr "Скрыть справочное объявление"
-
-#~ msgid "Dismiss Ko-fi support message"
-#~ msgstr "Скрыть сообщение о поддержке на Ko-fi"
-
-#~ msgid ""
-#~ "These open the full configuration pages. Changes there apply to the whole "
-#~ "server."
-#~ msgstr ""
-#~ "Открывает полные страницы настроек. Внесенные там изменения применятся ко "
-#~ "всему серверу."
-
-#~ msgid "begins with"
-#~ msgstr "начинается с"
-
-#~ msgid "contains"
-#~ msgstr "содержит"
-
-#~ msgid "does not contain"
-#~ msgstr "не содержит"
-
-#~ msgid "ends with"
-#~ msgstr "заканчивается на"
-
-#~ msgid "in the past N days"
-#~ msgstr "за последние N дней"
-
-#~ msgid "is"
-#~ msgstr "равно"
-
-#~ msgid "is not"
-#~ msgstr "не равно"
-
-#~ msgid "not in the past N days"
-#~ msgstr "не за последние N дней"
-
-#~ msgid "on or after"
-#~ msgstr "в эту дату или позже"
-
-#~ msgid "on or before"
-#~ msgstr "в эту дату или раньше"
-
-#~ msgid "≤"
-#~ msgstr "≤"
-
-#~ msgid "≥"
-#~ msgstr "≥"
-
 #~ msgid ""
 #~ "Off by default. When enabled, each user gets a hide button on the book "
 #~ "detail page that drops the book out of their own index/search/OPDS "
@@ -12793,9 +12818,9 @@ msgstr "Показать раздел прочитанного/непрочит�
 #~ "metadata.db при запуске. Если найдена только одна библиотека, она "
 #~ "монтируется автоматически; если найдено несколько, по умолчанию будет "
 #~ "смонтирована самая большая, а если ни одной нет, будет автоматически "
-#~ "создана и смонтирована новая. Для подробностей, <a href=\"https://github."
-#~ "com/crocodilestick/Calibre-Web-Automated/wiki/Configuration#database-"
-#~ "configuration\">см. здесь</a>!"
+#~ "создана и смонтирована новая. Для подробностей, <a href=\"https://"
+#~ "github.com/crocodilestick/Calibre-Web-Automated/wiki/"
+#~ "Configuration#database-configuration\">см. здесь</a>!"
 
 #~ msgid ""
 #~ "Therefore, when configuring your docker-compose file for CWA, <b>DO NOT "

--- a/cps/translations/sk/LC_MESSAGES/messages.po
+++ b/cps/translations/sk/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Štatistika"
 
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Upraviť používateľov"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Všetko"
@@ -1013,7 +1013,7 @@ msgstr "nie je naištalované"
 msgid "Execution permissions missing"
 msgstr "Chýba právo na vykonanie"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1060,7 +1060,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Neplatná rola"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2030,7 +2030,7 @@ msgstr "Aktuálna verzia"
 msgid "Unread Books"
 msgstr "Neprečítané knihy"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2041,7 +2041,7 @@ msgstr "Autori"
 msgid "Books ordered by Author"
 msgstr "Knihy usporiadané podľa autora"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Vydavatelia"
@@ -2050,7 +2050,7 @@ msgstr "Vydavatelia"
 msgid "Books ordered by publisher"
 msgstr "Knihy usporiadané podľa vydavateľa"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Kategórie"
@@ -2072,7 +2072,7 @@ msgstr "Série"
 msgid "Books ordered by series"
 msgstr "Knihy usporiadané podľa série"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2082,7 +2082,7 @@ msgstr "Jazyky"
 msgid "Books ordered by Languages"
 msgstr "Knihy usporiadané podľa jazyka"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Hodnotenia"
@@ -2099,7 +2099,7 @@ msgstr "Súborové formáty"
 msgid "Books ordered by file formats"
 msgstr "Knihy usporiadané podľa súborových formátov"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Police"
@@ -2136,7 +2136,7 @@ msgstr "{} Hviezdičiek"
 msgid "Search"
 msgstr "Hľadať"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2160,7 +2160,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Knihy"
 
@@ -2193,7 +2193,7 @@ msgstr "Zobraziť prečítané a neprečítané"
 msgid "Show unread"
 msgstr "Zobraziť neprečítané"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Objaviť"
 
@@ -2233,7 +2233,7 @@ msgstr "Archivované knihy"
 msgid "Show Archived Books"
 msgstr "Zobraziť archivované knihy"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2249,7 +2249,7 @@ msgstr "Zoznam kníh"
 msgid "Show Books List"
 msgstr "Zobraziť zoznam kníh"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2953,13 +2953,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Zmazať"
 
@@ -3115,8 +3115,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Zlúčiť"
 
@@ -3244,7 +3245,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3680,225 +3682,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "O programe"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Archivovaný"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3921,1326 +4040,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Previesť"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Popis"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Stiahnuť"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Upraviť"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "E-mail"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Povoliť synchronizáciu Kobo"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Šifrovanie"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Skryť"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identifikátory"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Jazyk"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Heslo"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Pokrok"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Hodnotenie"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5249,634 +5358,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Uložiť"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Vybrať"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Stav"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Značka"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Úloha"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Úlohy"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Používateľ"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Meno používateľa"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Zobraziť"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9054,10 +9153,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/sl/LC_MESSAGES/messages.po
+++ b/cps/translations/sl/LC_MESSAGES/messages.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Loco-Parser: loco_parse_po\n"
 "X-Loco-Source-Locale: sl_SI\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Statistika"
 
@@ -154,7 +154,7 @@ msgstr "Stolpec po meri št. %(column)d ne obstaja v zbirki podatkov Calibre"
 msgid "Edit Users"
 msgstr "Urejanje uporabnikov"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Vse"
@@ -1047,7 +1047,7 @@ msgstr "ni nameščen"
 msgid "Execution permissions missing"
 msgstr "Manjkajo dovoljenja za izvajanje"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1095,7 +1095,7 @@ msgstr "Ni bilo mogoče najti določenega imenika"
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1258,7 +1258,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Neveljavna vloga"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2092,7 +2092,7 @@ msgstr "Trenutna različica"
 msgid "Unread Books"
 msgstr "Neprebrane knjige"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2103,7 +2103,7 @@ msgstr "Avtorji"
 msgid "Books ordered by Author"
 msgstr "Knjige, razvrščene po avtorju"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Založniki"
@@ -2112,7 +2112,7 @@ msgstr "Založniki"
 msgid "Books ordered by publisher"
 msgstr "Knjige, razvrščene po založniku"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Kategorije"
@@ -2134,7 +2134,7 @@ msgstr "Serije"
 msgid "Books ordered by series"
 msgstr "Knjige, razvrščene po serijah"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2144,7 +2144,7 @@ msgstr "Jeziki"
 msgid "Books ordered by Languages"
 msgstr "Knjige, razvrščene po jezikih"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Ocene"
@@ -2161,7 +2161,7 @@ msgstr "Vrste datotek"
 msgid "Books ordered by file formats"
 msgstr "Knjige, razvrščene po vrstah datotek"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Police"
@@ -2198,7 +2198,7 @@ msgstr "{} zvezdic"
 msgid "Search"
 msgstr "Iskanje"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2222,7 +2222,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Knjige"
 
@@ -2255,7 +2255,7 @@ msgstr "Prikaži prebrano in neprebrano"
 msgid "Show unread"
 msgstr "Prikaži neprebrane"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Odkrivanje"
 
@@ -2295,7 +2295,7 @@ msgstr "Arhivirane knjige"
 msgid "Show Archived Books"
 msgstr "Prikaži arhivirane knjige"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2311,7 +2311,7 @@ msgstr "Seznam knjig"
 msgid "Show Books List"
 msgstr "Prikaži seznam knjig"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "Dvojniki"
 
@@ -3014,13 +3014,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Izbriši"
 
@@ -3176,8 +3176,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Združitev"
 
@@ -3305,7 +3306,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3741,225 +3743,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "O programu"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "Vse"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "Arhiv"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Arhivirano"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3982,1326 +4101,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "Pretvori"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr "Datum dodajanja"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Opis"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr "Opusti"
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Prenesi"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Uredi"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "E-pošta"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Omogoči sinhronizacijo s Kobo"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Šifriranje"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Skrij"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identifikatorji"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Jezik"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "Zadnjič spremenjeno"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Geslo"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Vrata"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Napredek"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Ocena"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5310,634 +5419,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Shrani"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Izberi"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "Pošlji"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Oznake"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Opravilo"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Opravila"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Uporabnik"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Uporabniško ime"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Oglejte si"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -8999,8 +9098,8 @@ msgid ""
 "\">kindle-epub-fix.netlify.app</a> tool made by <a href=\"https://github.com/"
 "innocenat\">innocenat</a>."
 msgstr ""
-"To orodje je bilo prilagojeno po orodju <a href=\"https://kindle-epub-fix."
-"netlify.app/\">kindle-epub-fix.netlify.app</a>, ki ga je izdelal <a "
+"To orodje je bilo prilagojeno po orodju <a href=\"https://kindle-epub-"
+"fix.netlify.app/\">kindle-epub-fix.netlify.app</a>, ki ga je izdelal <a "
 "href=\"https://github.com/innocenat\">innocenat</a>."
 
 #: cps/templates/cwa_settings.html:181
@@ -9197,10 +9296,6 @@ msgstr ""
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
 msgstr "Oznake/Žanri"
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
-msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
 #, fuzzy

--- a/cps/translations/sv/LC_MESSAGES/messages.po
+++ b/cps/translations/sv/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Statistik"
 
@@ -145,7 +145,7 @@ msgstr "Anpassad kolumn n.%(column)d finns inte i calibre-databasen"
 msgid "Edit Users"
 msgstr "Redigera användare"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Alla"
@@ -1015,7 +1015,7 @@ msgstr "inte installerad"
 msgid "Execution permissions missing"
 msgstr "Körningstillstånd saknas"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Ogiltig roll"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2032,7 +2032,7 @@ msgstr "Aktuell version"
 msgid "Unread Books"
 msgstr "Olästa böcker"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2043,7 +2043,7 @@ msgstr "Författare"
 msgid "Books ordered by Author"
 msgstr "Böcker ordnade efter författare"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Förlag"
@@ -2052,7 +2052,7 @@ msgstr "Förlag"
 msgid "Books ordered by publisher"
 msgstr "Böcker ordnade efter förlag"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Kategorier"
@@ -2074,7 +2074,7 @@ msgstr "Serier"
 msgid "Books ordered by series"
 msgstr "Böcker ordnade efter serier"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2084,7 +2084,7 @@ msgstr "Språk"
 msgid "Books ordered by Languages"
 msgstr "Böcker ordnade efter språk"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Betyg"
@@ -2101,7 +2101,7 @@ msgstr "Filformat"
 msgid "Books ordered by file formats"
 msgstr "Böcker ordnade av filformat"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Hyllor"
@@ -2138,7 +2138,7 @@ msgstr "{} stjärnor"
 msgid "Search"
 msgstr "Sök"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2162,7 +2162,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Böcker"
 
@@ -2196,7 +2196,7 @@ msgstr "Visa lästa och olästa"
 msgid "Show unread"
 msgstr "Visa olästa"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Upptäck"
 
@@ -2244,7 +2244,7 @@ msgstr "Arkiverade böcker"
 msgid "Show Archived Books"
 msgstr "Visa arkiverade böcker"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2260,7 +2260,7 @@ msgstr "Boklista"
 msgid "Show Books List"
 msgstr "Visa boklista"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2966,13 +2966,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Ta bort"
 
@@ -3128,8 +3128,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Slå samman"
 
@@ -3257,7 +3258,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3693,225 +3695,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Om"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Arkiverad"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3934,1326 +4053,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Beskrivning"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Hämta"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Redigera"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "E-post"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "Aktivera Kobo sync"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Identifierare"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Språk"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Lösenord"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Förlopp"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Betyg"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5262,634 +5371,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Spara"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Välj"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Status"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Taggar"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Uppgift"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Uppgifter"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Användare"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Smeknamn"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Visa"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9079,10 +9178,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/tr/LC_MESSAGES/messages.po
+++ b/cps/translations/tr/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "İstatistikler"
 
@@ -142,7 +142,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr ""
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Tümü"
@@ -991,7 +991,7 @@ msgstr "yüklü değil"
 msgid "Execution permissions missing"
 msgstr ""
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Geçersiz kitaplık seçildi"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgstr "Geçerli sürüm"
 msgid "Unread Books"
 msgstr "Okunmamışlar"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2008,7 +2008,7 @@ msgstr "Yazarlar"
 msgid "Books ordered by Author"
 msgstr "Yazara göre sıralanmış eKitaplar"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Yayıncılar"
@@ -2017,7 +2017,7 @@ msgstr "Yayıncılar"
 msgid "Books ordered by publisher"
 msgstr "Yayınevine göre sıralanmış eKitaplar"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Kategoriler"
@@ -2039,7 +2039,7 @@ msgstr "Seriler"
 msgid "Books ordered by series"
 msgstr "Seriye göre sıralanmış eKitaplar"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2049,7 +2049,7 @@ msgstr "Diller"
 msgid "Books ordered by Languages"
 msgstr "Dile göre sıralanmış eKitaplar"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Değerlendirmeler"
@@ -2067,7 +2067,7 @@ msgstr "Biçimler"
 msgid "Books ordered by file formats"
 msgstr "Biçime göre sıralanmış eKitaplar"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr ""
@@ -2105,7 +2105,7 @@ msgstr ""
 msgid "Search"
 msgstr "Ara"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2129,7 +2129,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "eKitaplar"
 
@@ -2163,7 +2163,7 @@ msgstr "Okunan ve okunmayanları göster"
 msgid "Show unread"
 msgstr "Okunmamışları göster"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Keşfet"
 
@@ -2211,7 +2211,7 @@ msgstr ""
 msgid "Show Archived Books"
 msgstr "Son eKitapları göster"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2227,7 +2227,7 @@ msgstr ""
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2934,13 +2934,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Sil"
 
@@ -3096,8 +3096,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr ""
 
@@ -3225,7 +3226,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3661,225 +3663,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Hakkında"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3902,1326 +4021,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Açıklama"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Düzenleme"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr ""
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "Şifreleme"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr ""
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Dil"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Şifre"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Port"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "İlerleme"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Değerlendirme"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5230,634 +5339,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr ""
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Durum"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Etiketler"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Görev"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Görevler"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Kullanıcı"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Kullanıcı adı"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9048,10 +9147,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/uk/LC_MESSAGES/messages.po
+++ b/cps/translations/uk/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Статистика"
 
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Керування сервером"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Всі"
@@ -1033,7 +1033,7 @@ msgstr "не встановлено"
 msgid "Execution permissions missing"
 msgstr "Відсутні права на виконання"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1240,7 +1240,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Не правильна роль"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2029,7 +2029,7 @@ msgstr "Поточна версія"
 msgid "Unread Books"
 msgstr "Непрочитані книги"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2040,7 +2040,7 @@ msgstr "Автори"
 msgid "Books ordered by Author"
 msgstr "Книги відсортовані за автором"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Видавництва"
@@ -2050,7 +2050,7 @@ msgstr "Видавництва"
 msgid "Books ordered by publisher"
 msgstr "Книги відсортовані за автором"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Категорії"
@@ -2072,7 +2072,7 @@ msgstr "Серії"
 msgid "Books ordered by series"
 msgstr "Книги відсортовані за серією"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2083,7 +2083,7 @@ msgstr "Мови"
 msgid "Books ordered by Languages"
 msgstr "Книги відсортовані за серією"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Рейтинги"
@@ -2102,7 +2102,7 @@ msgstr "Формати файлів"
 msgid "Books ordered by file formats"
 msgstr "Книги відсортовані за серією"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr "{} зірок"
 msgid "Search"
 msgstr "Пошук"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2164,7 +2164,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Книжки"
 
@@ -2198,7 +2198,7 @@ msgstr "Показувати прочитані та непрочитані кн
 msgid "Show unread"
 msgstr "Показати не прочитані"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Огляд"
 
@@ -2246,7 +2246,7 @@ msgstr "Архівні книжки"
 msgid "Show Archived Books"
 msgstr "Архівні книжки"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2262,7 +2262,7 @@ msgstr "Список книжок"
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2966,13 +2966,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Видалити"
 
@@ -3128,8 +3128,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Обʼєднати"
 
@@ -3257,7 +3258,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3693,225 +3695,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "Про програму"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Заархівовано"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3934,1326 +4053,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Опис"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Завантажити"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Редагувати"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr ""
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Сховати"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Ідентифікатори"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Мова"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Пароль"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Порт"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Прогрес"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5262,634 +5371,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Зберегти"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Статус"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Теги"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Завдання"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Завдання"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Користувач"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Показати"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9066,10 +9165,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/vi/LC_MESSAGES/messages.po
+++ b/cps/translations/vi/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "Thống kê"
 
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr "Chỉnh sửa người dùng"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "Tất cả"
@@ -991,7 +991,7 @@ msgstr "chưa cài đặt"
 msgid "Execution permissions missing"
 msgstr ""
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "Vai trò không hợp lệ"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -1990,7 +1990,7 @@ msgstr "Phiên bản hiện tại"
 msgid "Unread Books"
 msgstr "Sách chưa đọc"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2001,7 +2001,7 @@ msgstr "Tác giả"
 msgid "Books ordered by Author"
 msgstr "Sách sắp xếp theo tác giả"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "Nhà phát hành"
@@ -2010,7 +2010,7 @@ msgstr "Nhà phát hành"
 msgid "Books ordered by publisher"
 msgstr "Sách sắp xếp theo nhà phát hành"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "Chủ đề"
@@ -2032,7 +2032,7 @@ msgstr "Series"
 msgid "Books ordered by series"
 msgstr "Sách sắp xếp theo series"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2042,7 +2042,7 @@ msgstr "Ngôn ngữ"
 msgid "Books ordered by Languages"
 msgstr "Sách sắp xếp theo ngôn ngữ"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "Đánh giá"
@@ -2059,7 +2059,7 @@ msgstr "Định dạng file"
 msgid "Books ordered by file formats"
 msgstr "Sách sắp xếp theo định dạng"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "Giá sách"
@@ -2096,7 +2096,7 @@ msgstr "{} sao"
 msgid "Search"
 msgstr "Tìm kiếm"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2120,7 +2120,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "Sách"
 
@@ -2154,7 +2154,7 @@ msgstr "Hiển thị đã đọc và chưa đọc"
 msgid "Show unread"
 msgstr "Hiện thị sách chưa đọc"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "Khám phá"
 
@@ -2202,7 +2202,7 @@ msgstr "Sách đã lưu trữ"
 msgid "Show Archived Books"
 msgstr "Hiện thị sách trong kho"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2218,7 +2218,7 @@ msgstr "Danh sách sách"
 msgid "Show Books List"
 msgstr "Hiển thị danh sách sách"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2919,13 +2919,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "Xoá"
 
@@ -3081,8 +3081,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "Trộn"
 
@@ -3210,7 +3211,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3646,225 +3648,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "About"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "Lưu trữ"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3887,1326 +4006,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "Huỷ bỏ"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "Mô tả"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "Tải xuống"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "Chỉnh sửa"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "Địa chỉ email"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "Ẩn"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "Nhận diện"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "Ngôn ngữ"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "Mật khẩu"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "Cổng"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "Tiến độ"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "Đánh giá"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5215,634 +5324,624 @@ msgstr "STARTTLS"
 msgid "Save"
 msgstr "Lưu"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "Chọn"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "Trạng thái"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "Đánh dấu"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "Nhiệm vụ"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "Nhiệm vụ"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "Người dùng"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "Tên người dùng"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "Xem"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -9018,10 +9117,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "统计"
 
@@ -142,7 +142,7 @@ msgstr "自定义列号：%(column)d 在 Calibre 数据库中不存在"
 msgid "Edit Users"
 msgstr "管理用户"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "全部"
@@ -992,7 +992,7 @@ msgstr "未安装"
 msgid "Execution permissions missing"
 msgstr "缺少执行权限"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr "找不到指定的目录"
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "无效角色"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -2000,7 +2000,7 @@ msgstr "当前版本"
 msgid "Unread Books"
 msgstr "未读书籍"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -2011,7 +2011,7 @@ msgstr "作者"
 msgid "Books ordered by Author"
 msgstr "书籍按作者排序"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "出版社"
@@ -2020,7 +2020,7 @@ msgstr "出版社"
 msgid "Books ordered by publisher"
 msgstr "书籍按出版社排序"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "分类"
@@ -2042,7 +2042,7 @@ msgstr "丛书"
 msgid "Books ordered by series"
 msgstr "书籍按丛书排序"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2052,7 +2052,7 @@ msgstr "语言"
 msgid "Books ordered by Languages"
 msgstr "书籍按语言排序"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "评分"
@@ -2069,7 +2069,7 @@ msgstr "文件格式"
 msgid "Books ordered by file formats"
 msgstr "书籍按文件格式排序"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "书架列表"
@@ -2106,7 +2106,7 @@ msgstr "{} 星"
 msgid "Search"
 msgstr "搜索"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2130,7 +2130,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "书籍"
 
@@ -2163,7 +2163,7 @@ msgstr "显示已读或未读状态"
 msgid "Show unread"
 msgstr "显示未读"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "发现"
 
@@ -2203,7 +2203,7 @@ msgstr "归档书籍"
 msgid "Show Archived Books"
 msgstr "显示归档书籍"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgstr "书籍列表"
 msgid "Show Books List"
 msgstr "显示书籍列表"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr "重复书籍"
 
@@ -2921,13 +2921,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "删除数据"
 
@@ -3083,8 +3083,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "合并"
 
@@ -3212,7 +3213,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3648,225 +3650,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "关于"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "任何"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "归档"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3889,1326 +4008,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "取消"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr "转换"
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr "添加日期"
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "简介"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr "忽略"
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "下载书籍"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "编辑书籍"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "邮箱地址"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "启用 Kobo 同步"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "加密"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "隐藏"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "书号"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "语言"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "最后修改时间"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "密码"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "端口"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "任务进度"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "评分"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS 协议"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS 协议"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5217,634 +5326,624 @@ msgstr "STARTTLS 协议"
 msgid "Save"
 msgstr "保存"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "选择"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr "发送"
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "任务状态"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "在 Ko-fi 上支持我们 →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "标签"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "任务信息"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "任务列表"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "用户名称"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "用户名"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "查看书籍"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -8855,8 +8954,8 @@ msgid ""
 "innocenat\">innocenat</a>."
 msgstr ""
 "此工具改编自 <a href=\"https://github.com/innocenat\">innocenat</a> 制作的 "
-"<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-fix.netlify."
-"app</a> 工具。"
+"<a href=\"https://kindle-epub-fix.netlify.app/\">kindle-epub-"
+"fix.netlify.app</a> 工具。"
 
 #: cps/templates/cwa_settings.html:181
 msgid "Enable KOReader Sync (NextGen Plugin)"
@@ -8875,8 +8974,8 @@ msgid ""
 "temporarily lock metadata.db. To stop a running backfill, restart the "
 "container after disabling."
 msgstr ""
-"注意：启用此功能会在启动时启动校验和回填服务，该服务可能会暂时锁定 metadata."
-"db。要停止正在运行的回填，请在禁用后重新启动容器。"
+"注意：启用此功能会在启动时启动校验和回填服务，该服务可能会暂时锁定 "
+"metadata.db。要停止正在运行的回填，请在禁用后重新启动容器。"
 
 #: cps/templates/cwa_settings.html:192
 msgid "Enable Aggressive EPUB Fixer Mode (riskier)"
@@ -9052,10 +9151,6 @@ msgstr ""
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
 msgstr "标签/类型"
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
-msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385
 #, fuzzy
@@ -9738,8 +9833,8 @@ msgid ""
 "users with edit rights will see a badge on the Duplicates sidebar button and "
 "a notification popup when they login."
 msgstr ""
-"检测到未解决的重复项时显示弹出通知。管理员和具有编辑权限的用户在登录时，将"
-"在“重复项”侧边栏按钮上看到一个徽章，并会看到一个弹出通知。"
+"检测到未解决的重复项时显示弹出通知。管理员和具有编辑权限的用户在登录时，将在"
+"“重复项”侧边栏按钮上看到一个徽章，并会看到一个弹出通知。"
 
 #: cps/templates/cwa_settings.html:1197
 #, fuzzy

--- a/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.13.1\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr "統計"
 
@@ -142,7 +142,7 @@ msgstr "自定義列號：%(column)d在Calibre數據庫中不存在"
 msgid "Edit Users"
 msgstr "管理用戶"
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr "全部"
@@ -981,7 +981,7 @@ msgstr "未安裝"
 msgid "Execution permissions missing"
 msgstr "缺少執行權限"
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1183,7 +1183,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr "無效角色"
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -1978,7 +1978,7 @@ msgstr "當前版本"
 msgid "Unread Books"
 msgstr "未讀書籍"
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -1989,7 +1989,7 @@ msgstr "作者"
 msgid "Books ordered by Author"
 msgstr "書籍按作者排序"
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr "出版社"
@@ -1998,7 +1998,7 @@ msgstr "出版社"
 msgid "Books ordered by publisher"
 msgstr "書籍按出版社排序"
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr "分類"
@@ -2020,7 +2020,7 @@ msgstr "叢書"
 msgid "Books ordered by series"
 msgstr "書籍按叢書排序"
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -2030,7 +2030,7 @@ msgstr "語言"
 msgid "Books ordered by Languages"
 msgstr "書籍按語言排序"
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr "評分"
@@ -2047,7 +2047,7 @@ msgstr "文件格式"
 msgid "Books ordered by file formats"
 msgstr "書籍按文件格式排序"
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr "書架列表"
@@ -2083,7 +2083,7 @@ msgstr "{} 星"
 msgid "Search"
 msgstr "搜尋"
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2107,7 +2107,7 @@ msgid ""
 "can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr "書籍"
 
@@ -2141,7 +2141,7 @@ msgstr "顯示閱讀狀態"
 msgid "Show unread"
 msgstr "顯示未讀"
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr "發現"
 
@@ -2189,7 +2189,7 @@ msgstr "歸檔書籍"
 msgid "Show Archived Books"
 msgstr "顯示歸檔書籍"
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr "收藏"
 
@@ -2205,7 +2205,7 @@ msgstr "書籍列表"
 msgid "Show Books List"
 msgstr "顯示書籍列表"
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2907,13 +2907,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr "刪除數據"
 
@@ -3069,8 +3069,9 @@ msgstr "標記已讀"
 msgid "Mark unread"
 msgstr "標記未讀"
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr "合併"
 
@@ -3198,7 +3199,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3634,225 +3636,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole "
+"server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid ""
 "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr "從你的書庫中隨機挑選"
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above to "
 "run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr "關於"
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr "帳號設定"
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr "添加到收藏"
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr "管理員群組"
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr "進階"
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr "進階搜尋"
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr "全部書架"
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr "任何"
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr "任意格式"
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr "任何語言"
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr "任何叢書"
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr "任何標籤"
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr "歸檔"
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr "歸檔"
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr "返回書庫"
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr "返回經典視圖"
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr "基本配置"
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device on "
 "its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3875,1326 +3994,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr "取消"
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr "確認刪除 {name} 標籤"
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr "刪除書籍"
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr "刪除失敗"
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr "刪除 {name} 標籤"
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr "已刪除 {name} 標籤"
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr "簡介"
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr "下載書籍"
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates when "
 "it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr "編輯書籍"
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr "郵箱地址"
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr "啟用Kobo同步"
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr "加密"
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr "格式"
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr "格式 — 排除"
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr "格式 — 包含"
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr "前往你的書庫"
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr "隱藏"
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr "書號"
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr "語言"
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr "語言 — 包含"
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr "上次修改"
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr "上次同步"
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr "書庫設定"
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr "載入中"
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr "載入中..."
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr "登入類型"
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr "日誌"
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr "合併書架"
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr "標為已讀"
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr "標為未讀"
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr "匹配"
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr "我的帳號"
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr "最新"
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr "下一頁"
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid ""
 "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr "最舊"
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open the "
 "link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr "密碼"
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or use "
 "the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr "端口"
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr "任務進度"
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr "評分"
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr "評分 (星數)"
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr "閱讀狀態"
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a "
 "replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr "SSL/TLS協議"
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr "STARTTLS協議"
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5203,634 +5312,624 @@ msgstr "STARTTLS協議"
 msgid "Save"
 msgstr "儲存"
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr "搜尋書名，作者..."
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr "選擇"
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr "發送中..."
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr "叢書目錄"
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr "叢書 — 包含"
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr "登出"
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr "登入中..."
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr "智慧書架"
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr "開始掃描..."
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr "統計儀表板"
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr "任務狀態"
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr "在 Ko-fi 上支持我們 →"
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr "表格視圖"
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr "標籤"
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr "標籤"
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr "標籤 — 排除"
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr "標籤 — 包含"
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr "任務信息"
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr "任務列表"
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is fine "
 "— reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr "書名，作者，或 ISBN"
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr "最高評分"
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr "UI / 顯示設定"
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr "取消歸檔"
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr "取消隱藏"
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr "無書名"
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr "上傳失敗"
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr "上傳封面"
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr "上傳書籍"
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr "用戶名稱"
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr "用戶名"
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr "查看書籍"
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr "視圖設定"
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to make "
 "it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr "你的書庫"
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr "書籍"
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr "匹配書籍"
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr "{count} 本書"
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr "{count} 本書"
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr "返回書籍"
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr "返回登入"
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr "書庫"
 
@@ -8966,10 +9065,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385

--- a/findings/items/F-83cd73.json
+++ b/findings/items/F-83cd73.json
@@ -1,0 +1,11 @@
+{
+  "area": "i18n",
+  "body": "`scripts/extract_spa_strings.py --write` regenerates the AUTOGEN block from\nstatically-parseable frontend literals. Anchors added by hand INSIDE that block\nfor strings the parser cannot see (dynamic keys, runtime-built values) are\nremoved without warning — measured 2026-08-09: 72 removed / 37 added, net 31\nlost, including \"contains\" and \"begins with\".\n\nThe loss is silent twice over. `--write` reports only a count (\"530 anchored\nmsgid(s)\"), never a delta, and the damage does not surface until the NEXT\n`Update Translations` run marks the now-unextracted msgids obsolete, dropping\nreal translations from the compiled `.mo`. That run is tagged `[skip ci]`, so\nno test reports it either. fr/ru/de lost human-authored translations this way\nand main went red on a commit nobody tested.\n\nFix direction: `--write` should refuse to remove an anchor whose msgid still\ncarries a translation in any locale, and should print the add/remove delta\nrather than a total. The hand-maintained section above the marker (added in\n#1485) prevents recurrence but does not make the generator safe.",
+  "created": "2026-08-09",
+  "id": "F-83cd73",
+  "refs": [],
+  "severity": "correctness",
+  "source": "audit",
+  "status": "open",
+  "title": "extract_spa_strings.py --write silently discards hand-added anchors"
+}

--- a/messages.pot
+++ b/messages.pot
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: cps/about.py:59 cps/spa_strings.py:836
+#: cps/about.py:59 cps/spa_strings.py:884
 msgid "Statistics"
 msgstr ""
 
@@ -139,7 +139,7 @@ msgstr ""
 msgid "Edit Users"
 msgstr ""
 
-#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:410
+#: cps/admin.py:785 cps/opds.py:1311 cps/spa_strings.py:458
 #: cps/templates/grid.html:14 cps/templates/list.html:19
 msgid "All"
 msgstr ""
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Execution permissions missing"
 msgstr ""
 
-#: cps/cover_picker.py:121 cps/spa_strings.py:434
+#: cps/cover_picker.py:121 cps/spa_strings.py:482
 msgid "Back to edit metadata"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "Could not load a source image to preview."
 msgstr ""
 
-#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:509
+#: cps/cover_picker.py:573 cps/cover_picker.py:587 cps/spa_strings.py:557
 msgid "Cover save failed."
 msgstr ""
 
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Invalid book selection."
 msgstr ""
 
-#: cps/cwa_functions.py:2264 cps/spa_strings.py:441
+#: cps/cwa_functions.py:2264 cps/spa_strings.py:489
 msgid "Book not found."
 msgstr ""
 
@@ -1935,7 +1935,7 @@ msgstr ""
 msgid "Unread Books"
 msgstr ""
 
-#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:431
+#: cps/opds.py:212 cps/render_template.py:184 cps/spa_strings.py:479
 #: cps/templates/book_table.html:109 cps/templates/cwa_settings.html:334
 #: cps/templates/cwa_settings.html:336
 #: cps/templates/hardcover_review_matches.html:134
@@ -1946,7 +1946,7 @@ msgstr ""
 msgid "Books ordered by Author"
 msgstr ""
 
-#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:736
+#: cps/opds.py:218 cps/render_template.py:188 cps/spa_strings.py:784
 #: cps/templates/book_table.html:115 cps/web.py:2020
 msgid "Publishers"
 msgstr ""
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Books ordered by publisher"
 msgstr ""
 
-#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:455
+#: cps/opds.py:224 cps/render_template.py:178 cps/spa_strings.py:503
 #: cps/templates/book_table.html:110 cps/web.py:2172
 msgid "Categories"
 msgstr ""
@@ -1977,7 +1977,7 @@ msgstr ""
 msgid "Books ordered by series"
 msgstr ""
 
-#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:639
+#: cps/opds.py:236 cps/render_template.py:191 cps/spa_strings.py:687
 #: cps/templates/book_table.html:113 cps/templates/detail.html:930
 #: cps/templates/search_form.html:108 cps/web.py:2144
 msgid "Languages"
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Books ordered by Languages"
 msgstr ""
 
-#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:740
+#: cps/opds.py:242 cps/render_template.py:195 cps/spa_strings.py:788
 #: cps/web.py:2104
 msgid "Ratings"
 msgstr ""
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Books ordered by file formats"
 msgstr ""
 
-#: cps/opds.py:254 cps/spa_strings.py:808 cps/templates/layout.html:658
+#: cps/opds.py:254 cps/spa_strings.py:856 cps/templates/layout.html:658
 #: cps/templates/search_form.html:88
 msgid "Shelves"
 msgstr ""
@@ -2038,7 +2038,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: cps/remotelogin.py:76 cps/spa_strings.py:650 cps/templates/layout.html:357
+#: cps/remotelogin.py:76 cps/spa_strings.py:698 cps/templates/layout.html:357
 #: cps/templates/layout.html:404 cps/templates/login.html:11
 #: cps/templates/login.html:39 cps/web.py:2643
 msgid "Login"
@@ -2062,7 +2062,7 @@ msgid ""
 "checks can run after imports and metadata changes. "
 msgstr ""
 
-#: cps/render_template.py:148 cps/spa_strings.py:443
+#: cps/render_template.py:148 cps/spa_strings.py:491
 msgid "Books"
 msgstr ""
 
@@ -2095,7 +2095,7 @@ msgstr ""
 msgid "Show unread"
 msgstr ""
 
-#: cps/render_template.py:175 cps/spa_strings.py:549
+#: cps/render_template.py:175 cps/spa_strings.py:597
 msgid "Discover"
 msgstr ""
 
@@ -2135,7 +2135,7 @@ msgstr ""
 msgid "Show Archived Books"
 msgstr ""
 
-#: cps/render_template.py:206 cps/spa_strings.py:585
+#: cps/render_template.py:206 cps/spa_strings.py:633
 msgid "Favorites"
 msgstr ""
 
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "Show Books List"
 msgstr ""
 
-#: cps/render_template.py:216 cps/spa_strings.py:562
+#: cps/render_template.py:216 cps/spa_strings.py:610
 msgid "Duplicates"
 msgstr ""
 
@@ -2850,13 +2850,13 @@ msgstr ""
 msgid "Dark theme"
 msgstr ""
 
-#: cps/spa_strings.py:192 cps/templates/_book_organizer.html:155
-#: cps/templates/admin.html:27 cps/templates/book_edit.html:59
-#: cps/templates/book_table.html:66 cps/templates/book_table.html:145
-#: cps/templates/book_table.html:194 cps/templates/duplicates.html:718
-#: cps/templates/modal_dialogs.html:63 cps/templates/modal_dialogs.html:116
-#: cps/templates/read.html:188 cps/templates/user_edit.html:333
-#: cps/templates/user_table.html:150
+#: cps/spa_strings.py:192 cps/spa_strings.py:412
+#: cps/templates/_book_organizer.html:155 cps/templates/admin.html:27
+#: cps/templates/book_edit.html:59 cps/templates/book_table.html:66
+#: cps/templates/book_table.html:145 cps/templates/book_table.html:194
+#: cps/templates/duplicates.html:718 cps/templates/modal_dialogs.html:63
+#: cps/templates/modal_dialogs.html:116 cps/templates/read.html:188
+#: cps/templates/user_edit.html:333 cps/templates/user_table.html:150
 msgid "Delete"
 msgstr ""
 
@@ -3012,8 +3012,9 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: cps/spa_strings.py:234 cps/templates/book_table.html:48
-#: cps/templates/book_table.html:175 cps/templates/duplicates.html:745
+#: cps/spa_strings.py:234 cps/spa_strings.py:415
+#: cps/templates/book_table.html:48 cps/templates/book_table.html:175
+#: cps/templates/duplicates.html:745
 msgid "Merge"
 msgstr ""
 
@@ -3141,7 +3142,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: cps/spa_strings.py:263 cps/templates/shelf_order.html:33
+#: cps/spa_strings.py:263 cps/spa_strings.py:418
+#: cps/templates/shelf_order.html:33
 msgid "Saving…"
 msgstr ""
 
@@ -3578,225 +3580,342 @@ msgstr ""
 msgid "Refresh library"
 msgstr ""
 
-#: cps/spa_strings.py:395
+#: cps/spa_strings.py:405
+msgid "<"
+msgstr ""
+
+#: cps/spa_strings.py:406
+msgid "="
+msgstr ""
+
+#: cps/spa_strings.py:407
+msgid ">"
+msgstr ""
+
+#: cps/spa_strings.py:408
+msgid ""
+"A one-time full duplicate scan is needed. Run it from CWA settings, then "
+"return here."
+msgstr ""
+
+#: cps/spa_strings.py:409
+msgid "Date Added"
+msgstr ""
+
+#: cps/spa_strings.py:410 cps/spa_strings.py:590
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} book, which is kept."
+msgstr ""
+
+#: cps/spa_strings.py:411 cps/spa_strings.py:591
+#, python-brace-format
+msgid "Delete “{name}”? It is removed from {count} books, which are kept."
+msgstr ""
+
+#: cps/spa_strings.py:413
+msgid "Dismiss Ko-fi support message"
+msgstr ""
+
+#: cps/spa_strings.py:414
+msgid "Dismiss help announcement"
+msgstr ""
+
+#: cps/spa_strings.py:416
+msgid "Open Ko-fi →"
+msgstr ""
+
+#: cps/spa_strings.py:417 cps/templates/cwa_settings.html:376
+#: cps/templates/cwa_settings.html:378
+msgid "Publication Date"
+msgstr ""
+
+#: cps/spa_strings.py:419
+msgid "Support us on Ko-fi!"
+msgstr ""
+
+#: cps/spa_strings.py:420
+msgid ""
+"These open the full configuration pages. Changes there apply to the whole"
+" server."
+msgstr ""
+
+#: cps/spa_strings.py:421 cps/spa_strings.py:967
+#, python-brace-format
+msgid "“{name}” already exists on {count} book. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:422 cps/spa_strings.py:968
+#, python-brace-format
+msgid "“{name}” already exists on {count} books. Merge this tag into it?"
+msgstr ""
+
+#: cps/spa_strings.py:423
+msgid "begins with"
+msgstr ""
+
+#: cps/spa_strings.py:424
+msgid "contains"
+msgstr ""
+
+#: cps/spa_strings.py:425
+msgid "does not contain"
+msgstr ""
+
+#: cps/spa_strings.py:426
+msgid "ends with"
+msgstr ""
+
+#: cps/spa_strings.py:427
+msgid "in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:428
+msgid "is not"
+msgstr ""
+
+#: cps/spa_strings.py:429
+msgid "is"
+msgstr ""
+
+#: cps/spa_strings.py:430
+msgid "not in the past N days"
+msgstr ""
+
+#: cps/spa_strings.py:431
+msgid "on or after"
+msgstr ""
+
+#: cps/spa_strings.py:432
+msgid "on or before"
+msgstr ""
+
+#: cps/spa_strings.py:433
+msgid "≤"
+msgstr ""
+
+#: cps/spa_strings.py:434
+msgid "≥"
+msgstr ""
+
+#: cps/spa_strings.py:443
 msgid "(replace cover)"
 msgstr ""
 
-#: cps/spa_strings.py:396
+#: cps/spa_strings.py:444
 msgid "2:3 (publisher cover — no padding for typical covers)"
 msgstr ""
 
-#: cps/spa_strings.py:397 cps/templates/config_edit.html:245
+#: cps/spa_strings.py:445 cps/templates/config_edit.html:245
 #: cps/templates/cover_picker.html:108
 msgid "3:4 (generic)"
 msgstr ""
 
-#: cps/spa_strings.py:398
+#: cps/spa_strings.py:446
 msgid "A duplicate scan is already running. This list updates when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:399
+#: cps/spa_strings.py:447
 msgid "A few random picks from your library"
 msgstr ""
 
-#: cps/spa_strings.py:400
+#: cps/spa_strings.py:448
 msgid ""
 "A one-time full duplicate scan is needed. Use “Scan for duplicates” above"
 " to run it."
 msgstr ""
 
-#: cps/spa_strings.py:401 cps/templates/cover_picker.html:81
+#: cps/spa_strings.py:449 cps/templates/cover_picker.html:81
 msgid "API keys"
 msgstr ""
 
-#: cps/spa_strings.py:402 cps/templates/layout.html:681
+#: cps/spa_strings.py:450 cps/templates/layout.html:681
 #: cps/templates/stats.html:3
 msgid "About"
 msgstr ""
 
-#: cps/spa_strings.py:403
+#: cps/spa_strings.py:451
 msgid "Account settings"
 msgstr ""
 
-#: cps/spa_strings.py:404
+#: cps/spa_strings.py:452
 #, python-brace-format
 msgid "Account: {name}"
 msgstr ""
 
-#: cps/spa_strings.py:405
+#: cps/spa_strings.py:453
 msgid "Add identifier"
 msgstr ""
 
-#: cps/spa_strings.py:406 cps/templates/detail.html:700
+#: cps/spa_strings.py:454 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:703
 msgid "Add to favorites"
 msgstr ""
 
-#: cps/spa_strings.py:407
+#: cps/spa_strings.py:455
 msgid "Admin group"
 msgstr ""
 
-#: cps/spa_strings.py:408
+#: cps/spa_strings.py:456
 msgid "Advanced"
 msgstr ""
 
-#: cps/spa_strings.py:409
+#: cps/spa_strings.py:457
 msgid "Advanced search"
 msgstr ""
 
-#: cps/spa_strings.py:411
+#: cps/spa_strings.py:459
 msgid "All shelves"
 msgstr ""
 
-#: cps/spa_strings.py:412
+#: cps/spa_strings.py:460
 msgid "Allow remote (magic-link) login"
 msgstr ""
 
-#: cps/spa_strings.py:413
+#: cps/spa_strings.py:461
 msgid "Allowed groups (comma-separated)"
 msgstr ""
 
-#: cps/spa_strings.py:414 cps/templates/search_form.html:44
+#: cps/spa_strings.py:462 cps/templates/search_form.html:44
 #: cps/templates/search_form.html:165
 msgid "Any"
 msgstr ""
 
-#: cps/spa_strings.py:415
+#: cps/spa_strings.py:463
 msgid "Any format"
 msgstr ""
 
-#: cps/spa_strings.py:416
+#: cps/spa_strings.py:464
 msgid "Any language"
 msgstr ""
 
-#: cps/spa_strings.py:417
+#: cps/spa_strings.py:465
 msgid "Any series"
 msgstr ""
 
-#: cps/spa_strings.py:418
+#: cps/spa_strings.py:466
 msgid "Any tags"
 msgstr ""
 
-#: cps/spa_strings.py:419
+#: cps/spa_strings.py:467
 msgid "Apply selected"
 msgstr ""
 
-#: cps/spa_strings.py:420
+#: cps/spa_strings.py:468
 msgid ""
 "Apply to all selected (only filled fields change; replaces existing "
 "values):"
 msgstr ""
 
-#: cps/spa_strings.py:421 cps/templates/cover_picker.html:226
+#: cps/spa_strings.py:469 cps/templates/cover_picker.html:226
 msgid "Applying…"
 msgstr ""
 
-#: cps/spa_strings.py:422 cps/templates/book_table.html:54
+#: cps/spa_strings.py:470 cps/templates/book_table.html:54
 #: cps/templates/book_table.html:214 cps/templates/duplicates.html:660
 msgid "Archive"
 msgstr ""
 
-#: cps/spa_strings.py:423 cps/templates/detail.html:712
+#: cps/spa_strings.py:471 cps/templates/detail.html:712
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
 msgstr ""
 
-#: cps/spa_strings.py:424
+#: cps/spa_strings.py:472
 msgid "Ask in Discord"
 msgstr ""
 
-#: cps/spa_strings.py:425
+#: cps/spa_strings.py:473
 msgid "Authentication"
 msgstr ""
 
-#: cps/spa_strings.py:426
+#: cps/spa_strings.py:474
 msgid "Authentication & security"
 msgstr ""
 
-#: cps/spa_strings.py:427
+#: cps/spa_strings.py:475
 msgid "Author A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:428
+#: cps/spa_strings.py:476
 msgid "Author Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:429
+#: cps/spa_strings.py:477
 msgid "Authorised — signing you in…"
 msgstr ""
 
-#: cps/spa_strings.py:430
+#: cps/spa_strings.py:478
 msgid "Authorize URL"
 msgstr ""
 
-#: cps/spa_strings.py:432
+#: cps/spa_strings.py:480
 msgid "Auto-create users"
 msgstr ""
 
-#: cps/spa_strings.py:433
+#: cps/spa_strings.py:481
 msgid "Auto-create users on first login"
 msgstr ""
 
-#: cps/spa_strings.py:435
+#: cps/spa_strings.py:483
 msgid "Back to library"
 msgstr ""
 
-#: cps/spa_strings.py:436
+#: cps/spa_strings.py:484
 msgid "Back to the classic view"
 msgstr ""
 
-#: cps/spa_strings.py:437
+#: cps/spa_strings.py:485
 msgid "Base DN"
 msgstr ""
 
-#: cps/spa_strings.py:438
+#: cps/spa_strings.py:486
 msgid "Basic configuration"
 msgstr ""
 
-#: cps/spa_strings.py:439
+#: cps/spa_strings.py:487
 msgid "Book default"
 msgstr ""
 
-#: cps/spa_strings.py:440
+#: cps/spa_strings.py:488
 msgid "Book density"
 msgstr ""
 
-#: cps/spa_strings.py:442
+#: cps/spa_strings.py:490
 #, python-brace-format
 msgid "Book {number}"
 msgstr ""
 
-#: cps/spa_strings.py:444
+#: cps/spa_strings.py:492
 msgid "Books per page"
 msgstr ""
 
-#: cps/spa_strings.py:445
+#: cps/spa_strings.py:493
 msgid ""
 "Books that are not on a Kobo-sync shelf are then removed from the device "
 "on its next sync. They stay in your library here."
 msgstr ""
 
-#: cps/spa_strings.py:446
+#: cps/spa_strings.py:494
 msgid "Built-in providers (leave blank to disable):"
 msgstr ""
 
-#: cps/spa_strings.py:447
+#: cps/spa_strings.py:495
 msgid "Bulk actions"
 msgstr ""
 
-#: cps/spa_strings.py:448
+#: cps/spa_strings.py:496
 msgid "CA certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:449
+#: cps/spa_strings.py:497
 msgid "CWA settings (ingest/convert)"
 msgstr ""
 
-#: cps/spa_strings.py:450
+#: cps/spa_strings.py:498
 msgid "Can upload books"
 msgstr ""
 
-#: cps/spa_strings.py:451 cps/templates/admin.html:305
+#: cps/spa_strings.py:499 cps/templates/admin.html:305
 #: cps/templates/admin.html:319 cps/templates/book_edit.html:312
 #: cps/templates/book_table.html:176 cps/templates/book_table.html:195
 #: cps/templates/book_table.html:215 cps/templates/book_table.html:235
@@ -3819,1326 +3938,1316 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: cps/spa_strings.py:452
+#: cps/spa_strings.py:500
 msgid "Cancel rename"
 msgstr ""
 
-#: cps/spa_strings.py:453
+#: cps/spa_strings.py:501
 msgid "Cancel title edit"
 msgstr ""
 
-#: cps/spa_strings.py:454
+#: cps/spa_strings.py:502
 #, python-brace-format
 msgid "Cancel {task}"
 msgstr ""
 
-#: cps/spa_strings.py:456
+#: cps/spa_strings.py:504
 msgid "Certificate file path"
 msgstr ""
 
-#: cps/spa_strings.py:457
+#: cps/spa_strings.py:505
 msgid "Certificate path"
 msgstr ""
 
-#: cps/spa_strings.py:458 cps/templates/book_edit.html:192
+#: cps/spa_strings.py:506 cps/templates/book_edit.html:192
 #: cps/templates/cover_picker.html:12 cps/templates/detail.html:619
 #: cps/templates/detail.html:622 cps/templates/detail.html:744
 msgid "Change cover"
 msgstr ""
 
-#: cps/spa_strings.py:459
+#: cps/spa_strings.py:507
 msgid "Checking…"
 msgstr ""
 
-#: cps/spa_strings.py:460
+#: cps/spa_strings.py:508
 msgid "Choose a cover"
 msgstr ""
 
-#: cps/spa_strings.py:461
+#: cps/spa_strings.py:509
 msgid "Choose a cover image to upload"
 msgstr ""
 
-#: cps/spa_strings.py:462
+#: cps/spa_strings.py:510
 msgid "Choose an image…"
 msgstr ""
 
-#: cps/spa_strings.py:463
+#: cps/spa_strings.py:511
 msgid "Choose fields"
 msgstr ""
 
-#: cps/spa_strings.py:464
+#: cps/spa_strings.py:512
 msgid "Choose your theme"
 msgstr ""
 
-#: cps/spa_strings.py:465
+#: cps/spa_strings.py:513
 msgid "Clear default"
 msgstr ""
 
-#: cps/spa_strings.py:466
+#: cps/spa_strings.py:514
 msgid "Clear selection"
 msgstr ""
 
-#: cps/spa_strings.py:467
+#: cps/spa_strings.py:515
 msgid "Client ID"
 msgstr ""
 
-#: cps/spa_strings.py:468
+#: cps/spa_strings.py:516
 msgid "Client secret"
 msgstr ""
 
-#: cps/spa_strings.py:469
+#: cps/spa_strings.py:517
 msgid "Client secret (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:470
+#: cps/spa_strings.py:518
 msgid "Close reader"
 msgstr ""
 
-#: cps/spa_strings.py:471
+#: cps/spa_strings.py:519
 msgid "Columns"
 msgstr ""
 
-#: cps/spa_strings.py:472
+#: cps/spa_strings.py:520
 msgid "Comfortable"
 msgstr ""
 
-#: cps/spa_strings.py:473
+#: cps/spa_strings.py:521
 msgid "Compact"
 msgstr ""
 
-#: cps/spa_strings.py:474
+#: cps/spa_strings.py:522
 msgid "Configured"
 msgstr ""
 
-#: cps/spa_strings.py:475
+#: cps/spa_strings.py:523
 #, python-brace-format
 msgid "Confirm delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:476
+#: cps/spa_strings.py:524
 msgid "Confirm new password"
 msgstr ""
 
-#: cps/spa_strings.py:477 cps/tasks/convert.py:391
+#: cps/spa_strings.py:525 cps/tasks/convert.py:391
 msgid "Convert"
 msgstr ""
 
-#: cps/spa_strings.py:478
+#: cps/spa_strings.py:526
 msgid "Convert before sending"
 msgstr ""
 
-#: cps/spa_strings.py:479
+#: cps/spa_strings.py:527
 msgid "Convert from"
 msgstr ""
 
-#: cps/spa_strings.py:480
+#: cps/spa_strings.py:528
 msgid "Copied to clipboard"
 msgstr ""
 
-#: cps/spa_strings.py:481
+#: cps/spa_strings.py:529
 msgid "Copy link"
 msgstr ""
 
-#: cps/spa_strings.py:482
+#: cps/spa_strings.py:530
 msgid "Could not create shelf."
 msgstr ""
 
-#: cps/spa_strings.py:483
+#: cps/spa_strings.py:531
 msgid "Could not create the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:484
+#: cps/spa_strings.py:532
 msgid "Could not delete shelf."
 msgstr ""
 
-#: cps/spa_strings.py:485
+#: cps/spa_strings.py:533
 msgid "Could not delete tag"
 msgstr ""
 
-#: cps/spa_strings.py:486
+#: cps/spa_strings.py:534
 msgid "Could not load candidates."
 msgstr ""
 
-#: cps/spa_strings.py:487
+#: cps/spa_strings.py:535
 msgid "Could not load duplicates."
 msgstr ""
 
-#: cps/spa_strings.py:488
+#: cps/spa_strings.py:536
 msgid "Could not load highlights."
 msgstr ""
 
-#: cps/spa_strings.py:489
+#: cps/spa_strings.py:537
 msgid "Could not load stats."
 msgstr ""
 
-#: cps/spa_strings.py:490
+#: cps/spa_strings.py:538
 msgid "Could not load tasks."
 msgstr ""
 
-#: cps/spa_strings.py:491
+#: cps/spa_strings.py:539
 msgid "Could not load this text file."
 msgstr ""
 
-#: cps/spa_strings.py:492
+#: cps/spa_strings.py:540
 msgid "Could not load users."
 msgstr ""
 
-#: cps/spa_strings.py:493
+#: cps/spa_strings.py:541
 msgid "Could not read this comic archive."
 msgstr ""
 
-#: cps/spa_strings.py:494 cps/templates/detail.html:738
+#: cps/spa_strings.py:542 cps/templates/detail.html:738
 msgid "Could not reload metadata"
 msgstr ""
 
-#: cps/spa_strings.py:495
+#: cps/spa_strings.py:543
 msgid "Could not rename shelf."
 msgstr ""
 
-#: cps/spa_strings.py:496
+#: cps/spa_strings.py:544
 msgid "Could not reset password."
 msgstr ""
 
-#: cps/spa_strings.py:497 cps/templates/shelf_reorder.html:88
+#: cps/spa_strings.py:545 cps/templates/shelf_reorder.html:88
 msgid "Could not save order."
 msgstr ""
 
-#: cps/spa_strings.py:498
+#: cps/spa_strings.py:546
 msgid "Could not save reader settings."
 msgstr ""
 
-#: cps/spa_strings.py:499
+#: cps/spa_strings.py:547
 msgid "Could not save the default library filter."
 msgstr ""
 
-#: cps/spa_strings.py:500
+#: cps/spa_strings.py:548
 msgid "Could not save the shelf."
 msgstr ""
 
-#: cps/spa_strings.py:501
+#: cps/spa_strings.py:549
 msgid "Could not save title."
 msgstr ""
 
-#: cps/spa_strings.py:502
+#: cps/spa_strings.py:550
 msgid "Could not save your reading position."
 msgstr ""
 
-#: cps/spa_strings.py:503
+#: cps/spa_strings.py:551
 msgid "Could not start the duplicate scan."
 msgstr ""
 
-#: cps/spa_strings.py:504
+#: cps/spa_strings.py:552
 msgid "Could not update shelf."
 msgstr ""
 
-#: cps/spa_strings.py:505
+#: cps/spa_strings.py:553
 msgid "Could not update your account setting."
 msgstr ""
 
-#: cps/spa_strings.py:506
+#: cps/spa_strings.py:554
 msgid "Couldn’t start a magic link. Please try again."
 msgstr ""
 
-#: cps/spa_strings.py:507
+#: cps/spa_strings.py:555
 msgid "Cover locked"
 msgstr ""
 
-#: cps/spa_strings.py:508
+#: cps/spa_strings.py:556
 msgid "Cover not reachable"
 msgstr ""
 
-#: cps/spa_strings.py:510
+#: cps/spa_strings.py:558
 msgid "Cover updated from the selected result."
 msgstr ""
 
-#: cps/spa_strings.py:511
+#: cps/spa_strings.py:559
 msgid "Create"
 msgstr ""
 
-#: cps/spa_strings.py:512
+#: cps/spa_strings.py:560
 msgid "Create account"
 msgstr ""
 
-#: cps/spa_strings.py:513
+#: cps/spa_strings.py:561
 msgid "Create an account"
 msgstr ""
 
-#: cps/spa_strings.py:514
+#: cps/spa_strings.py:562
 msgid "Create failed."
 msgstr ""
 
-#: cps/spa_strings.py:515
+#: cps/spa_strings.py:563
 msgid "Create shelf and add book"
 msgstr ""
 
-#: cps/spa_strings.py:516
+#: cps/spa_strings.py:564
 msgid "Create user"
 msgstr ""
 
-#: cps/spa_strings.py:517
+#: cps/spa_strings.py:565
 #, python-brace-format
 msgid "Created {name}."
 msgstr ""
 
-#: cps/spa_strings.py:518
+#: cps/spa_strings.py:566
 msgid "Creating…"
 msgstr ""
 
-#: cps/spa_strings.py:519 cps/templates/config_edit.html:259
+#: cps/spa_strings.py:567 cps/templates/config_edit.html:259
 #: cps/templates/cover_picker.html:123
 msgid "Crop to fill — no border, trims the edges"
 msgstr ""
 
-#: cps/spa_strings.py:520 cps/templates/cover_picker.html:180
+#: cps/spa_strings.py:568 cps/templates/cover_picker.html:180
 msgid "Current"
 msgstr ""
 
-#: cps/spa_strings.py:521 cps/templates/cover_picker.html:23
+#: cps/spa_strings.py:569 cps/templates/cover_picker.html:23
 msgid "Current cover"
 msgstr ""
 
-#: cps/spa_strings.py:522
+#: cps/spa_strings.py:570
 msgid "Current password"
 msgstr ""
 
-#: cps/spa_strings.py:523 cps/templates/detail.html:849
+#: cps/spa_strings.py:571 cps/templates/detail.html:849
 #: cps/templates/image.html:27 cps/templates/index.html:45
 msgid "Currently reading"
 msgstr ""
 
-#: cps/spa_strings.py:524
+#: cps/spa_strings.py:572
 msgid "Custom border colour"
 msgstr ""
 
-#: cps/spa_strings.py:525
+#: cps/spa_strings.py:573
 msgid "Custom columns"
 msgstr ""
 
-#: cps/spa_strings.py:526
+#: cps/spa_strings.py:574
 msgid "Database & library path"
 msgstr ""
 
-#: cps/spa_strings.py:527 cps/templates/detail.html:904
+#: cps/spa_strings.py:575 cps/templates/detail.html:904
 msgid "Date added"
 msgstr ""
 
-#: cps/spa_strings.py:528
+#: cps/spa_strings.py:576
 msgid "Default (System Sans-Serif)"
 msgstr ""
 
-#: cps/spa_strings.py:529
+#: cps/spa_strings.py:577
 msgid "Default book language"
 msgstr ""
 
-#: cps/spa_strings.py:530
+#: cps/spa_strings.py:578
 msgid "Default interface language"
 msgstr ""
 
-#: cps/spa_strings.py:531
+#: cps/spa_strings.py:579
 msgid "Default library filter cleared."
 msgstr ""
 
-#: cps/spa_strings.py:532
+#: cps/spa_strings.py:580
 msgid "Default library filter saved."
 msgstr ""
 
-#: cps/spa_strings.py:533
+#: cps/spa_strings.py:581
 msgid "Default roles for new OAuth users:"
 msgstr ""
 
-#: cps/spa_strings.py:534
+#: cps/spa_strings.py:582
 msgid "Defaults live in Admin → Configuration → Kobo sync."
 msgstr ""
 
-#: cps/spa_strings.py:535
+#: cps/spa_strings.py:583
 msgid "Delete books"
 msgstr ""
 
-#: cps/spa_strings.py:536
+#: cps/spa_strings.py:584
 msgid "Delete failed."
 msgstr ""
 
-#: cps/spa_strings.py:537
+#: cps/spa_strings.py:585
 #, python-brace-format
 msgid "Delete shelf \"{name}\"? This cannot be undone."
 msgstr ""
 
-#: cps/spa_strings.py:538
+#: cps/spa_strings.py:586
 #, python-brace-format
 msgid "Delete tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:539
+#: cps/spa_strings.py:587
 msgid "Delete this smart shelf? Your books are not affected."
 msgstr ""
 
-#: cps/spa_strings.py:540
+#: cps/spa_strings.py:588
 #, python-brace-format
 msgid "Delete user \"{name}\"? Their shelves and reading data are removed too."
 msgstr ""
 
-#: cps/spa_strings.py:541
+#: cps/spa_strings.py:589
 #, python-brace-format
 msgid "Delete {name}"
 msgstr ""
 
-#: cps/spa_strings.py:542
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} book, which is kept."
-msgstr ""
-
-#: cps/spa_strings.py:543
-#, python-brace-format
-msgid "Delete “{name}”? It is removed from {count} books, which are kept."
-msgstr ""
-
-#: cps/spa_strings.py:544
+#: cps/spa_strings.py:592
 #, python-brace-format
 msgid "Deleted tag {name}"
 msgstr ""
 
-#: cps/spa_strings.py:545
+#: cps/spa_strings.py:593
 #, python-brace-format
 msgid "Deleted {name}."
 msgstr ""
 
-#: cps/spa_strings.py:546
+#: cps/spa_strings.py:594
 msgid "Dense"
 msgstr ""
 
-#: cps/spa_strings.py:547 cps/templates/book_edit.html:171
+#: cps/spa_strings.py:595 cps/templates/book_edit.html:171
 #: cps/templates/book_edit.html:461 cps/templates/cwa_settings.html:341
 #: cps/templates/cwa_settings.html:343 cps/templates/search_form.html:154
 msgid "Description"
 msgstr ""
 
-#: cps/spa_strings.py:548
+#: cps/spa_strings.py:596
 msgid "Disable standard password login"
 msgstr ""
 
-#: cps/spa_strings.py:550
+#: cps/spa_strings.py:598
 msgid "Discover picks updated."
 msgstr ""
 
-#: cps/spa_strings.py:551
+#: cps/spa_strings.py:599
 msgid "Discover — Random Picks"
 msgstr ""
 
-#: cps/spa_strings.py:552 cps/templates/cwng_feedback_popup.html:24
+#: cps/spa_strings.py:600 cps/templates/cwng_feedback_popup.html:24
 #: cps/templates/duplicates.html:618 cps/templates/layout.html:423
 #: cps/templates/layout.html:605
 msgid "Dismiss"
 msgstr ""
 
-#: cps/spa_strings.py:553
+#: cps/spa_strings.py:601
 msgid "Dismiss this group"
 msgstr ""
 
-#: cps/spa_strings.py:554
+#: cps/spa_strings.py:602
 msgid "Documentation"
 msgstr ""
 
-#: cps/spa_strings.py:555
+#: cps/spa_strings.py:603
 msgid "Done reordering"
 msgstr ""
 
-#: cps/spa_strings.py:556 cps/templates/admin.html:24
+#: cps/spa_strings.py:604 cps/templates/admin.html:24
 #: cps/templates/detail.html:647 cps/templates/shelf.html:9
 #: cps/templates/user_table.html:147
 msgid "Download"
 msgstr ""
 
-#: cps/spa_strings.py:557
+#: cps/spa_strings.py:605
 msgid "Drop files here, or click to choose"
 msgstr ""
 
-#: cps/spa_strings.py:558
+#: cps/spa_strings.py:606
 msgid "Duplicate"
 msgstr ""
 
-#: cps/spa_strings.py:559
+#: cps/spa_strings.py:607
 msgid "Duplicate books"
 msgstr ""
 
-#: cps/spa_strings.py:560
+#: cps/spa_strings.py:608
 msgid "Duplicate detection settings"
 msgstr ""
 
-#: cps/spa_strings.py:561
+#: cps/spa_strings.py:609
 msgid ""
 "Duplicate scan started. It runs in the background — this list updates "
 "when it finishes."
 msgstr ""
 
-#: cps/spa_strings.py:563 cps/templates/cover_picker.html:94
+#: cps/spa_strings.py:611 cps/templates/cover_picker.html:94
 msgid "E-reader preview"
 msgstr ""
 
-#: cps/spa_strings.py:564
+#: cps/spa_strings.py:612
 msgid "Each type (isbn, amazon, google, doi…) may appear once."
 msgstr ""
 
-#: cps/spa_strings.py:565 cps/templates/config_edit.html:253
+#: cps/spa_strings.py:613 cps/templates/config_edit.html:253
 #: cps/templates/cover_picker.html:117
 msgid "Edge blur — soft bokeh border"
 msgstr ""
 
-#: cps/spa_strings.py:566 cps/templates/config_edit.html:252
+#: cps/spa_strings.py:614 cps/templates/config_edit.html:252
 #: cps/templates/cover_picker.html:116
 msgid "Edge mirror — extend the artwork (recommended)"
 msgstr ""
 
-#: cps/spa_strings.py:567 cps/templates/admin.html:26
+#: cps/spa_strings.py:615 cps/templates/admin.html:26
 #: cps/templates/book_table.html:51 cps/templates/book_table.html:332
 #: cps/templates/duplicates.html:657 cps/templates/index.html:131
 #: cps/templates/user_table.html:131 cps/templates/user_table.html:149
 msgid "Edit"
 msgstr ""
 
-#: cps/spa_strings.py:568
+#: cps/spa_strings.py:616
 msgid "Edit public shelves"
 msgstr ""
 
-#: cps/spa_strings.py:569
+#: cps/spa_strings.py:617
 msgid "Edit smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:570
+#: cps/spa_strings.py:618
 #, python-brace-format
 msgid "Edit title for {title}"
 msgstr ""
 
-#: cps/spa_strings.py:571 cps/templates/admin.html:15
+#: cps/spa_strings.py:619 cps/templates/admin.html:15
 #: cps/templates/register.html:14 cps/templates/user_edit.html:200
 #: cps/templates/user_table.html:135
 msgid "Email"
 msgstr ""
 
-#: cps/spa_strings.py:572
+#: cps/spa_strings.py:620
 msgid "Email (SMTP) server"
 msgstr ""
 
-#: cps/spa_strings.py:573
+#: cps/spa_strings.py:621
 msgid "Email (optional)"
 msgstr ""
 
-#: cps/spa_strings.py:574
+#: cps/spa_strings.py:622
 msgid "Email claim"
 msgstr ""
 
-#: cps/spa_strings.py:575
+#: cps/spa_strings.py:623
 msgid "Email me a reset"
 msgstr ""
 
-#: cps/spa_strings.py:576
+#: cps/spa_strings.py:624
 msgid "Email settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:577 cps/templates/config_edit.html:208
+#: cps/spa_strings.py:625 cps/templates/config_edit.html:208
 msgid "Enable Kobo sync"
 msgstr ""
 
-#: cps/spa_strings.py:578 cps/templates/admin.html:80
+#: cps/spa_strings.py:626 cps/templates/admin.html:80
 #: cps/templates/email_edit.html:39
 msgid "Encryption"
 msgstr ""
 
-#: cps/spa_strings.py:579
+#: cps/spa_strings.py:627
 msgid "Expires in"
 msgstr ""
 
-#: cps/spa_strings.py:580
+#: cps/spa_strings.py:628
 msgid "Expose only selected shelves over OPDS"
 msgstr ""
 
-#: cps/spa_strings.py:581
+#: cps/spa_strings.py:629
 msgid "Failed to load shelves."
 msgstr ""
 
-#: cps/spa_strings.py:582
+#: cps/spa_strings.py:630
 msgid "Failed to load."
 msgstr ""
 
-#: cps/spa_strings.py:583 cps/templates/image.html:25
+#: cps/spa_strings.py:631 cps/templates/image.html:25
 msgid "Favorite"
 msgstr ""
 
-#: cps/spa_strings.py:584
+#: cps/spa_strings.py:632
 msgid "Favorited"
 msgstr ""
 
-#: cps/spa_strings.py:586
+#: cps/spa_strings.py:634
 msgid "Fetch"
 msgstr ""
 
-#: cps/spa_strings.py:587
+#: cps/spa_strings.py:635
 msgid "Fetch metadata from web"
 msgstr ""
 
-#: cps/spa_strings.py:588
+#: cps/spa_strings.py:636
 msgid "Files"
 msgstr ""
 
-#: cps/spa_strings.py:589
+#: cps/spa_strings.py:637
 msgid ""
 "Files are queued for the library's ingest process and appear once "
 "imported."
 msgstr ""
 
-#: cps/spa_strings.py:590 cps/templates/config_edit.html:250
+#: cps/spa_strings.py:638 cps/templates/config_edit.html:250
 #: cps/templates/cover_picker.html:114
 msgid "Fill style"
 msgstr ""
 
-#: cps/spa_strings.py:591
+#: cps/spa_strings.py:639
 #, python-brace-format
 msgid "Filter {items}"
 msgstr ""
 
-#: cps/spa_strings.py:592
+#: cps/spa_strings.py:640
 #, python-brace-format
 msgid "Filter {items}…"
 msgstr ""
 
-#: cps/spa_strings.py:593
+#: cps/spa_strings.py:641
 msgid "Font family"
 msgstr ""
 
-#: cps/spa_strings.py:594
+#: cps/spa_strings.py:642
 msgid "Font size"
 msgstr ""
 
-#: cps/spa_strings.py:595
+#: cps/spa_strings.py:643
 msgid "Forgot password?"
 msgstr ""
 
-#: cps/spa_strings.py:596
+#: cps/spa_strings.py:644
 msgid "Format queued — it will appear once processed."
 msgstr ""
 
-#: cps/spa_strings.py:597
+#: cps/spa_strings.py:645
 msgid "Formats"
 msgstr ""
 
-#: cps/spa_strings.py:598
+#: cps/spa_strings.py:646
 msgid "Formats — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:599
+#: cps/spa_strings.py:647
 msgid "Formats — include"
 msgstr ""
 
-#: cps/spa_strings.py:600
+#: cps/spa_strings.py:648
 msgid "From address"
 msgstr ""
 
-#: cps/spa_strings.py:601
+#: cps/spa_strings.py:649
 msgid "Full user table & restrictions"
 msgstr ""
 
-#: cps/spa_strings.py:602
+#: cps/spa_strings.py:650
 msgid "Generate a new link"
 msgstr ""
 
-#: cps/spa_strings.py:603
+#: cps/spa_strings.py:651
 msgid "Give your smart shelf a name."
 msgstr ""
 
-#: cps/spa_strings.py:604
+#: cps/spa_strings.py:652
 msgid "Go to your library"
 msgstr ""
 
-#: cps/spa_strings.py:605 cps/templates/config_edit.html:254
+#: cps/spa_strings.py:653 cps/templates/config_edit.html:254
 #: cps/templates/cover_picker.html:118
 msgid "Gradient — palette-matched top/bottom blend"
 msgstr ""
 
-#: cps/spa_strings.py:606
+#: cps/spa_strings.py:654
 msgid "Group claim"
 msgstr ""
 
-#: cps/spa_strings.py:607
+#: cps/spa_strings.py:655
 msgid "Group members field"
 msgstr ""
 
-#: cps/spa_strings.py:608
+#: cps/spa_strings.py:656
 msgid "Group name"
 msgstr ""
 
-#: cps/spa_strings.py:609
+#: cps/spa_strings.py:657
 msgid "Group object filter"
 msgstr ""
 
-#: cps/spa_strings.py:610
+#: cps/spa_strings.py:658
 msgid "HTML is allowed and sanitized on display."
 msgstr ""
 
-#: cps/spa_strings.py:611
+#: cps/spa_strings.py:659
 msgid "Header name"
 msgstr ""
 
-#: cps/spa_strings.py:612
+#: cps/spa_strings.py:660
 msgid "Help & support"
 msgstr ""
 
-#: cps/spa_strings.py:613
+#: cps/spa_strings.py:661
 msgid "Help menu"
 msgstr ""
 
-#: cps/spa_strings.py:614 cps/templates/detail.html:770
+#: cps/spa_strings.py:662 cps/templates/detail.html:770
 msgid "Hidden"
 msgstr ""
 
-#: cps/spa_strings.py:615 cps/templates/readcbr.html:173
+#: cps/spa_strings.py:663 cps/templates/readcbr.html:173
 msgid "Hide"
 msgstr ""
 
-#: cps/spa_strings.py:616
+#: cps/spa_strings.py:664
 msgid "Hide Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:617
+#: cps/spa_strings.py:665
 msgid "Hide fields"
 msgstr ""
 
-#: cps/spa_strings.py:618
+#: cps/spa_strings.py:666
 msgid "Hide password"
 msgstr ""
 
-#: cps/spa_strings.py:619
+#: cps/spa_strings.py:667
 msgid "Highlight"
 msgstr ""
 
-#: cps/spa_strings.py:620
+#: cps/spa_strings.py:668
 msgid "Highlights"
 msgstr ""
 
-#: cps/spa_strings.py:621
+#: cps/spa_strings.py:669
 msgid "Hot"
 msgstr ""
 
-#: cps/spa_strings.py:622
+#: cps/spa_strings.py:670
 msgid "Hot — Most Downloaded"
 msgstr ""
 
-#: cps/spa_strings.py:623
+#: cps/spa_strings.py:671
 msgid "Icon"
 msgstr ""
 
-#: cps/spa_strings.py:624
+#: cps/spa_strings.py:672
 msgid "Identifier type"
 msgstr ""
 
-#: cps/spa_strings.py:625
+#: cps/spa_strings.py:673
 msgid "Identifier value"
 msgstr ""
 
-#: cps/spa_strings.py:626 cps/templates/book_edit.html:175
+#: cps/spa_strings.py:674 cps/templates/book_edit.html:175
 msgid "Identifiers"
 msgstr ""
 
-#: cps/spa_strings.py:627 cps/templates/book_edit.html:128
+#: cps/spa_strings.py:675 cps/templates/book_edit.html:128
 #: cps/templates/detail.html:899
 msgid "Imported as"
 msgstr ""
 
-#: cps/spa_strings.py:628
+#: cps/spa_strings.py:676
 msgid "In your book"
 msgstr ""
 
-#: cps/spa_strings.py:629
+#: cps/spa_strings.py:677
 msgid ""
 "In-browser reading currently supports EPUB. Use download or the classic "
 "reader for other formats."
 msgstr ""
 
-#: cps/spa_strings.py:630
+#: cps/spa_strings.py:678
 msgid "Issuer / base URL"
 msgstr ""
 
-#: cps/spa_strings.py:631
+#: cps/spa_strings.py:679
 msgid "It may have moved, or it might still live in the classic interface."
 msgstr ""
 
-#: cps/spa_strings.py:632 cps/templates/detail.html:1017
+#: cps/spa_strings.py:680 cps/templates/detail.html:1017
 msgid "KOReader Progress"
 msgstr ""
 
-#: cps/spa_strings.py:633
+#: cps/spa_strings.py:681
 msgid "Key file path"
 msgstr ""
 
-#: cps/spa_strings.py:634
+#: cps/spa_strings.py:682
 msgid "Key path"
 msgstr ""
 
-#: cps/spa_strings.py:635
+#: cps/spa_strings.py:683
 msgid "Kobo Clara HD / 2E / BW / Colour (1072×1448)"
 msgstr ""
 
-#: cps/spa_strings.py:636
+#: cps/spa_strings.py:684
 msgid "Kobo Libra Color / Libra 2 (1264×1680)"
 msgstr ""
 
-#: cps/spa_strings.py:637
+#: cps/spa_strings.py:685
 msgid "Kobo sync on"
 msgstr ""
 
-#: cps/spa_strings.py:638 cps/templates/book_edit.html:163
+#: cps/spa_strings.py:686 cps/templates/book_edit.html:163
 #: cps/templates/cwa_settings.html:1128 cps/templates/listenmp3.html:69
 msgid "Language"
 msgstr ""
 
-#: cps/spa_strings.py:640
+#: cps/spa_strings.py:688
 msgid "Languages — include"
 msgstr ""
 
-#: cps/spa_strings.py:641 cps/templates/detail.html:908
+#: cps/spa_strings.py:689 cps/templates/detail.html:908
 msgid "Last modified"
 msgstr ""
 
-#: cps/spa_strings.py:642 cps/templates/detail.html:1029
+#: cps/spa_strings.py:690 cps/templates/detail.html:1029
 msgid "Last synced"
 msgstr ""
 
-#: cps/spa_strings.py:643
+#: cps/spa_strings.py:691
 msgid "Library settings"
 msgstr ""
 
-#: cps/spa_strings.py:644 cps/templates/read.html:132
+#: cps/spa_strings.py:692 cps/templates/read.html:132
 msgid "Line height"
 msgstr ""
 
-#: cps/spa_strings.py:645
+#: cps/spa_strings.py:693
 msgid "Load more"
 msgstr ""
 
-#: cps/spa_strings.py:646 cps/templates/admin.html:301
+#: cps/spa_strings.py:694 cps/templates/admin.html:301
 #: cps/templates/admin.html:333 cps/templates/config_db.html:4
 #: cps/templates/config_edit.html:4 cps/templates/cwa_settings.html:4
 #: cps/templates/read.html:74
 msgid "Loading"
 msgstr ""
 
-#: cps/spa_strings.py:647
+#: cps/spa_strings.py:695
 msgid "Loading new Discover picks."
 msgstr ""
 
-#: cps/spa_strings.py:648 cps/templates/cover_picker.html:87
+#: cps/spa_strings.py:696 cps/templates/cover_picker.html:87
 msgid "Loading…"
 msgstr ""
 
-#: cps/spa_strings.py:649 cps/templates/cover_picker.html:37
+#: cps/spa_strings.py:697 cps/templates/cover_picker.html:37
 msgid "Lock cover"
 msgstr ""
 
-#: cps/spa_strings.py:651
+#: cps/spa_strings.py:699
 msgid "Login button text"
 msgstr ""
 
-#: cps/spa_strings.py:652
+#: cps/spa_strings.py:700
 msgid "Login method"
 msgstr ""
 
-#: cps/spa_strings.py:653
+#: cps/spa_strings.py:701
 msgid "Login with"
 msgstr ""
 
-#: cps/spa_strings.py:654
+#: cps/spa_strings.py:702
 msgid "Logs"
 msgstr ""
 
-#: cps/spa_strings.py:655
+#: cps/spa_strings.py:703
 msgid "Looks good"
 msgstr ""
 
-#: cps/spa_strings.py:656
+#: cps/spa_strings.py:704
 msgid "Low-res"
 msgstr ""
 
-#: cps/spa_strings.py:657
+#: cps/spa_strings.py:705
 msgid "Magic link"
 msgstr ""
 
-#: cps/spa_strings.py:658
+#: cps/spa_strings.py:706
 msgid "Magic link QR code"
 msgstr ""
 
-#: cps/spa_strings.py:659
+#: cps/spa_strings.py:707
 msgid "Make private"
 msgstr ""
 
-#: cps/spa_strings.py:660
+#: cps/spa_strings.py:708
 msgid "Make public"
 msgstr ""
 
-#: cps/spa_strings.py:661
+#: cps/spa_strings.py:709
 msgid "Make this my default library view"
 msgstr ""
 
-#: cps/spa_strings.py:662
+#: cps/spa_strings.py:710
 msgid "Manage admin role from OAuth group"
 msgstr ""
 
-#: cps/spa_strings.py:663
+#: cps/spa_strings.py:711
 msgid "Manage shelves"
 msgstr ""
 
-#: cps/spa_strings.py:664 cps/templates/_book_organizer.html:139
+#: cps/spa_strings.py:712 cps/templates/_book_organizer.html:139
 #: cps/templates/book_table.html:60 cps/templates/book_table.html:254
 msgid "Mark as read"
 msgstr ""
 
-#: cps/spa_strings.py:665 cps/templates/_book_organizer.html:145
+#: cps/spa_strings.py:713 cps/templates/_book_organizer.html:145
 #: cps/templates/book_table.html:63 cps/templates/book_table.html:274
 msgid "Mark as unread"
 msgstr ""
 
-#: cps/spa_strings.py:666
+#: cps/spa_strings.py:714
 msgid "Match"
 msgstr ""
 
-#: cps/spa_strings.py:667
+#: cps/spa_strings.py:715
 msgid "Max"
 msgstr ""
 
-#: cps/spa_strings.py:668
+#: cps/spa_strings.py:716
 msgid "Max authors shown"
 msgstr ""
 
-#: cps/spa_strings.py:669
+#: cps/spa_strings.py:717
 msgid "Maximum rating"
 msgstr ""
 
-#: cps/spa_strings.py:670
+#: cps/spa_strings.py:718
 msgid "Member user filter"
 msgstr ""
 
-#: cps/spa_strings.py:671
+#: cps/spa_strings.py:719
 #, python-brace-format
 msgid "Merge into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:672
+#: cps/spa_strings.py:720
 #, python-brace-format
 msgid "Merged into {name}"
 msgstr ""
 
-#: cps/spa_strings.py:673
+#: cps/spa_strings.py:721
 msgid "Metadata URL (OIDC auto-discovery)"
 msgstr ""
 
-#: cps/spa_strings.py:674
+#: cps/spa_strings.py:722
 msgid "Min"
 msgstr ""
 
-#: cps/spa_strings.py:675
+#: cps/spa_strings.py:723
 msgid "Minimum rating"
 msgstr ""
 
-#: cps/spa_strings.py:676
+#: cps/spa_strings.py:724
 msgid "More cover options (search providers, e-reader preview)"
 msgstr ""
 
-#: cps/spa_strings.py:677
+#: cps/spa_strings.py:725
 msgid "More server configuration"
 msgstr ""
 
-#: cps/spa_strings.py:678
+#: cps/spa_strings.py:726
 msgid "Move down"
 msgstr ""
 
-#: cps/spa_strings.py:679
+#: cps/spa_strings.py:727
 msgid "Move up"
 msgstr ""
 
-#: cps/spa_strings.py:680
+#: cps/spa_strings.py:728
 msgid "My account"
 msgstr ""
 
-#: cps/spa_strings.py:681
+#: cps/spa_strings.py:729
 msgid "Name"
 msgstr ""
 
-#: cps/spa_strings.py:682
+#: cps/spa_strings.py:730
 msgid "Need to report an issue? Try the new"
 msgstr ""
 
-#: cps/spa_strings.py:683 cps/templates/cover_picker.html:184
+#: cps/spa_strings.py:731 cps/templates/cover_picker.html:184
 msgid "New"
 msgstr ""
 
-#: cps/spa_strings.py:684
+#: cps/spa_strings.py:732
 msgid "New password"
 msgstr ""
 
-#: cps/spa_strings.py:685
+#: cps/spa_strings.py:733
 msgid "New shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:686
+#: cps/spa_strings.py:734
 msgid "New shelf name…"
 msgstr ""
 
-#: cps/spa_strings.py:687
+#: cps/spa_strings.py:735
 msgid "New shelf…"
 msgstr ""
 
-#: cps/spa_strings.py:688
+#: cps/spa_strings.py:736
 msgid "New smart shelf"
 msgstr ""
 
-#: cps/spa_strings.py:689
+#: cps/spa_strings.py:737
 msgid "New user"
 msgstr ""
 
-#: cps/spa_strings.py:690
+#: cps/spa_strings.py:738
 msgid "Newest"
 msgstr ""
 
-#: cps/spa_strings.py:691
+#: cps/spa_strings.py:739
 msgid "Newest published"
 msgstr ""
 
-#: cps/spa_strings.py:692
+#: cps/spa_strings.py:740
 msgid "Next page"
 msgstr ""
 
-#: cps/spa_strings.py:693
+#: cps/spa_strings.py:741
 msgid "No books match this smart shelf right now."
 msgstr ""
 
-#: cps/spa_strings.py:694
+#: cps/spa_strings.py:742
 msgid "No books match those criteria."
 msgstr ""
 
-#: cps/spa_strings.py:695 cps/templates/cover_picker.html:225
+#: cps/spa_strings.py:743 cps/templates/cover_picker.html:225
 msgid "No candidates found yet. Try a different search or refresh."
 msgstr ""
 
-#: cps/spa_strings.py:696
+#: cps/spa_strings.py:744
 msgid "No contents found."
 msgstr ""
 
-#: cps/spa_strings.py:697
+#: cps/spa_strings.py:745
 msgid "No duplicate groups found."
 msgstr ""
 
-#: cps/spa_strings.py:698
+#: cps/spa_strings.py:746
 msgid "No excluded tags"
 msgstr ""
 
-#: cps/spa_strings.py:699
+#: cps/spa_strings.py:747
 msgid "No highlights yet. Highlight while reading, or import from a Kobo device."
 msgstr ""
 
-#: cps/spa_strings.py:700
+#: cps/spa_strings.py:748
 #, python-brace-format
 msgid "No matching {items} for \"{query}\"."
 msgstr ""
 
-#: cps/spa_strings.py:701
+#: cps/spa_strings.py:749
 msgid "No pages found in this comic."
 msgstr ""
 
-#: cps/spa_strings.py:702
+#: cps/spa_strings.py:750
 msgid "No shelves yet — create one below."
 msgstr ""
 
-#: cps/spa_strings.py:703
+#: cps/spa_strings.py:751
 msgid "No shelves yet. Create one above to start collecting books."
 msgstr ""
 
-#: cps/spa_strings.py:704
+#: cps/spa_strings.py:752
 msgid "No sources need a key."
 msgstr ""
 
-#: cps/spa_strings.py:705
+#: cps/spa_strings.py:753
 msgid "No tasks running."
 msgstr ""
 
-#: cps/spa_strings.py:706
+#: cps/spa_strings.py:754
 #, python-brace-format
 msgid "No {items} yet."
 msgstr ""
 
-#: cps/spa_strings.py:707
+#: cps/spa_strings.py:755
 msgid "Not configured"
 msgstr ""
 
-#: cps/spa_strings.py:708
+#: cps/spa_strings.py:756
 msgid "Not set"
 msgstr ""
 
-#: cps/spa_strings.py:709
+#: cps/spa_strings.py:757
 msgid "Oldest"
 msgstr ""
 
-#: cps/spa_strings.py:710
+#: cps/spa_strings.py:758
 msgid "Oldest published"
 msgstr ""
 
-#: cps/spa_strings.py:711
+#: cps/spa_strings.py:759
 msgid ""
 "On another device where you’re already signed in, scan this code or open "
 "the link below to authorise this device."
 msgstr ""
 
-#: cps/spa_strings.py:712
+#: cps/spa_strings.py:760
 msgid "Open Account"
 msgstr ""
 
-#: cps/spa_strings.py:713
+#: cps/spa_strings.py:761
 msgid "Open classic reader"
 msgstr ""
 
-#: cps/spa_strings.py:714
+#: cps/spa_strings.py:762
 msgid "Open navigation"
 msgstr ""
 
-#: cps/spa_strings.py:715
+#: cps/spa_strings.py:763
 msgid "Open reader"
 msgstr ""
 
-#: cps/spa_strings.py:716
+#: cps/spa_strings.py:764
 msgid "Open the classic interface"
 msgstr ""
 
-#: cps/spa_strings.py:717
+#: cps/spa_strings.py:765
 msgid "Open the link below on your signed-in device."
 msgstr ""
 
-#: cps/spa_strings.py:718
+#: cps/spa_strings.py:766
 msgid "OpenLDAP server"
 msgstr ""
 
-#: cps/spa_strings.py:719
+#: cps/spa_strings.py:767
 msgid "Opens in classic view"
 msgstr ""
 
-#: cps/spa_strings.py:720
+#: cps/spa_strings.py:768
 msgid "PDF reader"
 msgstr ""
 
-#: cps/spa_strings.py:721
+#: cps/spa_strings.py:769
 msgid "Page margins"
 msgstr ""
 
-#: cps/spa_strings.py:722
+#: cps/spa_strings.py:770
 msgid "Page theme"
 msgstr ""
 
-#: cps/spa_strings.py:723
+#: cps/spa_strings.py:771
 #, python-brace-format
 msgid "Page {number}"
 msgstr ""
 
-#: cps/spa_strings.py:724
+#: cps/spa_strings.py:772
 msgid ""
 "Pages marked below open in the classic view. Changes there apply to the "
 "whole server."
 msgstr ""
 
-#: cps/spa_strings.py:725 cps/templates/admin.html:20
+#: cps/spa_strings.py:773 cps/templates/admin.html:20
 #: cps/templates/login.html:22 cps/templates/login.html:23
 #: cps/templates/user_edit.html:211
 msgid "Password"
 msgstr ""
 
-#: cps/spa_strings.py:726
+#: cps/spa_strings.py:774
 msgid "Password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:727 cps/templates/cover_picker.html:14
+#: cps/spa_strings.py:775 cps/templates/cover_picker.html:14
 msgid ""
 "Pick a cover from any source we support, paste a URL, upload a file, or "
 "use the cover embedded in the book itself."
 msgstr ""
 
-#: cps/spa_strings.py:728
+#: cps/spa_strings.py:776
 #, python-brace-format
 msgid "Picked up {label}. Drag to reorder, release to drop."
 msgstr ""
 
-#: cps/spa_strings.py:729 cps/templates/admin.html:123
+#: cps/spa_strings.py:777 cps/templates/admin.html:123
 msgid "Port"
 msgstr ""
 
-#: cps/spa_strings.py:730
+#: cps/spa_strings.py:778
 msgid "Preparing your magic link…"
 msgstr ""
 
-#: cps/spa_strings.py:731
+#: cps/spa_strings.py:779
 msgid "Previous page"
 msgstr ""
 
-#: cps/spa_strings.py:732 cps/templates/duplicates.html:545
+#: cps/spa_strings.py:780 cps/templates/duplicates.html:545
 #: cps/templates/tasks.html:17
 msgid "Progress"
 msgstr ""
 
-#: cps/spa_strings.py:733
+#: cps/spa_strings.py:781
 msgid "Public"
 msgstr ""
 
-#: cps/spa_strings.py:734
+#: cps/spa_strings.py:782
 msgid "Published after"
 msgstr ""
 
-#: cps/spa_strings.py:735
+#: cps/spa_strings.py:783
 msgid "Published before"
 msgstr ""
 
-#: cps/spa_strings.py:737
+#: cps/spa_strings.py:785
 msgid "Random books shown"
 msgstr ""
 
-#: cps/spa_strings.py:738 cps/templates/book_edit.html:167
+#: cps/spa_strings.py:786 cps/templates/book_edit.html:167
 #: cps/templates/cwa_settings.html:369 cps/templates/cwa_settings.html:371
 msgid "Rating"
 msgstr ""
 
-#: cps/spa_strings.py:739
+#: cps/spa_strings.py:787
 msgid "Rating (stars)"
 msgstr ""
 
-#: cps/spa_strings.py:741
+#: cps/spa_strings.py:789
 msgid "Read status"
 msgstr ""
 
-#: cps/spa_strings.py:742
+#: cps/spa_strings.py:790
 msgid "Read status filter"
 msgstr ""
 
-#: cps/spa_strings.py:743
+#: cps/spa_strings.py:791
 msgid "Reader settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:744
+#: cps/spa_strings.py:792
 msgid "Reading appearance"
 msgstr ""
 
-#: cps/spa_strings.py:745
+#: cps/spa_strings.py:793
 msgid "Recipient(s)"
 msgstr ""
 
-#: cps/spa_strings.py:746
+#: cps/spa_strings.py:794
 msgid "Redirect host (full URL)"
 msgstr ""
 
-#: cps/spa_strings.py:747 cps/templates/cover_picker.html:154
+#: cps/spa_strings.py:795 cps/templates/cover_picker.html:154
 #: cps/templates/index.html:120
 msgid "Refresh"
 msgstr ""
 
-#: cps/spa_strings.py:748
+#: cps/spa_strings.py:796
 msgid "Registering…"
 msgstr ""
 
-#: cps/spa_strings.py:749
+#: cps/spa_strings.py:797
 msgid "Reload"
 msgstr ""
 
-#: cps/spa_strings.py:750 cps/templates/detail.html:739
+#: cps/spa_strings.py:798 cps/templates/detail.html:739
 #: cps/templates/detail.html:740
 msgid "Reload metadata from disk"
 msgstr ""
 
-#: cps/spa_strings.py:751
+#: cps/spa_strings.py:799
 msgid "Reloading…"
 msgstr ""
 
-#: cps/spa_strings.py:752
+#: cps/spa_strings.py:800
 msgid "Remember me"
 msgstr ""
 
-#: cps/spa_strings.py:753 cps/templates/detail.html:700
+#: cps/spa_strings.py:801 cps/templates/detail.html:700
 #: cps/templates/detail.html:701 cps/templates/detail.html:702
 msgid "Remove from favorites"
 msgstr ""
 
-#: cps/spa_strings.py:754 cps/templates/detail.html:809
+#: cps/spa_strings.py:802 cps/templates/detail.html:809
 #: cps/templates/detail.html:991
 msgid "Remove from shelf"
 msgstr ""
 
-#: cps/spa_strings.py:755
+#: cps/spa_strings.py:803
 msgid "Remove highlight"
 msgstr ""
 
-#: cps/spa_strings.py:756
+#: cps/spa_strings.py:804
 msgid "Remove identifier"
 msgstr ""
 
-#: cps/spa_strings.py:757
+#: cps/spa_strings.py:805
 msgid "Remove rule"
 msgstr ""
 
-#: cps/spa_strings.py:758
+#: cps/spa_strings.py:806
 msgid "Rename"
 msgstr ""
 
-#: cps/spa_strings.py:759
+#: cps/spa_strings.py:807
 msgid "Reorder"
 msgstr ""
 
-#: cps/spa_strings.py:760
+#: cps/spa_strings.py:808
 msgid "Replace cover with this one?"
 msgstr ""
 
-#: cps/spa_strings.py:761
+#: cps/spa_strings.py:809
 msgid "Replace cover?"
 msgstr ""
 
-#: cps/spa_strings.py:762
+#: cps/spa_strings.py:810
 msgid "Report Issue on Discord"
 msgstr ""
 
-#: cps/spa_strings.py:763
+#: cps/spa_strings.py:811
 msgid "Report Issue on GitHub"
 msgstr ""
 
-#: cps/spa_strings.py:764
+#: cps/spa_strings.py:812
 msgid "Require group membership"
 msgstr ""
 
-#: cps/spa_strings.py:765
+#: cps/spa_strings.py:813
 #, python-brace-format
 msgid "Reset password for {name}"
 msgstr ""
 
-#: cps/spa_strings.py:766
+#: cps/spa_strings.py:814
 #, python-brace-format
 msgid ""
 "Reset password for {name}? Their current password will stop working and a"
 " replacement will be emailed."
 msgstr ""
 
-#: cps/spa_strings.py:767
+#: cps/spa_strings.py:815
 msgid "Reverse-proxy header login"
 msgstr ""
 
-#: cps/spa_strings.py:768
+#: cps/spa_strings.py:816
 msgid "Rows per load"
 msgstr ""
 
-#: cps/spa_strings.py:769
+#: cps/spa_strings.py:817
 msgid "Run time"
 msgstr ""
 
-#: cps/spa_strings.py:770
+#: cps/spa_strings.py:818
 msgid "SMTP server"
 msgstr ""
 
-#: cps/spa_strings.py:771 cps/templates/email_edit.html:43
+#: cps/spa_strings.py:819 cps/templates/email_edit.html:43
 msgid "SSL/TLS"
 msgstr ""
 
-#: cps/spa_strings.py:772 cps/templates/email_edit.html:42
+#: cps/spa_strings.py:820 cps/templates/email_edit.html:42
 msgid "STARTTLS"
 msgstr ""
 
-#: cps/spa_strings.py:773 cps/templates/book_edit.html:313
+#: cps/spa_strings.py:821 cps/templates/book_edit.html:313
 #: cps/templates/config_db.html:116 cps/templates/config_edit.html:746
 #: cps/templates/config_view_edit.html:237 cps/templates/email_edit.html:71
 #: cps/templates/read.html:186 cps/templates/schedule_edit.html:47
@@ -5147,635 +5256,625 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: cps/spa_strings.py:774
+#: cps/spa_strings.py:822
 msgid "Save email settings"
 msgstr ""
 
-#: cps/spa_strings.py:775
+#: cps/spa_strings.py:823
 msgid "Save name"
 msgstr ""
 
-#: cps/spa_strings.py:776
+#: cps/spa_strings.py:824
 msgid "Save security settings"
 msgstr ""
 
-#: cps/spa_strings.py:777
+#: cps/spa_strings.py:825
 msgid "Save settings"
 msgstr ""
 
-#: cps/spa_strings.py:778
+#: cps/spa_strings.py:826
 msgid "Saved. Restart the server for the login changes to take effect."
 msgstr ""
 
-#: cps/spa_strings.py:779
+#: cps/spa_strings.py:827
 msgid "Scan for duplicates"
 msgstr ""
 
-#: cps/spa_strings.py:780
+#: cps/spa_strings.py:828
 msgid "Scheduled tasks"
 msgstr ""
 
-#: cps/spa_strings.py:781
+#: cps/spa_strings.py:829
 msgid "Scopes"
 msgstr ""
 
-#: cps/spa_strings.py:782
+#: cps/spa_strings.py:830
 msgid "Search title, author…"
 msgstr ""
 
-#: cps/spa_strings.py:783
+#: cps/spa_strings.py:831
 msgid "Searching every source…"
 msgstr ""
 
-#: cps/spa_strings.py:784 cps/templates/cover_picker.html:149
+#: cps/spa_strings.py:832 cps/templates/cover_picker.html:149
 #: cps/templates/cover_picker.html:224
 msgid "Searching…"
 msgstr ""
 
-#: cps/spa_strings.py:785
+#: cps/spa_strings.py:833
 msgid "Security settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:786
+#: cps/spa_strings.py:834
 msgid "See how each cover looks padded for your device"
 msgstr ""
 
-#: cps/spa_strings.py:787 cps/templates/modal_dialogs.html:98
+#: cps/spa_strings.py:835 cps/templates/modal_dialogs.html:98
 msgid "Select"
 msgstr ""
 
-#: cps/spa_strings.py:788
+#: cps/spa_strings.py:836
 msgid "Select multiple"
 msgstr ""
 
-#: cps/spa_strings.py:789 cps/templates/detail.html:1191
+#: cps/spa_strings.py:837 cps/templates/detail.html:1191
 msgid "Send"
 msgstr ""
 
-#: cps/spa_strings.py:790
+#: cps/spa_strings.py:838
 msgid "Send failed."
 msgstr ""
 
-#: cps/spa_strings.py:791
+#: cps/spa_strings.py:839
 msgid "Send to e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:792
+#: cps/spa_strings.py:840
 msgid "Send-to-eReader email"
 msgstr ""
 
-#: cps/spa_strings.py:793
+#: cps/spa_strings.py:841
 msgid "Sending…"
 msgstr ""
 
-#: cps/spa_strings.py:794
+#: cps/spa_strings.py:842
 msgid "Series index"
 msgstr ""
 
-#: cps/spa_strings.py:795
+#: cps/spa_strings.py:843
 msgid "Series view"
 msgstr ""
 
-#: cps/spa_strings.py:796
+#: cps/spa_strings.py:844
 msgid "Series — include"
 msgstr ""
 
-#: cps/spa_strings.py:797
+#: cps/spa_strings.py:845
 msgid "Serve over HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:798
+#: cps/spa_strings.py:846
 msgid "Server SSL / HTTPS"
 msgstr ""
 
-#: cps/spa_strings.py:799
+#: cps/spa_strings.py:847
 msgid "Server announcement (shown to all users)"
 msgstr ""
 
-#: cps/spa_strings.py:800
+#: cps/spa_strings.py:848
 msgid "Server host"
 msgstr ""
 
-#: cps/spa_strings.py:801
+#: cps/spa_strings.py:849
 msgid "Service account (DN)"
 msgstr ""
 
-#: cps/spa_strings.py:802
+#: cps/spa_strings.py:850
 msgid "Service password"
 msgstr ""
 
-#: cps/spa_strings.py:803
+#: cps/spa_strings.py:851
 msgid "Service password (leave blank to keep)"
 msgstr ""
 
-#: cps/spa_strings.py:804
+#: cps/spa_strings.py:852
 msgid ""
 "Set a metadata URL to auto-fill the endpoints below, or enter them "
 "manually."
 msgstr ""
 
-#: cps/spa_strings.py:805
+#: cps/spa_strings.py:853
 msgid "Settings saved."
 msgstr ""
 
-#: cps/spa_strings.py:806
+#: cps/spa_strings.py:854
 msgid "Shelf name"
 msgstr ""
 
-#: cps/spa_strings.py:807
+#: cps/spa_strings.py:855
 msgid "Shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:809
+#: cps/spa_strings.py:857
 msgid "Show Discover section"
 msgstr ""
 
-#: cps/spa_strings.py:810
+#: cps/spa_strings.py:858
 msgid "Show Read now and edit buttons"
 msgstr ""
 
-#: cps/spa_strings.py:811
+#: cps/spa_strings.py:859
 msgid "Show Table view"
 msgstr ""
 
-#: cps/spa_strings.py:812
+#: cps/spa_strings.py:860
 #, python-brace-format
 msgid "Show all {count} tags"
 msgstr ""
 
-#: cps/spa_strings.py:813
+#: cps/spa_strings.py:861
 #, python-brace-format
 msgid "Show all {items}"
 msgstr ""
 
-#: cps/spa_strings.py:814
+#: cps/spa_strings.py:862
 msgid "Show books in language"
 msgstr ""
 
-#: cps/spa_strings.py:815
+#: cps/spa_strings.py:863
 msgid "Show e-reader previews on each candidate"
 msgstr ""
 
-#: cps/spa_strings.py:816
+#: cps/spa_strings.py:864
 msgid "Show fewer tags"
 msgstr ""
 
-#: cps/spa_strings.py:817
+#: cps/spa_strings.py:865
 msgid "Show hidden books"
 msgstr ""
 
-#: cps/spa_strings.py:818
+#: cps/spa_strings.py:866
 msgid "Show password"
 msgstr ""
 
-#: cps/spa_strings.py:819
+#: cps/spa_strings.py:867
 msgid "Shuffle picks"
 msgstr ""
 
-#: cps/spa_strings.py:820
+#: cps/spa_strings.py:868
 msgid "Sign in with a magic link"
 msgstr ""
 
-#: cps/spa_strings.py:821
+#: cps/spa_strings.py:869
 msgid "Sign out"
 msgstr ""
 
-#: cps/spa_strings.py:822
+#: cps/spa_strings.py:870
 msgid "Signing in…"
 msgstr ""
 
-#: cps/spa_strings.py:823
+#: cps/spa_strings.py:871
 msgid "Site title"
 msgstr ""
 
-#: cps/spa_strings.py:824
+#: cps/spa_strings.py:872
 msgid "Smart shelf not found."
 msgstr ""
 
-#: cps/spa_strings.py:825
+#: cps/spa_strings.py:873
 msgid "Smart shelves"
 msgstr ""
 
-#: cps/spa_strings.py:826
+#: cps/spa_strings.py:874
 msgid "Solid: average colour of the cover"
 msgstr ""
 
-#: cps/spa_strings.py:827
+#: cps/spa_strings.py:875
 msgid "Solid: custom colour"
 msgstr ""
 
-#: cps/spa_strings.py:828
+#: cps/spa_strings.py:876
 msgid "Solid: most-common colour in the cover"
 msgstr ""
 
-#: cps/spa_strings.py:829
+#: cps/spa_strings.py:877
 msgid "Some sources need a key for better covers"
 msgstr ""
 
-#: cps/spa_strings.py:830
+#: cps/spa_strings.py:878
 msgid "Something went wrong"
 msgstr ""
 
-#: cps/spa_strings.py:831 cps/templates/cover_picker.html:228
+#: cps/spa_strings.py:879 cps/templates/cover_picker.html:228
 msgid "Something went wrong. Try again."
 msgstr ""
 
-#: cps/spa_strings.py:832
+#: cps/spa_strings.py:880
 msgid "Sort order"
 msgstr ""
 
-#: cps/spa_strings.py:833
+#: cps/spa_strings.py:881
 msgid "Source details"
 msgstr ""
 
-#: cps/spa_strings.py:834 cps/templates/detail.html:1023
+#: cps/spa_strings.py:882 cps/templates/detail.html:1023
 msgid "Started reading"
 msgstr ""
 
-#: cps/spa_strings.py:835
+#: cps/spa_strings.py:883
 msgid "Starting scan…"
 msgstr ""
 
-#: cps/spa_strings.py:837
+#: cps/spa_strings.py:885
 msgid "Statistics dashboard"
 msgstr ""
 
-#: cps/spa_strings.py:838 cps/templates/tasks.html:16
+#: cps/spa_strings.py:886 cps/templates/tasks.html:16
 msgid "Status"
 msgstr ""
 
-#: cps/spa_strings.py:839 cps/templates/config_edit.html:258
+#: cps/spa_strings.py:887 cps/templates/config_edit.html:258
 #: cps/templates/cover_picker.html:122
 msgid "Stretch to fill — no border, slight distortion"
 msgstr ""
 
-#: cps/spa_strings.py:840
+#: cps/spa_strings.py:888
 msgid "Support on Ko-fi →"
 msgstr ""
 
-#: cps/spa_strings.py:841
+#: cps/spa_strings.py:889
 msgid "Sync only my selected shelves"
 msgstr ""
 
-#: cps/spa_strings.py:842
+#: cps/spa_strings.py:890
 msgid "Sync only selected shelves to Kobo"
 msgstr ""
 
-#: cps/spa_strings.py:843
+#: cps/spa_strings.py:891
 msgid "Table view"
 msgstr ""
 
-#: cps/spa_strings.py:844
+#: cps/spa_strings.py:892
 msgid "Tag"
 msgstr ""
 
-#: cps/spa_strings.py:845 cps/templates/book_edit.html:139
+#: cps/spa_strings.py:893 cps/templates/book_edit.html:139
 #: cps/templates/search_form.html:52
 msgid "Tags"
 msgstr ""
 
-#: cps/spa_strings.py:846
+#: cps/spa_strings.py:894
 msgid "Tags — exclude"
 msgstr ""
 
-#: cps/spa_strings.py:847
+#: cps/spa_strings.py:895
 msgid "Tags — include"
 msgstr ""
 
-#: cps/spa_strings.py:848 cps/templates/config_edit.html:241
+#: cps/spa_strings.py:896 cps/templates/config_edit.html:241
 #: cps/templates/cover_picker.html:104
 msgid "Target aspect ratio"
 msgstr ""
 
-#: cps/spa_strings.py:849 cps/templates/tasks.html:15
+#: cps/spa_strings.py:897 cps/templates/tasks.html:15
 msgid "Task"
 msgstr ""
 
-#: cps/spa_strings.py:850 cps/tasks_status.py:37 cps/templates/layout.html:386
+#: cps/spa_strings.py:898 cps/tasks_status.py:37 cps/templates/layout.html:386
 #: cps/templates/tasks.html:7
 msgid "Tasks"
 msgstr ""
 
-#: cps/spa_strings.py:851
+#: cps/spa_strings.py:899
 msgid "Technical details"
 msgstr ""
 
-#: cps/spa_strings.py:852
+#: cps/spa_strings.py:900
 msgid "That URL is not a usable image."
 msgstr ""
 
-#: cps/spa_strings.py:853
+#: cps/spa_strings.py:901
 msgid "This format opens in the full-screen reader."
 msgstr ""
 
-#: cps/spa_strings.py:854
+#: cps/spa_strings.py:902
 msgid "This magic link expired. Generate a new one to try again."
 msgstr ""
 
-#: cps/spa_strings.py:855
+#: cps/spa_strings.py:903
 msgid "This page doesn't exist here."
 msgstr ""
 
-#: cps/spa_strings.py:856
+#: cps/spa_strings.py:904
 msgid ""
 "This page ran into an error and could not be displayed. Your library is "
 "fine — reloading usually fixes it."
 msgstr ""
 
-#: cps/spa_strings.py:857
+#: cps/spa_strings.py:905
 msgid "This shelf is empty. Add books from any book's page."
 msgstr ""
 
-#: cps/spa_strings.py:858
+#: cps/spa_strings.py:906
 msgid "Title A–Z"
 msgstr ""
 
-#: cps/spa_strings.py:859
+#: cps/spa_strings.py:907
 msgid "Title Z–A"
 msgstr ""
 
-#: cps/spa_strings.py:860
+#: cps/spa_strings.py:908
 msgid "Title, author, or ISBN"
 msgstr ""
 
-#: cps/spa_strings.py:861
+#: cps/spa_strings.py:909
 msgid "Token URL"
 msgstr ""
 
-#: cps/spa_strings.py:862
+#: cps/spa_strings.py:910
 msgid "Top Rated"
 msgstr ""
 
-#: cps/spa_strings.py:863
+#: cps/spa_strings.py:911
 msgid "Trust authentication header"
 msgstr ""
 
-#: cps/spa_strings.py:864
+#: cps/spa_strings.py:912
 msgid "UI / display configuration"
 msgstr ""
 
-#: cps/spa_strings.py:865 cps/templates/book_table.html:57
+#: cps/spa_strings.py:913 cps/templates/book_table.html:57
 #: cps/templates/book_table.html:234
 msgid "Unarchive"
 msgstr ""
 
-#: cps/spa_strings.py:866
+#: cps/spa_strings.py:914
 msgid "Unhide"
 msgstr ""
 
-#: cps/spa_strings.py:867
+#: cps/spa_strings.py:915
 msgid "Unlock the cover above to apply a new one."
 msgstr ""
 
-#: cps/spa_strings.py:868
+#: cps/spa_strings.py:916
 msgid "Unlock the cover to change it"
 msgstr ""
 
-#: cps/spa_strings.py:869
+#: cps/spa_strings.py:917
 msgid "Untitled"
 msgstr ""
 
-#: cps/spa_strings.py:870
+#: cps/spa_strings.py:918
 msgid "Update failed."
 msgstr ""
 
-#: cps/spa_strings.py:871 cps/templates/cover_picker.html:74
+#: cps/spa_strings.py:919 cps/templates/cover_picker.html:74
 msgid "Upload as cover"
 msgstr ""
 
-#: cps/spa_strings.py:872
+#: cps/spa_strings.py:920
 msgid "Upload books"
 msgstr ""
 
-#: cps/spa_strings.py:873
+#: cps/spa_strings.py:921
 msgid "Uploading is not available for your account on this server."
 msgstr ""
 
-#: cps/spa_strings.py:874
+#: cps/spa_strings.py:922
 msgid ""
 "Use these to connect OPDS readers or KOReader sync without your main "
 "password."
 msgstr ""
 
-#: cps/spa_strings.py:875 cps/templates/cover_picker.html:62
+#: cps/spa_strings.py:923 cps/templates/cover_picker.html:62
 #: cps/templates/cover_picker.html:193
 msgid "Use this cover"
 msgstr ""
 
-#: cps/spa_strings.py:876 cps/templates/tasks.html:13
+#: cps/spa_strings.py:924 cps/templates/tasks.html:13
 #: cps/templates/tasks.html:42 cps/templates/tasks.html:65
 msgid "User"
 msgstr ""
 
-#: cps/spa_strings.py:877
+#: cps/spa_strings.py:925
 msgid "User administration"
 msgstr ""
 
-#: cps/spa_strings.py:878
+#: cps/spa_strings.py:926
 msgid "User object filter"
 msgstr ""
 
-#: cps/spa_strings.py:879
+#: cps/spa_strings.py:927
 msgid "Userinfo URL"
 msgstr ""
 
-#: cps/spa_strings.py:880 cps/templates/admin.html:14
+#: cps/spa_strings.py:928 cps/templates/admin.html:14
 #: cps/templates/login.html:17 cps/templates/login.html:19
 #: cps/templates/register.html:9 cps/templates/user_edit.html:192
 #: cps/templates/user_table.html:134
 msgid "Username"
 msgstr ""
 
-#: cps/spa_strings.py:881
+#: cps/spa_strings.py:929
 msgid "Username claim"
 msgstr ""
 
-#: cps/spa_strings.py:882
+#: cps/spa_strings.py:930
 msgid "Versions"
 msgstr ""
 
-#: cps/spa_strings.py:883 cps/templates/user_table.html:148
+#: cps/spa_strings.py:931 cps/templates/user_table.html:148
 msgid "View"
 msgstr ""
 
-#: cps/spa_strings.py:884
+#: cps/spa_strings.py:932
 msgid "View settings"
 msgstr ""
 
-#: cps/spa_strings.py:885
+#: cps/spa_strings.py:933
 msgid "Viewer"
 msgstr ""
 
-#: cps/spa_strings.py:886
+#: cps/spa_strings.py:934
 msgid "Waiting for you to authorise…"
 msgstr ""
 
-#: cps/spa_strings.py:887 cps/templates/cover_picker.html:40
+#: cps/spa_strings.py:935 cps/templates/cover_picker.html:40
 msgid "When locked, fetching metadata will not overwrite this cover."
 msgstr ""
 
-#: cps/spa_strings.py:888 cps/templates/detail.html:1023
+#: cps/spa_strings.py:936 cps/templates/detail.html:1023
 msgid "When reading progress was first synced"
 msgstr ""
 
-#: cps/spa_strings.py:889
+#: cps/spa_strings.py:937
 msgid ""
 "Your Kobo is still set to sync your whole library, so marking this shelf "
 "does nothing on its own. Switch your account to shelf-only syncing to "
 "make it take effect."
 msgstr ""
 
-#: cps/spa_strings.py:890
+#: cps/spa_strings.py:938
 msgid "Your Library"
 msgstr ""
 
-#: cps/spa_strings.py:891
+#: cps/spa_strings.py:939
 msgid "Your browser cannot play this audio format."
 msgstr ""
 
-#: cps/spa_strings.py:892
+#: cps/spa_strings.py:940
 msgid "Your personal digital library"
 msgstr ""
 
-#: cps/spa_strings.py:893
+#: cps/spa_strings.py:941
 msgid "Your saved e-reader address is shown — change it for this send only."
 msgstr ""
 
-#: cps/spa_strings.py:894
+#: cps/spa_strings.py:942
 msgid "all rules"
 msgstr ""
 
-#: cps/spa_strings.py:895
+#: cps/spa_strings.py:943
 msgid "any rule"
 msgstr ""
 
-#: cps/spa_strings.py:896
+#: cps/spa_strings.py:944
 msgid "books"
 msgstr ""
 
-#: cps/spa_strings.py:897
+#: cps/spa_strings.py:945
 msgid "books match"
 msgstr ""
 
-#: cps/spa_strings.py:898
+#: cps/spa_strings.py:946
 msgid "copies"
 msgstr ""
 
-#: cps/spa_strings.py:899
+#: cps/spa_strings.py:947
 msgid "e-reader"
 msgstr ""
 
-#: cps/spa_strings.py:900
+#: cps/spa_strings.py:948
 msgid "e.g. Unread sci-fi"
 msgstr ""
 
-#: cps/spa_strings.py:901
+#: cps/spa_strings.py:949
 msgid "eReader email subject"
 msgstr ""
 
-#: cps/spa_strings.py:902
+#: cps/spa_strings.py:950
 msgid "shared"
 msgstr ""
 
-#: cps/spa_strings.py:903
+#: cps/spa_strings.py:951
 msgid "to"
 msgstr ""
 
-#: cps/spa_strings.py:904
+#: cps/spa_strings.py:952
 msgid "type (isbn, amazon, doi…)"
 msgstr ""
 
-#: cps/spa_strings.py:905
+#: cps/spa_strings.py:953
 msgid "value"
 msgstr ""
 
-#: cps/spa_strings.py:906
+#: cps/spa_strings.py:954
 msgid "you"
 msgstr ""
 
-#: cps/spa_strings.py:907
+#: cps/spa_strings.py:955
 #, python-brace-format
 msgid "{count} book"
 msgstr ""
 
-#: cps/spa_strings.py:908
+#: cps/spa_strings.py:956
 #, python-brace-format
 msgid "{count} books"
 msgstr ""
 
-#: cps/spa_strings.py:909
+#: cps/spa_strings.py:957
 #, python-brace-format
 msgid "{count} file queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:910
+#: cps/spa_strings.py:958
 #, python-brace-format
 msgid "{count} file rejected"
 msgstr ""
 
-#: cps/spa_strings.py:911
+#: cps/spa_strings.py:959
 #, python-brace-format
 msgid "{count} files queued for import"
 msgstr ""
 
-#: cps/spa_strings.py:912
+#: cps/spa_strings.py:960
 #, python-brace-format
 msgid "{count} files rejected"
 msgstr ""
 
-#: cps/spa_strings.py:913
+#: cps/spa_strings.py:961
 #, python-brace-format
 msgid "{count} result"
 msgstr ""
 
-#: cps/spa_strings.py:914
+#: cps/spa_strings.py:962
 #, python-brace-format
 msgid "{count} results"
 msgstr ""
 
-#: cps/spa_strings.py:915
+#: cps/spa_strings.py:963
 #, python-brace-format
 msgid "{count} results for \"{query}\""
 msgstr ""
 
-#: cps/spa_strings.py:916
+#: cps/spa_strings.py:964
 #, python-brace-format
 msgid "{field} (comma separated)"
 msgstr ""
 
-#: cps/spa_strings.py:917
+#: cps/spa_strings.py:965
 #, python-brace-format
 msgid "{n} found"
 msgstr ""
 
-#: cps/spa_strings.py:918
+#: cps/spa_strings.py:966
 #, python-brace-format
 msgid "{ok} of {total} sources answered"
 msgstr ""
 
-#: cps/spa_strings.py:919
-#, python-brace-format
-msgid "“{name}” already exists on {count} book. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:920
-#, python-brace-format
-msgid "“{name}” already exists on {count} books. Merge this tag into it?"
-msgstr ""
-
-#: cps/spa_strings.py:921
+#: cps/spa_strings.py:969
 msgid "…or paste an image URL"
 msgstr ""
 
-#: cps/spa_strings.py:922
+#: cps/spa_strings.py:970
 msgid "← Back to book"
 msgstr ""
 
-#: cps/spa_strings.py:923
+#: cps/spa_strings.py:971
 msgid "← Back to sign in"
 msgstr ""
 
-#: cps/spa_strings.py:924
+#: cps/spa_strings.py:972
 msgid "← Library"
 msgstr ""
 
@@ -8824,10 +8923,6 @@ msgstr ""
 
 #: cps/templates/cwa_settings.html:355 cps/templates/cwa_settings.html:357
 msgid "Tags/Genres"
-msgstr ""
-
-#: cps/templates/cwa_settings.html:376 cps/templates/cwa_settings.html:378
-msgid "Publication Date"
 msgstr ""
 
 #: cps/templates/cwa_settings.html:383 cps/templates/cwa_settings.html:385


### PR DESCRIPTION
## Why

`main` was red and nothing said so. HEAD was `fea5b0e48 Update translations [skip ci]`; because of the skip no workflow ran on it, so `gh run list --branch main` reported the previous commit's SUCCESS while every PR branched off it inherited a red Fast Tests.

## Root cause

1. `extract_spa_strings.py --write` regenerated the AUTOGEN block and dropped 31 hand-added anchors that lived inside it (filed as `F-83cd73`).
2. The next Update Translations run extracted a `.pot` without them, and msgmerge moved their entries to obsolete `#~` across all 28 locales.
3. fr and nl lost 23 SPA interface strings and rendered them in English — the #615 symptom. `test_api_v1_i18n` went red.

## Fix

The anchors move ABOVE the AUTOGEN marker so regeneration cannot drop them again.

The translations themselves needed no re-translation. msgmerge revives an obsolete entry on an exact msgid match, and that revival is not fuzzy, so `--no-fuzzy-matching` does not suppress it — running `update_translations.sh` brought all of them back with their original strings.

One of the 31 is deliberately not restored. `Border fill style` is rendered nowhere: both cover pickers label the control `Fill style` (`cover_picker.html:114` via `_()`, `CoverPicker.tsx:205` via `t()`), both already anchored and translated. The phrase survives only in changelog prose and a test comment, and no locale in the tree has ever carried a translation for it. Re-anchoring it put a msgid nobody can see into the SPA-chrome catalog, which is what then required fr and nl to translate it. Dropped rather than translated, with the reason recorded beside the block.

## Verification

- Red before / green after on the exact failing gates: `test_615_residual_i18n` and `test_api_v1_i18n` fr+nl.
- Verified against the **compiled `.mo`**, not the `.po`: fr `contains`→`contient`, `begins with`→`commence par`, `Date Added`→`Date d'ajout`; nl `bevat`, `begint met`, `Datum toegevoegd`.
- Full fast suite: **5813 passed, 102 skipped, 0 failed**.
- `Border fill style` confirmed untranslated in all 28 locales before removal, so nothing was discarded.

## Merge gate (rule 3)

- (a) CI green on head.
- (b) Red/green demonstrated on the real gates above; the i18n suite is the regression test.
- (c) Our own AI-authored change, so no AI-to-AI review. `/security-review` not applicable — no auth/session/CSRF, crypto, subprocess, user-controlled path, or new route; the diff is translation literals and generated catalogs.
- (d) No new dependencies, licences, or external URLs.
- (e) This body, plus `state/completed.log`.

## Note on the label

This carries `safe-tier-1` but touches `cps/spa_strings.py`, which `TIER1_PATHS_REGEX` (`\.(po|pot|md)$|^README`) does not match. It validates `ok` anyway because that regex is not enforced on the auto-merge path — independently re-confirmed here against this PR, and already on the ledger as `F-79d746`. Merging under the rule-3 gate rather than relying on the unenforced label.

Filed while investigating: `F-b24b81` — the `[skip ci]` on translation commits is what let this reach main unseen, and the cheap pre-commit i18n guard does **not** catch it (measured: the completeness test passes on `fea5b0e48`, because dropping the anchors shrank the catalog it checks).