### PR TITLE
Route the three orphaned README sections so the wiki can publish again

### DIFF
--- a/scripts/generate-wiki.py
+++ b/scripts/generate-wiki.py
@@ -51,6 +51,12 @@ IGNORED_SLUGS = {
     # mirrored to its own wiki page by the update-translations CI workflow; the
     # Contributing page links to the live table instead of freezing a copy.
     "README.md#translations",
+    # Container heading with an EMPTY body: every child section under it
+    # (network shares, Calibre coexistence, plugins, reverse proxy, Hardcover)
+    # is transcluded individually into wiki-src/Configuration.md, whose H1 *is*
+    # this section. Transcluding the parent would also pull its children and
+    # duplicate all five on that page.
+    "README.md#common-configurations",
 }
 
 # Wiki pages this generator does NOT own (managed elsewhere). sync-wiki.sh

--- a/wiki-src/Configuration.md
+++ b/wiki-src/Configuration.md
@@ -6,6 +6,7 @@ Reading-sync setups have their own pages: **[[KOReader Sync]]** and **[[Kobo Syn
 - [Calibre desktop coexistence](#calibre-desktop-coexistence)
 - [Calibre plugins (DeDRM and others)](#calibre-plugins-dedrm-and-others)
 - [Reverse proxy / Cloudflare Tunnel](#reverse-proxy--cloudflare-tunnel)
+- [Reverse proxy with a prefix](#reverse-proxy-with-a-prefix)
 - [Hardcover metadata provider](#hardcover-metadata-provider)
 
 ---
@@ -23,6 +24,10 @@ Reading-sync setups have their own pages: **[[KOReader Sync]]** and **[[Kobo Syn
 ---
 
 {{repo:README.md#reverse-proxy--cloudflare-tunnel|heading}}
+
+---
+
+{{repo:README.md#reverse-proxy-with-a-prefix|heading}}
 
 ---
 

--- a/wiki-src/Contributing.md
+++ b/wiki-src/Contributing.md
@@ -4,6 +4,10 @@
 
 ---
 
+{{repo:README.md#supporting-the-project|heading}}
+
+---
+
 ## Translations
 
 The interface ships with a wide set of locales. Completion is auto-refreshed on every push to `main`, so the live status table (with per-language completion percentages) lives in the [README](https://github.com/new-usemame/Calibre-Web-NextGen#translations) rather than here, where it would drift.


### PR DESCRIPTION
## Why

The wiki generator's drift tripwire fails on three README sections no template consumes. Now that the publishing path resolves the **canonical** generator and templates (rather than the stale outer pair), that failure is the last thing standing between the **seven written-but-never-published install guides** and the live wiki — Docker Compose, Dockge, Portainer, QNAP, Synology, TrueNAS SCALE, Unraid. For a self-hosted product those are the highest-intent pages we have.

Context: #1492 recorded the finding; this clears the blocker.

## What, and why each one differs

Deliberately not a blanket `IGNORED_SLUGS` dump — two of the three are real content.

| Section | Disposition | Reason |
|---|---|---|
| `#reverse-proxy-with-a-prefix` | Transcluded into `Configuration.md` + TOC entry | Real content (nginx block); belongs beside the existing reverse-proxy section |
| `#supporting-the-project` | Transcluded into `Contributing.md`, above Translations | Real content; belongs next to "how to help" |
| `#common-configurations` | `IGNORED_SLUGS`, reason recorded inline | **Container heading with an empty body.** Its five children are already transcluded individually into `Configuration.md`, whose H1 *is* this section. Transcluding the parent also pulls its children and would duplicate all five |

## Verification — generated before and after, not just diff-read

```
BEFORE (origin/main):  exit 1
  - README.md#common-configurations
  - README.md#reverse-proxy-with-a-prefix
  - README.md#supporting-the-project

AFTER  (this branch):  exit 0
  OK: rendered 22 files (20 pages + sidebar/footer)
```

Checked on the **rendered output**, not the templates:

- `Configuration.md` contains each of its six `##` headings **exactly once** — no duplication from the container-heading decision
- The prefix section renders with its full nginx `location /cwa/` block
- `Contributing.md` renders `## Supporting the project` with the funding-stats block
- All seven install guides present in the output set
- **Zero** unresolved `{{repo:}}` directives across all 22 files

## Note for whoever looks next

The funding-stats block this publishes to the wiki for the first time is **stale**: it reads *188 releases / 673 merged PRs* against an actual **200 / 860**. It is generated by `scripts/funding-stats.sh` and is out of scope here, but it now has a public surface, so it is worth a regeneration run.

No new dependencies, licenses, or external URLs.