### PR TITLE
Fold the duplicate Fixed heading that turned main red

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ is for things you can see or feel when running the app.
   each searched for it as plain text and came back with nothing — Goodreads in
   particular looked broken because of it. The editions lookup now asks only the
   source that understands it. Reported by @briffaantoine (#303).
+- **The reading app's catalog now calls "Discover" by the same name the website
+  does — and shows it in your language.** In an OPDS reader the entry was
+  labelled "Random Books", while the sidebar, the new interface and the link
+  itself all said Discover. Worse, on a German, Khmer or Norwegian server that
+  one entry stayed in English while everything around it was translated, because
+  the old wording had never been signed off by a translator. It now reads
+  Discover, translated, in all 28 languages. Reported by @chloeroform (#1097).
 
 ### Added
 
@@ -54,16 +61,6 @@ is for things you can see or feel when running the app.
   proportions honest and trims a strip off the two long edges instead. The six
   original styles are untouched and Edge mirror is still the default, so nothing
   changes unless you pick one. Requested by @mgrimace (#1280).
-
-### Fixed
-
-- **The reading app's catalog now calls "Discover" by the same name the website
-  does — and shows it in your language.** In an OPDS reader the entry was
-  labelled "Random Books", while the sidebar, the new interface and the link
-  itself all said Discover. Worse, on a German, Khmer or Norwegian server that
-  one entry stayed in English while everything around it was translated, because
-  the old wording had never been signed off by a translator. It now reads
-  Discover, translated, in all 28 languages. Reported by @chloeroform (#1097).
 
 ## [v4.1.33] - 2026-08-08
 


### PR DESCRIPTION
`main` is red, and has been since `56d3ec0` (#1512). One test:

```
FAILED tests/unit/test_changelog_release_sections.py::test_no_section_repeats_a_kind_heading
  ## [Unreleased] repeats: Fixed
```

That blocks every merge and holds the release train.

## What happened

`[Unreleased]` had two `### Fixed` headings:

```
## [Unreleased]
### Fixed      line 19
### Added      line 46
### Fixed      line 58   <- duplicate
```

#1512 added its entry as a **new** `### Fixed` block rather than into the existing one — `### Added` was the last heading when that branch was cut, so the new block landed after it. Nothing about the change itself is wrong; the entry went to the wrong place in the file.

## The fix

The Discover entry moves into the existing `### Fixed` block, verbatim. No wording changes, nothing dropped, `[Unreleased]` back to one `Fixed` and one `Added`.

| | before | after |
|---|---|---|
| `test_changelog_release_sections.py` | **1 failed**, 4 passed | 5 passed |
| whole changelog + version group | — | **52 passed** |

Verified against `origin/main` in a clean worktree, red before the edit and green after.

## Why not #1529

#1529 was auto-opened to fix this by reverting #1512. That would go green **for the wrong reason** — it clears the duplicate heading by deleting a shipped user-facing fix along with it, taking the translated OPDS "Discover" entry (@chloeroform, #1097) back out to repair a formatting artifact. It is also currently failing `Detect changed paths`, so it is not landing as-is.

Recommend closing #1529 once this merges.

## Scope

Documentation only — one file, `CHANGELOG.md`, no code paths touched. Rule 6 clean: no dependencies, licences or external URLs.
