### PR TITLE
Make the reader's toolbar controls big enough for a thumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- **The reader's buttons are big enough to hit on a phone.** Close, contents,
+  appearance, highlights and full screen were 34 pixels square in the new UI's
+  reader — reachable with a mouse, fiddly with a thumb while turning pages. They
+  are now 44, the size Apple and Google both recommend, and the book title
+  shortens to make room instead of the buttons shrinking (#325).
 - **Typing in the reader no longer loses your place in the box.** Opening a
   panel in the new UI's reader — the contents list, the appearance controls, the
   highlight popover or the note box — put the cursor back at the top of that

--- a/frontend/e2e/reader-notes.spec.ts
+++ b/frontend/e2e/reader-notes.spec.ts
@@ -524,3 +524,71 @@ test.describe('reader fullscreen (#325)', () => {
     await expect(exitButton).toHaveAttribute('aria-pressed', 'true');
   });
 });
+
+/*
+ * Touch targets on the reader toolbar (#325).
+ *
+ * The controls were 34x34 — above WCAG 2.2 SC 2.5.8's 24x24 floor, so nothing
+ * flagged them, and under the 44x44 this project wants and every platform
+ * guideline recommends. That combination is why it survived: conformant, and
+ * still awkward with a thumb mid-page-turn.
+ *
+ * MEASURES AND HIT-TESTS, because the two can disagree. A box can report 44x44
+ * while an overlay, clip or stacking context takes its edge, and the arithmetic
+ * gives no hint when that happens — a sibling session measured an expander
+ * claiming 44 and hit-testing at 40. So each control is probed at the four
+ * inset corners of its own reported box.
+ *
+ * The narrow viewport is deliberate and is the case that actually broke: with
+ * 44px buttons the toolbar has less slack, and because .bookTitle lacked
+ * `min-width: 0` it refused to shrink, so the browser compressed the close
+ * control to 16px wide on a 320px screen instead — smaller than before the
+ * change was made to improve it.
+ */
+test.describe('reader toolbar touch targets (#325)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('every toolbar control is at least 44x44 and receives a tap at its edges',
+    async ({ page }, testInfo) => {
+      test.setTimeout(120_000);
+      const bookId = await openReaderOnEpub(page, testInfo.project.name === 'mobile' ? 2 : 1);
+      expect(bookId, 'an EPUB that renders in the reader').not.toBeNull();
+
+      const NAMES = ['Close reader', 'Table of contents', 'Reading appearance',
+                     'Highlights and notes', 'Full screen'];
+      const undersized: string[] = [];
+      const stolen: string[] = [];
+
+      for (const name of NAMES) {
+        const control = page.getByRole('button', { name }).first()
+          .or(page.getByRole('link', { name }).first());
+        // Full screen hides itself where the browser cannot support it, so a
+        // missing control is legitimate rather than a failure.
+        if (!(await control.isVisible().catch(() => false))) continue;
+        const box = await control.boundingBox();
+        expect(box, `${name} has a layout box`).not.toBeNull();
+        if (box!.width < 44 || box!.height < 44) {
+          undersized.push(`${name} (${Math.round(box!.width)}x${Math.round(box!.height)})`);
+        }
+        const corners = [[2, 2], [-2, 2], [2, -2], [-2, -2]].map(([dx, dy]) => ({
+          x: dx > 0 ? box!.x + dx : box!.x + box!.width + dx,
+          y: dy > 0 ? box!.y + dy : box!.y + box!.height + dy,
+        }));
+        const hits = await page.evaluate(({ pts, label }) => pts.map((p) => {
+          const el = document.elementFromPoint(p.x, p.y);
+          const owner = el?.closest('button, a');
+          return owner?.getAttribute('aria-label') === label;
+        }), { pts: corners, label: name });
+        if (hits.some((h) => !h)) stolen.push(name);
+      }
+
+      expect(undersized, 'controls smaller than 44x44').toEqual([]);
+      expect(stolen, 'controls whose own box does not receive the tap').toEqual([]);
+
+      // The toolbar must absorb 44px controls by truncating the title, never by
+      // scrolling the page sideways.
+      const scrollsSideways = await page.evaluate(() =>
+        document.documentElement.scrollWidth > document.documentElement.clientWidth + 1);
+      expect(scrollsSideways, 'the reader page scrolls horizontally').toBe(false);
+    });
+});

--- a/frontend/src/pages/Reader.module.css
+++ b/frontend/src/pages/Reader.module.css
@@ -76,6 +76,13 @@
 
 .bookTitle {
   flex: 1 1 auto;
+  /* Without min-width:0 a flex item will not shrink below its content's
+   * min-content width, so `text-overflow: ellipsis` below never engages and the
+   * browser compresses the SIBLINGS instead. That is what squeezed the close
+   * control to 16px wide on a 320px phone once the icon buttons grew to 44px:
+   * the title refused to give, so the only flexible thing left did. The title is
+   * what should yield here — it is already truncated for length. */
+  min-width: 0;
   font-family: var(--font-display);
   font-size: var(--fs-sm);
   white-space: nowrap;
@@ -98,13 +105,32 @@
   border-left: 1px solid var(--reader-chrome-border);
 }
 
+/*
+ * 44x44, not 34x34. People read on phones, and every control in this bar is one
+ * you reach for mid-page-turn with a thumb.
+ *
+ * 34px cleared WCAG 2.2 SC 2.5.8 (24x24 minimum) so it was never a conformance
+ * failure — which is exactly why it survived: nothing flagged it. It is under
+ * the size this project wants, and under every platform guideline (44pt iOS,
+ * 48dp Android).
+ *
+ * Sized directly rather than with a negative-inset ::before expander. The bar is
+ * 48px tall, so 44px fits without touching layout, and a real box cannot be
+ * quietly eaten by an overflow clip or an ancestor's stacking context the way an
+ * expander can — a sibling session measured one of those claiming 44 and
+ * hit-testing at 40. The gap between buttons is --sp-3, so the enlarged boxes
+ * still do not touch.
+ */
 .iconBtn, .themeActive {
   position: relative; /* containing block for .annCount */
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
+  /* Never let the toolbar buy space by shrinking a tap target — that is how the
+   * close control ended up 16px wide. The title yields instead (min-width:0). */
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
   border-radius: var(--r-sm);
   color: var(--reader-chrome-muted);
   transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
@@ -345,7 +371,14 @@
 /* SC 2.5.8: 24x24 minimum target size. */
 .hiliteSwatch { width: 24px; height: 24px; border-radius: 50%; border: 2px solid var(--reader-chrome-border); cursor: pointer; }
 .hiliteSwatch:hover { border-color: var(--reader-chrome-text); }
-.hiliteCancel { color: var(--reader-chrome-muted); display: inline-flex; align-items: center; margin-left: 4px; }
+/* 44x44 for the same reason as .iconBtn: this is the dismiss control in three
+ * popovers, including the note composer, and it wrapped a 16px icon with no box
+ * of its own. Centred so the icon does not shift. */
+.hiliteCancel {
+  color: var(--reader-chrome-muted);
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 44px; min-height: 44px; margin-left: 4px;
+}
 .hiliteCancel:hover { color: var(--reader-chrome-text); }
 /* #782 — clearly-labeled remove action in the edit popover (icon + text so the
  * destructive intent is unambiguous, not color/position alone). Danger-red. */


### PR DESCRIPTION
## What was wrong

The reader toolbar's controls — close, contents, appearance, highlights and full screen — were **34×34**.

That clears WCAG 2.2 SC 2.5.8's 24×24 floor, so it was never a conformance failure and nothing flagged it. **That is exactly why it survived.** It is under the 44×44 this project asks for and under both platform guidelines (44pt iOS, 48dp Android), on the one screen people genuinely use one-handed while turning pages.

Measured, not read off the stylesheet — a sibling session raised the 34×34 figure from its own hit-test harness and I confirmed it independently on two phone sizes.

## The part worth reviewing: fixing it made things worse first

With 44px controls the toolbar has less slack. `.bookTitle` carried `flex: 1 1 auto` with `text-overflow: ellipsis` but **no `min-width: 0`** — and a flex item will not shrink below its content's min-content width. So the title refused to yield, the ellipsis never engaged, and the browser compressed the only other flexible item instead:

| viewport | "Close reader" after the naive fix |
|---|---|
| 393px (Pixel 5) | **31×44** |
| 320px (iPhone SE) | **16×44** |

16px wide — **less than half** the 34px the change set out to improve, and I would have shipped it if I had only measured the buttons I had just enlarged. The title now yields (it is already truncated for length) and controls carry `flex-shrink: 0`, so the toolbar can never buy space out of a tap target again.

## Why a real box, not an expander

Sized directly rather than with a negative-inset `::before`. The bar is 48px tall, so 44 fits without touching layout — and a real box cannot be quietly eaten by an overflow clip or an ancestor's stacking context the way an expander can. A sibling session measured exactly that: an expander claiming 44×44 that hit-tested at 40, with the arithmetic giving no hint.

## Verification

**Measured *and* hit-tested**, at 393px and 320px:

```
Close reader           44x44 PASS44 hit=[OK,OK,OK,OK]
Table of contents      44x44 PASS44 hit=[OK,OK,OK,OK]
Reading appearance     44x44 PASS44 hit=[OK,OK,OK,OK]
Highlights and notes   44x44 PASS44 hit=[OK,OK,OK,OK]
Full screen            44x44 PASS44 hit=[OK,OK,OK,OK]
page scrolls horizontally: false
```

Each control is probed at the four inset corners of **its own reported box**, resolving `elementFromPoint` back to that control — because a box that reports 44 can still receive taps at 40, and only the probe can tell you.

The regression test does both checks and asserts the toolbar absorbs the larger controls by truncating the title rather than scrolling the page sideways. **Mutation-verified**: reverted to the 34px CSS and confirmed it goes red, so it is testing the behaviour rather than co-existing with it.

Full reader suite: **13 passed** on desktop and mobile at `--workers=2`, with the served bundle verified as this build before and after the run.

`Full screen` hides itself where the browser cannot support it, so the test treats a missing control as legitimate rather than failing on it.

## Scope

One production file (`Reader.module.css`). No behaviour change beyond size, no new dependency, no schema change.

Addresses #325.