### PR TITLE
Stop the Highlights page showing a note as a highlight that lost its text

### DIFF
--- a/frontend/src/pages/Annotations.tsx
+++ b/frontend/src/pages/Annotations.tsx
@@ -12,6 +12,9 @@ interface Annotation {
   annotation_id: string;
   highlighted_text: string;
   highlight_color: string | null;
+  /** 'unanchored' means a note ABOUT the book with no passage — it has neither a
+   *  quote nor a colour, so it must not be drawn with either. NULL is legacy CFI. */
+  position_type?: string | null;
   note_text: string | null;
   chapter_progress: number | null;
   source: string | null;
@@ -64,19 +67,34 @@ export function Annotations({ id }: { id: string }) {
         <EmptyState message={t('No highlights yet. Highlight while reading, or import from a Kobo device.')} />
       ) : (
         <ul className={styles.list}>
-          {annotations.map((a) => (
+          {annotations.map((a) => {
+            /*
+             * A standalone note has no passage and no colour. The API projects a
+             * default colour for it (`r.highlight_color or "yellow"`, a legacy
+             * fallback for old rows), so rendering it unconditionally puts a
+             * swatch announced as "Yellow" beside an EMPTY blockquote — a
+             * highlight that appears to exist and to have lost its text. The row
+             * is a note; draw it as one.
+             */
+            const unanchored = a.position_type === 'unanchored';
+            return (
             <li key={a.annotation_id} className={styles.item}>
-              <span className={styles.bar} role="img" aria-label={colorName(a.highlight_color)}
-                style={{ background: COLOR_HEX[a.highlight_color || 'yellow'] || '#e6c34a' }} />
+              {!unanchored && (
+                <span className={styles.bar} role="img" aria-label={colorName(a.highlight_color)}
+                  style={{ background: COLOR_HEX[a.highlight_color || 'yellow'] || '#e6c34a' }} />
+              )}
               <div className={styles.body}>
-                <blockquote className={styles.quote}>{a.highlighted_text}</blockquote>
+                {!unanchored && (
+                  <blockquote className={styles.quote}>{a.highlighted_text}</blockquote>
+                )}
                 {a.note_text && <p className={styles.note}>{a.note_text}</p>}
                 {a.chapter_progress != null && (
                   <span className={styles.progress}>{Math.round(a.chapter_progress * 100)}%</span>
                 )}
               </div>
             </li>
-          ))}
+            );
+          })}
         </ul>
       )}
     </main>


### PR DESCRIPTION
## The bug

`Annotations.tsx` renders a colour bar and a `<blockquote>` **unconditionally**. A standalone note has neither a passage nor a colour, so it appeared on the Highlights page as *a highlight whose text had gone missing* — an empty quote beside a swatch announced to screen readers as **"Yellow"**.

## What hid it

The row *looks* coloured. The database holds `NULL`, but the API projects a legacy fallback for old rows:

```python
"highlight_color": r.highlight_color or "yellow",
```

so anything reading the payload sees a colour that was never stored. Checking the response would have said the row was yellow; only the database said otherwise.

## Third surface, same cause

This is the **third** place the same composition went wrong from one sentinel: the reader's drawer (#1542), the anchor-status resolver on the multi-device branch, and this page. **None of the three conflicted with anything on merge.**

A designed state reads as damage on every surface written before that state existed — and because the changes agree about every line, nothing puts it in front of a human. The general lesson is that an `ast`-level guard on the invariant catches this and a comment does not; that's what the sibling session built for its own half.

## Verification, with a positive control

On a book with **14** rows: **13** highlights render with both swatch and quote, and the **1** note renders with neither. No empty blockquote, no note wearing a swatch.

The control matters here. An earlier probe reported a clean zero — it used `/app/annotations/<id>` rather than the real route `/app/book/<id>/annotations`, so it was measuring an empty page and would have called any implementation correct. The row count is asserted for that reason: a blank page can no longer pass as a fix.

One production file. No schema change, no new dependency, no new route.

Addresses #325.