### PR TITLE
Add the searchable core for search-inside-the-book

### DIFF
--- a/frontend/src/lib/reader/searchBook.ts
+++ b/frontend/src/lib/reader/searchBook.ts
@@ -1,0 +1,126 @@
+/*
+ * Search inside an open book.
+ *
+ * Neither reader has ever had this: the classic reader's search box, nav link
+ * and results pane are all commented out in `read.html`, and there is no search
+ * JavaScript in the tree at all — so there was nothing to port. epub.js provides
+ * the per-section primitive; the work is doing it without melting the tab.
+ *
+ * WHY THIS IS NOT A ONE-LINER OVER `spine.each()`:
+ *
+ *  - **Memory.** Searching means loading each section's document. A novel has
+ *    hundreds. Loading them all — which is what mapping over the spine does —
+ *    holds every parsed DOM at once. Each section is unloaded immediately after
+ *    it is searched, so peak cost is one section, not the book.
+ *  - **Cancellation.** A reader types, and each keystroke would otherwise start
+ *    a full-book scan that keeps running after its results are irrelevant. Every
+ *    await checks the signal, so an abandoned search stops at the next section
+ *    instead of competing with the one the reader actually wants.
+ *  - **Bounding.** "the" in a long book matches thousands of times. Past a
+ *    couple of hundred hits the list is not usable and the cost is real, so it
+ *    stops and says it stopped rather than pretending it found everything.
+ *
+ * Dependencies are the book object's own shape rather than an epub.js import, so
+ * this is unit-testable against a fake spine — the same reason `create_annotation`
+ * takes its session and commit explicitly.
+ */
+
+/** One match: an EPUB CFI to navigate to, and the text around it. */
+export interface SearchHit {
+  cfi: string;
+  excerpt: string;
+  /** Spine href, so a result can name its chapter. */
+  href: string;
+}
+
+export interface SearchOutcome {
+  hits: SearchHit[];
+  /** True when the cap stopped the scan early, so the UI can say so rather than
+   *  implying these are all the matches in the book. */
+  truncated: boolean;
+  /** How many sections were actually searched — the honest denominator for a
+   *  cancelled or truncated run. */
+  sectionsSearched: number;
+}
+
+/** The slice of epub.js's Section this needs. Narrow on purpose: a fake in a
+ *  test implements three members rather than a book. */
+export interface SearchableSection {
+  href: string;
+  load: (request: unknown) => Promise<unknown>;
+  unload: () => void;
+  search?: (query: string, maxSeqEle?: number) => { cfi: string; excerpt: string }[];
+  find?: (query: string) => { cfi: string; excerpt: string }[];
+}
+
+export interface SearchableBook {
+  spine: { spineItems: SearchableSection[] };
+  load: { bind: (book: unknown) => unknown };
+}
+
+export const MIN_QUERY_LENGTH = 2;
+export const DEFAULT_HIT_CAP = 200;
+
+/**
+ * Search every section of `book` for `query`.
+ *
+ * Resolves with whatever was found before the cap, the signal, or the end of the
+ * book — whichever comes first. Never rejects for an unreadable section: one
+ * corrupt chapter should cost that chapter's results, not the whole search.
+ */
+export async function searchBook(
+  book: SearchableBook,
+  query: string,
+  opts: { signal?: AbortSignal; cap?: number } = {},
+): Promise<SearchOutcome> {
+  const trimmed = query.trim();
+  const cap = opts.cap ?? DEFAULT_HIT_CAP;
+  const empty: SearchOutcome = { hits: [], truncated: false, sectionsSearched: 0 };
+
+  // A one-character query matches essentially every section and is never what
+  // the reader meant; treat it as "nothing typed yet" rather than as a search
+  // that found the whole book.
+  if (trimmed.length < MIN_QUERY_LENGTH) return empty;
+
+  const sections = book?.spine?.spineItems ?? [];
+  const hits: SearchHit[] = [];
+  let sectionsSearched = 0;
+  let truncated = false;
+
+  for (const section of sections) {
+    if (opts.signal?.aborted) break;
+    if (hits.length >= cap) { truncated = true; break; }
+
+    try {
+      await section.load(book.load.bind(book));
+      // `search` handles a phrase that spans element boundaries; `find` is the
+      // exact-substring fallback for environments without a TreeWalker. Prefer
+      // the former and degrade rather than throwing.
+      const raw = section.search
+        ? section.search(trimmed)
+        : section.find
+          ? section.find(trimmed)
+          : [];
+      for (const match of raw) {
+        if (hits.length >= cap) { truncated = true; break; }
+        hits.push({ cfi: match.cfi, excerpt: match.excerpt, href: section.href });
+      }
+      sectionsSearched += 1;
+    } catch {
+      // A section that will not parse costs its own results and nothing else.
+      sectionsSearched += 1;
+    } finally {
+      // Unload on every exit from the block.
+      //
+      // Defensive rather than load-bearing as the code stands: the catch above
+      // swallows the throw, so control reaches here either way, and no test can
+      // currently distinguish `finally` from a plain statement after the block
+      // (checked by mutation). It stays because the first `return` or rethrow
+      // added inside that try would make it the difference between unloading and
+      // leaking a parsed DOM per section -- and a leak is silent.
+      try { section.unload(); } catch { /* already gone */ }
+    }
+  }
+
+  return { hits, truncated, sectionsSearched };
+}

--- a/frontend/tests/unit/searchBook.test.ts
+++ b/frontend/tests/unit/searchBook.test.ts
@@ -1,0 +1,194 @@
+/*
+ * Tests for search-inside-the-book.
+ *
+ * Node's built-in runner and native type stripping, matching reportBuilder's
+ * choice: the frontend ships no test framework on purpose, because adding one is
+ * a new dependency and operator-gated. These now actually run in CI, via
+ * tests/unit/test_frontend_unit_suites_run.py.
+ *
+ * Run: NODE_OPTIONS=--experimental-strip-types node --test frontend/tests/unit/searchBook.test.ts
+ *
+ * The module takes the book's shape rather than importing epub.js, so every case
+ * below uses a fake spine. That is what makes the properties that matter here —
+ * unloading, cancelling, capping — testable at all: none of them are observable
+ * from the return value.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  searchBook, MIN_QUERY_LENGTH, DEFAULT_HIT_CAP,
+  type SearchableBook, type SearchableSection,
+} from '../../src/lib/reader/searchBook.ts';
+
+/** A section that records whether it was loaded and unloaded. */
+function fakeSection(
+  href: string,
+  matches: { cfi: string; excerpt: string }[],
+  opts: { throwOnLoad?: boolean; throwOnSearch?: boolean } = {},
+) {
+  const state = { loaded: 0, unloaded: 0, searched: 0 };
+  const section: SearchableSection & { state: typeof state } = {
+    href,
+    state,
+    load: async () => {
+      state.loaded += 1;
+      if (opts.throwOnLoad) throw new Error(`cannot load ${href}`);
+      return undefined;
+    },
+    unload: () => { state.unloaded += 1; },
+    search: () => {
+      state.searched += 1;
+      if (opts.throwOnSearch) throw new Error(`cannot search ${href}`);
+      return matches;
+    },
+  };
+  return section;
+}
+
+function fakeBook(sections: SearchableSection[]): SearchableBook {
+  return { spine: { spineItems: sections }, load: { bind: () => undefined } };
+}
+
+const hit = (n: string) => ({ cfi: `epubcfi(/6/${n})`, excerpt: `…${n}…` });
+
+describe('searchBook', () => {
+  test('returns a hit per match, tagged with the section it came from', async () => {
+    const book = fakeBook([
+      fakeSection('ch1.xhtml', [hit('a'), hit('b')]),
+      fakeSection('ch2.xhtml', [hit('c')]),
+    ]);
+    const out = await searchBook(book, 'whale');
+    assert.equal(out.hits.length, 3);
+    assert.deepEqual(out.hits.map((h) => h.href), ['ch1.xhtml', 'ch1.xhtml', 'ch2.xhtml']);
+    assert.equal(out.sectionsSearched, 2);
+    assert.equal(out.truncated, false);
+  });
+
+  test('unloads every section it loads', async () => {
+    // The property that keeps a long book from exhausting memory, and it is
+    // invisible in the return value — only the fake can see it.
+    const sections = [fakeSection('a', [hit('1')]), fakeSection('b', []), fakeSection('c', [hit('2')])];
+    await searchBook(fakeBook(sections), 'whale');
+    for (const s of sections as (SearchableSection & { state: { loaded: number; unloaded: number } })[]) {
+      assert.equal(s.state.loaded, 1, `${s.href} loaded once`);
+      assert.equal(s.state.unloaded, 1, `${s.href} unloaded once`);
+    }
+  });
+
+  test('unloads a section even when searching it throws', async () => {
+    // The error path is exactly where an unload gets skipped, and a book with a
+    // few bad chapters is the case that would then hold their DOMs.
+    const bad = fakeSection('bad', [], { throwOnSearch: true });
+    const good = fakeSection('good', [hit('1')]);
+    const out = await searchBook(fakeBook([bad, good]), 'whale');
+    assert.equal((bad as unknown as { state: { unloaded: number } }).state.unloaded, 1);
+    assert.equal(out.hits.length, 1, 'the good section still contributes');
+  });
+
+  test('a section that will not load costs only its own results', async () => {
+    const broken = fakeSection('broken', [hit('x')], { throwOnLoad: true });
+    const fine = fakeSection('fine', [hit('y')]);
+    const out = await searchBook(fakeBook([broken, fine]), 'whale');
+    assert.equal(out.hits.length, 1);
+    assert.equal(out.hits[0].href, 'fine');
+    assert.equal((broken as unknown as { state: { unloaded: number } }).state.unloaded, 1);
+  });
+
+  test('stops at the cap and says that it did', async () => {
+    const many = Array.from({ length: 10 }, (_, i) =>
+      fakeSection(`s${i}`, [hit('1'), hit('2'), hit('3')]));
+    const out = await searchBook(fakeBook(many), 'the', { cap: 5 });
+    assert.equal(out.hits.length, 5);
+    assert.equal(out.truncated, true, 'the UI must be able to say these are not all the matches');
+    // ...and it stopped early rather than searching the whole book and slicing.
+    assert.ok(out.sectionsSearched < 10, `searched ${out.sectionsSearched} of 10`);
+  });
+
+  test('an exact-cap result is not reported as truncated', async () => {
+    // Off-by-one guard: exactly `cap` hits with nothing left over is complete,
+    // and claiming otherwise tells the reader to refine a search that was fine.
+    // 'x' would be below MIN_QUERY_LENGTH and search nothing -- which is what
+    // this asserted on the first run, and it was the test that was wrong.
+    const out = await searchBook(fakeBook([fakeSection('only', [hit('1'), hit('2')])]), 'whale', { cap: 2 });
+    assert.equal(out.hits.length, 2);
+    assert.equal(out.truncated, false);
+  });
+
+  test('unloads the section it was in when the cap stopped it mid-way', async () => {
+    /*
+     * Pins the observable property: a section the cap interrupted is still
+     * unloaded.
+     *
+     * Honest about what this does NOT prove. Moving the unload out of `finally`
+     * passes every test in this file, including this one, so the `finally` is
+     * defensive rather than load-bearing today: the catch swallows the throw and
+     * execution reaches the unload anyway, the inner cap `break` only leaves the
+     * inner loop, and the outer breaks happen before anything is loaded. It is
+     * kept because the next `return` or `throw` added inside that block would
+     * make it matter, and a leaked section DOM is silent when it happens.
+     */
+    const first = fakeSection('first', [hit('1'), hit('2'), hit('3')]);
+    const out = await searchBook(fakeBook([first, fakeSection('second', [hit('4')])]), 'whale', { cap: 2 });
+    assert.equal(out.hits.length, 2);
+    assert.equal(out.truncated, true);
+    assert.equal((first as unknown as { state: { unloaded: number } }).state.unloaded, 1,
+      'the section the cap interrupted must still be unloaded');
+  });
+
+  test('an aborted search stops instead of finishing the book', async () => {
+    const controller = new AbortController();
+    const sections = Array.from({ length: 20 }, (_, i) => fakeSection(`s${i}`, [hit('1')]));
+    // Abort as soon as the first section has been searched.
+    const original = sections[0].search!;
+    sections[0].search = (q: string) => { const r = original(q); controller.abort(); return r; };
+
+    const out = await searchBook(fakeBook(sections), 'whale', { signal: controller.signal });
+    assert.ok(out.sectionsSearched < 20, `searched ${out.sectionsSearched} of 20 after abort`);
+    const untouched = (sections[19] as unknown as { state: { loaded: number } }).state.loaded;
+    assert.equal(untouched, 0, 'sections after the abort are never loaded');
+  });
+
+  test('a query shorter than the minimum searches nothing at all', async () => {
+    const s = fakeSection('a', [hit('1')]);
+    for (const q of ['', ' ', 'x'.repeat(MIN_QUERY_LENGTH - 1)]) {
+      const out = await searchBook(fakeBook([s]), q);
+      assert.equal(out.hits.length, 0, `${JSON.stringify(q)} should not search`);
+    }
+    assert.equal((s as unknown as { state: { loaded: number } }).state.loaded, 0,
+      'a too-short query must not load a single section');
+  });
+
+  test('whitespace around a query does not change what is searched', async () => {
+    let seen = '';
+    const s: SearchableSection = {
+      href: 'a', load: async () => undefined, unload: () => {},
+      search: (q) => { seen = q; return []; },
+    };
+    await searchBook(fakeBook([s]), '  whale  ');
+    assert.equal(seen, 'whale');
+  });
+
+  test('falls back to find() where search() is unavailable', async () => {
+    // epub.js itself degrades this way when there is no TreeWalker; the module
+    // must not simply return nothing on that path.
+    const s: SearchableSection = {
+      href: 'a', load: async () => undefined, unload: () => {},
+      find: () => [hit('1')],
+    };
+    const out = await searchBook(fakeBook([s]), 'whale');
+    assert.equal(out.hits.length, 1);
+  });
+
+  test('an empty or missing spine is not an error', async () => {
+    assert.equal((await searchBook(fakeBook([]), 'whale')).hits.length, 0);
+    const noSpine = { load: { bind: () => undefined } } as unknown as SearchableBook;
+    assert.equal((await searchBook(noSpine, 'whale')).hits.length, 0);
+  });
+
+  test('the default cap is a real number, not Infinity', async () => {
+    // A cap nobody set is the case that would let "the" return every match in a
+    // long book, which is the scenario this exists for.
+    assert.ok(Number.isFinite(DEFAULT_HIT_CAP) && DEFAULT_HIT_CAP > 0, String(DEFAULT_HIT_CAP));
+  });
+});


### PR DESCRIPTION
## Why this is a new feature, not a parity restoration

Neither reader has ever had search. The classic reader's search box, nav link and results pane are **all commented out** in `read.html`, and there is no search JavaScript in the tree at all — so there was nothing to port. The brief called this *"probably the single most-missed reading feature after notes."*

epub.js provides the per-section primitive. The work is doing it without melting the tab.

## Three properties, none visible in the return value

That's why the module takes the **book's shape** rather than importing epub.js, and is tested against a fake spine — the same reason `create_annotation` takes its session and commit explicitly.

- **Memory.** Searching loads each section's document, and a novel has hundreds. Mapping over the spine holds every parsed DOM at once. Each section is unloaded immediately after it's searched, so peak cost is one section, not the book.
- **Cancellation.** A reader types. Without a signal, each keystroke starts a full-book scan that keeps running after its results stop mattering — competing with the search they actually want.
- **Bounding.** "the" matches thousands of times in a long book. Past a couple of hundred hits the list isn't usable, so it stops and **reports that it stopped** rather than implying it found everything.

## Mutation results, including a negative one

13 tests. Stating these precisely because one is negative:

| mutation | result |
|---|---|
| disable the hit cap | **2 tests fail** |
| disable the minimum-query-length guard | **1 test fails** |
| move `unload()` out of `finally` | **nothing fails** |

That last row is documented honestly in both the source and the test rather than papered over. As the code stands, the `catch` swallows the throw so control reaches the unload anyway; the inner cap `break` only leaves the inner loop; and the outer breaks happen before anything is loaded. **No reachable path distinguishes `finally` from a plain statement.** It's kept as defence against the next `return` or rethrow added inside that block — a leaked section DOM is silent — and it's labelled as defence, not as something a test proves.

I'd rather say that than let a comment claim coverage the suite doesn't have.

## Two of my own mistakes, recorded in place

Both cost real time and both are the kind that recur:

- A **Python-style `!r`** inside a JS template literal. Node reports this as a bare `'test failed'` at the *tail* of its output, with the actual `SyntaxError` at the *head* — so `| tail` shows you nothing useful.
- An **exact-cap test whose query was one character**, below `MIN_QUERY_LENGTH`. It asserted on a search the module had correctly refused to run; the test was wrong, not the code.

## Scope

One production file (`frontend/src/lib/reader/searchBook.ts`). **No consumer yet** — the UI is the next piece, deliberately separate so each stays reviewable, the same sequencing that worked for the standalone-notes backend and UI.

The suite runs in CI via the wrapper added in #1545, so this lands with a gate that actually executes it.