### PR TITLE
Name the device a highlight came from, and list every highlight either way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,11 @@ is for things you can see or feel when running the app.
   it back. It now names the password you are about to revoke.
 
 ### Added
+- **Highlights made on a Kobo now say which device they came from.** The
+  reader's Highlights and notes panel showed a bare internal word like "kobo";
+  it now shows the name you gave the device. Highlights with no device recorded
+  — everything made before this was tracked — are listed exactly as before, just
+  without a label (#325).
 - **You can now write a note about a book without highlighting anything first.**
   Notes could only ever be attached to a passage, so there was nowhere to put a
   thought about the book as a whole — "the argument in chapter 3 never lands"

--- a/frontend/e2e/reader-notes.spec.ts
+++ b/frontend/e2e/reader-notes.spec.ts
@@ -868,3 +868,97 @@ test.describe('reader: writing a standalone note (#325)', () => {
       }, bookId!);
     });
 });
+
+/*
+ * Device labels in the highlights drawer (#325).
+ *
+ * The affordance was built when the drawer landed and deliberately left unwired:
+ * the backend had no attribution yet, so labelling would have rendered a field
+ * that resolved to nothing. It is wired now that a real non-NULL
+ * `origin_device_id` is observable on the wire, not merely promised.
+ *
+ * The property under test is the OUTER JOIN, and it is the one that would hurt
+ * a real library: on the household instance only 3 of 14 rows carry attribution
+ * at all, the rest predating the feature. Filtering rows on whether their device
+ * resolves would empty most of the drawer in order to add a label — a strictly
+ * worse reader experience delivered as a feature.
+ */
+test.describe('reader drawer: device labels (#325)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('every highlight is listed, whether or not its device resolves', async ({ page }) => {
+    test.setTimeout(120_000);
+    const bookId = await openReaderOnEpub(page, 2);
+    expect(bookId, 'an EPUB that renders in the reader').not.toBeNull();
+
+    /*
+     * Seed the rows this asserts on. openReaderOnEpub clears the book first, so
+     * without this the drawer and the server both hold zero and "listed ===
+     * total" is 0 === 0 -- true, and about nothing. The positive control below
+     * caught exactly that on the first run.
+     *
+     * A MIXED set on purpose: an anchored highlight and an unanchored note. They
+     * differ in attribution and in what the row renders, which is the difference
+     * the outer join has to survive.
+     */
+    await page.evaluate(async (id) => {
+      const csrf = (await (await fetch('/api/v1/auth/csrf', { credentials: 'include' })).json()).csrf_token;
+      const post = (body: unknown) => fetch(`/annotations/${id}`, {
+        method: 'POST', credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf },
+        body: JSON.stringify(body),
+      });
+      await post({ cfi_range: 'epubcfi(/6/4!/4/2/2,/1:0,/1:12)', highlighted_text: 'a passage', highlight_color: 'yellow' });
+      await post({ position_type: 'unanchored', note_text: 'a thought about the whole book' });
+    }, bookId!);
+
+    const server = await page.evaluate(async (id) => {
+      const j = await (await fetch(`/annotations/${id}/data.json`, { credentials: 'include' })).json();
+      const rows = j.annotations || [];
+      return {
+        total: rows.length,
+        withOrigin: rows.filter((a: { origin_device_id?: string | null }) => a.origin_device_id != null).length,
+        hasDevicesEnvelope: 'devices' in j,
+      };
+    }, bookId!);
+
+    // Positive control: without rows, every assertion below is vacuously true.
+    expect(server.total, 'the test book has highlights to list').toBeGreaterThan(0);
+
+    await page.reload();
+    await waitForReaderRender(page);
+    await page.getByRole('button', { name: 'Highlights and notes' }).click();
+    await expect(drawer(page)).toBeVisible();
+    const listed = await drawer(page).locator('li').count();
+
+    /*
+     * The row count is the server's row count -- the drawer lists everything
+     * stored, and does not quietly drop a class of row.
+     *
+     * WHAT THIS DOES NOT CATCH, stated because I checked: filtering rows on
+     * whether their device RESOLVES is invisible here. Every row this test can
+     * create through the API is attributed (the web reader is itself a
+     * registered device), so a `.filter(r => r.origin_device_id)` in the loader
+     * keeps all of them and the count still matches -- verified by mutation.
+     * The rows that would expose it are the unattributed ones predating the
+     * feature: 11 of 14 on the household instance. Reproducing that here means
+     * either a fixture the API cannot make or asserting against a book this
+     * spec does not own, which is the collision F-08685b describes.
+     *
+     * So this guards "no class of row is dropped" -- mutation-verified against
+     * a loader that discards unanchored notes -- and the outer-join rule itself
+     * rests on the loader's comment and on review, not on this assertion.
+     */
+    expect(listed, 'every stored highlight is listed, attributed or not')
+      .toBe(server.total);
+
+    // And no row renders a raw public id -- an unresolved device is unlabelled,
+    // never a uuid shown to a reader.
+    const text = (await drawer(page).innerText()).toLowerCase();
+    expect(text, 'a device id must never be rendered raw')
+      .not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/);
+
+    // Leave the shared fixture as found (F-08685b).
+    await clearAnnotationsViaApi(page, bookId!);
+  });
+});

--- a/frontend/src/pages/Reader.tsx
+++ b/frontend/src/pages/Reader.tsx
@@ -45,6 +45,10 @@ interface AnnRow {
   /** 'webreader' | 'kobo' | 'koreader' | null — shown so a device highlight is
    *  identifiable, and because only some origins carry a usable CFI. */
   source: string | null;
+  /** Public id of the device that MADE this highlight, or null. Resolved
+   *  against the `devices` map in the same response — never rendered raw, and
+   *  never used to filter: see the loader below. */
+  origin_device_id?: string | null;
   /** 'cfi' | 'pdf_quad' | 'comic_page' | 'koreader_xpointer' | 'unanchored' |
    *  null. Only 'unanchored' concerns this list: such a row is a note ABOUT the
    *  book with no passage attached, so it must not be drawn as a highlight that
@@ -197,6 +201,10 @@ export function Reader({ id }: { id: string }) {
   // data.json on mount so a tapped highlight can show its note without a
   // round-trip, and kept in step with every create/edit/remove.
   const notesRef = useRef<Map<string, string>>(new Map());
+  /* public_id -> label, from the same response as the rows. An OLDER backend
+   * omits the envelope entirely, which is how a client can tell; an empty map
+   * then means every row is simply unlabelled rather than wrong. */
+  const [devices, setDevices] = useState<Record<string, { label?: string }>>({});
   const renditionRef = useRef<any>(null);
   const bookRef = useRef<any>(null);
 
@@ -885,6 +893,18 @@ export function Reader({ id }: { id: string }) {
           .then((d) => {
             if (cancelled || !d) return;
             notesRef.current.clear();
+            /*
+             * Take the rows and the device map from the SAME response, and take
+             * every row regardless of whether its device resolves.
+             *
+             * This is an outer join on purpose. On a real library only a
+             * minority of rows carry attribution at all — measured 3 of 14 on
+             * the household instance, the rest predating the feature — so
+             * filtering on resolution would empty most of the drawer to add a
+             * label. An unresolved id renders as no label; it never removes a
+             * highlight the reader made.
+             */
+            setDevices((d.devices || {}) as Record<string, { label?: string }>);
             setAnnList((d.annotations || []) as AnnRow[]);
             (d.annotations || []).forEach((a: any) => {
               const note = (a.note_text || '').trim();
@@ -1146,11 +1166,26 @@ export function Reader({ id }: { id: string }) {
                               {row.note_text}
                             </span>
                           )}
-                          {/* Origin matters to a reader who syncs a device: it
-                              explains why some rows cannot be jumped to. */}
-                          {row.source && row.source !== 'webreader' && (
-                            <span className={styles.annSource}>{row.source}</span>
-                          )}
+                          {/*
+                            * Which device made it. Matters to a reader who syncs
+                            * one, because it explains why some rows cannot be
+                            * jumped to.
+                            *
+                            * Prefer the device's own label over the raw `source`
+                            * slug — "Kobo Clara" is what the reader named it;
+                            * "kobo" is what our schema calls it. Falls back to
+                            * the slug when the id does not resolve, and shows
+                            * nothing at all rather than an id when neither is
+                            * available.
+                            */}
+                          {(() => {
+                            const label = row.origin_device_id
+                              ? devices[row.origin_device_id]?.label
+                              : undefined;
+                            const shown = label
+                              || (row.source && row.source !== 'webreader' ? row.source : '');
+                            return shown ? <span className={styles.annSource}>{shown}</span> : null;
+                          })()}
                         </span>
                       </button>
                     </li>


### PR DESCRIPTION
## What changes

The drawer showed a bare schema slug — `kobo` — where it had any origin at all. It now shows **the device's own label**, the name the reader gave it, falling back to the slug and then to nothing rather than ever rendering a raw public id.

The affordance was built when the drawer landed (#1509) and **deliberately left unwired**: the backend had no attribution, so labelling would have rendered a field that resolved to nothing. It's wired now that a real non-NULL `origin_device_id` is *observable*, not promised — probed against main's own build after #1531:

```
devices: { "c5a0c68e-…": { label: "Web reader", model: "CWNG web reader", type: "webreader" } }
rowCount: 14   withOrigin: 3
```

## That 3-of-14 is the design constraint

**Attribution is a minority of rows and always will be** — everything predating the feature has none. So the join is an **outer** one: an unresolved id renders as no label and never removes a highlight the reader made.

Filtering rows on resolution would empty most of the drawer in order to add a label — a strictly worse reader experience, delivered as a feature.

## The test is honest about its own reach

It guards **"no class of row is dropped"**, and that is mutation-verified: a loader that discards unanchored notes turns it red.

It does **not** catch filtering on device resolution, and the comment says so in place rather than implying coverage it lacks. Every row the test can create through the API is attributed — the web reader is itself a registered device — so `.filter(r => r.origin_device_id)` keeps all of them and the count still matches. **I checked that by mutation rather than assuming it.** The rows that would expose it are the unattributed ones; reproducing those means either a fixture the API cannot make, or asserting against a book this spec does not own, which is the collision `F-08685b` describes.

The outer-join rule therefore rests on the loader's comment and on review — which is a weaker guarantee than a test, and worth saying out loud.

## The positive control earned its place

The first run failed on *"the test book has highlights to list"*. `openReaderOnEpub` clears the book before rendering, so the assertion was `0 === 0` — true, and about nothing. The test now seeds a mixed set (an anchored highlight and an unanchored note) and cleans up after itself.

## Verification

Full reader suite: **22 passed, 1 skipped**, desktop + mobile at `--workers=2`, served bundle verified as this build before and after.

One production file (`Reader.tsx`). No schema change, no new dependency, no new route.

Addresses #325.