### PR TITLE
Run the SPA e2e suite on main, and make the summary prove it ran

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -498,6 +498,7 @@ jobs:
     if: |
       always() && (
       startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.ref == 'refs/heads/dev' ||
       (github.event_name == 'workflow_dispatch' && inputs.run_e2e) ||
       (github.event_name == 'pull_request' && needs.changed_paths.outputs.frontend == 'true')
@@ -881,6 +882,9 @@ jobs:
           # fork carve-out mirrors the e2e job's own continue-on-error, so the
           # two cannot disagree about what is being gated.
           IS_FRONTEND_PR: ${{ needs.changed_paths.outputs.frontend == 'true' && github.event.pull_request.head.repo.fork != true }}
+          # Every push to main runs and gates on the SPA e2e suite. Keep this
+          # event-scoped so workflow_dispatch continues to honor run_e2e.
+          IS_MAIN_PUSH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           echo "Fast Tests:        ${{ needs.fast-tests.result }}"
           echo "Frontend Build:    ${{ needs.frontend-build.result }}"
@@ -889,6 +893,29 @@ jobs:
           echo "Is tier-2 PR:      $IS_TIER2_PR"
           echo "Is build PR:       $IS_BUILD_PR"
           echo "Is frontend PR:    $IS_FRONTEND_PR"
+          echo "Is main push:      $IS_MAIN_PUSH"
+
+          # A required summary must positively prove that every hard-gated
+          # main-push lane completed. Reject skipped/cancelled as well as
+          # failure; otherwise a later broken job condition silently turns
+          # coverage off while this required check stays green.
+          if [[ "$IS_MAIN_PUSH" == "true" ]]; then
+            if [[ "${{ needs.fast-tests.result }}" != "success" ]]; then
+              echo "❌ Fast tests did not succeed on a push to main"
+              echo "   Actual result: ${{ needs.fast-tests.result }}"
+              exit 1
+            fi
+            if [[ "${{ needs.frontend-build.result }}" != "success" ]]; then
+              echo "❌ Frontend build did not succeed on a push to main"
+              echo "   Actual result: ${{ needs.frontend-build.result }}"
+              exit 1
+            fi
+            if [[ "${{ needs.e2e-tests.result }}" != "success" ]]; then
+              echo "❌ SPA e2e suite did not succeed on a push to main"
+              echo "   Actual result: ${{ needs.e2e-tests.result }}"
+              exit 1
+            fi
+          fi
 
           if [[ "${{ needs.fast-tests.result }}" == "failure" ]]; then
             echo "❌ Fast tests failed"
@@ -940,9 +967,11 @@ jobs:
           # (#1130). Warning-and-continuing is how a red suite kept satisfying
           # merge-gate condition (a): this summary is the single required
           # check, and auto-merge.yml fires on it, so "just warn" meant the
-          # gate reported its own failure as a pass. Tag and main runs stay
-          # advisory here — the job itself is already non-advisory there, and
-          # failing the summary too would block auto-revert decisions.
+          # gate reported its own failure as a pass. Main pushes are also a
+          # hard gate here: branch protection reads this summary, so relying
+          # only on the failed e2e job would still let the required check pass.
+          # Tag and dev runs stay advisory in the summary; the e2e job itself
+          # remains non-advisory there.
           if [[ "${{ needs.e2e-tests.result }}" == "failure" ]]; then
             if [[ "$IS_FRONTEND_PR" == "true" ]]; then
               echo "❌ SPA e2e suite failed on a frontend PR — this is a hard gate."

--- a/tests/unit/test_summary_gate_requires_success.py
+++ b/tests/unit/test_summary_gate_requires_success.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Behavioural test of the `Test Suite Summary` gate, by EXECUTING its shell.
+
+Why this exists rather than another static assertion about the YAML: the defect
+it guards against is not a missing string, it is a *decision*. The old summary
+enumerated the bad state (`result == "failure"`) instead of requiring the good
+one, so on a push to main every other state — `skipped`, `cancelled` — fell
+through to `exit 0`. The required check went green having verified nothing, and
+that is exactly how the SPA e2e suite came to never run on main without anyone
+noticing (F-54d342).
+
+A gate written as "nothing was bad" admits every state that is neither good nor
+bad. Reading the YAML confirms the intent you already hold; running it is what
+tells you which states actually pass. So this extracts the real `run:` block and
+executes it under substituted job results.
+
+Includes a POSITIVE CONTROL (all-success must exit 0). Without one, a harness
+that rejects everything would look like a perfect gate.
+"""
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Same convention as test_workflow_safety_invariants.py.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+
+
+def _summary_shell():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    m = re.search(
+        r"- name: Check test results\n(.*?)\n        run: \|\n(.*?)"
+        r"(?=\n      - name:|\n  [a-z_]+:\n|\Z)",
+        text,
+        re.S,
+    )
+    assert m, "could not locate the Test Suite Summary 'Check test results' run block"
+    body = m.group(2)
+    return "\n".join(
+        line[10:] if line.startswith(" " * 10) else line for line in body.split("\n")
+    )
+
+
+def _render(shell, *, event, ref, fast, build, integration, e2e,
+            is_frontend_pr="false", is_tier2="false", is_build_pr="false",
+            changed_paths="success"):
+    subs = {
+        "needs.fast-tests.result": fast,
+        "needs.frontend-build.result": build,
+        "needs.integration-tests.result": integration,
+        "needs.e2e-tests.result": e2e,
+        "needs.changed_paths.result": changed_paths,
+        "github.event_name": event,
+        "github.ref": ref,
+    }
+    for key, value in subs.items():
+        shell = shell.replace("${{ " + key + " }}", value)
+    # Any residual GitHub expression is a boolean we are not exercising.
+    shell = re.sub(r"\$\{\{[^}]*\}\}", "false", shell)
+    is_main_push = "true" if (event == "push" and ref == "refs/heads/main") else "false"
+    env = (
+        f"IS_TIER2_PR={is_tier2}\n"
+        f"IS_BUILD_PR={is_build_pr}\n"
+        f"IS_FRONTEND_PR={is_frontend_pr}\n"
+        f"IS_MAIN_PUSH={is_main_push}\n"
+    )
+    return "set -o pipefail\n" + env + shell
+
+
+def _run(**kwargs):
+    script = _render(_summary_shell(), **kwargs)
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    return proc.returncode, proc.stdout
+
+
+MAIN_PUSH = dict(event="push", ref="refs/heads/main")
+
+
+def test_positive_control_all_success_passes():
+    """The control. Without it, a harness that fails everything looks perfect."""
+    rc, _ = _run(**MAIN_PUSH, fast="success", build="success",
+                 integration="success", e2e="success")
+    assert rc == 0
+
+
+@pytest.mark.parametrize("e2e_result", ["failure", "skipped", "cancelled"])
+def test_main_push_requires_e2e_success_not_merely_absence_of_failure(e2e_result):
+    """Every non-success e2e result must fail the required summary on main.
+
+    `skipped` and `cancelled` are the ones that matter: those are what a broken
+    job condition produces, and letting them through would silently turn the
+    coverage off while this check stays green — reinstating F-54d342 with a fix
+    apparently in place.
+    """
+    rc, out = _run(**MAIN_PUSH, fast="success", build="success",
+                   integration="success", e2e=e2e_result)
+    assert rc == 1, f"main push with e2e={e2e_result} must fail the summary; got rc=0\n{out}"
+    assert e2e_result in out, "the summary should name the actual result it rejected"
+
+
+@pytest.mark.parametrize("job,kwargs", [
+    ("fast-tests", dict(fast="skipped", build="success", integration="success", e2e="success")),
+    ("frontend-build", dict(fast="success", build="cancelled", integration="success", e2e="success")),
+])
+def test_main_push_requires_the_other_hard_gated_lanes_too(job, kwargs):
+    rc, out = _run(**MAIN_PUSH, **kwargs)
+    assert rc == 1, f"main push with {job} not succeeding must fail the summary\n{out}"
+
+
+def test_integration_stays_advisory_on_main():
+    """Deliberate carve-out: integration-tests' own continue-on-error evaluates
+    true on a main push, so hard-gating it here would change existing behaviour
+    and block the auto-revert path the workflow documents."""
+    rc, _ = _run(**MAIN_PUSH, fast="success", build="success",
+                 integration="skipped", e2e="success")
+    assert rc == 0
+
+
+def test_non_frontend_pr_still_passes_with_e2e_skipped():
+    """The PR path is deliberately path-gated: a backend-only PR skips the SPA
+    suite by design and must not be blocked by this change."""
+    rc, _ = _run(event="pull_request", ref="refs/heads/topic",
+                 fast="success", build="success", integration="skipped",
+                 e2e="skipped", is_frontend_pr="false")
+    assert rc == 0


### PR DESCRIPTION
Fixes **F-54d342**. Operator-approved, built with Sol per their instruction.

## The defect

The SPA e2e suite has **never run on a push to main**. Measured: `E2E Tests (SPA) | skipped | steps=0` on all 12 most recent main runs — *including the commit that added a reader e2e spec.*

So a regression lands on main unseen and first surfaces on somebody's unrelated PR days later, where it reads as **their** fault. That is not hypothetical: it happened on 2026-08-10 and cost several sessions an afternoon. It also defeats the correct debugging instinct, because A/B-ing against main finds no result to compare with.

## Two causes — and the second is why the obvious fix isn't enough

1. `changed_paths` carries `if: github.event_name == 'pull_request'`, so on a push it's skipped and its outputs come back empty.
2. **The `e2e-tests` if-condition has no main-branch case at all.** Compare `integration-tests`, which includes `github.ref == 'refs/heads/main'`.

The approved fix was "run `changed_paths` on push" — **that alone would have left e2e skipped on main anyway.** A fix that looks like it worked while changing nothing, which is the same self-concealing shape as the bug.

## What changed

**Trigger:** an event-scoped main-push case on `e2e-tests`. Deliberately `github.event_name == 'push' && …` rather than a bare `github.ref` check, so a `workflow_dispatch` targeting main still honours `run_e2e`. Not path-gated on push — that avoids `github.event.before` being the all-zero SHA on a first push or unreachable after a force-push, i.e. fallback logic whose own failure could silently suppress the gate. Cost is precedented: `integration-tests` already runs ~11 min on every main push.

**The part that matters more than the trigger — the summary now proves it ran.** `Test Suite Summary` is the required check branch protection reads, and it enumerated the *bad* state (`result == "failure"`) instead of requiring the good one, so `skipped` and `cancelled` fell through to `exit 0`. On a main push it now requires `success` from fast-tests, frontend-build and e2e, and names the actual result it rejected.

Without this, the fix would be self-concealing: any later edit breaking the new condition turns coverage off while the required check stays green.

`integration-tests` is deliberately **not** hard-gated — its own `continue-on-error` evaluates true on a main push, so requiring success would change documented behaviour and block the auto-revert path.

## Verified by executing the gate, not reading it

`tests/unit/test_summary_gate_requires_success.py` extracts the real `run:` block and runs it under substituted job results:

| | result |
|---|---|
| against this workflow | **8 passed** |
| against pre-fix main | **5 failed, 3 passed** |

The 3 passing on both are the **positive control** (all-success must exit 0 — without one, a harness that rejects everything looks like a perfect gate) and the two must-not-change cases: integration advisory on main, and a backend-only PR still skipping the SPA suite by design.

Worth recording what the old gate did on a main push with a **failing** e2e: it printed `⛔ E2E tests failed - do not release!` **and then exited 0.** A gate that announces its own failure and passes anyway.

51 workflow tests pass; YAML parses.

## Known remaining fail-open shapes — listed, not fixed

Sol enumerated these; all are pre-existing and out of scope here:

1. The PR-side `changed_paths` guard rejects only `failure`; `cancelled` leaves both path-derived gates reading "not applicable".
2. Frontend-PR e2e gating rejects only `failure` — a same-repo frontend PR with e2e `cancelled` still satisfies the summary.
3. Tier-2/build-PR integration gating, same shape.
4. & 5. fast-tests and frontend-build outside the main-push path, same shape.
6. Tag/dev e2e results are not positively required by the summary.
7. Advisory integration on main/dev — intentional, but note `continue-on-error` normalises a failing job to a **successful dependency result**.

Worth a follow-up that generalises the positive-assertion pattern across all lanes rather than patching each.

## Rule 6

No new dependencies, actions, or external URLs.