### PR TITLE
Enforce safe-tier-1's path allowlist instead of assuming it

### DIFF
--- a/findings/items/F-389161.json
+++ b/findings/items/F-389161.json
@@ -1,0 +1,14 @@
+{
+  "area": "ci",
+  "body": "`TIER1_PATHS_REGEX` (`\\.(po|pot|md)$|^README`) has been in\n`.github/policy/tier-policy.config` and on the `Policy` dataclass since the module was\nwritten. It was parsed, exposed in `describe`, and **consulted nowhere**. `validate_fork_pr`\nnever referenced it, so a PR labelled `safe-tier-1` was path-checked only against\n`FORBIDDEN_PATHS_REGEX` (auth/csrf/session/admin/migrations/deps/container) -- leaving the\nwhole of `cps/` outside those areas eligible to auto-merge with no human eyes.\n\nMeasured before the fix, with negative controls to show the validator could still refuse:\n\n    validate-fork-pr --tier safe-tier-1  files=[cps/opds.py]      -> {\"ok\": true}\n    validate-fork-pr --tier safe-tier-1  files=[requirements.txt] -> forbidden_path\n    validate-fork-pr --tier safe-tier-1  base=some-feature-branch -> unprotected_base\n\nNothing else covered it, and each near-miss is worth naming because each looks like it does:\n\n- `tier-label-guard.yml` restricts **who** may apply the label, never **what** the PR touches.\n- `auto-merge.yml`'s CHANGES-vs-upstream requirement runs only `if [ \"$tier\" = \"safe-tier-2\" ]`,\n  and its own comment states the reason: *\"Tier-1 (.po + *.md only) is exempt.\"* That premise\n  was never established anywhere -- the exemption rests on the unchecked property.\n- The tier table in CLAUDE.md defines tier-1 as \".po / *.md / README, no code\", so the rule was\n  documented policy carried entirely by whoever applied the label.\n\nReal instance: **#1529**, an auto-revert opened by our own automation, sat labelled\n`safe-tier-1` while reverting `cps/opds.py` and deleting `test_1097_opds_discover_naming.py`\n(194 lines). Simulated against `main` it merged CLEAN and left the CHANGELOG entry claiming\nthe fix had shipped -- code reverted, regression test gone, release notes still advertising it.\nClosed by hand on 2026-08-12 rather than merged.\n\nFixed by enforcing the allowlist in `validate_fork_pr` for `safe-tier-1`, failing closed with a\nnew `tier1_paths` category that names the offending files. Red/green: two new tests fail\nwithout the change, 25 pass with it; tier-2 is deliberately unaffected.\n\nFollow-up worth a deliberate decision rather than a silent widening: `findings/items/*.json`\nis not on the allowlist, so ledger-only PRs (#1487, and #1534 which I merged as tier-1 myself)\nnow demote to needs-review. That may be the right call or the allowlist may want extending --\nbut extending it is a config edit, which is precisely the deliberation the gate exists to force.",
+  "created": "2026-08-12",
+  "id": "F-389161",
+  "refs": [
+    "#1529",
+    "#1487"
+  ],
+  "severity": "correctness",
+  "source": "audit",
+  "status": "open",
+  "title": "safe-tier-1's path allowlist was loaded but never enforced"
+}

--- a/scripts/lib/tier_policy.py
+++ b/scripts/lib/tier_policy.py
@@ -97,7 +97,8 @@ class Policy:
 class ValidationResult:
     ok: bool
     reason: str = ""
-    # forbidden_path | forbidden_diff | tier_caps | unprotected_base | ok
+    # forbidden_path | tier1_paths | forbidden_diff | tier_caps |
+    # unprotected_base | ok
     category: str = ""
 
     def to_dict(self) -> dict:
@@ -335,6 +336,42 @@ def validate_fork_pr(
             ),
             category="forbidden_path",
         )
+
+    # 1b. Tier-1 path allowlist.
+    #
+    # TIER1_PATHS_REGEX has been in tier-policy.config and on the Policy
+    # dataclass since the module was written, and until now it was never
+    # consulted -- loaded, exposed in `describe`, and enforced nowhere. Tier-1
+    # is defined as ".po under cps/translations, *.md, README*, no code", and
+    # that definition was carried entirely by whoever applied the label.
+    #
+    # Nothing else covers the gap. tier-label-guard.yml gates WHO may apply the
+    # label, not WHAT the PR touches. The forbidden-path check above covers only
+    # auth/csrf/session/admin/migrations/deps/container, so the whole of `cps/`
+    # outside those areas passed. And auto-merge.yml's CHANGES-vs-upstream
+    # requirement explicitly *exempts* tier-1 on the stated grounds that it is
+    # ".po + *.md only" -- a premise nothing established.
+    #
+    # Observed 2026-08-10: #1529, an auto-revert labelled `safe-tier-1`,
+    # reverted cps/opds.py and deleted a 194-line regression test. It was
+    # eligible to auto-merge without human eyes and nothing in this path would
+    # have stopped it.
+    #
+    # Fails closed: an unrecognised path demotes to needs-review rather than
+    # merging. Widening tier-1 is a config edit, which is the point.
+    if tier == "safe-tier-1":
+        off_allowlist = [p for p in paths if not policy.tier1_paths_regex.search(p)]
+        if off_allowlist:
+            shown = ", ".join(off_allowlist[:5])
+            more = f" (+{len(off_allowlist) - 5} more)" if len(off_allowlist) > 5 else ""
+            return ValidationResult(
+                ok=False,
+                reason=(
+                    f"safe-tier-1 allows only translations and docs, but this PR "
+                    f"changes {shown}{more}; demoted to needs-review."
+                ),
+                category="tier1_paths",
+            )
 
     # 2. Tier-2 size caps. Tier-1 has no LOC cap because translations can
     # legitimately span many files / many lines.

--- a/tests/unit/test_tier_policy_module.py
+++ b/tests/unit/test_tier_policy_module.py
@@ -175,6 +175,54 @@ def test_validate_tier1_translation_passes(policy):
     assert r.ok
 
 
+def test_validate_tier1_code_change_demotes(policy):
+    """safe-tier-1 must refuse a code file, not just a forbidden one.
+
+    Regression for the real shape: #1529 was an auto-revert labelled
+    `safe-tier-1` that reverted `cps/opds.py` and deleted a 194-line
+    regression test. `cps/opds.py` is not in FORBIDDEN_PATHS_REGEX
+    (auth/csrf/session/admin/migrations/deps/container), so the forbidden-path
+    check passed it, and TIER1_PATHS_REGEX -- which exists precisely to say
+    "translations and docs only" -- was loaded but never consulted. The PR was
+    eligible to auto-merge with no human eyes.
+    """
+    pr = {
+        "additions": 3, "changedFiles": 1, "baseRefName": "main",
+        "files": [{"path": "cps/opds.py"}],
+    }
+    r = tier_policy.validate_fork_pr(pr, "+x = 1\n", policy, tier="safe-tier-1")
+    assert not r.ok
+    assert r.category == "tier1_paths"
+    assert "cps/opds.py" in r.reason
+
+
+def test_validate_tier1_names_every_offending_path(policy):
+    """The demotion has to say which files, or nobody can act on it."""
+    pr = {
+        "additions": 4, "changedFiles": 3, "baseRefName": "main",
+        "files": [
+            {"path": "cps/translations/de/LC_MESSAGES/messages.po"},
+            {"path": "cps/opds.py"},
+            {"path": "cps/kobo.py"},
+        ],
+    }
+    r = tier_policy.validate_fork_pr(pr, "+x = 1\n", policy, tier="safe-tier-1")
+    assert not r.ok
+    assert "cps/opds.py" in r.reason and "cps/kobo.py" in r.reason
+    # The legitimate file is not reported as a problem.
+    assert "messages.po" not in r.reason
+
+
+def test_validate_tier2_code_change_is_unaffected_by_the_tier1_allowlist(policy):
+    """Tier-2 exists to carry small code changes; it must not inherit the gate."""
+    pr = {
+        "additions": 3, "changedFiles": 1, "baseRefName": "main",
+        "files": [{"path": "cps/opds.py"}],
+    }
+    r = tier_policy.validate_fork_pr(pr, "+x = 1\n", policy, tier="safe-tier-2")
+    assert r.ok
+
+
 def test_validate_forbidden_path_demotes(policy):
     pr = {
         "additions": 1, "changedFiles": 1, "baseRefName": "main",


### PR DESCRIPTION
`TIER1_PATHS_REGEX` has been in `.github/policy/tier-policy.config` and on the `Policy` dataclass since the module was written. It was parsed, exposed in `describe`, and **consulted nowhere**.

So a `safe-tier-1` PR was path-checked only against `FORBIDDEN_PATHS_REGEX` (auth/csrf/session/admin/migrations/deps/container) — leaving the rest of `cps/` eligible to auto-merge **with no human eyes**.

## Measured before the fix

With negative controls, so this isn't a validator that says yes to everything:

| input | result |
|---|---|
| tier-1, `cps/opds.py` | **`{"ok": true}`** |
| tier-1, `requirements.txt` | `forbidden_path` |
| tier-1, base `some-feature-branch` | `unprotected_base` |

## Why nothing else caught it

Each of these looks like it covers the case:

- **`tier-label-guard.yml`** restricts *who* may apply the label, never *what* the PR touches.
- **`auto-merge.yml`**'s CHANGES-vs-upstream requirement runs only `if [ "$tier" = "safe-tier-2" ]`, and its comment gives the reason: *"Tier-1 (.po + \*.md only) is exempt."* **The exemption rests on a premise nothing established.**
- **CLAUDE.md**'s tier table defines tier-1 as ".po / \*.md / README, no code" — documented policy carried entirely by whoever applied the label.

## The real instance

**#1529**, an auto-revert opened by our own automation, sat labelled `safe-tier-1` while reverting `cps/opds.py` and deleting `test_1097_opds_discover_naming.py` (194 lines). Simulated against `main` it merged **CLEAN** and left the CHANGELOG entry claiming the fix had shipped — code reverted, regression test gone, release notes still advertising it. I closed it by hand today.

## The change

Enforce the allowlist for `safe-tier-1`, failing closed, with a new `tier1_paths` category that **names the offending files** so the demotion is actionable.

| | before | after |
|---|---|---|
| new tier-1 tests | **2 failed** | 2 passed |
| `test_tier_policy_module.py` | 23 passed | **25 passed** |
| `test_tier_policy_module.sh` | — | 20 passed |
| `test_tier_policy.sh` | — | 10 passed |

Tier-2 is deliberately unaffected — it exists to carry small code changes — and there's a test pinning that, so this can't quietly widen.

## One consequence worth a deliberate decision

`findings/items/*.json` is **not** on the allowlist, so ledger-only PRs (#1487, and #1534 which I merged as tier-1 myself) now demote to `needs-review`. That may be correct, or the allowlist may want extending — but extending it is a config edit, which is exactly the deliberation this gate exists to force. Not doing it silently here.

Records `F-389161`.