### PR TITLE
Ignore worktrees created inside the checkout, which wedge every tick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,6 +242,14 @@ metadata_temp/
 # Claude Code workspace cache (per-developer local skill state).
 .claude/
 
+# Git worktrees created inside the checkout. A worktree here is untracked, so
+# it makes `git status --porcelain` non-empty, which trips the autopilot
+# preflight's clean-tree gate (scripts/preflight.sh) and fails every tick until
+# someone removes it. Ignoring is also strictly safer than leaving it visible:
+# while untracked, a plain `git clean -fd` in the checkout would DELETE a live
+# worktree along with any uncommitted work in it.
+.worktrees/
+
 # Playwright MCP capture artifacts (per-session page/console snapshots).
 # These can incidentally contain auth headers, CSRF tokens, or API keys
 # from whatever page was open at capture time. Never commit.

--- a/tests/unit/test_gitignore_worktrees.py
+++ b/tests/unit/test_gitignore_worktrees.py
@@ -1,0 +1,50 @@
+"""A git worktree created inside the checkout must be ignored.
+
+`git worktree add .worktrees/<name>` run from inside the checkout leaves an
+untracked directory behind. That makes `git status --porcelain` non-empty, and
+the autopilot preflight treats a dirty checkout as a reason to stop — so one
+stray worktree fails every tick until a human notices. The failure reads as a
+legitimate "someone left work in the tree" warning rather than a wedge, which
+is what makes it expensive.
+
+Ignoring it is also strictly safer than leaving it visible: while the directory
+is untracked, a plain `git clean -fd` in the checkout would delete a live
+worktree along with any uncommitted work inside it.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# `.git` is a directory in a normal clone and a file in a linked worktree.
+pytestmark = pytest.mark.skipif(
+    not (REPO_ROOT / ".git").exists(), reason="not a git checkout"
+)
+
+
+def _check_ignore(path: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "check-ignore", "-q", path],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_worktrees_directory_is_ignored():
+    assert _check_ignore(".worktrees/").returncode == 0, (
+        ".worktrees/ is not ignored. A worktree created inside the checkout "
+        "makes `git status --porcelain` non-empty, which wedges the autopilot "
+        "preflight's clean-tree gate on every tick."
+    )
+
+
+def test_files_inside_a_worktree_are_ignored_too():
+    """Ignoring the directory must cover its contents, not just its name."""
+    assert _check_ignore(".worktrees/example-branch/cps/admin.py").returncode == 0, (
+        "a file inside .worktrees/ is still visible to git status; the ignore "
+        "rule must cover the directory's contents"
+    )


### PR DESCRIPTION
## Symptom

Every autopilot tick fails preflight, with what looks like a legitimate warning:

```
repo/ has uncommitted changes — investigate before draining
```

Nothing is actually uncommitted. A `git worktree add .worktrees/<name>` run from
inside the checkout leaves an **untracked directory**, so `git status --porcelain`
is non-empty and the clean-tree gate stops the tick — and keeps stopping it until
a human notices.

This is the third instance of the same class: the `wikisite/` wedge (08-09) and
the `.key` / `app.db` one (#1470). The durable fix each time is the ignore entry:
the artifact still gets written, it just stops being visible to the gate.

## Why ignoring is *safer*, not laxer

While `.worktrees/` is untracked, a plain `git clean -fd` in the checkout would
**delete a live worktree** along with any uncommitted work inside it. Ignoring it
removes that hazard — only `clean -fdx` reaches an ignored path.

## Tests

`tests/unit/test_gitignore_worktrees.py` drives `git check-ignore`, so it pins the
real behaviour rather than the presence of a line in a file.

Verified in both directions — with the `.gitignore` change stashed and nothing else
altered:

```
=== GREEN (with the fix) ===   2 passed
=== RED control (fix stashed) ===
FAILED test_worktrees_directory_is_ignored
FAILED test_files_inside_a_worktree_are_ignored_too
```

Branched from `origin/main` (`f2597fbfa`), not a stale local `main`.