### PR TITLE
Record the German translation improvement in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- **More of the interface reads in German.** Coverage went from 1,891 to 2,071
+  translated phrases: 121 phrases that had no German at all now have it, and 59
+  entries that gettext had guessed and marked provisional — provisional entries
+  are dropped when the catalogue is compiled, so they were showing in English
+  regardless — are now confirmed translations. One of them was **Import**, which
+  had been guessed as "Wichtig:" ("Important:"). Contributed by
+  [@chaosblog](https://github.com/new-usemame/Calibre-Web-NextGen/pull/1549)
+  ([#1549](https://github.com/new-usemame/Calibre-Web-NextGen/pull/1549)).
 - **The reader's Black page theme is back, and it is actually black.** The
   classic reader has four page themes; the new UI's reader only ever showed
   three, and anyone who had chosen **Black** was quietly given the dark theme


### PR DESCRIPTION
#1549 merged as a community contribution. Release notes are built from
`CHANGELOG.md [Unreleased]`, so without an entry the contribution reaches the
next release with no credit and no user-facing description.

Symptom-first, matching the shape used for the Traditional Chinese entry
(#1424): what a German-speaking user will notice, then who did it.

The "provisional" wording is deliberate — a fuzzy PO entry is dropped at compile
time, so those 59 phrases were showing in English no matter what the catalogue
said. That is the part a reader would otherwise find surprising.