### PR TITLE
Generated translation commits must run the tests that exist for them

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -92,7 +92,7 @@ jobs:
             echo "No translation changes to commit"
             echo "TRANSLATION_COMMITTED=0" >> $GITHUB_ENV
           else
-            git commit -m "Update translations [skip ci]"
+            git commit -m "Update translations"
             # The autopilot pushes docs commits to main minutes after each
             # merge, so a bare `git push` here loses that race and fails
             # non-fast-forward (3 of the last 30 runs). The commit holds

--- a/tests/unit/test_update_translations_commit_ci.py
+++ b/tests/unit/test_update_translations_commit_ci.py
@@ -1,0 +1,71 @@
+"""Keep generated translation commits inside the normal test pipeline.
+
+The translation refresh is executable build input, not inert bookkeeping:
+``pybabel update`` can produce catalogue shapes that only the compile tests
+catch, and the same workflow regenerates a README that is also under test.
+The release preflight now requires a positive Test Suite Summary verdict, so a
+translation commit that suppresses CI would also wedge the release train when
+it becomes main's head.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "update-translations.yml"
+)
+
+
+def _translation_commit_step() -> dict:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")) or {}
+    matches = [
+        step
+        for job in (workflow.get("jobs") or {}).values()
+        for step in (job.get("steps") or [])
+        if isinstance(step, dict) and step.get("name") == "Commit translation updates"
+    ]
+    assert len(matches) == 1, (
+        "update-translations.yml must have exactly one named translation commit "
+        f"step; found {len(matches)}"
+    )
+    return matches[0]
+
+
+def test_translation_commit_runs_ci_and_keeps_its_canonical_message():
+    run = _translation_commit_step().get("run")
+    assert isinstance(run, str), "the translation commit step must contain a run script"
+
+    # Assemble the Actions control markers so this source never casually copies
+    # one as a single token. GitHub scans the entire generated commit message,
+    # and any of these suppresses every workflow for that main commit.
+    #
+    # All five documented spellings are checked, not just the one this workflow
+    # happened to use. Pinning a single variant would let the next edit reach
+    # for a synonym and silently restore the defect while this test stayed
+    # green -- the gate would still be named in the suite but would no longer
+    # deny anything.
+    skip = "skip"
+    ci = "ci"
+    suppression_markers = (
+        f"[{skip} {ci}]",
+        f"[{ci} {skip}]",
+        f"[no {ci}]",
+        f"[{skip} actions]",
+        f"[actions {skip}]",
+    )
+    lowered = run.lower()
+    present = [marker for marker in suppression_markers if marker in lowered]
+    assert not present, (
+        f"the translation commit message suppresses CI via {present}; generated "
+        "catalogues and README changes must receive the normal Test Suite verdict"
+    )
+    assert 'git commit -m "Update translations"' in run, (
+        "the workflow must emit the canonical, tested translation commit message"
+    )


### PR DESCRIPTION
## The symptom

Seven of the last twenty commits on `main` carry **no `Test Suite Summary` check-run at all**. Sixteen of the last sixty are generated translation commits, which land carrying an Actions control marker and therefore run nothing.

`main`'s head as I write this is one of them.

## Why these commits are not inert

`scripts/update_translations.sh` runs a `pybabel update`, rewriting every `cps/translations/*/LC_MESSAGES/messages.po`. That is exactly the operation that produced the **v4.0.47** `hu.po` obsolete-`#~ msgid` collision — `compile_translations.sh` silently skipped Hungarian, the `.mo` never entered the image, and Hungarian users got the English fallback for a full release cycle.

`tests/unit/test_translations_compile.py` exists *because of that incident*. The marker skips it.

The same workflow also regenerates `README.md`, and `grep -rln README tests/` returns **5** files. The README is under test too.

So the workflow most able to reintroduce a shipped defect is the one workflow that skips the test written to catch it.

## The second reason, which is about releases

The release train tags `origin/main` by default, and this bot can push **after** the release roll commit. When it does, the bookkeeping checks all still pass — changelog section, `VERSION`, What's New entry are all still in the tree — while the commit actually being tagged has no verdict at all.

This is coupled to a change in the local release machinery (`scripts/preflight-release-tag.sh`), which now refuses to tag a commit whose latest `Test Suite Summary` is not completed-and-successful. Without this PR, a translation commit sitting at main's head would carry no verdict and **wedge the release train** rather than gate it. Both halves have to land.

## The change

One line: drop the marker so these commits are verified like every other commit on main.

## Tests

`tests/unit/test_update_translations_commit_ci.py` parses the workflow YAML, locates the uniquely-named commit step, and asserts **all five documented skip spellings** are absent — not just the one this workflow happened to use. Pinning a single variant would let a later edit reach for a synonym and leave a gate that is still named in the suite but no longer denies anything.

It assembles the markers from string fragments rather than writing them literally. GitHub scans the entire commit message: v4.1.15's roll commit got **zero** workflow runs because it mentioned the token only to say it was *not* using it, and that read exactly like an Actions outage.

**Verified by mutation:** reintroducing a marker — deliberately using a *synonym* rather than the original spelling — turns the test red. Restoring the fix turns it green.

## Cost

Roughly 7 extra Test Suite runs per 30 main commits. This repo's CI is GitHub-hosted `ubuntu-latest`, which the cost policy keeps inside the included minutes.

## Rule 6

No new dependencies, licenses, or external service URLs. `yaml` and `pytest` are already used by the existing workflow-contract tests.