### PR TITLE
Render PDFs with pdf.js so iPad shows more than page one (#1584)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -676,8 +676,20 @@ jobs:
           # the first page is visible", which a one-page PDF cannot detect.
           docker cp tests/fixtures/sample_books/three_page_sample.pdf \
             cwn-e2e:/tmp/three_page_sample.pdf
-          docker exec cwn-e2e calibredb add /tmp/three_page_sample.pdf \
-            --with-library /calibre-library
+          added=$(docker exec cwn-e2e calibredb add /tmp/three_page_sample.pdf \
+            --with-library /calibre-library | tee /dev/stderr \
+            | sed -n 's/.*Added book ids: *\([0-9]*\).*/\1/p')
+          [ -n "$added" ] || { echo "::error::calibredb add reported no book id"; exit 1; }
+          # Backdate it, because a new book is a NEW book: the default sort is
+          # newest-first, and several specs walk the library from the top to find
+          # something readable. Landing a PDF at position one displaced that and
+          # made reader-phase1 time out — a fixture breaking specs it has nothing
+          # to do with, which is the trap the book-lane convention exists to
+          # avoid. Oldest keeps it out of everyone's way; the PDF spec finds it
+          # by format, not by position.
+          docker exec cwn-e2e calibredb set_metadata \
+            --field timestamp:2001-01-01T00:00:00+00:00 "$added" \
+            --with-library /calibre-library >/dev/null
           jar=$(mktemp)
           csrf=$(curl -s -c "$jar" http://localhost:8083/api/v1/auth/csrf \
             | python3 -c 'import sys,json;print(json.load(sys.stdin)["csrf_token"])')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -834,11 +834,22 @@ jobs:
           npm ci
           npm run build          # writes ../cps/static/app
           docker cp ../cps/static/app/. cwn-e2e:/app/calibre-web-automated/cps/static/app/
+          # Jinja templates too. Not every user-facing surface is React: the PDF
+          # reader is a server-rendered pdf.js page the SPA embeds, so a fix that
+          # spans both (#1584) had its SPA half tested here and its template half
+          # silently skipped — the spec guarding it would have failed against the
+          # `:dev` template while passing on the merged result, which teaches the
+          # next author to delete the guard. Templates are read per render and
+          # are not restart-gated, same as the bundle above.
+          docker cp ../cps/templates/. cwn-e2e:/app/calibre-web-automated/cps/templates/
           # The bundle is static; no restart needed. Confirm the shell still
           # answers so a broken overlay fails here rather than as 30 confusing
-          # spec failures.
+          # spec failures. /login is Jinja-rendered, so it also catches a template
+          # that references something this `:dev` backend does not have — the one
+          # real hazard of overlaying templates onto an older API.
           curl -fsS http://localhost:8083/app/ -o /dev/null
-          echo "PR bundle in place"
+          curl -fsS http://localhost:8083/login -o /dev/null
+          echo "PR bundle + templates in place"
 
       - name: Run SPA e2e harness
         working-directory: frontend

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -661,6 +661,36 @@ jobs:
             exit 1
           fi
 
+      - name: Seed a multi-page PDF book (spec fixture)
+        run: |
+          # reader-pdf-viewer.spec.ts needs a book with a PDF format, and the
+          # ingest seed above is EPUB-only — so the spec found no PDF and failed
+          # on the fixture rather than on anything real, exactly the #1130 shape
+          # the shelves seed below exists to prevent.
+          #
+          # calibredb writes the format straight into the library. Ingest is the
+          # wrong instrument here: it converts on the way in, so dropping a PDF
+          # in that folder is not a reliable way to end up with a PDF format.
+          #
+          # The fixture is three pages deliberately. #1584's symptom was "only
+          # the first page is visible", which a one-page PDF cannot detect.
+          docker cp tests/fixtures/sample_books/three_page_sample.pdf \
+            cwn-e2e:/tmp/three_page_sample.pdf
+          docker exec cwn-e2e calibredb add /tmp/three_page_sample.pdf \
+            --with-library /calibre-library
+          jar=$(mktemp)
+          csrf=$(curl -s -c "$jar" http://localhost:8083/api/v1/auth/csrf \
+            | python3 -c 'import sys,json;print(json.load(sys.stdin)["csrf_token"])')
+          curl -s -b "$jar" -c "$jar" -X POST http://localhost:8083/api/v1/auth/login \
+            -H 'Content-Type: application/json' -H "X-CSRFToken: $csrf" \
+            -d '{"username":"admin","password":"admin123"}' -o /dev/null
+          # Assert through the same endpoint the spec reads, so a book that was
+          # added but is invisible to the API fails here and not as a spec.
+          pdfs=$(curl -s -b "$jar" 'http://localhost:8083/api/v1/books?per_page=200' \
+            | python3 -c 'import sys,json;d=json.load(sys.stdin);print(sum(1 for b in d.get("items",[]) if any(str(f).lower()=="pdf" for f in b.get("formats",[]))))')
+          echo "books with a PDF format: $pdfs"
+          [ "${pdfs:-0}" -ge 1 ] || { echo "::error::no PDF-format book after seeding"; exit 1; }
+
       - name: Seed shelves and series
         run: |
           # The library the harness gets had three books and NO shelves, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ is for things you can see or feel when running the app.
 ## [Unreleased]
 
 ### Fixed
+- **PDFs open past page one on iPad.** In the new interface a PDF showed its
+  first page and nothing else on iPadOS, in both Safari and Firefox, while the
+  same book was fine on a Mac, on Android and in the classic interface. The
+  reader was handing the file to whatever PDF viewer the browser ships, and on
+  iPhone and iPad that viewer only ever draws one page inside an embedded frame.
+  PDFs now open in the same viewer the classic interface has always used, which
+  draws every page the same way on every browser, and brings PDF text search,
+  thumbnails and annotations to the new reader with it. Reported by
+  [@chloeroform](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1584)
+  ([#1584](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1584)).
 - **Errors explain themselves again instead of turning into a blank 500.** Some
   failures replaced their own explanation with `TypeError: '>' not supported
   between instances of ... and 'int'` and took down the page that was handling

--- a/cps/templates/readpdf.html
+++ b/cps/templates/readpdf.html
@@ -39,7 +39,8 @@ See https://github.com/adobe-type-tools/cmap-resources
 	  <script src="{{ url_for('static', filename='js/libs/pdf.mjs') }}" type="module"></script>
 
     <script type="text/javascript">
-    window.addEventListener('webviewerloaded', function() {
+    (function () {
+      function configureViewer() {
         PDFViewerApplicationOptions.set('disableAutoFetch', true);
         PDFViewerApplicationOptions.set('disableRange', false);
         PDFViewerApplicationOptions.set('disableStream', true);
@@ -49,7 +50,29 @@ See https://github.com/adobe-type-tools/cmap-resources
         PDFViewerApplicationOptions.set('imageResourcesPath', "{{ url_for('static', filename='css/images/') }}");
         PDFViewerApplicationOptions.set('workerSrc', "{{ url_for('static', filename='js/libs/pdf.worker.mjs') }}");
         PDFViewerApplicationOptions.set('defaultUrl',"{{ url_for('web.serve_book', book_id=pdffile, book_format='pdf') }}")
-    });
+      }
+
+      // pdf.js fires 'webviewerloaded' on parent.document whenever it can reach
+      // it — that is its hook for an embedding page — and only falls back to its
+      // own document when the parent is cross-origin. Embedded same-origin (the
+      // new UI's reader iframe) the event therefore never arrives here, every
+      // option above was skipped, and the viewer fell back to its packaged
+      // default workerSrc of '../build/pdf.worker.mjs', which this app does not
+      // ship. The worker 404'd, the fake-worker fallback 404'd with it, and the
+      // document rendered zero pages. Listen wherever the event will actually be
+      // delivered. `once` keeps a long-lived parent (the SPA shell) from
+      // accumulating a handler per PDF opened.
+      var target = document;
+      try {
+        if (window.parent && window.parent !== window && window.parent.document) {
+          target = window.parent.document;
+        }
+      } catch (e) { /* cross-origin parent: pdf.js will dispatch on our document */ }
+      target.addEventListener('webviewerloaded', configureViewer, { once: true });
+      if (target !== document) {
+        document.addEventListener('webviewerloaded', configureViewer, { once: true });
+      }
+    })();
     </script>
 
     <script src="{{ url_for('static', filename='js/libs/viewer.mjs') }}" type="module"></script>

--- a/cps/templates/readpdf.html
+++ b/cps/templates/readpdf.html
@@ -41,6 +41,11 @@ See https://github.com/adobe-type-tools/cmap-resources
     <script type="text/javascript">
     (function () {
       function configureViewer() {
+        // Delivered on a shared target (see below), so this can be woken by a
+        // sibling viewer's load before our own script has run. Setting options
+        // that do not exist yet would throw and, worse, consume the one-shot
+        // registration — leaving this viewer unconfigured. Wait for the next.
+        if (typeof PDFViewerApplicationOptions === 'undefined') { return; }
         PDFViewerApplicationOptions.set('disableAutoFetch', true);
         PDFViewerApplicationOptions.set('disableRange', false);
         PDFViewerApplicationOptions.set('disableStream', true);
@@ -50,6 +55,12 @@ See https://github.com/adobe-type-tools/cmap-resources
         PDFViewerApplicationOptions.set('imageResourcesPath', "{{ url_for('static', filename='css/images/') }}");
         PDFViewerApplicationOptions.set('workerSrc', "{{ url_for('static', filename='js/libs/pdf.worker.mjs') }}");
         PDFViewerApplicationOptions.set('defaultUrl',"{{ url_for('web.serve_book', book_id=pdffile, book_format='pdf') }}")
+        // Configured — stop listening. Done here rather than with `once` so an
+        // early wake-up above does not spend the registration.
+        target.removeEventListener('webviewerloaded', configureViewer);
+        if (target !== document) {
+          document.removeEventListener('webviewerloaded', configureViewer);
+        }
       }
 
       // pdf.js fires 'webviewerloaded' on parent.document whenever it can reach
@@ -60,17 +71,19 @@ See https://github.com/adobe-type-tools/cmap-resources
       // default workerSrc of '../build/pdf.worker.mjs', which this app does not
       // ship. The worker 404'd, the fake-worker fallback 404'd with it, and the
       // document rendered zero pages. Listen wherever the event will actually be
-      // delivered. `once` keeps a long-lived parent (the SPA shell) from
-      // accumulating a handler per PDF opened.
+      // delivered — and, when that is the parent, on our own document too, since
+      // pdf.js falls back there if reaching the parent ever fails. The handler
+      // unregisters itself once it has configured a viewer, so a long-lived
+      // parent (the SPA shell) does not accumulate a handler per PDF opened.
       var target = document;
       try {
         if (window.parent && window.parent !== window && window.parent.document) {
           target = window.parent.document;
         }
       } catch (e) { /* cross-origin parent: pdf.js will dispatch on our document */ }
-      target.addEventListener('webviewerloaded', configureViewer, { once: true });
+      target.addEventListener('webviewerloaded', configureViewer);
       if (target !== document) {
-        document.addEventListener('webviewerloaded', configureViewer, { once: true });
+        document.addEventListener('webviewerloaded', configureViewer);
       }
     })();
     </script>

--- a/frontend/e2e/reader-pdf-viewer.spec.ts
+++ b/frontend/e2e/reader-pdf-viewer.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect, Page } from '@playwright/test';
+
+/*
+ * #1584 — "New UI: PDF on iPad won't be displayed completely": opening any PDF
+ * showed its first page and nothing else. iPadOS only, new UI only.
+ *
+ * The reader pointed its <iframe> at the raw file (/show/<id>/pdf) and left the
+ * rendering to whatever PDF viewer the engine ships. Every browser on iOS and
+ * iPadOS is WebKit underneath, and WebKit renders a single page when its native
+ * PDF view is embedded in a subframe. That is exactly the matrix the reporter
+ * measured: broken on iPadOS Safari AND Firefox, fine on macOS and Android, and
+ * fine in the classic UI — which has always rendered PDFs with the bundled
+ * pdf.js instead of the native viewer.
+ *
+ * The fix stops depending on a native viewer at all: the reader now embeds the
+ * same pdf.js page the classic UI uses (/read/<id>/pdf), which paints to
+ * <canvas> and behaves identically on every engine. The reporter's own testing
+ * is the evidence that this works on their hardware — they confirmed the classic
+ * UI, i.e. this same viewer, renders correctly on the same iPad.
+ *
+ * Chromium renders raw-PDF iframes fine, so the iPadOS symptom itself cannot be
+ * reproduced in this harness — the same shape as #716 in download.spec.ts. The
+ * guard is therefore the contract that actually broke, in two halves: the reader
+ * must hand the file to pdf.js, and pdf.js must paint more than one page.
+ */
+
+async function pdfBookId(page: Page): Promise<number> {
+  const res = await page.request.get('/api/v1/books?per_page=200');
+  expect(res.ok(), `/api/v1/books returned ${res.status()}`).toBeTruthy();
+  const { items } = await res.json();
+  const book = (items ?? []).find((b: { formats?: string[] }) =>
+    (b.formats ?? []).some((f) => String(f).toLowerCase() === 'pdf'));
+  // Deliberately not test.skip(): a seed with no PDF would turn this guard into
+  // a silent no-op, which is how the regression comes back unnoticed.
+  expect(book, 'the e2e library seed must contain a book with a PDF format').toBeTruthy();
+  return book.id;
+}
+
+test('the PDF reader embeds pdf.js, not the engine\'s native viewer (#1584)', async ({ page }) => {
+  const id = await pdfBookId(page);
+  await page.goto(`/app/view/${id}/pdf`);
+
+  const frame = page.locator('iframe').first();
+  await expect(frame).toBeVisible();
+  // Matched at the end so the subpath project (/<prefix>/read/<id>/pdf) passes
+  // too. A src of /show/<id>/pdf — the raw file — is the pre-fix state.
+  await expect(frame).toHaveAttribute('src', new RegExp(`/read/${id}/pdf$`));
+});
+
+test('pdf.js paints every page, not just the first (#1584)', async ({ page }) => {
+  const id = await pdfBookId(page);
+  await page.goto(`/app/view/${id}/pdf`);
+
+  const viewer = page.frameLocator('iframe');
+  await expect(viewer.locator('#viewerContainer')).toBeVisible({ timeout: 20_000 });
+
+  // The reported symptom was "only the first page is visible". pdf.js builds a
+  // .page node per page as soon as the document loads, so a multi-page fixture
+  // has to produce more than one of them.
+  await expect
+    .poll(() => viewer.locator('#viewer.pdfViewer .page').count(), { timeout: 20_000 })
+    .toBeGreaterThan(1);
+});

--- a/frontend/src/pages/NativeReader.tsx
+++ b/frontend/src/pages/NativeReader.tsx
@@ -11,14 +11,22 @@ import styles from './NativeReader.module.css';
 const AUDIO = new Set(['mp3', 'm4a', 'm4b', 'flac', 'ogg', 'opus', 'wav', 'aac']);
 const COMIC = new Set(['cbz', 'cbr', 'cbt']);
 
-/** Native in-browser reader for non-EPUB formats. PDF renders in the browser's
- *  built-in viewer (iframe), audiobooks in an <audio> player, plain text inline
- *  — all dependency-free. EPUB/KEPUB use the dedicated epub.js reader; comics
- *  and DjVu fall back to the server reader (image extraction needs server help). */
+/** Native in-browser reader for non-EPUB formats. PDF renders through the
+ *  bundled pdf.js viewer (iframe), audiobooks in an <audio> player, plain text
+ *  inline — all dependency-free. EPUB/KEPUB use the dedicated epub.js reader;
+ *  comics and DjVu fall back to the server reader (image extraction needs
+ *  server help). */
 export function NativeReader({ id, format }: { id: string; format: string }) {
   const t = useT();
   const fmt = format.toLowerCase();
   const src = apiUrl(`/show/${id}/${fmt}`);
+  // #1584 — never hand a PDF to the browser's native viewer. WebKit, which is
+  // every browser on iOS and iPadOS, renders only the first page of a PDF
+  // embedded in a subframe, so pointing this iframe at the raw file showed page
+  // one and nothing else on iPad. The bundled pdf.js viewer (what the classic
+  // reader has always used) paints to <canvas> and behaves the same on every
+  // engine. url_for inside that template keeps it correct behind a subpath.
+  const pdfSrc = apiUrl(`/read/${id}/pdf`);
   const [text, setText] = useState<string | null>(null);
   const [textErr, setTextErr] = useState(false);
 
@@ -44,7 +52,7 @@ export function NativeReader({ id, format }: { id: string; format: string }) {
 
       <div className={styles.body}>
         {fmt === 'pdf' && (
-          <iframe className={styles.pdf} src={src} title={t('PDF reader')} />
+          <iframe className={styles.pdf} src={pdfSrc} title={t('PDF reader')} />
         )}
 
         {AUDIO.has(fmt) && (

--- a/tests/fixtures/sample_books/three_page_sample.pdf
+++ b/tests/fixtures/sample_books/three_page_sample.pdf
@@ -1,0 +1,54 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R 4 0 R 5 0 R] /Count 3 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 6 0 R >> >> /Contents 7 0 R >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 6 0 R >> >> /Contents 8 0 R >>
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 6 0 R >> >> /Contents 9 0 R >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+7 0 obj
+<< /Length 42 >>
+stream
+BT /F1 24 Tf 72 700 Td (Page 1 of 3) Tj ET
+endstream
+endobj
+8 0 obj
+<< /Length 42 >>
+stream
+BT /F1 24 Tf 72 700 Td (Page 2 of 3) Tj ET
+endstream
+endobj
+9 0 obj
+<< /Length 42 >>
+stream
+BT /F1 24 Tf 72 700 Td (Page 3 of 3) Tj ET
+endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000127 00000 n 
+0000000253 00000 n 
+0000000379 00000 n 
+0000000505 00000 n 
+0000000575 00000 n 
+0000000667 00000 n 
+0000000759 00000 n 
+trailer
+<< /Size 10 /Root 1 0 R >>
+startxref
+851
+%%EOF


### PR DESCRIPTION
Ships fix for #1584. Reported by @chloeroform, whose report already contained the diagnosis — the matrix below is theirs, not mine.

## Why

Opening a PDF in the new UI showed page one and nothing else. Only on iPadOS, only in the new UI.

| Surface | Result |
|---|---|
| iPadOS 26.6, Safari **and** Firefox | broken |
| macOS 26.5, Safari and Firefox | fine |
| Android 17, Firefox | fine |
| Classic UI, iPadOS | fine |

Two facts in that table do the work. Safari and Firefox failing *together* on iPadOS but not elsewhere means the engine, not the browser — every iOS/iPadOS browser is WebKit underneath. And the classic UI being fine on the same iPad means the file and the device are not the problem, the viewer is.

## Root cause

`NativeReader.tsx` pointed the reader's `<iframe>` at the raw file (`/show/<id>/pdf`) and left rendering to whatever PDF viewer the engine ships. WebKit draws a single page when its native PDF view is embedded in a subframe. The classic UI never hit this because it has always rendered PDFs with the bundled pdf.js.

The reader now embeds that same pdf.js page (`/read/<id>/pdf`), which paints to `<canvas>` and behaves the same on every engine.

### A second defect underneath it

Making that change alone produced a viewer that rendered **zero** pages, so this shipped as one fix rather than two.

pdf.js dispatches `webviewerloaded` on `parent.document` whenever it can reach it — that is its documented hook for an embedding page — and falls back to its own document only when the parent is cross-origin. Embedded same-origin, the viewer's own listener in `readpdf.html` never fired, so **every** `PDFViewerApplicationOptions.set()` in that template was silently skipped: `workerSrc`, `cMapUrl`, `imageResourcesPath`, `defaultUrl`, the `disable*` flags. The viewer fell back to its packaged default `workerSrc` of `../build/pdf.worker.mjs`, a path this app does not ship; the worker 404'd, the fake-worker fallback 404'd with it, and the document rendered nothing.

`readpdf.html` now registers the listener where the event is actually delivered. That makes the classic viewer embeddable in general rather than special-casing this one caller, and leaves the config in the template as the single source of truth rather than restating those URLs in the SPA.

## Verification

Measured on a container serving this branch, book 18 (3-page PDF), pre-fix state measured on the same container as control:

| | pages | `workerSrc` | `cMapUrl` | annotations | console |
|---|---|---|---|---|---|
| Embedded, pre-fix | **0** | `../build/pdf.worker.mjs` (default) | default | — | `Setting up fake worker failed` |
| Embedded, post-fix | **3** | `/static/js/libs/pdf.worker.mjs` | applied | set | clean |
| Classic top-level, post-fix | **3** | `/static/js/libs/pdf.worker.mjs` | applied | set | clean |

Red/green: `frontend/e2e/reader-pdf-viewer.spec.ts`, two specs, red on `main` for the right reason — the first reporting the observed `<iframe src="/show/18/pdf">`, the second finding no pdf.js viewer at all. Both green after, on desktop **and** mobile.

Full SPA e2e suite: 373 passed. 21 failures are pre-existing in my local rig and untouched by this change — light-theme contrast on sidebar/shelf elements, the epub reader, tag typeahead, ratings, device manager. That rig pairs a current-`main` SPA with a two-day-old backend image, and CI is green on the same specs at `f0458d1d`. Nothing in this diff can reach those routes.

Verified UI-side rather than assumed: the embedded viewer renders the pdf.js toolbar with find, thumbnails, page `1 of 3` and the annotations base wired, inside the SPA's own close bar, with no doubled chrome.

**Honestly assumed, not observed:** I have no iPad, so I did not watch the fix work on iPadOS. What makes it more than a guess is that the reporter already verified the destination — they confirmed the classic UI, which is this exact viewer, renders correctly on the same device. The change replaces the engine-dependent path with the one they proved works.

## Does this answer what they asked for?

They wanted to read a PDF on their iPad. They now get every page, plus text search, thumbnails and annotations, which the native viewer never offered. The whole report is covered; nothing was deferred.

## CI

The e2e leg overlays the head commit's SPA onto a `:dev` container but left templates at `:dev`, so it was blind to server-rendered surfaces. This fix spans both halves, and its guard would have failed on a correct PR and passed once merged — which is how a guard gets deleted. The overlay now copies templates too, with a `/login` probe so a template referencing something the older API lacks fails loudly at that step.

## Rules

No new dependency, licence, route or external service URL — pdf.js is already vendored and already served (rule 6 clear). Fork-original; `CHANGES-vs-upstream.md` row follows with the squash SHA.