### PR TITLE
chore(cps): move `cps` `main()` logic into `cps/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Changed
+
+- **Running it outside Docker no longer means hunting down `cps.py`.** If you
+  install Calibre-Web NextGen as a Python package — packaging it for a distro,
+  running it under systemd, or just off a checkout — you can now start it with
+  `python -m cps`, the ordinary way to start a Python application. Starting it
+  by the path to `cps.py` still works and is unchanged, so nothing you have set
+  up needs touching. Thanks to @chloeroform.
+
 ### Fixed
 
 - **Metadata and cover enforcement no longer stops until the next restart if the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **A first start that fails no longer leaves you with a server you can't log
+  in to.** If creating the settings database failed on first run, startup went
+  on to create an empty one anyway. That empty file looked like an existing
+  install on the next boot, so the step that creates your admin account was
+  skipped and there was no way in — and no way to retry, because the file now
+  existed. The failure is now reported and the empty file is never created, so
+  the next start tries again properly.
+
 - **Metadata and cover enforcement no longer stops until the next restart if the
   enforcer is killed.** The enforcer takes a lock so two copies can't run over
   each other, and released it only on a clean exit. If it was killed instead —

--- a/cps.py
+++ b/cps.py
@@ -14,8 +14,9 @@ import sys
 path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, path)
 
-from cps.main import main
+from cps.main import hide_console_windows, main
 
 
 if __name__ == '__main__':
+    hide_console_windows()
     main()

--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
-__package__ = "cps"
-
 import sys
 import os
 import mimetypes

--- a/cps/__main__.py
+++ b/cps/__main__.py
@@ -6,14 +6,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
-import os
-import sys
-
-
-# Add local path to sys.path, so we can import cps
-path = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, path)
-
 from cps.main import main
 
 

--- a/cps/__main__.py
+++ b/cps/__main__.py
@@ -6,8 +6,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
-from cps.main import main
+from cps.main import hide_console_windows, main
 
 
 if __name__ == '__main__':
+    hide_console_windows()
     main()

--- a/cps/cli.py
+++ b/cps/cli.py
@@ -41,8 +41,14 @@ class CliParameter(object):
         self.arg_parser()
 
     def arg_parser(self):
+        # prog is pinned because argparse otherwise derives it from
+        # basename(sys.argv[0]) -- which under `python -m cps` is the literal
+        # `__main__.py`. `cps` is the one name that reads correctly for both
+        # the module invocation the container uses and the cps.py script that
+        # bare-metal installs still call.
         parser = argparse.ArgumentParser(description='Calibre-Web NextGen is a web app providing '
-                                                     'a interface for browsing, reading and downloading eBooks\n')
+                                                     'a interface for browsing, reading and downloading eBooks\n',
+                                         prog='cps')
         parser.add_argument('-p', metavar='path', help='path and name to settings db, e.g. /opt/cw.db')
         parser.add_argument('-g', metavar='path', help='path and name to gdrive db, e.g. /opt/gd.db')
         parser.add_argument('-c', metavar='path', help='path and name to SSL certfile, '

--- a/cps/cli.py
+++ b/cps/cli.py
@@ -42,8 +42,7 @@ class CliParameter(object):
 
     def arg_parser(self):
         parser = argparse.ArgumentParser(description='Calibre-Web NextGen is a web app providing '
-                                                     'a interface for browsing, reading and downloading eBooks\n',
-                                         prog='cps.py')
+                                                     'a interface for browsing, reading and downloading eBooks\n')
         parser.add_argument('-p', metavar='path', help='path and name to settings db, e.g. /opt/cw.db')
         parser.add_argument('-g', metavar='path', help='path and name to gdrive db, e.g. /opt/gd.db')
         parser.add_argument('-c', metavar='path', help='path and name to SSL certfile, '

--- a/cps/main.py
+++ b/cps/main.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
+import os
 import sys
 
 from . import create_app, limiter
@@ -16,7 +17,23 @@ def request_username():
     return request.authorization.username
 
 
+def hide_console_windows():
+    import ctypes
+
+    kernel32 = ctypes.WinDLL('kernel32')
+    user32 = ctypes.WinDLL('user32')
+
+    SW_HIDE = 0
+
+    hWnd = kernel32.GetConsoleWindow()
+    if hWnd:
+        user32.ShowWindow(hWnd, SW_HIDE)
+
+
 def main():
+    if os.name == "nt":
+        hide_console_windows()
+
     app = create_app()
 
     from .cwa_functions import switch_theme, library_refresh, convert_library, epub_fixer, cover_enforcer_ui, cwa_stats, cwa_check_status, cwa_settings, cwa_logs, profile_pictures, cwa_internal

--- a/cps/main.py
+++ b/cps/main.py
@@ -18,6 +18,16 @@ def request_username():
 
 
 def hide_console_windows():
+    """Hide the console window on Windows. No-op everywhere else.
+
+    Call this from a script entry point, never from main(). main() is also the
+    `cps` console script (pyproject [project.scripts]), and a Windows user who
+    types `cps` in a terminal wants that terminal: hiding it takes their server
+    output and their Ctrl-C with it while the process keeps running.
+    """
+    if os.name != "nt":
+        return
+
     import ctypes
 
     kernel32 = ctypes.WinDLL('kernel32')
@@ -31,9 +41,6 @@ def hide_console_windows():
 
 
 def main():
-    if os.name == "nt":
-        hide_console_windows()
-
     app = create_app()
 
     from .cwa_functions import switch_theme, library_refresh, convert_library, epub_fixer, cover_enforcer_ui, cwa_stats, cwa_check_status, cwa_settings, cwa_logs, profile_pictures, cwa_internal

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -79,16 +79,34 @@ if [[ ! -f /config/app.db ]]; then
   if ! cwa-as-abc python3 -P -m cps -d > /dev/null 2>&1; then
     echo "[cwa-init] ERROR: could not create app.db (python3 -P -m cps -d failed)"
   fi
-  # handle app.db updates for kepubify and ext binary path
-  # borrowed from crocodilestick because it's a better solution than what i was doing
-  sqlite3 /config/app.db <<EOS
+
+  # Only touch app.db if the initializer actually produced one.
+  #
+  # sqlite3 CREATES the file it is pointed at, so running it after a failed
+  # init manufactures a 0-byte /config/app.db out of nothing. That is worse
+  # than the missing file it replaces: cps.ub.init_db() branches on
+  # os.path.exists(), and the existing-file branch runs migrations while the
+  # fresh-database branch is the one that calls create_admin_user() and
+  # create_anonymous_user(). A phantom app.db therefore yields a server with a
+  # schema, no admin account and no way to log in -- and because the file now
+  # exists, this block never runs again to retry.
+  #
+  # Leaving the path absent keeps first-run recoverable: the next start takes
+  # the first-run path again.
+  if [[ -f /config/app.db ]]; then
+    # handle app.db updates for kepubify and ext binary path
+    # borrowed from crocodilestick because it's a better solution than what i was doing
+    sqlite3 /config/app.db <<EOS
     update settings set config_kepubifypath='/usr/bin/kepubify' where config_kepubifypath is NULL or LENGTH(config_kepubifypath)=0;
 EOS
-
-  if [[ $? == 0 ]]; then
-    echo "Successfully set kepubify paths in '/config/app.db'!"
-  elif [[ $? > 0 ]]; then
-    echo "Could not set binary paths for '/config/app.db' (see errors above)."
+    # Captured immediately: the old `elif [[ $? > 0 ]]` re-read $? from the
+    # preceding [[ ]], not from sqlite3, and compared it as a string.
+    sqlite_rc=$?
+    if [[ $sqlite_rc -eq 0 ]]; then
+      echo "Successfully set kepubify paths in '/config/app.db'!"
+    else
+      echo "Could not set binary paths for '/config/app.db' (see errors above)."
+    fi
   fi
 fi
 
@@ -211,18 +229,25 @@ fi
 #  Ensure correct binary paths in app.db
 #------------------------------------------------------------------------------------------------------------------------
 
-echo "[cwa-init] Setting binary paths in '/config/app.db' to the correct ones..."
+# Same guard as the first-run block above, and this is the call that actually
+# needed it: this one runs on EVERY start, so a failed first run reaches it
+# with no /config/app.db and sqlite3 creates a 0-byte one. Guarding only the
+# first-run block would have achieved nothing.
+if [[ -f /config/app.db ]]; then
+    echo "[cwa-init] Setting binary paths in '/config/app.db' to the correct ones..."
 
-sqlite3 /config/app.db <<EOS
+    sqlite3 /config/app.db <<EOS
     update settings set config_kepubifypath='/usr/bin/kepubify', config_converterpath='/usr/bin/ebook-convert', config_binariesdir='/usr/bin';
 EOS
+    sqlite_rc=$?
 
-if [[ $? == 0 ]]
-then
-    echo "[cwa-init] Successfully set binary paths in '/config/app.db'!"
-elif [[ $? > 0 ]]
-then
-    echo "[cwa-init] Service could not successfully set binary paths for '/config/app.db' (see errors above)."
+    if [[ $sqlite_rc -eq 0 ]]; then
+        echo "[cwa-init] Successfully set binary paths in '/config/app.db'!"
+    else
+        echo "[cwa-init] Service could not successfully set binary paths for '/config/app.db' (see errors above)."
+    fi
+else
+    echo "[cwa-init] No '/config/app.db' to configure — first-run initialization did not produce one."
 fi
 
 #------------------------------------------------------------------------------------------------------------------------

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -68,7 +68,17 @@ export CALIBRE_DBPATH=/config
 
 if [[ ! -f /config/app.db ]]; then
   echo "First time run, creating app.db..."
-  cwa-as-abc python3 -m cps -d > /dev/null 2>&1
+  # -P for the same reason as svc-calibre-web-automated: cwd here is /config,
+  # a user-writable volume, and `python -m` would otherwise import a stray
+  # /config/cps.py or /config/cps/ instead of the application.
+  #
+  # The failure is reported rather than swallowed. stdout stays discarded (the
+  # first-run banner is noise), but with the output going to /dev/null a failed
+  # app.db creation used to surface only as the sqlite3 call below failing
+  # against a database that was never made -- which names the wrong cause.
+  if ! cwa-as-abc python3 -P -m cps -d > /dev/null 2>&1; then
+    echo "[cwa-init] ERROR: could not create app.db (python3 -P -m cps -d failed)"
+  fi
   # handle app.db updates for kepubify and ext binary path
   # borrowed from crocodilestick because it's a better solution than what i was doing
   sqlite3 /config/app.db <<EOS

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -68,7 +68,7 @@ export CALIBRE_DBPATH=/config
 
 if [[ ! -f /config/app.db ]]; then
   echo "First time run, creating app.db..."
-  cd /app/calibre-web-automated && cwa-as-abc python3 /app/calibre-web-automated/cps.py -d > /dev/null 2>&1
+  cwa-as-abc python3 -m cps -d > /dev/null 2>&1
   # handle app.db updates for kepubify and ext binary path
   # borrowed from crocodilestick because it's a better solution than what i was doing
   sqlite3 /config/app.db <<EOS

--- a/root/etc/s6-overlay/s6-rc.d/svc-calibre-web-automated/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-calibre-web-automated/run
@@ -11,4 +11,4 @@ export CALIBRE_DBPATH=/config
 
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${CWA_PORT_OVERRIDE:-8083}" \
-        cd /app/calibre-web-automated cwa-as-abc python3 /app/calibre-web-automated/cps.py
+        cwa-as-abc python3 -m cps

--- a/root/etc/s6-overlay/s6-rc.d/svc-calibre-web-automated/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-calibre-web-automated/run
@@ -9,6 +9,13 @@ echo "[svc-calibre-web-automated] Starting Calibre-Web server on port ${CWA_PORT
 
 export CALIBRE_DBPATH=/config
 
+# -P keeps the current directory off sys.path. This unit no longer chdirs into
+# the app root, so it inherits cwd /config (the Dockerfile WORKDIR) -- and
+# /config is a volume the user mounts and writes. `python -m` puts cwd at
+# sys.path[0], so without -P a stray /config/cps.py or /config/cps/ is imported
+# in place of the application and the server never starts. The package itself
+# resolves from anywhere because the image installs it editable (Dockerfile
+# STEP 6), which is what makes dropping the chdir safe in the first place.
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${CWA_PORT_OVERRIDE:-8083}" \
-        cwa-as-abc python3 -m cps
+        cwa-as-abc python3 -P -m cps

--- a/tests/unit/test_1596_module_entry_point.py
+++ b/tests/unit/test_1596_module_entry_point.py
@@ -14,13 +14,20 @@ installs the package editable (Dockerfile STEP 6,
 cwd. The container's own working directory is ``/config``, not the app root,
 so nothing else was holding that invocation up.
 
-That makes the entry point a real contract with two halves and no coverage:
+Dropping the chdir has a second consequence the units now guard with ``-P``:
+``python -m`` puts the cwd at ``sys.path[0]``, and the cwd here is ``/config``
+-- a volume the *user* mounts and writes. A stray ``/config/cps.py`` or
+``/config/cps/`` would be imported in place of the application. Verified: both
+forms hijack startup without ``-P`` and are ignored with it.
+
+That makes the entry point a real contract with three halves and no coverage:
 
 1. ``python -m cps`` must work **from an arbitrary cwd**. Testing it from the
    repo root would pass even if the editable install were the only thing
    making it work in production, so every test here runs from ``tmp_path``.
 2. ``cps.py`` must keep working, because bare-metal and systemd installs (and
    ``AI_README.md``) still invoke it by path.
+3. The cwd must not be able to supply the ``cps`` that gets imported.
 
 Without a pin, a later edit can silently restore cwd-dependence or drop
 ``__main__.py`` and the failure only shows up as a container that will not
@@ -28,6 +35,7 @@ boot — and in ``cwa-init`` it would not even be visible, since that call
 redirects to ``/dev/null``.
 """
 
+import ast
 import subprocess
 import sys
 from pathlib import Path
@@ -56,6 +64,16 @@ def _run_help(args, cwd):
     )
 
 
+def _poison(directory):
+    """Drop a cps.py in `directory` that fails loudly if it ever gets imported.
+
+    Stands in for whatever a user might leave in their mounted /config.
+    """
+    (directory / "cps.py").write_text(
+        'raise SystemExit("shadowed: the cwd copy of cps was imported")\n'
+    )
+
+
 class TestModuleEntryPoint:
     """`python -m cps` — what the s6 longrun actually execs."""
 
@@ -65,11 +83,11 @@ class TestModuleEntryPoint:
         cwd is tmp_path on purpose. The s6 unit no longer chdirs into the app
         root, so resolving `cps` from somewhere else is the whole contract.
         """
-        result = _run_help(["-m", "cps"], cwd=tmp_path)
+        result = _run_help(["-P", "-m", "cps"], cwd=tmp_path)
 
         assert result.returncode == 0, (
-            "`python -m cps --help` must succeed from an arbitrary cwd; the s6 "
-            f"longrun runs it with cwd=/config.\nstderr:\n{result.stderr}"
+            "`python -P -m cps --help` must succeed from an arbitrary cwd; the s6 "
+            f"longrun runs exactly that with cwd=/config.\nstderr:\n{result.stderr}"
         )
         assert "usage:" in result.stdout.lower(), (
             f"expected argparse usage on stdout, got:\n{result.stdout!r}"
@@ -83,7 +101,7 @@ class TestModuleEntryPoint:
         without replacing it, so the invocation the PR *promotes* printed the
         least useful name of the three.
         """
-        usage = _run_help(["-m", "cps"], cwd=tmp_path).stdout.splitlines()[0]
+        usage = _run_help(["-P", "-m", "cps"], cwd=tmp_path).stdout.splitlines()[0]
 
         assert "__main__" not in usage, (
             f"--help must not call the program __main__.py; got: {usage!r}"
@@ -105,15 +123,89 @@ class TestModuleEntryPoint:
         assert "usage:" in result.stdout.lower()
 
 
+class TestCwdCannotShadowTheApplication:
+    """/config is a user-mounted volume and it is the service's cwd."""
+
+    def test_minus_P_ignores_a_cps_py_sitting_in_the_cwd(self, tmp_path):
+        """The guard that lets the units run without chdir'ing into the app root."""
+        _poison(tmp_path)
+
+        result = _run_help(["-P", "-m", "cps"], cwd=tmp_path)
+
+        assert result.returncode == 0, (
+            "-P must keep cwd off sys.path so a stray /config/cps.py cannot be "
+            f"imported in place of the app.\nstderr:\n{result.stderr}"
+        )
+        assert "shadowed" not in result.stderr.lower()
+
+    def test_without_minus_P_the_cwd_copy_wins(self, tmp_path):
+        """Control: proves the -P above is load-bearing, not decoration.
+
+        If this ever stops shadowing, the guard is being kept for a hazard that
+        no longer exists and the test above has quietly stopped proving anything.
+        """
+        _poison(tmp_path)
+
+        result = _run_help(["-m", "cps"], cwd=tmp_path)
+
+        assert result.returncode != 0 and "shadowed" in result.stderr.lower(), (
+            "expected the cwd copy of cps to win without -P; if it no longer "
+            f"does, revisit why the units pass -P.\nstderr:\n{result.stderr}"
+        )
+
+
+class TestConsoleHidingStaysOutOfMain:
+    """`cps` (the console script) must not hide a Windows user's terminal.
+
+    pyproject exposes ``cps = "cps.main:main"``, so anything main() does on
+    import-and-call happens to someone who just typed ``cps`` at a prompt.
+    Hiding their console loses the server output and their Ctrl-C while the
+    process keeps running. Only the two *script* entry points hide it, which is
+    what cps.py did before #1596 moved the call into main().
+    """
+
+    def _main_fn(self):
+        tree = ast.parse((REPO_ROOT / "cps" / "main.py").read_text())
+        return next(
+            n for n in tree.body
+            if isinstance(n, ast.FunctionDef) and n.name == "main"
+        )
+
+    def test_main_does_not_hide_the_console(self):
+        calls = [
+            n.func.id
+            for n in ast.walk(self._main_fn())
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        ]
+
+        assert "hide_console_windows" not in calls, (
+            "main() is the `cps` console-script entry point; hiding the console "
+            "there hits users who invoked it from a terminal on purpose."
+        )
+
+    @pytest.mark.parametrize(
+        "entry", [REPO_ROOT / "cps.py", REPO_ROOT / "cps" / "__main__.py"],
+        ids=["cps.py", "cps/__main__.py"],
+    )
+    def test_script_entry_points_still_hide_it(self, entry):
+        body = entry.read_text()
+
+        assert "hide_console_windows()" in body, (
+            f"{entry.name} must keep the Windows console-hiding behaviour that "
+            "cps.py had before the entry point moved."
+        )
+
+
 class TestS6UnitsUseTheModule:
     """Pin the boot command itself, so a revert cannot be silent."""
 
     @pytest.mark.parametrize("unit", [SVC_RUN, INIT_RUN], ids=["svc", "cwa-init"])
-    def test_unit_invokes_the_module(self, unit):
+    def test_unit_invokes_the_module_with_safe_path(self, unit):
         body = unit.read_text()
 
-        assert "python3 -m cps" in body, (
-            f"{unit.name} must start the app as a module; found:\n{body}"
+        assert "python3 -P -m cps" in body, (
+            f"{unit.name} must start the app as a module with -P; without it the "
+            f"unit's cwd (/config, user-writable) lands on sys.path[0].\nfound:\n{body}"
         )
 
     @pytest.mark.parametrize("unit", [SVC_RUN, INIT_RUN], ids=["svc", "cwa-init"])
@@ -130,5 +222,7 @@ class TestS6UnitsUseTheModule:
         """__main__.py stays a thin shim — the logic belongs in cps/main.py."""
         body = (REPO_ROOT / "cps" / "__main__.py").read_text()
 
-        assert "from cps.main import main" in body
+        assert "from cps.main import" in body, (
+            "__main__.py should import the entry point rather than reimplement it"
+        )
         assert "main()" in body

--- a/tests/unit/test_1596_module_entry_point.py
+++ b/tests/unit/test_1596_module_entry_point.py
@@ -1,0 +1,134 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""``python -m cps`` is the container's entry point — pin it.
+
+#1596 (by @chloeroform) moved ``main()`` into the package, added
+``cps/__main__.py``, and switched both s6 units from
+``cd /app/calibre-web-automated && python3 .../cps.py`` to a bare
+``python3 -m cps``. Dropping the ``cd`` is only safe because the image
+installs the package editable (Dockerfile STEP 6,
+``pip install -e /app/calibre-web-automated``), so ``cps`` imports from any
+cwd. The container's own working directory is ``/config``, not the app root,
+so nothing else was holding that invocation up.
+
+That makes the entry point a real contract with two halves and no coverage:
+
+1. ``python -m cps`` must work **from an arbitrary cwd**. Testing it from the
+   repo root would pass even if the editable install were the only thing
+   making it work in production, so every test here runs from ``tmp_path``.
+2. ``cps.py`` must keep working, because bare-metal and systemd installs (and
+   ``AI_README.md``) still invoke it by path.
+
+Without a pin, a later edit can silently restore cwd-dependence or drop
+``__main__.py`` and the failure only shows up as a container that will not
+boot — and in ``cwa-init`` it would not even be visible, since that call
+redirects to ``/dev/null``.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+S6 = REPO_ROOT / "root/etc/s6-overlay/s6-rc.d"
+SVC_RUN = S6 / "svc-calibre-web-automated/run"
+INIT_RUN = S6 / "cwa-init/run"
+
+# Long enough for a cold `import cps` (it builds the Flask app and logs
+# ProxyFix setup on the way past) without hanging a CI job if --help ever
+# stops short-circuiting.
+HELP_TIMEOUT = 120
+
+
+def _run_help(args, cwd):
+    """Invoke the app's --help out-of-process and return the CompletedProcess."""
+    return subprocess.run(
+        [sys.executable, *args, "--help"],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=HELP_TIMEOUT,
+    )
+
+
+class TestModuleEntryPoint:
+    """`python -m cps` — what the s6 longrun actually execs."""
+
+    def test_module_is_executable_from_an_unrelated_cwd(self, tmp_path):
+        """RED before #1596: 'No module named cps.__main__'.
+
+        cwd is tmp_path on purpose. The s6 unit no longer chdirs into the app
+        root, so resolving `cps` from somewhere else is the whole contract.
+        """
+        result = _run_help(["-m", "cps"], cwd=tmp_path)
+
+        assert result.returncode == 0, (
+            "`python -m cps --help` must succeed from an arbitrary cwd; the s6 "
+            f"longrun runs it with cwd=/config.\nstderr:\n{result.stderr}"
+        )
+        assert "usage:" in result.stdout.lower(), (
+            f"expected argparse usage on stdout, got:\n{result.stdout!r}"
+        )
+
+    def test_help_names_the_program_not_the_dunder_file(self, tmp_path):
+        """RED before the prog= fix: 'usage: __main__.py [-h] ...'.
+
+        argparse falls back to basename(sys.argv[0]), which under `-m` is the
+        package's __main__.py. #1596 dropped prog='cps.py' as no longer true
+        without replacing it, so the invocation the PR *promotes* printed the
+        least useful name of the three.
+        """
+        usage = _run_help(["-m", "cps"], cwd=tmp_path).stdout.splitlines()[0]
+
+        assert "__main__" not in usage, (
+            f"--help must not call the program __main__.py; got: {usage!r}"
+        )
+        assert "cps" in usage, f"--help should name the program cps; got: {usage!r}"
+
+    def test_legacy_script_entry_point_still_works(self, tmp_path):
+        """cps.py is retained for bare-metal/systemd installs — keep it working.
+
+        Run from tmp_path too: cps.py anchors sys.path to its own directory, so
+        it must not need the caller to be in the app root either.
+        """
+        result = _run_help([str(REPO_ROOT / "cps.py")], cwd=tmp_path)
+
+        assert result.returncode == 0, (
+            "cps.py must keep working; systemd units and AI_README.md invoke it "
+            f"by path.\nstderr:\n{result.stderr}"
+        )
+        assert "usage:" in result.stdout.lower()
+
+
+class TestS6UnitsUseTheModule:
+    """Pin the boot command itself, so a revert cannot be silent."""
+
+    @pytest.mark.parametrize("unit", [SVC_RUN, INIT_RUN], ids=["svc", "cwa-init"])
+    def test_unit_invokes_the_module(self, unit):
+        body = unit.read_text()
+
+        assert "python3 -m cps" in body, (
+            f"{unit.name} must start the app as a module; found:\n{body}"
+        )
+
+    @pytest.mark.parametrize("unit", [SVC_RUN, INIT_RUN], ids=["svc", "cwa-init"])
+    def test_unit_does_not_reintroduce_the_script_path(self, unit):
+        """The old form only worked because the unit chdir'd first."""
+        body = unit.read_text()
+
+        assert "calibre-web-automated/cps.py" not in body, (
+            f"{unit.name} still execs cps.py by path; that pairing needs the "
+            "`cd /app/calibre-web-automated` this change removed."
+        )
+
+    def test_main_module_delegates_to_cps_main(self):
+        """__main__.py stays a thin shim — the logic belongs in cps/main.py."""
+        body = (REPO_ROOT / "cps" / "__main__.py").read_text()
+
+        assert "from cps.main import main" in body
+        assert "main()" in body

--- a/tests/unit/test_1596_module_entry_point.py
+++ b/tests/unit/test_1596_module_entry_point.py
@@ -64,14 +64,31 @@ def _run_help(args, cwd):
     )
 
 
-def _poison(directory):
-    """Drop a cps.py in `directory` that fails loudly if it ever gets imported.
+_SHADOW = 'raise SystemExit("shadowed: the cwd copy of cps was imported")\n'
+
+# Both shapes a user can leave in their mounted /config. A module and a package
+# take different paths through the import system, and the package form is the
+# one a half-extracted archive or a stray checkout actually produces -- so
+# pinning only `cps.py` would leave the more likely accident uncovered.
+POISON_FORMS = ("module", "package")
+
+
+def _poison(directory, form="module"):
+    """Plant a `cps` in `directory` that fails loudly if it ever gets imported.
 
     Stands in for whatever a user might leave in their mounted /config.
     """
-    (directory / "cps.py").write_text(
-        'raise SystemExit("shadowed: the cwd copy of cps was imported")\n'
-    )
+    if form == "module":
+        (directory / "cps.py").write_text(_SHADOW)
+    elif form == "package":
+        package = directory / "cps"
+        package.mkdir()
+        (package / "__init__.py").write_text(_SHADOW)
+        # A package is only a viable hijack if `-m` can find an entry point,
+        # so give it the same one the real package has.
+        (package / "__main__.py").write_text(_SHADOW)
+    else:  # pragma: no cover - guards a typo in a parametrize list
+        raise ValueError(f"unknown poison form: {form}")
 
 
 class TestModuleEntryPoint:
@@ -126,31 +143,34 @@ class TestModuleEntryPoint:
 class TestCwdCannotShadowTheApplication:
     """/config is a user-mounted volume and it is the service's cwd."""
 
-    def test_minus_P_ignores_a_cps_py_sitting_in_the_cwd(self, tmp_path):
+    @pytest.mark.parametrize("form", POISON_FORMS)
+    def test_minus_P_ignores_a_cps_sitting_in_the_cwd(self, tmp_path, form):
         """The guard that lets the units run without chdir'ing into the app root."""
-        _poison(tmp_path)
+        _poison(tmp_path, form)
 
         result = _run_help(["-P", "-m", "cps"], cwd=tmp_path)
 
         assert result.returncode == 0, (
-            "-P must keep cwd off sys.path so a stray /config/cps.py cannot be "
-            f"imported in place of the app.\nstderr:\n{result.stderr}"
+            f"-P must keep cwd off sys.path so a stray /config/cps ({form} form) "
+            f"cannot be imported in place of the app.\nstderr:\n{result.stderr}"
         )
         assert "shadowed" not in result.stderr.lower()
 
-    def test_without_minus_P_the_cwd_copy_wins(self, tmp_path):
+    @pytest.mark.parametrize("form", POISON_FORMS)
+    def test_without_minus_P_the_cwd_copy_wins(self, tmp_path, form):
         """Control: proves the -P above is load-bearing, not decoration.
 
         If this ever stops shadowing, the guard is being kept for a hazard that
         no longer exists and the test above has quietly stopped proving anything.
         """
-        _poison(tmp_path)
+        _poison(tmp_path, form)
 
         result = _run_help(["-m", "cps"], cwd=tmp_path)
 
         assert result.returncode != 0 and "shadowed" in result.stderr.lower(), (
-            "expected the cwd copy of cps to win without -P; if it no longer "
-            f"does, revisit why the units pass -P.\nstderr:\n{result.stderr}"
+            f"expected the cwd copy of cps ({form} form) to win without -P; if "
+            f"it no longer does, revisit why the units pass -P.\n"
+            f"stderr:\n{result.stderr}"
         )
 
 
@@ -226,3 +246,106 @@ class TestS6UnitsUseTheModule:
             "__main__.py should import the entry point rather than reimplement it"
         )
         assert "main()" in body
+
+
+class TestFailedFirstRunLeavesNoPhantomDatabase:
+    """cwa-init must not invent an app.db the initializer failed to create.
+
+    `sqlite3 <path>` creates the file it is pointed at. Running it after a
+    failed `python3 -P -m cps -d` therefore replaces "no database" with a
+    0-byte one, and cps.ub.init_db() branches on os.path.exists(): the
+    existing-file branch migrates, and only the fresh branch calls
+    create_admin_user()/create_anonymous_user(). The user gets a schema with no
+    admin account, no login, and no retry -- the enclosing
+    `if [[ ! -f /config/app.db ]]` never fires again.
+    """
+
+    # Every sqlite3 call, not just the first-run one. The unconditional
+    # "ensure correct binary paths" call further down runs on EVERY start, so
+    # it is the one a failed first run actually reaches; guarding only the
+    # first-run block would leave the phantom database exactly as reachable.
+    GUARD = "if [[ -f /config/app.db ]]"
+
+    def test_every_sqlite3_call_is_guarded_on_the_database_existing(self):
+        lines = INIT_RUN.read_text().splitlines()
+
+        calls = [i for i, line in enumerate(lines) if "sqlite3 /config/app.db" in line]
+        assert calls, "expected cwa-init to touch app.db with sqlite3 at all"
+
+        unguarded = []
+        for index in calls:
+            # Walk back to the nearest enclosing app.db conditional.
+            preceding = [
+                line.strip()
+                for line in lines[:index]
+                if "/config/app.db ]]" in line
+            ]
+            if not preceding or not preceding[-1].startswith(self.GUARD):
+                unguarded.append(index + 1)
+
+        assert not unguarded, (
+            f"sqlite3 calls on lines {unguarded} of {INIT_RUN.name} are not "
+            f"inside an `{self.GUARD}` guard. sqlite3 creates the file it is "
+            "pointed at, so an unguarded call turns a failed first run into a "
+            "phantom 0-byte app.db — and cps.ub.init_db() then takes its "
+            "existing-database branch and never creates the admin user."
+        )
+
+    def test_sqlite3_status_is_captured_not_reread(self):
+        """`$?` after an `if [[ ]]` reports the test, not the command."""
+        body = INIT_RUN.read_text()
+
+        assert "sqlite_rc=$?" in body, (
+            "capture sqlite3's exit status immediately; the old "
+            "`elif [[ $? > 0 ]]` re-read $? from the preceding [[ ]] and "
+            "compared it as a string"
+        )
+        # Comments are stripped: the fix's own comment quotes the old form to
+        # explain it, and a test that cannot tell code from prose would fail on
+        # its own documentation.
+        code = "\n".join(
+            line for line in body.splitlines() if not line.strip().startswith("#")
+        )
+        assert "$? > 0" not in code, (
+            "the string-comparing rc check is back (shellcheck SC2071): `>` "
+            "inside [[ ]] compares strings, and $? there re-reads the "
+            "preceding test rather than the command"
+        )
+
+    def test_phantom_database_would_skip_admin_creation(self):
+        """Pins WHY the guard matters, so nobody 'simplifies' it away.
+
+        If init_db ever creates the admin user on both branches, this test
+        fails and the guard above can be reconsidered on purpose rather than
+        by accident.
+        """
+        source = (REPO_ROOT / "cps" / "ub.py").read_text()
+        tree = ast.parse(source)
+
+        init_db = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "init_db"
+        )
+        branch = next(
+            node
+            for node in init_db.body
+            if isinstance(node, ast.If)
+            and "exists" in ast.dump(node.test)
+        )
+
+        def calls(statements):
+            return {
+                n.func.id
+                for stmt in statements
+                for n in ast.walk(stmt)
+                if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            }
+
+        assert "create_admin_user" in calls(branch.orelse), (
+            "expected the fresh-database branch to create the admin user"
+        )
+        assert "create_admin_user" not in calls(branch.body), (
+            "init_db now creates an admin user even when app.db already "
+            "exists — re-evaluate the cwa-init phantom-database guard"
+        )


### PR DESCRIPTION
This is another step toward the bare-metal path: start CWNG by relying only on the Python package, without requiring additional external entry point scripts. Currently, external relies on the `cps.py` script to start CWNG.

This change moves the main logic from `cps.py` into `cps/`, where it more naturally belongs, and start CWNG using the more Pythonic `python -m cps` invocation instead of executing `cps.py` directly.

We keep the `cps.py` script for backward compatibility.

cc @Thovi98.