### PR TITLE
Stamp every imported book with the import time, not just the last (#1331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **Books you just imported now show up at the top of "Newest".** Drop several
+  books into the ingest folder at once and most of them landed somewhere in the
+  middle of the library instead of at the front, sorted as if they had been
+  added years ago. `calibredb` takes a book's "date added" from the file's own
+  metadata, which for most EPUBs is its publication date, so a 1998 novel
+  imported today was filed under 1998. That was already corrected on the way
+  in, but only for the last book of each batch — every other book in the same
+  run kept its publication date. All of them are stamped now. Existing books
+  keep the dates they have; this applies to imports from here on. Reported by
+  @jdaybell, and @Oakwhisper caught that the earlier tie-break fix, while real,
+  was not the whole cause.
+
 - **Reading on a Kobo now moves KOReader too.** Read a few chapters on the
   Kobo, open the same book in KOReader or a KOReader-based device, and it
   stayed wherever that device last was. The book page showed the Kobo's

--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -73,6 +73,18 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
   map, with a test that enumerates `cps/` so the next copy fails. `TBD`,
   release TBD.
 
+- **Every imported book gets the import time, not its publication date**
+  (fork #1331, second cause) — `calibredb add` derives `books.timestamp` from
+  the file's own metadata, which for most EPUBs is the publication date, so an
+  old novel imported today filed itself under its publication year and sat in
+  the middle of "Newest". `ingest_processor` already corrected this, but only
+  for `last_added_book_id`, while `_parse_added_book_ids` exists precisely
+  because one add can report several ids (`Added book ids: 4, 5`) — so every
+  book in a batch except the last kept a publication date. The correction moves
+  to `stamp_books_with_import_time()` over the whole batch. Needs no tie to
+  occur, which is why the total-order fix above did not cover it; @Oakwhisper
+  flagged that gap on the thread. `TBD`, release TBD.
+
 - **Amazon high-res covers reachable by ASIN, not only ISBN** (fork #304) — the
   CDN probe is edition-keyed and an ISBN-10 is just a print edition's ASIN, but
   only ISBNs were ever passed, so Kindle-only books were unreachable in both the

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -825,6 +825,50 @@ _ACSM_PLUGIN_RAN_GUIDANCE = (
 )
 
 
+def stamp_books_with_import_time(connection, book_ids, now=None):
+    """Set ``books.timestamp`` to the import time for every freshly added book.
+
+    ``calibredb add`` derives ``timestamp`` from the file's own metadata, which
+    for most EPUBs is the publication date and can be years old. Left alone, a
+    book imported today lands wherever its publication date falls in "Newest"
+    rather than at the top, which is fork #1331 as @Oakwhisper described it: one
+    book added that day, sitting in the middle of the list.
+
+    One ``calibredb add`` can report several ids — ``_parse_added_book_ids``
+    handles ``Added book ids: 4, 5`` precisely because that happens — so every
+    id from the run needs the same correction. Stamping only the last one leaves
+    the rest of the batch carrying publication dates, which is what made the
+    ordering look arbitrary rather than simply wrong.
+
+    :param connection: Open sqlite3 connection to ``metadata.db`` with the
+        ``title_sort`` function registered, since updating ``books`` fires a
+        trigger that calls it.
+    :param book_ids: The ids ``calibredb add`` reported. ``None`` entries and
+        duplicates are ignored; a non-integer id is skipped rather than raising.
+    :param now: Timestamp to write, in calibre's stored format. Defaults to the
+        current time.
+    :return: Number of rows updated.
+    """
+    ids = set()
+    for book_id in book_ids or []:
+        try:
+            ids.add(int(book_id))
+        except (TypeError, ValueError):
+            continue
+    if not ids:
+        return 0
+    if now is None:
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S+00:00")
+    ordered = sorted(ids)
+    placeholders = ",".join("?" * len(ordered))
+    cur = connection.cursor()
+    cur.execute(
+        "UPDATE books SET timestamp = ? WHERE id IN ({})".format(placeholders),
+        [now, *ordered],
+    )
+    return cur.rowcount
+
+
 def _acsm_plugin_failure_reason(converter_output):
     """The line where an ACSM plugin reported its own failure, or None.
 
@@ -1639,16 +1683,21 @@ class NewBookProcessor:
             # so they appear at the top of "Recently Added" views.
             # calibredb sets timestamp from EPUB metadata (publication date), which can be
             # years in the past, making new imports invisible in recently-added sorting.
-            if self.last_added_book_id is not None:
+            # Every id from this add, not just the last: one add can report
+            # several (see _parse_added_book_ids), and any id left unstamped
+            # keeps the publication date calibredb gave it (fork #1331).
+            imported_ids = self.last_added_book_ids or (
+                [self.last_added_book_id] if self.last_added_book_id is not None else []
+            )
+            if imported_ids:
                 try:
                     with sqlite3.connect(self.metadata_db, timeout=30) as con:
                         if not self._register_title_sort_function(con):
                             print("[ingest-processor] INFO: Skipping timestamp adjust (title_sort SQL function unavailable).", flush=True)
                         else:
-                            cur = con.cursor()
                             now = datetime.now().strftime("%Y-%m-%d %H:%M:%S+00:00")
-                            cur.execute('UPDATE books SET timestamp = ? WHERE id = ?', (now, self.last_added_book_id))
-                            print(f"[ingest-processor] INFO: Set timestamp to {now} for newly imported book id={self.last_added_book_id}.", flush=True)
+                            affected = stamp_books_with_import_time(con, imported_ids, now)
+                            print(f"[ingest-processor] INFO: Set timestamp to {now} for {affected} newly imported book(s): {imported_ids}.", flush=True)
                 except Exception as e:
                     print(f"[ingest-processor] WARN: Failed to set timestamp for new book: {e}", flush=True)
 

--- a/tests/unit/test_1331_stamp_every_imported_book.py
+++ b/tests/unit/test_1331_stamp_every_imported_book.py
@@ -1,0 +1,180 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for the second half of fork #1331 — a freshly imported book
+sorting into the *middle* of "Newest" rather than the top.
+
+#1331 was first fixed as a tie-break problem: every book list paged with
+LIMIT/OFFSET over an ORDER BY naming one non-unique column, so tied rows came
+back in whatever order SQLite's plan walked. That fix is real and stays.
+
+It is not the whole story, and @Oakwhisper said so on the thread: *"It wasn't
+tie-breaking because there was no tie. In my case I had only added one book
+that day and it was showing up in the middle of the list instead of at the
+beginning."* A total order cannot put a book at the top if its stored
+``timestamp`` genuinely is not recent — and for imported books it often is not.
+
+``calibredb add`` derives ``books.timestamp`` from the file's own metadata,
+which for most EPUBs is the **publication date**. ``ingest_processor`` knows
+this and corrects it back to the import time, but it corrected only
+``last_added_book_id`` — a single id — while ``_parse_added_book_ids`` exists
+precisely because one add can report several (``Added book ids: 4, 5``). Every
+book in a multi-id add except the last therefore kept a publication date as its
+"date added", and sorted wherever that date fell: 1998 for an old novel, i.e.
+the middle of the library.
+
+That is the reported symptom exactly, it needs no tie to happen, and it
+survived the tie-break fix. These tests pin the correction covering the whole
+batch. ``test_prefix_shape_leaves_batch_stranded`` is the control: it applies
+the old single-id logic to the same fixture and asserts the symptom returns, so
+these tests fail if the call site regresses to stamping one id.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+
+# The library the user already had: ordinary books, real import dates.
+EXISTING = [
+    (101, "Existing A", "2026-08-01 10:00:00+00:00"),
+    (102, "Existing B", "2026-08-02 10:00:00+00:00"),
+    (103, "Existing C", "2026-08-03 10:00:00+00:00"),
+]
+
+# One `calibredb add` reporting three ids. calibredb stamped each with the
+# book's publication date, so left uncorrected they scatter through the library.
+IMPORTED_WITH_PUBDATES = [
+    (201, "Imported 1998", "1998-04-11 00:00:00+00:00"),
+    (202, "Imported 2005", "2005-09-02 00:00:00+00:00"),
+    (203, "Imported 2012", "2012-01-30 00:00:00+00:00"),
+]
+
+IMPORT_TIME = "2026-08-14 21:00:00+00:00"
+
+
+@pytest.fixture
+def library():
+    """An in-memory metadata.db-shaped ``books`` table, mid-import."""
+    con = sqlite3.connect(":memory:")
+    con.execute(
+        "CREATE TABLE books ("
+        " id INTEGER PRIMARY KEY,"
+        " title TEXT,"
+        " timestamp TIMESTAMP,"
+        " last_modified TIMESTAMP)"
+    )
+    for book_id, title, ts in EXISTING + IMPORTED_WITH_PUBDATES:
+        con.execute(
+            "INSERT INTO books (id, title, timestamp, last_modified) VALUES (?,?,?,?)",
+            (book_id, title, ts, ts),
+        )
+    con.commit()
+    yield con
+    con.close()
+
+
+def newest_first(con):
+    """The ids "Newest" shows, in order, using the #1331 total order."""
+    return [
+        row[0]
+        for row in con.execute(
+            "SELECT id FROM books ORDER BY timestamp DESC, id DESC"
+        )
+    ]
+
+
+def test_premise_uncorrected_import_lands_in_the_middle(library):
+    """Guard the fixture's premise: this is the bug, before any correction.
+
+    Without it a later refactor could make the other tests pass vacuously.
+    """
+    order = newest_first(library)
+    assert order[:3] == [103, 102, 101], "existing books should lead while imports are unstamped"
+    for imported_id in (201, 202, 203):
+        assert order.index(imported_id) >= 3, "an unstamped import should not be at the top"
+
+
+def test_every_imported_book_is_stamped_and_leads_the_list(library):
+    """The whole batch gets the import time, so all three lead "Newest"."""
+    import ingest_processor
+
+    affected = ingest_processor.stamp_books_with_import_time(
+        library, [201, 202, 203], now=IMPORT_TIME
+    )
+    assert affected == 3
+
+    order = newest_first(library)
+    assert order[:3] == [203, 202, 201], (
+        "every book from one add should sit at the top of Newest, id-desc among themselves"
+    )
+    assert order[3:] == [103, 102, 101]
+
+
+def test_prefix_shape_leaves_batch_stranded(library):
+    """Control: the old single-id correction reproduces @Oakwhisper's symptom.
+
+    This is what the code did before the fix. It is asserted rather than
+    described so that a regression to stamping one id fails a test instead of
+    quietly restoring the bug.
+    """
+    library.execute(
+        "UPDATE books SET timestamp = ? WHERE id = ?", (IMPORT_TIME, 203)
+    )
+
+    order = newest_first(library)
+    assert order[0] == 203, "the last id of the add is fine — it is the one that got stamped"
+    # The other two are still carrying publication dates, stranded mid-library.
+    assert order.index(201) > order.index(101), "1998 import sorts below a real 2026 book"
+    assert order.index(202) > order.index(101), "2005 import sorts below a real 2026 book"
+
+
+def test_single_book_add_still_works(library):
+    """The common case — one file, one id — keeps behaving."""
+    import ingest_processor
+
+    assert ingest_processor.stamp_books_with_import_time(
+        library, [201], now=IMPORT_TIME
+    ) == 1
+    assert newest_first(library)[0] == 201
+
+
+def test_ignores_none_duplicates_and_junk_ids(library):
+    """Callers pass whatever calibredb parsing produced; never raise on it."""
+    import ingest_processor
+
+    affected = ingest_processor.stamp_books_with_import_time(
+        library, [201, 201, None, "202", "not-an-id"], now=IMPORT_TIME
+    )
+    assert affected == 2, "201 counted once, '202' coerced, junk and None dropped"
+
+    assert ingest_processor.stamp_books_with_import_time(library, [], now=IMPORT_TIME) == 0
+    assert ingest_processor.stamp_books_with_import_time(library, None, now=IMPORT_TIME) == 0
+
+
+def test_call_site_passes_the_whole_batch():
+    """Source pin: the ingest path must hand over every id, not the last one.
+
+    The behavioural tests above exercise the helper directly, so they stay green
+    even if the call site regresses to ``last_added_book_id``. This pins the
+    wiring that actually reaches a user.
+    """
+    import inspect
+
+    import ingest_processor
+
+    source = inspect.getsource(ingest_processor)
+
+    assert "stamp_books_with_import_time(con, imported_ids, now)" in source, (
+        "the ingest path should stamp the collected batch"
+    )
+    assert "self.last_added_book_ids or (" in source, (
+        "imported_ids should prefer the plural list, falling back to the single id"
+    )
+    assert "UPDATE books SET timestamp = ? WHERE id = ?" not in source, (
+        "the single-id import stamp is the bug; it should not come back"
+    )


### PR DESCRIPTION
## Why

[#1331](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1331) was fixed once, as a tie-break problem, in 984294e81. That fix is real and stays.

It was not the whole cause, and @Oakwhisper said so on the thread:

> Functionally this fixes it, but the underlying analysis I don't think is correct. It wasn't tie-breaking because there was no tie. In my case I had only added one book that day and it was showing up in the middle of the list instead of at the beginning.

He is right. A total order cannot put a book at the top of "Newest" if its stored date added genuinely is not recent — and for imported books it often is not.

## Root cause

`calibredb add` derives `books.timestamp` from the file's own metadata, which for most EPUBs is the **publication date**. `ingest_processor` knows this and corrects it back to the import time — but it corrected only `last_added_book_id`, a single id:

```python
cur.execute('UPDATE books SET timestamp = ? WHERE id = ?', (now, self.last_added_book_id))
```

`_parse_added_book_ids` exists precisely because one add can report several ids (it has an explicit case for `Added book ids: 4, 5`), and `last_added_book_id` is just `added_ids[-1]`. Every book in a multi-id add except the last therefore kept a publication date as its date added, and sorted wherever that year fell — the middle of the library. The very next line already used the plural list, which is what makes this a slip rather than a design choice.

This needs no tie to occur, which is why the total-order fix did not cover it.

## Fix

The correction moves into `stamp_books_with_import_time(connection, book_ids, now)` — takes the whole batch, coerces and dedupes ids, drops `None`/junk rather than raising, updates in one statement. The call site passes `last_added_book_ids`, falling back to the single id.

## Reproduction and validation

`tests/unit/test_1331_stamp_every_imported_book.py`, 6 tests. Red/green measured by stashing only the source change:

- **pre-fix: 4 failed, 2 passed**
- **post-fix: 6 passed**

The 2 that pass in both states are deliberate: `test_premise_uncorrected_import_lands_in_the_middle` guards the fixture's premise so the others cannot pass vacuously, and `test_prefix_shape_leaves_batch_stranded` is the control — it applies the old single-id logic to the same fixture and asserts @Oakwhisper's symptom returns, so a regression to stamping one id fails a test rather than quietly restoring the bug.

`test_call_site_passes_the_whole_batch` pins the wiring, since the behavioural tests exercise the helper directly and would stay green if the call site regressed.

**Real-schema verification** (the in-memory fixture has no triggers; calibre's `books` table does):

```
rows updated: 3
before: [(221,'2026-08-03 21:08:52+00:00'), (222,'2026-08-04 02:27:47+00:00'), (223,'2026-08-04 02:48:32+00:00')]
after:  [(221,'2026-08-14 21:30:00+00:00'), (222,'2026-08-14 21:30:00+00:00'), (223,'2026-08-14 21:30:00+00:00')]
sort intact (no title clobber): ('Picture of Dorian Gray, The',)
newest-first top 5: [223, 222, 221, 220, 219]
```

Run against a copy of a live `metadata.db`. Confirms `books_update_trg` requires `title_sort` to be registered — the existing guard already does this, and an unregistered connection raises `no such function: title_sort` rather than silently writing, so the guard is load-bearing and stays.

Regression sweep: `230 passed, 7 skipped` across the ingest/sort/timestamp suites.

## Fix the intent

1. **What was the person trying to do?** See books they just added at the top of the library, which is what "Newest" claims to show.
2. **Can they now, in their configuration?** For imports from here on, yes — every book in a batch is stamped. **Books already in the library keep the publication dates they were given; this does not backfill.** That is a deliberate limit and it is stated in the changelog and will be in the close-out, because a reporter who already has a scrambled library will otherwise read this as a fix that did not work.
3. **Whole ask or a slice?** Whole ask for the ingest path. The web-UI upload path is a separate route and was not audited here.
4. **Other symptoms from the same cause?** Yes — "Recently Added" and any date-added view drew from the same column, and all of them are corrected by this.
5. **Would the reporter recognise it?** @Oakwhisper's objection was that there was no tie. This says: correct, the tie was a second, real bug, and here is the one you actually hit.

## Blast radius

One new module-level function, one call site. `last_added_book_ids` is set at both add paths and by `_fallback_last_added_book_id`. SQL is parameterised — placeholders are generated as `?` characters only and ids are int-coerced before binding. No new dependencies, licenses, or external URLs (rule 6 clear). No auth/session/CSRF/crypto/subprocess/user-path/new-route surface, so `/security-review` does not apply per the operator's directive.

## Tier

`needs-review` — fork-original behaviour change.

Addresses #1331.