### PR TITLE
Offer the exact match first, and let Enter add what was typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **Typing a tag that already exists now offers that tag first, and Enter adds
+  what you actually typed.** Typing "Romance" pre-selected "Paranormal Romance",
+  and pressing Enter applied it, because suggestions came back in no particular
+  order and the menu always highlighted its first row. On a large library the
+  exact match could be missing altogether, since only the first 25 matches are
+  shown and nothing put the best one among them. Suggestions are now ordered
+  exact match, then values starting with what you typed, then the rest, and no
+  suggestion is highlighted until you arrow into the list — so Enter adds your
+  text and ArrowDown then Enter takes a suggestion. This also makes it possible
+  again to type a value that sits inside an existing one, like adding "foo" when
+  "Fools and Jesters" exists. Applies to tags, authors, series and publishers in
+  both the new and the classic editor. Reported by @magdalar.
+
 - **Books you just imported now show up at the top of "Newest".** Drop several
   books into the ingest folder at once and most of them landed somewhere in the
   middle of the library instead of at the front, sorted as if they had been

--- a/cps/db.py
+++ b/cps/db.py
@@ -837,6 +837,37 @@ def _make_session_factory(engine):
     return factory
 
 
+def rank_typeahead_names(names, query):
+    """Order typeahead suggestions best-match-first: exact, then prefix, then
+    anywhere, alphabetical within each rank.
+
+    The suggestion query is a `LIKE %query%`, which on its own returns whatever
+    order the name index yields. That put "Conduct of life -- Fiction" ahead of
+    the tag "Life" and "Paranormal Romance" ahead of "Romance" (#1398), and the
+    editor pre-selects the first row, so Enter applied a tag the user had not
+    typed. Callers cap the list AFTER ranking, so an exact match can no longer
+    be truncated away by a library with many partial matches.
+
+    Ordering only -- nothing is filtered out, so free-text entry of a genuinely
+    new value is unaffected.
+    """
+    needle = (query or '').strip().lower()
+    if not needle:
+        return sorted(names, key=lambda name: name.lower())
+
+    def sort_key(name):
+        lowered = name.lower()
+        if lowered == needle:
+            rank = 0
+        elif lowered.startswith(needle):
+            rank = 1
+        else:
+            rank = 2
+        return rank, lowered
+
+    return sorted(names, key=sort_key)
+
+
 class CalibreDB:
     _init = False
     engine = None
@@ -1838,8 +1869,11 @@ class CalibreDB:
         query = query or ''
         entries = self.session.query(database).filter(tag_filter). \
             filter(func.lower(database.name).ilike("%" + query + "%")).all()
-        # json_dumps = json.dumps([dict(name=escape(r.name.replace(*replace))) for r in entries])
-        json_dumps = json.dumps([dict(name=r.name.replace(*replace)) for r in entries])
+        # Ranked here rather than in one caller so the classic editor and the SPA
+        # editor agree on which suggestion is the best match (#1398).
+        names = rank_typeahead_names([r.name.replace(*replace) for r in entries], query)
+        # json_dumps = json.dumps([dict(name=escape(name)) for name in names])
+        json_dumps = json.dumps([dict(name=name) for name in names])
         return json_dumps
 
     def check_exists_book(self, authr, title):

--- a/findings/items/F-893659.json
+++ b/findings/items/F-893659.json
@@ -1,0 +1,13 @@
+{
+  "area": "metadata-editor",
+  "body": "`CalibreDB.get_typeahead` builds its filter as `func.lower(database.name).ilike(\"%\" + query + \"%\")`\nwith the user's term interpolated directly, so a literal `%` or `_` in what the\nuser types is treated as a LIKE wildcard rather than as a character.\n\nTyping \"50%\" in the tag field matches every tag beginning \"50\", and \"_\" matches\nany single character. Parameterised through SQLAlchemy, so this is not an\ninjection — it is a correctness/UX wrinkle: you cannot search for a value that\ncontains one of those characters, and a lone \"%\" matches the whole library.\n\nPre-existing; predates the #1398 ranking work and was left alone there to keep\nthat change scoped to the reported defect. Fix would be to escape `%`, `_` and\nthe escape character itself in the term and pass `escape=\"\\\\\"` to `ilike`.\n\nObserved 2026-08-14 while fixing #1398.",
+  "created": "2026-08-14",
+  "id": "F-893659",
+  "refs": [
+    "#1398"
+  ],
+  "severity": "correctness",
+  "source": "audit",
+  "status": "open",
+  "title": "Typeahead query interpolates the raw term into a LIKE pattern, so % and _ act as wildcards"
+}

--- a/frontend/e2e/tag-quick-add-typeahead.spec.ts
+++ b/frontend/e2e/tag-quick-add-typeahead.spec.ts
@@ -39,15 +39,26 @@ async function probeSeed(page: Page): Promise<Probe> {
         .then((r) => (r.ok ? r.json() : null))
         .catch(() => null);
 
-    const tags = (await j('/api/v1/tags'))?.items ?? [];
-    // A tag with enough characters to type a meaningful prefix of.
-    const tag = tags.find((t: any) => typeof t?.name === 'string' && t.name.length >= 4);
-    const bookId = (await j('/api/v1/books?per_page=1'))?.items?.[0]?.id ?? null;
+    const names: string[] = ((await j('/api/v1/tags'))?.items ?? [])
+      .map((t: any) => t?.name).filter((n: any) => typeof n === 'string');
+    const lower = new Set(names.map((n) => n.toLowerCase()));
+    // Two constraints the earlier probe missed, both of which made these specs
+    // fail on a seed where the first book happens to be well-tagged:
+    //  - the field hides tags the book ALREADY has, so a candidate already on
+    //    that book yields an empty menu and no listbox to assert on. Picking an
+    //    untagged book removes the whole class.
+    //  - a prefix that is itself a tag now ranks first (#1398), so accepting
+    //    the top suggestion would legitimately leave the field unchanged and
+    //    the "suggestion is longer than what I typed" assertions would fail.
+    const books = (await j('/api/v1/books?per_page=50'))?.items ?? [];
+    const bookId = books.find((b: any) => (b?.tags ?? []).length === 0)?.id ?? null;
+
+    const tag = names.find((n) => n.length >= 4 && !lower.has(n.slice(0, 3).toLowerCase()));
 
     return {
       bookId,
-      tagName: tag?.name ?? null,
-      prefix: tag?.name ? tag.name.slice(0, 3) : null,
+      tagName: tag ?? null,
+      prefix: tag ? tag.slice(0, 3) : null,
     };
   });
 }

--- a/frontend/e2e/tag-typeahead-exact-match.spec.ts
+++ b/frontend/e2e/tag-typeahead-exact-match.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect, Page } from '@playwright/test';
+import { collectPageErrors, assertNoPageErrors } from './utils';
+
+/*
+ * Typeahead offers the exact match first, and Enter commits what you typed (#1398).
+ *
+ * @magdalar: typing "Romance" pre-selected "Paranormal Romance", and Enter took
+ * that instead of the tag actually typed. Two causes, both user-visible here:
+ *
+ *   1. The suggestion query had no ordering, so an anywhere-match could sort
+ *      ahead of the exact one. Reproduced on a real library — q="life" answered
+ *      ["Conduct of life -- Fiction", "Life", ...].
+ *   2. The menu pre-marked its first row as active, so Enter always accepted a
+ *      row the user never navigated to. That also made any value sharing a
+ *      substring with an existing tag impossible to type ("foo" kept becoming
+ *      "Fools and Jesters").
+ *
+ * These belong in a browser rather than a render test: (2) is a key-composition
+ * bug between the combobox and the host's Enter binding, and it looks correct in
+ * source either way. The existing quick-add spec pins ArrowDown+Enter, which
+ * must keep working — this pins the untouched-Enter path beside it.
+ *
+ * Seed-resilient: skips rather than fails when the library has no suitable tag.
+ */
+
+interface Probe {
+  bookId: number | null;
+  /** A tag whose name is contained in some OTHER tag's name — the shape that
+   *  lets an anywhere-match outrank the exact one. */
+  exact: string | null;
+  /** A prefix of a real tag that is NOT itself a tag, i.e. the "foo" case. */
+  novel: string | null;
+}
+
+async function probeSeed(page: Page): Promise<Probe> {
+  // Navigate first — relative fetches on about:blank resolve to nothing, which
+  // would skip every test while reporting green.
+  if (!page.url().includes('/app')) await page.goto('/app/');
+  return page.evaluate(async () => {
+    const j = (u: string): Promise<any> =>
+      fetch(u, { headers: { Accept: 'application/json' } })
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null);
+
+    const names: string[] = ((await j('/api/v1/tags'))?.items ?? [])
+      .map((t: any) => t?.name).filter((n: any) => typeof n === 'string');
+    const lower = new Set(names.map((n) => n.toLowerCase()));
+
+    // A book with NO tags. The field hides tags the book already carries, so on
+    // a well-tagged book the candidates below are filtered out and the menu is
+    // correctly empty — which reads as a failure but is really a bad seed pick.
+    const books = (await j('/api/v1/books?per_page=50'))?.items ?? [];
+    const bookId = books.find((b: any) => (b?.tags ?? []).length === 0)?.id ?? null;
+
+    // The exact tag must be contained in another tag that sorts BEFORE it.
+    // That is the only shape the old unordered query actually got wrong, so
+    // anything looser makes this test pass with or without the fix:
+    // "Conduct of life -- Fiction" sorts ahead of "Life" and hid it, while
+    // "Fantasy fiction" sorts after "Fantasy" and never did.
+    const exact = names.find((n) => n.length >= 3 && names.some((other) => {
+      const o = other.toLowerCase();
+      const needle = n.toLowerCase();
+      return other !== n && o.includes(needle) && o < needle;
+    })) ?? null;
+
+    // A 3-char prefix that is not itself a tag — the "foo" / "Fools and
+    // Jesters" case. Its source tag keeps the menu open when Enter is pressed,
+    // which is the race the reporter actually hit.
+    const source = names.find((n) => n.length >= 5 && !lower.has(n.slice(0, 3).toLowerCase()));
+    const novel = source ? source.slice(0, 3) : null;
+
+    return { bookId, exact, novel };
+  });
+}
+
+async function openQuickAdd(page: Page, bookId: number) {
+  await page.goto(`/app/book/${bookId}`);
+  const addButton = page.getByRole('button', { name: /add tag/i }).last();
+  await addButton.waitFor({ state: 'visible' });
+  await addButton.click();
+  return page.getByRole('combobox', { name: /add tag/i });
+}
+
+test.describe('typeahead exact-match ranking and Enter (#1398)', () => {
+  test('the exact match is offered first, ahead of longer tags containing it', async ({ page }) => {
+    const seed = await probeSeed(page);
+    test.skip(!seed.bookId || !seed.exact, 'seed has no tag contained in another tag');
+
+    const field = await openQuickAdd(page, seed.bookId!);
+    await field.fill(seed.exact!);
+
+    const options = page.getByRole('listbox').getByRole('option');
+    await expect(options.first()).toBeVisible();
+    // Pre-fix this was whichever anywhere-match the name index happened to
+    // yield first, which is the tag the user then got by pressing Enter.
+    await expect(options.first()).toHaveText(seed.exact!);
+  });
+
+  test('no suggestion is pre-selected before the user navigates', async ({ page }) => {
+    const seed = await probeSeed(page);
+    test.skip(!seed.bookId || !seed.exact, 'seed has no suitable tag');
+
+    const field = await openQuickAdd(page, seed.bookId!);
+    await field.fill(seed.exact!);
+    await expect(page.getByRole('listbox').getByRole('option').first()).toBeVisible();
+
+    // The mechanism behind the reported Enter bug: an active option means the
+    // combobox owns Enter, so the host's "add what I typed" never runs.
+    await expect(field).not.toHaveAttribute('aria-activedescendant', /./);
+    await expect(page.getByRole('listbox').getByRole('option', { selected: true })).toHaveCount(0);
+
+    // ArrowDown still activates the first option — the existing quick-add spec
+    // depends on that path and users still need it.
+    await field.press('ArrowDown');
+    await expect(field).toHaveAttribute('aria-activedescendant', /./);
+  });
+
+  test('Enter adds exactly what was typed, even when it is inside an existing tag', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    const seed = await probeSeed(page);
+    test.skip(!seed.bookId || !seed.novel, 'seed has no tag prefix that is not itself a tag');
+
+    const field = await openQuickAdd(page, seed.bookId!);
+    await field.fill(seed.novel!);
+    // Wait for the menu, so this exercises the race the reporter hit: pre-fix,
+    // Enter after the fetch landed took the suggestion instead of the text.
+    await expect(page.getByRole('listbox').getByRole('option').first()).toBeVisible();
+    await field.press('Enter');
+
+    const added = page.getByRole('button', { name: `Remove tag ${seed.novel!}` });
+    await expect(added).toBeVisible({ timeout: 10_000 });
+
+    // Leave the library as we found it.
+    await added.click();
+    await expect(added).toHaveCount(0, { timeout: 10_000 });
+
+    assertNoPageErrors(errors);
+  });
+});

--- a/frontend/src/components/MetadataTypeahead.tsx
+++ b/frontend/src/components/MetadataTypeahead.tsx
@@ -68,7 +68,12 @@ export function MetadataTypeahead(props: Props) {
   const delim = multi ? sep.trim() : null;
   const [open, setOpen] = useState(false);
   const [suggestions, setSuggestions] = useState<string[]>([]);
-  const [activeIndex, setActiveIndex] = useState(0);
+  // -1 = nothing chosen yet, so what you typed is what Enter commits. Starting
+  // at 0 pre-selected the first row and Enter silently applied it instead of the
+  // text under the caret, which made a value that merely SHARES a substring with
+  // an existing one impossible to type ("foo" became "Fools and Jesters", #1398).
+  // Manual selection is also what the WAI-ARIA combobox pattern asks for.
+  const [activeIndex, setActiveIndex] = useState(-1);
   const wrapRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const caretRef = useRef<number>(value.length);
@@ -98,7 +103,8 @@ export function MetadataTypeahead(props: Props) {
         const data = await res.json();
         const list: string[] = Array.isArray(data?.suggestions) ? data.suggestions : [];
         setSuggestions(list.filter((s) => !currentTokens.has(s.toLowerCase())));
-        setActiveIndex(0);
+        // A fresh list must not silently re-arm Enter on a row nobody picked.
+        setActiveIndex(-1);
       } catch {
         /* aborted or offline — leave the last list, dropdown just won't update */
       }
@@ -179,10 +185,12 @@ export function MetadataTypeahead(props: Props) {
       case 'ArrowUp':
         e.preventDefault();
         if (!open) { openAndFetch(); return; }
-        setActiveIndex((i) => Math.max(i - 1, 0));
+        // From nothing, wrap to the last option; from the first, step back out
+        // to your own text rather than sticking on row 0.
+        setActiveIndex((i) => (i === -1 ? suggestions.length - 1 : i - 1));
         break;
       case 'Enter':
-        if (open && suggestions[activeIndex]) {
+        if (open && activeIndex >= 0 && suggestions[activeIndex]) {
           e.preventDefault();
           choose(suggestions[activeIndex]);
         }

--- a/tests/unit/test_1398_typeahead_exact_match_ranking.py
+++ b/tests/unit/test_1398_typeahead_exact_match_ranking.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Unit tests for typeahead suggestion ranking (#1398).
+
+@magdalar reported that typing an existing tag offers a different tag first:
+typing "Romance" pre-selects "Paranormal Romance". Reproduced on a real library
+against the live route — `GET /api/v1/metadata/typeahead/tags?q=life` answered
+["Conduct of life -- Fiction", "Life", "Spain -- Social life and customs ..."],
+so the exact tag was second and the SPA's Enter applied the first one.
+
+Root cause: `get_typeahead` ran `LIKE %q%` with no ORDER BY, so SQLite returned
+name-index order and an exact match sorted wherever the alphabet put it. The
+editor then kept only the first 25, so on a large library an exact match could
+be truncated away before it was ever offered.
+
+Pins: exact > prefix > anywhere ordering, alphabetical tiebreak, case-insensitive
+exact match, empty query, no rows dropped, that `get_typeahead` itself applies
+the ranking (so the classic editor is ranked too, not just the SPA), and that an
+exact match survives the result cap.
+"""
+import json
+
+import pytest
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.orm import sessionmaker
+from types import SimpleNamespace
+
+try:  # SQLAlchemy 2.x
+    from sqlalchemy.orm import declarative_base
+except ImportError:  # pragma: no cover - SQLAlchemy 1.3
+    from sqlalchemy.ext.declarative import declarative_base
+
+
+# The exact rows the live library returned for q="life", in the order the
+# unranked query produced them. This is the reporter's bug, verbatim.
+LIVE_REPRO = ["Conduct of life -- Fiction", "Life",
+              "Spain -- Social life and customs -- 16th century -- Fiction"]
+
+
+# ── the pure ranking helper ──────────────────────────────────────────────────
+
+@pytest.mark.unit
+def test_exact_match_ranks_first_live_repro():
+    from cps.db import rank_typeahead_names
+    assert rank_typeahead_names(LIVE_REPRO, "life")[0] == "Life"
+
+
+@pytest.mark.unit
+def test_prefix_beats_anywhere_match():
+    from cps.db import rank_typeahead_names
+    ranked = rank_typeahead_names(
+        ["Paranormal Romance", "Romance novels", "Historical Romance"], "romance")
+    assert ranked[0] == "Romance novels"
+
+
+@pytest.mark.unit
+def test_exact_beats_prefix():
+    from cps.db import rank_typeahead_names
+    ranked = rank_typeahead_names(["Romance novels", "Romance", "Paranormal Romance"], "romance")
+    assert ranked[:2] == ["Romance", "Romance novels"]
+
+
+@pytest.mark.unit
+def test_exact_match_is_case_insensitive_and_keeps_stored_casing():
+    from cps.db import rank_typeahead_names
+    ranked = rank_typeahead_names(["Epic fantasy", "FANTASY"], "fantasy")
+    assert ranked[0] == "FANTASY"
+
+
+@pytest.mark.unit
+def test_ties_are_alphabetical_within_a_rank():
+    from cps.db import rank_typeahead_names
+    ranked = rank_typeahead_names(["Sci-fi zebra", "Sci-fi apple", "Sci-fi mango"], "sci-fi")
+    assert ranked == ["Sci-fi apple", "Sci-fi mango", "Sci-fi zebra"]
+
+
+@pytest.mark.unit
+def test_empty_query_is_alphabetical_and_does_not_raise():
+    from cps.db import rank_typeahead_names
+    assert rank_typeahead_names(["beta", "Alpha"], "") == ["Alpha", "beta"]
+    assert rank_typeahead_names(["beta", "Alpha"], None) == ["Alpha", "beta"]
+
+
+@pytest.mark.unit
+def test_ranking_drops_nothing():
+    from cps.db import rank_typeahead_names
+    names = ["Life", "Conduct of life", "Still life", "unrelated"]
+    assert sorted(rank_typeahead_names(names, "life")) == sorted(names)
+
+
+@pytest.mark.unit
+def test_exact_match_survives_the_result_cap():
+    """The editor keeps only the first N. Ranking has to happen before that cut,
+    or a library with more than N partial matches never offers the exact tag."""
+    from cps.api.edit import _TYPEAHEAD_LIMIT
+    from cps.db import rank_typeahead_names
+    # 40 anywhere-matches that all sort alphabetically ahead of the exact tag.
+    noise = ["Anywhere life %02d" % i for i in range(40)]
+    ranked = rank_typeahead_names(noise + ["Life"], "life")
+    assert "Life" in ranked[:_TYPEAHEAD_LIMIT]
+
+
+# ── get_typeahead applies it, so the classic editor is ranked too ────────────
+
+Base = declarative_base()
+
+
+class _Tag(Base):
+    __tablename__ = "tags"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+def _session_with(names):
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    for i, name in enumerate(names, start=1):
+        session.add(_Tag(id=i, name=name))
+    session.commit()
+    return session
+
+
+@pytest.mark.unit
+def test_get_typeahead_returns_exact_match_first():
+    """Ranking lives in the shared query, not in one caller, so /get_tags_json
+    and the SPA endpoint agree on what the best match is."""
+    from cps.db import CalibreDB
+    session = _session_with(LIVE_REPRO)
+    fake = SimpleNamespace(ensure_session=lambda: None, session=session)
+    names = [row["name"] for row in json.loads(CalibreDB.get_typeahead(fake, _Tag, "life"))]
+    assert names[0] == "Life"
+    assert sorted(names) == sorted(LIVE_REPRO)
+
+
+@pytest.mark.unit
+def test_get_typeahead_still_applies_the_name_replacement():
+    from cps.db import CalibreDB
+    session = _session_with(["Doe, John|Roe, Jane"])
+    fake = SimpleNamespace(ensure_session=lambda: None, session=session)
+    names = [row["name"] for row in json.loads(
+        CalibreDB.get_typeahead(fake, _Tag, "doe", ("|", ",")))]
+    assert names == ["Doe, John,Roe, Jane"]


### PR DESCRIPTION
Addresses #1398, reported by @magdalar.

## What the person was trying to do

Add a tag they already have to a book, by typing its name. Typing "Romance"
pre-selected "Paranormal Romance", and Enter applied that instead. Separately,
a value that merely overlaps an existing tag could not be typed at all: "foo"
became "Fools and Jesters" unless you beat the lookup to it.

## Root causes — two, independent

**1. Suggestions had no order.** `get_typeahead` ran `LIKE %query%` and `.all()`
with no `ORDER BY`, so SQLite returned name-index order and an exact match
landed wherever the alphabet put it. The editor then keeps only the first 25,
so on a large library the exact match could be truncated away before it was
ever offered.

Reproduced on a real library, against the live route:

```
# before
GET /api/v1/metadata/typeahead/tags?q=life
{"suggestions":["Conduct of life -- Fiction","Life","Spain -- Social life ..."]}

# after
{"suggestions":["Life","Conduct of life -- Fiction","Spain -- Social life ..."]}
```

Ranking lives in the shared query rather than in one caller, so `/get_tags_json`
(classic editor) is ranked identically — verified on the same instance.

**2. The menu always armed its first row.** `activeIndex` initialised to `0` and
reset to `0` on every fetch, so an option was always active and Enter always
took it. The book page does bind Enter to "add exactly what I typed", but the
combobox consumed the key before the host saw it. Nothing is active until the
user arrows in now, which is also what the WAI-ARIA editable-combobox pattern
specifies (`aria-activedescendant` is absent until then).

## Verification

Red/green at both layers, with the red baseline actually measured, not assumed.

- `tests/unit/test_1398_typeahead_exact_match_ranking.py` — 10 tests. Pre-fix
  **9 failed, 1 passed**; post-fix all pass. Uses a real in-memory SQLAlchemy
  session for the `get_typeahead` cases rather than mocks, and the "exact match
  survives the cap" case pins the truncation half.
- `frontend/e2e/tag-typeahead-exact-match.spec.ts` — 3 specs driving the real
  SPA in `cwn-local`. Pre-fix **3/3 red**; post-fix **17/17 green** across
  desktop and mobile together with the existing quick-add spec.
- Live HTTP on the running container for both the SPA and classic routes, shown
  above. Deployed via `docker cp` + restart, container `healthy`.
- `pytest tests/unit -k "typeahead or tag or edit or db"` — 621 passed, 6
  skipped, 0 failed.

The e2e red baseline needed two probe corrections to be honest: the first
candidate it picked was already ordered correctly by accident, so the test
passed with and without the fix. It now requires a containing tag that sorts
*before* the exact one, which is the only shape the unordered query actually
got wrong.

## Also fixed: a pre-existing e2e seed bug

Two specs in `tag-quick-add-typeahead.spec.ts` were failing on `main` before
this change (confirmed by reverting only the source files and re-running). The
probe picked the first book and the first tag independently; when that book
already carried the tag, the field correctly hid it, the menu was empty, and
the specs failed on the seed rather than on a defect. It now picks an untagged
book and a prefix that is not itself a tag. Without this the specs would have
gone on reporting a fault that was not there.

## Blast radius

- `get_typeahead` is shared by tags, authors, series and publishers, and by both
  editors. Ordering only — nothing is filtered, so free-text entry of a new
  value is unchanged, and the existing name-replacement behaviour is pinned by a
  test.
- `EditBook` uses the same component without an Enter binding, so Enter there now
  falls through to the form. That form already submits on Enter from its plain
  inputs (title), so this makes the fields consistent rather than introducing a
  new behaviour.
- `ArrowUp` from nothing wraps to the last option and from the first steps back
  out to the typed text, instead of sticking on row 0.

## Deliberately not in this change

@magdalar's third point — a tag already on the book is hidden from suggestions
with no indication, which is confusing while "Show more tags" is collapsing the
list. Hiding applied values is what stops the menu offering a pick that is a
silent no-op, so the fix is to make the state visible rather than to allow a
duplicate. Raised on the issue with a proposed shape; not bundled here.

Observed and left alone: the query interpolates the raw term into a `LIKE`
pattern, so a literal `%` or `_` acts as a wildcard. Pre-existing, parameterised
so not an injection, and out of scope here.

## Tier

`needs-review` — fork-original, multi-file. No new dependencies, licenses or
external URLs. Touches no auth/session/CSRF, crypto, subprocess, user-controlled
path or new route, so `/security-review` does not apply.
