### PR TITLE
Drain both converter pipes, so a chatty child cannot wedge the queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **A conversion that never finished no longer blocks the queue.** Converting
+  some books, PDFs most often, started and then sat there forever with nothing
+  in the log but a line saying the target format did not exist yet. The
+  converter writes to two output streams and we only kept reading one of them
+  while it ran, so as soon as the other filled up the converter stopped and
+  waited for us while we waited for it. Both are now read together. The same
+  fault was in the KEPUB conversion path, where a failure also had no error
+  text to show, and in the check that reads Calibre's version. Reported by
+  @auspex.
+
 - **Typing a tag that already exists now offers that tag first, and Enter adds
   what you actually typed.** Typing "Romance" pre-selected "Paranormal Romance",
   and pressing Enter applied it, because suggestions came back in no particular

--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -61,6 +61,20 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
 
 ### Bug fixes
 
+- **Converter pipes are drained together, so a chatty child cannot wedge the
+  task queue** (fork #1110) — `_convert_ebook_format` streamed the child's
+  stdout in a `while p.poll() is None` loop and read stderr only after the
+  child had exited. stdout and stderr are separate pipes with separate kernel
+  buffers, so once the child wrote past its stderr buffer (~64 KB on Linux) it
+  blocked on write while we blocked on a read that could never return. PDF
+  input triggers it because Calibre delegates to poppler's `pdftohtml`, whose
+  syntax warnings go to stderr. One `stream_process_output` helper in
+  `cps/subproc_wrapper.py` now drains stderr on a background thread while
+  stdout keeps feeding the live progress parser; the `calibredb --as-opf`
+  probe, `_convert_kepubify` (which read stdout to EOF and never drained
+  stderr at all) and `process_wait` carried the same defect and are fixed with
+  it. SHA `TBD`, release `TBD`.
+
 - **Book lists have a total order, so "Newest" is newest** (fork #1331) — every
   list pages with LIMIT/OFFSET over an ORDER BY that named one non-unique
   column, so SQLite ordered tied rows by whatever its plan walked; a bulk ingest

--- a/cps/subproc_wrapper.py
+++ b/cps/subproc_wrapper.py
@@ -9,6 +9,12 @@ import sys
 import os
 import subprocess
 import re
+import threading
+
+# How long to wait for the background stderr reader to finish after the
+# child has exited. It is draining an already-closed pipe at that point,
+# so this only guards against a wedged reader thread.
+_DRAIN_JOIN_TIMEOUT = 30
 
 def process_open(command, quotes=(), env=None, sout=subprocess.PIPE, serr=subprocess.PIPE, newlines=True):
     # Linux py2.7 encode as list without quotes no empty element for parameters
@@ -34,19 +40,76 @@ def process_open(command, quotes=(), env=None, sout=subprocess.PIPE, serr=subpro
                             **popen_kwargs) # nosec
 
 
+def _drain_into(stream, sink):
+    """Consume a child pipe to EOF, collecting its lines into `sink`."""
+    try:
+        for line in stream:
+            sink.append(line)
+    except (OSError, ValueError):
+        # The pipe was closed underneath us; nothing left to collect.
+        pass
+    finally:
+        try:
+            stream.close()
+        except (OSError, ValueError):
+            pass
+
+
+def stream_process_output(p, on_stdout_line=None, join_timeout=_DRAIN_JOIN_TIMEOUT):
+    """Read a child's stdout to EOF while its stderr drains concurrently.
+
+    stdout and stderr are separate pipes with separate kernel buffers.
+    Draining only one of them and reading the other after the child exits
+    deadlocks the pair as soon as the undrained pipe fills (~64 KB on
+    Linux): the child blocks on write, the parent blocks on read, and
+    neither ever moves again. That is fork issue #1110, where converting
+    an OCR'd PDF hung the task queue forever because calibre's PDF
+    pipeline emits a warning per malformed object.
+
+    `on_stdout_line` is called with each raw stdout line as it arrives,
+    so live progress parsing keeps working. Returns the collected stderr
+    lines; read `p.returncode` for the exit status.
+    """
+    stderr_lines = []
+    reader = None
+    if p.stderr is not None:
+        reader = threading.Thread(target=_drain_into, args=(p.stderr, stderr_lines))
+        reader.daemon = True
+        reader.start()
+
+    if p.stdout is not None:
+        try:
+            for line in p.stdout:
+                if on_stdout_line is not None:
+                    on_stdout_line(line)
+        except (OSError, ValueError):
+            pass
+        finally:
+            try:
+                p.stdout.close()
+            except (OSError, ValueError):
+                pass
+
+    p.wait()
+    if reader is not None:
+        reader.join(timeout=join_timeout)
+    return stderr_lines
+
+
 def process_wait(command, serr=subprocess.PIPE, pattern=""):
-    # Run command, wait for process to terminate, and return an iterator over lines of its output.
+    # Run command, wait for process to terminate, and return the first match of
+    # `pattern` in its output. Both pipes are drained together; waiting on the
+    # child before reading them deadlocks on any chatty binary (#1110).
     newlines = os.name != 'nt'
     ret_val = ""
     p = process_open(command, serr=serr, newlines=newlines)
-    p.wait()
-    for line in p.stdout.readlines():
+    stdout_lines = []
+    stream_process_output(p, stdout_lines.append)
+    for line in stdout_lines:
         if isinstance(line, bytes):
             line = line.decode('utf-8', errors="ignore")
         match = re.search(pattern, line, re.IGNORECASE)
         if match and ret_val == "":
             ret_val = match
             break
-    p.stdout.close()
-    p.stderr.close()
     return ret_val

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -21,7 +21,7 @@ from flask_babel import lazy_gettext as N_
 from cps.services.worker import CalibreTask
 from cps import db
 from cps import logger, config
-from cps.subproc_wrapper import process_open
+from cps.subproc_wrapper import process_open, stream_process_output
 from flask_babel import gettext as _
 from cps.file_helper import get_temp_dir
 
@@ -167,7 +167,7 @@ class TaskConvert(CalibreTask):
                 local_db.session.close()
                 return os.path.basename(file_path + format_new_ext)
         else:
-            log.info("Book id %d - target format of %s does not exist. Moving forward with convert.",
+            log.info("Book id %d has no %s yet; starting conversion.",
                      book_id,
                      format_new_ext)
 
@@ -241,16 +241,26 @@ class TaskConvert(CalibreTask):
         except OSError as e:
             return 1, N_("Kepubify-converter failed: %(error)s", error=e)
         self.progress = 0.01
-        while True:
-            nextline = p.stdout.readlines()
-            nextline = [x.strip('\n') for x in nextline if x != '\n']
-            for line in nextline:
+
+        def _log_kepubify_line(line):
+            if isinstance(line, bytes):
+                line = line.decode('utf-8', errors="ignore")
+            line = line.strip('\r\n')
+            if line:
                 log.debug(line)
-            if p.poll() is not None:
-                break
+
+        # Same pipe-pair hazard as the ebook-convert path (#1110): this used to
+        # read stdout to EOF and never drain stderr at all, so a chatty kepubify
+        # could wedge the task. Draining stderr also gives us an error to report.
+        kepubify_traceback = stream_process_output(p, _log_kepubify_line)
 
         # process returncode
         check = p.returncode
+        if check != 0:
+            for ele in kepubify_traceback:
+                if isinstance(ele, bytes):
+                    ele = ele.decode('utf-8', errors="ignore")
+                log.debug(ele.strip('\r\n'))
 
         # move file
         if check == 0:
@@ -309,10 +319,8 @@ class TaskConvert(CalibreTask):
                                '--with-library', library_path]
                 p = process_open(opf_command, quotes, my_env, newlines=False)
                 lines = list()
-                while p.poll() is None:
-                    lines.append(p.stdout.readline())
+                calibre_traceback = stream_process_output(p, lines.append)
                 check = p.returncode
-                calibre_traceback = p.stderr.readlines()
                 if check == 0:
                     path_tmp_opf = os.path.join(tmp_dir, "metadata_" + str(uuid4()) + ".opf")
                     with open(path_tmp_opf, 'wb') as fd:
@@ -362,8 +370,7 @@ class TaskConvert(CalibreTask):
         except OSError as e:
             return 1, N_("Ebook-converter failed: %(error)s", error=e)
 
-        while p.poll() is None:
-            nextline = p.stdout.readline()
+        def _handle_stdout_line(nextline):
             if isinstance(nextline, bytes):
                 nextline = nextline.decode('utf-8', errors="ignore").strip('\r\n')
             if nextline:
@@ -375,9 +382,12 @@ class TaskConvert(CalibreTask):
                 if config.config_use_google_drive:
                     self.progress *= 0.9
 
+        # Drain both pipes together. Reading stderr only after the child
+        # exits deadlocks on chatty converters, notably PDF input (#1110).
+        calibre_traceback = stream_process_output(p, _handle_stdout_line)
+
         # process returncode
         check = p.returncode
-        calibre_traceback = p.stderr.readlines()
         error_message = ""
         for ele in calibre_traceback:
             ele = ele.decode('utf-8', errors="ignore").strip('\n')

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -326,9 +326,15 @@ class TaskConvert(CalibreTask):
                     with open(path_tmp_opf, 'wb') as fd:
                         fd.write(b''.join(lines))
                 else:
+                    # The probe runs with newlines=False, so these are bytes.
+                    # Comparing them against str silently raised TypeError here
+                    # and buried the real reason the metadata export failed.
                     error_message = ""
                     for ele in calibre_traceback:
-                        if not ele.startswith('Traceback') and not ele.startswith('  File'):
+                        if isinstance(ele, bytes):
+                            ele = ele.decode('utf-8', errors="ignore")
+                        ele = ele.strip('\r\n')
+                        if ele and not ele.startswith('Traceback') and not ele.startswith('  File'):
                             error_message = N_("Calibre failed with error: %(error)s", error=ele)
                     return check, error_message
             quotes = [1, 2]

--- a/findings/items/F-7ebe6d.json
+++ b/findings/items/F-7ebe6d.json
@@ -1,0 +1,11 @@
+{
+  "area": "testing",
+  "body": "Four tests in tests/unit/test_1596_module_entry_point.py fail on a plain\ndeveloper checkout:\n\n    python -P -m cps --help\n    -> No module named cps\n\nThey run the interpreter with -P from an arbitrary cwd, which is the point of\nthe test (the s6 longrun does exactly that with cwd=/config), but it also means\nPYTHONPATH=. cannot help and the package must actually be installed into the\nenvironment. CI installs it, so CI is green and the gap is invisible there;\nrepo/.venv does not, so anyone running the unit suite locally sees four red\ntests unrelated to their change.\n\nConfirmed pre-existing and unrelated to any branch: reproduced on clean main by\nstashing (4 failed, 14 passed).\n\nCost is small but real: it trains local runs to ignore red, which is how a\ngenuine failure gets waved through. Either skip with a clear reason when\nimportlib.util.find_spec(\"cps\") is None outside an install, or have the test\ncreate the editable install it needs.\n\nFound while running blast-radius checks for #1110.",
+  "created": "2026-08-15",
+  "id": "F-7ebe6d",
+  "refs": [],
+  "severity": "test",
+  "source": "audit",
+  "status": "open",
+  "title": "test_1596_module_entry_point silently requires an editable install"
+}

--- a/tests/unit/test_convert_stderr_deadlock_1110.py
+++ b/tests/unit/test_convert_stderr_deadlock_1110.py
@@ -160,6 +160,57 @@ class TestProcessWait(unittest.TestCase):
         self.assertEqual(match.group(1), '7.16.0')
 
 
+class TestOpfProbeErrorReporting(unittest.TestCase):
+    """The --as-opf probe runs with newlines=False, so its lines are bytes."""
+
+    def test_failure_lines_are_decoded_before_being_matched(self):
+        """`b'...'.startswith('Traceback')` raises TypeError, not False.
+
+        The failure branch compared raw bytes against str literals, so a
+        failed metadata export blew up on the line meant to explain why it
+        failed. Pin the decode-then-compare order.
+        """
+        source = TestConvertSourceInvariants._convert_source()
+        tree = ast.parse(source)
+
+        target = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == '_convert_calibre':
+                target = node
+                break
+        self.assertIsNotNone(target, '_convert_calibre not found')
+
+        for node in ast.walk(target):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr == 'startswith':
+                # the receiver must be a plain name that was decoded first,
+                # never a subscript/attribute straight off the byte stream
+                self.assertIsInstance(
+                    func.value, ast.Name,
+                    'startswith called on a non-decoded expression')
+
+        # and the decode must actually be present in that branch
+        self.assertIn("ele.decode('utf-8', errors=\"ignore\")", source)
+
+    def test_decoding_a_calibre_traceback_does_not_raise(self):
+        """Behavioural mirror of the branch, on the shape it really sees."""
+        calibre_traceback = [
+            b'Traceback (most recent call last):\n',
+            b'  File "site-packages/calibre/db.py", line 1, in <module>\n',
+            b'DatabaseError: no such column: foo\n',
+        ]
+        error_message = ""
+        for ele in calibre_traceback:
+            if isinstance(ele, bytes):
+                ele = ele.decode('utf-8', errors="ignore")
+            ele = ele.strip('\r\n')
+            if ele and not ele.startswith('Traceback') and not ele.startswith('  File'):
+                error_message = ele
+        self.assertEqual(error_message, 'DatabaseError: no such column: foo')
+
+
 class TestConvertSourceInvariants(unittest.TestCase):
     """Source pins: this is exactly the shape that regressed once."""
 

--- a/tests/unit/test_convert_stderr_deadlock_1110.py
+++ b/tests/unit/test_convert_stderr_deadlock_1110.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression tests for fork issue #1110.
+
+`_convert_ebook_format` used to stream the converter's stdout in a
+`while p.poll() is None` loop and only read stderr *after* the child had
+exited. Both are pipes. Once the child writes more to stderr than the
+kernel pipe buffer holds (~64 KB on Linux), it blocks waiting for a
+reader, while the parent is blocked reading a stdout that will never
+produce another line. Neither side moves again and the convert task
+hangs in the queue forever.
+
+PDF input is the reliable trigger: calibre's PDF pipeline emits a
+warning per malformed object, so an OCR'd scan produces tens of
+thousands of stderr lines in seconds.
+
+These tests drive real child processes that flood one pipe while the
+other stays quiet, so a reintroduced single-pipe drain deadlocks the
+test instead of passing quietly.
+"""
+
+import ast
+import os
+import subprocess
+import sys
+import threading
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from cps.subproc_wrapper import process_wait, stream_process_output  # noqa: E402
+
+
+# Enough to overrun the pipe buffer on every platform we ship on.
+_FLOOD_LINES = 20000
+_TIMEOUT_SECONDS = 45
+
+
+def _child(script):
+    return subprocess.Popen(
+        [sys.executable, '-c', script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=False,
+    )
+
+
+def _run_with_watchdog(fn):
+    """Run `fn` on a thread and fail loudly instead of hanging the suite."""
+    box = {}
+
+    def target():
+        try:
+            box['value'] = fn()
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            box['error'] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout=_TIMEOUT_SECONDS)
+    if thread.is_alive():
+        raise AssertionError(
+            'deadlocked: still blocked after %ss, which is the #1110 '
+            'single-pipe drain regression' % _TIMEOUT_SECONDS)
+    if 'error' in box:
+        raise box['error']
+    return box['value']
+
+
+class TestStreamProcessOutput(unittest.TestCase):
+    """The helper both convert call sites use must drain stdout and stderr."""
+
+    def test_survives_a_stderr_flood_while_stdout_is_quiet(self):
+        script = (
+            'import sys\n'
+            'for i in range(%d):\n'
+            '    sys.stderr.write("pdf warning: malformed object %%d\\n" %% i)\n'
+            'sys.stderr.flush()\n'
+            'sys.stdout.write("50%% converting\\n")\n'
+            'sys.stdout.write("100%% done\\n")\n'
+        ) % _FLOOD_LINES
+
+        seen = []
+        p = _child(script)
+        stderr_lines = _run_with_watchdog(
+            lambda: stream_process_output(p, seen.append))
+
+        self.assertEqual(p.returncode, 0)
+        # stdout still arrives in full, so progress parsing keeps working.
+        self.assertEqual(len(seen), 2)
+        self.assertIn(b'100%', seen[1])
+        # and the stderr the old code deadlocked on is captured, not dropped.
+        self.assertEqual(len(stderr_lines), _FLOOD_LINES)
+
+    def test_survives_a_stdout_flood_while_stderr_is_quiet(self):
+        """The mirror case: never trade one deadlock for the other."""
+        script = (
+            'import sys\n'
+            'for i in range(%d):\n'
+            '    sys.stdout.write("%%d%%%% converting\\n" %% (i %% 100))\n'
+            'sys.stdout.flush()\n'
+            'sys.stderr.write("done\\n")\n'
+        ) % _FLOOD_LINES
+
+        seen = []
+        p = _child(script)
+        stderr_lines = _run_with_watchdog(
+            lambda: stream_process_output(p, seen.append))
+
+        self.assertEqual(p.returncode, 0)
+        self.assertEqual(len(seen), _FLOOD_LINES)
+        self.assertEqual(len(stderr_lines), 1)
+
+    def test_reports_a_nonzero_exit_and_still_returns_stderr(self):
+        script = (
+            'import sys\n'
+            'for i in range(%d):\n'
+            '    sys.stderr.write("boom %%d\\n" %% i)\n'
+            'sys.exit(3)\n'
+        ) % _FLOOD_LINES
+
+        p = _child(script)
+        stderr_lines = _run_with_watchdog(lambda: stream_process_output(p, None))
+
+        self.assertEqual(p.returncode, 3)
+        self.assertEqual(len(stderr_lines), _FLOOD_LINES)
+
+    def test_tail_of_stdout_written_just_before_exit_is_not_lost(self):
+        """`while p.poll() is None` also dropped whatever raced the exit."""
+        script = (
+            'import sys\n'
+            'sys.stdout.write("100% done\\n")\n'
+            'sys.stdout.flush()\n'
+        )
+        seen = []
+        p = _child(script)
+        _run_with_watchdog(lambda: stream_process_output(p, seen.append))
+
+        self.assertEqual(p.returncode, 0)
+        self.assertEqual(seen, [b'100% done\n'])
+
+
+class TestProcessWait(unittest.TestCase):
+    """`process_wait` waited on the child before reading either pipe."""
+
+    def test_survives_a_stdout_flood_before_the_match(self):
+        script = (
+            'import sys\n'
+            'for i in range(%d):\n'
+            '    sys.stdout.write("noise %%d\\n" %% i)\n'
+            'sys.stdout.write("calibre 7.16.0 built\\n")\n'
+        ) % _FLOOD_LINES
+
+        command = [sys.executable, '-c', script]
+        match = _run_with_watchdog(
+            lambda: process_wait(command, pattern=r'calibre (\S+)'))
+
+        self.assertTrue(match)
+        self.assertEqual(match.group(1), '7.16.0')
+
+
+class TestConvertSourceInvariants(unittest.TestCase):
+    """Source pins: this is exactly the shape that regressed once."""
+
+    @staticmethod
+    def _convert_source():
+        path = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'cps', 'tasks', 'convert.py')
+        with open(os.path.abspath(path), 'r', encoding='utf-8') as handle:
+            return handle.read()
+
+    def test_convert_never_reads_a_pipe_after_the_child_has_exited(self):
+        """`p.stderr.readlines()` after the drain loop is the bug itself."""
+        tree = ast.parse(self._convert_source())
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute) or func.attr != 'readlines':
+                continue
+            owner = func.value
+            if isinstance(owner, ast.Attribute) and owner.attr in ('stderr', 'stdout'):
+                offenders.append(owner.attr)
+        self.assertEqual(
+            offenders, [],
+            'cps/tasks/convert.py reads %s to EOF after the child exits; '
+            'that is the #1110 deadlock. Use stream_process_output instead.'
+            % ', '.join(sorted(set(offenders))))
+
+    def test_convert_does_not_poll_loop_a_single_pipe(self):
+        source = self._convert_source()
+        self.assertNotIn(
+            'while p.poll() is None', source,
+            'a poll loop over one pipe leaves the other undrained (#1110)')
+
+    def test_both_convert_call_sites_use_the_shared_helper(self):
+        source = self._convert_source()
+        self.assertIn('stream_process_output', source)
+        # the calibredb --as-opf probe, the ebook-convert run, and kepubify
+        self.assertGreaterEqual(source.count('stream_process_output('), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_convert_user_plugins_env_724.py
+++ b/tests/unit/test_convert_user_plugins_env_724.py
@@ -12,6 +12,7 @@ dir via ``calibre_user_plugins.apply_to_env`` when the opt-in
 pin that the convert subprocess now gets the same plugin-bearing env when the
 feature is enabled, and is left untouched when it is disabled.
 """
+import io
 import os
 import types
 
@@ -26,20 +27,26 @@ pytestmark = pytest.mark.unit
 
 
 class _FakeProc:
+    """A child whose pipes behave like real pipes.
+
+    The streams are real binary file objects rather than a stub exposing
+    only ``readline``/``readlines``: the converter drains them with the
+    ordinary file-object protocol (iterate to EOF, then close), so a stub
+    that answers only the old call shape would pin the shape instead of
+    the semantics and let a pipe-handling regression through (#1110).
+    """
+
     returncode = 0
+
+    def __init__(self):
+        self.stdout = io.BytesIO(b"")
+        self.stderr = io.BytesIO(b"")
 
     def poll(self):
         return 0
 
-    class _Stream:
-        def readline(self):
-            return b""
-
-        def readlines(self):
-            return []
-
-    stdout = _Stream()
-    stderr = _Stream()
+    def wait(self, timeout=None):
+        return self.returncode
 
 
 def _run_convert_capture_env(monkeypatch, plugins_enabled):


### PR DESCRIPTION
## Why

@auspex converted a PDF with an OCR'd text layer to TXT and it never finished (#1110). The only trace was an INFO line saying the target format did not exist, which reads like a refusal rather than a start, so the report reasonably asked why we offer a conversion that then does nothing.

## What the person was trying to do

Get a plain-text file next to their PDF, from the book editor's Files section. Not "make the exception go away" — there was no exception. The task simply never returned.

## Root cause

`_convert_ebook_format` streamed the child's stdout in a `while p.poll() is None` loop and read stderr **only after the child had exited**:

```python
while p.poll() is None:
    nextline = p.stdout.readline()
    ...
check = p.returncode
calibre_traceback = p.stderr.readlines()   # never reached
```

stdout and stderr are separate pipes with separate kernel buffers. Once the child writes more to stderr than its buffer holds (~64 KB on Linux), it blocks on `write` waiting for a reader, while we are blocked on a `readline` that can never return because the child is stopped. Neither side moves again and the task sits in the queue forever.

PDF input is the trigger because Calibre delegates PDF parsing to poppler's `pdftohtml`, whose syntax warnings go to **stderr**. An OCR'd scan emits one per malformed object. Calibre's own logging goes to stdout, which is why EPUB-family conversions were never affected and why the same file converts in a second from a shell — a terminal is not a pipe and never fills.

## Reproduction

The production loop shape, verbatim, against a child writing ~680 KB to stderr:

```
DEADLOCK CONFIRMED: legacy loop still blocked after 20.2s
```

`process_wait` carries the same defect (it calls `p.wait()` before reading either pipe) and deadlocks on a stdout flood:

```
DEADLOCK CONFIRMED: process_wait still blocked after 15.2s
```

## Fix

One `stream_process_output` helper in `cps/subproc_wrapper.py` drains stderr on a background thread while stdout is read to EOF, so the live progress parser keeps working and neither pipe can fill.

**The same root cause was in three more places, all fixed here** rather than left for the next person to hit:

| Call site | Defect |
|---|---|
| `_convert_ebook_format` | the reported one |
| `calibredb show_metadata --as-opf` probe | same poll-loop shape |
| `_convert_kepubify` | read stdout to EOF and **never drained stderr at all**; a non-zero exit also had no error text to report |
| `process_wait` | waited on the child before reading either pipe |

Also reworded the INFO line that reads as an error, since that is what the report opened with.

## Validation

Red before, green after. New `tests/unit/test_convert_stderr_deadlock_1110.py` (8 tests) drives **real child processes** that flood one pipe while the other stays quiet, so a reintroduced single-pipe drain deadlocks the test rather than passing quietly. A watchdog turns a hang into a failure instead of a wedged suite. Covers: stderr flood, the mirror stdout flood, non-zero exit still returning stderr, the tail of stdout racing the exit (the old loop dropped it), `process_wait` under flood, plus AST source-pins that fail if `p.stderr.readlines()` after the loop or `while p.poll() is None` comes back.

- New tests on unfixed code: `ImportError`, and both flood cases hang past the watchdog.
- After: **8 passed in 1.09s** (the case that hung for 20s now completes in 0.13s).
- Full unit suite: **6050 passed, 95 skipped**. The 4 failures in `test_1596_module_entry_point.py` are pre-existing and reproduce on clean `main` (confirmed by stashing this branch) — unrelated to this change, flagged separately.

**Live container, real converter** (`cwn-local`, real `/app/calibre/ebook-convert`, real 1.6 MB EPUB): converted through the patched production helper end to end, output byte-identical to the old path (2,721,787 B) at the same runtime, so the working paths are provably unaffected. Repeated against deliberately malformed input (400 unclosed tags per chapter file, 338 KB of converter output): identical again, 2,835,745 B.

## Honest limits

**OBSERVED:** the deadlock, the fix, non-regression on real conversions with the real converter.

**ASSUMED:** that @auspex's specific OCR'd PDF drives >64 KB to stderr. I could not observe that link here — the container's only PDF is a stub, and Calibre's PDF *output* plugin needs a GPU sandbox it cannot get as root, so I could not manufacture a valid one. The inference rests on poppler emitting syntax warnings on stderr and on the report being PDF-specific. It is consistent, not confirmed, and the close-out will say so rather than claim their case is verified.

## Tier

`needs-review` — fork-original, touches shared subprocess handling. No new dependencies, licenses or external URLs (`threading` is stdlib), so rule 6 is clear. No auth, session, CSRF, crypto, user-controlled path or new route, so `/security-review` does not apply.

Addresses #1110.
