### PR TITLE
Detect text direction per field, so RTL metadata reads right-to-left (#1073)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ is for things you can see or feel when running the app.
   each one links through to that shelf. Adding or removing the book from the
   menu updates the list straight away. Reported by @lguerard.
 
+### Fixed
+
+- **Arabic, Hebrew and Farsi titles now read the right way round.** Book titles,
+  authors, series names, descriptions and custom column values written in a
+  right-to-left script were rendered left-to-right on the book page and on the
+  grid and shelf cards, so the text started from the wrong edge and punctuation
+  landed on the wrong side. Direction is now detected per field from the text
+  itself, so a library with no language metadata set gets it right too, and a
+  right-to-left title above a Latin author renders each correctly. The classic
+  book page is fixed as well. Reported by @raphaelbahat.
+
 ## [v4.1.35] - 2026-08-15
 
 ### Changed

--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -61,6 +61,16 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
 
 ### Bug fixes
 
+- **RTL metadata renders right-to-left in both UIs** (fork #1073) — there was no
+  `dir` attribute anywhere in the SPA or the classic templates, so Arabic,
+  Hebrew and Farsi titles, authors, series and descriptions inherited the
+  document's `ltr` direction and rendered from the wrong edge. Each text field
+  now carries `dir="auto"`, resolving direction from that string's own first
+  strong directional character rather than from book-level language metadata,
+  which most libraries leave unset. `BookCard`'s `text-align: left` became
+  `start` so alignment follows the resolved direction instead of overriding it.
+  Reported by @raphaelbahat. SHA TBD, release TBD.
+
 - **Converter pipes are drained together, so a chatty child cannot wedge the
   task queue** (fork #1110) — `_convert_ebook_format` streamed the child's
   stdout in a `while p.poll() is None` loop and read stderr only after the

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -829,8 +829,11 @@
                             </div>
                         </div>
 
-                        <h2 id="title">{{ entry.title }}</h2>
-                        <p class="author">
+                        {# dir="auto" per field (#1073): direction resolves from each
+                           string's own first strong character, so RTL titles and authors
+                           render right-to-left without the library needing a language set. #}
+                        <h2 id="title" dir="auto">{{ entry.title }}</h2>
+                        <p class="author" dir="auto">
                             {% for author in entry.ordered_authors %}
                                 <a href="{{ url_for('web.books_list',  data='author', sort_param='stored', book_id=author.id ) }}">{{ author.name.replace('|',',') }}</a>
                                 {% if not loop.last %}
@@ -874,7 +877,7 @@
                             {% endif %}
                         </div>
                         {% if entry.series|length > 0 %}
-                            <p id="book_of">{{ _("Book %(index)s of %(range)s", index=entry.series_index|formatfloat(2), range=(url_for('web.books_list', data='series', sort_param='stored', book_id=entry.series[0].id)|escapedlink(entry.series[0].name))|safe) }}</p>
+                            <p id="book_of" dir="auto">{{ _("Book %(index)s of %(range)s", index=entry.series_index|formatfloat(2), range=(url_for('web.books_list', data='series', sort_param='stored', book_id=entry.series[0].id)|escapedlink(entry.series[0].name))|safe) }}</p>
                         {% endif %}
 
                         <div class="book-metadata">
@@ -1098,7 +1101,7 @@
                 {% if entry.comments|length > 0 and entry.comments[0].text|length > 0 %}
                     <div class="book-detail-description">
                         <h3 id="decription">{{ _('Description:') }}</h3>
-                        {{ entry.comments[0].text|clean_string|safe }}
+                        <div dir="auto">{{ entry.comments[0].text|clean_string|safe }}</div>
                     </div>
                 {% endif %}
                 <div id="shelf-action-errors" class="pull-left" role="alert"></div>

--- a/frontend/e2e/rtl-auto-direction.spec.ts
+++ b/frontend/e2e/rtl-auto-direction.spec.ts
@@ -1,0 +1,219 @@
+import { test, expect, Page } from '@playwright/test';
+import { collectPageErrors, assertNoPageErrors } from './utils';
+
+/*
+ * #1073 regression — RTL titles, authors, series and descriptions must render
+ * right-to-left in the new UI.
+ *
+ * Reported by @raphaelbahat with screenshots of the single-book view and the
+ * shelf/catalog view: Arabic and Hebrew metadata rendered left-to-right, so the
+ * text read from the wrong edge and trailing punctuation landed on the wrong
+ * side. There was no `dir` attribute anywhere in the SPA or the classic
+ * templates, so every string inherited the document's ltr direction.
+ *
+ * The fix puts dir="auto" on each text-bearing field, which resolves direction
+ * from that string's own first strong directional character, and changes the
+ * card's `text-align: left` to `start` so alignment follows the resolved
+ * direction rather than overriding it.
+ *
+ * These specs fail on the pre-fix build: without dir="auto" the computed
+ * direction on an Arabic title is "ltr", not "rtl".
+ *
+ * Seeded through the same endpoint the edit page uses, and restored in a
+ * finally so the run leaves the library exactly as it found it.
+ */
+
+// Arabic; first strong character is RTL. "The Little Prince".
+const RTL_TITLE = 'الأمير الصغير';
+const RTL_AUTHOR = 'أنطوان دو سانت إكزوبيري';
+const RTL_SERIES = 'سلسلة الكلاسيكيات';
+
+async function csrfToken(page: Page): Promise<string> {
+  const res = await page.request.get('/api/v1/auth/csrf');
+  const body = (await res.json()) as { csrf_token: string };
+  return body.csrf_token;
+}
+
+interface Meta {
+  title: string;
+  authors: string;
+  series?: string | null;
+  series_index?: number | null;
+}
+
+async function readMeta(page: Page, id: number): Promise<Meta> {
+  const res = await page.request.get(`/api/v1/books/${id}/metadata`);
+  expect(res.ok(), 'metadata read should succeed').toBeTruthy();
+  const m = (await res.json()) as Record<string, unknown>;
+  return {
+    title: String(m.title ?? ''),
+    authors: String(m.authors ?? ''),
+    series: (m.series as string | null) ?? null,
+    series_index: (m.series_index as number | null) ?? null,
+  };
+}
+
+async function writeMeta(page: Page, id: number, patch: Record<string, unknown>) {
+  const res = await page.request.post(`/api/v1/books/${id}/metadata`, {
+    headers: { 'X-CSRFToken': await csrfToken(page) },
+    data: patch,
+  });
+  expect(res.ok(), `metadata write should succeed (got ${res.status()})`).toBeTruthy();
+}
+
+async function firstBookId(page: Page): Promise<number | null> {
+  const res = await page.request.get('/api/v1/books?per_page=1');
+  const body = (await res.json()) as { total: number; items: Array<{ id: number }> };
+  if ((body.total ?? 0) < 1) return null;
+  return body.items[0].id;
+}
+
+// Serial: every spec here renames the SAME book and restores it. In parallel
+// they would race on each other's title rather than on the product.
+test.describe.configure({ mode: 'serial' });
+
+test.describe('#1073 automatic RTL text direction', () => {
+  test('an Arabic title, author and series render RTL on the book page', async ({ page }) => {
+    const errors = collectPageErrors(page);
+    const bookId = await firstBookId(page);
+    test.skip(bookId === null, 'no seeded book to rename');
+    const id = bookId as number;
+
+    const original = await readMeta(page, id);
+    try {
+      await writeMeta(page, id, {
+        title: RTL_TITLE,
+        authors: RTL_AUTHOR,
+        series: RTL_SERIES,
+        series_index: 1,
+      });
+
+      await page.goto(`/app/book/${id}`, { waitUntil: 'domcontentloaded' });
+
+      const title = page.getByRole('heading', { level: 1 });
+      await expect(title).toHaveText(RTL_TITLE);
+
+      // The load-bearing assertion. Pre-fix this is "ltr" (inherited from the
+      // document); post-fix dir="auto" resolves it from the Arabic text itself.
+      const titleDir = await title.evaluate((el) => getComputedStyle(el).direction);
+      expect(titleDir, 'Arabic <h1> title must compute RTL').toBe('rtl');
+
+      const authorLine = page.locator('p').filter({ hasText: RTL_AUTHOR }).first();
+      await expect(authorLine).toBeVisible();
+      expect(
+        await authorLine.evaluate((el) => getComputedStyle(el).direction),
+        'Arabic author line must compute RTL',
+      ).toBe('rtl');
+
+      const seriesLine = page.locator('p').filter({ hasText: RTL_SERIES }).first();
+      await expect(seriesLine).toBeVisible();
+      expect(
+        await seriesLine.evaluate((el) => getComputedStyle(el).direction),
+        'Arabic series line must compute RTL',
+      ).toBe('rtl');
+    } finally {
+      await writeMeta(page, id, {
+        title: original.title,
+        authors: original.authors,
+        series: original.series,
+        series_index: original.series_index,
+      });
+    }
+    assertNoPageErrors(errors);
+  });
+
+  test('an Arabic card title renders RTL and sits flush to the right edge', async ({ page }) => {
+    const bookId = await firstBookId(page);
+    test.skip(bookId === null, 'no seeded book to rename');
+    const id = bookId as number;
+
+    const original = await readMeta(page, id);
+    try {
+      await writeMeta(page, id, { title: RTL_TITLE, authors: RTL_AUTHOR });
+
+      await page.goto('/app');
+      const cardTitle = page.locator('p').filter({ hasText: RTL_TITLE }).first();
+      await expect(cardTitle).toBeVisible();
+
+      expect(
+        await cardTitle.evaluate((el) => getComputedStyle(el).direction),
+        'Arabic card title must compute RTL',
+      ).toBe('rtl');
+
+      // Alignment, not just direction. `text-align: left` on the card control
+      // would leave direction correct and the text still pinned to the left
+      // edge — the exact half-fix this guards against. Measure the rendered
+      // text run against its box: RTL text in a box wider than the text must
+      // end flush right, not start flush left.
+      const gap = await cardTitle.evaluate((el) => {
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        const text = range.getBoundingClientRect();
+        const box = el.getBoundingClientRect();
+        return { left: text.left - box.left, right: box.right - text.right,
+                 slack: box.width - text.width };
+      });
+      // Only meaningful when the text is narrower than its box.
+      if (gap.slack > 4) {
+        expect(gap.right, 'RTL card title should be flush right, not left').toBeLessThan(gap.left);
+      }
+    } finally {
+      await writeMeta(page, id, { title: original.title, authors: original.authors });
+    }
+  });
+
+  test('the classic book page also renders an Arabic title RTL', async ({ page }) => {
+    // The same defect existed in the classic templates, which are a separate
+    // render path from the SPA and are what a user on the old theme still sees.
+    // detail.html had no `dir` anywhere either, so this is the second face of
+    // one root cause rather than a separate bug.
+    const bookId = await firstBookId(page);
+    test.skip(bookId === null, 'no seeded book to rename');
+    const id = bookId as number;
+
+    const original = await readMeta(page, id);
+    try {
+      await writeMeta(page, id, { title: RTL_TITLE, authors: RTL_AUTHOR });
+
+      // No /app prefix: this is the classic server-rendered page.
+      await page.goto(`/book/${id}`, { waitUntil: 'domcontentloaded' });
+      const title = page.locator('h2#title');
+      await expect(title).toHaveText(RTL_TITLE);
+      expect(
+        await title.evaluate((el) => getComputedStyle(el).direction),
+        'Arabic title on the classic page must compute RTL',
+      ).toBe('rtl');
+
+      const author = page.locator('p.author').first();
+      await expect(author).toBeVisible();
+      expect(
+        await author.evaluate((el) => getComputedStyle(el).direction),
+        'Arabic author on the classic page must compute RTL',
+      ).toBe('rtl');
+    } finally {
+      await writeMeta(page, id, { title: original.title, authors: original.authors });
+    }
+  });
+
+  test('a Latin title still renders LTR', async ({ page }) => {
+    // Guards the obvious over-correction: dir="auto" must resolve per string,
+    // so switching a field to RTL for one book cannot flip everyone else.
+    const bookId = await firstBookId(page);
+    test.skip(bookId === null, 'no seeded book');
+    const id = bookId as number;
+
+    const original = await readMeta(page, id);
+    try {
+      await writeMeta(page, id, { title: 'The Little Prince', authors: original.authors });
+      await page.goto(`/app/book/${id}`, { waitUntil: 'domcontentloaded' });
+      const title = page.getByRole('heading', { level: 1 });
+      await expect(title).toHaveText('The Little Prince');
+      expect(
+        await title.evaluate((el) => getComputedStyle(el).direction),
+        'Latin title must stay LTR',
+      ).toBe('ltr');
+    } finally {
+      await writeMeta(page, id, { title: original.title, authors: original.authors });
+    }
+  });
+});

--- a/frontend/src/components/BookCard.module.css
+++ b/frontend/src/components/BookCard.module.css
@@ -25,7 +25,11 @@
   background: none;
   border: none;
   padding: 0;
-  text-align: left;
+  /* `start`, not `left`: the card's text nodes carry dir="auto" (#1073), so an
+     Arabic or Hebrew title computes as RTL. A hardcoded `left` would win over
+     that and pin the text to the wrong edge, leaving the direction correct but
+     the alignment visibly wrong. `start` resolves per element's own direction. */
+  text-align: start;
   text-decoration: none;
   color: inherit;
   transition: transform var(--dur-base) var(--ease-out);

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -118,12 +118,18 @@ export function BookCard({
     </div>
   );
 
+  // dir="auto" per field, not once on the card (#1073, reported by @raphaelbahat).
+  // The browser picks direction from the first strong directional character in
+  // THAT string, so a Hebrew title above an English author renders each the right
+  // way round. A single card-level or book-level flag has to be wrong about one
+  // of them, and keying off the book's language metadata would miss the many
+  // libraries that leave language unset — which is the case in the report.
   const info = (
     <div className={styles.info}>
-      <p className={styles.title}>{book.title}</p>
-      <p className={styles.author}>{authorStr}</p>
+      <p className={styles.title} dir="auto">{book.title}</p>
+      <p className={styles.author} dir="auto">{authorStr}</p>
       {seriesLine && (
-        <p className={styles.series} data-testid="book-card-series">{seriesLine}</p>
+        <p className={styles.series} dir="auto" data-testid="book-card-series">{seriesLine}</p>
       )}
     </div>
   );

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -319,9 +319,12 @@ export function BookDetail() {
         {/* RIGHT: info */}
         <div className={styles.infoCol}>
           <div>
-            <h1 className={styles.title}>{book.title}</h1>
+            {/* dir="auto" per field (#1073): direction follows each string's own
+                first strong character, so a Hebrew title and a Latin series name
+                on the same page each render correctly. */}
+            <h1 className={styles.title} dir="auto">{book.title}</h1>
             {book.authors.length > 0 && (
-              <p className={styles.authors}>
+              <p className={styles.authors} dir="auto">
                 {book.authors.map((a, i) => (
                   <span key={a.id}>
                     {i > 0 && AUTHOR_SEPARATOR}
@@ -331,7 +334,7 @@ export function BookDetail() {
               </p>
             )}
             {book.series && (
-              <p className={styles.series}>
+              <p className={styles.series} dir="auto">
                 <Link href={`/series/${book.series.id}`} className={styles.metaLink}>
                   {book.series.name}
                 </Link>
@@ -669,7 +672,7 @@ export function BookDetail() {
             {(book.custom_columns ?? []).map((column) => (
               <Fragment key={`custom-${column.id}`}>
                 <dt className={styles.metaLabel}>{column.name}</dt>
-                <dd className={styles.metaValue}>
+                <dd className={styles.metaValue} dir="auto">
                   {column.datatype === 'comments' && column.values[0]?.value_html ? (
                     <span
                       // value_html is sanitized by the API serializer.
@@ -689,6 +692,7 @@ export function BookDetail() {
           {book.description_html && (
             <div
               className={styles.description}
+              dir="auto"
               // description_html is sanitized server-side in serialize_book_detail
               // (cps/clean_html.clean_string — bleach/nh3 allowlist, same as the
               // legacy templates), so it is safe to render here.


### PR DESCRIPTION
Fixes the RTL rendering @raphaelbahat reported in #1073.

## Symptom

Arabic, Hebrew and Farsi metadata rendered left-to-right, so the text started from the wrong edge and trailing punctuation landed on the wrong side. Reproduced from the reporter's screenshots on both surfaces they flagged: the single-book view and the shelf/catalog view.

## Root cause

There was no `dir` attribute anywhere in either UI — zero matches across `frontend/src` and `cps/templates/`. Every string therefore inherited the document's `ltr` direction regardless of its script. This is not a partial or wrong RTL implementation; there was none.

## Fix

`dir="auto"` on each text-bearing field, so the browser resolves direction from that field's own first strong directional character.

**Deliberate departure from the reporter's suggestion.** They proposed keying off the book's language metadata. Per-field detection is used instead for two reasons: a large share of libraries leave language unset, so a metadata-driven rule would have left the reporter's own screenshots unchanged; and direction is a property of each field, not of the book, so a Hebrew title with a Latin publisher renders both correctly where a single book-level flag has to be wrong about one of them. It also adds no requests and no metadata plumbing. This is stated in the issue thread too, so the reporter can challenge it.

`BookCard`'s `text-align: left` becomes `start`. Without that the direction resolves correctly and the text still sits flush left — direction right, alignment wrong. The card spec measures that specifically rather than trusting the attribute.

## Scope, including what is not done

- SPA book page: title, authors, series, description, custom column values
- SPA grid and shelf cards: title, author, series
- Classic detail page: title, author, series, description

**Not done:** the classic grid/list cards. That markup is copy-pasted across six templates (`index.html`, `search.html`, `shelf.html`, `author.html`, `shelfdown.html`, `shelf_order.html`) rather than living in a macro, and the e2e harness is SPA-oriented, so I would be shipping six edits I could not verify. Called out in the issue thread rather than left silent.

## Verification

Red/green on `cwn-local`, measured as computed style rather than asserted on the attribute:

| Spec | Pre-fix | Post-fix |
|---|---|---|
| Arabic `<h1>` title, author, series (SPA book page) | `direction: ltr` ❌ | `rtl` ✅ |
| Arabic card title + flush-right alignment | `direction: ltr` ❌ | `rtl`, text flush right ✅ |
| Arabic title + author (classic detail page) | `direction: ltr` ❌ | `rtl` ✅ |
| Latin title still LTR (over-correction guard) | — | `ltr` ✅ |

9/9 green across desktop (1280×800) and mobile (375×667). The classic-page red was captured by re-deploying the pre-fix `detail.html` into the container and re-running, so that half is a real red/green and not a source-pin.

Specs seed through `POST /api/v1/books/<id>/metadata` — the same endpoint the edit page uses — and restore the original metadata in a `finally`, so a run leaves the library as it found it.

### Rig note

The local `calibre-web-nextgen:local` image was three days old, so the container's Python lagged `main` by 15 commits while the SPA was current. That mismatch produced unrelated local failures in `a11y`, `book-detail-shelf-membership` and `edit-rating`. The full `cps/` tree was copied into the container and it was restarted before the verification runs above. CI is the arbiter for the full-suite result.

## Tier

`needs-review` — fork-original, multi-file, touches a shared card style. No new dependencies, licenses or external URLs. No auth, session, CSRF, crypto, subprocess, file-path or new-route surface, so `/security-review` does not apply.

Reported by @raphaelbahat.

