### PR TITLE
fix(annotation): never discard a Kobo highlight over a malformed content location

### DIFF
--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -207,8 +207,18 @@ def _upsert_annotation(session, payload, book, user, *, origin_device_id=None):
                 f"{_book_uuid(book)}!!{chapter_filename}", book_uuid=_book_uuid(book)
             )
         except ContentIdError:
-            log.warning("Rejecting annotation %s with invalid content location", annotation_id)
-            return None
+            # content_id is DERIVED, nullable and recomputable; the highlight is
+            # none of those things. For a sideloaded book the device is the only
+            # other copy, so discarding the row here destroys text that exists
+            # nowhere else -- which is exactly what happened between 2026-08-13
+            # and 2026-08-15. Degrade the locator, never the annotation;
+            # ub.backfill_annotation_content_ids repairs the column later.
+            log.warning(
+                "Annotation %s has an unusable content location %r; storing it "
+                "without a content_id rather than discarding the highlight",
+                annotation_id, chapter_filename,
+            )
+            normalized_content_id = None
     ann = (
         session.query(ub.Annotation)
         .filter(

--- a/tests/unit/test_annotation_never_discarded_on_bad_location.py
+++ b/tests/unit/test_annotation_never_discarded_on_bad_location.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""A malformed content location must never destroy the user's highlight.
+
+Regression guard for the #1531 fallout: ``_upsert_annotation`` began validating
+the derived ``content_id`` and returning ``None`` when the check failed, which
+discarded the entire annotation -- text, note, colour and span anchors -- over a
+locator field that is nullable and recomputable.  On the household instance that
+silently dropped 95 Kobo highlights in two days.
+
+``content_id`` is ``nullable=True`` (cps/ub.py).  It is derived data.  The
+highlighted text is the irreplaceable part and it is device-local for sideloaded
+books, so dropping it loses data that exists nowhere else.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
+from cps.services.annotation_sync import (
+    dispatch_annotation_sync,
+    reset_registry_for_testing,
+)
+
+BOOK_UUID = "9e5251ad-d530-4e58-9121-8b8336099fdd"
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    reset_registry_for_testing()
+    yield
+    reset_registry_for_testing()
+
+
+@pytest.fixture
+def patched_session(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    session.execute(text("PRAGMA foreign_keys=ON"))
+    user = ub.User(name="u", email="u@e.com", role=0, password="x")
+    session.add(user)
+    session.commit()
+    monkeypatch.setattr(ub, "session", session)
+    monkeypatch.setattr(ub, "session_commit", lambda: session.commit())
+    yield session, user
+    session.close()
+
+
+def _book():
+    """A book WITH a uuid -- the existing dispatcher fixture has none, which is
+    exactly why the content-id gate was dead code in every test and shipped."""
+    return SimpleNamespace(id=347, title="Flatland", uuid=BOOK_UUID)
+
+
+def _payload(chapter_filename):
+    return {
+        "id": "1e0f4b1a-0000-4000-8000-000000000001",
+        "highlightedText": "Be patient, for the world is broad and wide.",
+        "highlightColor": "yellow",
+        "noteText": "irreplaceable user note",
+        "location": {"span": {
+            "chapterFilename": chapter_filename,
+            "chapterProgress": 0.5,
+            "startPath": "span#kobo\\.5\\.1",
+            "endPath": "span#kobo\\.5\\.3",
+            "startChar": 0,
+            "endChar": 44,
+        }},
+    }
+
+
+# Shapes a real Kobo can emit that the #1531 grammar rejects outright.
+@pytest.mark.parametrize("chapter_filename", [
+    "/OPS/chapter-006.xml",                                    # absolute
+    "./OPS/chapter-006.xml",                                   # dot segment
+    "OPS//chapter-006.xml",                                    # empty segment
+    "OPS\\chapter-006.xml",                                    # backslash
+    "file:///mnt/onboard/Flatland.kepub.epub#(6)OPS/chapter-006.xml",  # device ContentID
+])
+def test_bad_content_location_never_discards_the_annotation(
+    patched_session, chapter_filename,
+):
+    session, user = patched_session
+
+    dispatch_annotation_sync([_payload(chapter_filename)], _book(), user)
+
+    rows = session.query(ub.Annotation).all()
+    assert len(rows) == 1, (
+        f"highlight was DESTROYED for chapterFilename={chapter_filename!r}; "
+        "a derived locator must never cost the user their annotation"
+    )
+    row = rows[0]
+    assert row.highlighted_text == "Be patient, for the world is broad and wide."
+    assert row.note_text == "irreplaceable user note"
+    assert row.highlight_color == "yellow"
+    # The span anchors survive too -- they are what re-render the highlight.
+    assert row.start_container_path == "span#kobo\\.5\\.1"
+    assert row.end_container_path == "span#kobo\\.5\\.3"
+
+
+def test_valid_content_location_still_normalizes(patched_session):
+    """The happy path must keep working -- this is not a licence to stop validating."""
+    session, user = patched_session
+
+    dispatch_annotation_sync([_payload("OPS/chapter-006.xml")], _book(), user)
+
+    row = session.query(ub.Annotation).one()
+    assert row.content_id == f"{BOOK_UUID}!!OPS/chapter-006.xml"


### PR DESCRIPTION
## The bug

`#1531` added content-id validation to `_upsert_annotation`. Its failure path is `return None`, which **discards the entire annotation** — highlighted text, note, colour and both span anchors — because a *derived* locator field failed a grammar check.

`content_id` is `Column(String, nullable=True)` (`cps/ub.py:987`) and is recomputable via `ub.backfill_annotation_content_ids`. The highlighted text is neither. For a sideloaded book the Kobo is the only other copy, so dropping the row loses text that exists nowhere else.

## Measured impact on a live instance

| | |
|---|---|
| Image carrying #1531 started | `2026-08-13 18:38:11` |
| First discard | `2026-08-13 18:40:37` (2m26s later) |
| Highlights destroyed | **95**, across **95 distinct annotation ids** (no retries — each was a one-shot upload) |
| Annotations stored in that window | **0**, for any book |

The ids never repeat, so the device does not re-send. **The data is not recoverable server-side** — deploying this stops the bleeding, it does not restore what was already dropped.

## Why no test caught it

The gate is dead code in the existing suite. `tests/unit/test_annotation_sync_dispatcher.py`'s `_book()` returns a `SimpleNamespace` with no `uuid`, so `_book_uuid(book)` returns `None` and `if chapter_filename and _book_uuid(book):` never enters the validation branch. The new test uses a book that has a `uuid`.

## The fix

Degrade the locator, never the annotation. A content location outside the accepted grammar now sets `content_id = NULL` and logs the offending value; the annotation is stored regardless. Valid locations normalize exactly as before.

## Security note

This does **not** weaken the validator. A malformed `content_id` is stored as `NULL`, never persisted raw — so no untrusted value reaches the column. That is strictly safer than the pre-#1531 behaviour (`ann.content_id = f"{uuid}!!{chapter_filename}"`, unvalidated) and equally safe as #1531, minus the data loss.

## Verification

- Red/green: `tests/unit/test_annotation_never_discarded_on_bad_location.py` — 5 parametrized real-world Kobo shapes (absolute path, `./` segment, `//` empty segment, backslash, device `file:///mnt/onboard/...#(N)path` ContentID). All 5 fail on `main` with `highlight was DESTROYED`, all pass with the fix.
- Happy path asserted separately: a valid location still yields `<uuid>!!OPS/chapter-006.xml`.
- `pytest tests/unit -k "annotation or kobo or readingservice"` → **768 passed, 3 skipped, 0 failed**.

## Not covered here

Why the device reports a location our grammar rejects is still open, and is being investigated separately against the physical Kobo. This PR is the data-loss stop, not the explanation.