### PR TITLE
fix(kobo): stop the annotation download from deleting the device's highlights

### DIFF
--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -366,6 +366,37 @@ def handle_annotations(entitlement_id):
     PATCH includes content (i.e. annotations come from Kobo).  An always-persist
     path independent of any sync target lands in sub-project (2).
     """
+    if request.method == "GET":
+        book = get_book_by_entitlement_id(entitlement_id)
+        if book is not None:
+            # This entitlement is a book WE delivered. Kobo's cloud has never heard
+            # of it, so it answers the download direction with a success-shaped
+            # "no annotations" -- and Nickel acts on that by DELETING every local
+            # Bookmark row for the book (upstream calibre-web #2610).
+            #
+            # Measured on real hardware 2026-08-15: 88 correctly-anchored highlights
+            # at 11:58; one sync at 12:07 uploaded a single annotation and deleted
+            # the other 87. For a sideloaded book the device is frequently the only
+            # copy, so a 200-empty here is a DESTRUCTIVE operation even though the
+            # verb is GET.
+            #
+            # We deliberately do not answer with our own snapshot either: an
+            # internally-complete server view would tell a second device to drop
+            # annotations it has not uploaded yet. 503 + Retry-After is the one
+            # response that cannot be read as "you have none" -- it is explicitly
+            # non-authoritative, so the device keeps what it holds.
+            log.info(
+                "Not proxying annotation download for locally-owned book %s (%s); "
+                "Kobo's empty answer would delete the device's copy",
+                book.id, entitlement_id,
+            )
+            response = make_response(
+                jsonify({"error": "Annotation download unavailable for sideloaded content"}),
+                503,
+            )
+            response.headers["Retry-After"] = "3600"
+            return response
+
     if request.method == "PATCH":
         try:
             data = request.get_json() or {}

--- a/tests/unit/test_kobo_annotations_get_never_authoritative_empty.py
+++ b/tests/unit/test_kobo_annotations_get_never_authoritative_empty.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""The annotation DOWNLOAD direction must never hand Nickel an authoritative empty set.
+
+Kobo's cloud has never heard of a sideloaded book. Forwarding
+``GET /api/v3/content/<uuid>/annotations`` to it yields a success-shaped "you have
+no annotations" answer, and Nickel acts on that by DELETING every local Bookmark
+row for the book -- upstream calibre-web #2610.
+
+Reproduced on the operator's own hardware 2026-08-15: 88 highlights were present
+and correctly anchored at 11:58; one sync at 12:07 uploaded a single annotation
+and deleted the other 87. For a sideloaded book the device is frequently the only
+copy, so a 200-empty here is a destructive operation even though the verb is GET.
+
+The one response that cannot be misread as "you have none" is an explicitly
+non-authoritative failure. We return 503 + Retry-After for books we own, and keep
+proxying for content we do NOT own (real Kobo store books, where Kobo's cloud is
+genuinely authoritative).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+import cps.readingservices as rs
+
+
+BOOK_UUID = "9e5251ad-d530-4e58-9121-8b8336099fdd"
+
+
+@pytest.fixture
+def app():
+    return Flask(__name__)
+
+
+@pytest.fixture
+def no_proxy(monkeypatch):
+    """Fail loudly if the download direction reaches Kobo for a book we own."""
+    calls = []
+
+    def _proxy():
+        calls.append(True)
+        raise AssertionError(
+            "GET annotations was proxied to Kobo's cloud for a book we own -- "
+            "its empty answer deletes the device's only copy (calibre-web #2610)"
+        )
+
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", _proxy)
+    return calls
+
+
+def _view():
+    # strip the auth/config decorator; functools.wraps exposes the original
+    return rs.handle_annotations.__wrapped__
+
+
+def test_get_for_a_book_we_own_is_not_proxied_and_is_not_success(app, monkeypatch, no_proxy):
+    monkeypatch.setattr(
+        rs, "get_book_by_entitlement_id",
+        lambda eid: SimpleNamespace(id=347, title="Flatland", uuid=BOOK_UUID),
+    )
+    with app.test_request_context(
+        f"/api/v3/content/{BOOK_UUID}/annotations?limit=100", method="GET"
+    ):
+        resp = _view()(BOOK_UUID)
+
+    status = resp.status_code if hasattr(resp, "status_code") else resp[1]
+    assert status == 503, f"expected a non-authoritative 503, got {status}"
+    assert not (200 <= status < 300), "a 2xx here tells Nickel to delete local highlights"
+    assert resp.headers.get("Retry-After"), "503 must carry Retry-After so the device retries"
+
+
+def test_get_for_content_we_do_not_own_still_proxies(app, monkeypatch):
+    """A real Kobo store book is Kobo's data; its cloud IS authoritative there."""
+    sentinel = object()
+    monkeypatch.setattr(rs, "get_book_by_entitlement_id", lambda eid: None)
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+
+    with app.test_request_context("/api/v3/content/not-ours/annotations", method="GET"):
+        assert _view()("not-ours") is sentinel
+
+
+def test_patch_upload_direction_still_proxies(app, monkeypatch):
+    """Uploads are harmless and must keep working -- only the download is destructive."""
+    sentinel = object()
+    monkeypatch.setattr(rs, "get_book_by_entitlement_id", lambda eid: None)
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+
+    with app.test_request_context(
+        f"/api/v3/content/{BOOK_UUID}/annotations", method="PATCH",
+        json={"updatedAnnotations": []},
+    ):
+        assert _view()(BOOK_UUID) is sentinel


### PR DESCRIPTION
## The bug

CWNG advertises itself as the device's `reading_services_host` whenever Kobo sync is on (`cps/kobo.py`), then forwards `GET /api/v3/content/<uuid>/annotations` to `readingservices.kobo.com`. Kobo's cloud has never heard of a sideloaded book, so it answers with a **success-shaped empty set** — and Nickel acts on that by **deleting every local `Bookmark` row for the book**.

This is upstream [calibre-web #2610](https://github.com/janeczku/calibre-web/issues/2610), open since 2022, 13 comments, previously never root-caused because nobody had read the device DB during the event.

## Reproduced end-to-end on real hardware today

Device DB read over USB (`/Volumes/KOBOeReader/.kobo/KoboReader.sqlite`):

```
11:58   88 highlights present, correctly anchored   (VolumeID 9e5251ad-…)
12:07   one sync:  1 annotation PATCHed up
                   GET .../annotations?limit=100  → proxied to Kobo
after   0 Bookmark rows for that book
```

**87 highlights deleted, never uploaded.** The server holds exactly 1 of the 88. For a sideloaded book the device is frequently the only copy, so a 200-empty on this route is a **destructive operation even though the verb is GET**.

## The fix

When the entitlement resolves to a book we own, don't proxy the download direction. Return **503 + `Retry-After`** — the one response that cannot be read as "you have none", so the device keeps what it holds.

Unchanged:
- Content we do **not** own still proxies — there Kobo's cloud genuinely is authoritative.
- The **PATCH upload direction** is untouched; uploads are harmless and still work.

## Why not answer with our own snapshot

Deliberately rejected. An internally-complete server view would tell a *second* device to drop annotations it hasn't uploaded yet, and a regenerated KEPUB shifts KoboSpan ids so a correct-looking snapshot installs misplaced anchors. Answering safely requires the full write-back design. This PR stops the data loss now; it does not claim to solve the download direction.

## Verification

- `tests/unit/test_kobo_annotations_get_never_authoritative_empty.py` — the download-for-an-owned-book test fails on `main` with *"GET annotations was proxied to Kobo's cloud for a book we own"*, passes with the fix. Two companion tests pin that unowned content still proxies and that PATCH is unaffected.
- `pytest tests/unit -k "annotation or kobo or readingservice"` → **771 passed, 3 skipped, 0 failed**.