### PR TITLE
fix(kepub): contain OPF manifest items that escape the OPF directory

### DIFF
--- a/cps/services/kepub_package_normalizer.py
+++ b/cps/services/kepub_package_normalizer.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Make kepubify output safe for Kobo's non-normalizing package resolver."""
+
+import copy
+import os
+import posixpath
+import re
+import stat
+import tempfile
+import zipfile
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
+
+from lxml import etree
+
+from .. import logger
+
+
+log = logger.create()
+
+_CONTAINER_PATH = "META-INF/container.xml"
+_CONTAINER_NS = "urn:oasis:names:tc:opendocument:xmlns:container"
+_TEXT_DOCUMENT_SUFFIXES = (
+    ".css", ".htm", ".html", ".ncx", ".opf", ".svg", ".xhtml", ".xml",
+)
+_REFERENCE_ATTRIBUTE_RE = re.compile(
+    rb"(?P<prefix>\b(?:[A-Za-z_][\w.-]*:)?(?:href|src)\s*=\s*)"
+    rb"(?P<quote>['\"])(?P<value>.*?)(?P=quote)",
+    re.IGNORECASE | re.DOTALL,
+)
+_CSS_URL_RE = re.compile(
+    rb"(?P<prefix>\burl\(\s*)(?P<quote>['\"]?)(?P<value>.*?)"
+    rb"(?P=quote)(?P<suffix>\s*\))",
+    re.IGNORECASE | re.DOTALL,
+)
+_KOBO_SPAN_RE = re.compile(
+    rb"<(?:(?:[A-Za-z_][\w.-]*):)?span\b[^>]*\bclass\s*=\s*"
+    rb"(['\"])[^'\"]*\bkoboSpan\b[^'\"]*\1[^>]*>",
+    re.IGNORECASE,
+)
+_XML_PARSER = etree.XMLParser(resolve_entities=False, no_network=True, recover=False)
+
+
+def _package_document_path(archive):
+    container = etree.fromstring(archive.read(_CONTAINER_PATH), parser=_XML_PARSER)
+    rootfiles = container.xpath(
+        "//container:rootfile/@full-path", namespaces={"container": _CONTAINER_NS})
+    if not rootfiles:
+        raise ValueError("EPUB container does not name a package document")
+    package_path = posixpath.normpath(rootfiles[0])
+    if package_path.startswith("../") or package_path.startswith("/"):
+        raise ValueError("EPUB package document path escapes the archive")
+    return package_path
+
+
+def _manifest_items(opf_bytes):
+    package = etree.fromstring(opf_bytes, parser=_XML_PARSER)
+    return package.xpath("//*[local-name()='manifest']/*[local-name()='item']")
+
+
+def _split_local_reference(value):
+    parts = urlsplit(value)
+    if parts.scheme or parts.netloc or parts.path.startswith("/"):
+        return None
+    path = unquote(parts.path)
+    if "\\" in path:
+        raise ValueError("EPUB reference contains a backslash")
+    return parts, path
+
+
+def _resolve_reference(document_path, reference_path):
+    return posixpath.normpath(posixpath.join(posixpath.dirname(document_path), reference_path))
+
+
+def _inside_directory(path, directory):
+    if not directory or directory == ".":
+        return not path.startswith("../") and path != ".." and not path.startswith("/")
+    return path == directory or path.startswith(directory + "/")
+
+
+def _collision_safe_destination(source, opf_directory, occupied):
+    basename = posixpath.basename(source)
+    stem, extension = posixpath.splitext(basename)
+    candidate = posixpath.join(opf_directory, basename) if opf_directory else basename
+    counter = 1
+    while candidate in occupied:
+        renamed = "{}-{}{}".format(stem, counter, extension)
+        candidate = posixpath.join(opf_directory, renamed) if opf_directory else renamed
+        counter += 1
+    return candidate
+
+
+def _plan_relocations(opf_path, opf_bytes, archive_names):
+    opf_directory = posixpath.dirname(opf_path)
+    occupied = set(archive_names)
+    relocations = {}
+    for item in _manifest_items(opf_bytes):
+        href = item.get("href")
+        if not href:
+            continue
+        split = _split_local_reference(href)
+        if split is None:
+            continue
+        _, href_path = split
+        source = _resolve_reference(opf_path, href_path)
+        if _inside_directory(source, opf_directory):
+            continue
+        if source not in archive_names:
+            raise ValueError("escaping manifest item is missing: {}".format(source))
+        if source not in relocations:
+            destination = _collision_safe_destination(source, opf_directory, occupied)
+            relocations[source] = destination
+            occupied.add(destination)
+    return relocations
+
+
+def _encoded_relative_path(target, document_path):
+    base = posixpath.dirname(document_path) or "."
+    relative = posixpath.relpath(target, base)
+    return quote(relative, safe="/@:+!$&'()*+,;=-._~")
+
+
+def _rewrite_reference(value, old_document, new_document, relocations, rewrite_all):
+    try:
+        split = _split_local_reference(value)
+    except (TypeError, ValueError):
+        return value
+    if split is None:
+        return value
+    parts, reference_path = split
+    if not reference_path:
+        return value
+    original_target = _resolve_reference(old_document, reference_path)
+    target = relocations.get(original_target, original_target)
+    if not rewrite_all and target == original_target:
+        return value
+    new_path = _encoded_relative_path(target, new_document)
+    return urlunsplit(("", "", new_path, parts.query, parts.fragment))
+
+
+def _rewrite_document(content, old_document, new_document, relocations):
+    rewrite_all = old_document != new_document
+
+    def replace_attribute(match):
+        value = match.group("value").decode("utf-8")
+        rewritten = _rewrite_reference(
+            value, old_document, new_document, relocations, rewrite_all)
+        if rewritten == value:
+            return match.group(0)
+        return (match.group("prefix") + match.group("quote")
+                + rewritten.encode("utf-8") + match.group("quote"))
+
+    def replace_css_url(match):
+        value = match.group("value").decode("utf-8")
+        rewritten = _rewrite_reference(
+            value, old_document, new_document, relocations, rewrite_all)
+        if rewritten == value:
+            return match.group(0)
+        return (match.group("prefix") + match.group("quote")
+                + rewritten.encode("utf-8") + match.group("quote") + match.group("suffix"))
+
+    rewritten = _REFERENCE_ATTRIBUTE_RE.sub(replace_attribute, content)
+    if old_document.lower().endswith(".css"):
+        rewritten = _CSS_URL_RE.sub(replace_css_url, rewritten)
+    return rewritten
+
+
+def _rewritten_entries(infos, contents, relocations):
+    entries = []
+    for info in infos:
+        old_name = info.filename
+        new_name = relocations.get(old_name, old_name)
+        content = contents[old_name]
+        if (old_name in relocations
+                or old_name.lower().endswith(_TEXT_DOCUMENT_SUFFIXES)):
+            content = _rewrite_document(content, old_name, new_name, relocations)
+        new_info = copy.copy(info)
+        new_info.filename = new_name
+        new_info.orig_filename = new_name
+        entries.append((new_info, content))
+    return entries
+
+
+def _span_counts(contents, relocations=None):
+    relocations = relocations or {}
+    return {
+        relocations.get(name, name): len(_KOBO_SPAN_RE.findall(content))
+        for name, content in contents.items()
+    }
+
+
+def _write_archive(path, entries, comment):
+    mimetype = next((entry for entry in entries if entry[0].filename == "mimetype"), None)
+    if mimetype is None:
+        raise ValueError("EPUB archive has no mimetype entry")
+    ordered = [mimetype] + [entry for entry in entries if entry is not mimetype]
+    with zipfile.ZipFile(path, "w", allowZip64=True) as archive:
+        archive.comment = comment
+        for info, content in ordered:
+            if info.filename == "mimetype":
+                info.compress_type = zipfile.ZIP_STORED
+            archive.writestr(info, content)
+
+
+def _validate_rewritten_archive(path, expected_span_counts):
+    with zipfile.ZipFile(path) as archive:
+        infos = archive.infolist()
+        if not infos or infos[0].filename != "mimetype":
+            raise ValueError("mimetype is not the first EPUB entry")
+        if infos[0].compress_type != zipfile.ZIP_STORED:
+            raise ValueError("mimetype is compressed")
+        if archive.read(infos[0]) != b"application/epub+zip":
+            raise ValueError("mimetype has unexpected content")
+        if archive.testzip() is not None:
+            raise ValueError("rewritten KEPUB failed its CRC check")
+        opf_path = _package_document_path(archive)
+        opf_directory = posixpath.dirname(opf_path)
+        for item in _manifest_items(archive.read(opf_path)):
+            href = item.get("href")
+            if not href:
+                continue
+            split = _split_local_reference(href)
+            if split is None:
+                continue
+            _, href_path = split
+            if not _inside_directory(_resolve_reference(opf_path, href_path), opf_directory):
+                raise ValueError("rewritten manifest still escapes the OPF directory")
+        contents = {info.filename: archive.read(info) for info in infos}
+        if _span_counts(contents) != expected_span_counts:
+            raise ValueError("KoboSpan counts changed while normalizing the package")
+
+
+def normalize_kepub_package(path):
+    """Normalize escaping OPF manifest items in ``path`` atomically.
+
+    Return ``True`` when the archive changed, ``False`` for a clean byte-identical
+    no-op, and ``None`` when validation failed. Failures are logged and never
+    escape; the original archive is left untouched.
+    """
+    path = os.fspath(path)
+    temporary_path = None
+    try:
+        original_stat = os.stat(path)
+        with zipfile.ZipFile(path) as archive:
+            infos = archive.infolist()
+            names = [info.filename for info in infos]
+            if len(names) != len(set(names)):
+                raise ValueError("KEPUB contains duplicate ZIP member names")
+            if archive.testzip() is not None:
+                raise ValueError("KEPUB failed its CRC check")
+            contents = {info.filename: archive.read(info) for info in infos}
+            opf_path = _package_document_path(archive)
+            relocations = _plan_relocations(opf_path, contents[opf_path], set(names))
+            if not relocations:
+                return False
+            entries = _rewritten_entries(infos, contents, relocations)
+            expected_span_counts = _span_counts(contents, relocations)
+            comment = archive.comment
+
+        descriptor, temporary_path = tempfile.mkstemp(
+            dir=os.path.dirname(os.path.abspath(path)),
+            prefix="." + os.path.basename(path) + ".",
+            suffix=".normalize.tmp",
+        )
+        os.close(descriptor)
+        _write_archive(temporary_path, entries, comment)
+        _validate_rewritten_archive(temporary_path, expected_span_counts)
+        os.chmod(temporary_path, stat.S_IMODE(original_stat.st_mode))
+        os.replace(temporary_path, path)
+        temporary_path = None
+        return True
+    except Exception as error:
+        log.warning("Could not normalize KEPUB package %s; original preserved: %s", path, error)
+        return None
+    finally:
+        if temporary_path is not None:
+            try:
+                os.unlink(temporary_path)
+            except OSError:
+                pass

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -275,8 +275,15 @@ class TaskConvert(CalibreTask):
                 os.close(temp_fd)
                 try:
                     copyfile(converted_file[0], temp_destination)
-                    if normalize_kepub_package(temp_destination) is None:
-                        return 1, N_("Kepubify output package normalization failed")
+                    # None means the normalizer could not process this package.
+                    # Continue with the un-normalized KEPUB rather than failing the
+                    # conversion: an un-normalized KEPUB is exactly what we ship
+                    # today, whereas withholding it drops the user back to EPUB
+                    # delivery, where a Kobo cannot save highlights at all
+                    # (upstream calibre-web #1484). The normalizer already logs a
+                    # warning, leaves the archive untouched, and _valid_archive
+                    # below still rejects a genuinely corrupt one.
+                    normalize_kepub_package(temp_destination)
                     if not _valid_archive(temp_destination, format_new_ext[1:]):
                         return 1, N_("Kepubify produced an invalid KEPUB archive")
                     os.replace(temp_destination, destination)

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -24,6 +24,7 @@ from cps import logger, config
 from cps.subproc_wrapper import process_open, stream_process_output
 from flask_babel import gettext as _
 from cps.file_helper import get_temp_dir
+from cps.services.kepub_package_normalizer import normalize_kepub_package
 
 from cps.tasks.mail import TaskEmail
 from cps import gdriveutils, helper
@@ -274,6 +275,8 @@ class TaskConvert(CalibreTask):
                 os.close(temp_fd)
                 try:
                     copyfile(converted_file[0], temp_destination)
+                    if normalize_kepub_package(temp_destination) is None:
+                        return 1, N_("Kepubify output package normalization failed")
                     if not _valid_archive(temp_destination, format_new_ext[1:]):
                         return 1, N_("Kepubify produced an invalid KEPUB archive")
                     os.replace(temp_destination, destination)

--- a/notes/KOBO-HIGHLIGHT-LOSS-ROOT-CAUSE-2026-08-15.md
+++ b/notes/KOBO-HIGHLIGHT-LOSS-ROOT-CAUSE-2026-08-15.md
@@ -1,0 +1,116 @@
+# Kobo highlight loss — two independent root causes, both measured on hardware
+
+**Date:** 2026-08-15 · **Reporter:** household instance · **Symptom as reported:**
+*"On a Kobo reading a KEPUB, I highlight something, leave the book, come back, and the highlight is gone."*
+
+Everything below was measured, not inferred. The device DB was read over USB from
+`/Volumes/KOBOeReader/.kobo/KoboReader.sqlite` (copy it off first — `sqlite3` `mode=ro`
+against the mounted volume fails with *unable to open database file*).
+
+---
+
+## Cause 1 — highlights never render: a `../` OPF href splits the chapter identity
+
+Kobo identifies a chapter as `<book-uuid>!<opf-dir>!<href>`. A `Bookmark` renders only when
+`Bookmark.ContentID` **exactly equals** a `content` row with `ContentType=9`. No fuzzy matching.
+
+The affected book's OPF (`OPS/epb.opf`) declared the EPUB3 nav at the ZIP ROOT:
+
+```xml
+<item id="nav" href="../nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+```
+
+Nickel joins `opf_dir + href` **without normalizing `..`**, so:
+
+```
+nav path        = "OPS/../nav.xhtml"
+nav's directory = "OPS/.."
+nav link        = "OPS/chapter-017.xml"
+joined          = "OPS/../OPS/chapter-017.xml"   <- what got written to Bookmark.ContentID
+```
+
+Both identities are visible side by side in `content`:
+
+| ContentType | ContentID |
+|---|---|
+| 9 (chapter, used for rendering) | `<uuid>!OPS!chapter-017.xml` |
+| 899 (TOC entry) | `<uuid>!OPS!../OPS/chapter-017.xml-2` |
+
+All 88 of the book's `Bookmark` rows carried the TOC-derived form → **0 matches** → nothing drawn.
+A control book returned `matching content row exists: 1`; this book returned `0`.
+
+**Census query — orphaned highlights, device-wide:**
+
+```sql
+select b.VolumeID, count(*) n,
+  sum(case when exists(select 1 from content c where c.ContentID=b.ContentID) then 1 else 0 end) matched
+from Bookmark b group by b.VolumeID;
+```
+
+907 of 3016 were orphaned. Two distinct reasons: this bug (Flatland 88, All Quiet 9), and
+*book no longer on the device* (Iliad 584, King in Yellow 220, Republic 6 — those have **no**
+`ContentType=9` rows at all and are not repairable by rewriting; they'd render again if the book
+returned to the same path).
+
+**Library scan:** 5 of 216 books (2.3%) carry an escaping OPF href, every one `../nav.xhtml`.
+Perfect correlation on the instance: every book with one has **zero** stored annotations ever;
+all 604 stored annotations come from books without one.
+
+**Repair** (device in USB mass-storage mode, Nickel not running): `UPDATE Bookmark SET ContentID`
+to `<uuid>!<opf-dir>!<normpath(href)>`, scoped by `VolumeID`. Verify each target has a
+`ContentType='9'` row first; hash every other volume's rows before/after to prove isolation. PK is
+`BookmarkID`, so rewriting `ContentID` cannot collide. 88/88 restored this way.
+
+**Durable fix:** normalize escaping manifest hrefs during EPUB→KEPUB conversion (PR #1637).
+
+---
+
+## Cause 2 — highlights are then DELETED: the annotation download returns an authoritative empty set
+
+This is upstream [calibre-web #2610](https://github.com/janeczku/calibre-web/issues/2610), open
+since 2022 and never root-caused because nobody had read the device DB during the event.
+
+CWNG advertises itself as `reading_services_host` whenever Kobo sync is on, then forwards
+`GET /api/v3/content/<uuid>/annotations` to `readingservices.kobo.com`. **Kobo's cloud has never
+heard of a sideloaded book**, so it answers with a success-shaped empty set — and Nickel acts on
+that by deleting every local `Bookmark` row for the book.
+
+```
+11:58   88 highlights present and correctly anchored (after the Cause-1 repair)
+12:07   one sync:  1 annotation PATCHed up
+                   GET .../annotations?limit=100  -> proxied to Kobo
+after   0 Bookmark rows for that book
+```
+
+**87 deleted, never uploaded.** The server held exactly 1 of 88. For a sideloaded book the device is
+frequently the only copy, so a 200-empty here is a **destructive operation even though the verb is
+GET**.
+
+⚠️ **Repairing Cause 1 EXPOSES annotations to Cause 2.** While the ContentIDs were malformed the
+rows were invisible to the sync reconciliation and survived; making them well-formed made them
+eligible for deletion. **Fix the server before repairing a device.**
+
+**Fix (PR #1636):** when the entitlement resolves to a book we own, do not proxy the download
+direction — return **503 + `Retry-After`**, the one response that cannot be read as "you have none".
+Content we do not own still proxies (there Kobo's cloud genuinely is authoritative); PATCH upload is
+untouched.
+
+Deliberately **not** answering with our own snapshot: an internally-complete server view would tell
+a second device to drop annotations it has not uploaded yet, and a regenerated KEPUB shifts KoboSpan
+ids so a correct-looking snapshot installs misplaced anchors.
+
+---
+
+## Cause 3 (ours) — the server was discarding every Kobo highlight
+
+Independent of the device, #1531 added content-id validation to `_upsert_annotation` whose failure
+path was `return None`, discarding the whole annotation over a derived, nullable, recomputable
+field. Deployed 2026-08-13 18:38:11; first discard 18:40:37; **95 highlights across 95 distinct ids
+destroyed in under 48 hours**, zero annotations stored for any book in that window.
+
+It shipped because the gate was dead code in tests: the dispatcher fixture's `_book()` is a
+`SimpleNamespace` with no `uuid`, so the branch was never entered.
+
+Fixed in #1635 (never discard) and #1638 (normalize contained traversals so `content_id` is correct
+rather than NULL). The validator was *right* that the value was malformed — it was the canary for
+Cause 1 — but it was wrong to charge the user for the discovery.

--- a/tests/unit/test_kepub_package_normalizer.py
+++ b/tests/unit/test_kepub_package_normalizer.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression coverage for Kobo-safe KEPUB package path normalization."""
+
+import logging
+import re
+import zipfile
+
+import pytest
+from lxml import etree
+
+
+CONTAINER_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OPS/epb.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+"""
+
+FLATLAND_OPF = b"""<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="uid">flatland-test</dc:identifier>
+  </metadata>
+  <manifest>
+    <item id="nav" href="../nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="chapter" href="chapter-001.xml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="chapter"/></spine>
+</package>
+"""
+
+CLEAN_OPF = FLATLAND_OPF.replace(b'href="../nav.xhtml"', b'href="nav.xhtml"')
+
+NAV_XHTML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body><nav>
+  <a href="OPS/chapter-001.xml#start">Chapter one</a>
+  <iframe src="OPS/chapter-001.xml#preview"></iframe>
+</nav></body></html>
+"""
+
+CHAPTER_XHTML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <a href="../nav.xhtml">Contents</a>
+  <p><span class="koboSpan" id="kobo.1.1">A</span>
+     <span id="kobo.1.2" class="koboSpan extra">B</span></p>
+</body></html>
+"""
+
+
+def _write_package(path, *, opf=FLATLAND_OPF, nav_path="nav.xhtml", extra_entries=()):
+    entries = [
+        ("mimetype", b"application/epub+zip", zipfile.ZIP_STORED),
+        ("META-INF/container.xml", CONTAINER_XML, zipfile.ZIP_DEFLATED),
+        ("OPS/epb.opf", opf, zipfile.ZIP_DEFLATED),
+        (nav_path, NAV_XHTML, zipfile.ZIP_DEFLATED),
+        ("OPS/chapter-001.xml", CHAPTER_XHTML, zipfile.ZIP_DEFLATED),
+    ]
+    entries.extend((name, content, zipfile.ZIP_DEFLATED) for name, content in extra_entries)
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, content, compression in entries:
+            archive.writestr(name, content, compress_type=compression)
+
+
+def _normalizer():
+    from cps.services.kepub_package_normalizer import normalize_kepub_package
+
+    return normalize_kepub_package
+
+
+def _manifest_hrefs(opf_bytes):
+    root = etree.fromstring(opf_bytes)
+    return root.xpath("//*[local-name()='manifest']/*[local-name()='item']/@href")
+
+
+@pytest.mark.unit
+def test_flatland_shape_relocates_escaping_nav_and_preserves_link_targets(tmp_path):
+    package = tmp_path / "flatland.kepub"
+    _write_package(package)
+
+    assert _normalizer()(package) is True
+
+    with zipfile.ZipFile(package) as archive:
+        names = set(archive.namelist())
+        opf = archive.read("OPS/epb.opf")
+        hrefs = _manifest_hrefs(opf)
+        nav_href = hrefs[0]
+        nav_path = "OPS/" + nav_href
+        nav = archive.read(nav_path)
+        chapter = archive.read("OPS/chapter-001.xml")
+
+    assert all(".." not in href.split("/") for href in hrefs)
+    assert nav_path in names
+    assert "nav.xhtml" not in names
+    assert b'href="chapter-001.xml#start"' in nav
+    assert b'src="chapter-001.xml#preview"' in nav
+    assert b'href="' + nav_href.encode() + b'"' in chapter
+
+
+@pytest.mark.unit
+def test_second_normalization_is_a_byte_identical_no_op(tmp_path):
+    package = tmp_path / "flatland.kepub"
+    _write_package(package)
+    normalize = _normalizer()
+
+    assert normalize(package) is True
+    first = package.read_bytes()
+    assert normalize(package) is False
+
+    assert package.read_bytes() == first
+
+
+@pytest.mark.unit
+def test_clean_package_is_completely_untouched(tmp_path):
+    package = tmp_path / "clean.kepub"
+    _write_package(package, opf=CLEAN_OPF, nav_path="OPS/nav.xhtml")
+    before = package.read_bytes()
+
+    assert _normalizer()(package) is False
+
+    assert package.read_bytes() == before
+
+
+@pytest.mark.unit
+def test_kobo_span_markup_and_per_file_counts_are_preserved_exactly(tmp_path):
+    package = tmp_path / "spans.kepub"
+    _write_package(package)
+    span_pattern = re.compile(rb"<span\b[^>]*\bclass=(['\"])\b[^>]*koboSpan[^>]*>.*?</span>", re.DOTALL)
+
+    with zipfile.ZipFile(package) as archive:
+        before = {name: len(span_pattern.findall(archive.read(name))) for name in archive.namelist()}
+        chapter_before = archive.read("OPS/chapter-001.xml")
+        exact_spans = re.findall(rb"<span\b[^>]*>.*?</span>", chapter_before, re.DOTALL)
+
+    assert _normalizer()(package) is True
+
+    with zipfile.ZipFile(package) as archive:
+        after = {name: len(span_pattern.findall(archive.read(name))) for name in archive.namelist()}
+        chapter_after = archive.read("OPS/chapter-001.xml")
+
+    assert {name: count for name, count in after.items() if count} == {
+        name: count for name, count in before.items() if count
+    }
+    assert all(span in chapter_after for span in exact_spans)
+
+
+@pytest.mark.unit
+def test_mimetype_remains_first_and_stored(tmp_path):
+    package = tmp_path / "mimetype.kepub"
+    _write_package(package)
+
+    assert _normalizer()(package) is True
+
+    with zipfile.ZipFile(package) as archive:
+        first = archive.infolist()[0]
+        assert first.filename == "mimetype"
+        assert first.compress_type == zipfile.ZIP_STORED
+        assert archive.read(first) == b"application/epub+zip"
+
+
+@pytest.mark.unit
+def test_relocation_uses_a_collision_safe_name(tmp_path):
+    package = tmp_path / "collision.kepub"
+    existing = b"<html xmlns=\"http://www.w3.org/1999/xhtml\"><body>existing</body></html>"
+    _write_package(package, extra_entries=(("OPS/nav.xhtml", existing),))
+
+    assert _normalizer()(package) is True
+
+    with zipfile.ZipFile(package) as archive:
+        hrefs = _manifest_hrefs(archive.read("OPS/epb.opf"))
+        assert hrefs[0] == "nav-1.xhtml"
+        assert archive.read("OPS/nav.xhtml") == existing
+        assert "OPS/nav-1.xhtml" in archive.namelist()
+        assert b'href="nav-1.xhtml"' in archive.read("OPS/chapter-001.xml")
+
+
+@pytest.mark.unit
+def test_corrupt_input_is_preserved_and_only_logs_a_warning(tmp_path, caplog):
+    package = tmp_path / "corrupt.kepub"
+    original = b"PK\x03\x04not-a-readable-archive"
+    package.write_bytes(original)
+
+    with caplog.at_level(logging.WARNING):
+        assert _normalizer()(package) is None
+
+    assert package.read_bytes() == original
+    assert any("normalize" in record.getMessage().lower() for record in caplog.records)
+
+
+@pytest.mark.unit
+def test_conversion_normalization_failure_does_not_replace_existing_kepub(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    import cps.helper  # noqa: F401 - establish the application's normal import order
+    from cps.tasks import convert
+
+    book_path = tmp_path / "book"
+    (tmp_path / "book.epub").write_bytes(b"source")
+    (tmp_path / "book.kepub.epub").write_bytes(b"kepubify output")
+    destination = tmp_path / "book.kepub"
+    destination.write_bytes(b"existing valid kepub")
+    process = SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(convert.config, "config_embed_metadata", False, raising=False)
+    monkeypatch.setattr(convert.config, "config_binariesdir", "", raising=False)
+    monkeypatch.setattr(convert.config, "config_kepubifypath", "/bin/kepubify", raising=False)
+    monkeypatch.setattr(convert, "process_open", lambda *_args, **_kwargs: process)
+    monkeypatch.setattr(convert, "stream_process_output", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(convert, "normalize_kepub_package", lambda _path: None)
+    task = convert.TaskConvert(str(book_path), 1, "convert", {}, None)
+
+    check, error = task._convert_kepubify(str(book_path), ".epub", ".kepub")
+
+    assert check == 1
+    assert "normalization failed" in str(error).lower()
+    assert destination.read_bytes() == b"existing valid kepub"

--- a/tests/unit/test_kepub_package_normalizer.py
+++ b/tests/unit/test_kepub_package_normalizer.py
@@ -189,7 +189,44 @@ def test_corrupt_input_is_preserved_and_only_logs_a_warning(tmp_path, caplog):
 
 
 @pytest.mark.unit
-def test_conversion_normalization_failure_does_not_replace_existing_kepub(tmp_path, monkeypatch):
+def test_conversion_continues_when_normalization_cannot_process_the_package(tmp_path, monkeypatch):
+    """A normalizer that cannot handle a package must not withhold the KEPUB.
+
+    An un-normalized KEPUB is exactly what we shipped before this feature existed.
+    Failing the conversion instead drops the user back to EPUB delivery, where a
+    Kobo cannot save highlights at all (upstream calibre-web #1484) -- strictly
+    worse than the problem normalization is trying to prevent. A genuinely corrupt
+    archive is still rejected, but by `_valid_archive`, which is its job.
+    """
+    from types import SimpleNamespace
+
+    import cps.helper  # noqa: F401 - establish the application's normal import order
+    from cps.tasks import convert
+
+    book_path = tmp_path / "book"
+    (tmp_path / "book.epub").write_bytes(b"source")
+    # a VALID archive that the normalizer simply declines to process
+    _write_package(tmp_path / "src.kepub.epub")
+    (tmp_path / "book.kepub.epub").write_bytes((tmp_path / "src.kepub.epub").read_bytes())
+    destination = tmp_path / "book.kepub"
+    process = SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(convert.config, "config_embed_metadata", False, raising=False)
+    monkeypatch.setattr(convert.config, "config_binariesdir", "", raising=False)
+    monkeypatch.setattr(convert.config, "config_kepubifypath", "/bin/kepubify", raising=False)
+    monkeypatch.setattr(convert, "process_open", lambda *_args, **_kwargs: process)
+    monkeypatch.setattr(convert, "stream_process_output", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(convert, "normalize_kepub_package", lambda _path: None)
+    task = convert.TaskConvert(str(book_path), 1, "convert", {}, None)
+
+    check, error = task._convert_kepubify(str(book_path), ".epub", ".kepub")
+
+    assert check == 0, f"conversion should still succeed, got error: {error}"
+    assert destination.exists(), "the un-normalized KEPUB must still be delivered"
+
+
+@pytest.mark.unit
+def test_conversion_corrupt_archive_still_does_not_replace_existing_kepub(tmp_path, monkeypatch):
     from types import SimpleNamespace
 
     import cps.helper  # noqa: F401 - establish the application's normal import order
@@ -213,5 +250,5 @@ def test_conversion_normalization_failure_does_not_replace_existing_kepub(tmp_pa
     check, error = task._convert_kepubify(str(book_path), ".epub", ".kepub")
 
     assert check == 1
-    assert "normalization failed" in str(error).lower()
+    assert "invalid kepub archive" in str(error).lower()
     assert destination.read_bytes() == b"existing valid kepub"


### PR DESCRIPTION
## Why

An OPF manifest href that escapes the OPF directory makes a Kobo derive **two different identities for the same chapter**, and highlights written under the wrong one are stored forever but never render.

Traced end-to-end on real hardware 2026-08-15 (device DB read over USB):

```
OPF (OPS/epb.opf):  <item id="nav" href="../nav.xhtml" properties="nav"/>
Nickel resolves:    OPS/ + ../nav.xhtml  →  "OPS/../nav.xhtml"   (no normalization)
nav's directory:    "OPS/.."
nav link:           OPS/chapter-017.xml
joined:             "OPS/../OPS/chapter-017.xml"
```

Both identities appear side by side in the device's `content` table:

```
ContentType 9   (chapter, used for rendering):  <uuid>!OPS!chapter-017.xml
ContentType 899 (TOC entry):                    <uuid>!OPS!../OPS/chapter-017.xml-2
```

All 88 of the affected book's `Bookmark` rows carried the TOC-derived form and matched **zero** `content` rows. A control book returned `matching content row exists: 1`; this book returned `0`.

Correlation on the reporting instance: **every** book whose OPF contains a `../` href has zero stored annotations ever; all 604 stored annotations come from books without one.

We produce the KEPUB specifically so Kobo devices get proper KoboSpans, so this conversion is the right place to guarantee the package cannot trigger the bug.

## What it does

`cps/services/kepub_package_normalizer.py` relocates escaping manifest items into the OPF directory and recomputes every reference — `href`, `src`, namespaced `*:href`, CSS `url(...)` — both *inside* the relocated document and *to* it from elsewhere. Collision-safe naming, `mimetype` kept first and STORED, atomic temp-file replace.

Hooked into `TaskConvert._convert_kepubify`, the single chokepoint every KEPUB passes through (manual conversion, on-demand conversion, and the startup backfill all route through it).

**KoboSpan preservation is enforced, not assumed**: only affected attribute values are rewritten (no whole-document reserialization), and per-file span counts are compared before/after with the rewrite rejected on any change. That matters — `scripts/cover_enforcer.py:698-725` records that `ebook-polish` inflated ~7,016 spans to ~13,500.

## Failure behaviour

A package the normalizer cannot process logs a warning, leaves the archive untouched, and **conversion continues with the un-normalized KEPUB** — exactly what shipped before this feature, so it cannot regress anyone. Withholding the KEPUB instead would drop the user back to EPUB delivery, where a Kobo cannot save highlights at all ([calibre-web #1484](https://github.com/janeczku/calibre-web/issues/1484)) — strictly worse than the problem being solved. A genuinely corrupt archive is still rejected by `_valid_archive`, and an existing destination KEPUB is never overwritten. Both pinned by tests.

## Verification

- 9 tests in `tests/unit/test_kepub_package_normalizer.py`, written red first (the 6 original cases all failed with `ModuleNotFoundError` before the module existed): Flatland-shaped fixture, idempotence (byte-identical no-op), clean package untouched, KoboSpan markup and per-file counts preserved exactly, `mimetype` first and STORED, corrupt input preserved with only a warning, collision-safe naming, conversion-continues-on-decline, corrupt-archive-preserves-destination.
- `pytest tests/unit -k "kepub or annotation or kobo"` → **834 passed, 3 skipped, 0 failed**.

Implementation by Sol; the failure-handling correction and its two tests added on review.