### PR TITLE
fix(annotation): normalize contained dot segments in a content location

### DIFF
--- a/cps/services/annotation_content_id.py
+++ b/cps/services/annotation_content_id.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import posixpath
 import re
 import uuid
 from pathlib import PurePosixPath
@@ -47,9 +48,18 @@ def _chapter(value: str) -> str:
         raise ContentIdError("content_id chapter path is not relative")
     if any(ord(char) < 32 or ord(char) == 127 for char in value):
         raise ContentIdError("content_id chapter path contains control characters")
-    if any(part in ("", ".", "..") for part in value.split("/")):
-        raise ContentIdError("content_id chapter path contains an unsafe segment")
-    return value
+    # Real clients emit CONTAINED traversals. A Kobo whose OPF references a file
+    # outside the OPF directory (an EPUB3 nav at the zip root declared
+    # href="../nav.xhtml") joins paths without normalizing, so it sends e.g.
+    # "OPS/../OPS/chapter-017.xml" -- unambiguously "OPS/chapter-017.xml".
+    # This guard exists to stop a path ESCAPING the book container, not to reject
+    # every dot segment; rejecting the contained case cost real annotations their
+    # content_id and left them unresolvable in the web reader.
+    normalized = posixpath.normpath(value)
+    if (normalized.startswith("../") or normalized.startswith("/")
+            or normalized in (".", "..")):
+        raise ContentIdError("content_id chapter path escapes the book container")
+    return normalized
 
 
 def normalize_content_id(value, *, book_uuid=None, allow_legacy_file_uri=False):

--- a/tests/unit/test_content_id_normalizes_contained_traversal.py
+++ b/tests/unit/test_content_id_normalizes_contained_traversal.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""A path that stays inside the container should normalize, not be rejected.
+
+Real Kobo hardware emits `chapterFilename` values like `OPS/../OPS/chapter-017.xml`
+when the book's OPF references a file outside the OPF directory (an EPUB3 nav at
+the zip root declared `href="../nav.xhtml"`). Nickel joins without normalizing, so
+the `..` reaches us verbatim. That path is unambiguously `OPS/chapter-017.xml`.
+
+The grammar's job is to stop traversal ESCAPING the container, not to reject every
+dot segment. Rejecting the contained case cost real annotations their content_id
+and left them unresolvable in the web reader.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cps.services.annotation_content_id import normalize_content_id, ContentIdError
+
+UUID = "9e5251ad-d530-4e58-9121-8b8336099fdd"
+
+
+@pytest.mark.parametrize("raw,expected", [
+    # the exact shape measured on the operator's Kobo, 2026-08-15
+    ("OPS/../OPS/chapter-017.xml", "OPS/chapter-017.xml"),
+    ("OEBPS/../OEBPS/chapter001.html", "OEBPS/chapter001.html"),
+    ("./OPS/chapter-006.xml", "OPS/chapter-006.xml"),
+    ("OPS//chapter-006.xml", "OPS/chapter-006.xml"),
+    ("OPS/sub/../chapter-006.xml", "OPS/chapter-006.xml"),
+    # already clean -> unchanged
+    ("OPS/chapter-006.xml", "OPS/chapter-006.xml"),
+])
+def test_contained_traversal_normalizes(raw, expected):
+    assert normalize_content_id(f"{UUID}!!{raw}", book_uuid=UUID) == f"{UUID}!!{expected}"
+
+
+@pytest.mark.parametrize("raw", [
+    "../outside.xml",              # escapes the container
+    "OPS/../../outside.xml",       # escapes after descending
+    "/OPS/chapter-006.xml",        # absolute
+    "OPS\\chapter-006.xml",        # backslash
+    "OPS/chapter-006.xml\n",       # control character
+    "..",                          # bare traversal
+])
+def test_escaping_or_malformed_still_rejected(raw):
+    with pytest.raises(ContentIdError):
+        normalize_content_id(f"{UUID}!!{raw}", book_uuid=UUID)
+
+
+def test_normalization_is_idempotent():
+    once = normalize_content_id(f"{UUID}!!OPS/../OPS/chapter-017.xml", book_uuid=UUID)
+    twice = normalize_content_id(once, book_uuid=UUID)
+    assert once == twice


### PR DESCRIPTION
## Why

Real Kobo hardware emits `chapterFilename` values containing `..` when the book's OPF references a file outside the OPF directory. Captured from the operator's device 2026-08-15:

```json
"span": {
  "chapterFilename": "OPS/../OPS/chapter-017.xml",
  "chapterTitle": "Section 17.",
  "startPath": "span#kobo\\.5\\.2"
}
```

That path is unambiguously `OPS/chapter-017.xml`. `_chapter` rejected it because it treated *every* dot segment as unsafe — but the guard exists to stop a path **escaping the book container**, not to reject cosmetic variance a client produced.

## Impact

With #1635 such annotations now survive, but with `content_id = NULL`, which leaves them unresolvable in CWNG's own web reader. With this change they resolve correctly.

## The change

Contained traversals normalize via `posixpath.normpath`. Paths that genuinely escape still raise.

The security boundary is unchanged, and this is demonstrable: the six escape cases in the new test (`../outside`, `OPS/../../outside`, `/abs`, bare `..`, backslash, control character) **already passed before this commit and still pass** — the red run was 6 failed / 7 passed, with every failure a normalization case and every escape case green.

`content_id` never reaches the filesystem (verified: no `os.path`/`open`/`join`/`send_file`/`zipfile` call sites take it), so it is an identifier only.

## Verification

- `tests/unit/test_content_id_normalizes_contained_traversal.py` — 13 tests: 6 contained-traversal normalizations including the exact measured shape, 6 escape/malformed rejections, and idempotence.
- `pytest tests/unit -k "annotation or kobo or content_id or readingservice"` → **781 passed, 3 skipped, 0 failed**.