### PR TITLE
Stop the KEPUB normalizer loading books it will not touch, and re-close the content-id authority gap

### DIFF
--- a/cps/services/annotation_content_id.py
+++ b/cps/services/annotation_content_id.py
@@ -48,6 +48,11 @@ def _chapter(value: str) -> str:
         raise ContentIdError("content_id chapter path is not relative")
     if any(ord(char) < 32 or ord(char) == 127 for char in value):
         raise ContentIdError("content_id chapter path contains control characters")
+    # Preserve the existing rejection of empty path segments before normpath
+    # can erase them. Besides repeated separators, this rejects URL authority
+    # syntax such as "http://example.test/chapter.xhtml".
+    if "" in value.split("/"):
+        raise ContentIdError("content_id chapter path contains an unsafe segment")
     # Real clients emit CONTAINED traversals. A Kobo whose OPF references a file
     # outside the OPF directory (an EPUB3 nav at the zip root declared
     # href="../nav.xhtml") joins paths without normalizing, so it sends e.g.

--- a/cps/services/kepub_package_normalizer.py
+++ b/cps/services/kepub_package_normalizer.py
@@ -244,15 +244,16 @@ def normalize_kepub_package(path):
         with zipfile.ZipFile(path) as archive:
             infos = archive.infolist()
             names = [info.filename for info in infos]
+            opf_path = _package_document_path(archive)
+            opf_bytes = archive.read(opf_path)
+            relocations = _plan_relocations(opf_path, opf_bytes, set(names))
+            if not relocations:
+                return False
             if len(names) != len(set(names)):
                 raise ValueError("KEPUB contains duplicate ZIP member names")
             if archive.testzip() is not None:
                 raise ValueError("KEPUB failed its CRC check")
             contents = {info.filename: archive.read(info) for info in infos}
-            opf_path = _package_document_path(archive)
-            relocations = _plan_relocations(opf_path, contents[opf_path], set(names))
-            if not relocations:
-                return False
             entries = _rewritten_entries(infos, contents, relocations)
             expected_span_counts = _span_counts(contents, relocations)
             comment = archive.comment

--- a/tests/unit/test_content_id_normalizes_contained_traversal.py
+++ b/tests/unit/test_content_id_normalizes_contained_traversal.py
@@ -26,7 +26,6 @@ UUID = "9e5251ad-d530-4e58-9121-8b8336099fdd"
     ("OPS/../OPS/chapter-017.xml", "OPS/chapter-017.xml"),
     ("OEBPS/../OEBPS/chapter001.html", "OEBPS/chapter001.html"),
     ("./OPS/chapter-006.xml", "OPS/chapter-006.xml"),
-    ("OPS//chapter-006.xml", "OPS/chapter-006.xml"),
     ("OPS/sub/../chapter-006.xml", "OPS/chapter-006.xml"),
     # already clean -> unchanged
     ("OPS/chapter-006.xml", "OPS/chapter-006.xml"),
@@ -42,10 +41,18 @@ def test_contained_traversal_normalizes(raw, expected):
     "OPS\\chapter-006.xml",        # backslash
     "OPS/chapter-006.xml\n",       # control character
     "..",                          # bare traversal
+    "OPS//chapter-006.xml",        # empty segment
 ])
 def test_escaping_or_malformed_still_rejected(raw):
     with pytest.raises(ContentIdError):
         normalize_content_id(f"{UUID}!!{raw}", book_uuid=UUID)
+
+
+def test_url_authority_syntax_still_rejected():
+    with pytest.raises(ContentIdError):
+        normalize_content_id(
+            f"{UUID}!!http://example.test/chapter.xhtml", book_uuid=UUID,
+        )
 
 
 def test_normalization_is_idempotent():

--- a/tests/unit/test_kepub_package_normalizer.py
+++ b/tests/unit/test_kepub_package_normalizer.py
@@ -123,6 +123,25 @@ def test_clean_package_is_completely_untouched(tmp_path):
 
 
 @pytest.mark.unit
+def test_clean_package_reads_only_container_and_opf(tmp_path, monkeypatch):
+    import cps.services.kepub_package_normalizer as normalizer
+
+    package = tmp_path / "clean.kepub"
+    _write_package(package, opf=CLEAN_OPF, nav_path="OPS/nav.xhtml")
+    read_names = []
+
+    class RecordingZipFile(zipfile.ZipFile):
+        def read(self, name, *args, **kwargs):
+            read_names.append(name.filename if isinstance(name, zipfile.ZipInfo) else name)
+            return super().read(name, *args, **kwargs)
+
+    monkeypatch.setattr(normalizer.zipfile, "ZipFile", RecordingZipFile)
+
+    assert normalizer.normalize_kepub_package(package) is False
+    assert read_names == ["META-INF/container.xml", "OPS/epb.opf"]
+
+
+@pytest.mark.unit
 def test_kobo_span_markup_and_per_file_counts_are_preserved_exactly(tmp_path):
     package = tmp_path / "spans.kepub"
     _write_package(package)


### PR DESCRIPTION
## Why

Two defects found by an adversarial review of #1637 and #1638. Both PRs merged while that review was still running, so the findings arrive as a follow-up instead of as review comments. Neither is a flaw in what those PRs set out to do — one is a cost the new code pays on a path it did not need to, the other is a guard that got wider by accident.

## 1. The KEPUB normalizer materialized every archive it was handed, including the ones it then declined to touch

`normalize_kepub_package` read **every ZIP member into a dict** and ran `testzip()` before it worked out whether any relocation was needed:

```python
contents = {info.filename: archive.read(info) for info in infos}   # whole archive, resident
opf_path = _package_document_path(archive)
relocations = _plan_relocations(opf_path, contents[opf_path], set(names))
if not relocations:
    return False                                                    # ...and none of it was used
```

The overwhelmingly common case is a package with no escaping manifest item, so the overwhelmingly common case paid full uncompressed-archive memory for nothing. That is on **every kepubify conversion** and on **every book of the startup backfill**.

It matters because of what the path did before: `_valid_archive` verifies with `testzip()`, which streams in chunks and never holds the archive. So this introduced a resident-memory spike where there had only ever been a streaming read — on the low-RAM NAS and Pi hosts this project actually runs on, in a change whose stated promise was that it "cannot regress anyone".

Now the plan is computed from `META-INF/container.xml` and the OPF alone, and a clean package returns before anything else is read.

**Deferred, not dropped:** duplicate-member-name and CRC rejection now happen once a relocation is known to be needed — still before any rewrite or replacement, which is where they protect something. On the conversion path nothing is lost either way, because `_valid_archive` runs `testzip()` on the result immediately afterwards.

## 2. Normalizing content ids quietly started accepting URL authority syntax

#1638 replaced a segment-by-segment check with `posixpath.normpath`. The old check rejected an **empty** segment; `normpath` collapses one. So `//` stopped being an error:

```
before #1638:  "http://example.test/chapter.xhtml"  -> rejected ("unsafe segment")
after  #1638:  accepted, stored as "http:/example.test/chapter.xhtml"
```

That contradicts #1638's own claim that "the security boundary is unchanged". No live exploit follows from it — `content_id` is an opaque identifier that reaches neither the filesystem nor any URL (no `os.path`/`open`/`send_file` call site takes it, and no frontend `href`/`fetch` does either), so such a value simply matches nothing. It is closed here because a guard should not widen by accident, not because something is currently reachable through it.

The empty-segment rejection is restored ahead of `normpath`. The `OPS//chapter-006.xml` case moves from the "normalizes" list to the "rejects" list — collapsing an empty segment was speculative generosity that the real bug never asked for, and it is what opened this.

**Deliberately unchanged:** `C:/outside/ch.xhtml` and `%2e%2e/outside.xhtml` are accepted by `main` today and are still accepted. They are only unsafe for a consumer that applies Windows or URL-decoding semantics, there is no such consumer, and changing them here would be an unrelated behaviour change.

## Verification

Red/green, run against **exactly what is on `main` today** (`e0cd5cf5a`), not against a reconstruction:

| | red on current `main` | green here |
|---|---|---|
| `test_clean_package_reads_only_container_and_opf` | 1 failed, 9 passed | 10 passed |
| `test_escaping_or_malformed_still_rejected[OPS//chapter-006.xml]`, `test_url_authority_syntax_still_rejected` | 2 failed, 12 passed | 14 passed |

The kepub test asserts the property directly rather than a proxy for it: a recording `ZipFile` subclass captures every `read()`, and the assertion is `read_names == ["META-INF/container.xml", "OPS/epb.opf"]`.

Wider sweep: `pytest tests/unit -k "annotation or content_id or kobo or koreader or kepub or convert"` → **1001 passed, 3 skipped, 0 failed**.

Practical verification on real books, since this code rewrites users' files:

- All 13 structurally-valid EPUBs in `tests/fixtures/sample_books` (Alice, Sherlock, Pride and Prejudice, the RTL/vertical and international-filename fixtures) → `False`, and **byte-identical** on disk afterwards. The two deliberately-corrupt fixtures → `None`, also byte-identical.
- Real `alice_in_wonderland.epub` mutated into the actual bug shape — a real chapter hoisted to the zip root with its manifest entry rewritten to `href="../…"` — then normalized: returns `True`, all 19 manifest items still resolve to real members, **zero** escaping hrefs remain, `mimetype` first and `ZIP_STORED`, CRC clean, spine parses, all 22 members intact.

## Known limitations, stated rather than implied

From the same adversarial review; none are regressions introduced here, and all fail open (the original archive is preserved and the un-normalized KEPUB still ships):

- A package that **does** need relocation still materializes fully — the decompression-ratio exposure is reduced to the rare path, not eliminated.
- A Latin-1 encoded XHTML with a non-UTF-8 byte in an `href` raises `UnicodeDecodeError` inside the rewriter, so that book is left un-normalized.
- A manifest `href` spelled with an XML entity (`../nav&amp;.xhtml` for member `nav&.xhtml`) is planned from the decoded value but not matched by the byte-level rewriter, so validation rejects the rewrite and the original is kept.
- `_span_counts` compares counts, so it could not detect one KoboSpan removed and another added in the same file. No current code path synthesizes or removes spans.
- The symlink/hardlink caveat in the review does not apply at the only call site: `normalize_kepub_package` is handed a fresh `tempfile.mkstemp` file (`cps/tasks/convert.py:271`), never a library file.
