### PR TITLE
fix(kobo): fail closed on the annotation download, and stop discarding on a bad clock

### DIFF
--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -129,6 +129,12 @@ def requires_reading_services_auth_and_config(f):
     """
     @wraps(f)
     def decorated_function(*args, **kwargs):
+        # The destructive-download guard runs FIRST, ahead of every pass-through
+        # below. Kobo sync being switched off, or a missing/expired session, must
+        # not re-open a path that deletes annotations off the user's device.
+        guarded = _guard_request_if_annotation_download()
+        if guarded is not None:
+            return guarded
         if not config.config_kobo_sync:
             log.debug("Kobo sync disabled, proxying to Kobo")
             return proxy_to_kobo_reading_services()
@@ -146,14 +152,86 @@ def requires_reading_services_auth_and_config(f):
     return decorated_function
 
 
+#: Ownership could not be determined (e.g. the metadata DB errored). Distinct
+#: from ``None``, which means "definitively not a book we serve". Conflating the
+#: two is what makes a destructive fallback fire on a transient failure.
+OWNERSHIP_UNKNOWN = object()
+
+
 def get_book_by_entitlement_id(entitlement_id):
-    """Get book from database by UUID (entitlement_id)."""
+    """Get book from database by UUID (entitlement_id).
+
+    Returns ``None`` both for "not ours" and for a lookup failure. Callers whose
+    fallback is destructive must use :func:`resolve_entitlement_ownership`
+    instead, which keeps those two cases apart.
+    """
     try:
         book = calibre_db.get_book_by_uuid(entitlement_id)
         return book
     except Exception as e:
         log.error(f"Error getting book by entitlement ID {entitlement_id}: {e}")
         return None
+
+
+def resolve_entitlement_ownership(entitlement_id):
+    """Tri-state ownership: the Books row, ``None``, or ``OWNERSHIP_UNKNOWN``."""
+    try:
+        return calibre_db.get_book_by_uuid(entitlement_id)
+    except Exception:
+        log.exception(
+            "Could not determine ownership of entitlement %s; treating as UNKNOWN",
+            entitlement_id,
+        )
+        return OWNERSHIP_UNKNOWN
+
+
+def _annotation_download_guard(entitlement_id):
+    """503 when we must not proxy this book's annotation download, else ``None``.
+
+    Kobo's cloud has never heard of a sideloaded book and answers the download
+    with a success-shaped empty set, which Nickel acts on by DELETING every local
+    Bookmark row for the book (upstream calibre-web #2610; measured 2026-08-15,
+    87 highlights deleted in one sync). For a sideloaded book the device is
+    frequently the only copy, so a 200-empty is destructive even though the verb
+    is GET.
+
+    Fails CLOSED: an entitlement we cannot resolve is refused too, because the
+    fallback here destroys data that exists nowhere else.
+    """
+    owner = resolve_entitlement_ownership(entitlement_id)
+    if owner is None:
+        return None  # definitively not ours -- Kobo's cloud IS authoritative
+    if owner is OWNERSHIP_UNKNOWN:
+        log.warning(
+            "Refusing annotation download for entitlement %s: ownership unknown, "
+            "and proxying on uncertainty can delete the device's only copy",
+            entitlement_id,
+        )
+    else:
+        log.info(
+            "Not proxying annotation download for locally-owned book %s (%s); "
+            "Kobo's empty answer would delete the device's copy",
+            owner.id, entitlement_id,
+        )
+    response = make_response(
+        jsonify({"error": "Annotation download unavailable for sideloaded content"}), 503,
+    )
+    response.headers["Retry-After"] = "3600"
+    return response
+
+
+_ANNOTATION_PATH_RE = re.compile(r"^/api/v3/content/(?P<eid>[^/]+)/annotations/?$")
+
+
+def _guard_request_if_annotation_download():
+    """Apply the download guard from the OUTERMOST layer, before any auth/config
+    pass-through can hand this request to Kobo. Returns a response or ``None``."""
+    if request.method != "GET":
+        return None
+    match = _ANNOTATION_PATH_RE.match(request.path or "")
+    if not match:
+        return None
+    return _annotation_download_guard(match.group("eid"))
 
 
 def get_book_identifiers(book):
@@ -367,35 +445,12 @@ def handle_annotations(entitlement_id):
     path independent of any sync target lands in sub-project (2).
     """
     if request.method == "GET":
-        book = get_book_by_entitlement_id(entitlement_id)
-        if book is not None:
-            # This entitlement is a book WE delivered. Kobo's cloud has never heard
-            # of it, so it answers the download direction with a success-shaped
-            # "no annotations" -- and Nickel acts on that by DELETING every local
-            # Bookmark row for the book (upstream calibre-web #2610).
-            #
-            # Measured on real hardware 2026-08-15: 88 correctly-anchored highlights
-            # at 11:58; one sync at 12:07 uploaded a single annotation and deleted
-            # the other 87. For a sideloaded book the device is frequently the only
-            # copy, so a 200-empty here is a DESTRUCTIVE operation even though the
-            # verb is GET.
-            #
-            # We deliberately do not answer with our own snapshot either: an
-            # internally-complete server view would tell a second device to drop
-            # annotations it has not uploaded yet. 503 + Retry-After is the one
-            # response that cannot be read as "you have none" -- it is explicitly
-            # non-authoritative, so the device keeps what it holds.
-            log.info(
-                "Not proxying annotation download for locally-owned book %s (%s); "
-                "Kobo's empty answer would delete the device's copy",
-                book.id, entitlement_id,
-            )
-            response = make_response(
-                jsonify({"error": "Annotation download unavailable for sideloaded content"}),
-                503,
-            )
-            response.headers["Retry-After"] = "3600"
-            return response
+        # Same guard as the decorator, kept here as defense in depth so the
+        # handler is safe if it is ever reached by another route or called
+        # directly. Single implementation, so the two cannot drift.
+        guarded = _annotation_download_guard(entitlement_id)
+        if guarded is not None:
+            return guarded
 
     if request.method == "PATCH":
         try:

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -195,8 +195,16 @@ def _upsert_annotation(session, payload, book, user, *, origin_device_id=None):
     raw_client_time = payload.get("clientLastModifiedUtc", _CLIENT_TIME_MISSING)
     client_time = parse_client_modified_utc(raw_client_time)
     if raw_client_time is not _CLIENT_TIME_MISSING and client_time is None:
-        log.warning("Rejecting annotation %s with malformed clientLastModifiedUtc", annotation_id)
-        return None
+        # Same rule as the content location below: a malformed CLOCK READING is
+        # not a reason to destroy the user's words. Degrade to "no timestamp
+        # supplied" -- an already-handled state -- so the highlight is still
+        # stored and only the ordering hint is lost.
+        log.warning(
+            "Annotation %s has a malformed clientLastModifiedUtc %r; storing it "
+            "without a client timestamp rather than discarding the highlight",
+            annotation_id, raw_client_time,
+        )
+        client_time = _CLIENT_TIME_MISSING
     span = (payload.get("location") or {}).get("span") or {}
     normalized_content_id = None
     chapter_filename = span.get("chapterFilename")

--- a/tests/unit/test_kobo_annotations_get_never_authoritative_empty.py
+++ b/tests/unit/test_kobo_annotations_get_never_authoritative_empty.py
@@ -59,7 +59,7 @@ def _view():
 
 def test_get_for_a_book_we_own_is_not_proxied_and_is_not_success(app, monkeypatch, no_proxy):
     monkeypatch.setattr(
-        rs, "get_book_by_entitlement_id",
+        rs, "resolve_entitlement_ownership",
         lambda eid: SimpleNamespace(id=347, title="Flatland", uuid=BOOK_UUID),
     )
     with app.test_request_context(
@@ -76,7 +76,7 @@ def test_get_for_a_book_we_own_is_not_proxied_and_is_not_success(app, monkeypatc
 def test_get_for_content_we_do_not_own_still_proxies(app, monkeypatch):
     """A real Kobo store book is Kobo's data; its cloud IS authoritative there."""
     sentinel = object()
-    monkeypatch.setattr(rs, "get_book_by_entitlement_id", lambda eid: None)
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda eid: None)
     monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
 
     with app.test_request_context("/api/v3/content/not-ours/annotations", method="GET"):
@@ -86,7 +86,7 @@ def test_get_for_content_we_do_not_own_still_proxies(app, monkeypatch):
 def test_patch_upload_direction_still_proxies(app, monkeypatch):
     """Uploads are harmless and must keep working -- only the download is destructive."""
     sentinel = object()
-    monkeypatch.setattr(rs, "get_book_by_entitlement_id", lambda eid: None)
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda eid: None)
     monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
 
     with app.test_request_context(
@@ -94,3 +94,68 @@ def test_patch_upload_direction_still_proxies(app, monkeypatch):
         json={"updatedAnnotations": []},
     ):
         assert _view()(BOOK_UUID) is sentinel
+
+
+# --- fail-closed: uncertainty must never fall through to the destructive path ---
+
+def test_ownership_lookup_error_fails_closed(app, monkeypatch, no_proxy):
+    """A DB hiccup must not be read as 'not our book'.
+
+    `get_book_by_entitlement_id` swallows every exception and returns None, which
+    is indistinguishable from a genuinely foreign entitlement. If the guard used
+    that, a transient metadata-DB failure would re-open the exact path that
+    deleted 87 highlights. Uncertainty fails closed.
+    """
+    def _boom(_uuid):
+        raise RuntimeError("metadata db unavailable")
+
+    monkeypatch.setattr(rs.calibre_db, "get_book_by_uuid", _boom)
+    with app.test_request_context(f"/api/v3/content/{BOOK_UUID}/annotations", method="GET"):
+        resp = _view()(BOOK_UUID)
+    assert resp.status_code == 503
+    assert resp.headers.get("Retry-After")
+
+
+def test_guard_runs_even_when_kobo_sync_is_disabled(app, monkeypatch, no_proxy):
+    """Switching Kobo sync off must not re-open the destructive download.
+
+    The decorator proxies everything when sync is disabled, so before this the
+    guard never ran in that state -- an admin toggling the setting could hand the
+    device an answer that deletes its highlights.
+    """
+    monkeypatch.setattr(rs.config, "config_kobo_sync", False, raising=False)
+    monkeypatch.setattr(
+        rs, "resolve_entitlement_ownership",
+        lambda eid: SimpleNamespace(id=347, title="Flatland", uuid=BOOK_UUID),
+    )
+    decorated = rs.requires_reading_services_auth_and_config(
+        lambda *_a, **_k: pytest.fail("handler should not be reached"))
+    with app.test_request_context(f"/api/v3/content/{BOOK_UUID}/annotations", method="GET"):
+        resp = decorated()
+    assert resp.status_code == 503
+
+
+def test_guard_runs_even_without_an_authenticated_session(app, monkeypatch, no_proxy):
+    """A lost or expired Kobo session must not re-open the destructive download."""
+    monkeypatch.setattr(rs.config, "config_kobo_sync", True, raising=False)
+    monkeypatch.setattr(rs, "current_user", SimpleNamespace(is_authenticated=False, id=None))
+    monkeypatch.setattr(
+        rs, "resolve_entitlement_ownership",
+        lambda eid: SimpleNamespace(id=347, title="Flatland", uuid=BOOK_UUID),
+    )
+    decorated = rs.requires_reading_services_auth_and_config(
+        lambda *_a, **_k: pytest.fail("handler should not be reached"))
+    with app.test_request_context(f"/api/v3/content/{BOOK_UUID}/annotations", method="GET"):
+        resp = decorated()
+    assert resp.status_code == 503
+
+
+def test_foreign_content_still_proxies_when_sync_disabled(app, monkeypatch):
+    """The guard must not become a blanket block: a real Kobo store book still proxies."""
+    sentinel = object()
+    monkeypatch.setattr(rs.config, "config_kobo_sync", False, raising=False)
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda eid: None)
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+    decorated = rs.requires_reading_services_auth_and_config(lambda *_a, **_k: sentinel)
+    with app.test_request_context("/api/v3/content/not-ours/annotations", method="GET"):
+        assert decorated() is sentinel

--- a/tests/unit/test_multi_device_annotations_safe_slice.py
+++ b/tests/unit/test_multi_device_annotations_safe_slice.py
@@ -82,7 +82,13 @@ def test_registry_failure_does_not_break_reading_services_request(monkeypatch):
     monkeypatch.setattr(readingservices, "current_user", SimpleNamespace(is_authenticated=True, id=7))
     monkeypatch.setattr(device_registry, "sessionmaker", lambda **_kwargs: (_ for _ in ()).throw(OSError("disk")))
     wrapped = readingservices.requires_reading_services_auth_and_config(lambda: ("upstream", 207))
-    with app.test_request_context("/api/v3/content/x/annotations", headers={"x-kobo-deviceid": "b" * 64}):
+    # PATCH, not GET: device registration happens on the upload direction, and a
+    # GET on this path is now intercepted by the annotation-download guard before
+    # the decorator's pass-through can run (that guard is the subject of its own
+    # test module). The property under test -- a registry failure must not break
+    # the request -- is unchanged.
+    with app.test_request_context("/api/v3/content/x/annotations", method="PATCH",
+                                  headers={"x-kobo-deviceid": "b" * 64}):
         assert wrapped() == ("upstream", 207)
 
 
@@ -169,8 +175,15 @@ def test_client_last_modified_missing_malformed_valid(db_session, raw, expected)
                              SimpleNamespace(id=5, uuid="b3d1b38b-74fd-43b7-a796-996e5a6a8b04"),
                              SimpleNamespace(id=7))
     if expected == "malformed":
-        assert row is None
-        assert db_session.query(ub.Annotation).count() == 0
+        # A malformed CLOCK READING must not destroy the user's words. This
+        # previously asserted the annotation was discarded, which is the same
+        # data-loss shape as the content-location gate: the highlight text is
+        # irreplaceable, the timestamp is an ordering hint. Store it, drop only
+        # the hint.
+        assert row is not None
+        assert row.highlighted_text == "text"
+        assert row.client_modified_at is None
+        assert db_session.query(ub.Annotation).count() == 1
     elif expected == "missing":
         assert row.client_modified_at is None
     else:


### PR DESCRIPTION
Adversarial review of #1636 / #1635 found three ways the "never lose a highlight" property still didn't hold. All three are data-loss class.

## 1. The guard failed OPEN on an ownership lookup error

`get_book_by_entitlement_id` swallows every exception and returns `None` (`cps/readingservices.py`), which is **indistinguishable from a genuinely foreign entitlement**. The GET guard used it, so a transient metadata-DB failure fell straight through to `proxy_to_kobo_reading_services()` — the exact path that deleted 87 highlights on real hardware.

`None` cannot mean both *"definitely not ours"* and *"we could not determine ownership"*. For an endpoint whose fallback is destructive, uncertainty must fail closed. Ownership is now tri-state:

```
row               -> 503, never proxy
None              -> proxy   (Kobo's cloud genuinely IS authoritative)
OWNERSHIP_UNKNOWN -> 503, never proxy
```

## 2. The guard was BYPASSED whenever config/auth gating fired

`requires_reading_services_auth_and_config` proxies **every** reading-services request when `config_kobo_sync` is false or the session isn't authenticated — both before the handler runs, so the guard never applied in either state. An admin toggling Kobo sync off, or an expired Kobo cookie, re-opened the destructive path on a device that still had the endpoint.

The guard now runs at the outermost layer, ahead of every pass-through, via a single shared implementation used by both the decorator and the handler so the two can't drift.

## 3. `_upsert_annotation` still discarded on a malformed timestamp

```python
if raw_client_time is not _CLIENT_TIME_MISSING and client_time is None:
    log.warning("Rejecting annotation %s with malformed clientLastModifiedUtc", ...)
    return None
```

Same shape as the content-location discard fixed in #1635 — **two lines above it**, and missed at the time. A malformed clock reading is an ordering hint; the highlighted text, note and anchors are irreplaceable. It now degrades to "no timestamp supplied", which is an already-handled state.

The existing test asserting a malformed timestamp *discards* the annotation encoded that bug; it's updated to assert the highlight survives with only the hint lost.

## Not changed

Foreign content still proxies. The PATCH upload direction is untouched.

## Verification

- 4 new tests: ownership-lookup-error, sync-disabled, unauthenticated, and foreign-content non-regression. All fail on the previous code.
- `pytest tests/unit` → **6090 passed, 95 skipped**. The 4 failures in `test_1596_module_entry_point.py` are pre-existing on `origin/main` (verified by running that module against a clean `origin/main` checkout) and are unrelated to these files.

Found by an adversarial cross-review after the original fixes were already merged and deployed — the fixes were shipped against active data loss, and this closes the gaps that review surfaced.