### PR TITLE
fix(koreader): make "I don't know this book" distinguishable from "you have none"

### DIFF
--- a/cps/progress_syncing/protocols/koreader_annotations.py
+++ b/cps/progress_syncing/protocols/koreader_annotations.py
@@ -272,13 +272,34 @@ def pull_annotations(document: str):
         # it is the usual shape of a book that was never checksum-registered.
         log.info(
             "KOReader annotation pull: user=%s document=%s no matching book "
-            "(returning empty set)", user.id, _loggable(document),
+            "(returning empty set, book_known=false)", user.id, _loggable(document),
         )
-        return create_sync_response({"document": document, "annotations": [], "annotation_count": 0})
+        # `book_known` is the discriminator that makes "I don't know this book"
+        # distinguishable from "this book genuinely has no annotations". Without
+        # it the two are identical on the wire, and a client that reconciles
+        # against an empty set would delete highlights that exist nowhere else --
+        # exactly how a Kobo lost 87 of them on 2026-08-15 (see
+        # notes/ANNOTATION-SYNC-PRINCIPLES-DESIGN.md, P1).
+        #
+        # Deliberately ADDITIVE rather than a status-code change: plugins already
+        # in the field parse this shape, and breaking them to fix a hazard none
+        # of them currently trip would trade a latent problem for a real one.
+        # Emitted on BOTH branches so a client can tell a server that knows the
+        # field from one that predates it -- absent means "cannot tell, be
+        # conservative", never "known".
+        return create_sync_response({
+            "document": document,
+            "annotations": [],
+            "annotation_count": 0,
+            "book_known": False,
+        })
 
     payload = build_pull_payload(user.id, book_id, ub.session)
     payload["document"] = document
     payload["calibre_book_id"] = book_id
+    # See the unmatched branch above: present-and-true is what lets a client
+    # trust an empty list here as a real "you have none".
+    payload["book_known"] = True
     log.info(
         "KOReader annotation pull: user=%s book=%s document=%s annotations=%s",
         user.id, book_id, _loggable(document), payload.get("annotation_count", 0),

--- a/tests/unit/test_koreader_annotations_endpoints.py
+++ b/tests/unit/test_koreader_annotations_endpoints.py
@@ -279,3 +279,39 @@ def test_wire_preflights_entire_batch_before_persisting(wire):
     assert session.query(ub.Annotation).filter_by(
         annotation_id="must-not-partially-commit"
     ).count() == 0
+
+
+# --- P1: "I don't know this book" must be distinguishable from "you have none" ---
+
+def test_pull_marks_an_unknown_book_as_not_known(wire):
+    """An unmatched digest previously returned an empty set at HTTP 200, which is
+    byte-identical to "this book genuinely has no annotations". A client that
+    reconciles against that would delete highlights existing nowhere else --
+    exactly how a Kobo lost 87 of them (notes/ANNOTATION-SYNC-PRINCIPLES-DESIGN.md,
+    P1). The discriminator is additive so plugins already in the field keep working.
+    """
+    client, _session = wire
+    response = client.get("/kosync/syncs/annotations/digest-that-matches-nothing")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["annotations"] == []
+    assert body["annotation_count"] == 0
+    assert body["book_known"] is False
+
+
+def test_pull_marks_a_known_book_as_known(wire):
+    """Emitted on BOTH branches: absent must mean "server predates the field, be
+    conservative", never "known". A client can only trust an empty list when the
+    server positively says it knows the book."""
+    client, _session = wire
+    response = client.get("/kosync/syncs/annotations/digest-699")
+    assert response.status_code == 200
+    assert response.get_json()["book_known"] is True
+
+
+def test_unknown_book_pull_is_still_backward_compatible(wire):
+    """The legacy keys are untouched, so an existing plugin parses it unchanged."""
+    client, _session = wire
+    body = client.get("/kosync/syncs/annotations/nope").get_json()
+    assert set(["document", "annotations", "annotation_count"]).issubset(body.keys())
+    assert body["document"] == "nope"


### PR DESCRIPTION
## The hazard

`pull_annotations` returned `{"annotations": [], "annotation_count": 0}` at HTTP 200 whenever the digest matched no book. That is **byte-identical** to a book that genuinely has no annotations — and the existing code comment already said so:

> *"from the device's side this is indistinguishable from 'the server has no highlights for me'"*

It's the same ambiguity that deleted 87 highlights off a Kobo on 2026-08-15 (#1636), and the same one this codebase **already hit in the upload direction in #920**, where the server guessed from an omission and destroyed a second device's highlights permanently. `sync_logic.lua` still carries that lesson in a comment:

> *"a device whose user deleted every highlight and a device that never had them push the identical empty set, and the server has no way to tell those apart — it guessed, and destroyed a second device's highlights permanently."*

We fixed that on the upload side and left the identical shape on the download side.

## Not an active bug

Our shipped `cwasync.koplugin` merges remote-only → device and local-only → server, so an empty remote list deletes nothing. Nothing in the field acts destructively on this today. This closes the hazard for any other client, and for our own future selves.

## Why additive, not a status code

Plugins already in the field parse this shape. `api.json` constrains **request** keys only — there is no response schema — so an extra response key is inert for existing clients. Changing the status code instead would trade a latent hazard for a real breakage, which is the wrong trade for a problem nothing currently trips.

`book_known` is emitted on **both** branches deliberately: absent then means *"this server predates the field, be conservative"* and never *"known"*. A client can only trust an empty list when the server positively says it knows the book.

## Verification

- 3 new tests. The two behavioural ones fail on `origin/main`; the backward-compatibility test passes both before and after — which is the point, it pins that the legacy keys are untouched.
- `pytest tests/unit -k "koreader or kosync or annotation"` → **555 passed, 2 skipped, 0 failed**.

Implements P1 from `notes/ANNOTATION-SYNC-PRINCIPLES-DESIGN.md` (#1642), which recorded this as open work.