### PR TITLE
fix(kepub): close three gaps an adversarial review found in #1637/#1635

### DIFF
--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -149,7 +149,8 @@ def _book_uuid(book):
     return None
 
 
-def _kobo_payload_matches_row(annotation, payload, span, normalized_content_id):
+def _kobo_payload_matches_row(annotation, payload, span, normalized_content_id,
+                              content_location_rejected=False):
     """True only when applying the payload would leave every stored field unchanged."""
     def supplied(mapping, key, current):
         return mapping.get(key) if key in mapping else current
@@ -170,7 +171,8 @@ def _kobo_payload_matches_row(annotation, payload, span, normalized_content_id):
         supplied(payload, "noteText", annotation.note_text),
         supplied(payload, "highlightColor", annotation.highlight_color),
         chapter_progress if chapter_progress is not None else annotation.chapter_progress,
-        normalized_content_id or annotation.content_id,
+        normalized_content_id if normalized_content_id else (
+            None if content_location_rejected else annotation.content_id),
         supplied(span, "startPath", annotation.start_container_path),
         supplied(span, "endPath", annotation.end_container_path),
         supplied(span, "startChar", annotation.start_offset),
@@ -207,6 +209,12 @@ def _upsert_annotation(session, payload, book, user, *, origin_device_id=None):
         client_time = _CLIENT_TIME_MISSING
     span = (payload.get("location") or {}).get("span") or {}
     normalized_content_id = None
+    #: "the client supplied a chapter and it was unusable", which is NOT the same
+    #: as "the client supplied no chapter". Only the former should clear a
+    #: previously-stored locator: keeping a stale one would point the annotation
+    #: at a chapter the device no longer says it is in, and would let an
+    #: equal-clock payload be mistaken for a no-op.
+    content_location_rejected = False
     chapter_filename = span.get("chapterFilename")
     if chapter_filename and _book_uuid(book):
         from cps.services.annotation_content_id import normalize_content_id, ContentIdError
@@ -227,6 +235,7 @@ def _upsert_annotation(session, payload, book, user, *, origin_device_id=None):
                 annotation_id, chapter_filename,
             )
             normalized_content_id = None
+            content_location_rejected = True
     ann = (
         session.query(ub.Annotation)
         .filter(
@@ -250,6 +259,7 @@ def _upsert_annotation(session, payload, book, user, *, origin_device_id=None):
             # payloads therefore use arrival order as the deterministic tie.
             if _kobo_payload_matches_row(
                 ann, payload, span, normalized_content_id,
+                content_location_rejected,
             ):
                 return None
     if ann is None:
@@ -276,6 +286,11 @@ def _upsert_annotation(session, payload, book, user, *, origin_device_id=None):
         ann.chapter_progress = chapter_progress
     if normalized_content_id:
         ann.content_id = normalized_content_id
+    elif content_location_rejected:
+        # Supplied and unusable -> the stored locator is now known-wrong. Clear
+        # it rather than leaving a stale pointer; the highlight itself stays, and
+        # ub.backfill_annotation_content_ids can rebuild the column later.
+        ann.content_id = None
     if "startPath" in span:
         ann.start_container_path = span.get("startPath")
     if "endPath" in span:

--- a/cps/services/kepub_package_normalizer.py
+++ b/cps/services/kepub_package_normalizer.py
@@ -41,6 +41,24 @@ _KOBO_SPAN_RE = re.compile(
 _XML_PARSER = etree.XMLParser(resolve_entities=False, no_network=True, recover=False)
 
 
+#: A KEPUB is a book. Anything past this is either broken or hostile, and
+#: reading it would exhaust the conversion worker -- MemoryError is not an
+#: Exception, so the module's own catch cannot recover from it. Books are
+#: user-uploadable, so this bound is reachable by input we do not control.
+MAX_TOTAL_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+
+
+def _reject_oversized_archive(infos):
+    total = 0
+    for info in infos:
+        total += info.file_size
+        if total > MAX_TOTAL_UNCOMPRESSED_BYTES:
+            raise ValueError(
+                "KEPUB decompresses to more than %d bytes; refusing to load it"
+                % MAX_TOTAL_UNCOMPRESSED_BYTES
+            )
+
+
 def _package_document_path(archive):
     container = etree.fromstring(archive.read(_CONTAINER_PATH), parser=_XML_PARSER)
     rootfiles = container.xpath(
@@ -59,9 +77,22 @@ def _manifest_items(opf_bytes):
 
 
 def _split_local_reference(value):
+    """Split a local reference into (urlsplit parts, decoded path), or None when
+    it points outside the package entirely.
+
+    ``None`` means "not ours to touch" and every caller treats it as skip, so it
+    must mean ONLY that. An absolute local path is not external -- it is a
+    reference we cannot contain -- and silently skipping it would let a manifest
+    href escape the OPF directory while we report the package clean, which is the
+    exact invariant this module exists to guarantee.
+    """
     parts = urlsplit(value)
-    if parts.scheme or parts.netloc or parts.path.startswith("/"):
-        return None
+    if parts.scheme or parts.netloc:
+        return None  # genuinely external (http:, data:, //host/...) -- leave alone
+    if parts.path.startswith("/"):
+        raise ValueError(
+            "EPUB reference is an absolute path and cannot be contained: %r" % value
+        )
     path = unquote(parts.path)
     if "\\" in path:
         raise ValueError("EPUB reference contains a backslash")
@@ -253,6 +284,7 @@ def normalize_kepub_package(path):
                 raise ValueError("KEPUB contains duplicate ZIP member names")
             if archive.testzip() is not None:
                 raise ValueError("KEPUB failed its CRC check")
+            _reject_oversized_archive(infos)
             contents = {info.filename: archive.read(info) for info in infos}
             entries = _rewritten_entries(infos, contents, relocations)
             expected_span_counts = _span_counts(contents, relocations)

--- a/tests/unit/test_annotation_never_discarded_on_bad_location.py
+++ b/tests/unit/test_annotation_never_discarded_on_bad_location.py
@@ -112,3 +112,52 @@ def test_valid_content_location_still_normalizes(patched_session):
 
     row = session.query(ub.Annotation).one()
     assert row.content_id == f"{BOOK_UUID}!!OPS/chapter-006.xml"
+
+
+def test_a_newly_invalid_location_clears_the_stored_one_rather_than_leaving_it_stale(
+    patched_session,
+):
+    """"Supplied and unusable" is not "not supplied".
+
+    Only the first should clear a previously-stored locator. Keeping a stale one
+    points the annotation at a chapter the device no longer claims it is in, and
+    lets an equal-clock payload be mistaken for a no-op. The highlight itself
+    still survives either way -- that is the invariant from #1635.
+    """
+    session, user = patched_session
+    book = _book()
+
+    good = _payload("OPS/chapter-006.xml")
+    good["clientLastModifiedUtc"] = "2026-08-15T10:00:00Z"
+    dispatch_annotation_sync([good], book, user)
+    row = session.query(ub.Annotation).one()
+    assert row.content_id == f"{BOOK_UUID}!!OPS/chapter-006.xml"
+
+    moved = _payload("OPS/../../outside.xml")   # escapes the container -> unusable
+    moved["clientLastModifiedUtc"] = "2026-08-15T11:00:00Z"
+    moved["highlightedText"] = "same highlight, relocated"
+    dispatch_annotation_sync([moved], book, user)
+
+    row = session.query(ub.Annotation).one()
+    assert row.content_id is None, "a known-wrong locator must not be left in place"
+    assert row.highlighted_text == "same highlight, relocated", "the highlight survives"
+
+
+def test_an_update_with_no_location_at_all_leaves_the_stored_one_alone(patched_session):
+    """The other half of the distinction: silence is not a retraction."""
+    session, user = patched_session
+    book = _book()
+
+    good = _payload("OPS/chapter-006.xml")
+    good["clientLastModifiedUtc"] = "2026-08-15T10:00:00Z"
+    dispatch_annotation_sync([good], book, user)
+
+    quiet = {
+        "id": good["id"],
+        "highlightedText": "text only, no location block",
+        "clientLastModifiedUtc": "2026-08-15T11:00:00Z",
+    }
+    dispatch_annotation_sync([quiet], book, user)
+
+    row = session.query(ub.Annotation).one()
+    assert row.content_id == f"{BOOK_UUID}!!OPS/chapter-006.xml"

--- a/tests/unit/test_kepub_package_normalizer.py
+++ b/tests/unit/test_kepub_package_normalizer.py
@@ -271,3 +271,63 @@ def test_conversion_corrupt_archive_still_does_not_replace_existing_kepub(tmp_pa
     assert check == 1
     assert "invalid kepub archive" in str(error).lower()
     assert destination.read_bytes() == b"existing valid kepub"
+
+
+# --- hardening: gaps found by adversarial review of #1637 ---
+
+ABSOLUTE_HREF_OPF = FLATLAND_OPF.replace(b'href="../nav.xhtml"', b'href="/nav.xhtml"')
+
+
+@pytest.mark.unit
+def test_an_absolute_manifest_href_is_not_silently_treated_as_external(tmp_path, caplog):
+    """`None` from the reference splitter means "not ours to touch", and every
+    caller treats it as skip. An absolute local path is not external -- it is a
+    reference we cannot contain -- so lumping it in with http:/data: would let a
+    manifest href escape the OPF directory while we report the package clean.
+    That is precisely the invariant this module exists to guarantee.
+    """
+    package = tmp_path / "absolute.kepub"
+    _write_package(package, opf=ABSOLUTE_HREF_OPF)
+    original = package.read_bytes()
+
+    with caplog.at_level("WARNING"):
+        result = _normalizer()(package)
+
+    assert result is None, "an uncontainable href must not report success"
+    assert package.read_bytes() == original, "the original must be left untouched"
+    assert any("normalize" in r.getMessage().lower() for r in caplog.records)
+
+
+@pytest.mark.unit
+def test_a_genuinely_external_href_is_still_left_alone(tmp_path):
+    """The fix must not make real external references an error."""
+    external = FLATLAND_OPF.replace(
+        b'href="../nav.xhtml"', b'href="https://example.invalid/nav.xhtml"')
+    package = tmp_path / "external.kepub"
+    _write_package(package, opf=external)
+
+    result = _normalizer()(package)
+
+    # nothing escapes the OPF dir any more, so this is a clean no-op, not a failure
+    assert result is False
+
+
+@pytest.mark.unit
+def test_an_archive_that_decompresses_past_the_bound_is_refused(tmp_path, monkeypatch, caplog):
+    """MemoryError is not an Exception, so the module's own catch cannot recover
+    from exhausting the conversion worker. Books are user-uploadable, so this
+    bound is reachable by input we do not control. Checked BEFORE the read.
+    """
+    from cps.services import kepub_package_normalizer as mod
+
+    package = tmp_path / "big.kepub"
+    _write_package(package)
+    original = package.read_bytes()
+    monkeypatch.setattr(mod, "MAX_TOTAL_UNCOMPRESSED_BYTES", 8)  # smaller than any real book
+
+    with caplog.at_level("WARNING"):
+        result = mod.normalize_kepub_package(package)
+
+    assert result is None
+    assert package.read_bytes() == original
+    assert any("decompresses to more than" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
None of these are active data loss. All three are real, and each is a case where a guard's *promise* was wider than what it actually delivered.

## 1. An absolute manifest href was silently skipped

`_split_local_reference` returned `None` for `href="/nav.xhtml"` — the **same** return it uses for genuinely external `http:` / `data:` references — and both the relocation planner and the validator read `None` as "skip".

So a package could retain a manifest href that escapes the OPF directory while we reported it clean. That is precisely the invariant this module exists to guarantee.

Now:
- **external** (scheme or netloc) → left alone, unchanged
- **absolute local path** → a package error; it is a reference we cannot *contain*, not one that is none of our business
- **relative** → resolved and contained, as before

## 2. The decompressed archive was read with no bound

Every member was read into memory, then read again during validation. `MemoryError` is **not** an `Exception`, so the module's own `except Exception` cannot recover from exhausting the conversion worker — and books are user-uploadable, so this input isn't ours to trust.

Total uncompressed size is now checked **before** the read.

## 3. An existing annotation kept a stale locator when a new one was invalid

The write path only assigned `content_id` when the normalized value was truthy, so an annotation receiving a newly-**invalid** location silently kept its old one — pointing at a chapter the device no longer claims to be in, and letting an equal-clock payload be mistaken for a no-op.

*"Supplied and unusable"* is not *"not supplied"*. Only the former means the stored locator is known-wrong, and it is now cleared explicitly. The highlight itself still survives — the #1635 invariant is unchanged — and the equal-clock comparator was taught the same distinction so a stale locator can't make a real edit look like a retry.

## Verification

- 3 new normalizer tests + 2 new annotation tests, including the two **non-regressions** that matter: a genuinely external href is still left alone, and an update carrying no location block still leaves the stored locator intact.
- `pytest tests/unit -k "annotation or kobo or kepub or koreader"` → **918 passed, 3 skipped, 0 failed**.
- Full `pytest tests/unit` → 6090 passed; the 4 failures in `test_1596_module_entry_point.py` are pre-existing on `origin/main` (verified against a clean checkout) and unrelated.

Findings 5, 7 and 8 from the adversarial review that also produced #1639 and #1640.