### PR TITLE
fix(kobo): shape covers for the Kobo that is actually asking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Covers are now shaped for the Kobo that is actually asking.** The server-side
+  cover padding had one aspect setting for the whole instance, so a household with
+  two different Kobos had to pick a winner — the other device got covers padded to
+  someone else's screen. Every authenticated Kobo request already announces its
+  model, and the server already records it, so the padding now follows the device.
+  An unrecognised model keeps the configured setting exactly as before.
+
+
 ## [v4.1.36] - 2026-08-15
 
 ### Added

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -29,6 +29,7 @@ from flask import (
     Response,
     send_from_directory,
     g,
+    has_request_context,
 )
 from .cw_login import current_user
 from werkzeug.datastructures import Headers
@@ -1113,12 +1114,75 @@ def _normalize_cover_uuid(image_id):
     return normalize_cover_uuid(image_id)
 
 
+def _requesting_device_aspect():
+    """Aspect preset for the Kobo making *this* request, or None.
+
+    The padding aspect is a single instance-wide setting, which is wrong the
+    moment a household owns two different Kobos: one of them gets covers shaped
+    for the other. We already record every device's model (`Device.model`, fed
+    by the `x-kobo-devicemodel` header on every authenticated Kobo request), so
+    the information needed to shape covers correctly is present and was simply
+    never consulted.
+
+    Resolution order:
+      1. the `x-kobo-devicemodel` header on this request -- the device speaking
+         for itself, and the only source that is certainly about *this* device;
+      2. the model recorded for this user's Kobo, when the header is absent and
+         the answer is unambiguous (exactly one registered Kobo).
+
+    Returns None whenever the answer is not certain -- unknown model, no
+    request context, no user, or more than one candidate device with no header
+    to disambiguate. None means "keep the configured aspect", i.e. exactly
+    today's behaviour, so this can only make covers more correct, never less.
+    """
+    try:
+        if not has_request_context():
+            return None
+
+        header_model = request.headers.get("x-kobo-devicemodel")
+        preset = cover_preview.preset_for_device_model(header_model)
+        if preset:
+            return preset
+
+        # No usable header. Fall back to what this user's Kobo told us
+        # earlier, but only when there is exactly one candidate -- with two
+        # Kobos on one account and no header, any pick is a coin toss and the
+        # configured value is the more honest answer.
+        user_id = getattr(current_user, "id", None)
+        if not user_id:
+            return None
+        models = [
+            row[0]
+            for row in ub.session.query(ub.Device.model)
+            .filter(ub.Device.user_id == user_id,
+                    ub.Device.kind == "kobo",
+                    ub.Device.active.is_(True))
+            .all()
+        ]
+        candidates = {cover_preview.preset_for_device_model(m) for m in models}
+        candidates.discard(None)
+        if len(candidates) == 1:
+            return candidates.pop()
+        return None
+    except Exception as exc:
+        # Cover shaping must never be the reason a sync or a cover fetch fails.
+        log.debug("Kobo Sync: could not resolve a per-device cover aspect: %s", exc)
+        return None
+
+
 def _current_padding_settings():
-    """Snapshot of the admin's Kobo-padding config. Centralized so the
-    sync-metadata path and the cover-serving path agree on the same hash."""
+    """Snapshot of the admin's Kobo-padding config, with the aspect narrowed to
+    the requesting device when we can identify it.
+
+    Centralized so the sync-metadata path and the cover-serving path agree on
+    the same hash -- and note that agreement is what makes the per-device
+    aspect safe: `settings_hash()` already folds in `target_aspect`, so two
+    devices resolve to two different CoverImageIds and two different cache
+    entries, with no cross-contamination and no extra bookkeeping."""
+    configured = getattr(config, "config_kobo_cover_padding_aspect", "kobo_libra_color") or "kobo_libra_color"
     return cover_preview.CoverPreviewSettings(
         enabled=bool(getattr(config, "config_kobo_cover_padding_enabled", False)),
-        target_aspect=getattr(config, "config_kobo_cover_padding_aspect", "kobo_libra_color") or "kobo_libra_color",
+        target_aspect=_requesting_device_aspect() or configured,
         fill_mode=getattr(config, "config_kobo_cover_padding_fill_mode", "edge_mirror") or "edge_mirror",
         manual_color=getattr(config, "config_kobo_cover_padding_color", "") or "",
     )

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1114,6 +1114,9 @@ def _normalize_cover_uuid(image_id):
     return normalize_cover_uuid(image_id)
 
 
+_REQUESTING_DEVICE_ASPECT_G_KEY = "_kobo_requesting_device_aspect"
+
+
 def _requesting_device_aspect():
     """Aspect preset for the Kobo making *this* request, or None.
 
@@ -1128,46 +1131,59 @@ def _requesting_device_aspect():
       1. the `x-kobo-devicemodel` header on this request -- the device speaking
          for itself, and the only source that is certainly about *this* device;
       2. the model recorded for this user's Kobo, when the header is absent and
-         the answer is unambiguous (exactly one registered Kobo).
+         the answer is unambiguous (exactly one preset is implied).
 
     Returns None whenever the answer is not certain -- unknown model, no
     request context, no user, or more than one candidate device with no header
     to disambiguate. None means "keep the configured aspect", i.e. exactly
     today's behaviour, so this can only make covers more correct, never less.
     """
+    if not has_request_context():
+        return None
+
+    resolved = None
     try:
-        if not has_request_context():
-            return None
+        if hasattr(g, _REQUESTING_DEVICE_ASPECT_G_KEY):
+            return getattr(g, _REQUESTING_DEVICE_ASPECT_G_KEY)
 
         header_model = request.headers.get("x-kobo-devicemodel")
         preset = cover_preview.preset_for_device_model(header_model)
         if preset:
-            return preset
-
-        # No usable header. Fall back to what this user's Kobo told us
-        # earlier, but only when there is exactly one candidate -- with two
-        # Kobos on one account and no header, any pick is a coin toss and the
-        # configured value is the more honest answer.
-        user_id = getattr(current_user, "id", None)
-        if not user_id:
-            return None
-        models = [
-            row[0]
-            for row in ub.session.query(ub.Device.model)
-            .filter(ub.Device.user_id == user_id,
-                    ub.Device.kind == "kobo",
-                    ub.Device.active.is_(True))
-            .all()
-        ]
-        candidates = {cover_preview.preset_for_device_model(m) for m in models}
-        candidates.discard(None)
-        if len(candidates) == 1:
-            return candidates.pop()
-        return None
+            resolved = preset
+        else:
+            # No usable header. Fall back to what this user's Kobos told us
+            # earlier, but only when their mapped models imply one preset.
+            # Different presets with no header are ambiguous; the configured
+            # value is the more honest answer.
+            user_id = getattr(current_user, "id", None)
+            if user_id:
+                models = [
+                    row[0]
+                    for row in ub.session.query(ub.Device.model)
+                    .filter(ub.Device.user_id == user_id,
+                            ub.Device.kind == "kobo",
+                            ub.Device.active.is_(True))
+                    .all()
+                ]
+                candidates = {cover_preview.preset_for_device_model(m) for m in models}
+                candidates.discard(None)
+                if len(candidates) == 1:
+                    resolved = candidates.pop()
     except Exception as exc:
         # Cover shaping must never be the reason a sync or a cover fetch fails.
         log.debug("Kobo Sync: could not resolve a per-device cover aspect: %s", exc)
-        return None
+        resolved = None
+
+    # This function runs once per book on sync-metadata construction. Cache
+    # both a preset and the fail-safe None for this request so an absent or
+    # unrecognised header cannot turn into one Device query per book.
+    try:
+        setattr(g, _REQUESTING_DEVICE_ASPECT_G_KEY, resolved)
+    except Exception as exc:
+        # A cache failure must not make cover shaping fail. Resolution remains
+        # usable for this call; the next call will simply resolve again.
+        log.debug("Kobo Sync: could not cache the per-device cover aspect: %s", exc)
+    return resolved
 
 
 def _current_padding_settings():

--- a/cps/services/cover_preview.py
+++ b/cps/services/cover_preview.py
@@ -156,6 +156,51 @@ PRESET_GROUPS = (
 
 DEFAULT_PRESET = "kobo_libra_color"
 
+# Kobo's `x-kobo-devicemodel` header, normalised, mapped to the preset that
+# names the same hardware.
+#
+# Deliberately an ALLOW-LIST, not a parse. The header is client-controlled, so
+# an unrecognised value resolves to None and the caller keeps the instance
+# setting -- falling back is always correct, guessing a ratio is not. Only
+# families we ship a name-matched preset for appear here; nothing is inferred
+# from a model name we have not seen.
+#
+# Observed values from real hardware on this instance (2026-08-15):
+#   "Kobo Clara BW"      -> kobo_clara_bw
+#   "Kobo Libra Colour"  -> kobo_libra_color   (note Kobo's British spelling)
+_DEVICE_MODEL_PRESETS = {
+    "koboclarabw":    "kobo_clara_bw",
+    "koboclaracolor": "kobo_clara_color",
+    "koboclara2e":    "kobo_clara_2e",
+    "koboclarahd":    "kobo_clara",
+    "kobolibracolor": "kobo_libra_color",
+    "kobolibra2":     "kobo_libra_2",
+    "kobosage":       "kobo_sage",
+    "koboforma":      "kobo_forma",
+    "koboelipsa2e":   "kobo_elipsa_2e",
+}
+
+# Matches the bound device_registry already applies to the same header, and the
+# width of Device.model. A longer value is a client doing something odd, not a
+# device we know.
+_DEVICE_MODEL_MAX_LEN = 160
+
+
+def preset_for_device_model(model):
+    """Resolve a Kobo device-model string to one of our aspect presets.
+
+    Returns None for anything not positively recognised, including None, a
+    non-string, an over-long value, or a known-shaped name we do not ship a
+    preset for. Callers treat None as "keep the configured aspect".
+    """
+    if not model or not isinstance(model, str):
+        return None
+    if len(model) > _DEVICE_MODEL_MAX_LEN:
+        return None
+    key = "".join(ch for ch in model.lower() if ch.isalnum()).replace("colour", "color")
+    return _DEVICE_MODEL_PRESETS.get(key)
+
+
 # How close the source must be to the target ratio to skip padding entirely.
 _RATIO_EPSILON = 0.005
 

--- a/tests/unit/test_kobo_per_device_cover_aspect.py
+++ b/tests/unit/test_kobo_per_device_cover_aspect.py
@@ -1,0 +1,152 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Cover padding must follow the Kobo that is actually asking.
+
+The padding aspect is a single instance-wide setting. The moment a household
+owns two different Kobos, one of them gets covers shaped for the other -- a
+Clara BW (1072x1448) served covers padded to a Libra Colour (1264x1680) is a
+real, measured configuration on the maintainer's own instance.
+
+Every authenticated Kobo request already carries `x-kobo-devicemodel`, and we
+already persist it as `Device.model`. This maps that to the aspect preset we
+already ship, and does so through an ALLOW-LIST: an unrecognised model must
+fall back to the configured value, never to a guessed ratio.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _ensure_cps_stub():
+    cps_pkg = sys.modules.get("cps")
+    if cps_pkg is None:
+        cps_pkg = types.ModuleType("cps")
+        cps_pkg.__path__ = [str(REPO_ROOT / "cps")]
+        sys.modules["cps"] = cps_pkg
+
+    constants = sys.modules.get("cps.constants") or types.ModuleType("cps.constants")
+    if not hasattr(constants, "USER_AGENT"):
+        constants.USER_AGENT = "Calibre-Web-NextGen-tests"
+    sys.modules["cps.constants"] = constants
+    cps_pkg.constants = constants
+
+    logger_mod = sys.modules.get("cps.logger") or types.ModuleType("cps.logger")
+    if not hasattr(logger_mod, "create"):
+        logger_mod.create = lambda *_a, **_k: types.SimpleNamespace(
+            debug=lambda *_a, **_k: None, warning=lambda *_a, **_k: None,
+            info=lambda *_a, **_k: None, error=lambda *_a, **_k: None,
+        )
+    sys.modules["cps.logger"] = logger_mod
+    cps_pkg.logger = logger_mod
+
+    if "cps.services" not in sys.modules:
+        services_pkg = types.ModuleType("cps.services")
+        services_pkg.__path__ = [str(REPO_ROOT / "cps" / "services")]
+        sys.modules["cps.services"] = services_pkg
+
+
+@pytest.fixture(scope="module")
+def cover_preview():
+    _ensure_cps_stub()
+    spec = importlib.util.spec_from_file_location(
+        "cps.services.cover_preview", REPO_ROOT / "cps" / "services" / "cover_preview.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["cps.services.cover_preview"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Values observed from real hardware on the maintainer's instance, 2026-08-15,
+# read out of the `device` table that `x-kobo-devicemodel` populates.
+OBSERVED_ON_HARDWARE = [
+    ("Kobo Clara BW", "kobo_clara_bw"),
+    ("Kobo Libra Colour", "kobo_libra_color"),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("model,expected", OBSERVED_ON_HARDWARE)
+def test_models_seen_on_real_hardware_resolve(cover_preview, model, expected):
+    assert cover_preview.preset_for_device_model(model) == expected
+
+
+@pytest.mark.unit
+def test_kobos_british_spelling_is_handled(cover_preview):
+    """Kobo ships "Colour", our preset keys say "color". The device wins."""
+    assert (cover_preview.preset_for_device_model("Kobo Libra Colour")
+            == cover_preview.preset_for_device_model("Kobo Libra Color")
+            == "kobo_libra_color")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("model,expected", [
+    ("Kobo Clara 2E", "kobo_clara_2e"),
+    ("Kobo Clara HD", "kobo_clara"),
+    ("Kobo Libra 2", "kobo_libra_2"),
+    ("Kobo Sage", "kobo_sage"),
+    ("Kobo Forma", "kobo_forma"),
+    ("Kobo Elipsa 2E", "kobo_elipsa_2e"),
+    ("kobo clara bw", "kobo_clara_bw"),
+    ("KOBO CLARA BW", "kobo_clara_bw"),
+    ("Kobo  Clara   BW", "kobo_clara_bw"),
+])
+def test_known_families_resolve_case_and_space_insensitively(cover_preview, model, expected):
+    assert cover_preview.preset_for_device_model(model) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("junk", [
+    None, "", "   ", 12345, b"Kobo Clara BW", [],
+    "Kobo Nia",                 # real device, no name-matched preset -> must not guess
+    "Kobo Aura ONE",            # ditto
+    "Not A Kobo",
+    "Kobo Clara BW; DROP TABLE device",
+    "A" * 200,                  # over the bound device_registry applies
+])
+def test_anything_unrecognised_falls_back_rather_than_guessing(cover_preview, junk):
+    """The header is client-controlled. Returning None keeps the configured
+    aspect, which is exactly today's behaviour -- the one safe answer."""
+    assert cover_preview.preset_for_device_model(junk) is None
+
+
+@pytest.mark.unit
+def test_every_mapped_preset_actually_exists(cover_preview):
+    """A mapping to a preset key we do not ship would resolve to a bogus ratio
+    downstream. Catch it here rather than on someone's e-reader."""
+    for key in cover_preview._DEVICE_MODEL_PRESETS.values():
+        assert key in cover_preview.PRESET_ASPECTS, f"{key} is not a real preset"
+        assert key in cover_preview.PRESET_LABELS, f"{key} has no UI label"
+
+
+@pytest.mark.unit
+def test_the_two_household_devices_really_do_disagree(cover_preview):
+    """The whole point. If these ratios were equal the feature would be noise."""
+    clara = cover_preview.PRESET_ASPECTS["kobo_clara_bw"]
+    libra = cover_preview.PRESET_ASPECTS["kobo_libra_color"]
+    assert clara != libra
+    ratio_clara = clara[0] / clara[1]
+    ratio_libra = libra[0] / libra[1]
+    # Must exceed the engine's own no-op threshold, or padding would skip anyway.
+    assert abs(ratio_clara - ratio_libra) > cover_preview._RATIO_EPSILON
+
+
+@pytest.mark.unit
+def test_aspect_participates_in_the_settings_hash(cover_preview):
+    """Two devices must produce two CoverImageIds and two cache entries.
+    If the hash ignored the aspect, the first device to fetch a cover would
+    poison the cache for the second."""
+    def mk(aspect):
+        return cover_preview.CoverPreviewSettings(
+            enabled=True, target_aspect=aspect, fill_mode="edge_mirror", manual_color="")
+    assert mk("kobo_clara_bw").settings_hash() != mk("kobo_libra_color").settings_hash()

--- a/tests/unit/test_kobo_per_device_cover_aspect_behavior.py
+++ b/tests/unit/test_kobo_per_device_cover_aspect_behavior.py
@@ -1,0 +1,218 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Behavioral coverage for request-specific Kobo cover aspect selection."""
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+from cps import kobo
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Column:
+    """Small SQLAlchemy-column stand-in used by the neighboring Kobo tests."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def __eq__(self, value):
+        return _Predicate(self.name, value)
+
+    def is_(self, value):
+        return _Predicate(self.name, value)
+
+
+@dataclass(frozen=True)
+class _Predicate:
+    field: str
+    value: object
+
+
+class _Device:
+    model = _Column("model")
+    user_id = _Column("user_id")
+    kind = _Column("kind")
+    active = _Column("active")
+
+
+@dataclass
+class _DeviceRow:
+    model: str
+    user_id: int = 7
+    kind: str = "kobo"
+    active: bool = True
+
+
+class _DeviceQuery:
+    def __init__(self, rows):
+        self.rows = rows
+        self.predicates = []
+
+    def filter(self, *predicates):
+        self.predicates.extend(predicates)
+        return self
+
+    def all(self):
+        matching = [
+            row for row in self.rows
+            if all(getattr(row, predicate.field) == predicate.value
+                   for predicate in self.predicates)
+        ]
+        return [(row.model,) for row in matching]
+
+
+class _DeviceSession:
+    def __init__(self, rows=(), error=None):
+        self.rows = list(rows)
+        self.error = error
+        self.query_count = 0
+
+    def query(self, projected_column):
+        assert projected_column is _Device.model
+        self.query_count += 1
+        if self.error is not None:
+            raise self.error
+        return _DeviceQuery(self.rows)
+
+
+@pytest.fixture
+def resolution_harness(monkeypatch):
+    session = _DeviceSession()
+    monkeypatch.setattr(kobo.ub, "Device", _Device)
+    monkeypatch.setattr(kobo.ub, "session", session)
+    monkeypatch.setattr(kobo, "current_user", SimpleNamespace(id=7))
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_cover_padding_aspect", "kobo_libra_color",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_cover_padding_enabled", True, raising=False,
+    )
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_cover_padding_fill_mode", "edge_mirror",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_cover_padding_color", "", raising=False,
+    )
+    return SimpleNamespace(app=Flask(__name__), session=session)
+
+
+def _aspect():
+    return kobo._current_padding_settings().target_aspect
+
+
+def test_recognised_header_wins_over_config_and_registered_device(resolution_harness):
+    resolution_harness.session.rows = [_DeviceRow("Kobo Libra Colour")]
+
+    with resolution_harness.app.test_request_context(
+        "/kobo/token/v1/library/sync",
+        headers={"x-kobo-devicemodel": "Kobo Clara BW"},
+    ):
+        assert kobo._requesting_device_aspect() == "kobo_clara_bw"
+        assert _aspect() == "kobo_clara_bw"
+
+    assert resolution_harness.session.query_count == 0
+
+
+def test_one_active_registered_kobo_supplies_its_preset(resolution_harness):
+    resolution_harness.session.rows = [_DeviceRow("Kobo Clara BW")]
+
+    with resolution_harness.app.test_request_context("/kobo/token/v1/library/sync"):
+        assert kobo._requesting_device_aspect() == "kobo_clara_bw"
+        assert _aspect() == "kobo_clara_bw"
+
+
+def test_different_registered_presets_keep_configured_value(resolution_harness):
+    resolution_harness.session.rows = [
+        _DeviceRow("Kobo Clara BW"),
+        _DeviceRow("Kobo Libra Colour"),
+    ]
+
+    with resolution_harness.app.test_request_context("/kobo/token/v1/library/sync"):
+        assert kobo._requesting_device_aspect() is None
+        assert _aspect() == "kobo_libra_color"
+
+
+def test_same_registered_presets_collapse_to_one_answer(resolution_harness):
+    resolution_harness.session.rows = [
+        _DeviceRow("Kobo Clara BW"),
+        _DeviceRow("KOBO CLARA BW"),
+    ]
+
+    with resolution_harness.app.test_request_context("/kobo/token/v1/library/sync"):
+        assert kobo._requesting_device_aspect() == "kobo_clara_bw"
+        assert _aspect() == "kobo_clara_bw"
+
+
+@pytest.mark.parametrize("unknown_header", ["Kobo Nia", "junk", "A" * 161])
+def test_unrecognised_header_falls_through_to_registry(
+    resolution_harness, unknown_header,
+):
+    resolution_harness.session.rows = [_DeviceRow("Kobo Clara BW")]
+
+    with resolution_harness.app.test_request_context(
+        "/kobo/token/v1/library/sync",
+        headers={"x-kobo-devicemodel": unknown_header},
+    ):
+        assert kobo._requesting_device_aspect() == "kobo_clara_bw"
+        assert _aspect() == "kobo_clara_bw"
+
+    assert resolution_harness.session.query_count == 1
+
+
+def test_registry_ignores_other_users_inactive_devices_and_non_kobos(
+    resolution_harness,
+):
+    resolution_harness.session.rows = [
+        _DeviceRow("Kobo Clara BW"),
+        _DeviceRow("Kobo Libra Colour", user_id=8),
+        _DeviceRow("Kobo Libra Colour", active=False),
+        _DeviceRow("Kobo Libra Colour", kind="android"),
+    ]
+
+    with resolution_harness.app.test_request_context("/kobo/token/v1/library/sync"):
+        assert kobo._requesting_device_aspect() == "kobo_clara_bw"
+        assert _aspect() == "kobo_clara_bw"
+
+
+def test_no_request_context_keeps_configured_value_without_query(resolution_harness):
+    assert kobo._requesting_device_aspect() is None
+    assert _aspect() == "kobo_libra_color"
+    assert resolution_harness.session.query_count == 0
+
+
+def test_device_query_failure_keeps_configured_value_and_does_not_escape(
+    resolution_harness,
+):
+    resolution_harness.session.error = RuntimeError("device registry unavailable")
+
+    with resolution_harness.app.test_request_context("/kobo/token/v1/library/sync"):
+        assert kobo._requesting_device_aspect() is None
+        assert _aspect() == "kobo_libra_color"
+
+    assert resolution_harness.session.query_count == 1
+
+
+def test_current_padding_settings_queries_devices_once_per_request_and_re_resolves_next_request(
+    resolution_harness,
+):
+    resolution_harness.session.rows = [_DeviceRow("Kobo Clara BW")]
+
+    with resolution_harness.app.test_request_context("/kobo/token/v1/library/sync"):
+        assert [_aspect() for _ in range(12)] == ["kobo_clara_bw"] * 12
+        assert resolution_harness.session.query_count == 1
+
+    resolution_harness.session.rows = [_DeviceRow("Kobo Libra Colour")]
+    with resolution_harness.app.test_request_context("/kobo/token/v1/library/sync"):
+        assert _aspect() == "kobo_libra_color"
+
+    assert resolution_harness.session.query_count == 2


### PR DESCRIPTION
## The problem

Kobo cover padding has **one aspect setting for the whole instance**
(`config_kobo_cover_padding_aspect`). With one Kobo that is fine. With two different
Kobos on the same server there is no correct value — whichever you pick, the other
device is served covers padded to someone else's screen.

Found while onboarding a second physical device. `app.db`'s `device` table on the
maintainer's instance:

| model | platform | firmware | screen |
|---|---|---|---|
| Kobo Libra Colour | nickel | 4.45.23697 | 1264×1680 |
| Kobo Clara BW | nickel | 4.42.23291 | 1072×1448 |

…with the instance pinned to `kobo_libra_color`. Those ratios are 0.7524 and 0.7403 —
a ~1.6% difference, which is **above** the padding engine's own `_RATIO_EPSILON`
(0.005), so the Clara was genuinely being padded to the wrong shape rather than
harmlessly skipped.

## Why it was easy

Everything needed was already present and simply never read:

- every authenticated Kobo request carries `x-kobo-devicemodel`
- `cps/services/device_registry.py` already bounds it and persists it as `Device.model`
- we already ship a `kobo_clara_bw` preset (1072×1448) in `cover_preview.PRESET_ASPECTS`

Nothing in the tree branched on device model or firmware. A repo-wide search for
`x-kobo-devicemodel` returns only the registry that records it.

## What changed

`_current_padding_settings()` narrows the aspect to the requesting device:

1. the `x-kobo-devicemodel` header on this request — the device speaking for itself;
2. failing that, the model recorded for this user's Kobos, **only when they imply a
   single preset** (with two Kobos of different shapes and no header, any pick is a
   coin toss and the configured value is the more honest answer).

Anything uncertain resolves to `None` and keeps the configured aspect. **The change can
make covers more correct; it cannot make them less.**

The resolution is **memoized per request** on `flask.g`. `_current_padding_settings()`
is called once per book while building sync metadata, so without the cache a device
whose header is absent or unmapped would cost one `Device` query per book on a full
sync — a per-book query on exactly the large-library path we are separately fixing for
a sync loop (#1634 / #1656). The fail-safe `None` is cached too, which is the case that
would otherwise have re-queried every time.

## Safety

- **Allow-list, not a parse.** The header is client-controlled. Only families with a
  name-matched preset resolve; values are length-bounded to the same 160 chars
  `device_registry` already applies. `Kobo Nia` and `Kobo Aura ONE` deliberately do
  **not** resolve — guessing a ratio from a model name we have not measured is worse
  than falling back.
- **Kobo spells it "Colour".** Our preset keys say `color`. Normalised, with a test.
- **The client-controlled value never reaches a path.** The resolved preset key is one
  of nine fixed strings, and it enters `cache_filename_for` only through
  `settings_hash()`, a hex digest — never as a raw filename component.
- **Cache correctness is free.** `CoverPreviewSettings.settings_hash()` already folds in
  `target_aspect`, and that hash is already appended to the CoverImageId — so two devices
  naturally get two IDs and two cache entries, and the first device to fetch a cover
  cannot poison it for the second. A test pins that so a future change to the hash cannot
  silently break it.
- Wrapped in a `try/except` that logs at debug and falls back: cover shaping must never
  be why a sync or a cover fetch fails.

## Tests

**26 lookup-table tests** in `tests/unit/test_kobo_per_device_cover_aspect.py`, including
the two model strings observed on real hardware, the British-spelling case, junk/hostile
input, a check that every mapped preset exists in both `PRESET_ASPECTS` and
`PRESET_LABELS`, and a check that the two household devices really do disagree by more
than `_RATIO_EPSILON`.

**11 behavioural tests** in `tests/unit/test_kobo_per_device_cover_aspect_behavior.py`,
against the real `cps.kobo` functions rather than the lookup table: header beats config
and beats a registered device; one registered Kobo supplies its preset; two different
registered presets keep the configured value; two identical ones collapse to one answer;
an unrecognised header falls through to the registry; other users' rows, inactive rows
and non-Kobo rows are ignored; no request context keeps the configured value without
querying; a failing device query keeps the configured value and does not escape; and the
memoization holds at one query per request while re-resolving on the next request.

### Red/green

With `cps/kobo.py` restored to `origin/main` and both test files left in place:

```
$ git restore --source=origin/main --worktree cps/kobo.py
$ pytest -q tests/unit/test_kobo_per_device_cover_aspect_behavior.py
11 failed in 2.36s

$ git restore --source=HEAD --worktree cps/kobo.py
$ pytest -q tests/unit/test_kobo_per_device_cover_aspect_behavior.py
11 passed in 1.84s
```

Scoped suite: `pytest -q -k "kobo or cover"` → `1164 passed, 33 skipped`.

## End-to-end verification on the real protocol

Driven against a container running this branch's `cps/` with the real padding pipeline
(`use_IM=True`), instance configured to `kobo_libra_color`, padding enabled. Real HTTP,
real Kobo sync endpoint, real cover endpoint, same book:

`GET /kobo/<token>/v1/library/sync` — `CoverImageId` for the same book:

| request | CoverImageId |
|---|---|
| `x-kobo-devicemodel: Kobo Clara BW` | `f5bf555e-…-1786847827-p05f9435f06` |
| `x-kobo-devicemodel: Kobo Libra Colour` | `f5bf555e-…-1786847827-p6f9e824134` |
| no header | `f5bf555e-…-1786847827-p6f9e824134` |

`GET /kobo/<token>/<id>/1080/1440/false/image.jpg` — the JPEG actually served:

| request | HTTP | served | ratio | preset ratio |
|---|---|---|---|---|
| Clara BW | 200 | 1680×2269 | 0.74041 | 0.74033 (1072×1448) |
| Libra Colour | 200 | 1680×2233 | 0.75235 | 0.75238 (1264×1680) |
| no header | 200 | 1680×2233 | 0.75235 | configured value |

The two devices' covers differ by 0.01194 in ratio — above `_RATIO_EPSILON`, so this is a
real difference and not rounding noise. The header-less response is **byte-identical** to
the configured-aspect one (SHA-256 `75a779f6…`), which is the fail-safe demonstrated at
the byte level rather than argued.

## Honest limitation

The header-first path is proven for the **sync/metadata** request — that is where the
`device` rows above came from. Whether Nickel also sends `x-kobo-devicemodel` on the
**cover image** request is **not yet measured** on real hardware; the table above supplies
the header explicitly. If Nickel does not send it there, the second resolution step (one
unambiguous registered Kobo) covers the per-person-per-device household, and a household
with two differently-shaped Kobos falls back to the configured aspect on the cover path —
which is today's behaviour, so the worst case is no worse than before. That gap is
recorded as a pending finding against this PR: the `-p<hash>` suffix in the CoverImageId
is stripped by `_normalize_cover_uuid` rather than decoded, so the cover request cannot
today recover the aspect the sync response minted it with. Making the ID self-describing
is the obvious closing move if the measurement says the header is absent.
