### PR TITLE
fix(kepub): re-arm the backfill when a new device grows its work-set

### DIFF
--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -156,6 +156,12 @@ class _Settings(_Base):
     config_kobo_cover_padding_color = Column(String, default="")
     config_kobo_prefer_kepub = Column(Boolean, default=True)
     config_kobo_kepub_backfill_completed = Column(Boolean, default=False)
+    # High-water mark over KoboSyncedBooks.id covered by the last successful
+    # backfill. The boolean above cannot express "done for what existed THEN",
+    # and the backfill's work-set is exactly the set that grows when a device
+    # pairs -- so a one-shot latch answers "completed" while the new device's
+    # books have no KEPUB. Monotonic id, so any new sync row re-arms it.
+    config_kobo_kepub_backfill_watermark = Column(Integer, default=0)
     # Versioned repair gates can advance without accumulating one-off booleans.
     config_kobo_kepub_package_repair_version = Column(Integer, default=0)
 

--- a/cps/tasks/kepub_backfill.py
+++ b/cps/tasks/kepub_backfill.py
@@ -5,6 +5,7 @@ import os
 import threading
 
 from flask_babel import lazy_gettext as N_
+from sqlalchemy import func
 
 from .. import config, db, helper, logger, ub
 from ..epub import get_epub_layout
@@ -47,6 +48,8 @@ def _clear_pending(task):
 
 class TaskKepubBackfill(CalibreTask):
     def __init__(self):
+        #: highest KoboSyncedBooks.id this run covered; persisted only on success
+        self.covered_watermark = 0
         super().__init__(N_(u"Convert Kobo books missing KEPUB"))
         self.converted = 0
         self.skipped = 0
@@ -66,6 +69,10 @@ class TaskKepubBackfill(CalibreTask):
             app_session = ub.get_new_session_instance()
             try:
                 book_ids = [row[0] for row in app_session.query(ub.KoboSyncedBooks.book_id).distinct().all()]
+                # Captured with the work-set, not after it: a device pairing
+                # mid-run must re-arm the next boot rather than be silently
+                # marked covered by this one.
+                self.covered_watermark = _synced_books_watermark(app_session)
             finally:
                 app_session.close()
 
@@ -114,11 +121,19 @@ class TaskKepubBackfill(CalibreTask):
                 # Persist first, then flip the in-memory flag: a save() that
                 # raises would otherwise leave this process believing the
                 # migration is done while the next boot re-reads False.
+                previous_watermark = getattr(
+                    config, "config_kobo_kepub_backfill_watermark", 0)
+                # The boolean no longer gates anything -- the watermark does --
+                # but we keep WRITING it so a rollback to an image that still
+                # reads it behaves correctly instead of re-running the whole
+                # backfill. Write-only on purpose; do not "clean it up".
                 config.config_kobo_kepub_backfill_completed = True
+                config.config_kobo_kepub_backfill_watermark = self.covered_watermark
                 try:
                     config.save()
                 except Exception:
                     config.config_kobo_kepub_backfill_completed = False
+                    config.config_kobo_kepub_backfill_watermark = previous_watermark
                     raise
             if self.failed:
                 self._handleError(N_(u"%(count)d KEPUB conversion(s) failed", count=self.failed))
@@ -190,8 +205,38 @@ def enqueue_kepub_backfill(user="System", hidden=False):
     return True
 
 
+def _synced_books_watermark(app_session):
+    """Highest KoboSyncedBooks.id, or 0. Monotonic, so it only ever grows."""
+    return app_session.query(func.max(ub.KoboSyncedBooks.id)).scalar() or 0
+
+
+def outstanding_kepub_backfill_watermark():
+    """Current watermark if it is ahead of what we last covered, else None.
+
+    The old boolean gate could not express "done for the library as it was
+    THEN". The work-set is `select distinct book_id from kobo_synced_books`,
+    and pairing a device is precisely what grows it -- so the latch reported
+    completed while the new device's books had no KEPUB and were converted at
+    download time with the device waiting (or, on failure, delivered as plain
+    EPUB, which cannot reliably hold highlights). Measured on a live instance
+    right after a device paired: 216 synced, 34 with KEPUB, flag "completed".
+    """
+    app_session = ub.get_new_session_instance()
+    try:
+        current = _synced_books_watermark(app_session)
+    finally:
+        app_session.close()
+    covered = getattr(config, "config_kobo_kepub_backfill_watermark", 0) or 0
+    return current if current > covered else None
+
+
 def enqueue_startup_kepub_backfill():
-    if not config.config_kobo_kepub_backfill_completed:
+    # Deliberately gated on the watermark alone, not on the boolean. An install
+    # upgrading with completed=True and no watermark performs exactly one
+    # catch-up scan -- which is the point: that install is the one carrying
+    # unconverted books. The scan is cheap because _backfill_one_book already
+    # skips any book that has a KEPUB or lacks an EPUB.
+    if outstanding_kepub_backfill_watermark() is not None:
         return enqueue_kepub_backfill(hidden=True)
     return False
 

--- a/tests/unit/test_1419_kepub_backfill_survives_one_bad_book.py
+++ b/tests/unit/test_1419_kepub_backfill_survives_one_bad_book.py
@@ -46,6 +46,10 @@ class _Query:
     def distinct(self):
         return self
 
+    def scalar(self):
+        # max(KoboSyncedBooks.id) -- the backfill's re-arm watermark
+        return len(self._rows)
+
     def all(self):
         return self._rows
 

--- a/tests/unit/test_kepub_backfill_rearms_for_a_new_device.py
+++ b/tests/unit/test_kepub_backfill_rearms_for_a_new_device.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""The KEPUB backfill must re-arm when its work-set grows.
+
+`config_kobo_kepub_backfill_completed` was a one-shot global boolean, but the
+task's work-set is `select distinct book_id from kobo_synced_books` — and
+pairing a device is *precisely* what grows that set. So the latch answered
+"completed" while the newly-synced books had no KEPUB at all.
+
+Measured on a live instance immediately after a Kobo Clara BW paired: **216
+books synced, 34 with a KEPUB, 182 without**, with the flag set to completed.
+Those 182 convert at download time with the device waiting, and a conversion
+failure delivers plain EPUB — which cannot reliably hold highlights on a Kobo
+(upstream janeczku/calibre-web#1484). The stale latch therefore lands as
+"highlighting doesn't work on my new Kobo".
+
+A boolean cannot express "done for the library as it was THEN". A monotonic
+high-water mark over KoboSyncedBooks.id can.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
+from cps.tasks import kepub_backfill
+
+
+@pytest.fixture
+def app_session(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    ub.Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    monkeypatch.setattr(ub, "get_new_session_instance", lambda: session)
+    monkeypatch.setattr(kepub_backfill.ub, "get_new_session_instance", lambda: session)
+    yield session
+    session.close()
+
+
+def _sync(session, user_id, book_id):
+    row = ub.KoboSyncedBooks(user_id=user_id, book_id=book_id)
+    session.add(row)
+    session.commit()
+    return row
+
+
+@pytest.fixture(autouse=True)
+def _enqueueable(monkeypatch):
+    """Make enqueue reachable; the gate under test is the watermark, not these."""
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_prefer_kepub", True, raising=False)
+    monkeypatch.setattr(kepub_backfill.config, "config_kepubifypath", "/bin/kepubify", raising=False)
+    monkeypatch.setattr(kepub_backfill.config, "config_use_google_drive", False, raising=False)
+    queued = []
+    monkeypatch.setattr(kepub_backfill, "enqueue_kepub_backfill",
+                        lambda **kw: queued.append(kw) or True)
+    return queued
+
+
+def test_a_newly_paired_device_rearms_a_completed_backfill(app_session, monkeypatch, _enqueueable):
+    for book_id in (1, 2, 3):
+        _sync(app_session, user_id=1, book_id=book_id)
+    covered = kepub_backfill._synced_books_watermark(app_session)
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_completed", True, raising=False)
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark", covered, raising=False)
+
+    assert kepub_backfill.enqueue_startup_kepub_backfill() is False, "nothing new yet"
+
+    # a second device pairs and syncs the same library
+    for book_id in (1, 2, 3):
+        _sync(app_session, user_id=2, book_id=book_id)
+
+    assert kepub_backfill.enqueue_startup_kepub_backfill() is True
+    assert _enqueueable == [{"hidden": True}]
+
+
+def test_no_new_sync_rows_does_not_rearm(app_session, monkeypatch, _enqueueable):
+    _sync(app_session, user_id=1, book_id=1)
+    covered = kepub_backfill._synced_books_watermark(app_session)
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark", covered, raising=False)
+
+    assert kepub_backfill.enqueue_startup_kepub_backfill() is False
+    assert _enqueueable == []
+
+
+def test_an_upgraded_install_performs_exactly_one_catch_up_scan(app_session, monkeypatch, _enqueueable):
+    """completed=True with no watermark is the population carrying unconverted
+    books. One catch-up scan is the point, not a regression -- and it is cheap,
+    because _backfill_one_book already skips any book that has a KEPUB."""
+    for book_id in (1, 2):
+        _sync(app_session, user_id=1, book_id=book_id)
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_completed", True, raising=False)
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark", 0, raising=False)
+
+    assert kepub_backfill.enqueue_startup_kepub_backfill() is True
+
+    # once that run records what it covered, it stops
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark",
+                        kepub_backfill._synced_books_watermark(app_session), raising=False)
+    assert kepub_backfill.enqueue_startup_kepub_backfill() is False
+
+
+def test_the_boolean_alone_no_longer_gates_startup(app_session, monkeypatch, _enqueueable):
+    """The regression in one line: completed=True must NOT suppress new work."""
+    _sync(app_session, user_id=1, book_id=1)
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_completed", True, raising=False)
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark", 0, raising=False)
+
+    assert kepub_backfill.enqueue_startup_kepub_backfill() is True
+
+
+def test_watermark_is_none_when_nothing_is_outstanding(app_session, monkeypatch):
+    _sync(app_session, user_id=1, book_id=1)
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark",
+                        kepub_backfill._synced_books_watermark(app_session), raising=False)
+    assert kepub_backfill.outstanding_kepub_backfill_watermark() is None
+
+
+def test_an_empty_sync_table_is_not_outstanding(app_session, monkeypatch):
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark", 0, raising=False)
+    assert kepub_backfill.outstanding_kepub_backfill_watermark() is None
+    assert kepub_backfill.enqueue_startup_kepub_backfill() is False

--- a/tests/unit/test_kobo_prefer_kepub.py
+++ b/tests/unit/test_kobo_prefer_kepub.py
@@ -122,6 +122,7 @@ def test_backfill_is_composite_idempotent_preserves_sync_rows_and_skips_gdrive(m
 
     class Query:
         def distinct(self): return self
+        def scalar(self): return 2  # max(KoboSyncedBooks.id) for the watermark
         def all(self): return list(sync_rows)
 
     class AppSession:
@@ -166,6 +167,7 @@ def test_backfill_continues_after_per_book_oserror_and_completes(monkeypatch):
 
     class Query:
         def distinct(self): return self
+        def scalar(self): return 2  # max(KoboSyncedBooks.id) for the watermark
         def all(self): return [(1,), (2,)]
 
     class AppSession:


### PR DESCRIPTION
## The bug in one line

`config_kobo_kepub_backfill_completed` is a **one-shot global boolean**, but the work it gates is `select distinct book_id from kobo_synced_books` — and **pairing a device is precisely what grows that set**.

So the latch answers "completed" while the newly-synced books have no KEPUB at all.

## Measured on a live instance

Immediately after a Kobo Clara BW paired:

| | |
|---|---|
| Books synced | **216** |
| With a KEPUB | **34** |
| Without | **182** |
| `config_kobo_kepub_backfill_completed` | **True** |

Those 182 convert at download time *with the device waiting*, and a conversion failure delivers plain EPUB — which cannot reliably hold highlights on a Kobo ([janeczku/calibre-web#1484](https://github.com/janeczku/calibre-web/issues/1484)).

So this reaches the user as **"highlighting doesn't work on my new Kobo"** — the same symptom as the v4.1.36 annotation work, arrived at by a completely different route.

## The fix

A boolean cannot express *"done for the library as it was THEN"*. Replaced with a **monotonic high-water mark over `KoboSyncedBooks.id`**, so any new sync row re-arms it. Startup is gated on the watermark **alone** — the boolean can no longer suppress new work.

Same lesson #1645 independently reached, where the repair gate is an integer version specifically to avoid accumulating one-off booleans.

## Three deliberate choices

**1. Existing installs are NOT seeded to their current max.** That would mark every upgrading install as already-covered — and those are *exactly* the installs carrying unconverted books. They perform one catch-up scan instead, which is the point of the change rather than a cost of it. It's cheap because `_backfill_one_book` already skips any book with a KEPUB: on that same instance, **216 scanned, 182 converted, 34 correctly skipped, ~3.5 min wall clock**.

**2. The boolean is still written**, on purpose, so a rollback to an image that still *reads* it behaves correctly instead of re-running everything. Write-only by design; the comment says so, so nobody "cleans it up".

**3. Reads use `getattr(config, ..., 0)`**, matching the existing pattern for `config_kobo_kepub_package_repair_version` — a `ConfigSQL` built without the column must not raise.

## Verification

- 6 new tests, **all red on the previous code**: a newly-paired device re-arms; no new rows doesn't; an upgraded install does exactly one catch-up scan; the boolean alone no longer gates; and the two empty/nothing-outstanding edges.
- `pytest tests/unit` → **6121 passed, 95 skipped, 0 failed**.
- Two existing test doubles needed `.scalar()` on their fake `_Query`. That's a double gap, not a production defect — the production path uses a real session.
- Confirmed nothing else in `cps/` gates on the boolean: the admin "Convert missing KEPUBs now" button calls `enqueue_kepub_backfill` directly and is ungated, which is why triggering it by hand worked as a stopgap.

Found by the session bringing up a physical Clara BW; the measurements are theirs.