### PR TITLE
fix(kobo): stop pinning the device cursor, so large libraries can finish syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ is for things you can see or feel when running the app.
   needed twice the round trips to finish. Books were never sent twice — this was
   throughput and reporting, not duplication.
 
+- **Kobo full-library sync now completes for libraries with more than about
+  100 pending books.** Large syncs could repeat the same first page forever,
+  adding thousands of duplicate entitlements to the reader until the server
+  failed. Each completed page now advances the device to the next one, so the
+  library drains normally instead of flooding the Kobo.
 
 ## [v4.1.36] - 2026-08-15
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -724,10 +724,13 @@ def HandleSyncRequest():
 
     # no. of books returned
     book_count = changed_entries.count()
-    # Mirror the reading-states branch below: only signal `continue` when
-    # the result set exceeds the batch cap, so an exhaustive batch ends
-    # the session and the device persists the advanced synctoken.
-    cont_sync = bool(book_count > SYNC_ITEM_LIMIT)
+    # PR #248 established that Kobo firmware pins the request cursor whenever
+    # `x-kobo-sync: continue` is present.  Comparing against the page cap fixed
+    # partial pages, but a full page still formed a closed loop: firmware kept
+    # the old token, so the same full page was returned forever.  End every
+    # local session so the advanced composite cursor is persisted; the device
+    # starts the next session with that returned token and drains the next page.
+    cont_sync = False
     log.debug("Kobo Sync: remaining books to sync: {}".format(book_count))
     # generate reading state data
     changed_reading_states = ub.session.query(ub.KoboReadingState)
@@ -752,7 +755,9 @@ def HandleSyncRequest():
              ub.KoboReadingState.book_id.notin_(reading_states_in_new_entitlements)))\
         .order_by(ub.KoboReadingState.last_modified)
     log.debug("Kobo Sync: changed states: {}".format(changed_reading_states.count()))
-    cont_sync |= bool(changed_reading_states.count() > SYNC_ITEM_LIMIT)
+    # Do not set local continuation for a full reading-state page.  It has the
+    # same firmware cursor-pinning semantics as the books signal above; ending
+    # the session is what lets the returned reading-state cursor take effect.
     for kobo_reading_state in changed_reading_states.limit(SYNC_ITEM_LIMIT).all():
         book = calibre_db.session.query(db.Books).filter(db.Books.id == kobo_reading_state.book_id).one_or_none()
         if book:
@@ -862,18 +867,9 @@ def HandleSyncRequest():
             ta = ta.replace(tzinfo=None)
         new_archived_last_modified = max(ta, new_archived_last_modified)
 
-    # If there are MORE pending deletions than SYNC_ITEM_LIMIT, mark
-    # cont_sync so the device comes back for the next page rather than
-    # losing tombstones to the page cap.
-    if len(pending_deletions) >= SYNC_ITEM_LIMIT:
-        remaining = (
-            ub.session.query(ub.KoboDeletedBook)
-            .filter(ub.KoboDeletedBook.user_id == current_user.id)
-            .filter(ub.KoboDeletedBook.deleted_at > new_archived_last_modified)
-            .count()
-        )
-        if remaining > 0:
-            cont_sync = True
+    # Likewise, never set local continuation for deletion pages.  The returned
+    # archive cursor must be persisted before the next page can be selected;
+    # pinning the old cursor would just replay these tombstones indefinitely.
 
     # update last created timestamp to distinguish between new and changed entitlements
     if not cont_sync:

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -887,12 +887,12 @@ def HandleSyncRequest():
     sync_token.archive_last_modified = new_archived_last_modified
     sync_token.reading_state_last_modified = new_reading_state_last_modified
 
-    return generate_sync_response(sync_token, sync_results, cont_sync)
+    return generate_sync_response(sync_token, sync_results)
 
 
-def generate_sync_response(sync_token, sync_results, set_cont=False):
+def generate_sync_response(sync_token, sync_results):
     extra_headers = {}
-    if config.config_kobo_proxy and not set_cont:
+    if config.config_kobo_proxy:
         # Merge in sync results from the official Kobo store.
         try:
             store_response = make_request_to_kobo_store(sync_token)
@@ -900,14 +900,27 @@ def generate_sync_response(sync_token, sync_results, set_cont=False):
             store_sync_results = store_response.json()
             sync_results += store_sync_results
             sync_token.merge_from_store_response(store_response)
-            extra_headers["x-kobo-sync"] = store_response.headers.get("x-kobo-sync")
-            extra_headers["x-kobo-sync-mode"] = store_response.headers.get("x-kobo-sync-mode")
-            extra_headers["x-kobo-recent-reads"] = store_response.headers.get("x-kobo-recent-reads")
+            for header_name in (
+                "x-kobo-sync",
+                "x-kobo-sync-mode",
+                "x-kobo-recent-reads",
+            ):
+                header_value = store_response.headers.get(header_name)
+                if header_value is None:
+                    continue
+                # Kobo firmware pins the incoming token whenever `continue`
+                # is present.  Local page selection depends on the device
+                # persisting our returned token, so a store continuation must
+                # never escape on the combined response.
+                if (
+                    header_name == "x-kobo-sync"
+                    and str(header_value).strip().lower() == "continue"
+                ):
+                    continue
+                extra_headers[header_name] = header_value
 
         except Exception as ex:
             log.error_or_exception("Failed to receive or parse response from Kobo's sync endpoint: {}".format(ex))
-    if set_cont:
-        extra_headers["x-kobo-sync"] = "continue"
     sync_token.to_headers(extra_headers)
 
     # Track Kobo sync activity

--- a/tests/unit/test_832_kobo_side_loaded_removal.py
+++ b/tests/unit/test_832_kobo_side_loaded_removal.py
@@ -71,7 +71,7 @@ def test_stock_store_proxy_results_remain_after_local_removal(monkeypatch):
     response_source = inspect.getsource(generate_sync_response)
     assert handler_source.index("pending_deletions") < handler_source.index(
         "return generate_sync_response")
-    assert "if config.config_kobo_proxy and not set_cont" in response_source
+    assert "if config.config_kobo_proxy" in response_source
     assert "sync_results += store_sync_results" in response_source
 
     class Token:
@@ -85,7 +85,11 @@ def test_stock_store_proxy_results_remain_after_local_removal(monkeypatch):
 
     store_response = SimpleNamespace(
         json=lambda: [{"NewEntitlement": {"source": "official-store"}}],
-        headers={"x-kobo-sync-mode": "store-mode"},
+        headers={
+            "x-kobo-sync": "continue",
+            "x-kobo-sync-mode": "store-mode",
+            "x-kobo-recent-reads": "recent-reads",
+        },
     )
     from cps import kobo as kobo_module
     monkeypatch.setattr(kobo_module.config, "config_kobo_proxy", True, raising=False)
@@ -105,25 +109,29 @@ def test_stock_store_proxy_results_remain_after_local_removal(monkeypatch):
     ]
     assert token.merged is True
     assert response.headers["x-kobo-synctoken"] == "round-tripped-wrapper"
+    assert "x-kobo-sync" not in response.headers
     assert response.headers["x-kobo-sync-mode"] == "store-mode"
+    assert response.headers["x-kobo-recent-reads"] == "recent-reads"
 
 
-def test_local_continuation_does_not_contact_official_store(monkeypatch):
+def test_missing_store_headers_are_omitted(monkeypatch):
     class Token:
+        def merge_from_store_response(self, _response):
+            pass
+
         def to_headers(self, headers):
             headers["x-kobo-synctoken"] = "local-page-token"
 
-    called = []
     from cps import kobo as kobo_module
     monkeypatch.setattr(kobo_module.config, "config_kobo_proxy", True, raising=False)
     monkeypatch.setattr("cps.kobo.make_request_to_kobo_store",
-                        lambda _token: called.append(True))
+                        lambda _token: SimpleNamespace(json=lambda: [], headers={}))
     monkeypatch.setattr("scripts.cwa_db.CWA_DB", lambda: SimpleNamespace(
         log_activity=lambda **_kwargs: None))
     app = Flask(__name__)
     with app.test_request_context("/"):
-        response = generate_sync_response(Token(), [
-            {"ChangedEntitlement": {"source": "local-hard-delete"}}
-        ], set_cont=True)
-    assert called == []
-    assert response.headers["x-kobo-sync"] == "continue"
+        response = generate_sync_response(Token(), [])
+
+    assert "x-kobo-sync" not in response.headers
+    assert "x-kobo-sync-mode" not in response.headers
+    assert "x-kobo-recent-reads" not in response.headers

--- a/tests/unit/test_832_kobo_side_loaded_removal.py
+++ b/tests/unit/test_832_kobo_side_loaded_removal.py
@@ -39,7 +39,7 @@ def test_discovered_sync_handler_emits_changed_not_deleted_entitlement():
     block is outside the store-proxy branch."""
     source = inspect.getsource(HandleSyncRequest)
     tombstone_block = source[source.index("pending_deletions"):source.index(
-        "# If there are MORE pending deletions")]
+        "# Likewise, never set local continuation")]
     assert '"ChangedEntitlement"' in tombstone_block
     assert "create_deleted_book_entitlement" in tombstone_block
     assert "create_deleted_book_metadata" in tombstone_block
@@ -66,7 +66,7 @@ def test_side_loaded_hard_delete_payload_is_removed_hidden_and_not_downloadable(
 
 def test_stock_store_proxy_results_remain_after_local_removal(monkeypatch):
     """Stock-Kobo invariant: local results are extended with store results,
-    never replaced, and only after local continuation has drained."""
+    never replaced, after the local page advances its persisted cursor."""
     handler_source = inspect.getsource(HandleSyncRequest)
     response_source = inspect.getsource(generate_sync_response)
     assert handler_source.index("pending_deletions") < handler_source.index(

--- a/tests/unit/test_kobo_cont_sync_batch_cap.py
+++ b/tests/unit/test_kobo_cont_sync_batch_cap.py
@@ -3,163 +3,117 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
-"""Regression tests for the Kobo cont_sync paging signal (PR #248).
+"""Source pins for the Kobo local-continuation invariant.
 
-@ikerios captured a Kobo Forma (FW 4.45.23684) stuck in a sync loop after a
-factory reset: ~3 sync requests/sec for 15+ hours against a 393-book
-library, with logs showing 2 changed entries per request — well below
-``SYNC_ITEM_LIMIT = 100`` — yet the server kept emitting
-``x-kobo-sync: continue``.
+PR #248 established the crucial wire behavior on a Kobo Forma running firmware
+4.45.23684: ``x-kobo-sync: continue`` is a paging signal that makes firmware
+keep its request cursor pinned, not a freshness signal.  It changed the books
+writer from ``bool(book_count)`` to ``book_count > SYNC_ITEM_LIMIT``, fixing
+the loop when the pending set fit in one page.
 
-Root cause in ``cps/kobo.py:HandleSyncRequest``: the books branch set
-``cont_sync = bool(book_count)`` — True for any non-zero count — while the
-reading-states branch seventeen lines below correctly used
-``cont_sync |= bool(changed_reading_states.count() > SYNC_ITEM_LIMIT)``.
-The Kobo protocol treats ``x-kobo-sync: continue`` as a paging signal
-("more pages exist, keep your cursor pinned"), not a freshness signal.
-When the current batch is exhaustive, emitting ``continue`` is a contract
-violation: the firmware suppresses synctoken persistence, the device
-re-requests with the same cursor, the server returns the same rows with
-``continue``, and the loop self-perpetuates.
+Fork #1634 exposed the remaining half of that contract.  A pending set larger
+than the cap still emitted ``continue``; firmware therefore retained the old
+token, and the server selected the same full page forever.  A local page can
+advance only when the device persists the returned token, so no books,
+reading-state, or deletion queue in ``HandleSyncRequest`` may set local
+continuation.  The batch limits remain; each response ends the session and the
+device starts its next session using the advanced cursor.
 
-These tests source-pin that both cont_sync assignments in
-``HandleSyncRequest`` use the same ``> SYNC_ITEM_LIMIT`` semantic — so a
-future refactor can't silently drop the books-branch fix back to the
-``bool(book_count)`` shape.
-
-Complementary to fork #220's tests in ``test_kobo_bug_cluster_2026_05_17.py``,
-which fixed the cursor-advance side (``BookShelf.date_added`` folded into
-``new_books_last_modified``). PR #248 fixes the signal side. Both fixes
-are required for the loop to terminate on ``else``-branch users.
+These source pins preserve #248's protocol finding while enforcing the
+stronger invariant proved by #1634.  The real request/response behavior is
+covered separately by ``test_kobo_cont_sync_firmware_cursor.py``.
 """
 
-import inspect
-import re
-import sys
+import ast
 from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
 
 
 def _handle_sync_request_source():
-    """Pull ``HandleSyncRequest`` source via sys.modules so blueprint
-    re-exports can't shadow the submodule attribute.
+    source = (Path(__file__).resolve().parents[2] / "cps" / "kobo.py").read_text()
+    tree = ast.parse(source)
+    handler = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "HandleSyncRequest"
+    )
+    return ast.get_source_segment(source, handler)
 
-    Avoids ``from cps import kobo`` which can trigger Flask app boot and
-    is fragile across pytest import modes.
-    """
-    repo_root = Path(__file__).resolve().parents[2]
-    src = (repo_root / "cps" / "kobo.py").read_text()
-    return src
+
+def _cont_sync_writers(source):
+    tree = ast.parse(source)
+    writers = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "cont_sync"
+            for target in node.targets
+        ):
+            writers.append(node)
+        elif (
+            isinstance(node, (ast.AugAssign, ast.AnnAssign))
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "cont_sync"
+        ):
+            writers.append(node)
+    return writers
 
 
-def _cont_sync_lines(src):
-    """Return every line of source that assigns to ``cont_sync``.
-
-    Books branch uses ``=`` (initial assignment); reading-states branch
-    uses ``|=`` (aggregation). Matching to end-of-line dodges the nested-
-    paren trap that ``[^)]+`` falls into (``bool(x.count() > LIMIT)`` has
-    inner parens).
-    """
-    return re.findall(
-        r"^[ \t]*cont_sync\s*(?:=|\|=)\s*[^\n]+$",
-        src,
-        re.MULTILINE,
+def test_handle_sync_has_one_false_local_continuation_writer():
+    """No local queue may pin the device cursor with ``continue``."""
+    source = _handle_sync_request_source()
+    writers = _cont_sync_writers(source)
+    assert len(writers) == 1, (
+        "HandleSyncRequest must initialize cont_sync exactly once and never "
+        f"rewrite or aggregate it from a local queue; found {len(writers)} "
+        f"writers: {[ast.dump(writer) for writer in writers]}"
+    )
+    writer = writers[0]
+    assert isinstance(writer, ast.Assign)
+    assert isinstance(writer.value, ast.Constant) and writer.value.value is False, (
+        "The sole HandleSyncRequest cont_sync writer must be `False`; any "
+        "local `True` value makes Kobo firmware pin the incoming cursor."
     )
 
 
-def test_books_branch_cont_sync_uses_sync_item_limit_compare():
-    """The books-branch ``cont_sync`` assignment must compare against
-    ``SYNC_ITEM_LIMIT`` — not simply ``bool(book_count)``.
-
-    The broken shape is what stranded @ikerios's Forma at 3 req/sec for
-    15 hours. Pin the corrected pattern by source so a refactor can't
-    revert to the bug.
-    """
-    src = _handle_sync_request_source()
-    lines = _cont_sync_lines(src)
-    initial = [l for l in lines if re.match(r"^[ \t]*cont_sync\s*=\s", l)]
-    assert initial, (
-        "Expected a `cont_sync = ...` initial assignment in cps/kobo.py "
-        "(books-branch paging signal). If the assignment shape changed, "
-        "update this test — but keep the > SYNC_ITEM_LIMIT semantic."
-    )
-    line = initial[0]
-    assert "SYNC_ITEM_LIMIT" in line, (
-        f"The books-branch cont_sync assignment must reference "
-        f"SYNC_ITEM_LIMIT (not just bool(book_count)). Current line: "
-        f"{line!r}. Without the cap comparison, any non-zero book_count "
-        f"emits 'x-kobo-sync: continue', the device suppresses synctoken "
-        f"persistence, and the loop self-perpetuates."
-    )
-    assert ">" in line, (
-        f"The books-branch cont_sync assignment must use the > comparison "
-        f"with SYNC_ITEM_LIMIT (mirror the reading-states branch). "
-        f"Current line: {line!r}"
-    )
+def test_books_stay_page_capped_but_never_request_local_continuation():
+    """#248's batch cap remains while #1634 removes its unsafe signal."""
+    source = _handle_sync_request_source()
+    page = "books_list = changed_entries.limit(SYNC_ITEM_LIMIT).all()"
+    count = "book_count = changed_entries.count()"
+    terminal = "cont_sync = False"
+    assert page in source
+    assert count in source
+    assert terminal in source
+    assert source.index(page) < source.index(count) < source.index(terminal)
+    assert "cont_sync = bool(book_count" not in source
 
 
-def test_reading_states_branch_cont_sync_uses_sync_item_limit_compare():
-    """Defense-in-depth: the reading-states branch was already correct
-    before PR #248 — pin it so a future refactor that "unifies" both
-    branches doesn't accidentally regress this one too.
-    """
-    src = _handle_sync_request_source()
-    lines = _cont_sync_lines(src)
-    aggregations = [l for l in lines if re.match(r"^[ \t]*cont_sync\s*\|=", l)]
-    assert aggregations, (
-        "Expected a `cont_sync |= ...` aggregation in cps/kobo.py "
-        "(reading-states branch). If the aggregation shape changed, "
-        "update this test — but keep the > SYNC_ITEM_LIMIT semantic."
-    )
-    line = aggregations[0]
-    assert "SYNC_ITEM_LIMIT" in line and ">" in line, (
-        f"The reading-states cont_sync |= must compare against "
-        f"SYNC_ITEM_LIMIT with the > operator. Current line: {line!r}"
-    )
+def test_reading_states_stay_page_capped_without_continuation_writer():
+    """A full reading-state page must also let its returned cursor persist."""
+    source = _handle_sync_request_source()
+    assert (
+        "for kobo_reading_state in "
+        "changed_reading_states.limit(SYNC_ITEM_LIMIT).all():"
+    ) in source
+    assert "cont_sync |= bool(changed_reading_states" not in source
+    assert "cont_sync = bool(changed_reading_states" not in source
 
 
-def test_both_count_based_cont_sync_assignments_use_same_pattern():
-    """Both ``cont_sync (=|\\|=) bool(<count>)`` sites must use the same
-    ``> SYNC_ITEM_LIMIT`` shape.
-
-    There's a third ``cont_sync = True`` site downstream that's correctly
-    guarded by an outer ``if len(pending_deletions) >= SYNC_ITEM_LIMIT``
-    block (tombstone-pagination path) — that one doesn't need the inline
-    comparison and is intentionally excluded from this pin.
-    """
-    src = _handle_sync_request_source()
-    bool_lines = [
-        l for l in _cont_sync_lines(src)
-        if re.search(r"bool\s*\(", l)
-    ]
-    assert len(bool_lines) >= 2, (
-        f"Expected at least two `cont_sync (=|\\|=) bool(...)` sites in "
-        f"cps/kobo.py (books branch + reading-states branch); found "
-        f"{len(bool_lines)}: {bool_lines}"
-    )
-    for m in bool_lines:
-        assert "SYNC_ITEM_LIMIT" in m and ">" in m, (
-            f"Every count-based cont_sync assignment must reference "
-            f"SYNC_ITEM_LIMIT with the > operator (paging signal "
-            f"semantics, not freshness). Offending line: {m!r}"
-        )
-
-
-def test_broken_pattern_bool_book_count_alone_is_gone():
-    """The literal broken pattern ``bool(book_count)`` (alone, no
-    comparison) must not appear in ``HandleSyncRequest``. Pinning the
-    exact pre-fix string protects against a copy-paste revert.
-    """
-    src = _handle_sync_request_source()
-    # Allow the variable name to appear in unrelated contexts. The check
-    # is "bool(book_count) followed by close-paren and end-of-expression"
-    # — the broken assignment shape exactly.
-    assert not re.search(
-        r"cont_sync\s*=\s*bool\(\s*book_count\s*\)",
-        src,
-    ), (
-        "The pre-fix `cont_sync = bool(book_count)` pattern must not "
-        "reappear. It treats any non-zero count as 'more pages exist', "
-        "which the Kobo firmware honors by pinning the synctoken — "
-        "infinite sync loop. Use `bool(book_count > SYNC_ITEM_LIMIT)` "
-        "to mirror the reading-states branch."
+def test_deletions_stay_page_capped_without_continuation_writer():
+    """Deletion tombstones page via the persisted archive cursor, not a pin."""
+    source = _handle_sync_request_source()
+    pending_start = source.index("pending_deletions = (")
+    pending_end = source.index("for tombstone in pending_deletions:")
+    pending_query = source[pending_start:pending_end]
+    assert ".limit(SYNC_ITEM_LIMIT)" in pending_query
+    assert "cont_sync = True" not in source
+    assert "cont_sync |= " not in source
+    assert (
+        "return generate_sync_response(sync_token, sync_results, cont_sync)"
+        in source
     )

--- a/tests/unit/test_kobo_cont_sync_batch_cap.py
+++ b/tests/unit/test_kobo_cont_sync_batch_cap.py
@@ -114,6 +114,6 @@ def test_deletions_stay_page_capped_without_continuation_writer():
     assert "cont_sync = True" not in source
     assert "cont_sync |= " not in source
     assert (
-        "return generate_sync_response(sync_token, sync_results, cont_sync)"
+        "return generate_sync_response(sync_token, sync_results)"
         in source
     )

--- a/tests/unit/test_kobo_cont_sync_firmware_cursor.py
+++ b/tests/unit/test_kobo_cont_sync_firmware_cursor.py
@@ -35,7 +35,14 @@ def _book_id(sync_item):
     return int(envelope["BookEntitlement"]["Id"])
 
 
-def test_full_library_sync_drains_when_firmware_pins_cursor_on_continue(monkeypatch):
+@pytest.mark.parametrize(
+    "proxy_enabled",
+    [False, True],
+    ids=["local-only", "proxy-store-continue"],
+)
+def test_full_library_sync_drains_when_firmware_pins_cursor_on_continue(
+    monkeypatch, proxy_enabled
+):
     """Every book arrives once across bounded firmware-shaped sync sessions."""
     from cps import db, kobo as kobo_module, kobo_sync_status, ub
 
@@ -95,7 +102,12 @@ def test_full_library_sync_drains_when_firmware_pins_cursor_on_continue(monkeypa
     monkeypatch.setattr(kobo_module, "current_user", user)
     monkeypatch.setattr(kobo_sync_status, "current_user", user)
     monkeypatch.setattr(kobo_module, "SYNC_ITEM_LIMIT", limit)
-    monkeypatch.setattr(kobo_module.config, "config_kobo_proxy", False, raising=False)
+    monkeypatch.setattr(
+        kobo_module.config,
+        "config_kobo_proxy",
+        proxy_enabled,
+        raising=False,
+    )
     monkeypatch.setattr(
         kobo_module.config,
         "config_kobo_sync_magic_shelves",
@@ -124,6 +136,23 @@ def test_full_library_sync_drains_when_firmware_pins_cursor_on_continue(monkeypa
         "get_metadata",
         lambda book: {"EntitlementId": str(book.id)},
     )
+    store_calls = []
+    if proxy_enabled:
+        store_response = SimpleNamespace(
+            json=lambda: [],
+            headers={
+                "x-kobo-sync": "continue",
+                "x-kobo-sync-mode": "test-mode",
+                "x-kobo-recent-reads": "test-recent-reads",
+                "x-kobo-synctoken": "test-store-token",
+            },
+        )
+
+        def store_sync(token):
+            store_calls.append(token)
+            return store_response
+
+        monkeypatch.setattr(kobo_module, "make_request_to_kobo_store", store_sync)
 
     app = Flask(__name__)
     app.wsgi_app = SimpleNamespace(is_proxied=True)
@@ -181,6 +210,7 @@ def test_full_library_sync_drains_when_firmware_pins_cursor_on_continue(monkeypa
             f"each seeded book must be delivered exactly once; got {deliveries}"
         )
         assert len(pages) <= ceil(total_books / limit)
+        assert len(store_calls) == (len(pages) if proxy_enabled else 0)
     finally:
         session.close()
         engine.dispose()

--- a/tests/unit/test_kobo_cont_sync_firmware_cursor.py
+++ b/tests/unit/test_kobo_cont_sync_firmware_cursor.py
@@ -1,0 +1,186 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Behavioral regression for fork #1634 (recurrence of #347).
+
+Kobo firmware treats ``x-kobo-sync: continue`` as an instruction to keep the
+request cursor pinned.  It persists the returned ``x-kobo-synctoken`` only
+after a response without ``continue``.  A server-side page that advances its
+token but also emits ``continue`` therefore cannot drain: the next request
+uses the old token and receives the same page again.
+
+This test drives the real ``HandleSyncRequest`` body repeatedly, with real
+SQLAlchemy queries over a small seeded library.  The item limit is patched
+down so the test remains fast, while the request-token feedback loop models
+the observed firmware contract rather than the server's intended contract.
+"""
+
+from datetime import datetime
+from math import ceil
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine, event, true
+from sqlalchemy.orm import sessionmaker
+
+
+pytestmark = pytest.mark.unit
+
+
+def _book_id(sync_item):
+    envelope = sync_item.get("NewEntitlement") or sync_item.get("ChangedEntitlement")
+    if not envelope or "BookMetadata" not in envelope:
+        return None
+    return int(envelope["BookEntitlement"]["Id"])
+
+
+def test_full_library_sync_drains_when_firmware_pins_cursor_on_continue(monkeypatch):
+    """Every book arrives once across bounded firmware-shaped sync sessions."""
+    from cps import db, kobo as kobo_module, kobo_sync_status, ub
+
+    engine = create_engine("sqlite://")
+    event.listen(
+        engine,
+        "connect",
+        lambda connection, _record: connection.execute(
+            "ATTACH DATABASE ':memory:' AS calibre"
+        ),
+    )
+    db.Base.metadata.create_all(engine)
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+
+    limit = 3
+    total_books = limit * 2 + 1
+    shared_modified = datetime(2026, 8, 12, 5, 9, 48, 351127)
+    books = [
+        db.Books(
+            f"Book {book_id}",
+            f"Book {book_id}",
+            "Author",
+            shared_modified,
+            db.Books.DEFAULT_PUBDATE,
+            "1.0",
+            shared_modified,
+            f"book-{book_id}",
+            0,
+            [],
+            [],
+        )
+        for book_id in range(1, total_books + 1)
+    ]
+    session.add_all(books)
+    session.flush()
+    for book in books:
+        book.uuid = f"book-uuid-{book.id}"
+        session.add(db.Data(book.id, "EPUB", 1, f"book-{book.id}"))
+    session.commit()
+
+    user = SimpleNamespace(
+        id=17,
+        name="firmware-contract-test",
+        kobo_only_shelves_sync=False,
+        role_download=lambda: True,
+    )
+    fake_calibre_db = SimpleNamespace(
+        session=session,
+        reconnect_db=lambda *_args, **_kwargs: None,
+        common_filters=lambda **_kwargs: true(),
+    )
+
+    monkeypatch.setattr(ub, "session", session)
+    monkeypatch.setattr(ub, "session_commit", lambda *_args, **_kwargs: session.commit())
+    monkeypatch.setattr(kobo_module, "calibre_db", fake_calibre_db)
+    monkeypatch.setattr(kobo_module, "current_user", user)
+    monkeypatch.setattr(kobo_sync_status, "current_user", user)
+    monkeypatch.setattr(kobo_module, "SYNC_ITEM_LIMIT", limit)
+    monkeypatch.setattr(kobo_module.config, "config_kobo_proxy", False, raising=False)
+    monkeypatch.setattr(
+        kobo_module.config,
+        "config_kobo_sync_magic_shelves",
+        False,
+        raising=False,
+    )
+    monkeypatch.setattr(kobo_module, "get_download_url_for_book", lambda *_args: "/download")
+    monkeypatch.setattr(
+        kobo_module,
+        "get_magic_shelf_book_ids_for_kobo",
+        lambda _user_id: (set(), True),
+    )
+    monkeypatch.setattr(
+        kobo_module,
+        "get_magic_shelf_membership_added_at",
+        lambda _user_id: None,
+    )
+    monkeypatch.setattr(kobo_module, "sync_shelves", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        kobo_module,
+        "create_book_entitlement",
+        lambda book, archived=False: {"Id": str(book.id), "IsRemoved": archived},
+    )
+    monkeypatch.setattr(
+        kobo_module,
+        "get_metadata",
+        lambda book: {"EntitlementId": str(book.id)},
+    )
+
+    app = Flask(__name__)
+    app.wsgi_app = SimpleNamespace(is_proxied=True)
+    device_token = ""
+    pages = []
+    deliveries = []
+    delivered = set()
+    request_bound = ceil(total_books / limit) + 1
+
+    try:
+        for request_number in range(1, request_bound + 1):
+            sent_token = device_token
+            headers = {}
+            if sent_token:
+                headers[kobo_module.SyncToken.SyncToken.SYNC_TOKEN_HEADER] = sent_token
+
+            with app.test_request_context("/v1/library/sync", headers=headers):
+                response = kobo_module.HandleSyncRequest.__wrapped__()
+
+            page = tuple(
+                book_id
+                for item in response.get_json()
+                if (book_id := _book_id(item)) is not None
+            )
+            if pages:
+                assert page != pages[-1][0], (
+                    "firmware-pinned cursor re-delivered the identical page "
+                    f"{page} on requests {request_number - 1} and {request_number}; "
+                    f"x-kobo-sync values were {pages[-1][1]!r} and "
+                    f"{response.headers.get('x-kobo-sync')!r}"
+                )
+
+            continuation = response.headers.get("x-kobo-sync")
+            pages.append((page, continuation))
+            deliveries.extend(page)
+            delivered.update(page)
+
+            # Observed firmware contract: `continue` pins the request token;
+            # only a terminal response commits the server's returned cursor.
+            if continuation != "continue":
+                device_token = response.headers[
+                    kobo_module.SyncToken.SyncToken.SYNC_TOKEN_HEADER
+                ]
+
+            if len(delivered) == total_books:
+                break
+        else:
+            pytest.fail(
+                f"sync did not drain {total_books} books within {request_bound} requests; "
+                f"delivered={sorted(delivered)}, pages={pages}"
+            )
+
+        assert delivered == set(range(1, total_books + 1))
+        assert len(deliveries) == total_books, (
+            f"each seeded book must be delivered exactly once; got {deliveries}"
+        )
+        assert len(pages) <= ceil(total_books / limit)
+    finally:
+        session.close()
+        engine.dispose()


### PR DESCRIPTION
Fixes #1634. Also closes out #347, which was the same bug reported in May and auto-closed after an incomplete fix.

## What users see

Kobo sync of any library with more than ~100 pending rows never finished. The device kept adding the same books until "My Books" showed tens of thousands of entries against a library of a few hundred, and the server eventually fell over. Two unrelated reporters on #1634, plus the original #347 reporter, all on different hardware.

## Root cause, from a production log

@pahamrick attached a full server log of the live failure. It shows the loop directly:

- Every request carries the **identical** device token — cursor `2026-08-12 05:09:48.351127`, `books_last_id=536`.
- Every response delivers the **same 100 books**, ids 437–536, once per second, indefinitely.
- `changed entries: 3481` never shrinks.

PR #248 established the governing wire fact, from a Kobo Forma trace: **`x-kobo-sync: continue` makes the firmware keep its request cursor pinned.** It is a paging signal, not a freshness signal — the device deliberately does not persist the returned `x-kobo-synctoken` while it is set.

#248 fixed only the case where the pending set fit inside one page (`bool(book_count)` → `book_count > SYNC_ITEM_LIMIT`). The larger case is a closed loop:

1. we emit a full page, advance the cursor correctly, **and** set `continue`;
2. the firmware therefore discards our advanced cursor and re-sends the old one;
3. `book_count` is recomputed from that pinned cursor, so it stays 3481;
4. `3481 > 100`, so we set `continue` again.

The count can only shrink if the device carries the cursor forward, and `continue` is exactly what stops it doing so. A server page cannot advance without the device persisting the token, so **no queue in `HandleSyncRequest` may set local continuation** — books, reading states, or deletions.

That is why this survived so long: libraries inside one page never set `continue`, so they always worked.

## The change

`cps/kobo.py` — every local `continue` writer removed from the books, reading-state and deletion paths. All three `SYNC_ITEM_LIMIT` caps stay; each response now ends the session, the device persists the advanced cursor, and its next session selects the next page.

## Why the last fix didn't hold, and what stops the next one drifting

`tests/unit/test_kobo_cont_sync_batch_cap.py` was a **source-pin** test — it parsed `HandleSyncRequest` and checked the comparison had the right *shape*. The shape was right and the semantics were wrong, so it passed throughout. That is the actual reason #347 came back as #1634.

It is rewritten to pin the stronger invariant (exactly one `cont_sync` writer, always `False`; every queue cap retained) with #248's wire finding preserved in the docstring — this fix depends on that finding, it does not revert it.

The real coverage is new: `tests/unit/test_kobo_cont_sync_firmware_cursor.py` drives the real handler over real SQLAlchemy queries and **models the firmware, not the server's intent** — when a response carries `continue`, the next request re-sends the *previous* token, exactly as the hardware does. It asserts the library drains and that no two consecutive pages are identical.

## Evidence

RED before the fix — the reported symptom, not a harness error:

```
AssertionError: firmware-pinned cursor re-delivered the identical page (1, 2, 3) on requests 1 and 2;
x-kobo-sync values were 'continue' and 'continue'
assert (1, 2, 3) != (1, 2, 3)
```

GREEN after: all seeded books drain exactly once in three bounded sessions.

Full Kobo unit suite: **417 passed / 1 skipped → 418 passed / 1 skipped** (419 collected). No existing test changed its pass state.

## Deliberately unchanged

- No `KoboSyncedBooks` filtering added — it is user-keyed and would lock a second device out of books the first already received.
- The composite `(books_last_modified, books_last_id)` cursor, both `.distinct()` shapes and all magic-shelf logic are untouched. #1648 owns the sync-all `.distinct()` fix separately.
- No new dependencies, no license changes, no new external URLs.

## The proxy path, found in review

With local continuation gone, `generate_sync_response` runs its store-proxy branch on every page — and it forwarded the store's `x-kobo-sync` header verbatim. A `continue` arriving from the Kobo store would have re-pinned the cursor and reproduced the identical loop, **in exactly the configuration both reporters run** ("Proxy Unknown Requests to Kobo Store" enabled).

Fixed in the second commit: a store-supplied `continue` is suppressed, other store headers (`x-kobo-sync-mode`, `x-kobo-recent-reads`, non-`continue` `x-kobo-sync`) still forward, and a header the store omits is now omitted rather than set to `None`. Covered by a second parameterisation of the behavioural test that stubs the store returning `continue` and requires the library to drain anyway — RED against the first commit with the same identical-page assertion.

**Known consequence, stated deliberately:** a proxy-enabled install now makes one Kobo Store round-trip per page instead of one per sync. Each corresponds to one device-initiated request and stays bounded to one outbound call per request. Avoiding it would need a store-deferral protocol and token lifecycle, which is out of scope for a cursor-loop fix.

## Verification

Independently re-run by the reviewer, not taken from the implementer's report:

- **RED**: with `cps/kobo.py` reverted to `c73f8d3f6` and the new tests in place — both variants fail with `firmware-pinned cursor re-delivered the identical page (1, 2, 3) on requests 1 and 2; x-kobo-sync values were 'continue' and 'continue'`.
- **GREEN**: full Kobo unit suite at this head — **419 passed, 1 skipped** (48 test files).
- **Live HTTP**, real container (`cwn-local`), real Kobo auth token, real `GET /kobo/<token>/v1/library/sync`: `200 OK`, **no `x-kobo-sync` header emitted**, returned `x-kobo-synctoken` accepted on a second request and the changed-set shrank (10 → 9 items) — so the cursor is honoured over the wire, not just in tests. Container restored to its original file afterwards.

**What the live check does not cover:** that instance's library is 51 books / 92 format rows, below `SYNC_ITEM_LIMIT`, so the over-the-cap drain itself is proven by the behavioural regression — real handler, real Flask request context, real SQLAlchemy, patched cap — rather than against a >100-row live library. Stated rather than glossed, since that gap is where the previous two fixes went wrong.

## Why this is labelled for review rather than self-merged

This is the third attempt at this code path — #220 fixed the cursor side, #248 fixed half the signal side, and both looked correct and left users looping. The failure mode is silent and reaches every Kobo user. The evidence above is what I'd merge on; a second pair of eyes on a protocol change with that history is worth the delay.
