### PR TITLE
docs(kobo): correct a wrong root-cause claim, and route highlights properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,32 @@ Read your CWA library on a Kobo e-reader, with reading progress syncing both way
 1. In Admin → Edit Basic Configuration, turn on **Enable Kobo sync**.
 2. Open your user page (Admin → Users → your user, or your own profile) and click **Create/View** next to **Kobo Sync Token**. The dialog shows the exact `api_endpoint=` line for your account.
 3. Plug the Kobo into a computer over USB and open `.kobo/Kobo/Kobo eReader.conf` in a text editor. Add or replace the `api_endpoint=` line with the one from the dialog, save, and eject the device cleanly.
-4. On the Kobo, sync. Books on your Kobo Sync shelves appear on the device, and progress flows back to CWA.
+4. **In the same file, also set `reading_services_host=` to the same base URL** (no token path — e.g. `reading_services_host=https://books.example.com`). See the warning below for why this matters.
+5. On the Kobo, sync. Books on your Kobo Sync shelves appear on the device, and progress flows back to CWA.
+
+> ### ⚠️ `api_endpoint` alone does not route your highlights
+>
+> `api_endpoint` routes **library sync**. Your **highlights and notes** travel over a separate
+> reading-services channel governed by `reading_services_host`, and if that key still points at
+> Kobo, your annotation traffic never reaches your server at all.
+>
+> That matters because the server-side protection against a Kobo deleting its own highlights after
+> a sync (upstream [calibre-web#2610](https://github.com/janeczku/calibre-web/issues/2610)) works by
+> answering that channel — **and it cannot protect a request it never receives.**
+>
+> CWA does advertise the correct host during sync initialization, but a device that already has the
+> key set to Kobo's server has been **observed keeping it**: on a Kobo Clara BW (firmware 4.42),
+> seven syncs with highlights present produced **zero** annotation-path requests until the key was
+> set by hand. Set it explicitly rather than relying on the handshake.
+>
+> **To verify it took**, make a highlight on the device and sync while watching the log. You should
+> see the annotation path, e.g.:
+>
+> ```bash
+> docker logs -f calibre-web 2>&1 | grep -iE "annotations|reading services"
+> ```
+>
+> Silence there means annotations are still going to Kobo, whatever the library sync is doing.
 
 To confirm the device is reaching your server, watch the logs while you sync — you should see requests to `/kobo/<token>/v1/...`:
 

--- a/notes/KOBO-HIGHLIGHT-LOSS-ROOT-CAUSE-2026-08-15.md
+++ b/notes/KOBO-HIGHLIGHT-LOSS-ROOT-CAUSE-2026-08-15.md
@@ -36,7 +36,8 @@ Both identities are visible side by side in `content`:
 | 9 (chapter, used for rendering) | `<uuid>!OPS!chapter-017.xml` |
 | 899 (TOC entry) | `<uuid>!OPS!../OPS/chapter-017.xml-2` |
 
-All 88 of the book's `Bookmark` rows carried the TOC-derived form → **0 matches** → nothing drawn.
+All 88 of the book's `Bookmark` rows carried a form matching neither table → **0 matches** →
+nothing drawn. (Not literally the `ContentType=899` value either — see Cause 1b below.)
 A control book returned `matching content row exists: 1`; this book returned `0`.
 
 **Census query — orphaned highlights, device-wide:**
@@ -82,8 +83,23 @@ query. The `LIKE VolumeID || '%'` probe was never validated against a volume kno
 
 ## Cause 1b — a fragment-anchored TOC (wider than the `../` case)
 
-Nickel takes the chapter identity from the TOC entry **including the fragment**; the `ContentType=9`
-row has none, so the exact match fails:
+The `Bookmark.ContentID` matches **neither** the chapter row **nor** the TOC row. It is a *third*
+form — the opf directory joined to the **raw TOC href**, without the `-N` disambiguator the
+`ContentType=899` rows carry:
+
+| what | ContentID |
+|---|---|
+| `ContentType=9` (what rendering looks up) | `…!OEBPS!…541-h-0.htm.xhtml` |
+| `ContentType=899` (the TOC entry) | `…!OEBPS!…541-h-0.htm.xhtml#pgepubid00005`**`-2`** |
+| **`Bookmark.ContentID`** | `…!OEBPS!…541-h-0.htm.xhtml#pgepubid00005` |
+
+`matches_899 = 0/3`, `matches_9 = 0/3`. **This also sharpens Cause 1 above:** those Flatland
+bookmarks were not carrying "the TOC-derived form" in the 899 sense either — the 899 row was
+`<uuid>!OPS!../OPS/chapter-017.xml-2` while the Bookmark was `OPS/../OPS/chapter-017.xml`. Both
+bugs are the same third form. **ASSUMED:** the exact derivation rule; the two observed cases differ
+in whether the `<uuid>!<opf-dir>!` prefix survives, and that is not established.
+
+The exact match against `ContentType=9` therefore fails:
 
 ```
 Bookmark.ContentID     <uuid>!OEBPS!..._541-h-0.htm.xhtml#pgepubid00005
@@ -96,6 +112,29 @@ TOC links carry a fragment. Both OPF manifests are clean.
 
 ⚠️ **The defect is entirely in the NCX, so #1637 does not touch it, and we ship these today.**
 **92 of 216 books (42.6%)** have a fragment-anchored TOC — against #1637's 5 of 216.
+
+### Two fixes that look obvious and are both wrong
+
+**Stripping fragments from the NCX is NOT a fix.** The fragment is load-bearing navigation:
+collapsing it would put Age of Innocence's 42 TOC targets onto 7 documents, and Dune's 1,780 onto a
+handful. That trades invisible highlights for a broken table of contents.
+
+**Normalising server-side does NOT fix rendering.** #1638 normalises the `content_id` *we* store,
+which is right for our records, but the row Nickel draws from lives on the device. No server-side
+change can make its exact match succeed.
+
+**Why 1984 works** is the clue to the real shape: it was already split into per-chapter files, so
+every TOC href targets a whole document and carries no fragment. The discriminator is not "the TOC
+has fragments" but **"the TOC targets a position inside a document rather than a document"**.
+
+So the candidate fix is splitting spine documents at TOC anchor targets during conversion — the
+shape already hardware-proven by 1984. ⚠️ **Not yet designed or shipped, deliberately:** regenerating
+a KEPUB shifts KoboSpan ids, so doing this to 92 of 216 books in a live library is a mass
+re-anchoring event that would invalidate highlights users already hold. Any such fix needs a story
+for books that already carry highlights, and probably applies to new conversions only.
+
+**The 810-highlight recovery is independent of all of this** and stands alone: stripping the
+fragment from `Bookmark.ContentID` re-anchors every one, with no conversion change.
 
 **Library scan:** 5 of 216 books (2.3%) carry an escaping OPF href, every one `../nav.xhtml`.
 Perfect correlation on the instance: every book with one has **zero** stored annotations ever;

--- a/notes/KOBO-HIGHLIGHT-LOSS-ROOT-CAUSE-2026-08-15.md
+++ b/notes/KOBO-HIGHLIGHT-LOSS-ROOT-CAUSE-2026-08-15.md
@@ -47,10 +47,55 @@ select b.VolumeID, count(*) n,
 from Bookmark b group by b.VolumeID;
 ```
 
-907 of 3016 were orphaned. Two distinct reasons: this bug (Flatland 88, All Quiet 9), and
-*book no longer on the device* (Iliad 584, King in Yellow 220, Republic 6 — those have **no**
-`ContentType=9` rows at all and are not repairable by rewriting; they'd render again if the book
-returned to the same path).
+907 of 3016 were orphaned.
+
+🚨 **CORRECTED 2026-08-16 — the original reading of 810 of those was WRONG, and the error is
+instructive.** This note first said Iliad (584), King in Yellow (220) and Republic (6) had *no*
+`ContentType=9` rows because the book had been removed from the device, and were therefore not
+repairable. **All 810 are repairable**, and the books were never gone.
+
+The mistake was the probe: chapter rows were looked for with `ContentID LIKE VolumeID || '%'`, which
+returns zero for a `file:///mnt/onboard/...` volume **regardless of whether the book is present** —
+because those volumes' chapter ids are not prefixed by the volume path. "No rows found" was read as
+"book removed" when it meant "this query cannot see this volume shape".
+
+**The control that settles it: the Odyssey.** Same `file:///` volume shape, 400 bookmarks,
+**400/400 rendering**, and zero fragments. A "book is gone" explanation cannot survive it.
+
+The real second cause is a **fragment-anchored TOC** — see below. Verified on the same backup:
+
+| volume | bookmarks | anchored | carry `#` |
+|---|---|---|---|
+| Iliad | 608 | 24 | **584** |
+| King in Yellow | 221 | 1 | **220** |
+| Odyssey | 400 | **400** | 0 |
+| three others | 873 | 873 | 0 |
+
+```
+fragmented: 810     repairable (exact ContentType=9 match after stripping '#'): 810
+```
+
+**Generalises:** a negative from a query is only as good as a positive control run through the same
+query. The `LIKE VolumeID || '%'` probe was never validated against a volume known to work.
+
+---
+
+## Cause 1b — a fragment-anchored TOC (wider than the `../` case)
+
+Nickel takes the chapter identity from the TOC entry **including the fragment**; the `ContentType=9`
+row has none, so the exact match fails:
+
+```
+Bookmark.ContentID     <uuid>!OEBPS!..._541-h-0.htm.xhtml#pgepubid00005
+content ContentType=9  <uuid>!OEBPS!..._541-h-0.htm.xhtml
+```
+
+Measured on a Clara BW / 4.42, both books converted by current `main`: **1984** — 6 highlights, 6
+anchored, TOC carries 0 fragments. **The Age of Innocence** — 3 highlights, **0 anchored**, all 42
+TOC links carry a fragment. Both OPF manifests are clean.
+
+⚠️ **The defect is entirely in the NCX, so #1637 does not touch it, and we ship these today.**
+**92 of 216 books (42.6%)** have a fragment-anchored TOC — against #1637's 5 of 216.
 
 **Library scan:** 5 of 216 books (2.3%) carry an escaping OPF href, every one `../nav.xhtml`.
 Perfect correlation on the instance: every book with one has **zero** stored annotations ever;


### PR DESCRIPTION
Two corrections, one of them to a claim this repo shipped in `notes/KOBO-HIGHLIGHT-LOSS-ROOT-CAUSE-2026-08-15.md`.

## 1. A wrong claim, retracted

The note said 810 orphaned highlights (Iliad 584, King in Yellow 220, Republic 6) had no chapter rows **because those books had been removed from the device**, and were therefore not repairable. **That is wrong. All 810 are repairable and the books were never gone.**

The error was the probe. Chapter rows were looked for with `ContentID LIKE VolumeID || '%'`, which returns zero for a `file:///mnt/onboard/…` volume *regardless of whether the book is present* — those volumes' chapter ids aren't prefixed by the volume path. "No rows found" was read as "book removed" when it meant "this query cannot see this volume shape".

**The Odyssey is the control that settles it:** same `file:///` volume shape, 400 bookmarks, **400/400 rendering**, zero fragments. A "book is gone" explanation cannot survive it.

Verified against the same device backup:

| volume | bookmarks | anchored | carry `#` |
|---|---|---|---|
| Iliad | 608 | 24 | **584** |
| King in Yellow | 221 | 1 | **220** |
| Odyssey | 400 | **400** | 0 |

```
fragmented: 810     repairable (exact ContentType=9 match after stripping '#'): 810
```

**The generalisable lesson, and the reason this is worth a commit rather than a quiet edit:** a negative result from a query is only as good as a positive control run through that same query. The `LIKE VolumeID || '%'` probe was never validated against a volume known to work — and it reports zero for the Odyssey too.

## 2. Cause 1b — a fragment-anchored TOC, wider than the `../` case

Nickel takes the chapter identity from the TOC entry **including the fragment**; the `ContentType=9` row has none, so the exact match fails:

```
Bookmark.ContentID     <uuid>!OEBPS!..._541-h-0.htm.xhtml#pgepubid00005
content ContentType=9  <uuid>!OEBPS!..._541-h-0.htm.xhtml
```

Clara BW / 4.42, both books converted by current `main`: **1984** — 6 highlights, 6 anchored, TOC has 0 fragments. **The Age of Innocence** — 3 highlights, **0 anchored**, all 42 TOC links carry a fragment. Both OPF manifests are clean.

⚠️ **It lives entirely in the NCX, so #1637 does not touch it — we produce these today.** **92 of 216 books (42.6%)**, against #1637's 5 of 216. The code fix is not in this PR; this records the mechanism and scope so it isn't re-derived.

## 3. README — `api_endpoint` alone does not route highlights

`api_endpoint` routes library sync. Highlights travel over `reading_services_host`, and a device that already has that key pointed at Kobo has been **observed keeping it** — seven syncs on a Clara BW at 4.42 with highlights present produced **zero** annotation-path requests until it was set by hand.

That leaves #1636's protection unable to fire, because **it cannot answer a request it never receives**. Anyone following the previous instructions has unprotected annotations. Adds the explicit step plus a log check to verify it took.

It also means any "highlights survived a sync" observation taken on a device configured that way is **not** evidence the guard works — the destructive path may simply never have been exercised.

---

Fragment mechanism, the 42.6% library scan, and the `reading_services_host` observation were measured by the session bringing up the physical Clara BW. The 810-repairable verification is independent, run against a separate device backup.