### PR TITLE
fix: harden annotation ingestion and KEPUB repair (round 2)

### DIFF
--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -156,11 +156,9 @@ class _Settings(_Base):
     config_kobo_cover_padding_color = Column(String, default="")
     config_kobo_prefer_kepub = Column(Boolean, default=True)
     config_kobo_kepub_backfill_completed = Column(Boolean, default=False)
-    # High-water mark over KoboSyncedBooks.id covered by the last successful
-    # backfill. The boolean above cannot express "done for what existed THEN",
-    # and the backfill's work-set is exactly the set that grows when a device
-    # pairs -- so a one-shot latch answers "completed" while the new device's
-    # books have no KEPUB. Monotonic id, so any new sync row re-arms it.
+    # Legacy #1647 watermark retained only for schema/rollback compatibility.
+    # It is deliberately not read: SQLite can reuse KoboSyncedBooks INTEGER
+    # PRIMARY KEY values after deletes, so max(id) is not a monotonic work-set.
     config_kobo_kepub_backfill_watermark = Column(Integer, default=0)
     # Versioned repair gates can advance without accumulating one-off booleans.
     config_kobo_kepub_package_repair_version = Column(Integer, default=0)

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -454,7 +454,13 @@ def handle_annotations(entitlement_id):
 
     if request.method == "PATCH":
         try:
-            data = request.get_json() or {}
+            data = request.get_json(silent=True)
+            if not isinstance(data, dict):
+                log.warning(
+                    "Ignoring local annotation capture for entitlement %s: "
+                    "PATCH body is not a JSON object", entitlement_id,
+                )
+                data = {}
             log_annotation_data(entitlement_id, "PATCH", data)
             book = get_book_by_entitlement_id(entitlement_id)
             if book is None:
@@ -466,12 +472,22 @@ def handle_annotations(entitlement_id):
                 from cps.services import annotation_sync
                 updated = data.get("updatedAnnotations")
                 deleted = data.get("deletedAnnotationIds")
-                if updated:
+                if updated is not None and not isinstance(updated, list):
+                    log.warning(
+                        "Ignoring updatedAnnotations for entitlement %s: expected a list",
+                        entitlement_id,
+                    )
+                elif updated:
                     annotation_sync.dispatch_annotation_sync(
                         updated, book, current_user,
                         origin_device_id=getattr(g, "annotation_origin_device_id", None),
                     )
-                if deleted:
+                if deleted is not None and not isinstance(deleted, list):
+                    log.warning(
+                        "Ignoring deletedAnnotationIds for entitlement %s: expected a list",
+                        entitlement_id,
+                    )
+                elif deleted:
                     annotation_sync.dispatch_annotation_deletes(
                         deleted, current_user, book_id=book.id,
                     )

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -149,8 +149,7 @@ def _book_uuid(book):
     return None
 
 
-def _kobo_payload_matches_row(annotation, payload, span, normalized_content_id,
-                              content_location_rejected=False):
+def _kobo_payload_matches_row(annotation, payload, span, normalized_content_id):
     """True only when applying the payload would leave every stored field unchanged."""
     def supplied(mapping, key, current):
         return mapping.get(key) if key in mapping else current
@@ -171,8 +170,7 @@ def _kobo_payload_matches_row(annotation, payload, span, normalized_content_id,
         supplied(payload, "noteText", annotation.note_text),
         supplied(payload, "highlightColor", annotation.highlight_color),
         chapter_progress if chapter_progress is not None else annotation.chapter_progress,
-        normalized_content_id if normalized_content_id else (
-            None if content_location_rejected else annotation.content_id),
+        normalized_content_id or annotation.content_id,
         supplied(span, "startPath", annotation.start_container_path),
         supplied(span, "endPath", annotation.end_container_path),
         supplied(span, "startChar", annotation.start_offset),
@@ -191,30 +189,50 @@ def _upsert_annotation(session, payload, book, user, *, origin_device_id=None):
     independent of any registered sync target (Hardcover etc.).
     """
     from cps import ub
+    if not isinstance(payload, dict):
+        log.warning("Skipping non-object annotation payload of type %s", type(payload).__name__)
+        return None
     annotation_id = payload.get("id")
     if not annotation_id:
         return None
     raw_client_time = payload.get("clientLastModifiedUtc", _CLIENT_TIME_MISSING)
     client_time = parse_client_modified_utc(raw_client_time)
+    client_time_rejected = False
     if raw_client_time is not _CLIENT_TIME_MISSING and client_time is None:
-        # Same rule as the content location below: a malformed CLOCK READING is
-        # not a reason to destroy the user's words. Degrade to "no timestamp
-        # supplied" -- an already-handled state -- so the highlight is still
-        # stored and only the ordering hint is lost.
+        # A rejected reading is NOT an absent reading. Existing rows deliberately
+        # ignore undated updates, but applying that policy here would discard the
+        # user's edit over a malformed ordering hint. Apply by arrival order and
+        # retain any last-known-valid stored clock.
         log.warning(
             "Annotation %s has a malformed clientLastModifiedUtc %r; storing it "
             "without a client timestamp rather than discarding the highlight",
             annotation_id, raw_client_time,
         )
         client_time = _CLIENT_TIME_MISSING
-    span = (payload.get("location") or {}).get("span") or {}
+        client_time_rejected = True
+
+    location = payload.get("location")
+    if location is None:
+        span = {}
+    elif not isinstance(location, dict):
+        log.warning(
+            "Annotation %s has a non-object location; preserving the annotation "
+            "without the rejected derived location", annotation_id,
+        )
+        span = {}
+    else:
+        supplied_span = location.get("span")
+        if supplied_span is None:
+            span = {}
+        elif not isinstance(supplied_span, dict):
+            log.warning(
+                "Annotation %s has a non-object location.span; preserving the "
+                "annotation without the rejected derived location", annotation_id,
+            )
+            span = {}
+        else:
+            span = supplied_span
     normalized_content_id = None
-    #: "the client supplied a chapter and it was unusable", which is NOT the same
-    #: as "the client supplied no chapter". Only the former should clear a
-    #: previously-stored locator: keeping a stale one would point the annotation
-    #: at a chapter the device no longer says it is in, and would let an
-    #: equal-clock payload be mistaken for a no-op.
-    content_location_rejected = False
     chapter_filename = span.get("chapterFilename")
     if chapter_filename and _book_uuid(book):
         from cps.services.annotation_content_id import normalize_content_id, ContentIdError
@@ -223,19 +241,17 @@ def _upsert_annotation(session, payload, book, user, *, origin_device_id=None):
                 f"{_book_uuid(book)}!!{chapter_filename}", book_uuid=_book_uuid(book)
             )
         except ContentIdError:
-            # content_id is DERIVED, nullable and recomputable; the highlight is
-            # none of those things. For a sideloaded book the device is the only
-            # other copy, so discarding the row here destroys text that exists
-            # nowhere else -- which is exactly what happened between 2026-08-13
-            # and 2026-08-15. Degrade the locator, never the annotation;
-            # ub.backfill_annotation_content_ids repairs the column later.
+            # content_id is derived and nullable; the highlight is neither. A
+            # rejected replacement also does not prove an existing validated
+            # locator is wrong, so preserve the last-known-valid value. The
+            # content-id backfill only normalizes non-NULL values and cannot
+            # reconstruct one after it has been cleared.
             log.warning(
                 "Annotation %s has an unusable content location %r; storing it "
-                "without a content_id rather than discarding the highlight",
+                "without discarding the highlight or its last valid content_id",
                 annotation_id, chapter_filename,
             )
             normalized_content_id = None
-            content_location_rejected = True
     ann = (
         session.query(ub.Annotation)
         .filter(
@@ -249,18 +265,18 @@ def _upsert_annotation(session, payload, book, user, *, origin_device_id=None):
         stored = ann.client_modified_at
         if stored.tzinfo is not None:
             stored = stored.astimezone(timezone.utc).replace(tzinfo=None)
-        if client_time is _CLIENT_TIME_MISSING or client_time < stored:
+        if client_time is _CLIENT_TIME_MISSING and not client_time_rejected:
             log.info("Ignoring stale or undated update for annotation %s", annotation_id)
             return None
-        if client_time == stored:
+        if client_time is not _CLIENT_TIME_MISSING and client_time < stored:
+            log.info("Ignoring stale or undated update for annotation %s", annotation_id)
+            return None
+        if client_time is not _CLIENT_TIME_MISSING and client_time == stored:
             # Kobo clocks have second precision. A byte-equivalent retry is a
             # no-op, but a real edit can share the same second and must not be
             # eaten merely because its clock ties. Equal-clock divergent
             # payloads therefore use arrival order as the deterministic tie.
-            if _kobo_payload_matches_row(
-                ann, payload, span, normalized_content_id,
-                content_location_rejected,
-            ):
+            if _kobo_payload_matches_row(ann, payload, span, normalized_content_id):
                 return None
     if ann is None:
         ann = ub.Annotation(
@@ -286,11 +302,6 @@ def _upsert_annotation(session, payload, book, user, *, origin_device_id=None):
         ann.chapter_progress = chapter_progress
     if normalized_content_id:
         ann.content_id = normalized_content_id
-    elif content_location_rejected:
-        # Supplied and unusable -> the stored locator is now known-wrong. Clear
-        # it rather than leaving a stale pointer; the highlight itself stays, and
-        # ub.backfill_annotation_content_ids can rebuild the column later.
-        ann.content_id = None
     if "startPath" in span:
         ann.start_container_path = span.get("startPath")
     if "endPath" in span:
@@ -500,24 +511,58 @@ def _mark_pending(session, annotation, user):
 
 
 def dispatch_annotation_sync(payload_annotations, book, user, *, origin_device_id=None) -> None:
-    """For each annotation in the PATCH payload, persist locally then push to each enabled handler."""
+    """Persist each valid annotation independently, then fan it out.
+
+    Device batches are a transport convenience, not a transaction boundary: one
+    malformed member or failed write must not roll back already-preserved user
+    data or prevent later members from being attempted.
+    """
     from cps import ub
     if not payload_annotations:
         return
+    if not isinstance(payload_annotations, list):
+        log.warning("Skipping annotation batch because updatedAnnotations is not a list")
+        return
     jobs = []
-    for payload in payload_annotations:
-        ann = _upsert_annotation(
-            ub.session, payload, book, user, origin_device_id=origin_device_id,
-        )
-        if ann is None:
+    for index, payload in enumerate(payload_annotations):
+        if not isinstance(payload, dict):
+            log.warning(
+                "Skipping non-object annotation member at updatedAnnotations[%d]", index,
+            )
             continue
-        if _background_enqueue() is not None:
-            if _mark_pending(ub.session, ann, user):
-                jobs.append({"op": "push", "annotation": ann.id,
-                             "book": book.id, "payload": payload})
+        pending_job = None
+        try:
+            ann = _upsert_annotation(
+                ub.session, payload, book, user, origin_device_id=origin_device_id,
+            )
+            if ann is None:
+                continue
+            if _background_enqueue() is not None:
+                if _mark_pending(ub.session, ann, user):
+                    pending_job = {"op": "push", "annotation": ann.id,
+                                   "book": book.id, "payload": payload}
+            else:
+                push_annotation_to_handlers(ub.session, ann, book, user, payload=payload)
+            committed = ub.session_commit()
+            if committed is False:
+                log.error(
+                    "Annotation %s could not be committed; continuing with the batch",
+                    payload.get("id"),
+                )
+                continue
+        except Exception:
+            # A failed SQLAlchemy transaction poisons the scoped session until an
+            # explicit rollback. Do that here, then continue: prior annotations
+            # were committed independently and later annotations still deserve a
+            # chance to persist.
+            log.exception(
+                "Annotation member updatedAnnotations[%d] failed; rolling back that "
+                "member and continuing", index,
+            )
+            ub.session.rollback()
             continue
-        push_annotation_to_handlers(ub.session, ann, book, user, payload=payload)
-    ub.session_commit()
+        if pending_job is not None:
+            jobs.append(pending_job)
     _enqueue(user, jobs, book=book)
 
 

--- a/cps/services/kepub_package_normalizer.py
+++ b/cps/services/kepub_package_normalizer.py
@@ -41,11 +41,20 @@ _KOBO_SPAN_RE = re.compile(
 _XML_PARSER = etree.XMLParser(resolve_entities=False, no_network=True, recover=False)
 
 
-#: A KEPUB is a book. Anything past this is either broken or hostile, and
-#: reading it would exhaust the conversion worker -- MemoryError is not an
-#: Exception, so the module's own catch cannot recover from it. Books are
-#: user-uploadable, so this bound is reachable by input we do not control.
-MAX_TOTAL_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+#: This implementation temporarily holds the source members, rewritten members,
+#: output ZIP and validation members at the same time. A 2 GiB input therefore
+#: implied several GiB of peak memory -- not a meaningful worker-safety bound.
+#: 256 MiB still accommodates unusually image-heavy books while capping that
+#: multi-copy peak near a scale a normal container can survive. On refusal the
+#: original is untouched and conversion retains its existing delivery fallback.
+MAX_TOTAL_UNCOMPRESSED_BYTES = 256 * 1024 * 1024
+
+#: Structural XML is read before relocation can be planned, so it also needs a
+#: per-entry bound. Real container.xml files are normally under 1 KiB; 1 MiB is
+#: generous. A very large manifest can be legitimate, hence a separate 16 MiB
+#: ceiling, but it must not be able to allocate hundreds of MiB on its own.
+MAX_CONTAINER_XML_BYTES = 1 * 1024 * 1024
+MAX_PACKAGE_DOCUMENT_BYTES = 16 * 1024 * 1024
 
 
 def _reject_oversized_archive(infos):
@@ -59,8 +68,27 @@ def _reject_oversized_archive(infos):
             )
 
 
+def _read_bounded_member(archive, name, limit, description):
+    """Read one structural member without trusting only ZIP metadata."""
+    try:
+        info = archive.getinfo(name)
+    except KeyError as error:
+        raise ValueError("KEPUB is missing {}".format(description)) from error
+    if info.file_size > limit:
+        raise ValueError("{} exceeds {} bytes".format(description, limit))
+    with archive.open(info, "r") as member:
+        content = member.read(limit + 1)
+    if len(content) > limit:
+        raise ValueError("{} exceeds {} bytes".format(description, limit))
+    return content
+
+
 def _package_document_path(archive):
-    container = etree.fromstring(archive.read(_CONTAINER_PATH), parser=_XML_PARSER)
+    container = etree.fromstring(
+        _read_bounded_member(
+            archive, _CONTAINER_PATH, MAX_CONTAINER_XML_BYTES, "container.xml"),
+        parser=_XML_PARSER,
+    )
     rootfiles = container.xpath(
         "//container:rootfile/@full-path", namespaces={"container": _CONTAINER_NS})
     if not rootfiles:
@@ -236,6 +264,7 @@ def _write_archive(path, entries, comment):
 def _validate_rewritten_archive(path, expected_span_counts):
     with zipfile.ZipFile(path) as archive:
         infos = archive.infolist()
+        _reject_oversized_archive(infos)
         if not infos or infos[0].filename != "mimetype":
             raise ValueError("mimetype is not the first EPUB entry")
         if infos[0].compress_type != zipfile.ZIP_STORED:
@@ -246,7 +275,9 @@ def _validate_rewritten_archive(path, expected_span_counts):
             raise ValueError("rewritten KEPUB failed its CRC check")
         opf_path = _package_document_path(archive)
         opf_directory = posixpath.dirname(opf_path)
-        for item in _manifest_items(archive.read(opf_path)):
+        opf_bytes = _read_bounded_member(
+            archive, opf_path, MAX_PACKAGE_DOCUMENT_BYTES, "package document")
+        for item in _manifest_items(opf_bytes):
             href = item.get("href")
             if not href:
                 continue
@@ -274,9 +305,14 @@ def normalize_kepub_package(path):
         original_stat = os.stat(path)
         with zipfile.ZipFile(path) as archive:
             infos = archive.infolist()
+            # This is intentionally the first operation after reading the central
+            # directory: no member read and no full CRC/decompression pass may
+            # happen before the cheap declared-size rejection.
+            _reject_oversized_archive(infos)
             names = [info.filename for info in infos]
             opf_path = _package_document_path(archive)
-            opf_bytes = archive.read(opf_path)
+            opf_bytes = _read_bounded_member(
+                archive, opf_path, MAX_PACKAGE_DOCUMENT_BYTES, "package document")
             relocations = _plan_relocations(opf_path, opf_bytes, set(names))
             if not relocations:
                 return False
@@ -284,7 +320,6 @@ def normalize_kepub_package(path):
                 raise ValueError("KEPUB contains duplicate ZIP member names")
             if archive.testzip() is not None:
                 raise ValueError("KEPUB failed its CRC check")
-            _reject_oversized_archive(infos)
             contents = {info.filename: archive.read(info) for info in infos}
             entries = _rewritten_entries(infos, contents, relocations)
             expected_span_counts = _span_counts(contents, relocations)
@@ -323,9 +358,12 @@ def kepub_package_needs_normalization(path):
     path = os.fspath(path)
     try:
         with zipfile.ZipFile(path) as archive:
-            names = {info.filename for info in archive.infolist()}
+            infos = archive.infolist()
+            _reject_oversized_archive(infos)
+            names = {info.filename for info in infos}
             opf_path = _package_document_path(archive)
-            opf_bytes = archive.read(opf_path)
+            opf_bytes = _read_bounded_member(
+                archive, opf_path, MAX_PACKAGE_DOCUMENT_BYTES, "package document")
             return bool(_plan_relocations(opf_path, opf_bytes, names))
     except Exception as error:
         log.warning("Could not inspect KEPUB package %s: %s", path, error)

--- a/cps/tasks/kepub_backfill.py
+++ b/cps/tasks/kepub_backfill.py
@@ -5,7 +5,6 @@ import os
 import threading
 
 from flask_babel import lazy_gettext as N_
-from sqlalchemy import func
 
 from .. import config, db, helper, logger, ub
 from ..epub import get_epub_layout
@@ -48,8 +47,6 @@ def _clear_pending(task):
 
 class TaskKepubBackfill(CalibreTask):
     def __init__(self):
-        #: highest KoboSyncedBooks.id this run covered; persisted only on success
-        self.covered_watermark = 0
         super().__init__(N_(u"Convert Kobo books missing KEPUB"))
         self.converted = 0
         self.skipped = 0
@@ -69,10 +66,6 @@ class TaskKepubBackfill(CalibreTask):
             app_session = ub.get_new_session_instance()
             try:
                 book_ids = [row[0] for row in app_session.query(ub.KoboSyncedBooks.book_id).distinct().all()]
-                # Captured with the work-set, not after it: a device pairing
-                # mid-run must re-arm the next boot rather than be silently
-                # marked covered by this one.
-                self.covered_watermark = _synced_books_watermark(app_session)
             finally:
                 app_session.close()
 
@@ -107,33 +100,19 @@ class TaskKepubBackfill(CalibreTask):
                 except Exception as error:
                     log.error("KEPUB backfill could not close its database session: %s", error)
 
-            # The startup backfill is a bounded migration attempt. Individual
-            # failures remain visible on the task, but must not make every boot
-            # repeat the same bulk conversion against an unwritable library.
-            #
-            # A run that converted nothing at all and failed at least once is a
-            # broken environment (read-only books volume, a mount that arrived
-            # late), not a finished migration. Checking it off would strand the
-            # library with no KEPUBs, no retry and -- because the startup task is
-            # hidden -- no explanation. Leave the flag clear so the next boot
-            # tries again.
+            # The legacy completion flag no longer gates startup: every eligible
+            # boot performs the cheap idempotent scan. Keep writing it for safe
+            # rollback to an older release, but do not mark a wholly failed run
+            # complete for that older reader.
             if self.converted or not self.failed:
                 # Persist first, then flip the in-memory flag: a save() that
                 # raises would otherwise leave this process believing the
                 # migration is done while the next boot re-reads False.
-                previous_watermark = getattr(
-                    config, "config_kobo_kepub_backfill_watermark", 0)
-                # The boolean no longer gates anything -- the watermark does --
-                # but we keep WRITING it so a rollback to an image that still
-                # reads it behaves correctly instead of re-running the whole
-                # backfill. Write-only on purpose; do not "clean it up".
                 config.config_kobo_kepub_backfill_completed = True
-                config.config_kobo_kepub_backfill_watermark = self.covered_watermark
                 try:
                     config.save()
                 except Exception:
                     config.config_kobo_kepub_backfill_completed = False
-                    config.config_kobo_kepub_backfill_watermark = previous_watermark
                     raise
             if self.failed:
                 self._handleError(N_(u"%(count)d KEPUB conversion(s) failed", count=self.failed))
@@ -205,40 +184,15 @@ def enqueue_kepub_backfill(user="System", hidden=False):
     return True
 
 
-def _synced_books_watermark(app_session):
-    """Highest KoboSyncedBooks.id, or 0. Monotonic, so it only ever grows."""
-    return app_session.query(func.max(ub.KoboSyncedBooks.id)).scalar() or 0
-
-
-def outstanding_kepub_backfill_watermark():
-    """Current watermark if it is ahead of what we last covered, else None.
-
-    The old boolean gate could not express "done for the library as it was
-    THEN". The work-set is `select distinct book_id from kobo_synced_books`,
-    and pairing a device is precisely what grows it -- so the latch reported
-    completed while the new device's books had no KEPUB and were converted at
-    download time with the device waiting (or, on failure, delivered as plain
-    EPUB, which cannot reliably hold highlights). Measured on a live instance
-    right after a device paired: 216 synced, 34 with KEPUB, flag "completed".
-    """
-    app_session = ub.get_new_session_instance()
-    try:
-        current = _synced_books_watermark(app_session)
-    finally:
-        app_session.close()
-    covered = getattr(config, "config_kobo_kepub_backfill_watermark", 0) or 0
-    return current if current > covered else None
-
-
 def enqueue_startup_kepub_backfill():
-    # Deliberately gated on the watermark alone, not on the boolean. An install
-    # upgrading with completed=True and no watermark performs exactly one
-    # catch-up scan -- which is the point: that install is the one carrying
-    # unconverted books. The scan is cheap because _backfill_one_book already
-    # skips any book that has a KEPUB or lacks an EPUB.
-    if outstanding_kepub_backfill_watermark() is not None:
-        return enqueue_kepub_backfill(hidden=True)
-    return False
+    """Queue the cheap idempotent scan whenever KEPUB preference is available.
+
+    KoboSyncedBooks rows are deleted during ordinary reconciliation and SQLite
+    may reuse their INTEGER PRIMARY KEY values, so no max-id watermark can prove
+    the work-set unchanged. The task already skips existing KEPUBs and missing
+    EPUBs before conversion; scanning is the reliable and inexpensive gate.
+    """
+    return enqueue_kepub_backfill(hidden=True)
 
 
 def is_kepub_backfill_pending():

--- a/tests/unit/test_1419_kepub_backfill_survives_one_bad_book.py
+++ b/tests/unit/test_1419_kepub_backfill_survives_one_bad_book.py
@@ -46,10 +46,6 @@ class _Query:
     def distinct(self):
         return self
 
-    def scalar(self):
-        # max(KoboSyncedBooks.id) -- the backfill's re-arm watermark
-        return len(self._rows)
-
     def all(self):
         return self._rows
 

--- a/tests/unit/test_annotation_never_discarded_on_bad_location.py
+++ b/tests/unit/test_annotation_never_discarded_on_bad_location.py
@@ -114,15 +114,12 @@ def test_valid_content_location_still_normalizes(patched_session):
     assert row.content_id == f"{BOOK_UUID}!!OPS/chapter-006.xml"
 
 
-def test_a_newly_invalid_location_clears_the_stored_one_rather_than_leaving_it_stale(
+def test_a_newly_invalid_location_preserves_the_last_known_valid_locator(
     patched_session,
 ):
-    """"Supplied and unusable" is not "not supplied".
-
-    Only the first should clear a previously-stored locator. Keeping a stale one
-    points the annotation at a chapter the device no longer claims it is in, and
-    lets an equal-clock payload be mistaken for a no-op. The highlight itself
-    still survives either way -- that is the invariant from #1635.
+    """A malformed replacement does not prove the validated stored locator is
+    wrong. Preserve the last-known-valid value; the current backfill normalizes
+    non-NULL locators and cannot reconstruct one that was cleared.
     """
     session, user = patched_session
     book = _book()
@@ -139,8 +136,20 @@ def test_a_newly_invalid_location_clears_the_stored_one_rather_than_leaving_it_s
     dispatch_annotation_sync([moved], book, user)
 
     row = session.query(ub.Annotation).one()
-    assert row.content_id is None, "a known-wrong locator must not be left in place"
+    assert row.content_id == f"{BOOK_UUID}!!OPS/chapter-006.xml"
     assert row.highlighted_text == "same highlight, relocated", "the highlight survives"
+
+
+def test_a_new_annotation_with_an_invalid_location_is_stored_with_null_content_id(
+    patched_session,
+):
+    session, user = patched_session
+
+    dispatch_annotation_sync([_payload("OPS/../../outside.xml")], _book(), user)
+
+    row = session.query(ub.Annotation).one()
+    assert row.content_id is None
+    assert row.highlighted_text == "Be patient, for the world is broad and wide."
 
 
 def test_an_update_with_no_location_at_all_leaves_the_stored_one_alone(patched_session):

--- a/tests/unit/test_annotation_sync_dispatcher.py
+++ b/tests/unit/test_annotation_sync_dispatcher.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import pytest
 from datetime import datetime, timezone
 from sqlalchemy import create_engine, text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 
 from cps import ub
@@ -177,3 +178,83 @@ def test_tombstone_is_terminal_against_repeat_push(patched_session):
     dispatch_annotation_sync([payload], _book(), user)  # re-push
     st = s.query(ub.AnnotationSyncTarget).one()
     assert st.status == "tombstone"  # NOT resurrected
+
+
+@pytest.mark.parametrize("bad_location", ["not-an-object", [], {"span": "not-an-object"}])
+def test_malformed_location_shape_degrades_without_dropping_the_batch(
+    patched_session, bad_location,
+):
+    """A derived location is optional; its bad shape cannot eat user text or
+    prevent a later well-formed annotation in the same PATCH from landing."""
+    s, user = patched_session
+    malformed = _payload("uuid-bad-location", text_="keep this text")
+    malformed["location"] = bad_location
+
+    dispatch_annotation_sync([
+        _payload("uuid-before", text_="before"),
+        malformed,
+        _payload("uuid-after", text_="after"),
+    ], _book(), user)
+
+    rows = {
+        row.annotation_id: row.highlighted_text
+        for row in s.query(ub.Annotation).order_by(ub.Annotation.id).all()
+    }
+    assert rows == {
+        "uuid-before": "before",
+        "uuid-bad-location": "keep this text",
+        "uuid-after": "after",
+    }
+
+
+def test_non_object_annotation_member_is_skipped_without_dropping_later_members(
+    patched_session,
+):
+    s, user = patched_session
+
+    dispatch_annotation_sync([
+        _payload("uuid-before", text_="before"),
+        "not-an-annotation-object",
+        _payload("uuid-after", text_="after"),
+    ], _book(), user)
+
+    assert [row.annotation_id for row in s.query(ub.Annotation).order_by(ub.Annotation.id)] == [
+        "uuid-before", "uuid-after",
+    ]
+
+
+def test_database_failure_rolls_back_only_that_member_and_later_members_continue(
+    patched_session, monkeypatch,
+):
+    """Successful members are committed independently; a genuine DB failure is
+    explicitly rolled back and cannot poison the scoped session or the rest of
+    the device's batch."""
+    from cps.services import annotation_sync
+
+    s, user = patched_session
+    original = annotation_sync._upsert_annotation
+    rollback_calls = []
+    original_rollback = s.rollback
+
+    def recording_rollback():
+        rollback_calls.append(True)
+        return original_rollback()
+
+    def fail_one(session, payload, book, user, **kwargs):
+        if payload.get("id") == "uuid-db-failure":
+            raise OperationalError("INSERT", {}, RuntimeError("disk unavailable"))
+        return original(session, payload, book, user, **kwargs)
+
+    monkeypatch.setattr(s, "rollback", recording_rollback)
+    monkeypatch.setattr(annotation_sync, "_upsert_annotation", fail_one)
+
+    dispatch_annotation_sync([
+        _payload("uuid-before", text_="before"),
+        _payload("uuid-db-failure", text_="lost only with failed write"),
+        _payload("uuid-after", text_="after"),
+    ], _book(), user)
+
+    assert rollback_calls == [True]
+    assert [row.annotation_id for row in s.query(ub.Annotation).order_by(ub.Annotation.id)] == [
+        "uuid-before", "uuid-after",
+    ]

--- a/tests/unit/test_kepub_backfill_rearms_for_a_new_device.py
+++ b/tests/unit/test_kepub_backfill_rearms_for_a_new_device.py
@@ -1,21 +1,11 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""The KEPUB backfill must re-arm when its work-set grows.
+"""Startup KEPUB backfill is an idempotent scan, not a surrogate-id watermark.
 
-`config_kobo_kepub_backfill_completed` was a one-shot global boolean, but the
-task's work-set is `select distinct book_id from kobo_synced_books` — and
-pairing a device is *precisely* what grows that set. So the latch answered
-"completed" while the newly-synced books had no KEPUB at all.
-
-Measured on a live instance immediately after a Kobo Clara BW paired: **216
-books synced, 34 with a KEPUB, 182 without**, with the flag set to completed.
-Those 182 convert at download time with the device waiting, and a conversion
-failure delivers plain EPUB — which cannot reliably hold highlights on a Kobo
-(upstream janeczku/calibre-web#1484). The stale latch therefore lands as
-"highlighting doesn't work on my new Kobo".
-
-A boolean cannot express "done for the library as it was THEN". A monotonic
-high-water mark over KoboSyncedBooks.id can.
+SQLite may reuse ``INTEGER PRIMARY KEY`` values after deletes, and this table is
+regularly pruned during shelf/device reconciliation.  Startup therefore queues
+the cheap scan whenever KEPUB preference is enabled; the task itself skips
+books that already have KEPUB and converts only missing work.
 """
 
 from __future__ import annotations
@@ -29,13 +19,10 @@ from cps.tasks import kepub_backfill
 
 
 @pytest.fixture
-def app_session(monkeypatch):
+def app_session():
     engine = create_engine("sqlite:///:memory:")
     ub.Base.metadata.create_all(engine)
-    Session = sessionmaker(bind=engine)
-    session = Session()
-    monkeypatch.setattr(ub, "get_new_session_instance", lambda: session)
-    monkeypatch.setattr(kepub_backfill.ub, "get_new_session_instance", lambda: session)
+    session = sessionmaker(bind=engine)()
     yield session
     session.close()
 
@@ -49,7 +36,6 @@ def _sync(session, user_id, book_id):
 
 @pytest.fixture(autouse=True)
 def _enqueueable(monkeypatch):
-    """Make enqueue reachable; the gate under test is the watermark, not these."""
     monkeypatch.setattr(kepub_backfill.config, "config_kobo_prefer_kepub", True, raising=False)
     monkeypatch.setattr(kepub_backfill.config, "config_kepubifypath", "/bin/kepubify", raising=False)
     monkeypatch.setattr(kepub_backfill.config, "config_use_google_drive", False, raising=False)
@@ -59,66 +45,83 @@ def _enqueueable(monkeypatch):
     return queued
 
 
-def test_a_newly_paired_device_rearms_a_completed_backfill(app_session, monkeypatch, _enqueueable):
+def _assert_startup_scan_queued(queue):
+    assert kepub_backfill.enqueue_startup_kepub_backfill() is True
+    assert queue == [{"hidden": True}]
+
+
+def test_startup_always_queues_the_idempotent_scan(_enqueueable):
+    _assert_startup_scan_queued(_enqueueable)
+
+
+def test_a_newly_paired_device_still_rearms_a_completed_backfill(
+    app_session, monkeypatch, _enqueueable,
+):
     for book_id in (1, 2, 3):
         _sync(app_session, user_id=1, book_id=book_id)
-    covered = kepub_backfill._synced_books_watermark(app_session)
-    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_completed", True, raising=False)
-    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark", covered, raising=False)
+    monkeypatch.setattr(
+        kepub_backfill.config, "config_kobo_kepub_backfill_completed", True, raising=False)
 
-    assert kepub_backfill.enqueue_startup_kepub_backfill() is False, "nothing new yet"
-
-    # a second device pairs and syncs the same library
     for book_id in (1, 2, 3):
         _sync(app_session, user_id=2, book_id=book_id)
 
-    assert kepub_backfill.enqueue_startup_kepub_backfill() is True
-    assert _enqueueable == [{"hidden": True}]
+    _assert_startup_scan_queued(_enqueueable)
 
 
-def test_no_new_sync_rows_does_not_rearm(app_session, monkeypatch, _enqueueable):
-    _sync(app_session, user_id=1, book_id=1)
-    covered = kepub_backfill._synced_books_watermark(app_session)
-    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark", covered, raising=False)
+def test_delete_max_then_insert_cannot_suppress_the_startup_scan(app_session, _enqueueable):
+    rows = [_sync(app_session, 1, book_id) for book_id in (1, 2, 3)]
+    old_max = rows[-1].id
+    app_session.delete(rows[-1])
+    app_session.commit()
+    replacement = _sync(app_session, 2, 4)
+    assert replacement.id == old_max, "precondition: SQLite reused the deleted maximum id"
 
-    assert kepub_backfill.enqueue_startup_kepub_backfill() is False
-    assert _enqueueable == []
-
-
-def test_an_upgraded_install_performs_exactly_one_catch_up_scan(app_session, monkeypatch, _enqueueable):
-    """completed=True with no watermark is the population carrying unconverted
-    books. One catch-up scan is the point, not a regression -- and it is cheap,
-    because _backfill_one_book already skips any book that has a KEPUB."""
-    for book_id in (1, 2):
-        _sync(app_session, user_id=1, book_id=book_id)
-    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_completed", True, raising=False)
-    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark", 0, raising=False)
-
-    assert kepub_backfill.enqueue_startup_kepub_backfill() is True
-
-    # once that run records what it covered, it stops
-    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark",
-                        kepub_backfill._synced_books_watermark(app_session), raising=False)
-    assert kepub_backfill.enqueue_startup_kepub_backfill() is False
+    _assert_startup_scan_queued(_enqueueable)
 
 
-def test_the_boolean_alone_no_longer_gates_startup(app_session, monkeypatch, _enqueueable):
-    """The regression in one line: completed=True must NOT suppress new work."""
-    _sync(app_session, user_id=1, book_id=1)
-    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_completed", True, raising=False)
-    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark", 0, raising=False)
+def test_clear_and_repopulate_with_lower_ids_cannot_suppress_the_startup_scan(
+    app_session, _enqueueable,
+):
+    rows = [_sync(app_session, 1, book_id) for book_id in (1, 2, 3)]
+    old_max = rows[-1].id
+    app_session.query(ub.KoboSyncedBooks).delete()
+    app_session.commit()
+    replacement = _sync(app_session, 2, 9)
+    assert replacement.id < old_max, "precondition: repopulation restarted below old watermark"
 
-    assert kepub_backfill.enqueue_startup_kepub_backfill() is True
-
-
-def test_watermark_is_none_when_nothing_is_outstanding(app_session, monkeypatch):
-    _sync(app_session, user_id=1, book_id=1)
-    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark",
-                        kepub_backfill._synced_books_watermark(app_session), raising=False)
-    assert kepub_backfill.outstanding_kepub_backfill_watermark() is None
+    _assert_startup_scan_queued(_enqueueable)
 
 
-def test_an_empty_sync_table_is_not_outstanding(app_session, monkeypatch):
-    monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_watermark", 0, raising=False)
-    assert kepub_backfill.outstanding_kepub_backfill_watermark() is None
+def test_id_reuse_is_irrelevant_even_when_legacy_watermark_equals_current_max(
+    app_session, monkeypatch, _enqueueable,
+):
+    row = _sync(app_session, 1, 1)
+    monkeypatch.setattr(
+        kepub_backfill.config, "config_kobo_kepub_backfill_watermark", row.id, raising=False)
+    app_session.delete(row)
+    app_session.commit()
+    replacement = _sync(app_session, 2, 2)
+    assert replacement.id == row.id
+
+    _assert_startup_scan_queued(_enqueueable)
+
+
+@pytest.mark.parametrize(
+    "prefer_kepub,kepubify,gdrive",
+    [(False, "/bin/kepubify", False), (True, "", False), (True, "/bin/kepubify", True)],
+)
+def test_existing_startup_safety_gates_still_apply(
+    monkeypatch, _enqueueable, prefer_kepub, kepubify, gdrive,
+):
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_prefer_kepub", prefer_kepub)
+    monkeypatch.setattr(kepub_backfill.config, "config_kepubifypath", kepubify)
+    monkeypatch.setattr(kepub_backfill.config, "config_use_google_drive", gdrive)
+
+    # The startup path delegates these gates to the ordinary enqueue function.
+    # Exercise the real function rather than the recording fixture.
+    monkeypatch.undo()
+    monkeypatch.setattr(kepub_backfill.config, "config_kobo_prefer_kepub", prefer_kepub,
+                        raising=False)
+    monkeypatch.setattr(kepub_backfill.config, "config_kepubifypath", kepubify, raising=False)
+    monkeypatch.setattr(kepub_backfill.config, "config_use_google_drive", gdrive, raising=False)
     assert kepub_backfill.enqueue_startup_kepub_backfill() is False

--- a/tests/unit/test_kepub_package_normalizer.py
+++ b/tests/unit/test_kepub_package_normalizer.py
@@ -131,9 +131,9 @@ def test_clean_package_reads_only_container_and_opf(tmp_path, monkeypatch):
     read_names = []
 
     class RecordingZipFile(zipfile.ZipFile):
-        def read(self, name, *args, **kwargs):
+        def open(self, name, *args, **kwargs):
             read_names.append(name.filename if isinstance(name, zipfile.ZipInfo) else name)
-            return super().read(name, *args, **kwargs)
+            return super().open(name, *args, **kwargs)
 
     monkeypatch.setattr(normalizer.zipfile, "ZipFile", RecordingZipFile)
 
@@ -150,9 +150,9 @@ def test_clean_repair_probe_reads_only_container_and_opf(tmp_path, monkeypatch):
     read_names = []
 
     class RecordingZipFile(zipfile.ZipFile):
-        def read(self, name, *args, **kwargs):
+        def open(self, name, *args, **kwargs):
             read_names.append(name.filename if isinstance(name, zipfile.ZipInfo) else name)
-            return super().read(name, *args, **kwargs)
+            return super().open(name, *args, **kwargs)
 
     monkeypatch.setattr(normalizer.zipfile, "ZipFile", RecordingZipFile)
 
@@ -350,3 +350,73 @@ def test_an_archive_that_decompresses_past_the_bound_is_refused(tmp_path, monkey
     assert result is None
     assert package.read_bytes() == original
     assert any("decompresses to more than" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("probe", [False, True], ids=["normalizer", "repair-probe"])
+def test_total_size_is_rejected_before_any_member_read_or_crc_scan(
+    tmp_path, monkeypatch, caplog, probe,
+):
+    from cps.services import kepub_package_normalizer as mod
+
+    package = tmp_path / "early-bound.kepub"
+    _write_package(package)
+    reads = []
+    crc_scans = []
+    real_zip = zipfile.ZipFile
+
+    class NoEarlyReadZipFile(real_zip):
+        def read(self, *args, **kwargs):
+            reads.append(args[0] if args else None)
+            raise AssertionError("member read happened before total-size rejection")
+
+        def testzip(self):
+            crc_scans.append(True)
+            raise AssertionError("CRC scan happened before total-size rejection")
+
+    monkeypatch.setattr(mod, "MAX_TOTAL_UNCOMPRESSED_BYTES", 8)
+    monkeypatch.setattr(mod.zipfile, "ZipFile", NoEarlyReadZipFile)
+
+    with caplog.at_level("WARNING"):
+        result = (mod.kepub_package_needs_normalization(package) if probe
+                  else mod.normalize_kepub_package(package))
+
+    assert result is None
+    assert reads == []
+    assert crc_scans == []
+    assert "decompresses to more than" in caplog.text
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "member, limit_name, expected",
+    [
+        ("META-INF/container.xml", "MAX_CONTAINER_XML_BYTES", "container.xml"),
+        ("OPS/epb.opf", "MAX_PACKAGE_DOCUMENT_BYTES", "package document"),
+    ],
+)
+def test_structural_members_have_strict_per_entry_bounds(
+    tmp_path, monkeypatch, caplog, member, limit_name, expected,
+):
+    from cps.services import kepub_package_normalizer as mod
+
+    package = tmp_path / "structural-bound.kepub"
+    _write_package(package)
+    monkeypatch.setattr(mod, limit_name, 8, raising=False)
+
+    with caplog.at_level("WARNING"):
+        assert mod.normalize_kepub_package(package) is None
+    assert expected in caplog.text
+
+
+@pytest.mark.unit
+def test_repair_probe_applies_the_opf_per_entry_bound(tmp_path, monkeypatch, caplog):
+    from cps.services import kepub_package_normalizer as mod
+
+    package = tmp_path / "probe-opf-bound.kepub"
+    _write_package(package)
+    monkeypatch.setattr(mod, "MAX_PACKAGE_DOCUMENT_BYTES", 8, raising=False)
+
+    with caplog.at_level("WARNING"):
+        assert mod.kepub_package_needs_normalization(package) is None
+    assert "package document" in caplog.text

--- a/tests/unit/test_kobo_annotations_get_never_authoritative_empty.py
+++ b/tests/unit/test_kobo_annotations_get_never_authoritative_empty.py
@@ -96,6 +96,65 @@ def test_patch_upload_direction_still_proxies(app, monkeypatch):
         assert _view()(BOOK_UUID) is sentinel
 
 
+def test_patch_non_object_body_is_validated_locally_and_still_proxies(
+    app, monkeypatch, caplog,
+):
+    """Malformed local-capture input must be explicit, not an AttributeError
+    swallowed by the outer handler; upload pass-through remains unchanged."""
+    from cps.services import annotation_sync
+
+    sentinel = object()
+    dispatched = []
+    monkeypatch.setattr(
+        rs, "get_book_by_entitlement_id",
+        lambda _eid: SimpleNamespace(id=347, title="Flatland", identifiers=[]),
+    )
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+    monkeypatch.setattr(
+        rs, "current_user", SimpleNamespace(id=7, name="test-user", is_authenticated=True),
+    )
+    monkeypatch.setattr(
+        annotation_sync, "dispatch_annotation_sync",
+        lambda *args, **kwargs: dispatched.append((args, kwargs)),
+    )
+
+    with app.test_request_context(
+        f"/api/v3/content/{BOOK_UUID}/annotations", method="PATCH", json=["not", "an", "object"],
+    ), caplog.at_level("WARNING"):
+        assert _view()(BOOK_UUID) is sentinel
+
+    assert dispatched == []
+    assert "PATCH body is not a JSON object" in caplog.text
+
+
+def test_patch_non_list_annotation_batch_is_rejected_without_breaking_proxy(
+    app, monkeypatch, caplog,
+):
+    from cps.services import annotation_sync
+
+    sentinel = object()
+    monkeypatch.setattr(
+        rs, "get_book_by_entitlement_id",
+        lambda _eid: SimpleNamespace(id=347, title="Flatland", identifiers=[]),
+    )
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+    monkeypatch.setattr(
+        rs, "current_user", SimpleNamespace(id=7, name="test-user", is_authenticated=True),
+    )
+    monkeypatch.setattr(
+        annotation_sync, "dispatch_annotation_sync",
+        lambda *_args, **_kwargs: pytest.fail("non-list batch reached dispatcher"),
+    )
+
+    with app.test_request_context(
+        f"/api/v3/content/{BOOK_UUID}/annotations", method="PATCH",
+        json={"updatedAnnotations": {"id": "not-a-list"}},
+    ), caplog.at_level("WARNING"):
+        assert _view()(BOOK_UUID) is sentinel
+
+    assert "expected a list" in caplog.text
+
+
 # --- fail-closed: uncertainty must never fall through to the destructive path ---
 
 def test_ownership_lookup_error_fails_closed(app, monkeypatch, no_proxy):

--- a/tests/unit/test_kobo_prefer_kepub.py
+++ b/tests/unit/test_kobo_prefer_kepub.py
@@ -122,7 +122,6 @@ def test_backfill_is_composite_idempotent_preserves_sync_rows_and_skips_gdrive(m
 
     class Query:
         def distinct(self): return self
-        def scalar(self): return 2  # max(KoboSyncedBooks.id) for the watermark
         def all(self): return list(sync_rows)
 
     class AppSession:
@@ -167,7 +166,6 @@ def test_backfill_continues_after_per_book_oserror_and_completes(monkeypatch):
 
     class Query:
         def distinct(self): return self
-        def scalar(self): return 2  # max(KoboSyncedBooks.id) for the watermark
         def all(self): return [(1,), (2,)]
 
     class AppSession:

--- a/tests/unit/test_multi_device_annotations_safe_slice.py
+++ b/tests/unit/test_multi_device_annotations_safe_slice.py
@@ -190,6 +190,39 @@ def test_client_last_modified_missing_malformed_valid(db_session, raw, expected)
         assert row.client_modified_at == datetime(2026, 8, 9, 14, 52, 21)
 
 
+def test_malformed_client_clock_does_not_suppress_an_existing_annotation_edit(db_session):
+    """A rejected clock is not an undated update.
+
+    Once a row has a valid timestamp, collapsing a later malformed timestamp to
+    the ordinary "missing" sentinel makes the stale-update guard discard the
+    user's changed text and note.  Apply the edit by arrival order, but retain
+    the last valid ordering hint.
+    """
+    from cps.services.annotation_sync import _upsert_annotation
+
+    book = SimpleNamespace(id=5, uuid="b3d1b38b-74fd-43b7-a796-996e5a6a8b04")
+    user = SimpleNamespace(id=7)
+    row = _upsert_annotation(db_session, {
+        "id": "bad-clock-existing",
+        "highlightedText": "first",
+        "noteText": "first note",
+        "clientLastModifiedUtc": "2026-08-09T15:00:00Z",
+    }, book, user)
+    db_session.flush()
+
+    updated = _upsert_annotation(db_session, {
+        "id": "bad-clock-existing",
+        "highlightedText": "edited",
+        "noteText": "edited note",
+        "clientLastModifiedUtc": "not-a-clock",
+    }, book, user)
+
+    assert updated is row
+    assert row.highlighted_text == "edited"
+    assert row.note_text == "edited note"
+    assert row.client_modified_at == datetime(2026, 8, 9, 15, 0)
+
+
 def test_kobo_create_records_origin_once_and_update_cannot_replace_it(db_session):
     from cps import ub
     from cps.services.annotation_sync import _upsert_annotation


### PR DESCRIPTION
Five corrections from an adversarial proof pass over code merged earlier today. **Four are defects in my own commits**; the fifth is a retraction of a recommendation from the previous review that I implemented faithfully.

Nothing here is losing data on a running instance right now — #1635's store-the-annotation and #1636's download guard are both intact — but four of these are on `main`.

## 1. High — an existing annotation with a malformed clock was *still* discarded

#1640 fixed only half of this. A malformed `clientLastModifiedUtc` degraded to `_CLIENT_TIME_MISSING`, which preserves a **new** row — but for an **existing** row that sentinel hits the staleness gate and returns `None`, throwing away the text, note, colour and location changes.

```
new annotation + malformed clock       → stored
existing annotation + malformed clock  → silently ignored
```

My test only created a new row, so it never touched the broken branch. A supplied-but-malformed clock now has its own state, distinct from a genuinely absent one, and applies by arrival order while the stored valid timestamp survives.

## 2. High — one malformed member poisoned the whole PATCH batch

`_upsert_annotation` assumed `payload`, `location` and `span` were all dicts; `{"id":"x","location":"malformed"}` raised `AttributeError`. With no per-annotation boundary and a single commit after the loop, **one bad member meant earlier members never committed and later members were never visited** — while the device still received the proxied Kobo response and saw success.

Now: body and members validated, per-member persistence with explicit rollback on genuine DB failure, and a non-object `location`/`span` treated as a rejected derived location rather than permission to drop the annotation. A device batch is a transport container, not an all-or-nothing transaction.

## 3. High — the KEPUB size bound ran *after* three reads

My commit message said the check happened before the read. The code read `container.xml`, read the whole OPF, and ran `testzip()` (full CRC decompression) **first**. `MemoryError` isn't an `Exception`, so the module's own catch can't recover.

Now bounded from `infolist()` before any read, in both the normalizer and the repair probe, with per-entry bounds (`container.xml` 1 MiB, OPF 16 MiB) and a total of **256 MiB** instead of 2 GiB — because this path simultaneously holds source members, rewritten members, the output archive and validation data, so a 2 GiB *declared input* permitted several GiB of real peak.

## 4. High/medium — reverted: clearing a valid locator was wrong

The previous review recommended clearing `content_id` when a replacement location is rejected; I implemented it. **It was wrong.** A malformed replacement proves the *replacement* is unusable, not that the previously validated locator is wrong.

Worse, my comment claimed `ub.backfill_annotation_content_ids` could rebuild it. **That is false** — it selects `content_id IS NOT NULL`, so a cleared row is explicitly outside its work set. The clearing also broke CFI calculation, portable export and the CFI resolver.

Reverted, comparator special-case included, false comment deleted. New rows still store with `content_id = NULL`; #1635 and #1638 are untouched.

## 5. Medium/high — the backfill watermark stalls silently

`KoboSyncedBooks.id` has **no SQLite `AUTOINCREMENT`**, so ids are reused after deletion — and the app deletes those rows in four places. Reproduced: `delete all; insert → id 1; max 1`. My "monotonic, so it only ever grows" comment was false, and my tests only ever proved append-only growth.

Fixed by removing the watermark inference entirely and running the cheap idempotent scan at startup, since `_backfill_one_book` already skips any book with a KEPUB. **#1647's real fix is preserved** — a newly paired device still gets its books converted — and deletion, clearing, repopulation and id reuse are all handled because correctness no longer depends on a mutable surrogate key. New tests cover delete-max, clear-and-repopulate and id-reuse.

The obsolete column stays in the model for rollback safety and is no longer read or written.

## Verification

`pytest tests/unit` → **6137 passed, 95 skipped, 0 failed**, run independently before opening this.

## Not included

The pre-auth ownership oracle in #1640 is filed as #1660 rather than patched — the safe fix depends on measuring how Nickel handles `401` vs `503` on an expired session, and two remedies shipped today on sound reasoning turned out wrong in practice.

Implemented by Sol, which also found all five.