### PR TITLE
fix(kobo): stop telling users deleted books stay on their Kobo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **The delete warning no longer tells you the wrong thing about your Kobo.**
+  It said deleted books would stay on any paired Kobo and that you had to
+  archive and sync first. That stopped being true when deletions started sending
+  the device an instruction to archive its copy. The warning now describes what
+  actually happens, including the honest caveat: the device is told on its next
+  sync, and if that instruction cannot be recorded the book may still remain.
+
 - **Covers are now shaped for the Kobo that is actually asking.** The server-side
   cover padding had one aspect setting for the whole instance, so a household with
   two different Kobos had to pick a winner — the other device got covers padded to

--- a/cps/templates/modal_dialogs.html
+++ b/cps/templates/modal_dialogs.html
@@ -53,8 +53,7 @@
 		  </p>
           {% if config.config_kobo_sync %}
           <p>
-            <span>{{_('Important Kobo Note: deleted books will remain on any paired Kobo device.')}}</span>
-            <span>{{_('Books must first be archived and the device synced before a book can safely be deleted.')}}</span>
+            <span>{{_('Deleting this book also tries to archive its copy on paired Kobo devices the next time they sync. If that update cannot be recorded, the book may remain on a device.')}}</span>
           </p>
           {% endif %}
         </div>

--- a/cps/translations/ar/LC_MESSAGES/messages.po
+++ b/cps/translations/ar/LC_MESSAGES/messages.po
@@ -11285,14 +11285,11 @@ msgstr "والقرص الصلب"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
-msgstr "ملاحظة Kobo هامة: الكتب المحذوفة ستبقى على أي جهاز Kobo مقترن."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
+msgstr ""
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr "يجب أولاً أرشفة الكتب ومزامنة الجهاز قبل أن يتم حذف الكتاب بأمان."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12584,3 +12581,12 @@ msgstr "إظهار قسم المقروء/غير المقروء"
 
 #~ msgid "Return to Database config"
 #~ msgstr "العودة إلى تهيئة قاعدة البيانات"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr "ملاحظة Kobo هامة: الكتب المحذوفة ستبقى على أي جهاز Kobo مقترن."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr "يجب أولاً أرشفة الكتب ومزامنة الجهاز قبل أن يتم حذف الكتاب بأمان."

--- a/cps/translations/cs/LC_MESSAGES/messages.po
+++ b/cps/translations/cs/LC_MESSAGES/messages.po
@@ -11343,18 +11343,11 @@ msgstr "a z hard disku"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Důležitá Kobo poznámka: smazané knihy zůstanou na jakémkoli spárovaném "
-"zařízení Kobo."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Knihy musí být nejprve archivovány a zařízení musí být synchronizováno, než "
-"bude kniha bezpečně smazána."
 
 #: cps/templates/modal_dialogs.html
 #, fuzzy
@@ -12655,3 +12648,16 @@ msgstr "Zobrazit výběr sérií"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Kliknutím na obal načtěte metadata do formuláře"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Důležitá Kobo poznámka: smazané knihy zůstanou na jakémkoli spárovaném "
+#~ "zařízení Kobo."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Knihy musí být nejprve archivovány a zařízení musí být synchronizováno, než "
+#~ "bude kniha bezpečně smazána."

--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -11581,18 +11581,11 @@ msgstr "und von der Festplatte gelöscht"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Wichtiger Kobo Hinweis: Gelöschte Bücher bleiben auf allen verbundenen Kobo "
-"Geräten erhalten."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Bücher müssen zuerst archiviert werden und dann mit dem Gerät synchronisiert "
-"werden, bevor ein Buch sicher gelöscht werden kann."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -13174,3 +13167,16 @@ msgstr "Zeige Gelesen/Ungelesen-Abschnitt"
 
 #~ msgid "Sort descending according to series index"
 #~ msgstr "Sortiere nach Serienindex absteigend"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Wichtiger Kobo Hinweis: Gelöschte Bücher bleiben auf allen verbundenen Kobo "
+#~ "Geräten erhalten."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Bücher müssen zuerst archiviert werden und dann mit dem Gerät synchronisiert "
+#~ "werden, bevor ein Buch sicher gelöscht werden kann."

--- a/cps/translations/el/LC_MESSAGES/messages.po
+++ b/cps/translations/el/LC_MESSAGES/messages.po
@@ -11410,18 +11410,11 @@ msgstr "και σκληρός δίσκος"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Σημαντική Σημείωση Kobo: τα διαγραμμένα βιβλία θα παραμείνουν σε οποιαδήποτε "
-"συνδεδεμένη συσκευή Kobo."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Τα βιβλία πρέπει πρώτα να αρχειοθετηθούν και να συγχρονιστεί η συσκευή πριν "
-"μπορέσει να διαγραφεί με ασφάλεια το βιβλίο."
 
 #: cps/templates/modal_dialogs.html
 #, fuzzy
@@ -12729,3 +12722,16 @@ msgstr "Προβολή επιλογών σειράς"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Κάνε κλικ στο εξώφυλλο για φόρτωση μεταδεδομένων στη φόρμα"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Σημαντική Σημείωση Kobo: τα διαγραμμένα βιβλία θα παραμείνουν σε οποιαδήποτε "
+#~ "συνδεδεμένη συσκευή Kobo."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Τα βιβλία πρέπει πρώτα να αρχειοθετηθούν και να συγχρονιστεί η συσκευή πριν "
+#~ "μπορέσει να διαγραφεί με ασφάλεια το βιβλίο."

--- a/cps/translations/es/LC_MESSAGES/messages.po
+++ b/cps/translations/es/LC_MESSAGES/messages.po
@@ -11852,18 +11852,11 @@ msgstr "y del disco duro"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Nota importante de Kobo: los libros borrados permanecerán en cualquier "
-"dispositivo Kobo emparejado."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Los libros deben archivarse primero y sincronizarse con el dispositivo antes "
-"de poder borrarlos de forma segura."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -13531,3 +13524,16 @@ msgstr "Mostrar Selección Leidos/No Leidos"
 #, fuzzy
 #~ msgid "Mark Book as Read or Unread"
 #~ msgstr "Marcar como no leido"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Nota importante de Kobo: los libros borrados permanecerán en cualquier "
+#~ "dispositivo Kobo emparejado."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Los libros deben archivarse primero y sincronizarse con el dispositivo antes "
+#~ "de poder borrarlos de forma segura."

--- a/cps/translations/fi/LC_MESSAGES/messages.po
+++ b/cps/translations/fi/LC_MESSAGES/messages.po
@@ -11325,14 +11325,11 @@ msgstr "ja kiintolevyltä"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
 
 #: cps/templates/modal_dialogs.html
 #, fuzzy
@@ -12589,3 +12586,12 @@ msgstr "Näytä sarjavalinta"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Klikkaa kantta ladataksesi metadata lomakkeelle"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -11778,18 +11778,11 @@ msgstr "et du disque dur"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Note Kobo importante : les livres supprimés vont rester sur l'appareil Kobo "
-"appairé."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Les livres doivent d'abord être archivés et l'appareil synchronisé avant "
-"qu'un livre puisse être supprimé en tout sécurité."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -13580,3 +13573,16 @@ msgstr "Afficher la section Lu / Non lu"
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr ""
 #~ "Cliquer sur la couverture pour importer les métadonnées dans le formulaire"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Note Kobo importante : les livres supprimés vont rester sur l'appareil Kobo "
+#~ "appairé."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Les livres doivent d'abord être archivés et l'appareil synchronisé avant "
+#~ "qu'un livre puisse être supprimé en tout sécurité."

--- a/cps/translations/gl/LC_MESSAGES/messages.po
+++ b/cps/translations/gl/LC_MESSAGES/messages.po
@@ -11397,18 +11397,11 @@ msgstr "e do disco duro"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Nota de Kobo importante: os libros eliminados permanecerán nos dispositivos "
-"Kobo emparellados."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Antes de que un libro poida eliminarse con seguridade debe arquivarse e "
-"sincronizarse co dispositivo."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12777,3 +12770,16 @@ msgstr "Mostrar selección lidos/non lidos"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Premer na portada para cargar los metadatos no formulario"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Nota de Kobo importante: os libros eliminados permanecerán nos dispositivos "
+#~ "Kobo emparellados."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Antes de que un libro poida eliminarse con seguridade debe arquivarse e "
+#~ "sincronizarse co dispositivo."

--- a/cps/translations/hu/LC_MESSAGES/messages.po
+++ b/cps/translations/hu/LC_MESSAGES/messages.po
@@ -11531,18 +11531,11 @@ msgstr " és a merevlemezről"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Fontos Kobo megjegyzés: a törölt könyvek továbbra is megmaradnak minden "
-"párosított Kobo eszközön."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"A könyvek archiválása és az eszköz szinkronizálása szükséges ahhoz, hogy egy "
-"könyvet biztonságosan törölhessen."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -13199,3 +13192,16 @@ msgstr "Olvasott/olvasatlan mutatása"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Kattints a borítóra a metadatok betöltésére"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Fontos Kobo megjegyzés: a törölt könyvek továbbra is megmaradnak minden "
+#~ "párosított Kobo eszközön."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "A könyvek archiválása és az eszköz szinkronizálása szükséges ahhoz, hogy egy "
+#~ "könyvet biztonságosan törölhessen."

--- a/cps/translations/id/LC_MESSAGES/messages.po
+++ b/cps/translations/id/LC_MESSAGES/messages.po
@@ -11362,18 +11362,11 @@ msgstr "dan harddisk"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Catatan Penting Kobo: buku yang dihapus akan tetap ada di perangkat Kobo "
-"yang telah dipasangkan."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Buku harus diarsipkan terlebih dahulu dan perangkat disinkronkan sebelum "
-"buku dapat dihapus dengan aman."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12740,3 +12733,16 @@ msgstr "Tampilkan pilihan baca/belum dibaca"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Klik sampul untuk memuat metadata ke formulir"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Catatan Penting Kobo: buku yang dihapus akan tetap ada di perangkat Kobo "
+#~ "yang telah dipasangkan."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Buku harus diarsipkan terlebih dahulu dan perangkat disinkronkan sebelum "
+#~ "buku dapat dihapus dengan aman."

--- a/cps/translations/it/LC_MESSAGES/messages.po
+++ b/cps/translations/it/LC_MESSAGES/messages.po
@@ -11402,18 +11402,11 @@ msgstr "e dal disco rigido"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Nota importante su Kobo: i libri eliminati rimarranno su qualsiasi "
-"dispositivo Kobo associato."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"I libri devono essere prima archiviati e il dispositivo sincronizzato prima "
-"che un libro possa essere eliminato in sicurezza."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -13124,3 +13117,16 @@ msgstr "Mostra sezione Libri letti e Libri da leggere"
 
 #~ msgid "Separate Book Files from Library"
 #~ msgstr "Separa i file dei libri dalla biblioteca"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Nota importante su Kobo: i libri eliminati rimarranno su qualsiasi "
+#~ "dispositivo Kobo associato."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "I libri devono essere prima archiviati e il dispositivo sincronizzato prima "
+#~ "che un libro possa essere eliminato in sicurezza."

--- a/cps/translations/ja/LC_MESSAGES/messages.po
+++ b/cps/translations/ja/LC_MESSAGES/messages.po
@@ -11493,20 +11493,11 @@ msgstr "ローカルから完全に削除されます"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Koboに関する重要な注意：削除された書籍はペアリングされたKoboデバイスに残りま"
-"す。Koboに関する重要な注意: 削除された本はどの連携されたKobo端末にも残りま"
-"す。"
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"書籍を安全に削除するには、まず書籍をアーカイブしてデバイスを同期する必要があ"
-"ります。本を安全に削除するためには、初めに本をアーカイブした上で端末と同期す"
-"る必要があります"
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -13163,3 +13154,18 @@ msgstr "既読/未読セクションを表示"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "カバー画像をクリックしてメタデータをフォームに読み込んでください"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Koboに関する重要な注意：削除された書籍はペアリングされたKoboデバイスに残りま"
+#~ "す。Koboに関する重要な注意: 削除された本はどの連携されたKobo端末にも残りま"
+#~ "す。"
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "書籍を安全に削除するには、まず書籍をアーカイブしてデバイスを同期する必要があ"
+#~ "ります。本を安全に削除するためには、初めに本をアーカイブした上で端末と同期す"
+#~ "る必要があります"

--- a/cps/translations/km/LC_MESSAGES/messages.po
+++ b/cps/translations/km/LC_MESSAGES/messages.po
@@ -11271,14 +11271,11 @@ msgstr "និងពីថាសរឹង"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
 
 #: cps/templates/modal_dialogs.html
 #, fuzzy
@@ -12466,3 +12463,12 @@ msgstr "បង្ហាញជម្រើសស៊េរី"
 #, fuzzy
 #~ msgid "CWA Discord Server"
 #~ msgstr "ស្រាវជ្រាវ"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""

--- a/cps/translations/ko/LC_MESSAGES/messages.po
+++ b/cps/translations/ko/LC_MESSAGES/messages.po
@@ -11275,14 +11275,11 @@ msgstr "그리고 디스크에서도 삭제됩니다."
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
-msgstr "Kobo 알림: 삭제된 책은 연결된 Kobo 기기에 남아있습니다."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
+msgstr ""
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr "책을 안전하게 삭제하려면 먼저 보관 처리 후 기기 동기화가 필요합니다."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12875,3 +12872,12 @@ msgstr "읽음/읽지 않음 표시"
 
 #~ msgid "Separate Book Files from Library"
 #~ msgstr "책 저장 경로 분리"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr "Kobo 알림: 삭제된 책은 연결된 Kobo 기기에 남아있습니다."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr "책을 안전하게 삭제하려면 먼저 보관 처리 후 기기 동기화가 필요합니다."

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -11479,18 +11479,11 @@ msgstr "en van de harde schijf"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Belangrijke Kobo Opmerking: Verwijderde boeken zullen op alle gekoppelde "
-"Kobo Apparaten blijven."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Boeken moeten eerst worden gearchiveerd en het apparaat moet worden "
-"gesynchroniseerd, voordat een boek veilig kan worden verwijderd."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -13114,3 +13107,16 @@ msgstr "Toon gelezen/niet gelezen selectie"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Klik op de omslag om de metagegevens in het formulier te laden"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Belangrijke Kobo Opmerking: Verwijderde boeken zullen op alle gekoppelde "
+#~ "Kobo Apparaten blijven."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Boeken moeten eerst worden gearchiveerd en het apparaat moet worden "
+#~ "gesynchroniseerd, voordat een boek veilig kan worden verwijderd."

--- a/cps/translations/no/LC_MESSAGES/messages.po
+++ b/cps/translations/no/LC_MESSAGES/messages.po
@@ -11377,14 +11377,11 @@ msgstr ""
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
 
 #: cps/templates/modal_dialogs.html
 #, fuzzy
@@ -12750,3 +12747,12 @@ msgstr "Vis serieutvalg"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Klikk på omslaget for å laste metadata til skjemaet"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""

--- a/cps/translations/pl/LC_MESSAGES/messages.po
+++ b/cps/translations/pl/LC_MESSAGES/messages.po
@@ -11768,18 +11768,11 @@ msgstr "i z dysku twardego"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Ważne dla Kobo: usunięte książki pozostaną na każdym połączonym urządzeniu "
-"Kobo."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Książki muszą najpierw zostać zarchiwizowane a urządzenie zsynchronizowane, "
-"zanim książka będzie mogła zostać bezpiecznie usunięta."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -13409,3 +13402,16 @@ msgstr "Pokaż sekcję przeczytane/nieprzeczytane"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Kliknij okładkę, aby załadować metadane do formularza"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Ważne dla Kobo: usunięte książki pozostaną na każdym połączonym urządzeniu "
+#~ "Kobo."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Książki muszą najpierw zostać zarchiwizowane a urządzenie zsynchronizowane, "
+#~ "zanim książka będzie mogła zostać bezpiecznie usunięta."

--- a/cps/translations/pt/LC_MESSAGES/messages.po
+++ b/cps/translations/pt/LC_MESSAGES/messages.po
@@ -11429,18 +11429,11 @@ msgstr "e disco rígido"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Nota importante Kobo: os livros apagados continuarão existindo em qualquer "
-"dispositivo Kobo que esteja emparelhado."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Os livros devem primeiro ser arquivados e o dispositivo deve ser "
-"sincronizado antes que um livro possa ser apagado com segurança."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12811,3 +12804,16 @@ msgstr "Mostrar secção de lidos/não lidos"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Clique na capa para carregar os metadados para o formulário"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Nota importante Kobo: os livros apagados continuarão existindo em qualquer "
+#~ "dispositivo Kobo que esteja emparelhado."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Os livros devem primeiro ser arquivados e o dispositivo deve ser "
+#~ "sincronizado antes que um livro possa ser apagado com segurança."

--- a/cps/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/cps/translations/pt_BR/LC_MESSAGES/messages.po
@@ -11437,18 +11437,11 @@ msgstr "e disco rígido"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Nota importante Kobo: os livros apagados permanecerão em qualquer "
-"dispositivo Kobo emparelhado."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Os livros devem primeiro ser arquivados e o dispositivo deve ser "
-"sincronizado antes que um livro possa ser apagado com segurança."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -13093,3 +13086,16 @@ msgstr "Mostrar seção de lidos/não lidos"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Clique na capa para carregar os metadados para o formulário"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Nota importante Kobo: os livros apagados permanecerão em qualquer "
+#~ "dispositivo Kobo emparelhado."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Os livros devem primeiro ser arquivados e o dispositivo deve ser "
+#~ "sincronizado antes que um livro possa ser apagado com segurança."

--- a/cps/translations/ru/LC_MESSAGES/messages.po
+++ b/cps/translations/ru/LC_MESSAGES/messages.po
@@ -11789,18 +11789,11 @@ msgstr "и жёсткий диск"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Важное примечание для Kobo: удалённые книги останутся на любом подключённом "
-"устройстве Kobo."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Перед безопасным удалением книги необходимо сначала заархивировать её и "
-"синхронизировать устройство."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -13566,3 +13559,16 @@ msgstr "Показать раздел прочитанного/непрочит�
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Нажмите на обложку, чтобы получить метаданные"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Важное примечание для Kobo: удалённые книги останутся на любом подключённом "
+#~ "устройстве Kobo."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Перед безопасным удалением книги необходимо сначала заархивировать её и "
+#~ "синхронизировать устройство."

--- a/cps/translations/sk/LC_MESSAGES/messages.po
+++ b/cps/translations/sk/LC_MESSAGES/messages.po
@@ -11338,18 +11338,11 @@ msgstr "a pevný disk"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Dôležitá poznámka pre Kobo: zmazané knihy zostanú na každom spárovanom Kobo "
-"zariadení."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Kniha musí byť najskôr archivovaná a zariadenie synchronizované pred tým než "
-"môže byť kniha bezpečne zmazaná."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12706,3 +12699,16 @@ msgstr "Zobraziť sekciu Prečítané/Neprečítané"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Kliknite na oblálku aby ste načítali metadáta do formulára"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Dôležitá poznámka pre Kobo: zmazané knihy zostanú na každom spárovanom Kobo "
+#~ "zariadení."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Kniha musí byť najskôr archivovaná a zariadenie synchronizované pred tým než "
+#~ "môže byť kniha bezpečne zmazaná."

--- a/cps/translations/sl/LC_MESSAGES/messages.po
+++ b/cps/translations/sl/LC_MESSAGES/messages.po
@@ -11596,18 +11596,11 @@ msgstr "in iz trdega diska"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Pomembno opozorilo Kobo: izbrisane knjige bodo ostale v vsaki povezani "
-"napravi Kobo."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Preden lahko knjigo varno izbrišete, jo morate najprej arhivirati in "
-"sinhronizirati napravo."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -13210,3 +13203,16 @@ msgstr "Prikaži razdelek Prebrano/neprebrano"
 #~ msgstr ""
 #~ "Označi knjigo kot arhivirano ali ne, da se skrije v Calibre-Web in "
 #~ "izbriše iz Kobo bralnika"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Pomembno opozorilo Kobo: izbrisane knjige bodo ostale v vsaki povezani "
+#~ "napravi Kobo."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Preden lahko knjigo varno izbrišete, jo morate najprej arhivirati in "
+#~ "sinhronizirati napravo."

--- a/cps/translations/sv/LC_MESSAGES/messages.po
+++ b/cps/translations/sv/LC_MESSAGES/messages.po
@@ -11364,18 +11364,11 @@ msgstr "och från hårddisken"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
-"Viktigt Kobo-notering: borttagna böcker kommer att finnas kvar på alla "
-"kopplade Kobo-enheter."
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
-"Böcker måste först arkiveras och enheten synkroniseras innan en bok säkert "
-"kan tas bort."
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12699,3 +12692,16 @@ msgstr "Visa läst/oläst val"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Klicka på omslaget för att läsa in metadata till formuläret"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+#~ "Viktigt Kobo-notering: borttagna böcker kommer att finnas kvar på alla "
+#~ "kopplade Kobo-enheter."
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""
+#~ "Böcker måste först arkiveras och enheten synkroniseras innan en bok säkert "
+#~ "kan tas bort."

--- a/cps/translations/tr/LC_MESSAGES/messages.po
+++ b/cps/translations/tr/LC_MESSAGES/messages.po
@@ -11321,14 +11321,11 @@ msgstr ""
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
 
 #: cps/templates/modal_dialogs.html
 #, fuzzy
@@ -12569,3 +12566,12 @@ msgstr "Seri seçimini göster"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Forma metaveri yüklemek için kapağa tıklayın"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""

--- a/cps/translations/uk/LC_MESSAGES/messages.po
+++ b/cps/translations/uk/LC_MESSAGES/messages.po
@@ -11345,14 +11345,11 @@ msgstr "і з диску"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12580,3 +12577,12 @@ msgstr "Показувати вибір серії"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Натисніть на обкладинку, щоб отримати метадані"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""

--- a/cps/translations/vi/LC_MESSAGES/messages.po
+++ b/cps/translations/vi/LC_MESSAGES/messages.po
@@ -11305,14 +11305,11 @@ msgstr ""
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr ""
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12592,3 +12589,12 @@ msgstr "Hiển thị đã đọc và chưa đọc"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "Ấn vào ảnh cover để tải metadata vào form"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr ""

--- a/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -11403,14 +11403,11 @@ msgstr "，包括从硬盘中"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
-msgstr "Kobo 重要提示：被删除的书籍将保留在任何配对的 Kobo 设备上"
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
+msgstr ""
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr "在安全删除图书之前，必须先将图书归档并与设备同步"
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12891,3 +12888,12 @@ msgstr "显示已读、未读栏目"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "单击封面将元数据加载到表单"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr "Kobo 重要提示：被删除的书籍将保留在任何配对的 Kobo 设备上"
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr "在安全删除图书之前，必须先将图书归档并与设备同步"

--- a/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -11186,14 +11186,11 @@ msgstr "，包括從硬碟中"
 
 #: cps/templates/modal_dialogs.html
 msgid ""
-"Important Kobo Note: deleted books will remain on any paired Kobo device."
-msgstr "Kobo 重要說明：被刪除的書籍將保留在任何配對的 Kobo 設備上。"
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
+msgstr ""
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can safely "
-"be deleted."
-msgstr "必須先將書籍存檔並同步設備，然後才能安全地刪除書籍。"
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12492,3 +12489,12 @@ msgstr "顯示已讀/未讀選擇"
 
 #~ msgid "Click the cover to load metadata to the form"
 #~ msgstr "單擊封面將元數據加載到表單"
+
+#~ msgid ""
+#~ "Important Kobo Note: deleted books will remain on any paired Kobo device."
+#~ msgstr "Kobo 重要說明：被刪除的書籍將保留在任何配對的 Kobo 設備上。"
+
+#~ msgid ""
+#~ "Books must first be archived and the device synced before a book can safely "
+#~ "be deleted."
+#~ msgstr "必須先將書籍存檔並同步設備，然後才能安全地刪除書籍。"

--- a/messages.pot
+++ b/messages.pot
@@ -11026,14 +11026,12 @@ msgid "and hard disk"
 msgstr ""
 
 #: cps/templates/modal_dialogs.html
-msgid "Important Kobo Note: deleted books will remain on any paired Kobo device."
+msgid ""
+"Deleting this book also tries to archive its copy on paired Kobo devices the"
+" next time they sync. If that update cannot be recorded, the book may remain"
+" on a device."
 msgstr ""
 
-#: cps/templates/modal_dialogs.html
-msgid ""
-"Books must first be archived and the device synced before a book can "
-"safely be deleted."
-msgstr ""
 
 #: cps/templates/modal_dialogs.html
 msgid "Choose File Location"
@@ -12096,4 +12094,3 @@ msgstr ""
 #: cps/templates/user_table.html
 msgid "Show Read/Unread Section"
 msgstr ""
-

--- a/tests/unit/test_1649_kobo_delete_dialog.py
+++ b/tests/unit/test_1649_kobo_delete_dialog.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression coverage for the Kobo guidance in the delete-book dialog."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import jinja2
+import polib
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_DIR = REPO_ROOT / "cps" / "templates"
+TRANSLATIONS_DIR = REPO_ROOT / "cps" / "translations"
+
+OLD_MSGIDS = (
+    "Important Kobo Note: deleted books will remain on any paired Kobo device.",
+    "Books must first be archived and the device synced before a book can safely be deleted.",
+)
+NEW_MSGID = (
+    "Deleting this book also tries to archive its copy on paired Kobo devices the next time "
+    "they sync. If that update cannot be recorded, the book may remain on a device."
+)
+
+
+def _render_delete_dialog(kobo_sync):
+    environment = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(TEMPLATE_DIR)),
+        autoescape=True,
+    )
+    wrapper = environment.from_string(
+        "{% from 'modal_dialogs.html' import delete_book with context %}"
+        "{{ delete_book(True) }}"
+    )
+    return wrapper.render(
+        config=SimpleNamespace(config_kobo_sync=kobo_sync),
+        _=lambda message: message,
+    )
+
+
+@pytest.mark.unit
+def test_rendered_kobo_delete_guidance_is_honest_and_conditional():
+    enabled = _render_delete_dialog(True)
+    disabled = _render_delete_dialog(False)
+
+    assert NEW_MSGID in enabled
+    assert all(stale not in enabled for stale in OLD_MSGIDS)
+    assert NEW_MSGID not in disabled
+    assert all(stale not in disabled for stale in OLD_MSGIDS)
+
+
+@pytest.mark.unit
+def test_user_facing_sources_have_no_archive_before_delete_guidance():
+    roots = [REPO_ROOT / "README.md", REPO_ROOT / "docs", TEMPLATE_DIR]
+    stale_sites = []
+    for root in roots:
+        paths = [root] if root.is_file() else sorted(root.rglob("*"))
+        for path in paths:
+            if not path.is_file():
+                continue
+            try:
+                source = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                continue
+            for msgid in OLD_MSGIDS:
+                if msgid in source:
+                    stale_sites.append(str(path.relative_to(REPO_ROOT)))
+    assert stale_sites == []
+
+
+@pytest.mark.unit
+def test_changed_msgid_does_not_inherit_old_translations():
+    pot = polib.pofile(str(REPO_ROOT / "messages.pot"))
+    assert pot.find(NEW_MSGID, include_obsolete_entries=False) is not None
+    assert all(pot.find(old, include_obsolete_entries=False) is None for old in OLD_MSGIDS)
+
+    failures = []
+    for po_path in sorted(TRANSLATIONS_DIR.glob("*/LC_MESSAGES/messages.po")):
+        catalog = polib.pofile(str(po_path))
+        locale = po_path.parents[1].name
+        entry = catalog.find(NEW_MSGID, include_obsolete_entries=False)
+        obsolete_old_translations = {
+            old_entry.msgstr for old_entry in catalog.obsolete_entries()
+            if old_entry.msgid in OLD_MSGIDS and old_entry.msgstr
+        }
+        old_entries = [
+            old for old in OLD_MSGIDS
+            if catalog.find(old, include_obsolete_entries=False) is not None
+        ]
+        inherited_translation = (
+            entry is not None
+            and bool(entry.msgstr)
+            and entry.msgstr in obsolete_old_translations
+        )
+        if entry is None or old_entries or inherited_translation:
+            failures.append({
+                "locale": locale,
+                "new_msgid_present": entry is not None,
+                "new_msgstr": None if entry is None else entry.msgstr,
+                "active_old_msgids": old_entries,
+                "inherited_old_translation": inherited_translation,
+            })
+    assert failures == []


### PR DESCRIPTION
Closes #1649.

## The bug

With Kobo sync on, the delete confirmation said:

> Important Kobo Note: deleted books will remain on any paired Kobo device.
> Books must first be archived and the device synced before a book can safely be deleted.

That was true before tombstones. It is now **false**. `delete_whole_book()` calls
`kobo_sync_status.record_book_deletion(book_id, book.uuid)` *before* touching any rows — precisely
so the UUID still exists — and the sync handler plays those tombstones back as archived
`ChangedEntitlement`s.

So we were instructing users through an archive-then-sync ritual that is no longer needed, and
telling them their device would be left dirty when it will not.

## The fix

> Deleting this book also tries to archive its copy on paired Kobo devices the next time they sync.
> If that update cannot be recorded, the book may remain on a device.

Two things this deliberately does **not** overclaim:

* **"tries to"** — the tombstone write is wrapped in `try/except` and only logs a warning on
  failure, by design, so a tombstone failure never blocks the user's delete. An unconditional
  promise would be a new false statement replacing the old one.
* **"the next time they sync"** — a tombstone is delivered on the device's next sync, not instantly.

It also does not claim anything about books deleted *before* tombstones shipped. Those are still
stranded; that is #1650, handled separately.

## Enumeration

Grepped for the same stale guidance elsewhere: no matching copy in `README.md` or `docs/`. One
comment in `cps/ub.py` mentions propagating deleted shelves to paired devices — different
mechanism, not user-facing, left alone.

## i18n

Two English msgids replaced by one new msgid in `messages.pot` and all 28 shipped catalogs. Old
translations are marked obsolete rather than carried onto different English; new entries are empty
for translators. No `.mo` generated or hand-edited.

## Test

`tests/unit/test_1649_kobo_delete_dialog.py` renders the dialog with Kobo sync on and off, scans
user-facing sources for the stale guidance, and guards every active catalog against inherited
translations of the old string.

Verified: **2 of 3 fail** against the original template, all 3 pass here.
Full unit suite: **6206 passed, 95 skipped**.


---

## Independent verification (Opus manager, merge gate)

**The new sentence is true; the old one was not.** Checked against the implementation rather than
taken on trust. `cps/kobo_sync_status.py::record_book_deletion` records a tombstone per affected
user on hard-deletion, and the Kobo sync handler emits `DeletedEntitlement` for those rows on the
next sync — so a deleted book *is* removed from a paired device. It is called from the delete path
in `cps/editbooks.py` before the metadata.db row goes away. The two failure cases the new copy hedges
against ("if that update cannot be recorded") are real and visible in that function: a falsy
`book_uuid`, and no rows in `kobo_synced_books` for the book.

The retired string — *"deleted books will remain on any paired Kobo device"* — is therefore stale
guidance that pre-dates tombstones and actively misinforms. So does the second sentence it removes,
which instructed users to archive before deleting.

**Red/green by template revert.** Reverted only `cps/templates/modal_dialogs.html` to `747751ff2`,
keeping the new tests:

```
without the fix:  2 failed, 1 passed in 4.45s
with the fix:     3 passed in 3.90s   (tree restored clean)
```

The one test that passes in both states is the source-sweep assertion, which is a guard against the
old guidance reappearing elsewhere rather than a test of this template. Naming it because a test
that cannot fail is not evidence for the change.

`test_rendered_kobo_delete_guidance_is_honest_and_conditional` does render the template through Jinja
for both `config_kobo_sync` states, so the user-visible string is exercised rather than grepped.

**Translation churn is exactly what it should be.** `messages.pot` moves `+4 / -7` — the two old
strings out, one new string in. The 56 `#~` entries added across the `.po` files are those two
strings × the languages that had them; no other msgid was retired, and no fuzzy entries were
introduced (`0`).

### The tradeoff, stated plainly

The new string ships **untranslated in all 29 languages**, so a French or German user now sees this
one sentence in English where they previously saw translated text. I am taking that deliberately:
the translated text they saw was *wrong*, and accurate English beats a confidently translated
falsehood about whether their books are still on their device. `update-translations.yml` is the
route back to parity, and this is one short string.

**Rule 6:** no dependency, license, or external-service-URL change. Template and message catalogues
only — no code paths, routes, auth, or subprocess use, hence no security review.
