### PR TITLE
fix(kobo): warn in the log when a book cannot show its highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **The log now warns when a book cannot show highlights on a Kobo.** Some books
+  have a table of contents that points partway into a chapter file rather than at
+  the file itself. On a Kobo, every highlight made in such a book is stored
+  correctly and drawn nowhere — there is no error and nothing looks wrong, the
+  marks simply never appear. On one real library this affects 42% of books. After
+  a KEPUB is produced, the log now names the book and how many of its navigation
+  targets are affected, so the problem is at least visible. This does not fix the
+  rendering; that needs a conversion change with a migration story for highlights
+  people already hold.
+
 - **Covers are now shaped for the Kobo that is actually asking.** The server-side
   cover padding had one aspect setting for the whole instance, so a household with
   two different Kobos had to pick a winner — the other device got covers padded to

--- a/cps/services/kepub_package_normalizer.py
+++ b/cps/services/kepub_package_normalizer.py
@@ -55,6 +55,7 @@ MAX_TOTAL_UNCOMPRESSED_BYTES = 256 * 1024 * 1024
 #: ceiling, but it must not be able to allocate hundreds of MiB on its own.
 MAX_CONTAINER_XML_BYTES = 1 * 1024 * 1024
 MAX_PACKAGE_DOCUMENT_BYTES = 16 * 1024 * 1024
+MAX_TOC_DOCUMENT_BYTES = 16 * 1024 * 1024
 
 
 def _reject_oversized_archive(infos):
@@ -102,6 +103,85 @@ def _package_document_path(archive):
 def _manifest_items(opf_bytes):
     package = etree.fromstring(opf_bytes, parser=_XML_PARSER)
     return package.xpath("//*[local-name()='manifest']/*[local-name()='item']")
+
+
+def _toc_documents(opf_path, opf_bytes):
+    for item in _manifest_items(opf_bytes):
+        media_type = item.get("media-type", "")
+        properties = set(item.get("properties", "").split())
+        if media_type == "application/x-dtbncx+xml":
+            kind = "NCX"
+        elif "nav" in properties:
+            kind = "navigation"
+        else:
+            continue
+        href = item.get("href")
+        if not href:
+            continue
+        split = _split_local_reference(href)
+        if split is None:
+            continue
+        _, href_path = split
+        toc_path = _resolve_reference(opf_path, href_path)
+        if toc_path.startswith("../") or toc_path.startswith("/"):
+            raise ValueError("EPUB TOC path escapes the archive")
+        yield toc_path, kind
+
+
+def _toc_targets(toc_bytes, kind):
+    document = etree.fromstring(toc_bytes, parser=_XML_PARSER)
+    if kind == "NCX":
+        return document.xpath("//*[local-name()='content']/@src")
+
+    targets = []
+    for nav in document.xpath("//*[local-name()='nav']"):
+        epub_types = set()
+        for value in nav.xpath("@*[local-name()='type']"):
+            epub_types.update(value.split())
+        roles = set(nav.get("role", "").split())
+        if "toc" in epub_types or "doc-toc" in roles:
+            targets.extend(nav.xpath(".//*[local-name()='a']/@href"))
+    return targets
+
+
+def count_fragment_anchored_toc_targets(path):
+    """Count distinct fragment-bearing targets in manifest-declared TOCs.
+
+    Return zero when the archive or package document cannot be inspected.
+    Malformed individual TOCs are logged and skipped. This diagnostic never
+    modifies the EPUB and never lets user-file failures escape into conversion.
+    """
+    path = os.fspath(path)
+    try:
+        with zipfile.ZipFile(path) as archive:
+            infos = archive.infolist()
+            _reject_oversized_archive(infos)
+            opf_path = _package_document_path(archive)
+            opf_bytes = _read_bounded_member(
+                archive, opf_path, MAX_PACKAGE_DOCUMENT_BYTES, "package document")
+            toc_documents = list(_toc_documents(opf_path, opf_bytes))
+            fragment_targets = set()
+            for toc_path, kind in toc_documents:
+                try:
+                    toc_bytes = _read_bounded_member(
+                        archive, toc_path, MAX_TOC_DOCUMENT_BYTES,
+                        "{} TOC document".format(kind))
+                    for target in _toc_targets(toc_bytes, kind):
+                        try:
+                            split = _split_local_reference(target)
+                        except (TypeError, ValueError):
+                            continue
+                        if split is not None and split[0].fragment:
+                            _, target_path = split
+                            resolved_path = _resolve_reference(toc_path, target_path)
+                            fragment_targets.add((resolved_path, split[0].fragment))
+                except Exception as error:
+                    log.warning("Could not inspect %s TOC document in %s: %s",
+                                kind, path, error)
+            return len(fragment_targets)
+    except Exception as error:
+        log.warning("Could not inspect EPUB TOC fragments in %s: %s", path, error)
+        return 0
 
 
 def _split_local_reference(value):

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -24,7 +24,10 @@ from cps import logger, config
 from cps.subproc_wrapper import process_open, stream_process_output
 from flask_babel import gettext as _
 from cps.file_helper import get_temp_dir
-from cps.services.kepub_package_normalizer import normalize_kepub_package
+from cps.services.kepub_package_normalizer import (
+    count_fragment_anchored_toc_targets,
+    normalize_kepub_package,
+)
 
 from cps.tasks.mail import TaskEmail
 from cps import gdriveutils, helper
@@ -32,6 +35,17 @@ from cps.constants import SUPPORTED_CALIBRE_BINARIES
 from cps.string_helper import strip_whitespaces
 
 log = logger.create()
+
+
+def _log_fragment_anchored_toc(book, path):
+    count = count_fragment_anchored_toc_targets(path)
+    if count:
+        log.warning(
+            "KEPUB for book '%s' (id %d) has %d fragment-anchored TOC targets; "
+            "Kobo highlights in this book may not appear on the device",
+            book.title, book.id, count,
+        )
+    return count
 
 
 def _valid_archive(path, book_format):
@@ -187,6 +201,8 @@ class TaskConvert(CalibreTask):
         if check == 0:
             cur_book = local_db.get_book(book_id)
             if os.path.isfile(file_path + format_new_ext):
+                if self.settings['new_book_format'].upper() == 'KEPUB':
+                    _log_fragment_anchored_toc(cur_book, file_path + format_new_ext)
                 new_format = local_db.session.query(db.Data).filter(db.Data.book == book_id) \
                     .filter(db.Data.format == self.settings['new_book_format'].upper()).one_or_none()
                 if not new_format:

--- a/tests/unit/test_1657_kepub_toc_fragments.py
+++ b/tests/unit/test_1657_kepub_toc_fragments.py
@@ -1,0 +1,253 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Synthetic-archive coverage for fragment-anchored EPUB TOCs."""
+
+import logging
+from types import SimpleNamespace
+import zipfile
+
+import pytest
+
+
+CONTAINER_XML = b"""<?xml version="1.0"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OPS/book.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+"""
+
+NCX_WITH_FRAGMENTS = b"""<?xml version="1.0"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+  <navMap>
+    <navPoint><content src="chapter.xhtml#one"/></navPoint>
+    <navPoint><content src="chapter.xhtml"/></navPoint>
+    <navPoint><content src="chapter.xhtml#two"/></navPoint>
+  </navMap>
+</ncx>
+"""
+
+NCX_WITHOUT_FRAGMENTS = NCX_WITH_FRAGMENTS.replace(
+    b"chapter.xhtml#one", b"chapter-one.xhtml"
+).replace(
+    b"chapter.xhtml#two", b"chapter-two.xhtml"
+)
+
+NAV_WITH_FRAGMENTS = b"""<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:epub="http://www.idpf.org/2007/ops">
+  <body>
+    <nav epub:type="toc">
+      <ol>
+        <li><a href="chapter.xhtml#one">One</a></li>
+        <li><a href="chapter.xhtml">Whole document</a></li>
+        <li><a href="#local-position">Local position</a></li>
+      </ol>
+    </nav>
+    <nav epub:type="landmarks">
+      <a href="chapter.xhtml#not-a-toc-entry">Body</a>
+    </nav>
+  </body>
+</html>
+"""
+
+
+def _matching_dual_tocs(target_count):
+    ncx_targets = "\n".join(
+        '<navPoint><content src="chapters/chapter.xhtml#anchor-{0:03d}"/></navPoint>'.format(index)
+        for index in range(target_count)
+    )
+    nav_targets = "\n".join(
+        '<li><a href="../chapters/chapter.xhtml#anchor-{0:03d}">{0}</a></li>'.format(index)
+        for index in range(target_count)
+    )
+    ncx = (
+        '<?xml version="1.0"?>'
+        '<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/"><navMap>'
+        + ncx_targets
+        + '</navMap></ncx>'
+    ).encode()
+    nav = (
+        '<?xml version="1.0"?>'
+        '<html xmlns="http://www.w3.org/1999/xhtml" '
+        'xmlns:epub="http://www.idpf.org/2007/ops"><body>'
+        '<nav epub:type="toc"><ol>'
+        + nav_targets
+        + '</ol></nav></body></html>'
+    ).encode()
+    return ncx, nav
+
+
+def _opf(*manifest_items, version="3.0", spine_toc=""):
+    items = "\n".join(manifest_items)
+    toc_attribute = f' toc="{spine_toc}"' if spine_toc else ""
+    return f"""<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="{version}">
+  <manifest>{items}</manifest>
+  <spine{toc_attribute}/>
+</package>
+""".encode()
+
+
+def _write_epub(path, opf, members=()):
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("mimetype", b"application/epub+zip")
+        archive.writestr("META-INF/container.xml", CONTAINER_XML)
+        archive.writestr("OPS/book.opf", opf)
+        for name, content in members:
+            archive.writestr(name, content)
+    return path
+
+
+def _count(path):
+    from cps.services.kepub_package_normalizer import count_fragment_anchored_toc_targets
+
+    return count_fragment_anchored_toc_targets(path)
+
+
+@pytest.mark.unit
+def test_ncx_only_toc_counts_fragment_anchored_targets(tmp_path):
+    package = _write_epub(
+        tmp_path / "ncx-fragments.kepub",
+        _opf(
+            '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>',
+            version="2.0",
+            spine_toc="ncx",
+        ),
+        [("OPS/toc.ncx", NCX_WITH_FRAGMENTS)],
+    )
+
+    assert _count(package) == 2
+
+
+@pytest.mark.unit
+def test_toc_without_fragments_reports_zero(tmp_path):
+    package = _write_epub(
+        tmp_path / "ncx-clean.epub",
+        _opf(
+            '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>',
+            version="2.0",
+            spine_toc="ncx",
+        ),
+        [("OPS/toc.ncx", NCX_WITHOUT_FRAGMENTS)],
+    )
+
+    assert _count(package) == 0
+
+
+@pytest.mark.unit
+def test_nav_only_toc_counts_fragments_but_not_landmarks(tmp_path):
+    package = _write_epub(
+        tmp_path / "nav-fragments.epub",
+        _opf('<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>'),
+        [("OPS/nav.xhtml", NAV_WITH_FRAGMENTS)],
+    )
+
+    assert _count(package) == 2
+
+
+@pytest.mark.unit
+def test_matching_ncx_and_nav_targets_are_counted_once_per_package(tmp_path):
+    ncx, nav = _matching_dual_tocs(42)
+    package = _write_epub(
+        tmp_path / "dual-toc-fragments.kepub",
+        _opf(
+            '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>',
+            '<item id="nav" href="nav/toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>',
+            spine_toc="ncx",
+        ),
+        [("OPS/toc.ncx", ncx), ("OPS/nav/toc.xhtml", nav)],
+    )
+
+    assert _count(package) == 42
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("toc_state", ["absent", "malformed"])
+def test_absent_or_malformed_toc_never_raises(tmp_path, toc_state):
+    if toc_state == "absent":
+        opf = _opf('<item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>')
+        members = []
+    else:
+        opf = _opf('<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>')
+        members = [("OPS/nav.xhtml", b"<html><nav")]
+    package = _write_epub(tmp_path / f"{toc_state}.epub", opf, members)
+
+    assert _count(package) == 0
+
+
+@pytest.mark.unit
+def test_conversion_diagnostic_names_book_and_fragment_count(tmp_path, caplog, monkeypatch):
+    import cps.helper  # noqa: F401 - establish the application's normal import order
+    from cps.tasks import convert
+
+    book_path = tmp_path / "affected"
+    (tmp_path / "affected.epub").write_bytes(b"source")
+    book = SimpleNamespace(
+        id=42,
+        title="Synthetic Fragment Book",
+        path="Synthetic/Fragment Book",
+        data=[SimpleNamespace(name="affected")],
+    )
+
+    class Query:
+        def filter(self, *_args):
+            return self
+
+        def one_or_none(self):
+            return None
+
+    class Session:
+        def query(self, *_args):
+            return Query()
+
+        def merge(self, _row):
+            pass
+
+        def commit(self):
+            pass
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            pass
+
+    class LocalDB:
+        def __init__(self, **_kwargs):
+            self.session = Session()
+
+        def get_book(self, _book_id):
+            return book
+
+        def get_book_format(self, *_args):
+            return None
+
+    def convert_package(*_args):
+        _write_epub(
+            tmp_path / "affected.kepub",
+            _opf('<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>'),
+            [("OPS/nav.xhtml", NAV_WITH_FRAGMENTS)],
+        )
+        return 0, None
+
+    monkeypatch.setattr(convert.db, "CalibreDB", LocalDB)
+    monkeypatch.setattr(convert.config, "config_kepubifypath", "/bin/kepubify", raising=False)
+    monkeypatch.setattr(convert.config, "config_use_google_drive", False, raising=False)
+    monkeypatch.setattr(convert.helper, "mark_book_modified", lambda *_args, **_kwargs: None)
+    task = convert.TaskConvert(
+        str(book_path), 42, "convert",
+        {"old_book_format": "EPUB", "new_book_format": "KEPUB"}, None,
+    )
+    monkeypatch.setattr(task, "_convert_kepubify", convert_package)
+    monkeypatch.setattr(task, "_handleSuccess", lambda: None)
+
+    with caplog.at_level(logging.WARNING):
+        assert task._convert_ebook_format() == "affected.kepub"
+
+    message = caplog.text
+    assert "Synthetic Fragment Book" in message
+    assert "42" in message
+    assert "2 fragment-anchored TOC targets" in message
+    assert "highlights" in message.lower()


### PR DESCRIPTION
Partially addresses #1657 — this is the **diagnostic**, deliberately not the fix.

## What is being diagnosed

Kobo identifies a chapter as `<book-uuid>!<opf-dir>!<href>` and renders a highlight only when
`Bookmark.ContentID` is **byte-identical** to a `content` row with `ContentType=9`. No
normalisation, no fuzzy match.

When a table of contents points *into* a spine document rather than at it, Nickel builds the
bookmark id from the raw TOC href and keeps the fragment. Rendering then looks up the file without
one. Measured verbatim off a Kobo Clara BW (firmware 4.45.23792):

```
Bookmark        <uuid>!OEBPS!…541-h-0.htm.xhtml#pgepubid00005
ContentType=9   <uuid>!OEBPS!…541-h-0.htm.xhtml
ContentType=899 <uuid>!OEBPS!…541-h-0.htm.xhtml#pgepubid00005-2
```

Matches neither — it is a third form. Every highlight in such a book is stored perfectly and drawn
nowhere, with no error and nothing visibly wrong. Measured blast radius on one real library:
**92 of 216 books (42.6%)**, against 2.3% for the `../` defect fixed in #1637.

## Why this PR is not the fix

Two obvious repairs are both wrong:

* **Stripping fragments from the NCX** collapses one real book's 42 navigation targets onto 7
  documents. The fragment is load-bearing navigation.
* **Normalising server-side** fixes the `content_id` *we* store, but the row Nickel draws from lives
  on the device.

The real fix is splitting spine documents at TOC anchor targets during conversion — the shape a
working control book already has. That regenerates the KEPUB, which shifts every KoboSpan id, which
re-anchors highlights users already hold. It needs a migration story before it needs code.

So: make it **visible** first. After a successful KEPUB conversion the log names the book, its id,
and the affected target count.

## Implementation

Reuses `kepub_package_normalizer`'s existing guarded archive handling, package-document lookup,
manifest parsing and reference resolution rather than adding a second EPUB parser. Handles both NCX
and EPUB3 nav. A malformed or absent TOC yields no diagnostic instead of failing the conversion —
this runs over user files and must never raise.

## Validated against real books, not only fixtures

Run against two real KEPUBs whose ground truth was read off the device:

| book | detector | device ground truth |
|---|---|---|
| clean-TOC control | **0** | 0 fragments; 6/6 highlights anchored |
| affected book | **42** | 42 `ContentType=899` TOC rows |

An earlier revision reported **84** for the second book — it counted each target once per TOC
document, and that book declares both `toc.ncx` and a nav document carrying the same 42 targets.
The synthetic fixtures could not catch it, and their names say why: `…ncx_only…` and `…nav_only…`.
Neither covered a package declaring **both**, which is the common real-world shape. Targets are now
deduplicated per package and a both-TOCs fixture was added.

## Tests

7 tests: NCX-only, nav-only, both-TOCs, no-fragments, absent/malformed (parametrised, must not
raise), and the conversion diagnostic naming book, id, count and consequence.

`test_matching_ncx_and_nav_targets_are_counted_once_per_package` **fails on the double-counting
revision** and passes here. Full unit suite: **6206 passed, 95 skipped**.


---

## Independent verification (Opus manager, merge gate)

Re-derived from scratch on the PR head `a4867fb3`, not taken from the implementation leg's report.

**Red/green by product-code revert.** Kept the new test file, reverted only
`cps/services/kepub_package_normalizer.py` and `cps/tasks/convert.py` to `747751ff2`:

```
without the fix:  7 failed in 2.53s
with the fix:     7 passed in 1.73s   (tree restored clean, 0 dirty files)
```

**Practical verification against a real book, not a fixture.** Built a real KEPUB with
kepubify 4.0.4 from a real library EPUB (`The Count of Monte Cristo`) and ran the shipped
function against it:

```
count_fragment_anchored_toc_targets(book.kepub.epub) -> 126
ground truth: nav.xhtml contains 126 fragment refs, 126 distinct
```

The count matches an independent parse of the same archive exactly. Degradation checked too —
a missing file and a non-ZIP both return `0` with a logged warning rather than raising, which is
what keeps this out of the conversion path's way.

**Security review: not required, deliberately.** It reads user-supplied archives, so the trigger was
considered rather than skipped. It reuses `_XML_PARSER`
(`resolve_entities=False, no_network=True, recover=False`) **unchanged from main**, adds bounded
member reads (`MAX_TOC_DOCUMENT_BYTES`), and explicitly rejects TOC paths that escape the archive.
No new routes, no auth/session/CSRF, no subprocess, no writes — the function never modifies the EPUB.

**Rule 6:** no dependency, license, or external-service-URL changes. The `daisy.org` / `idpf.org` /
`w3.org` strings in the diff are XML namespace declarations; there are no network primitives in the
added lines.

### One honest caveat, recorded rather than fixed here

The title says "tell users"; what actually ships is a **server-side log warning**. For the operator
reading logs that is genuinely useful, but the affected *reader* still sees nothing — highlights
silently do not appear. The CHANGELOG entry is accurate about this ("The log now warns…", and it
states plainly that the rendering is not fixed), so nothing shipped overclaims. Surfacing this in
the UI is tracked separately; it is not a reason to hold a correct diagnostic.
