### PR TITLE
docs(changelog): five merged changes had no [Unreleased] entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Added
+
+- **Your library now tells you when it has repaired a book, and which books were
+  affected.** Some KEPUB files were produced with a packaging defect that stops a
+  Kobo from holding highlights in them. The defect was fixed for new conversions
+  in the last release, but books converted before that stayed broken until
+  something happened to re-convert them. The server now repairs those files
+  itself and raises a notice naming the books, because there is one part it
+  cannot repair: highlights already made in an affected book are stored against
+  the broken structure on the device, and no server-side fix can put those back.
+  You should know that rather than discover it later. Dismissing a notice
+  dismisses that occurrence only — if the same book is affected again, you are
+  told again.
+
 ### Fixed
 
 - **Kobo highlights now stay on the device when it syncs — the v4.1.36 fix did
@@ -82,6 +96,34 @@ is for things you can see or feel when running the app.
   adding thousands of duplicate entitlements to the reader until the server
   failed. Each completed page now advances the device to the next one, so the
   library drains normally instead of flooding the Kobo.
+- **A new Kobo no longer arrives with most of its books unable to hold
+  highlights.** The library converts books to Kobo's own format in the
+  background, and it tracked that work with a single "done" flag. Pairing a
+  device is exactly what adds more books to convert, so the flag said finished
+  while the newly-synced books had never been converted at all. On one real
+  library, 216 books were synced to a newly-paired Clara and 182 of them had no
+  converted copy. Those convert while the device waits, and if a conversion
+  fails the Kobo gets a plain EPUB, which cannot reliably hold highlights — so
+  this reached people as "highlighting doesn't work on my new Kobo". The
+  progress marker now moves with the library instead of latching once.
+- **Clearing a series now clears it on the Kobo too.** Setting or changing a
+  series already updated both copies of the book; removing one updated only the
+  EPUB. The Kobo kept displaying a series you had deleted, with nothing anywhere
+  to explain it. (The obvious shortcut — sending Kobo files through the same
+  polishing step as EPUBs — is deliberately not used, because it would re-cut
+  the internal position markers and move every Kobo reader's saved place in the
+  book.)
+- **An edit to a highlight is no longer thrown away when the device sends a
+  malformed timestamp.** A highlight arriving with an unreadable clock was kept
+  if it was new, but an edit to one you already had was silently ignored — the
+  changed text, note, colour and location were all discarded with no error. A
+  timestamp that is present but unreadable is now treated differently from one
+  that is genuinely absent, and the change is applied.
+- **A KOReader client can now tell "this book is unknown here" apart from "this
+  book has no highlights".** The server answered both with an empty list, which
+  is the same ambiguity that has twice destroyed highlights in this project —
+  once in each direction. Our own plugin was never at risk, but any other client
+  reading that answer had no way to distinguish them.
 
 ## [v4.1.36] - 2026-08-15
 


### PR DESCRIPTION
Changelog only. **Found while checking that the release notes would be truthful before the train departs**, which turned out to be the right check to run.

Six user-facing merges landed after the `v4.1.36` tag (cut 2026-08-15 13:58 EDT) and **five of them are described nowhere in `CHANGELOG.md`** — not under `[Unreleased]`, not under `v4.1.36`, not under any PR or issue number. Release notes are built from these entries, so those changes would have shipped invisibly. And since we never retract a published release, an omission here is permanent.

| PR | what a user would have noticed | section |
|---|---|---|
| #1645 | KEPUB repair, and the notice naming the books it could not fully repair | Added |
| #1647 | a newly-paired Kobo arriving with 182 of 216 books unable to hold highlights | Fixed |
| #1672 | clearing a series left it showing on the Kobo | Fixed |
| #1661 | an edit to an existing highlight silently discarded on a malformed clock | Fixed |
| #1643 | a KOReader client could not tell "unknown book" from "no highlights" | Fixed |

**#1644 deliberately gets no entry.** It hardens three guards whose promise was wider than their delivery, and its own summary is *"none of these are active data loss"*. There is no symptom a user could have noticed, and inventing one to fill a row is how a changelog stops being worth reading.

**Two claims in the new text were checked rather than assumed:**

- The #1645 entry says the conversion-time defect was fixed "in the last release". `git log v4.1.36 | grep '(#1637)'` → 1; the same against `v4.1.35` and `v4.1.34` → 0. Accurate.
- The 216/182 figures are the measurement in #1647's own body, taken on a live instance immediately after a Clara BW paired — not a round number I chose.

Three of these five are Kobo highlight-integrity issues arriving by completely different routes than #1679, which is worth noticing on its own: an unconverted book, a discarded edit, and an ambiguous empty answer all reach the user as *"my highlights don't work"*.