### PR TITLE
fix: ingest pipeline produces garbled ASCII paths for non-Latin titles and authors

### DIFF
--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -1268,6 +1268,105 @@ class NewBookProcessor:
         except Exception as e:
             print(f"[ingest-processor] WARN: Could not register title_sort function: {e}", flush=True)
             return False
+
+    def _fix_unicode_path(self, book_id: int) -> None:
+        """Rename the path calibredb add generated with ascii_filename() to the
+        CWA-canonical form produced by get_valid_filename_shared().
+
+        calibredb always uses its internal ascii_filename() UDF when constructing
+        on-disk paths, which transliterates Unicode (e.g. CJK characters) to
+        romanized ASCII regardless of any preference. For example, a book by
+        小野不由美 lands at Xiao Ye Bu You Mei/... on disk even when the library
+        is configured for Unicode filenames.
+
+        CWA's web-UI edit/save path already calls get_valid_filename_shared() and
+        preserves Unicode. This method applies the same logic immediately after
+        calibredb add so ingest and the web UI produce consistent paths.
+        """
+        try:
+            _ensure_project_root_on_path()
+            from cps.utils.filename_sanitizer import get_valid_filename_shared
+        except ImportError as e:
+            print(f"[ingest-processor] WARN: filename_sanitizer unavailable; skipping path fix: {e}", flush=True)
+            return
+
+        try:
+            with sqlite3.connect(get_app_db_path(), timeout=30) as con:
+                row = con.execute(
+                    "SELECT config_unicode_filename FROM settings LIMIT 1"
+                ).fetchone()
+            unicode_filename = bool(row[0]) if row and row[0] is not None else False
+        except Exception as e:
+            print(f"[ingest-processor] WARN: Could not read unicode_filename setting; skipping path fix: {e}", flush=True)
+            return
+
+        if unicode_filename:
+            return  # user wants ASCII filenames; calibredb already produced them
+
+        try:
+            with sqlite3.connect(self.metadata_db, timeout=30) as con:
+                if not self._register_title_sort_function(con):
+                    print(f"[ingest-processor] INFO: Skipping path fix for book {book_id} (title_sort unavailable).", flush=True)
+                    return
+                cur = con.cursor()
+                row = cur.execute(
+                    """SELECT b.title, b.path,
+                              (SELECT a.name FROM authors a
+                               JOIN books_authors_link l ON a.id = l.author
+                               WHERE l.book = b.id ORDER BY l.id ASC LIMIT 1)
+                       FROM books b WHERE b.id = ?""",
+                    (book_id,),
+                ).fetchone()
+                if not row:
+                    return
+                title, old_path, first_author = row
+                first_author = first_author or "Unknown"
+
+                try:
+                    author_dir = get_valid_filename_shared(first_author, chars=96)
+                    title_dir  = get_valid_filename_shared(title, chars=96)
+                    new_name   = (get_valid_filename_shared(title, chars=42)
+                                  + " - "
+                                  + get_valid_filename_shared(first_author, chars=42))
+                except ValueError as e:
+                    print(f"[ingest-processor] WARN: Skipping path fix for book {book_id}: invalid filename: {e}", flush=True)
+                    return
+
+                new_path = f"{author_dir}/{title_dir} ({book_id})"
+                if old_path == new_path:
+                    return  # already correct (ASCII-only title/author, or already fixed)
+
+                data_rows = cur.execute(
+                    "SELECT id, name, format FROM data WHERE book = ?", (book_id,)
+                ).fetchall()
+
+                old_abs = os.path.join(self.library_dir, old_path)
+                new_abs = os.path.join(self.library_dir, new_path)
+
+                if os.path.exists(old_abs):
+                    os.makedirs(os.path.dirname(new_abs), exist_ok=True)
+                    shutil.move(old_abs, new_abs)
+                elif not os.path.exists(new_abs):
+                    print(f"[ingest-processor] WARN: Path fix skipped for book {book_id}: directory not found at {old_abs!r}", flush=True)
+                    return
+
+                for data_id, old_name, fmt in data_rows:
+                    ext = fmt.lower()
+                    src = os.path.join(new_abs, f"{old_name}.{ext}")
+                    dst = os.path.join(new_abs, f"{new_name}.{ext}")
+                    if src != dst and os.path.exists(src):
+                        shutil.move(src, dst)
+                    cur.execute("UPDATE data SET name = ? WHERE id = ?", (new_name, data_id))
+
+                cur.execute("UPDATE books SET path = ? WHERE id = ?", (new_path, book_id))
+                print(
+                    f"[ingest-processor] INFO: Fixed path for book {book_id}: "
+                    f"{old_path!r} → {new_path!r}",
+                    flush=True,
+                )
+        except Exception as e:
+            print(f"[ingest-processor] WARN: Failed to fix path for book {book_id}: {e}", flush=True)
+
     def get_split_library(self) -> dict[str, str] | None:
         """Checks whether or not the user has split library enabled. Returns None if they don't and the path of the Split Library location if True."""
         app_db_path = get_app_db_path()
@@ -1742,6 +1841,11 @@ class NewBookProcessor:
                 self.fetch_metadata_if_enabled(book_id=self.last_added_book_id)
             else:
                 self.fetch_metadata_if_enabled(staged_path.stem)
+
+            # Fix paths garbled by calibredb add's ascii_filename() transliteration.
+            # Runs after fetch_metadata so any author-name update is already in the DB.
+            if self.last_added_book_id is not None:
+                self._fix_unicode_path(self.last_added_book_id)
 
             # Trigger auto-send for users who have it enabled
             if self.last_added_book_id is not None:


### PR DESCRIPTION
### Problem

When a user drops a Japanese (or any non-Latin) book into the CWA ingest folder, the resulting path on disk is romanized ASCII gibberish regardless of how the library is configured:

```
# What CWA creates after ingest:
Xiao Ye Bu You Mei/Hei Ci noDao (51042)/Hei Ci noDao - Xiao Ye Bu You Mei.epub

# What the user actually wanted:
小野不由美/黒祠の島 (51042)/黒祠の島 - 小野不由美.epub
```

This breaks file browsing, KOReader sync paths, any external tool that reads the library directory, and produces inconsistent output: a book edited through CWA's web UI gets a correct Unicode path, but the same book added through the ingest folder gets garbled ASCII.

The root cause is that `calibredb add` uses Calibre's internal `ascii_filename()` UDF which always transliterates CJK/Unicode to romanized ASCII, ignoring the `config_unicode_filename` preference. CWA never corrects this after the fact.

### Fix

Add `_fix_unicode_path(book_id)` to `NewBookProcessor`. It runs after each successful `calibredb add` — specifically after `fetch_metadata_if_enabled` (so any metadata-corrected author name is already in the DB) and before `trigger_auto_send_if_enabled` (so the file is at the correct path before being sent to devices).

The method:

- Reads `config_unicode_filename` from `app.db` — if `True` (user explicitly wants ASCII), calibredb already produced it and the method is a no-op
- Computes the canonical path using `get_valid_filename_shared()` from `cps/utils/filename_sanitizer.py` — **the same function the web-UI edit/save path already calls** — so ingest and the web UI are now consistent
- If the computed path differs from what calibredb generated, moves the book directory and renames all book files on disk, then updates `books.path` and `data.name` in `metadata.db`
- Registers `title_sort` via the existing `_register_title_sort_function` helper (required by the `books_update_trg` SQLite trigger)
- All error paths are non-fatal `WARN` prints; no existing behavior is affected if the method fails

### Before / After

| | Path after ingest |
|---|---|
| **Before** | `Xiao Ye Bu You Mei/Hei Ci noDao (51042)/` |
| **After** | `小野不由美/黒祠の島 (51042)/` |

### Testing

1. Set `config_unicode_filename = 0` in CWA settings (the default)
2. Drop a book with a Japanese/CJK author and title into the ingest folder
3. Confirm the library path is `{Japanese author}/{Japanese title} (id)/` instead of the transliterated form
4. Books with ASCII-only titles and authors: no change (method is a no-op)
5. `config_unicode_filename = 1`: no change (method returns early)

### Related

Same fix submitted upstream to crocodilestick/Calibre-Web-Automated: https://github.com/crocodilestick/Calibre-Web-Automated/pull/1493