### PR TITLE
feat(comic): opt-in ingest setting to move a misplaced ComicInfo.xml to the archive root

### DIFF
--- a/changelog.d/pr-1698.md
+++ b/changelog.d/pr-1698.md
@@ -1,0 +1,10 @@
+### Added
+
+- **New ingest setting: move a misplaced `ComicInfo.xml` to the archive root.**
+  The ComicInfo.xml standard requires the file at the root of a `.cbz`; some
+  real scan-group releases package it one folder down instead, alongside the
+  pages, and every reader we checked (including ComicTagger and Komga) then
+  silently gets no metadata from it. Off by default — turn it on in CWA
+  Settings and ingest repackages a copy with the file moved to root before
+  import, only when it's present but misplaced. Your original download is
+  never touched.

--- a/cps/comic.py
+++ b/cps/comic.py
@@ -148,6 +148,58 @@ def _extract_cover(tmp_file_name, original_file_extension, rar_executable):
     return cover.cover_processing(tmp_file_name, cover_data, extension)
 
 
+def flatten_comicinfo_to_root(archive_path):
+    """Move a misplaced ComicInfo.xml to the archive root, in place.
+
+    The ComicInfo.xml standard requires the file at the archive root;
+    comicapi's has_metadata/read_metadata do an exact-name lookup against
+    the archive's file list and only ever match a root-level entry, so a
+    real-world .cbz that packages it one folder down (a common scan-group
+    convention) never gets its metadata read at all, root or not. This is
+    consistent with every other reader we checked (ComicTagger, Komga) - it's
+    not a comicapi bug, it's the file that's out of spec. Rewriting the copy
+    fixes it for every future reader, not just this one import.
+
+    Only rewrites zip-based archives (.cbz) - .cbr/.cb7/.cbt aren't zip
+    containers and there's no free Python writer for RAR, so those are left
+    untouched. No-ops (returns False) when ComicInfo.xml is already at root,
+    absent entirely, or the archive isn't a zip - callers don't need to
+    check any of that first.
+
+    :returns: True if the archive was rewritten, False if left untouched.
+    """
+    if not zipfile.is_zipfile(archive_path):
+        return False
+
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        names = archive.namelist()
+        if "ComicInfo.xml" in names:
+            return False  # already at root
+
+        nested_name = next(
+            (name for name in names if os.path.basename(name).lower() == "comicinfo.xml"),
+            None,
+        )
+        if nested_name is None:
+            return False  # no ComicInfo.xml anywhere in the archive
+
+        entries = archive.infolist()
+        contents = {info.filename: archive.read(info) for info in entries}
+
+    tmp_path = archive_path + ".comicinfo-flatten.tmp"
+    with zipfile.ZipFile(tmp_path, "w") as out:
+        for info in entries:
+            data = contents[info.filename]
+            name = "ComicInfo.xml" if info.filename == nested_name else info.filename
+            new_info = zipfile.ZipInfo(name, date_time=info.date_time)
+            new_info.compress_type = info.compress_type
+            new_info.external_attr = info.external_attr
+            out.writestr(new_info, data)
+
+    os.replace(tmp_path, archive_path)
+    return True
+
+
 def get_comic_info(tmp_file_path, original_file_name, original_file_extension, rar_executable, no_cover_processing):
     if use_comic_meta:
         try:

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -194,6 +194,16 @@
         {{_("Aggressive mode applies more invasive fixes and will attempt lower-confidence encoding conversions. Safe mode is recommended for most libraries.")}}
       </p>
 
+      {% if cwa_settings.get('comic_flatten_comicinfo') %}
+      <input type="checkbox" id="comic_flatten_comicinfo" name="comic_flatten_comicinfo" value="True" checked style="accent-color: var(--color-secondary);" data-toggle="tooltip" data-placement="right" title="Does NOT require restart for changes to take effect">
+      {% else %}
+      <input type="checkbox" id="comic_flatten_comicinfo" name="comic_flatten_comicinfo" value="True" style="accent-color: var(--color-secondary);" data-toggle="tooltip" data-placement="right" title="Does NOT require restart for changes to take effect">
+      {% endif %}
+      <label for="comic_flatten_comicinfo" style="padding-left: 10px;">{{_('Move a misplaced ComicInfo.xml to the archive root on ingest')}}</label><br>
+      <p class="cwa-settings-tooltip">
+        {{_("The ComicInfo.xml standard requires the file to sit at the root of the archive; comicapi (and every other reader we're aware of) only looks there. Some real-world .cbz releases package it one folder down instead, so their title/series/author/publisher never get picked up. When enabled, ingest rewrites a copy of the archive with ComicInfo.xml moved to the root before it's imported — only when it's present but misplaced, never touching an already-correct file. Zip-based archives (.cbz) only; .cbr/.cb7/.cbt are not zip containers and are left as-is. Your original download is never modified, only the copy that gets imported.")}}
+      </p>
+
       {% if cwa_settings['archived_cleanup_enabled'] %}
       <input type="checkbox" id="archived_cleanup_enabled" name="archived_cleanup_enabled" value="True" checked style="accent-color: var(--color-secondary);" data-toggle="tooltip" data-placement="right" title="Runs daily by default">
       {% else %}

--- a/scripts/cwa_schema.sql
+++ b/scripts/cwa_schema.sql
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS cwa_settings(
     auto_metadata_enforcement SMALLINT DEFAULT 1 NOT NULL,
     kindle_epub_fixer SMALLINT DEFAULT 1 NOT NULL,
     kindle_epub_fixer_aggressive SMALLINT DEFAULT 0 NOT NULL,
+    comic_flatten_comicinfo SMALLINT DEFAULT 0 NOT NULL,
     koreader_sync_enabled SMALLINT DEFAULT 0 NOT NULL,
     auto_backup_epub_fixes SMALLINT DEFAULT 1 NOT NULL,
     archived_cleanup_enabled SMALLINT DEFAULT 1 NOT NULL,

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -156,6 +156,7 @@ TaskAutoSend = None
 WorkerThread = None
 _ub = None
 _uploader = None
+comic = None
 CWA_DB = None
 EPUBFixer = None
 audiobook = None
@@ -325,7 +326,7 @@ def _load_runtime_dependencies() -> None:
 
 def _load_optional_cps_modules() -> None:
     global _GDRIVE_AVAILABLE, _CPS_AVAILABLE
-    global _gdriveutils, _cps_config, fetch_and_apply_metadata, TaskAutoSend, WorkerThread, _ub, _uploader
+    global _gdriveutils, _cps_config, fetch_and_apply_metadata, TaskAutoSend, WorkerThread, _ub, _uploader, comic
 
     if _GDRIVE_AVAILABLE and _CPS_AVAILABLE:
         return
@@ -358,6 +359,7 @@ def _load_optional_cps_modules() -> None:
             from cps.services.worker import WorkerThread as LoadedWorkerThread
             from cps import ub as loaded_ub
             from cps import uploader as loaded_uploader
+            from cps import comic as loaded_comic
             from cps.calibre_init import init_calibre_db_from_app_db
             init_calibre_db_from_app_db(get_app_db_path())
             fetch_and_apply_metadata = loaded_fetch_and_apply_metadata
@@ -365,6 +367,7 @@ def _load_optional_cps_modules() -> None:
             WorkerThread = LoadedWorkerThread
             _ub = loaded_ub
             _uploader = loaded_uploader
+            comic = loaded_comic
             _CPS_AVAILABLE = True
             print("[ingest-processor] Auto-send and metadata functionality available", flush=True)
         except ImportError as e:
@@ -374,6 +377,7 @@ def _load_optional_cps_modules() -> None:
             WorkerThread = None
             _ub = None
             _uploader = None
+            comic = None
             _CPS_AVAILABLE = False
 
     except Exception as e:
@@ -1085,6 +1089,7 @@ class NewBookProcessor:
         self.convert_ignored_formats = _normalize_format_list(self.cwa_settings['auto_convert_ignored_formats'])
         self.convert_retained_formats = _normalize_format_list(self.cwa_settings.get('auto_convert_retained_formats', []))
         self.is_kindle_epub_fixer = self.cwa_settings['kindle_epub_fixer']
+        self.is_comic_flatten_comicinfo = self.cwa_settings.get('comic_flatten_comicinfo', 0)
 
         # Formats
         self.supported_book_formats = {
@@ -1762,6 +1767,15 @@ class NewBookProcessor:
             print(f"[ingest-processor] ERROR: Failed to stage file for import: {e}", flush=True)
             self.backup(self.filepath, backup_type="failed")
             return
+
+        if getattr(self, "is_comic_flatten_comicinfo", False) and comic is not None and staged_path.suffix.lower() == ".cbz":
+            try:
+                if comic.flatten_comicinfo_to_root(str(staged_path)):
+                    print(f"[ingest-processor] Moved a misplaced ComicInfo.xml to the "
+                          f"archive root: {staged_path.name}", flush=True)
+            except Exception as e:
+                print(f"[ingest-processor] WARN: Could not flatten ComicInfo.xml for "
+                      f"{staged_path.name}, importing as-is: {e}", flush=True)
 
         try:
             mark_ingest_batch_active()

--- a/tests/unit/test_1697_comicinfo_root_flatten.py
+++ b/tests/unit/test_1697_comicinfo_root_flatten.py
@@ -1,0 +1,229 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for fork issue #1697: comic auto-ingest can't read
+ComicInfo.xml when it's nested instead of sitting at the archive root.
+
+Root cause: comicapi's ``ComicArchive.has_cix()`` does
+``self.ci_xml_filename in self.archiver.get_filename_list()`` - an exact
+match against the bare string ``"ComicInfo.xml"``. A zip's file list keeps
+full internal paths, so this only ever matches a true root-level entry.
+Some real-world scan-group .cbz releases package ``ComicInfo.xml`` one
+folder down alongside the pages (confirmed against a live MyAnonamouse
+release, "Amazing Fantasy 015 - Facsimile Edition (1962)") - for those,
+``has_cix()`` silently returns False and the book gets no metadata from a
+file that genuinely carries some.
+
+This matches the documented ComicInfo.xml spec (root-only) and the same
+behavior in ComicTagger (comicapi's own parent project) and Komga - the
+file is technically out of spec, not comicapi being wrong. So the fix
+isn't to make detection more lenient (that would make CWA quietly diverge
+from every other reader); it's to fix the file. ``cps/comic.py``'s new
+``flatten_comicinfo_to_root()`` rewrites a copy of a .cbz with a misplaced
+ComicInfo.xml moved to the root - the same manual fix the ComicTagger
+community already recommends for this exact situation, just automated.
+Zip-based archives only (.cbz); .cbr/.cb7/.cbt aren't zip containers and
+there's no free Python RAR writer, so those are left untouched.
+
+Gated behind the new ``comic_flatten_comicinfo`` ingest setting (default
+off) - it rewrites a file, however narrowly scoped, so it's opt-in.
+``scripts/ingest_processor.py`` only ever calls it on the *staged copy*
+made by ``add_book_to_library`` (after ``shutil.copy2``), never the
+original - the source file (which may still be hardlinked elsewhere, e.g.
+a seeding torrent or another app's own library copy) is never touched.
+"""
+
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = str(REPO_ROOT / "scripts")
+
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import cps  # noqa: E402,F401  (registers application MIME types)
+from cps import comic  # noqa: E402
+import ingest_processor  # noqa: E402
+
+_COMIC_INFO = """<?xml version="1.0"?>
+<ComicInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Series>Test Fixture Series</Series>
+  <Number>7</Number>
+  <Publisher>Fixture Comics</Publisher>
+</ComicInfo>
+"""
+
+
+def _build_cbz(path, entries):
+    """entries: dict of {archive-internal-path: bytes-or-str}."""
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+
+
+def test_nested_comicinfo_is_moved_to_root(tmp_path):
+    """The reporter's exact case: ComicInfo.xml one folder down, alongside
+    the pages, must end up at the true archive root - RED on main, where
+    this function doesn't exist."""
+    path = tmp_path / "nested.cbz"
+    _build_cbz(path, {
+        "Some Series (2020)/page001.jpg": b"not a real jpeg, just needs to exist",
+        "Some Series (2020)/ComicInfo.xml": _COMIC_INFO,
+    })
+
+    changed = comic.flatten_comicinfo_to_root(str(path))
+
+    assert changed is True
+    with zipfile.ZipFile(path) as zf:
+        names = zf.namelist()
+        assert "ComicInfo.xml" in names
+        assert "Some Series (2020)/ComicInfo.xml" not in names
+        assert "Some Series (2020)/page001.jpg" in names  # untouched
+        assert zf.read("ComicInfo.xml").decode() == _COMIC_INFO
+
+
+def test_root_comicinfo_is_left_alone(tmp_path):
+    """Already correct -> no-op, and the archive isn't touched at all
+    (checked via mtime, not just the return value)."""
+    path = tmp_path / "already_root.cbz"
+    _build_cbz(path, {
+        "page001.jpg": b"page",
+        "ComicInfo.xml": _COMIC_INFO,
+    })
+    mtime_before = path.stat().st_mtime_ns
+
+    changed = comic.flatten_comicinfo_to_root(str(path))
+
+    assert changed is False
+    assert path.stat().st_mtime_ns == mtime_before
+
+
+def test_no_comicinfo_at_all_is_a_noop(tmp_path):
+    path = tmp_path / "untagged.cbz"
+    _build_cbz(path, {"page001.jpg": b"page"})
+
+    assert comic.flatten_comicinfo_to_root(str(path)) is False
+
+
+def test_non_zip_archive_is_a_noop(tmp_path):
+    """.cbr/.cb7/.cbt aren't zip containers; must degrade to a no-op
+    rather than raising on a file zipfile can't open."""
+    path = tmp_path / "not_a_zip.cbr"
+    path.write_bytes(b"Rar!\x1a\x07\x01\x00" + b"not really a rar either")
+
+    assert comic.flatten_comicinfo_to_root(str(path)) is False
+
+
+def test_flattened_archive_is_valid_and_complete(tmp_path):
+    """The rewrite must not corrupt or drop any other entry - checked with
+    zipfile's own integrity check, not just namelist membership."""
+    path = tmp_path / "multi_page.cbz"
+    entries = {f"Sub/page{i:03d}.jpg": f"page {i}".encode() for i in range(1, 6)}
+    entries["Sub/ComicInfo.xml"] = _COMIC_INFO
+    _build_cbz(path, entries)
+
+    comic.flatten_comicinfo_to_root(str(path))
+
+    with zipfile.ZipFile(path) as zf:
+        assert zf.testzip() is None
+        assert len(zf.namelist()) == len(entries)
+        for i in range(1, 6):
+            assert zf.read(f"Sub/page{i:03d}.jpg") == f"page {i}".encode()
+
+
+def test_flattening_twice_is_idempotent(tmp_path):
+    path = tmp_path / "nested.cbz"
+    _build_cbz(path, {
+        "Sub/page001.jpg": b"page",
+        "Sub/ComicInfo.xml": _COMIC_INFO,
+    })
+
+    first = comic.flatten_comicinfo_to_root(str(path))
+    second = comic.flatten_comicinfo_to_root(str(path))
+
+    assert first is True
+    assert second is False
+
+
+def test_flattening_makes_comicapi_find_the_metadata(tmp_path):
+    """End-to-end: comicapi's own has_metadata/read_metadata must actually
+    pick up the fixed archive, not just our namelist check."""
+    comicapi = pytest.importorskip("comicapi.comicarchive")
+    path = tmp_path / "nested.cbz"
+    _build_cbz(path, {
+        "Sub/page001.jpg": b"page",
+        "Sub/ComicInfo.xml": _COMIC_INFO,
+    })
+
+    archive = comicapi.ComicArchive(str(path))
+    assert archive.has_metadata(comicapi.MetaDataStyle.CIX) is False  # RED without the fix
+
+    comic.flatten_comicinfo_to_root(str(path))
+
+    archive = comicapi.ComicArchive(str(path))  # fresh instance, no cached state
+    assert archive.has_metadata(comicapi.MetaDataStyle.CIX) is True
+    md = archive.read_metadata(comicapi.MetaDataStyle.CIX)
+    assert md.series == "Test Fixture Series"
+    assert md.publisher == "Fixture Comics"
+
+
+def test_ingest_setting_defaults_off():
+    """A file-rewriting feature, however narrowly scoped, should be opt-in
+    - source-pin against the schema default drifting to on."""
+    schema_path = REPO_ROOT / "scripts" / "cwa_schema.sql"
+    schema = schema_path.read_text()
+    assert "comic_flatten_comicinfo SMALLINT DEFAULT 0 NOT NULL" in schema
+
+
+def test_ingest_only_flattens_staged_copy_not_the_original():
+    """Source-pin: the flatten call must happen after staging (the
+    shutil.copy2 that isolates the working copy from the original,
+    possibly-hardlinked-elsewhere file), not before."""
+    import inspect
+
+    src = inspect.getsource(ingest_processor.NewBookProcessor.add_book_to_library)
+    stage_idx = src.index("shutil.copy2(source_path, staged_path)")
+    flatten_idx = src.index("comic.flatten_comicinfo_to_root(str(staged_path))")
+    assert flatten_idx > stage_idx, (
+        "flatten_comicinfo_to_root must run on the staged copy, after "
+        "shutil.copy2 - never on the original source file"
+    )
+    # And it must be gated on the setting, not unconditional.
+    window = src[max(0, flatten_idx - 200):flatten_idx]
+    assert "is_comic_flatten_comicinfo" in window
+
+
+def test_ingest_setting_read_from_cwa_settings():
+    import inspect
+
+    src = inspect.getsource(ingest_processor.NewBookProcessor.__init__)
+    assert "self.is_comic_flatten_comicinfo = self.cwa_settings.get('comic_flatten_comicinfo'" in src
+
+
+def test_missing_attribute_on_a_bare_processor_does_not_raise():
+    """tests/unit/test_ingest_batch_dirty.py builds NewBookProcessor via
+    object.__new__() and sets only a handful of attributes by hand,
+    bypassing __init__ entirely - a pattern already in use elsewhere in
+    this suite, not something to work around. The comic-flatten check must
+    degrade to "disabled" via getattr, not raise AttributeError, when
+    is_comic_flatten_comicinfo was never set. Caught live: an early
+    version of this fix used a bare self.is_comic_flatten_comicinfo access
+    and broke exactly that test file's full-suite run (passed every time
+    in isolation, only failed as part of the complete suite - the
+    difference was never test order, it was this file's own bug)."""
+    import inspect
+
+    src = inspect.getsource(ingest_processor.NewBookProcessor.add_book_to_library)
+    assert 'getattr(self, "is_comic_flatten_comicinfo", False)' in src, (
+        "must use getattr with a default, not a bare attribute access, so "
+        "a processor built without __init__ (object.__new__, as an "
+        "existing test in this suite does) doesn't raise"
+    )


### PR DESCRIPTION
Fixes #1697.

comicapi's `has_cix()`/`read_cix()` match the bare string `"ComicInfo.xml"` against the archive's file list, which only matches a root-level entry. Some real .cbz releases nest it in a subfolder instead, so `has_metadata()` returns False and the book gets no metadata even though the file has some.

Checked ComicTagger (comicapi's parent project) and Komga - both have the same root-only requirement, it's the spec, not a comicapi bug. So the fix is to fix the file, the way the ComicTagger community already does by hand: move it to root.

`cps/comic.py`: `flatten_comicinfo_to_root()` rewrites a .cbz with a nested `ComicInfo.xml` promoted to root, everything else preserved. No-ops if already at root, absent, or not a zip - `.cbr`/`.cb7`/`.cbt` aren't zip containers and there's no free Python RAR writer, so those aren't handled.

New setting `comic_flatten_comicinfo`, off by default since it rewrites a file. Only ever applied to the staged copy in `add_book_to_library` (after `shutil.copy2`), never the original, since the source may still be hardlinked elsewhere.

Tests in `tests/unit/test_1697_comicinfo_root_flatten.py`. RED on main, green with the fix, full `unit` suite diffed patched vs unpatched with no new failures.

CHANGELOG entry under Unreleased.
