### PR TITLE
docs: disclose how AI is used in this project (#1631)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Library, settings, users, OAuth tokens, and KOReader sync state are preserved. S
 - **New here?** See [Quick start](#quick-start) below.
 - **Want to back the work?** [**Sponsor on GitHub**](https://github.com/sponsors/new-usemame) — no rewards, no paywalled features, one-time or monthly. [Here's what it actually pays for.](#supporting-the-project)
 - **Setting up with an AI assistant** (Claude, ChatGPT, etc.)? Point it at [`AI_README.md`](AI_README.md) — a setup guide written for the assistant to follow, verify, and hand back to you working.
+- **Wondering how AI is used here?** [`docs/AI-USAGE.md`](docs/AI-USAGE.md) — used heavily to develop this fork, not at all in the software you run, and what gates it.
 
 ---
 

--- a/docs/AI-USAGE.md
+++ b/docs/AI-USAGE.md
@@ -1,0 +1,56 @@
+# How AI is used in this project
+
+Asked for in [#1631](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1631). It's a fair
+question and it deserves a permanent answer rather than a reply buried in a thread.
+
+**Short version: AI is used heavily to develop this fork, and not at all in the software you run.**
+
+## In the software you run: none
+
+- No AI or LLM dependency in `requirements.txt` or `optional-requirements.txt`.
+- No inference API is called from anywhere in `cps/`.
+- No telemetry, and no AI feature.
+
+Your library, your metadata and your reading data are not sent to a model by this application. You
+can check this yourself — those are two files and one directory, and the repository is public.
+
+## In development: most of it
+
+- **Tracker automation.** Intake acknowledgements, labelling and follow-up nudges are posted by
+  automation. They carry an HTML marker such as `<!-- cwng:intake-ack -->` in the comment source, so
+  you can always tell one from a written reply.
+- **Patches and tests.** The majority of this fork's own fixes are written by an AI assistant
+  working from a written brief, including the regression tests that accompany them.
+- **Bookkeeping.** Upstream backports, changelog entries, release notes and translation refreshes.
+- **Issue replies.** Substantive replies are drafted the same way, from the actual code, and go out
+  under the maintainer's name because the maintainer owns what they say.
+
+## What gates it
+
+Not "a human reads every line" — that would be the untrue version of this page. The actual gates:
+
+1. **Full CI on the change's own head** — unit tests, Docker integration tests, frontend build.
+2. **A regression test that is verified to fail without the fix.** Not merely one that passes with
+   it. This is the check an AI cannot satisfy by being confident, which is why it is the one relied
+   on most.
+3. **A human merges anything from an outside contributor.** Community PRs are never merged
+   automatically, regardless of how green they are.
+4. **A human merges anything that adds a dependency, changes a licence, or introduces an external
+   service URL.** Automation is not permitted to do any of those.
+5. Anything that cannot meet the above is labelled `needs-review` and waits for a person.
+
+## Where this has failed
+
+v4.1.37 shipped a startup repair task that could never finish, which put some users into a container
+restart loop ([#1696](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1696)). It was found
+by a user, not by the process. The fix for it was itself sent back once by an independent review
+pass that found the completion marker could silently fail to save.
+
+That is the honest shape of the risk: this process catches a great deal and it does not catch
+everything. Patch releases stay small and `:vX.Y.Z` tags are immutable so you can pin or roll back,
+and reports like #1696 are why regressions get found at all.
+
+## Verifying any of this
+
+The repository is public, every merge is a squash commit naming its PR, and CI runs are public. If
+something here stops being accurate, that is a bug in this page — please open an issue.


### PR DESCRIPTION
Answers #1631, which asked how AI is used in this repo and noted — fairly — that the lack of any disclosure is itself a signal.

There was nothing written down. `AI_README.md` is a setup guide written *for* an assistant to follow; it says nothing about how the project is developed. `CONTRIBUTING.md` refers to "the autopilot script" in passing and never explains it. `GOVERNANCE.md` doesn't mention it at all.

`docs/AI-USAGE.md` states:

- **Nothing in the shipped software.** No AI/LLM dependency in `requirements.txt` or `optional-requirements.txt`, no inference endpoint anywhere in `cps/`, no telemetry. Verified by grep before writing the claim, and phrased so a reader can check it in two files and one directory.
- **Most of development.** Tracker automation (with the `<!-- cwng:intake-ack -->` marker named so anyone can tell an automated comment from a written one), patches and their regression tests, release bookkeeping, and issue replies.
- **The actual gates** — deliberately including the part that isn't flattering: a human does *not* read every line. What is true is full CI on the change's own head, a regression test verified to fail without the fix, and a human merge for anything from an outside contributor or anything touching dependencies/licences/external URLs.
- **Where it has failed**, by name: v4.1.37's non-converging startup task (#1696), found by a user rather than by the process.

Linked from the README next to the existing `AI_README.md` line.

Docs only — no code, no dependency, no external service URL. The one external link added is to the project's own issue tracker.
