### PR TITLE
fix(kobo): strip redundant TOC fragments so highlights render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,11 @@ is for things you can see or feel when running the app.
   books. Where the anchor sits at the very top of the chapter it points at it
   says nothing the file path does not already say, so conversion now drops it:
   517 such targets across 25 of those books, with every table-of-contents entry
-  kept exactly as it was. Chapter files themselves are not rewritten, so
-  highlights you already hold keep their positions. Two honest limits: a table of
+  kept exactly as it was. Chapter files themselves are left byte-for-byte
+  alone, so highlights you already hold keep their positions. In a few books the
+  contents page is part of the reading order and so is rewritten too — five of
+  the twenty-five here — but only its links change, and it carries none of the
+  markers a highlight attaches to. Two honest limits: a table of
   contents that points genuinely into the middle of a file — several chapters
   packed into one document, common in Project Gutenberg editions — still needs
   those files split, which is not part of this change; and highlights already

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ is for things you can see or feel when running the app.
   books. Where the anchor sits at the very top of the chapter it points at it
   says nothing the file path does not already say, so conversion now drops it:
   517 such targets across 25 of those books, with every table-of-contents entry
-  kept exactly as it was. Chapter files themselves are left byte-for-byte
+  kept exactly as it was. Books already in your library are repaired on the first
+  restart after upgrading, not only newly converted ones — each one is copied and
+  hash-checked before it is touched. Chapter files themselves are left byte-for-byte
   alone, so highlights you already hold keep their positions. In a few books the
   contents page is part of the reading order and so is rewritten too — five of
   the twenty-five here — but only its links change, and it carries none of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,15 @@ is for things you can see or feel when running the app.
   alone, so highlights you already hold keep their positions. In a few books the
   contents page is part of the reading order and so is rewritten too — five of
   the twenty-five here — but only its links change, and it carries none of the
-  markers a highlight attaches to. Two honest limits: a table of
-  contents that points genuinely into the middle of a file — several chapters
-  packed into one document, common in Project Gutenberg editions — still needs
-  those files split, which is not part of this change; and highlights already
-  stored under the unmatched name stay invisible, because this stops new ones
-  being filed that way rather than repairing old ones.
+  markers a highlight attaches to. **Highlights you already made in an affected
+  book come back, too** — once your reader downloads the repaired book it files
+  them under the corrected name and draws them again. Measured on a Kobo Clara BW
+  (firmware 4.45.23792): a highlight that matched no chapter on the device before
+  the repair matched exactly one after it, and appears on the page. Your reader
+  picks the repaired book up the next time it syncs and you open it. One honest
+  limit remains: a table of contents that points genuinely into the middle of a
+  file — several chapters packed into one document, common in Project Gutenberg
+  editions — still needs those files split, which is not part of this change.
 - **The log no longer overstates how many books cannot show highlights.** The
   warning added in v4.1.37 counted page-number anchors alongside real chapter
   entries, reporting 12,862 affected targets on a library whose true count is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Highlights made on a Kobo now appear in more books.** When a book's table of
+  contents points *into* a chapter file rather than at the file itself —
+  `chapter.xhtml#ch1` rather than `chapter.xhtml` — a Kobo files every highlight
+  you make in that chapter under a name nothing on the device answers to, so the
+  marks are saved and drawn nowhere. Nothing looks wrong and no error appears;
+  the highlights simply never show up. On one 212-book library this affected 57
+  books. Where the anchor sits at the very top of the chapter it points at it
+  says nothing the file path does not already say, so conversion now drops it:
+  517 such targets across 25 of those books, with every table-of-contents entry
+  kept exactly as it was. Chapter files themselves are not rewritten, so
+  highlights you already hold keep their positions. Two honest limits: a table of
+  contents that points genuinely into the middle of a file — several chapters
+  packed into one document, common in Project Gutenberg editions — still needs
+  those files split, which is not part of this change; and highlights already
+  stored under the unmatched name stay invisible, because this stops new ones
+  being filed that way rather than repairing old ones.
+- **The log no longer overstates how many books cannot show highlights.** The
+  warning added in v4.1.37 counted page-number anchors alongside real chapter
+  entries, reporting 12,862 affected targets on a library whose true count is
+  1,821, and 516 for one book whose table of contents has 63 chapters. It now
+  counts only the entries a Kobo actually derives chapter identity from.
+
 ## [v4.1.38] - 2026-08-17
 
 ### Added

--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -78,9 +78,10 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
   `object`/`iframe`/`embed`/`canvas`/`table`. 690 targets qualify, fully fixing
   15 books; verified across the real 212-book library at 25 books rewritten and
   517 targets stripped with every non-TOC member byte-identical, no navMap
-  collapse, and a byte-identical second pass. Spine documents are never
-  rewritten, so KoboSpan ids do not move and existing highlights keep their
-  anchors. A document or TOC that will not parse fails only the redundancy
+  collapse, and a byte-identical second pass. Non-TOC spine documents are
+  byte-identical; the five books that declare the EPUB3 nav in the spine change
+  only `href` values there and carry zero KoboSpan ids, so ids never move and
+  existing highlights keep their anchors. A document or TOC that will not parse fails only the redundancy
   proof — the target is left alone and unrelated relocation work still runs —
   which keeps HTML-ish EPUBs (unclosed `<meta>`, 7 books in the library) at
   `clean` instead of regressing them to a `retryable` repair loop. Also narrows
@@ -89,7 +90,9 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
   where the true count is 1,821. Not covered: a TOC anchoring genuinely
   mid-document (several chapters per file), which needs spine splitting and a
   re-anchoring migration story — 1,126 targets across 40 books, tracked
-  separately. 21 tests in `tests/unit/test_1657_kepub_toc_fragments.py`.
+  separately. 46 tests in `tests/unit/test_1657_kepub_toc_fragments.py`, plus
+  probe/normalize convergence coverage in
+  `tests/unit/test_1696_kepub_repair_convergence.py`.
 
 - **RTL metadata renders right-to-left in both UIs** (fork #1073) — there was no
   `dir` attribute anywhere in the SPA or the classic templates, so Arabic,

--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -61,6 +61,36 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
 
 ### Bug fixes
 
+- **Kobo highlights render in books whose TOC anchors into a chapter file**
+  (fork #1657) — Kobo draws a `Bookmark` only when `Bookmark.ContentID` exactly
+  equals a `content` row with `ContentType=9`, and it derives that id from the
+  TOC entry verbatim, fragment included. A TOC pointing at
+  `chapter.xhtml#ch1` therefore files every highlight in that chapter under an
+  id no spine row matches, and the marks are stored but never drawn. Measured on
+  a Kobo Libra Colour: 810 of 3,016 bookmarks orphaned, perfect correlation
+  (fragment present → orphaned, absent → anchored) with the Odyssey as a
+  400/400 clean control, and 810/810 exact-matching once the fragment is
+  stripped. 57 of 212 books in the reference library carry fragment-anchored
+  navMap targets. `cps/services/kepub_package_normalizer.py` now strips a TOC
+  fragment during conversion when it is provably redundant: exactly one distinct
+  fragment targets that document, the anchor exists, and nothing rendered
+  precedes it — no non-whitespace text and no `img`/`svg`/`video`/`audio`/
+  `object`/`iframe`/`embed`/`canvas`/`table`. 690 targets qualify, fully fixing
+  15 books; verified across the real 212-book library at 25 books rewritten and
+  517 targets stripped with every non-TOC member byte-identical, no navMap
+  collapse, and a byte-identical second pass. Spine documents are never
+  rewritten, so KoboSpan ids do not move and existing highlights keep their
+  anchors. A document or TOC that will not parse fails only the redundancy
+  proof — the target is left alone and unrelated relocation work still runs —
+  which keeps HTML-ish EPUBs (unclosed `<meta>`, 7 books in the library) at
+  `clean` instead of regressing them to a `retryable` repair loop. Also narrows
+  `count_fragment_anchored_toc_targets` to navMap/`epub:type="toc"` targets; it
+  had counted Gutenberg `pageList` page anchors, reporting 12,862 library-wide
+  where the true count is 1,821. Not covered: a TOC anchoring genuinely
+  mid-document (several chapters per file), which needs spine splitting and a
+  re-anchoring migration story — 1,126 targets across 40 books, tracked
+  separately. 21 tests in `tests/unit/test_1657_kepub_toc_fragments.py`.
+
 - **RTL metadata renders right-to-left in both UIs** (fork #1073) — there was no
   `dir` attribute anywhere in the SPA or the classic templates, so Arabic,
   Hebrew and Farsi titles, authors, series and descriptions inherited the

--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -87,7 +87,13 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
   `clean` instead of regressing them to a `retryable` repair loop. Also narrows
   `count_fragment_anchored_toc_targets` to navMap/`epub:type="toc"` targets; it
   had counted Gutenberg `pageList` page anchors, reporting 12,862 library-wide
-  where the true count is 1,821. Not covered: a TOC anchoring genuinely
+  where the true count is 1,821. Verified end-to-end on a Kobo Clara BW
+  (4.45.23792) through the real sync path: a highlight made in an unrepaired
+  fragment-anchored book stored a `ContentID` carrying `#` that matched 0
+  `ContentType=9` rows and did not render; after the server repaired the book and
+  the device re-downloaded it, the same highlight matched exactly 1 and is drawn
+  on the page, with no bookmark rows lost. Existing highlights are therefore
+  repaired, not merely prevented. Not covered: a TOC anchoring genuinely
   mid-document (several chapters per file), which needs spine splitting and a
   re-anchoring migration story — 1,126 targets across 40 books, tracked
   separately. 46 tests in `tests/unit/test_1657_kepub_toc_fragments.py`, plus

--- a/cps/services/kepub_package_normalizer.py
+++ b/cps/services/kepub_package_normalizer.py
@@ -485,6 +485,24 @@ def count_fragment_anchored_toc_targets(path):
     Return zero when the archive or package document cannot be inspected.
     Malformed individual TOCs are logged and skipped. This diagnostic never
     modifies the EPUB and never lets user-file failures escape into conversion.
+
+    This counts books AT RISK, not annotations actually affected, and that is
+    not a shortcut -- it is the only server-side signal that exists. The device
+    derives its local ``Bookmark.ContentID`` from the TOC entry verbatim,
+    fragment included, and that value never crosses the wire. OBSERVED
+    2026-08-17 on a Kobo Clara BW (4.45.23792): a highlight whose device-local
+    ContentID ended ``...-h-3.htm.xhtml#pgepubid00038`` was uploaded with
+
+        {"span": {"chapterFilename": "OEBPS/...-h-3.htm.xhtml", ...}}
+
+    -- no fragment. The only ``#`` in the payload are the KoboSpan anchors in
+    ``startPath``/``endPath``, which are unrelated. So the stored annotation is
+    correct and always was: on this instance 0 of 622 rows carry a fragment.
+
+    Do not go looking for a query that counts orphaned annotations, and do not
+    "fix" ingestion to preserve a fragment it never receives. Whether a given
+    annotation renders is decidable only on the device, by checking its
+    ContentID against a ``ContentType=9`` row in ``KoboReader.sqlite``.
     """
     path = os.fspath(path)
     try:

--- a/cps/services/kepub_package_normalizer.py
+++ b/cps/services/kepub_package_normalizer.py
@@ -279,11 +279,27 @@ def _xml_start_tag_ranges(source):
         bracket_depth = 0
         cursor = start + 2 if closing or declaration else start + 1
         while cursor < length:
-            byte = source[cursor]
             if quote_byte is not None:
-                if byte == quote_byte:
+                if source[cursor] == quote_byte:
                     quote_byte = None
-            elif byte in (ord("'"), ord('"')):
+                cursor += 1
+                continue
+            # Comments and processing instructions inside a DOCTYPE internal
+            # subset may contain bracket characters and text shaped like start
+            # tags. Skip them as lexical units so they cannot change the subset
+            # depth or this scanner's element numbering relative to lxml's. A
+            # desync makes an edit land on the wrong element, which validation
+            # then rejects on every repair attempt instead of converging.
+            if declaration and source.startswith(b"<!--", cursor):
+                comment_end = source.find(b"-->", cursor + 4)
+                cursor = length if comment_end < 0 else comment_end + 3
+                continue
+            if declaration and source.startswith(b"<?", cursor):
+                instruction_end = source.find(b"?>", cursor + 2)
+                cursor = length if instruction_end < 0 else instruction_end + 2
+                continue
+            byte = source[cursor]
+            if byte in (ord("'"), ord('"')):
                 quote_byte = byte
             elif declaration and byte == ord("["):
                 bracket_depth += 1

--- a/cps/services/kepub_package_normalizer.py
+++ b/cps/services/kepub_package_normalizer.py
@@ -77,6 +77,11 @@ MAX_TOTAL_UNCOMPRESSED_BYTES = 256 * 1024 * 1024
 MAX_CONTAINER_XML_BYTES = 1 * 1024 * 1024
 MAX_PACKAGE_DOCUMENT_BYTES = 16 * 1024 * 1024
 MAX_TOC_DOCUMENT_BYTES = 16 * 1024 * 1024
+MAX_CONTENT_DOCUMENT_BYTES = 16 * 1024 * 1024
+
+_RENDERED_PREDECESSOR_ELEMENTS = frozenset({
+    "audio", "canvas", "embed", "iframe", "img", "object", "svg", "table", "video",
+})
 
 
 def _reject_oversized_archive(infos):
@@ -154,10 +159,14 @@ def _toc_documents(opf_path, opf_bytes):
         yield toc_path, kind
 
 
-def _toc_targets(toc_bytes, kind):
-    document = etree.fromstring(toc_bytes, parser=_XML_PARSER)
+def _toc_target_elements(document, kind):
     if kind == "NCX":
-        return document.xpath("//*[local-name()='content']/@src")
+        return [
+            (element, "src")
+            for nav_map in document.xpath("//*[local-name()='navMap']")
+            for element in nav_map.xpath(
+                ".//*[local-name()='navPoint']/*[local-name()='content'][@src]")
+        ]
 
     targets = []
     for nav in document.xpath("//*[local-name()='nav']"):
@@ -166,8 +175,144 @@ def _toc_targets(toc_bytes, kind):
             epub_types.update(value.split())
         roles = set(nav.get("role", "").split())
         if "toc" in epub_types or "doc-toc" in roles:
-            targets.extend(nav.xpath(".//*[local-name()='a']/@href"))
+            targets.extend(
+                (element, "href")
+                for element in nav.xpath(".//*[local-name()='a'][@href]")
+            )
     return targets
+
+
+def _toc_targets(toc_bytes, kind):
+    document = etree.fromstring(toc_bytes, parser=_XML_PARSER)
+    return [element.get(attribute)
+            for element, attribute in _toc_target_elements(document, kind)]
+
+
+def _contained_toc_target(toc_path, value):
+    split = _split_local_reference(value)
+    if split is None:
+        return None
+    parts, target_path = split
+    resolved_path = _resolve_reference(toc_path, target_path)
+    if resolved_path == ".." or resolved_path.startswith("../") or resolved_path.startswith("/"):
+        raise UnsupportedKepubPackage("EPUB TOC target escapes the archive")
+    return parts, resolved_path
+
+
+def _element_local_name(element):
+    if not isinstance(element.tag, str):
+        return ""
+    return etree.QName(element).localname.lower()
+
+
+def _anchor_is_first_rendered_position(document_bytes, fragment):
+    """Whether ``fragment`` starts before any rendered body content.
+
+    The traversal stops at the matching element's start tag. Consequently an
+    anchor's own content and the tails of its ancestors are correctly excluded:
+    all of those render at or after the target position, never before it.
+    """
+    document = etree.fromstring(document_bytes, parser=_XML_PARSER)
+    bodies = document.xpath("//*[local-name()='body']")
+    if not bodies:
+        return False
+    body = bodies[0]
+
+    def visit(element):
+        if element.get("id") == fragment or element.get("name") == fragment:
+            return 1  # found before any disqualifying predecessor
+        if (element is not body
+                and _element_local_name(element) in _RENDERED_PREDECESSOR_ELEMENTS):
+            return -1
+        if element.text and element.text.strip():
+            return -1
+        for child in element:
+            result = visit(child)
+            if result:
+                return result
+            if child.tail and child.tail.strip():
+                return -1
+        return 0
+
+    return visit(body) == 1
+
+
+def _serialize_xml_like_source(document, source_bytes):
+    return etree.tostring(
+        document.getroottree(),
+        encoding="utf-8",
+        xml_declaration=source_bytes.lstrip().startswith(b"<?xml"),
+    )
+
+
+def _plan_toc_fragment_rewrites(archive, opf_path, opf_bytes):
+    """Return TOC-member replacements for provably redundant fragments."""
+    parsed_tocs = {}
+    fragment_targets = []
+    for toc_path, kind in _toc_documents(opf_path, opf_bytes):
+        key = (toc_path, kind)
+        if key in parsed_tocs:
+            continue
+        toc_bytes = _read_bounded_member(
+            archive, toc_path, MAX_TOC_DOCUMENT_BYTES,
+            "{} TOC document".format(kind))
+        document = etree.fromstring(toc_bytes, parser=_XML_PARSER)
+        parsed_tocs[key] = (document, toc_bytes)
+        for element, attribute in _toc_target_elements(document, kind):
+            target = _contained_toc_target(toc_path, element.get(attribute))
+            if target is None:
+                continue
+            parts, resolved_path = target
+            if parts.fragment:
+                fragment_targets.append(
+                    (toc_path, element, attribute, parts, resolved_path,
+                     unquote(parts.fragment)))
+
+    fragments_by_document = {}
+    for _toc_path, _element, _attribute, _parts, resolved_path, fragment in fragment_targets:
+        fragments_by_document.setdefault(resolved_path, set()).add(fragment)
+
+    content_cache = {}
+    changed_tocs = set()
+    archive_names = set(archive.namelist())
+    for toc_path, element, attribute, parts, resolved_path, fragment in fragment_targets:
+        if len(fragments_by_document[resolved_path]) != 1:
+            continue
+        if resolved_path not in archive_names:
+            continue
+        if resolved_path not in content_cache:
+            content_cache[resolved_path] = _read_bounded_member(
+                archive, resolved_path, MAX_CONTENT_DOCUMENT_BYTES,
+                "TOC target document")
+        if not _anchor_is_first_rendered_position(content_cache[resolved_path], fragment):
+            continue
+        element.set(attribute, urlunsplit(parts._replace(fragment="")))
+        changed_tocs.add(toc_path)
+
+    rewrites = {}
+    for (toc_path, _kind), (document, toc_bytes) in parsed_tocs.items():
+        if toc_path in changed_tocs:
+            rewrites[toc_path] = _serialize_xml_like_source(document, toc_bytes)
+    return rewrites
+
+
+def _toc_target_identities(opf_path, opf_bytes, read_member):
+    """Semantic multiset used to validate that only planned TOC targets changed."""
+    identities = Counter()
+    for toc_path, kind in _toc_documents(opf_path, opf_bytes):
+        toc_bytes = read_member(toc_path, kind)
+        document = etree.fromstring(toc_bytes, parser=_XML_PARSER)
+        for element, attribute in _toc_target_elements(document, kind):
+            value = element.get(attribute)
+            target = _contained_toc_target(toc_path, value)
+            if target is None:
+                identities[(toc_path, kind, "external", value)] += 1
+                continue
+            parts, resolved_path = target
+            identities[(
+                toc_path, kind, resolved_path, parts.query, unquote(parts.fragment)
+            )] += 1
+    return identities
 
 
 def count_fragment_anchored_toc_targets(path):
@@ -425,11 +570,24 @@ def _validate_package_document_rewrite(
         raise ValueError("package rewrite introduced an escaping manifest href")
 
 
-def _validate_normalized_archive(path, expected_span_counts):
+def _validate_normalized_archive(
+        path, expected_span_counts, expected_toc_target_identities):
     opf_path, opf_bytes = _validate_rewritten_archive(
         path, expected_span_counts)
     if _escaping_manifest_references(opf_path, opf_bytes):
         raise ValueError("rewritten manifest still escapes the OPF directory")
+    if expected_toc_target_identities is None:
+        raise ValueError("could not determine the expected rewritten TOC targets")
+    with zipfile.ZipFile(path) as archive:
+        rewritten_toc_target_identities = _toc_target_identities(
+            opf_path,
+            opf_bytes,
+            lambda toc_path, kind: _read_bounded_member(
+                archive, toc_path, MAX_TOC_DOCUMENT_BYTES,
+                "{} TOC document".format(kind)),
+        )
+    if rewritten_toc_target_identities != expected_toc_target_identities:
+        raise ValueError("TOC targets changed unexpectedly during package rewrite")
 
 
 def rewrite_package_document(path, transform):
@@ -522,7 +680,7 @@ def rewrite_package_document(path, transform):
 
 
 def normalize_kepub_package(path):
-    """Normalize escaping OPF manifest items in ``path`` atomically.
+    """Normalize unsafe package paths and redundant TOC fragments atomically.
 
     Return ``True`` when the archive changed, ``False`` for a clean byte-identical
     no-op, and ``None`` when validation failed. Failures are logged and never
@@ -539,19 +697,35 @@ def normalize_kepub_package(path):
             # happen before the cheap declared-size rejection.
             _reject_oversized_archive(infos)
             names = [info.filename for info in infos]
+            if len(names) != len(set(names)):
+                raise ValueError("KEPUB contains duplicate ZIP member names")
             opf_path = _package_document_path(archive)
             opf_bytes = _read_bounded_member(
                 archive, opf_path, MAX_PACKAGE_DOCUMENT_BYTES, "package document")
             relocations = _plan_relocations(opf_path, opf_bytes, set(names))
-            if not relocations:
+            toc_rewrites = _plan_toc_fragment_rewrites(archive, opf_path, opf_bytes)
+            if not relocations and not toc_rewrites:
                 return False
-            if len(names) != len(set(names)):
-                raise ValueError("KEPUB contains duplicate ZIP member names")
             if archive.testzip() is not None:
                 raise ValueError("KEPUB failed its CRC check")
-            contents = {info.filename: archive.read(info) for info in infos}
+            source_contents = {info.filename: archive.read(info) for info in infos}
+            contents = dict(source_contents)
+            contents.update(toc_rewrites)
             entries = _rewritten_entries(infos, contents, relocations)
-            expected_span_counts = _span_counts(contents, relocations)
+            expected_span_counts = _span_counts(source_contents, relocations)
+            expected_contents = {info.filename: content for info, content in entries}
+            expected_opf_path = relocations.get(opf_path, opf_path)
+            try:
+                expected_toc_target_identities = _toc_target_identities(
+                    expected_opf_path,
+                    expected_contents[expected_opf_path],
+                    lambda toc_path, _kind: expected_contents[toc_path],
+                )
+            except KeyError:
+                # A faulty rewrite can leave a TOC href pointing at a member it
+                # just relocated. Let the archive postconditions report the
+                # primary containment defect before failing this added check.
+                expected_toc_target_identities = None
             comment = archive.comment
 
         descriptor, temporary_path = tempfile.mkstemp(
@@ -561,7 +735,8 @@ def normalize_kepub_package(path):
         )
         os.close(descriptor)
         _write_archive(temporary_path, entries, comment)
-        _validate_normalized_archive(temporary_path, expected_span_counts)
+        _validate_normalized_archive(
+            temporary_path, expected_span_counts, expected_toc_target_identities)
         os.chmod(temporary_path, stat.S_IMODE(original_stat.st_mode))
         os.replace(temporary_path, path)
         temporary_path = None
@@ -578,7 +753,7 @@ def normalize_kepub_package(path):
 
 
 def kepub_package_needs_normalization(path):
-    """Cheap read-only probe: inspect only container.xml and the package document.
+    """Bounded read-only probe for package paths and redundant TOC fragments.
 
     Only this normalizer's explicit ``UnsupportedKepubPackage`` refusals are
     terminal. ZIP, parser, decoding, EOF, I/O, and unexpected failures are
@@ -603,7 +778,8 @@ def kepub_package_needs_normalization(path):
             opf_bytes = _read_bounded_member(
                 archive, opf_path, MAX_PACKAGE_DOCUMENT_BYTES, "package document")
             needs_normalization = bool(
-                _plan_relocations(opf_path, opf_bytes, set(names)))
+                _plan_relocations(opf_path, opf_bytes, set(names))
+                or _plan_toc_fragment_rewrites(archive, opf_path, opf_bytes))
             return KepubPackageInspection(
                 PROBE_NEEDS_NORMALIZATION if needs_normalization else PROBE_CLEAN)
     except UnsupportedKepubPackage as error:

--- a/cps/services/kepub_package_normalizer.py
+++ b/cps/services/kepub_package_normalizer.py
@@ -60,6 +60,11 @@ _KOBO_SPAN_RE = re.compile(
     re.IGNORECASE,
 )
 _XML_PARSER = etree.XMLParser(resolve_entities=False, no_network=True, recover=False)
+_XML_ATTRIBUTE_RE = re.compile(
+    rb"(?P<name>(?:[A-Za-z_][\w.-]*:)?[A-Za-z_][\w.-]*)\s*=\s*"
+    rb"(?P<quote>['\"])(?P<value>.*?)(?P=quote)",
+    re.DOTALL,
+)
 
 
 #: This implementation temporarily holds the source members, rewritten members,
@@ -80,7 +85,8 @@ MAX_TOC_DOCUMENT_BYTES = 16 * 1024 * 1024
 MAX_CONTENT_DOCUMENT_BYTES = 16 * 1024 * 1024
 
 _RENDERED_PREDECESSOR_ELEMENTS = frozenset({
-    "audio", "canvas", "embed", "iframe", "img", "object", "svg", "table", "video",
+    "audio", "br", "button", "canvas", "embed", "hr", "iframe", "img", "input",
+    "object", "picture", "select", "svg", "table", "video",
 })
 
 
@@ -233,9 +239,12 @@ def _anchor_is_first_rendered_position(document_bytes, fragment):
         if element.text and element.text.strip():
             return -1
         for child in element:
-            result = visit(child)
-            if result:
-                return result
+            # Comments and processing instructions have text in lxml's tree,
+            # but that text is markup metadata rather than rendered content.
+            if isinstance(child.tag, str):
+                result = visit(child)
+                if result:
+                    return result
             if child.tail and child.tail.strip():
                 return -1
         return 0
@@ -243,12 +252,85 @@ def _anchor_is_first_rendered_position(document_bytes, fragment):
     return visit(body) == 1
 
 
-def _serialize_xml_like_source(document, source_bytes):
-    return etree.tostring(
-        document.getroottree(),
-        encoding="utf-8",
-        xml_declaration=source_bytes.lstrip().startswith(b"<?xml"),
-    )
+def _xml_start_tag_ranges(source):
+    """Yield exact byte ranges for element start tags in well-formed XML."""
+    position = 0
+    length = len(source)
+    while position < length:
+        start = source.find(b"<", position)
+        if start < 0:
+            return
+        if source.startswith(b"<!--", start):
+            end = source.find(b"-->", start + 4)
+            position = length if end < 0 else end + 3
+            continue
+        if source.startswith(b"<![CDATA[", start):
+            end = source.find(b"]]>", start + 9)
+            position = length if end < 0 else end + 3
+            continue
+        if source.startswith(b"<?", start):
+            end = source.find(b"?>", start + 2)
+            position = length if end < 0 else end + 2
+            continue
+
+        closing = source.startswith(b"</", start)
+        declaration = source.startswith(b"<!", start)
+        quote_byte = None
+        bracket_depth = 0
+        cursor = start + 2 if closing or declaration else start + 1
+        while cursor < length:
+            byte = source[cursor]
+            if quote_byte is not None:
+                if byte == quote_byte:
+                    quote_byte = None
+            elif byte in (ord("'"), ord('"')):
+                quote_byte = byte
+            elif declaration and byte == ord("["):
+                bracket_depth += 1
+            elif declaration and byte == ord("]") and bracket_depth:
+                bracket_depth -= 1
+            elif byte == ord(">") and bracket_depth == 0:
+                break
+            cursor += 1
+        if cursor >= length:
+            return
+        if not closing and not declaration:
+            yield start, cursor + 1
+        position = cursor + 1
+
+
+def _rewrite_toc_attributes(source, edits):
+    """Apply selected fragment removals without serializing the TOC document.
+
+    ``edits`` contains ``(element_index, local_attribute_name)`` pairs. If the
+    exact lexical attribute cannot be identified, that edit is conservatively
+    skipped and every source byte remains intact.
+    """
+    replacements = []
+    wanted = set(edits)
+    for element_index, (start, end) in enumerate(_xml_start_tag_ranges(source)):
+        if not wanted:
+            break
+        tag = source[start:end]
+        for match in _XML_ATTRIBUTE_RE.finditer(tag):
+            attribute = match.group("name").rsplit(b":", 1)[-1].decode(
+                "ascii", errors="ignore").lower()
+            key = (element_index, attribute)
+            if key not in wanted:
+                continue
+            raw_value = match.group("value")
+            fragment_at = raw_value.find(b"#")
+            if fragment_at < 0:
+                continue
+            value_start = start + match.start("value")
+            replacements.append(
+                (value_start, value_start + len(raw_value), raw_value[:fragment_at]))
+            wanted.remove(key)
+
+    rewritten = source
+    for start, end, replacement in reversed(replacements):
+        rewritten = rewritten[:start] + replacement + rewritten[end:]
+    return rewritten
 
 
 def _plan_toc_fragment_rewrites(archive, opf_path, opf_bytes):
@@ -260,82 +342,123 @@ def _plan_toc_fragment_rewrites(archive, opf_path, opf_bytes):
         key = (toc_path, kind)
         if key in parsed_tocs:
             continue
-        toc_bytes = _read_bounded_member(
-            archive, toc_path, MAX_TOC_DOCUMENT_BYTES,
-            "{} TOC document".format(kind))
         try:
+            toc_bytes = _read_bounded_member(
+                archive, toc_path, MAX_TOC_DOCUMENT_BYTES,
+                "{} TOC document".format(kind))
             document = etree.fromstring(toc_bytes, parser=_XML_PARSER)
-        except etree.XMLSyntaxError as error:
-            log.warning("Could not parse %s TOC document %s: %s",
+        except (etree.XMLSyntaxError, UnsupportedKepubPackage) as error:
+            # Uniform fragment-proof rule: anything that prevents proving
+            # redundancy skips the affected target/TOC. Only package structure
+            # independent of this optional transform may refuse the package.
+            log.warning("Could not inspect %s TOC document %s: %s",
                         kind, toc_path, error)
             malformed_toc = True
             continue
         parsed_tocs[key] = (document, toc_bytes)
+        element_indexes = {
+            element: index
+            for index, element in enumerate(
+                node for node in document.iter() if isinstance(node.tag, str))
+        }
         for element, attribute in _toc_target_elements(document, kind):
-            target = _contained_toc_target(toc_path, element.get(attribute))
+            try:
+                target = _contained_toc_target(toc_path, element.get(attribute))
+            except (TypeError, ValueError, UnsupportedKepubPackage):
+                continue
             if target is None:
                 continue
             parts, resolved_path = target
             if parts.fragment:
                 fragment_targets.append(
-                    (toc_path, element, attribute, parts, resolved_path,
+                    (toc_path, element_indexes[element], attribute, parts, resolved_path,
                      unquote(parts.fragment)))
 
     if malformed_toc:
         # Distinct-fragment counting is package-wide. If even one declared TOC
         # is unreadable, stripping from another would no longer satisfy the
         # proof, but unrelated relocation work can still proceed.
-        return {}
+        return {}, {}
 
     fragments_by_document = {}
     for _toc_path, _element, _attribute, _parts, resolved_path, fragment in fragment_targets:
         fragments_by_document.setdefault(resolved_path, set()).add(fragment)
 
     content_cache = {}
-    changed_tocs = set()
+    edits_by_toc = {}
     archive_names = set(archive.namelist())
-    for toc_path, element, attribute, parts, resolved_path, fragment in fragment_targets:
+    for toc_path, element_index, attribute, _parts, resolved_path, fragment in fragment_targets:
         if len(fragments_by_document[resolved_path]) != 1:
             continue
         if resolved_path not in archive_names:
             continue
         if resolved_path not in content_cache:
-            content_cache[resolved_path] = _read_bounded_member(
-                archive, resolved_path, MAX_CONTENT_DOCUMENT_BYTES,
-                "TOC target document")
+            try:
+                content_cache[resolved_path] = _read_bounded_member(
+                    archive, resolved_path, MAX_CONTENT_DOCUMENT_BYTES,
+                    "TOC target document")
+            except UnsupportedKepubPackage:
+                content_cache[resolved_path] = None
+        if content_cache[resolved_path] is None:
+            continue
         if not _anchor_is_first_rendered_position(content_cache[resolved_path], fragment):
             continue
-        element.set(attribute, urlunsplit(parts._replace(fragment="")))
-        changed_tocs.add(toc_path)
+        edits_by_toc.setdefault(toc_path, set()).add((element_index, attribute))
 
     rewrites = {}
-    for (toc_path, _kind), (document, toc_bytes) in parsed_tocs.items():
-        if toc_path in changed_tocs:
-            rewrites[toc_path] = _serialize_xml_like_source(document, toc_bytes)
-    return rewrites
+    source_by_toc = {
+        toc_path: toc_bytes
+        for (toc_path, _kind), (_document, toc_bytes) in parsed_tocs.items()
+    }
+    for toc_path, edits in edits_by_toc.items():
+        source = source_by_toc[toc_path]
+        rewritten = _rewrite_toc_attributes(source, edits)
+        if rewritten != source:
+            rewrites[toc_path] = rewritten
+    return rewrites, edits_by_toc
 
 
-def _toc_target_identities(opf_path, opf_bytes, read_member):
-    """Semantic multiset used to validate that only planned TOC targets changed."""
+def _toc_target_identities_from_source(
+        opf_path, opf_bytes, contents, planned_edits=None, relocations=None):
+    """Build TOC identities from source bytes with explicit planned edits.
+
+    This expectation is independent of serialized/planned TOC output bytes: a
+    planner that drops or invents a target therefore cannot validate itself.
+    """
+    planned_edits = planned_edits or {}
+    relocations = relocations or {}
     identities = Counter()
     for toc_path, kind in _toc_documents(opf_path, opf_bytes):
-        toc_bytes = read_member(toc_path, kind)
+        toc_bytes = contents.get(toc_path)
+        destination_toc = relocations.get(toc_path, toc_path)
+        if toc_bytes is None:
+            identities[(destination_toc, kind, "missing")] += 1
+            continue
         try:
             document = etree.fromstring(toc_bytes, parser=_XML_PARSER)
         except etree.XMLSyntaxError:
-            # Relocation may legitimately rewrite a malformed TOC as raw text.
-            # Compare its exact expected bytes instead of attempting semantics.
-            identities[(toc_path, kind, "unparseable", toc_bytes)] += 1
+            identities[(destination_toc, kind, "unparseable")] += 1
             continue
+        elements = [node for node in document.iter() if isinstance(node.tag, str)]
+        element_indexes = {element: index for index, element in enumerate(elements)}
         for element, attribute in _toc_target_elements(document, kind):
             value = element.get(attribute)
-            target = _contained_toc_target(toc_path, value)
+            try:
+                target = _contained_toc_target(toc_path, value)
+            except (TypeError, ValueError, UnsupportedKepubPackage):
+                identities[(destination_toc, kind, "invalid", value)] += 1
+                continue
             if target is None:
-                identities[(toc_path, kind, "external", value)] += 1
+                identities[(destination_toc, kind, "external", value)] += 1
                 continue
             parts, resolved_path = target
+            fragment = parts.fragment
+            if (element_indexes[element], attribute) in planned_edits.get(toc_path, set()):
+                fragment = ""
+            destination_target = relocations.get(resolved_path, resolved_path)
             identities[(
-                toc_path, kind, resolved_path, parts.query, unquote(parts.fragment)
+                destination_toc, kind, destination_target, parts.query,
+                unquote(fragment),
             )] += 1
     return identities
 
@@ -596,23 +719,22 @@ def _validate_package_document_rewrite(
 
 
 def _validate_normalized_archive(
-        path, expected_span_counts, expected_toc_target_identities):
+        path, expected_span_counts, expected_toc_contents,
+        expected_toc_target_identities):
     opf_path, opf_bytes = _validate_rewritten_archive(
         path, expected_span_counts)
     if _escaping_manifest_references(opf_path, opf_bytes):
         raise ValueError("rewritten manifest still escapes the OPF directory")
-    if expected_toc_target_identities is None:
-        raise ValueError("could not determine the expected rewritten TOC targets")
     with zipfile.ZipFile(path) as archive:
-        rewritten_toc_target_identities = _toc_target_identities(
-            opf_path,
-            opf_bytes,
-            lambda toc_path, kind: _read_bounded_member(
-                archive, toc_path, MAX_TOC_DOCUMENT_BYTES,
-                "{} TOC document".format(kind)),
-        )
-    if rewritten_toc_target_identities != expected_toc_target_identities:
-        raise ValueError("TOC targets changed unexpectedly during package rewrite")
+        for toc_path, expected in expected_toc_contents.items():
+            if archive.read(toc_path) != expected:
+                raise ValueError(
+                    "TOC document differs from its exact planned rewrite: " + toc_path)
+        contents = {info.filename: archive.read(info) for info in archive.infolist()}
+    actual_identities = _toc_target_identities_from_source(
+        opf_path, opf_bytes, contents)
+    if actual_identities != expected_toc_target_identities:
+        raise ValueError("TOC targets differ from the source-plus-edits plan")
 
 
 def rewrite_package_document(path, transform):
@@ -727,8 +849,10 @@ def normalize_kepub_package(path):
             opf_path = _package_document_path(archive)
             opf_bytes = _read_bounded_member(
                 archive, opf_path, MAX_PACKAGE_DOCUMENT_BYTES, "package document")
+            declared_toc_paths = {path for path, _kind in _toc_documents(opf_path, opf_bytes)}
             relocations = _plan_relocations(opf_path, opf_bytes, set(names))
-            toc_rewrites = _plan_toc_fragment_rewrites(archive, opf_path, opf_bytes)
+            toc_rewrites, planned_toc_edits = _plan_toc_fragment_rewrites(
+                archive, opf_path, opf_bytes)
             if not relocations and not toc_rewrites:
                 return False
             if archive.testzip() is not None:
@@ -739,18 +863,17 @@ def normalize_kepub_package(path):
             entries = _rewritten_entries(infos, contents, relocations)
             expected_span_counts = _span_counts(source_contents, relocations)
             expected_contents = {info.filename: content for info, content in entries}
-            expected_opf_path = relocations.get(opf_path, opf_path)
-            try:
-                expected_toc_target_identities = _toc_target_identities(
-                    expected_opf_path,
-                    expected_contents[expected_opf_path],
-                    lambda toc_path, _kind: expected_contents[toc_path],
-                )
-            except KeyError:
-                # A faulty rewrite can leave a TOC href pointing at a member it
-                # just relocated. Let the archive postconditions report the
-                # primary containment defect before failing this added check.
-                expected_toc_target_identities = None
+            # Stronger than a semantic round-trip: each existing declared TOC
+            # must equal its source bytes with only the explicit lexical href
+            # edits and relocation-reference edits applied by the plan.
+            expected_toc_contents = {}
+            for source_toc_path in declared_toc_paths:
+                destination = relocations.get(source_toc_path, source_toc_path)
+                if destination in expected_contents:
+                    expected_toc_contents[destination] = expected_contents[destination]
+            expected_toc_target_identities = _toc_target_identities_from_source(
+                opf_path, opf_bytes, source_contents,
+                planned_edits=planned_toc_edits, relocations=relocations)
             comment = archive.comment
 
         descriptor, temporary_path = tempfile.mkstemp(
@@ -761,7 +884,8 @@ def normalize_kepub_package(path):
         os.close(descriptor)
         _write_archive(temporary_path, entries, comment)
         _validate_normalized_archive(
-            temporary_path, expected_span_counts, expected_toc_target_identities)
+            temporary_path, expected_span_counts, expected_toc_contents,
+            expected_toc_target_identities)
         os.chmod(temporary_path, stat.S_IMODE(original_stat.st_mode))
         os.replace(temporary_path, path)
         temporary_path = None
@@ -780,6 +904,13 @@ def normalize_kepub_package(path):
 def kepub_package_needs_normalization(path):
     """Bounded read-only probe for package paths and redundant TOC fragments.
 
+    The probe runs the same fragment-rewrite planner as normalization so its
+    answer includes the planner's proof and every conservative skip decision.
+    It decompresses each declared TOC at most once, bounded by
+    ``MAX_TOC_DOCUMENT_BYTES``, and each eligible distinct fragment-targeted
+    content document at most once, bounded by ``MAX_CONTENT_DOCUMENT_BYTES``
+    and retained only in the planner's per-call cache.
+
     Only this normalizer's explicit ``UnsupportedKepubPackage`` refusals are
     terminal. ZIP, parser, decoding, EOF, I/O, and unexpected failures are
     retryable because a short network-share read can surface as any of them.
@@ -788,7 +919,6 @@ def kepub_package_needs_normalization(path):
     That cache is deliberately best-effort, not proof of content identity: an
     undetected stat collision can defer one book until a future repair-version
     bump. This is preferred to hashing a package we may not safely read.
-    The archive is never materialized, preserving the clean-library fast path.
     """
     path = os.fspath(path)
     try:
@@ -802,9 +932,12 @@ def kepub_package_needs_normalization(path):
             opf_path = _package_document_path(archive)
             opf_bytes = _read_bounded_member(
                 archive, opf_path, MAX_PACKAGE_DOCUMENT_BYTES, "package document")
-            needs_normalization = bool(
-                _plan_relocations(opf_path, opf_bytes, set(names))
-                or _plan_toc_fragment_rewrites(archive, opf_path, opf_bytes))
+            relocations = _plan_relocations(opf_path, opf_bytes, set(names))
+            toc_rewrites, _planned_toc_edits = _plan_toc_fragment_rewrites(
+                archive, opf_path, opf_bytes)
+            # Convergence invariant: the probe must never report work for a
+            # package that these same planners would decline to change.
+            needs_normalization = bool(relocations or toc_rewrites)
             return KepubPackageInspection(
                 PROBE_NEEDS_NORMALIZATION if needs_normalization else PROBE_CLEAN)
     except UnsupportedKepubPackage as error:

--- a/cps/services/kepub_package_normalizer.py
+++ b/cps/services/kepub_package_normalizer.py
@@ -212,7 +212,13 @@ def _anchor_is_first_rendered_position(document_bytes, fragment):
     anchor's own content and the tails of its ancestors are correctly excluded:
     all of those render at or after the target position, never before it.
     """
-    document = etree.fromstring(document_bytes, parser=_XML_PARSER)
+    try:
+        document = etree.fromstring(document_bytes, parser=_XML_PARSER)
+    except etree.XMLSyntaxError:
+        # Recovery can discard or reorder malformed markup and thereby turn a
+        # genuinely mid-document anchor into an apparent first-rendered anchor.
+        # An unparseable target therefore fails only this conservative proof.
+        return False
     bodies = document.xpath("//*[local-name()='body']")
     if not bodies:
         return False
@@ -249,6 +255,7 @@ def _plan_toc_fragment_rewrites(archive, opf_path, opf_bytes):
     """Return TOC-member replacements for provably redundant fragments."""
     parsed_tocs = {}
     fragment_targets = []
+    malformed_toc = False
     for toc_path, kind in _toc_documents(opf_path, opf_bytes):
         key = (toc_path, kind)
         if key in parsed_tocs:
@@ -256,7 +263,13 @@ def _plan_toc_fragment_rewrites(archive, opf_path, opf_bytes):
         toc_bytes = _read_bounded_member(
             archive, toc_path, MAX_TOC_DOCUMENT_BYTES,
             "{} TOC document".format(kind))
-        document = etree.fromstring(toc_bytes, parser=_XML_PARSER)
+        try:
+            document = etree.fromstring(toc_bytes, parser=_XML_PARSER)
+        except etree.XMLSyntaxError as error:
+            log.warning("Could not parse %s TOC document %s: %s",
+                        kind, toc_path, error)
+            malformed_toc = True
+            continue
         parsed_tocs[key] = (document, toc_bytes)
         for element, attribute in _toc_target_elements(document, kind):
             target = _contained_toc_target(toc_path, element.get(attribute))
@@ -267,6 +280,12 @@ def _plan_toc_fragment_rewrites(archive, opf_path, opf_bytes):
                 fragment_targets.append(
                     (toc_path, element, attribute, parts, resolved_path,
                      unquote(parts.fragment)))
+
+    if malformed_toc:
+        # Distinct-fragment counting is package-wide. If even one declared TOC
+        # is unreadable, stripping from another would no longer satisfy the
+        # proof, but unrelated relocation work can still proceed.
+        return {}
 
     fragments_by_document = {}
     for _toc_path, _element, _attribute, _parts, resolved_path, fragment in fragment_targets:
@@ -301,7 +320,13 @@ def _toc_target_identities(opf_path, opf_bytes, read_member):
     identities = Counter()
     for toc_path, kind in _toc_documents(opf_path, opf_bytes):
         toc_bytes = read_member(toc_path, kind)
-        document = etree.fromstring(toc_bytes, parser=_XML_PARSER)
+        try:
+            document = etree.fromstring(toc_bytes, parser=_XML_PARSER)
+        except etree.XMLSyntaxError:
+            # Relocation may legitimately rewrite a malformed TOC as raw text.
+            # Compare its exact expected bytes instead of attempting semantics.
+            identities[(toc_path, kind, "unparseable", toc_bytes)] += 1
+            continue
         for element, attribute in _toc_target_elements(document, kind):
             value = element.get(attribute)
             target = _contained_toc_target(toc_path, value)

--- a/cps/tasks/kepub_package_repair.py
+++ b/cps/tasks/kepub_package_repair.py
@@ -28,7 +28,7 @@ from ..services.worker import (
 
 
 log = logger.create()
-REPAIR_VERSION = 1
+REPAIR_VERSION = 2
 NOTICE_TYPE = "kepub-package-repair"
 REPAIR_STATUS_DETECTED = "detected"
 REPAIR_STATUS_FILE_REPAIRED = "file_repaired"

--- a/tests/unit/test_1657_kepub_toc_fragments.py
+++ b/tests/unit/test_1657_kepub_toc_fragments.py
@@ -113,6 +113,12 @@ def _normalize(path):
     return normalize_kepub_package(path)
 
 
+def _probe(path):
+    from cps.services.kepub_package_normalizer import kepub_package_needs_normalization
+
+    return kepub_package_needs_normalization(path)
+
+
 def _ncx(nav_targets=(), page_targets=(), nav_list_targets=()):
     nav_points = "".join(
         '<navPoint id="n{0}"><content src="{1}"/></navPoint>'.format(index, target)
@@ -351,6 +357,107 @@ def test_non_zip_counter_and_normalizer_never_raise(tmp_path):
 
     assert _count(package) == 0
     assert _normalize(package) is None
+
+
+@pytest.mark.unit
+def test_htmlish_target_parse_failure_is_skipped_without_retryable_probe(tmp_path):
+    from cps.services import kepub_package_normalizer as normalizer
+
+    malformed = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><head>'
+        b'<meta name="generator" content="HTML"></head>'
+        b'<body><h1 id="top">Chapter</h1></body></html>'
+    )
+    package = _fragment_epub(
+        tmp_path, "htmlish-target.kepub", ["chapter.xhtml#top"],
+        {"chapter.xhtml": malformed})
+
+    assert _normalize(package) is False
+    assert _probe(package).status == normalizer.PROBE_CLEAN
+    assert _ncx_sources(package) == ["chapter.xhtml#top"]
+
+
+@pytest.mark.unit
+def test_htmlish_target_does_not_block_escaping_toc_relocation(tmp_path):
+    from cps.services import kepub_package_normalizer as normalizer
+
+    malformed = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><head>'
+        b'<meta name="generator" content="HTML"></head>'
+        b'<body><h1 id="top">Chapter</h1></body></html>'
+    )
+    package = _write_epub(
+        tmp_path / "htmlish-with-relocation.kepub",
+        _opf(
+            '<item id="ncx" href="../toc.ncx" media-type="application/x-dtbncx+xml"/>',
+            '<item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>',
+            version="2.0", spine_toc="ncx", spine_ids=["chapter"],
+        ),
+        [("toc.ncx", _ncx(["OPS/chapter.xhtml#top"])),
+         ("OPS/chapter.xhtml", malformed)],
+    )
+
+    assert _probe(package).status == normalizer.PROBE_NEEDS_NORMALIZATION
+    assert _normalize(package) is True
+    with zipfile.ZipFile(package) as archive:
+        assert "toc.ncx" not in archive.namelist()
+        assert "OPS/toc.ncx" in archive.namelist()
+        rewritten = archive.read("OPS/toc.ncx")
+    assert b'src="chapter.xhtml#top"' in rewritten
+    assert _probe(package).status == normalizer.PROBE_CLEAN
+
+
+@pytest.mark.unit
+def test_htmlish_target_is_skipped_while_valid_target_is_stripped(tmp_path):
+    malformed = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><head>'
+        b'<meta name="generator" content="HTML"></head>'
+        b'<body><h1 id="bad">Bad</h1></body></html>'
+    )
+    valid = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<h1 id="good">Good</h1></body></html>'
+    )
+    package = _fragment_epub(
+        tmp_path, "mixed-targets.kepub",
+        ["bad.xhtml#bad", "good.xhtml#good"],
+        {"bad.xhtml": malformed, "good.xhtml": valid})
+
+    assert _normalize(package) is True
+    assert _ncx_sources(package) == ["bad.xhtml#bad", "good.xhtml"]
+
+
+@pytest.mark.unit
+def test_absent_target_document_is_skipped_without_retryable_probe(tmp_path):
+    from cps.services import kepub_package_normalizer as normalizer
+
+    package = _fragment_epub(
+        tmp_path, "absent-target.kepub", ["missing.xhtml#top"], {})
+
+    assert _normalize(package) is False
+    assert _probe(package).status == normalizer.PROBE_CLEAN
+    assert _ncx_sources(package) == ["missing.xhtml#top"]
+
+
+@pytest.mark.unit
+def test_malformed_toc_does_not_block_escaping_href_relocation(tmp_path):
+    from cps.services import kepub_package_normalizer as normalizer
+
+    package = _write_epub(
+        tmp_path / "malformed-toc-with-relocation.kepub",
+        _opf(
+            '<item id="ncx" href="../toc.ncx" media-type="application/x-dtbncx+xml"/>',
+            version="2.0", spine_toc="ncx",
+        ),
+        [("toc.ncx", b"<ncx><navMap><navPoint>")],
+    )
+
+    assert _probe(package).status == normalizer.PROBE_NEEDS_NORMALIZATION
+    assert _normalize(package) is True
+    with zipfile.ZipFile(package) as archive:
+        assert "toc.ncx" not in archive.namelist()
+        assert archive.read("OPS/toc.ncx") == b"<ncx><navMap><navPoint>"
+    assert _probe(package).status == normalizer.PROBE_CLEAN
 
 
 @pytest.mark.unit

--- a/tests/unit/test_1657_kepub_toc_fragments.py
+++ b/tests/unit/test_1657_kepub_toc_fragments.py
@@ -726,6 +726,48 @@ def test_bom_prefixed_ncx_preserves_bom_and_all_non_target_bytes(tmp_path):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "internal_subset_item",
+    [
+        b'<!-- ]> <stray src="decoy.xhtml#wrong"/> -->',
+        b'<?trap ]> <stray src="decoy.xhtml#wrong"/> ?>',
+    ],
+    ids=["comment", "processing-instruction"],
+)
+def test_doctype_internal_subset_markup_cannot_desync_toc_edit(
+        tmp_path, internal_subset_item):
+    ncx = (
+        b'<?xml version="1.0"?>\n<!DOCTYPE ncx [ '
+        + internal_subset_item
+        + b' ]>\n<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/"><navMap>'
+        b'<navPoint><navLabel><text src="SIBLING.xhtml#zzz">One</text></navLabel>'
+        b'<content src="chapter.xhtml#top"/></navPoint></navMap></ncx>'
+    )
+    chapter = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<h1 id="top">Top</h1></body></html>'
+    )
+    package = _write_epub(
+        tmp_path / "doctype-internal-subset.kepub",
+        _opf(
+            '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>',
+            '<item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>',
+            version="2.0", spine_toc="ncx", spine_ids=["chapter"]),
+        [("OPS/toc.ncx", ncx), ("OPS/chapter.xhtml", chapter)],
+    )
+
+    assert _probe(package).status == "needs_normalization"
+    assert _normalize(package) is True
+    with zipfile.ZipFile(package) as archive:
+        rewritten = archive.read("OPS/toc.ncx")
+    assert rewritten == ncx.replace(
+        b'src="chapter.xhtml#top"', b'src="chapter.xhtml"')
+    assert b'src="SIBLING.xhtml#zzz"' in rewritten
+    assert _probe(package).status == "clean"
+    assert _normalize(package) is False
+
+
+@pytest.mark.unit
 def test_same_toc_path_declared_under_two_kinds_applies_both_edits(tmp_path):
     dual = b"""<?xml version="1.0"?>
 <html xmlns="http://www.w3.org/1999/xhtml"><body>

--- a/tests/unit/test_1657_kepub_toc_fragments.py
+++ b/tests/unit/test_1657_kepub_toc_fragments.py
@@ -460,6 +460,303 @@ def test_malformed_toc_does_not_block_escaping_href_relocation(tmp_path):
     assert _probe(package).status == normalizer.PROBE_CLEAN
 
 
+def _assert_nonterminal_probe(package):
+    from cps.services import kepub_package_normalizer as normalizer
+
+    assert _probe(package).status in {
+        normalizer.PROBE_CLEAN,
+        normalizer.PROBE_NEEDS_NORMALIZATION,
+    }
+
+
+@pytest.mark.unit
+def test_missing_manifest_declared_toc_skips_fragment_transform(tmp_path):
+    package = _write_epub(
+        tmp_path / "missing-declared-toc.kepub",
+        _opf(
+            '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>',
+            version="2.0", spine_toc="ncx"),
+    )
+
+    _assert_nonterminal_probe(package)
+    assert _normalize(package) is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "target",
+    [r"sub\ch1.xhtml#top", "/ch1.xhtml#top", "../ch1.xhtml#top"],
+    ids=["backslash", "absolute", "escaping"],
+)
+def test_uncontained_toc_target_skips_fragment_transform(tmp_path, target):
+    package = _fragment_epub(
+        tmp_path, "uncontained-target.kepub", [target],
+        {"ch1.xhtml": (
+            b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+            b'<h1 id="top">Top</h1></body></html>')})
+
+    _assert_nonterminal_probe(package)
+    assert _normalize(package) is False
+    assert _ncx_sources(package) == [target]
+
+
+@pytest.mark.unit
+def test_oversized_target_document_skips_fragment_transform(tmp_path):
+    from cps.services import kepub_package_normalizer as normalizer
+
+    oversized = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body><h1 id="top">Top</h1>'
+        + b"x" * normalizer.MAX_CONTENT_DOCUMENT_BYTES
+        + b"</body></html>"
+    )
+    package = _fragment_epub(
+        tmp_path, "oversized-content.kepub", ["chapter.xhtml#top"],
+        {"chapter.xhtml": oversized})
+
+    _assert_nonterminal_probe(package)
+    assert _normalize(package) is False
+    assert _ncx_sources(package) == ["chapter.xhtml#top"]
+
+
+@pytest.mark.unit
+def test_spine_nav_rewrite_changes_only_the_selected_href_bytes(tmp_path):
+    nav = (
+        b'\xef\xbb\xbf<?xml version="1.0" encoding="UTF-8"?>\n'
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<script src="s.js"></script><div class="x"></div>'
+        b'<span class="koboSpan" id="kobo.1.1"></span>'
+        b'<nav role="doc-toc"><a href="chapter.xhtml#top">Chapter</a></nav>'
+        b'</body></html>'
+    )
+    chapter = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<h1 id="top">Top</h1></body></html>'
+    )
+    package = _write_epub(
+        tmp_path / "spine-nav.kepub",
+        _opf(
+            '<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>',
+            '<item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>',
+            spine_ids=["nav", "chapter"]),
+        [("OPS/nav.xhtml", nav), ("OPS/chapter.xhtml", chapter)],
+    )
+
+    assert _normalize(package) is True
+    with zipfile.ZipFile(package) as archive:
+        rewritten = archive.read("OPS/nav.xhtml")
+        assert archive.read("OPS/chapter.xhtml") == chapter
+    assert rewritten == nav.replace(
+        b'href="chapter.xhtml#top"', b'href="chapter.xhtml"')
+    assert rewritten.startswith(b"\xef\xbb\xbf<?xml")
+    assert b'<script src="s.js"></script>' in rewritten
+    assert b'<div class="x"></div>' in rewritten
+    assert b'<span class="koboSpan" id="kobo.1.1"></span>' in rewritten
+
+
+@pytest.mark.unit
+def test_validation_rejects_planner_that_drops_a_toc_target(
+        tmp_path, monkeypatch):
+    from cps.services import kepub_package_normalizer as normalizer
+
+    package = _fragment_epub(
+        tmp_path, "planner-corruption.kepub", ["chapter.xhtml#top"],
+        {"chapter.xhtml": (
+            b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+            b'<h1 id="top">Top</h1></body></html>')})
+    original = package.read_bytes()
+    real_plan = normalizer._plan_toc_fragment_rewrites
+
+    def corrupt_plan(*args, **kwargs):
+        rewrites, edits = real_plan(*args, **kwargs)
+        rewrites["OPS/toc.ncx"] = rewrites["OPS/toc.ncx"].replace(
+            b'<navPoint id="n0"><content src="chapter.xhtml"/></navPoint>', b"")
+        return rewrites, edits
+
+    monkeypatch.setattr(normalizer, "_plan_toc_fragment_rewrites", corrupt_plan)
+
+    assert normalizer.normalize_kepub_package(package) is None
+    assert package.read_bytes() == original
+
+
+@pytest.mark.unit
+def test_probe_reads_fragment_targets_with_the_planners_bounded_cache(
+        tmp_path, monkeypatch):
+    from cps.services import kepub_package_normalizer as normalizer
+
+    package = _fragment_epub(
+        tmp_path, "cheap-probe.kepub", ["chapter.xhtml#top"],
+        {"chapter.xhtml": (
+            b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+            b'<h1 id="top">Top</h1></body></html>')})
+    real_read = normalizer._read_bounded_member
+    reads = []
+
+    def recording_read(archive, name, limit, description):
+        reads.append(name)
+        return real_read(archive, name, limit, description)
+
+    monkeypatch.setattr(normalizer, "_read_bounded_member", recording_read)
+
+    assert _probe(package).status == normalizer.PROBE_NEEDS_NORMALIZATION
+    assert reads.count("OPS/toc.ncx") == 1
+    assert reads.count("OPS/chapter.xhtml") == 1
+
+
+def _assert_probe_normalize_fixed_point(package):
+    from cps.services import kepub_package_normalizer as normalizer
+
+    rewrite_count = 0
+    for _round in range(3):
+        inspection = _probe(package)
+        if inspection.status == normalizer.PROBE_CLEAN:
+            assert rewrite_count <= 1
+            return
+        assert inspection.status == normalizer.PROBE_NEEDS_NORMALIZATION
+        # A needs-normalization answer is a promise that the planner will
+        # actually change the package, never a request for an endless rescan.
+        assert _normalize(package) is True
+        rewrite_count += 1
+    pytest.fail("probe and normalizer did not reach a fixed point in three rounds")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "skip_reason",
+    [
+        "oversized-target",
+        "absent-target",
+        "unparseable-target",
+        "unparseable-toc",
+        "malformed-href",
+        "multiple-distinct-fragments",
+    ],
+)
+def test_probe_and_normalizer_converge_for_fragment_skip_reasons(
+        tmp_path, monkeypatch, skip_reason):
+    from cps.services import kepub_package_normalizer as normalizer
+
+    valid_target = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<h1 id="top">Top</h1></body></html>'
+    )
+    if skip_reason == "oversized-target":
+        monkeypatch.setattr(normalizer, "MAX_CONTENT_DOCUMENT_BYTES", 64)
+        package = _fragment_epub(
+            tmp_path, "oversized-target.kepub", ["chapter.xhtml#top"],
+            {"chapter.xhtml": valid_target})
+    elif skip_reason == "absent-target":
+        package = _fragment_epub(
+            tmp_path, "absent-target-convergence.kepub",
+            ["missing.xhtml#top"], {})
+    elif skip_reason == "unparseable-target":
+        package = _fragment_epub(
+            tmp_path, "unparseable-target.kepub", ["chapter.xhtml#top"],
+            {"chapter.xhtml": b"<html><body><h1 id='top'>"})
+    elif skip_reason == "unparseable-toc":
+        package = _write_epub(
+            tmp_path / "unparseable-toc.kepub",
+            _opf(
+                '<item id="ncx" href="toc.ncx" '
+                'media-type="application/x-dtbncx+xml"/>',
+                version="2.0", spine_toc="ncx"),
+            [("OPS/toc.ncx", b"<ncx><navMap><navPoint>")],
+        )
+    elif skip_reason == "malformed-href":
+        package = _fragment_epub(
+            tmp_path, "malformed-href.kepub", [r"chapter\file.xhtml#top"],
+            {"chapter.xhtml": valid_target})
+    else:
+        package = _fragment_epub(
+            tmp_path, "multiple-fragments-convergence.kepub",
+            ["chapter.xhtml#top", "chapter.xhtml#second"],
+            {"chapter.xhtml": valid_target.replace(
+                b"</body>", b'<h2 id="second">Second</h2></body>')})
+
+    _assert_probe_normalize_fixed_point(package)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("element", ["hr", "br", "input", "select", "button", "picture"])
+def test_additional_rendered_elements_prevent_stripping(tmp_path, element):
+    prefix = ("<{}></{}>".format(element, element)).encode()
+    package = _fragment_epub(
+        tmp_path, "rendered-element.kepub", ["chapter.xhtml#top"],
+        {"chapter.xhtml": (
+            b'<html xmlns="http://www.w3.org/1999/xhtml"><body>' + prefix
+            + b'<h1 id="top">Top</h1></body></html>')})
+
+    assert _normalize(package) is False
+    assert _ncx_sources(package) == ["chapter.xhtml#top"]
+
+
+@pytest.mark.unit
+def test_comments_and_processing_instructions_do_not_prevent_stripping(tmp_path):
+    package = _fragment_epub(
+        tmp_path, "comment-before-anchor.kepub", ["chapter.xhtml#top"],
+        {"chapter.xhtml": (
+            b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+            b'<!-- generated by calibre --><?generator calibre?>'
+            b'<h1 id="top">Top</h1></body></html>')})
+
+    assert _normalize(package) is True
+    assert _ncx_sources(package) == ["chapter.xhtml"]
+
+
+@pytest.mark.unit
+def test_bom_prefixed_ncx_preserves_bom_and_all_non_target_bytes(tmp_path):
+    ncx = b"\xef\xbb\xbf" + _ncx(["chapter.xhtml#top"])
+    chapter = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<h1 id="top">Top</h1></body></html>'
+    )
+    package = _write_epub(
+        tmp_path / "bom-ncx.kepub",
+        _opf(
+            '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>',
+            '<item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>',
+            version="2.0", spine_toc="ncx", spine_ids=["chapter"]),
+        [("OPS/toc.ncx", ncx), ("OPS/chapter.xhtml", chapter)],
+    )
+
+    assert _normalize(package) is True
+    with zipfile.ZipFile(package) as archive:
+        rewritten = archive.read("OPS/toc.ncx")
+    assert rewritten == ncx.replace(
+        b'src="chapter.xhtml#top"', b'src="chapter.xhtml"')
+
+
+@pytest.mark.unit
+def test_same_toc_path_declared_under_two_kinds_applies_both_edits(tmp_path):
+    dual = b"""<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <navMap><navPoint><content src="one.xhtml#one"/></navPoint></navMap>
+  <nav role="doc-toc"><a href="two.xhtml#two">Two</a></nav>
+</body></html>"""
+    package = _write_epub(
+        tmp_path / "dual-kind-one-path.kepub",
+        _opf(
+            '<item id="ncx" href="nav.xhtml" media-type="application/x-dtbncx+xml"/>',
+            '<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>',
+            '<item id="one" href="one.xhtml" media-type="application/xhtml+xml"/>',
+            '<item id="two" href="two.xhtml" media-type="application/xhtml+xml"/>',
+            version="2.0", spine_toc="ncx", spine_ids=["one", "two"]),
+        [
+            ("OPS/nav.xhtml", dual),
+            ("OPS/one.xhtml", b'<html><body><h1 id="one">One</h1></body></html>'),
+            ("OPS/two.xhtml", b'<html><body><h1 id="two">Two</h1></body></html>'),
+        ],
+    )
+
+    assert _normalize(package) is True
+    with zipfile.ZipFile(package) as archive:
+        rewritten = archive.read("OPS/nav.xhtml")
+    assert b'src="one.xhtml"' in rewritten
+    assert b'href="two.xhtml"' in rewritten
+    assert b"#one" not in rewritten
+    assert b"#two" not in rewritten
+    assert _normalize(package) is False
+
+
 @pytest.mark.unit
 def test_toc_without_fragments_reports_zero(tmp_path):
     package = _write_epub(

--- a/tests/unit/test_1657_kepub_toc_fragments.py
+++ b/tests/unit/test_1657_kepub_toc_fragments.py
@@ -79,13 +79,14 @@ def _matching_dual_tocs(target_count):
     return ncx, nav
 
 
-def _opf(*manifest_items, version="3.0", spine_toc=""):
+def _opf(*manifest_items, version="3.0", spine_toc="", spine_ids=()):
     items = "\n".join(manifest_items)
     toc_attribute = f' toc="{spine_toc}"' if spine_toc else ""
+    itemrefs = "".join('<itemref idref="{}"/>'.format(item_id) for item_id in spine_ids)
     return f"""<?xml version="1.0"?>
 <package xmlns="http://www.idpf.org/2007/opf" version="{version}">
   <manifest>{items}</manifest>
-  <spine{toc_attribute}/>
+  <spine{toc_attribute}>{itemrefs}</spine>
 </package>
 """.encode()
 
@@ -106,6 +107,62 @@ def _count(path):
     return count_fragment_anchored_toc_targets(path)
 
 
+def _normalize(path):
+    from cps.services.kepub_package_normalizer import normalize_kepub_package
+
+    return normalize_kepub_package(path)
+
+
+def _ncx(nav_targets=(), page_targets=(), nav_list_targets=()):
+    nav_points = "".join(
+        '<navPoint id="n{0}"><content src="{1}"/></navPoint>'.format(index, target)
+        for index, target in enumerate(nav_targets)
+    )
+    pages = "".join(
+        '<pageTarget id="p{0}"><content src="{1}"/></pageTarget>'.format(index, target)
+        for index, target in enumerate(page_targets)
+    )
+    nav_targets_outside_map = "".join(
+        '<navTarget id="l{0}"><content src="{1}"/></navTarget>'.format(index, target)
+        for index, target in enumerate(nav_list_targets)
+    )
+    return (
+        '<?xml version="1.0"?>'
+        '<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">'
+        '<navMap>{}</navMap><pageList>{}</pageList><navList>{}</navList></ncx>'.format(
+            nav_points, pages, nav_targets_outside_map)
+    ).encode()
+
+
+def _fragment_epub(
+        tmp_path, name, nav_targets, chapters, page_targets=(), nav_list_targets=()):
+    manifest = [
+        '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>'
+    ]
+    members = [("OPS/toc.ncx", _ncx(nav_targets, page_targets, nav_list_targets))]
+    spine_ids = []
+    for index, (chapter_path, chapter_bytes) in enumerate(chapters.items()):
+        item_id = "chapter{}".format(index)
+        spine_ids.append(item_id)
+        manifest.append(
+            '<item id="{}" href="{}" media-type="application/xhtml+xml"/>'.format(
+                item_id, chapter_path.replace(" ", "%20")))
+        members.append(("OPS/" + chapter_path, chapter_bytes))
+    return _write_epub(
+        tmp_path / name,
+        _opf(*manifest, version="2.0", spine_toc="ncx", spine_ids=spine_ids),
+        members,
+    )
+
+
+def _ncx_sources(path):
+    from lxml import etree
+
+    with zipfile.ZipFile(path) as archive:
+        document = etree.fromstring(archive.read("OPS/toc.ncx"))
+    return document.xpath("//*[local-name()='content']/@src")
+
+
 @pytest.mark.unit
 def test_ncx_only_toc_counts_fragment_anchored_targets(tmp_path):
     package = _write_epub(
@@ -119,6 +176,181 @@ def test_ncx_only_toc_counts_fragment_anchored_targets(tmp_path):
     )
 
     assert _count(package) == 2
+
+
+@pytest.mark.unit
+def test_single_fragment_at_first_rendered_position_is_stripped_safely(tmp_path):
+    chapter = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<section><h1 id="ch1">Chapter</h1></section>tail after the anchor ancestor'
+        b'</body></html>'
+    )
+    package = _fragment_epub(
+        tmp_path, "top-anchor.kepub", ["chapter.xhtml#ch1"],
+        {"chapter.xhtml": chapter})
+    with zipfile.ZipFile(package) as archive:
+        chapter_before = archive.read("OPS/chapter.xhtml")
+
+    assert _normalize(package) is True
+    assert _ncx_sources(package) == ["chapter.xhtml"]
+    with zipfile.ZipFile(package) as archive:
+        assert archive.read("OPS/chapter.xhtml") == chapter_before
+
+    first_rewrite = package.read_bytes()
+    assert _normalize(package) is False
+    assert package.read_bytes() == first_rewrite
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        b"<p>Rendered before the anchor</p>",
+        b'<img src="cover.jpg" alt=""/>',
+    ],
+    ids=["preceding-text", "preceding-image"],
+)
+def test_rendered_content_before_anchor_prevents_stripping(tmp_path, prefix):
+    chapter = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>' + prefix
+        + b'<h1 id="ch1">Chapter</h1></body></html>'
+    )
+    package = _fragment_epub(
+        tmp_path, "rendered-predecessor.kepub", ["chapter.xhtml#ch1"],
+        {"chapter.xhtml": chapter})
+    before = package.read_bytes()
+
+    assert _normalize(package) is False
+    assert package.read_bytes() == before
+    assert _ncx_sources(package) == ["chapter.xhtml#ch1"]
+
+
+@pytest.mark.unit
+def test_two_distinct_fragments_into_one_document_are_both_preserved(tmp_path):
+    chapter = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<h1 id="one">One</h1><h2 id="two">Two</h2></body></html>'
+    )
+    package = _fragment_epub(
+        tmp_path, "multiple-fragments.kepub",
+        ["chapter.xhtml#one", "chapter.xhtml#two"],
+        {"chapter.xhtml": chapter})
+
+    assert _normalize(package) is False
+    assert _ncx_sources(package) == ["chapter.xhtml#one", "chapter.xhtml#two"]
+
+
+@pytest.mark.unit
+def test_missing_anchor_is_preserved(tmp_path):
+    chapter = b'<html xmlns="http://www.w3.org/1999/xhtml"><body><h1>Chapter</h1></body></html>'
+    package = _fragment_epub(
+        tmp_path, "missing-anchor.kepub", ["chapter.xhtml#absent"],
+        {"chapter.xhtml": chapter})
+
+    assert _normalize(package) is False
+    assert _ncx_sources(package) == ["chapter.xhtml#absent"]
+
+
+@pytest.mark.unit
+def test_legacy_named_anchor_at_top_is_stripped(tmp_path):
+    chapter = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<a name="legacy"></a><p>Chapter</p></body></html>'
+    )
+    package = _fragment_epub(
+        tmp_path, "legacy-anchor.kepub", ["chapter.xhtml#legacy"],
+        {"chapter.xhtml": chapter})
+
+    assert _normalize(package) is True
+    assert _ncx_sources(package) == ["chapter.xhtml"]
+
+
+@pytest.mark.unit
+def test_percent_encoded_and_spaced_targets_resolve_to_the_same_anchor(tmp_path):
+    chapter = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<h1 id="ch 1">Chapter</h1></body></html>'
+    )
+    package = _fragment_epub(
+        tmp_path, "encoded-spaces.kepub",
+        ["Chapter%2001.xhtml#ch%201", "Chapter 01.xhtml#ch 1"],
+        {"Chapter 01.xhtml": chapter})
+
+    assert _normalize(package) is True
+    assert _ncx_sources(package) == ["Chapter%2001.xhtml", "Chapter 01.xhtml"]
+
+
+@pytest.mark.unit
+def test_page_list_and_nav_target_fragments_are_ignored(tmp_path):
+    chapter = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<h1 id="chapter">Chapter</h1><a id="page1"></a><p>Page one</p></body></html>'
+    )
+    package = _fragment_epub(
+        tmp_path, "page-list.kepub", ["chapter.xhtml#chapter"],
+        {"chapter.xhtml": chapter},
+        page_targets=["chapter.xhtml#page1"],
+        nav_list_targets=["chapter.xhtml#page1"])
+
+    assert _count(package) == 1
+    assert _normalize(package) is True
+    assert _ncx_sources(package) == [
+        "chapter.xhtml", "chapter.xhtml#page1", "chapter.xhtml#page1"]
+
+
+@pytest.mark.unit
+def test_qualifying_targets_are_stripped_independently_within_a_book(tmp_path):
+    package = _fragment_epub(
+        tmp_path, "partial-safe-rewrite.kepub",
+        ["top.xhtml#top", "middle.xhtml#middle"],
+        {
+            "top.xhtml": (
+                b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+                b'<h1 id="top">Top</h1></body></html>'),
+            "middle.xhtml": (
+                b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+                b'<p>Earlier</p><h1 id="middle">Middle</h1></body></html>'),
+        },
+    )
+
+    assert _normalize(package) is True
+    assert _ncx_sources(package) == ["top.xhtml", "middle.xhtml#middle"]
+
+
+@pytest.mark.unit
+def test_epub3_doc_toc_is_rewritten_but_landmarks_are_not(tmp_path):
+    nav = b"""<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <nav role="doc-toc"><a href="chapter.xhtml#top">Chapter</a></nav>
+  <nav role="doc-landmarks"><a href="chapter.xhtml#top">Landmark</a></nav>
+</body></html>"""
+    chapter = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        b'<h1 id="top">Top</h1></body></html>'
+    )
+    package = _write_epub(
+        tmp_path / "epub3-nav.kepub",
+        _opf(
+            '<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>',
+            '<item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>',
+        ),
+        [("OPS/nav.xhtml", nav), ("OPS/chapter.xhtml", chapter)],
+    )
+
+    assert _normalize(package) is True
+    with zipfile.ZipFile(package) as archive:
+        rewritten = archive.read("OPS/nav.xhtml")
+    assert rewritten.count(b'href="chapter.xhtml"') == 1
+    assert rewritten.count(b'href="chapter.xhtml#top"') == 1
+
+
+@pytest.mark.unit
+def test_non_zip_counter_and_normalizer_never_raise(tmp_path):
+    package = tmp_path / "truncated.kepub"
+    package.write_bytes(b"PK\x03\x04truncated")
+
+    assert _count(package) == 0
+    assert _normalize(package) is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_1696_kepub_repair_convergence.py
+++ b/tests/unit/test_1696_kepub_repair_convergence.py
@@ -226,6 +226,26 @@ def test_startup_repair_converges_with_permanently_unsupported_book(
 
 
 @pytest.mark.unit
+def test_repair_version_two_rescans_install_completed_at_version_one(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        repair_task.config,
+        "config_kobo_kepub_package_repair_version",
+        1,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        repair_task,
+        "enqueue_kepub_package_repair",
+        lambda hidden: calls.append(hidden) or True,
+    )
+
+    assert repair_task.REPAIR_VERSION == 2
+    assert repair_task.enqueue_startup_kepub_package_repair() is True
+    assert calls == [True]
+
+
+@pytest.mark.unit
 def test_unsupported_skip_invalidates_for_file_identity_and_repair_version(
     app_session, tmp_path, monkeypatch
 ):

--- a/tests/unit/test_kepub_package_normalizer.py
+++ b/tests/unit/test_kepub_package_normalizer.py
@@ -49,13 +49,15 @@ CHAPTER_XHTML = b"""<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-def _write_package(path, *, opf=FLATLAND_OPF, nav_path="nav.xhtml", extra_entries=()):
+def _write_package(
+        path, *, opf=FLATLAND_OPF, nav_path="nav.xhtml",
+        nav_content=NAV_XHTML, chapter_content=CHAPTER_XHTML, extra_entries=()):
     entries = [
         ("mimetype", b"application/epub+zip", zipfile.ZIP_STORED),
         ("META-INF/container.xml", CONTAINER_XML, zipfile.ZIP_DEFLATED),
         ("OPS/epb.opf", opf, zipfile.ZIP_DEFLATED),
-        (nav_path, NAV_XHTML, zipfile.ZIP_DEFLATED),
-        ("OPS/chapter-001.xml", CHAPTER_XHTML, zipfile.ZIP_DEFLATED),
+        (nav_path, nav_content, zipfile.ZIP_DEFLATED),
+        ("OPS/chapter-001.xml", chapter_content, zipfile.ZIP_DEFLATED),
     ]
     entries.extend((name, content, zipfile.ZIP_DEFLATED) for name, content in extra_entries)
     with zipfile.ZipFile(path, "w") as archive:
@@ -112,6 +114,55 @@ def test_second_normalization_is_a_byte_identical_no_op(tmp_path):
 
 
 @pytest.mark.unit
+def test_escaping_href_relocation_composes_with_redundant_toc_fragment_strip(tmp_path):
+    package = tmp_path / "composed.kepub"
+    nav = NAV_XHTML.replace(
+        b"<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><nav>",
+        b"<html xmlns=\"http://www.w3.org/1999/xhtml\" "
+        b"xmlns:epub=\"http://www.idpf.org/2007/ops\"><body><nav epub:type=\"toc\">",
+    )
+    chapter = CHAPTER_XHTML.replace(
+        b'<a href="../nav.xhtml">Contents</a>',
+        b'<a id="start" href="../nav.xhtml">Contents</a>',
+    )
+    _write_package(package, nav_content=nav, chapter_content=chapter)
+
+    assert _normalizer()(package) is True
+
+    with zipfile.ZipFile(package) as archive:
+        hrefs = _manifest_hrefs(archive.read("OPS/epb.opf"))
+        relocated_nav = "OPS/" + hrefs[0]
+        rewritten_nav = archive.read(relocated_nav)
+        assert relocated_nav in archive.namelist()
+    assert b'href="chapter-001.xml"' in rewritten_nav
+    assert b'href="chapter-001.xml#start"' not in rewritten_nav
+
+
+@pytest.mark.unit
+def test_repair_probe_reports_redundant_toc_fragment(tmp_path):
+    from cps.services import kepub_package_normalizer as normalizer
+
+    opf = CLEAN_OPF
+    nav = NAV_XHTML.replace(
+        b"<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><nav>",
+        b"<html xmlns=\"http://www.w3.org/1999/xhtml\" "
+        b"xmlns:epub=\"http://www.idpf.org/2007/ops\"><body><nav epub:type=\"toc\">",
+    ).replace(b'href="OPS/chapter-001.xml#start"', b'href="chapter-001.xml#start"')
+    chapter = CHAPTER_XHTML.replace(
+        b'<a href="../nav.xhtml">Contents</a>',
+        b'<a id="start" href="../nav.xhtml">Contents</a>',
+    )
+    package = tmp_path / "probe-fragment.kepub"
+    _write_package(
+        package, opf=opf, nav_path="OPS/nav.xhtml",
+        nav_content=nav, chapter_content=chapter)
+
+    inspection = normalizer.kepub_package_needs_normalization(package)
+
+    assert inspection.status == normalizer.PROBE_NEEDS_NORMALIZATION
+
+
+@pytest.mark.unit
 def test_clean_package_is_completely_untouched(tmp_path):
     package = tmp_path / "clean.kepub"
     _write_package(package, opf=CLEAN_OPF, nav_path="OPS/nav.xhtml")
@@ -123,7 +174,7 @@ def test_clean_package_is_completely_untouched(tmp_path):
 
 
 @pytest.mark.unit
-def test_clean_package_reads_only_container_and_opf(tmp_path, monkeypatch):
+def test_clean_package_reads_only_bounded_structural_documents(tmp_path, monkeypatch):
     import cps.services.kepub_package_normalizer as normalizer
 
     package = tmp_path / "clean.kepub"
@@ -138,11 +189,11 @@ def test_clean_package_reads_only_container_and_opf(tmp_path, monkeypatch):
     monkeypatch.setattr(normalizer.zipfile, "ZipFile", RecordingZipFile)
 
     assert normalizer.normalize_kepub_package(package) is False
-    assert read_names == ["META-INF/container.xml", "OPS/epb.opf"]
+    assert read_names == ["META-INF/container.xml", "OPS/epb.opf", "OPS/nav.xhtml"]
 
 
 @pytest.mark.unit
-def test_clean_repair_probe_reads_only_container_and_opf(tmp_path, monkeypatch):
+def test_clean_repair_probe_reads_only_bounded_structural_documents(tmp_path, monkeypatch):
     import cps.services.kepub_package_normalizer as normalizer
 
     package = tmp_path / "clean-probe.kepub"
@@ -158,7 +209,7 @@ def test_clean_repair_probe_reads_only_container_and_opf(tmp_path, monkeypatch):
 
     inspection = normalizer.kepub_package_needs_normalization(package)
     assert inspection.status == normalizer.PROBE_CLEAN
-    assert read_names == ["META-INF/container.xml", "OPS/epb.opf"]
+    assert read_names == ["META-INF/container.xml", "OPS/epb.opf", "OPS/nav.xhtml"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Addresses #1657 (partially — see "What this does not cover"). **#1657 stays OPEN**: the
mid-document case is not covered by this PR, so this deliberately avoids a closing keyword.

## The defect

Kobo draws a `Bookmark` only when `Bookmark.ContentID` **exactly** equals a `content` row with
`ContentType=9`. There is no fuzzy matching. It derives that id from the TOC entry verbatim,
fragment included — so a TOC pointing at `chapter.xhtml#ch1` files every highlight made in that
chapter under an id no spine row carries. The highlight is stored on the device and drawn nowhere.
No error, nothing looks wrong.

## Measured on hardware

Read-only copy of `KoboReader.sqlite` from a Kobo Libra Colour, 3,016 bookmarks:

| volume | bookmarks | carry `#` | anchored |
|---|---|---|---|
| Iliad | 608 | 584 | 24 |
| King in Yellow | 221 | 220 | 1 |
| Republic | 6 | 6 | 0 |
| **Odyssey (control)** | 400 | **0** | **400** |

Fragment present → orphaned; absent → anchored, with the Odyssey ruling out "book no longer on the
device". 810 fragmented, and **810/810** get an exact `ContentType=9` match once the fragment is
stripped.

Reference library, 212 EPUBs: **57 books** carry fragment-anchored navMap targets, 1,821 targets
total. `kepubify` does not introduce them (883 in the source, 883 in its output) — the defect is
inherited from the source EPUB.

**A/B on the device, so the mechanism is OBSERVED and not inferred.** The same book was sideloaded
twice onto a Clara BW (firmware 4.45.23792) — one copy converted before this change, one after — and
Nickel was allowed to index both. Reading its own `content` table back:

| copy | TOC entries resolving to a `ContentType=9` row |
|---|---|
| before | **4 / 41** |
| after | **41 / 41** |

That is Nickel's own indexer answering, not our model of it.

## The fix

Strip a TOC fragment during conversion **only when it is provably redundant** — when the anchor it
names is the first thing rendered in the document it points at, so jumping to the document and
jumping to the anchor land in the same place. All four conditions must hold:

1. the target comes from the NCX `navMap` (or an `epub:type="toc"` nav), never `pageList`
2. exactly one distinct fragment targets that document
3. the anchor exists
4. nothing rendered precedes it — no non-whitespace text, and none of
   `img`/`svg`/`video`/`audio`/`object`/`iframe`/`embed`/`canvas`/`table`

**KoboSpan ids never move, so highlights already held keep their anchors.** Non-TOC spine documents
are byte-identical, asserted per book by the real-library harness. The stronger-sounding claim
"spine documents are never rewritten" would be false and is not made: 5 of the 25 rewritten books
declare their EPUB3 nav in the spine, so a spine document *is* rewritten there. Measured on those
five, the change is confined to `href` values, the line count is unchanged, and each carries **zero**
KoboSpan ids (0 -> 0) — there is no anchor in them to move. That is what makes this safe to apply to
an existing library.

A document or TOC that will not parse fails only the redundancy proof: the target is left alone and
unrelated relocation work still runs. Real EPUB content is frequently HTML rather than well-formed
XML (unclosed `<meta>` — 7 books in the reference library), and an earlier revision let that
exception escape, regressing those books from `clean` to `retryable` and re-creating the #1696
repair loop. A recovering parser is deliberately *not* used: recovery can drop or reorder markup and
turn a genuinely mid-document anchor into an apparent first-rendered one.

**Reach.** `REPAIR_VERSION` goes 1 -> 2, so `enqueue_startup_kepub_package_repair()` re-probes the
whole library on the first restart after upgrading and repairs the books already in it — this is not
limited to newly converted books. Without that bump an existing install would never rescan, and the
fix would only ever reach new conversions. `_backup_original` copies each affected package to
`CONFIG_DIR/kepub-repair-backups/<book_id>/` and verifies the copy's SHA-256 against the source
before the first mutation.

Also narrows `count_fragment_anchored_toc_targets` to the same strict selection. The v4.1.37
diagnostic counted Gutenberg `pageList` page anchors, reporting 12,862 targets library-wide where
the true count is 1,821, and 516 for a book whose TOC has 63 chapters.

## Convergence: the probe and the planner have to agree

The startup probe decided "needs normalization" with a *structural* test — does any TOC target carry
a fragment — while the planner separately decided whether that fragment was **provably** redundant.
Any package the planner declined for a reason the probe could not see was reported as work forever:

```
round 1: probe=needs_normalization  normalize=False
round 2: probe=needs_normalization  normalize=False
round 3: probe=needs_normalization  normalize=False
VERDICT: NO-PROGRESS LOOP
```

Found by running probe → normalize in a **loop** rather than calling each once; a single call looks
correct, which is why it survived review and a green suite. Reproduced on a book whose TOC-target
document exceeds `MAX_CONTENT_DOCUMENT_BYTES`. It is the same rescan-forever shape as #1696.

The probe now runs `_plan_toc_fragment_rewrites` itself — the exact planner normalization uses — so
the invariant *"the probe must never report work for a package these planners would decline to
change"* holds by construction rather than by keeping two predicates in step. The structural-only
probe is removed, and a bounded read that refuses inside the planner became a skip for that target
rather than an escaping refusal.

The probe's docstring claimed *"The archive is never materialized, preserving the clean-library fast
path."* That stopped being true when the probe learned about fragments. It is replaced with the
actual bounded cost: each declared TOC decompressed at most once, and each eligible
fragment-targeted content document at most once, both capped at 16 MiB.

## Verification

Against the **real 212-book library**, not fixtures:

```
books with fragment navMap targets : 57
books the normalizer rewrote       : 25
fragment targets stripped          : 517
FAILURES: none
```

asserting per book that every non-TOC member is byte-identical, the navMap entry count is
unchanged, no target path changed, no fragment was added, and a second pass is a byte-identical
no-op.

Red/green — three independent mutations of the fix, each caught:

| mutation | result |
|---|---|
| remove the malformed-document tolerance | 3 failed |
| ignore rendered content preceding the anchor | 2 failed |
| drop the single-distinct-fragment requirement | 1 failed |
| revert the probe to the structural-only fragment test | **8 failed** (4 of the 6 convergence cases) |
| restored | **53 passed** |

The last row is the one that matters for the convergence fix: a test that cannot fail proves
nothing, so the fix was broken at its choke point and the failures counted.

Independent convergence check, run outside pytest against the deployed container, with a positive
control so that "always answer clean" would not pass:

```
>16 MiB target : round 1  probe=clean                normalize=False   → converged
normal control : round 1  probe=needs_normalization  normalize=True
                 round 2  probe=clean                normalize=False   → converged
CONVERGENCE FAILURES: none
```

Full unit suite on this branch: **6371 passed, 95 skipped, pytest exit 0**.

Regression table for the 7 HTML-ish books, old vs new: all `False`/`clean`, none `None`/`retryable`.

## End-to-end on hardware, through the real sync path

Kobo Clara BW, firmware 4.45.23792, book served by this instance over the Kobo sync API — not a
fixture and not a sideload. A highlight was made in an unrepaired fragment-anchored book, then the
server repaired that one book and the device re-downloaded it.

| | before repair | after repair + re-download |
|---|---|---|
| highlight `ContentID` carries `#` | yes | **no** |
| matching `ContentType=9` rows | **0** | **1** |
| drawn on the page | no | **yes** (confirmed by screenshot) |
| TOC entries carrying `#` | 25 of 25 | 4 of 25 |
| bookmark rows lost | — | **none** |

Two things this settles that were previously assumed:

1. **The repair does not destroy existing annotations.** Every bookmark row survived; the dogears
   were restored from the server after the re-download.
2. **Existing highlights are repaired, not merely prevented.** The PR previously claimed the
   opposite. Once the book is rewritten, the device re-derives the identity without the fragment and
   the old highlight resolves and draws.

The device picks the repaired book up on the next sync — the metadata bump makes it offer the book as
`Download` again — and fetches it when the reader opens it.

## What this does not cover

- A TOC anchoring **genuinely mid-document** — several chapters packed into one file, common in
  Project Gutenberg editions. 1,126 targets across 40 books. That needs the spine documents split,
  which re-anchors highlights people already hold, so it needs its own migration story. #1657 stays
  open for it.
~~Highlights already stored under the unmatched id stay invisible.~~ **Retracted — measured false.**
See "End-to-end on hardware" below: existing highlights are repaired, not merely prevented.
