### PR TITLE
fix(spa): stop refetching the whole app on tab focus, and stop the unfiltered catalog fetching the API root (#1628)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,12 +36,17 @@ jobs:
   # ============================================================================
   # JOB 1: Fast Tests (Smoke + Unit)
   # Runs on: Every push, every PR
-  # Duration: ~2 minutes
+  # Duration: a few minutes (~4 on a healthy runner, plus the npm install)
   # Purpose: Catch basic errors immediately
   # ============================================================================
   fast-tests:
     name: Fast Tests (Smoke + Unit)
     runs-on: ubuntu-latest
+    # Bounds hangs in the SETUP steps, which the test step's own
+    # timeout-minutes cannot reach. This job runs two networked installs (apt
+    # and npm) before pytest starts; without a job-level cap a stall in either
+    # runs to GitHub's 6-hour default. Twice observed stalling in the apt step.
+    timeout-minutes: 25
     env:
       PYTHONDONTWRITEBYTECODE: '1'
     
@@ -74,6 +79,12 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies (npm ci)
+        working-directory: frontend
+        run: npm ci
 
       - name: Install system dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ is for things you can see or feel when running the app.
   app.** Window focus no longer triggers an app-wide burst of server requests,
   reducing unnecessary traffic for low-bandwidth connections while leaving
   live polling, such as the task queue, running normally.
+- **Opening the main library no longer downloads a page-sized response it
+  cannot use.** The unfiltered catalog asked the API for an entity list it had
+  not been given a name for, which the server answered with the full HTML
+  library page (~58KB). The app could not parse that as data, so it failed and
+  retried. Nothing on screen depended on it. That was unnecessary traffic
+  whenever the unfiltered library view loaded, and it is the second half of the
+  same bandwidth complaint as the focus-refetch fix above.
 
 ## [v4.1.38] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Returning to the browser tab no longer refreshes every cached part of the
+  app.** Window focus no longer triggers an app-wide burst of server requests,
+  reducing unnecessary traffic for low-bandwidth connections while leaving
+  live polling, such as the task queue, running normally.
+
 ## [v4.1.38] - 2026-08-17
 
 ### Added

--- a/frontend/e2e/refetch-on-focus.spec.ts
+++ b/frontend/e2e/refetch-on-focus.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect, type Request } from '@playwright/test';
+
+const isApiRequest = (request: Request) => request.url().includes('/api/');
+
+const isTaskQueuePoll = (request: Request) =>
+  new URL(request.url()).pathname.endsWith('/api/v1/tasks');
+
+test('returning to the tab does not refetch cached SPA queries', async ({ page }) => {
+  const inFlightApi = new Set<Request>();
+  page.on('request', (request) => {
+    if (isApiRequest(request)) inFlightApi.add(request);
+  });
+  page.on('requestfinished', (request) => inFlightApi.delete(request));
+  page.on('requestfailed', (request) => inFlightApi.delete(request));
+
+  // The desktop project supplies the same authenticated storage state used by
+  // browse.spec.ts; /app is the library/browse route exercised there.
+  await page.goto('/app');
+  await expect(page.locator('a[href*="/book/"]').first()).toBeVisible();
+  await page.waitForLoadState('networkidle');
+  await expect.poll(() => inFlightApi.size, {
+    message: 'the SPA must be idle before measuring focus-triggered traffic',
+    timeout: 10_000,
+  }).toBe(0);
+
+  const focusCycleRequests: string[] = [];
+  const countRequest = (request: Request) => {
+    if (!isApiRequest(request)) return;
+    // The task queue intentionally polls every four seconds. It can fire during
+    // this window independently of focus, so only that endpoint is excluded.
+    if (isTaskQueuePoll(request)) return;
+    focusCycleRequests.push(request.url());
+  };
+  page.on('request', countRequest);
+
+  // This Playwright version has no Emulation.setPageVisibilityState CDP command.
+  // Dispatch from document with bubbling so React Query v5's window-level
+  // visibilitychange listener receives the same hidden -> visible transition.
+  await page.evaluate(async () => {
+    const setVisibility = (state: 'hidden' | 'visible') => {
+      Object.defineProperty(document, 'hidden', {
+        configurable: true,
+        value: state === 'hidden',
+      });
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: state,
+      });
+      document.dispatchEvent(new Event('visibilitychange', { bubbles: true }));
+    };
+
+    setVisibility('hidden');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    setVisibility('visible');
+    window.dispatchEvent(new Event('focus'));
+  });
+
+  await page.waitForTimeout(2_000);
+  page.off('request', countRequest);
+
+  expect(
+    focusCycleRequests,
+    `focus cycle generated ${focusCycleRequests.length} non-polling /api/ requests`,
+  ).toHaveLength(0);
+});

--- a/frontend/src/lib/entityListQueryOptions.ts
+++ b/frontend/src/lib/entityListQueryOptions.ts
@@ -1,0 +1,10 @@
+export function createEntityListQueryOptions<T>(plural: string, queryFn: () => Promise<T>) {
+  return {
+    queryKey: ['entities', plural] as const,
+    queryFn,
+    staleTime: 60000,
+    // Catalog intentionally passes an empty plural when no entity filter is
+    // active; nothing consumes this query then, so do not fetch the API root.
+    enabled: plural !== '',
+  };
+}

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -6,6 +6,7 @@ import {
   getMetadataProviders, setMetadataProviderActive,
 } from './api';
 import { removeBookFromCache, applyBookEditToCache } from './scrollCache';
+import { createEntityListQueryOptions } from './entityListQueryOptions';
 import type { MetadataProvider, MetaSearchResponse } from './api';
 import type {
   Me, Book, BooksPage, BookDetail, EntityList, Shelf, ShelfDetail,
@@ -256,11 +257,10 @@ export function useBooks(q: BooksQuery) {
 /** Fetch an entity-browse list (authors/series/tags/publishers/languages).
  *  `plural` is the endpoint segment (e.g. "authors"). */
 export function useEntityList(plural: string) {
-  return useQuery<EntityList>({
-    queryKey: ['entities', plural],
-    queryFn: () => apiGet<EntityList>(`/api/v1/${plural}`),
-    staleTime: 60000,
-  });
+  return useQuery<EntityList>(createEntityListQueryOptions(
+    plural,
+    () => apiGet<EntityList>(`/api/v1/${plural}`),
+  ));
 }
 
 /** The tag a rename collided with, carried on the 409 so the caller can offer

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,0 +1,13 @@
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
+
+export function createQueryClient(handlers: { onError: (err: unknown) => void }): QueryClient {
+  return new QueryClient({
+    queryCache: new QueryCache({ onError: handlers.onError }),
+    mutationCache: new MutationCache({ onError: handlers.onError }),
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,11 +2,12 @@ import './styles/tokens.css';
 import './styles/global.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { QueryClient, QueryClientProvider, QueryCache, MutationCache } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { App } from './App';
 import { AnnouncerProvider } from './lib/a11y/announcer';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { AuthTransitionError, navigateToLogout, BASE_PREFIX } from './lib/api';
+import { createQueryClient } from './lib/queryClient';
 
 // Protected wrappers normalize every auth-loss shape and start the canonical
 // top-level logout navigation. Keep the cache transition here so no stale
@@ -18,10 +19,7 @@ function onUnauthorized(err: unknown) {
   }
 }
 
-const queryClient = new QueryClient({
-  queryCache: new QueryCache({ onError: onUnauthorized }),
-  mutationCache: new MutationCache({ onError: onUnauthorized }),
-});
+const queryClient = createQueryClient({ onError: onUnauthorized });
 
 // #855: last-resort render/lifecycle boundary for failures in the providers or
 // in App before the router-level boundary (App.tsx, which also resets on

--- a/frontend/tests/unit/entityListQueryOptions.test.ts
+++ b/frontend/tests/unit/entityListQueryOptions.test.ts
@@ -1,0 +1,70 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { QueryClient, QueryObserver } from '@tanstack/react-query';
+
+import { createEntityListQueryOptions } from '../../src/lib/entityListQueryOptions.ts';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function observedCallCount(plural: string): Promise<number> {
+  let calls = 0;
+  const queryFn = async () => {
+    calls += 1;
+    return { items: [] };
+  };
+  const options = createEntityListQueryOptions(plural, queryFn);
+  const client = new QueryClient();
+  const observer = new QueryObserver(client, options);
+  let resolveSuccess!: () => void;
+  const success = new Promise<void>((resolve) => { resolveSuccess = resolve; });
+  const unsubscribe = observer.subscribe((result) => {
+    if (result.isSuccess) resolveSuccess();
+  });
+
+  try {
+    if (plural === '') {
+      await delay(50);
+    } else {
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          success,
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(() => reject(new Error('enabled entity query did not settle')), 1_000);
+          }),
+        ]);
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
+    }
+    return calls;
+  } finally {
+    unsubscribe();
+    client.clear();
+  }
+}
+
+describe('createEntityListQueryOptions', () => {
+  test('runs only when an entity endpoint is present', () => {
+    const queryFn = async () => ({ items: [] });
+
+    assert.equal(createEntityListQueryOptions('', queryFn).enabled, false);
+    assert.equal(createEntityListQueryOptions('authors', queryFn).enabled, true);
+  });
+
+  test('preserves the entity-list cache contract', () => {
+    const queryFn = async () => ({ items: [] });
+
+    for (const plural of ['', 'authors']) {
+      const options = createEntityListQueryOptions(plural, queryFn);
+      assert.deepEqual(options.queryKey, ['entities', plural]);
+      assert.equal(options.staleTime, 60000);
+      assert.equal(options.queryFn, queryFn);
+    }
+  });
+
+  test('a real observer fetches only for a non-empty entity endpoint', async () => {
+    assert.equal(await observedCallCount(''), 0);
+    assert.equal(await observedCallCount('authors'), 1);
+  });
+});

--- a/frontend/tests/unit/queryClient.test.ts
+++ b/frontend/tests/unit/queryClient.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Regression coverage for the SPA-wide React Query configuration.
+ *
+ * Run the production configuration:
+ *   NODE_OPTIONS=--experimental-strip-types node --test frontend/tests/unit/queryClient.test.ts
+ *
+ * Reproduce the pre-fix configuration (expected to fail):
+ *   QUERY_CLIENT_TEST_PRE_FIX=1 NODE_OPTIONS=--experimental-strip-types \
+ *     node --test frontend/tests/unit/queryClient.test.ts
+ */
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { QueryClient } from '@tanstack/react-query';
+
+import { createQueryClient } from '../../src/lib/queryClient.ts';
+
+describe('createQueryClient', () => {
+  test('disables refetching cached queries when the window regains focus', () => {
+    const client = process.env.QUERY_CLIENT_TEST_PRE_FIX === '1'
+      ? new QueryClient({})
+      : createQueryClient({ onError: () => undefined });
+
+    assert.equal(client.getDefaultOptions().queries?.refetchOnWindowFocus, false);
+  });
+
+  test('routes query and mutation cache failures to the supplied handler', async () => {
+    const queryError = new Error('query failed');
+    const mutationError = new Error('mutation failed');
+    const handled: unknown[] = [];
+    const client = createQueryClient({ onError: (err) => handled.push(err) });
+
+    await assert.rejects(
+      client.fetchQuery({
+        queryKey: ['query-client-test'],
+        queryFn: async () => { throw queryError; },
+      }),
+      queryError,
+    );
+
+    const mutation = client.getMutationCache().build(client, {
+      mutationFn: async () => { throw mutationError; },
+    });
+    await assert.rejects(mutation.execute(undefined), mutationError);
+
+    assert.deepEqual(handled, [queryError, mutationError]);
+  });
+});

--- a/tests/unit/test_frontend_unit_suites_run.py
+++ b/tests/unit/test_frontend_unit_suites_run.py
@@ -31,6 +31,7 @@ pytestmark = pytest.mark.unit
 
 REPO = Path(__file__).resolve().parents[2]
 SUITE_DIR = REPO / "frontend" / "tests" / "unit"
+NODE_MODULES = REPO / "frontend" / "node_modules"
 # Explicit file paths, never the directory. `node --test <dir>` fails to apply
 # type stripping to the .ts files it discovers and reports a bare "test failed"
 # with no assertion behind it, while `node --test <file>` on the same suite
@@ -60,6 +61,18 @@ def test_frontend_unit_suite_passes(suite: Path):
                 "node; Fast Tests needs it too."
             )
         pytest.skip("no node available locally (CI has one)")
+
+    if not NODE_MODULES.is_dir():
+        if os.environ.get("CI"):
+            pytest.fail(
+                "frontend/node_modules is absent on CI: the Fast Tests job's "
+                "'Install frontend dependencies (npm ci)' step must run before "
+                "the frontend Node unit suites"
+            )
+        pytest.skip(
+            "frontend/node_modules is absent; run npm ci in frontend to execute "
+            "the frontend Node unit suites"
+        )
 
     # Type stripping is unflagged only from Node 23.6 and CI pins 22, so the
     # flag has to be supplied -- but it must go through NODE_OPTIONS, not argv.


### PR DESCRIPTION
Closes nothing on its own — see the note on #1628 below.

## The bug

`frontend/src/main.tsx` built its `QueryClient` with a `queryCache` and a `mutationCache` and **no `defaultOptions`**. React Query v5 therefore applied its built-in `refetchOnWindowFocus: true` to the whole SPA. There are ~110 `queryKey:` declarations in the tree and exactly **one** opt-out (`frontend/src/lib/coverPicker.ts:190`).

So every time a user came back to the tab, the app re-hit the server for essentially everything it had cached. That is what #1628 is about — it was filed by someone on a low-bandwidth connection.

## The fix

A `createQueryClient()` factory in `frontend/src/lib/queryClient.ts` that sets `defaultOptions.queries.refetchOnWindowFocus: false`, and `main.tsx` calling it. The `onUnauthorized` handler and its wiring into both caches are unchanged in effect.

The factory exists so the configuration can be **executed** by a test rather than grepped for. A source-pin would pass whether or not the client was actually built that way.

## The second cause, which the e2e spec found and I had not predicted

The spec asserts **zero** `/api/` requests across a hide/show cycle. After the app-wide default it went 3 → 1, and the survivor was not a focus refetch at all:

`frontend/src/pages/Catalog.tsx:384` deliberately calls `useEntityList('')` when no entity filter is active (`filtered` is `!!entityKind`). `useEntityList` had no `enabled` guard, so it built the bare URL `/api/v1/` and fetched it. Measured against a running instance:

```
/api/v1/about                   200 application/json      79 bytes
/api/v1/tasks                   200 application/json      13 bytes
/api/v1/                        200 text/html         58,041 bytes
/api/v1/definitely-not-a-route  200 text/html         58,832 bytes
```

Any unmatched path under `/api/v1/` returns **200 with the full HTML library page**. `apiGet` checks `res.ok` — true for 200 — then calls `res.json()`, which throws on HTML, so React Query retried it. Every load of the unfiltered library view pulled ~58KB it could not parse and then tried again.

Fixed by extracting the options into `frontend/src/lib/entityListQueryOptions.ts` with `enabled: plural !== ''`. Extracted rather than patched at the call site so no future caller can reintroduce it.

**The catch-all itself is not fixed here.** An API path that no longer exists answering 200 with a web page means a renamed or dropped endpoint reaches callers as a parse error rather than a clear 404. That is a real defect and it is filed separately; this PR only stops the SPA making one such request.

## CI: the suite could not run

`frontend/tests/unit/queryClient.test.ts` is the first SPA unit suite to import a node_modules package, and the Fast Tests job set up Node but never installed the frontend's dependencies — so it died with `ERR_MODULE_NOT_FOUND` in CI while passing locally. Structurally, no SPA unit test could import React, React Query, or any library at all.

- `npm ci` (with npm caching keyed on `frontend/package-lock.json`) added to Fast Tests.
- `tests/unit/test_frontend_unit_suites_run.py` now **fails loudly on CI** and skips locally with a reason when `frontend/node_modules` is absent, mirroring its existing treatment of a missing `node`. A suite that silently stops running is the exact hole that file exists to close.
- The job also gets `timeout-minutes: 25`. The existing cap is on the pytest *step*, which cannot bound a hang in an earlier step — and the observed hangs are in the apt install, twice, once for 4h37m. This change adds a second networked install to the same job, so it gets the bound the CI policy already asks for.

## Evidence

- **Red/green on the real runtime, reproduced by me independently of the author.**
  `frontend/tests/unit/entityListQueryOptions.test.ts` builds a real `QueryClient`
  and `QueryObserver` from the factory's own options and counts `queryFn`
  invocations: 0 for `''`, exactly 1 for `'authors'`. With the `enabled` line
  removed it fails `1 !== 0`. It also pins the cache contract that the extraction
  had to preserve — `queryKey` is exactly `['entities', plural]`, `staleTime` is
  exactly `60000`, and the `queryFn` passed in is the one returned.
  It asserts *behaviour*, not the shape of an options object: an earlier version
  only checked `.enabled`, which would still have passed if a refactor stopped
  `useEntityList` handing those options to `useQuery`.
- `frontend/tests/unit/queryClient.test.ts` drives a real `fetchQuery` rejection
  and a real mutation rejection and asserts both reach the supplied handler, so
  the auth-loss wiring moved into the factory is executed, not assumed.
- **The node_modules guard demonstrated in both directions**: with
  `frontend/node_modules` moved aside, `CI=1 pytest` fails with the message
  naming the npm ci step, and without `CI` it skips with a reason. Restored after.
- `npm run build` (tsc -b + vite) exits 0.
- Full local `tests/unit/` on this head: 6325 passed. Six failures, none from this
  change — four are the pre-existing `test_1596_module_entry_point.py` set that
  also fails on pristine `main`, and two are load artifacts that pass in isolation
  (one took 140s under full-suite load against a 120s cap; it runs in 28s alone).
- The user-visible half is the e2e spec in this PR, which runs in CI against the
  PR's own SPA bundle. That is the link I am relying on CI for rather than
  claiming locally: `cwn-local` serves its image's baked-in bundle, so verifying
  it here would have meant overwriting a shared container's assets.

## Scope, deliberately narrow

`staleTime`, `retry` and `gcTime` are untouched. Twelve queries set their own `staleTime` on purpose and a blanket default would have changed refetch-on-mount semantics across all ~110 keys — a much larger blast radius than the bug being fixed. `refetchOnWindowFocus` only.

`coverPicker.ts:190`'s explicit `false` is left in place. It is now redundant, not wrong.

## What users lose, stated plainly

Two queries run at `staleTime: 0` and were relying on focus to refresh:

- **`useDiscover`** — the Discover strip reshuffled on every tab return. That was one of the symptoms, not a feature.
- **`useBookmark`** — reading position. If you read the same book elsewhere and switch back to an already-open tab, the position no longer refreshes on focus alone. It still refetches on navigation or remount, and the reader writes it itself, so the window is narrow. Naming it because it is the one real regression in this change rather than pretending there is none.

Live polling is unaffected: the task queue's `refetchInterval: 4000` (`queries.ts:1286`) is a timer, not a focus subscription.

## Credit

@chloeroform diagnosed this in **#1653**, which fixes it for the Discover section. This is the app-wide version of that diagnosis, and it does not conflict with their PR — #1653 still applies cleanly on top and its explicit setting stays correct. @TangentFoxy pushed back that fixing Discover alone would only hide the problem; they were right, and this is the other half.

Refs #1628.
