### PR TITLE
fix(tests): stop the unit suite leaving user annotation payloads committable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,3 +287,13 @@ wiki-generated/
 /app.db-journal
 /app.db-wal
 /app.db-shm
+#
+# Same shape, found 2026-08-17: annotation_backup.get_backup_root() resolves
+# `Path(constants.CONFIG_DIR) / "annotation-backups"`, and under the unit suite
+# CONFIG_DIR is the checkout, so a plain `pytest tests/unit` leaves 22 real
+# gzipped annotation payloads at `<repo>/annotation-backups/<user>/<book>/`.
+# Those are user highlight data, they were untracked and unignored, and any
+# `git add -A` after a local test run would have committed them.
+# tests/unit/test_1712_annotation_backup_not_committable.py derives the name
+# from the service so this entry cannot drift away from what the code writes.
+/annotation-backups/

--- a/tests/unit/test_1712_annotation_backup_not_committable.py
+++ b/tests/unit/test_1712_annotation_backup_not_committable.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""The unit suite writes real annotation backups into the checkout (#1712).
+
+``annotation_backup.get_backup_root()`` resolves ``CONFIG_DIR/annotation-backups``
+at call time. In the container CONFIG_DIR is ``/config``; under pytest it is the
+repository, so running the suite leaves real gzipped highlight payloads at
+``<repo>/annotation-backups/<user_id>/<book_id>/<UTC>.json.gz``. They are user
+data, so the hazard is that an ``git add -A`` after a local run commits them.
+
+Ignoring the directory does not stop the writes -- it stops them being
+committable. The directory name is read back from the service rather than
+hardcoded, so renaming it in code without updating .gitignore fails here.
+"""
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.unit
+def test_annotation_backup_directory_is_git_ignored():
+    from cps.services import annotation_backup
+
+    # The name the service actually writes, not a copy of it.
+    directory = annotation_backup.get_backup_root().name
+    assert directory, "get_backup_root() must resolve to a named directory"
+
+    patterns = {
+        line.strip()
+        for line in (REPO_ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+    accepted = {
+        "/%s/" % directory, "/%s" % directory,
+        "%s/" % directory, directory,
+    }
+    assert patterns & accepted, (
+        "%r is written into the repository by the test suite and must be "
+        "git-ignored; .gitignore has none of %r" % (directory, sorted(accepted))
+    )
+
+
+@pytest.mark.unit
+def test_backup_root_follows_config_dir(monkeypatch, tmp_path):
+    """Redirecting CONFIG_DIR moves the backups -- the basis for a real fix."""
+    from cps import constants
+    from cps.services import annotation_backup
+
+    monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path))
+    assert annotation_backup.get_backup_root() == tmp_path / "annotation-backups"


### PR DESCRIPTION
Addresses #1712.

## The problem

`python3 -m pytest tests/unit` in a clean checkout leaves an untracked
`annotation-backups/` directory in the repository root, holding **real gzipped highlight payloads**
keyed `<user_id>/<book_id>/<UTC-iso>.json.gz`.

Measured on a clean worktree at `695d8f457` (no feature branch, no local changes): 6329 passed, 22
files left behind. A full run on this branch left 37.

```
$ find annotation-backups -type f | head -3
annotation-backups/2/7/2026-08-17T23-05-07-559087Z.json.gz
annotation-backups/2/101/2026-08-17T23-05-40-306000Z.json.gz
annotation-backups/9/42/2026-08-17T23-04-27-114730Z.json.gz
```

`annotation_backup.get_backup_root()` resolves `Path(constants.CONFIG_DIR) / "annotation-backups"`
at call time, and `CONFIG_DIR` is `os.environ.get('CALIBRE_DBPATH', BASE_DIR)` — `/config` in the
image, **the checkout** under pytest. So the production write path deposits production artifacts
into the source tree.

The directory was neither tracked nor ignored. That is the hazard: any `git add -A` after a local
test run commits somebody's highlights.

## What this does

Adds a root-anchored `/annotation-backups/` to `.gitignore`, in the same block as the existing
`/.key` and `/app.db` entries, which exist for exactly this shape (app writes under `/config`;
running from a clone puts them in the repo root).

**This ignores the files; it does not stop the writes.** The full fix is to point `CONFIG_DIR` at a
temp directory for the suite, and is deliberately out of scope here:

- `tests/unit/test_1474_cwa_db_config_dir_ssot.py` monkeypatches `CALIBRE_DBPATH` per test and
  reasons about `CONFIG_DIR`'s value, so moving it globally needs its own change and its own review.
- An autouse conftest fixture was tried earlier and rejected: importing
  `cps.services.annotation_backup` at collection time breaks
  `test_duplicate_scan_index_rewire.py`, which deliberately stubs `cps.services`
  (`ImportError: cannot import name 'annotation_backup'`, 19 errors).

## Tests

Two, in `tests/unit/test_1712_annotation_backup_not_committable.py`. The first reads the directory
name back **from `get_backup_root()`** rather than hardcoding it, so renaming it in code without
updating `.gitignore` fails here. The second pins the `CONFIG_DIR` → backup-root relationship the
real fix will build on.

Red/green: deleting the `.gitignore` line fails `test_annotation_backup_directory_is_git_ignored`
(`1 failed, 1 passed`); restored, `2 passed`.

## Verification

Full suite, real pytest exit code, not piped:

```
6328 passed, 100 skipped, 1015 warnings in 174.51s
SUITE_EXIT=0

annotation-backups/  -> 37 files created
git status --short   -> only the two intended changes
git check-ignore -v annotation-backups
  .gitignore:299:/annotation-backups/    annotation-backups
```

Found while verifying #1709; present on `main` and unrelated to that branch.