### PR TITLE
fix(kobo): normalize a KEPUB on the auto-ingest path, which never did

### DIFF
--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -34,6 +34,7 @@ import service_user
 # no-op fallback so callsites that reference these names work even if
 # the lazy load hasn't happened yet (or fails in a test environment).
 _calibre_plugins = None
+_normalize_kepub_package = None
 _CPS_ROOT = str(app_paths.app_root())
 
 # Anchor for the shared conversion budget (#1094). Bound at import so it
@@ -64,7 +65,7 @@ def _load_fork_cps_imports() -> None:
     @navels' fast-exit design. Safe to call multiple times; both
     rebinds are idempotent.
     """
-    global _calibre_plugins, metadata_db_write_lock
+    global _calibre_plugins, metadata_db_write_lock, _normalize_kepub_package
 
     if _CPS_ROOT not in sys.path:
         sys.path.insert(0, _CPS_ROOT)
@@ -80,6 +81,14 @@ def _load_fork_cps_imports() -> None:
         metadata_db_write_lock = _module_lock
     except ImportError:
         metadata_db_write_lock = _noop_metadata_db_write_lock
+
+    try:
+        from cps.services.kepub_package_normalizer import (
+            normalize_kepub_package as _module_normalize,
+        )
+        _normalize_kepub_package = _module_normalize
+    except ImportError:
+        _normalize_kepub_package = None
 
 
 # Retry calibredb add on transient "database is locked" / BusyError.
@@ -1571,6 +1580,26 @@ class NewBookProcessor:
 
 
     def add_book_to_library(self, book_path:str, text: bool=True, format: str="text" ) -> None:
+        # Normalize a KEPUB before it enters the library (#1715). Every ingest
+        # route lands here -- kepubify output, a file already in the target
+        # format, and a format the user told CWA not to convert -- and none of
+        # them normalized, so a Kobo would derive each chapter's id from the TOC
+        # entry verbatim, fragment included, and file every highlight made there
+        # under an id no spine row carries. The repair task cannot cover for this:
+        # it is one-shot per REPAIR_VERSION.
+        # Non-fatal by design: normalize_kepub_package logs and returns None with
+        # the archive untouched, and importing an un-normalized KEPUB beats
+        # refusing the ingest.
+        if os.path.splitext(book_path)[1].lower() == ".kepub":
+            if _normalize_kepub_package is None:
+                _load_optional_cps_modules()
+            if _normalize_kepub_package is not None:
+                try:
+                    _normalize_kepub_package(book_path)
+                except Exception as e:
+                    print(f"[ingest-processor] WARN: could not normalize KEPUB "
+                          f"{book_path}: {e}", flush=True)
+
         # If kindle-epub-fixer is on, run it first and import the *fixed* file.
         if self.target_format == "epub" and self.is_kindle_epub_fixer:
             fixed_epub_path = Path(self.tmp_conversion_dir) / os.path.basename(book_path)

--- a/tests/unit/test_1715_ingest_normalizes_kepub.py
+++ b/tests/unit/test_1715_ingest_normalizes_kepub.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Auto-ingest must normalize a KEPUB before it enters the library (#1715).
+
+Three ingest routes all reach ``add_book_to_library`` with a KEPUB that nothing
+has normalized: kepubify's own output, a file already in the target format
+(``is_target_format`` at ingest_processor.py), and a format the user told CWA not
+to convert. The repair task cannot cover for it -- it is one-shot per
+``REPAIR_VERSION`` -- so such a book keeps its fragment-anchored TOC targets
+permanently, and a Kobo files every highlight in those chapters under an id no
+``ContentType=9`` row carries.
+
+The normalization is the first thing ``add_book_to_library`` does, so these tests
+drive the real method with a stub ``self`` and assert on the file. The calibredb
+work further down is not stubbed; it is expected to fail on the stub and is
+irrelevant to what is being pinned here.
+"""
+import os
+import sys
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = str(REPO_ROOT / "scripts")
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import ingest_processor  # noqa: E402
+
+CONTAINER = ('<?xml version="1.0"?><container version="1.0" '
+             'xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles>'
+             '<rootfile full-path="OEBPS/content.opf" '
+             'media-type="application/oebps-package+xml"/></rootfiles></container>')
+OPF = ('<?xml version="1.0" encoding="UTF-8"?>'
+       '<package xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="i">'
+       '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title>t</dc:title></metadata>'
+       '<manifest><item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>'
+       '<item id="c1" href="chapter.xhtml" media-type="application/xhtml+xml"/></manifest>'
+       '<spine toc="ncx"><itemref idref="c1"/></spine></package>')
+NCX = ('<?xml version="1.0" encoding="UTF-8"?>'
+       '<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1"><navMap>'
+       '<navPoint id="n1" playOrder="1"><navLabel><text>One</text></navLabel>'
+       '<content src="chapter.xhtml#top"/></navPoint></navMap></ncx>')
+CHAPTER = ('<?xml version="1.0" encoding="UTF-8"?>'
+           '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>c</title></head>'
+           '<body><div id="top">x</div></body></html>')
+
+
+def _make_kepub(path):
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("mimetype", "application/epub+zip")
+        archive.writestr("META-INF/container.xml", CONTAINER)
+        archive.writestr("OEBPS/content.opf", OPF)
+        archive.writestr("OEBPS/toc.ncx", NCX)
+        archive.writestr("OEBPS/chapter.xhtml", CHAPTER)
+    return str(path)
+
+
+def _ncx_sources(path):
+    from lxml import etree
+    with zipfile.ZipFile(path) as archive:
+        doc = etree.fromstring(archive.read("OEBPS/toc.ncx"))
+    return [e.get("src") for e in doc.iter("{*}content")]
+
+
+def _run_add(book_path):
+    """Call the real method far enough to cover the normalization step."""
+    stub = SimpleNamespace(
+        target_format="kepub",
+        is_kindle_epub_fixer=False,
+        tmp_conversion_dir=os.path.dirname(book_path),
+        cwa_settings={},
+        metadata_db="/nonexistent/metadata.db",
+    )
+    try:
+        ingest_processor.NewBookProcessor.add_book_to_library(stub, book_path)
+    except Exception:
+        # Everything past normalization needs a real calibredb; not under test.
+        pass
+
+
+def test_ingested_kepub_has_its_redundant_fragment_stripped(tmp_path):
+    book = _make_kepub(tmp_path / "incoming.kepub")
+    assert _ncx_sources(book) == ["chapter.xhtml#top"]
+
+    _run_add(book)
+
+    assert _ncx_sources(book) == ["chapter.xhtml"], (
+        "an ingested KEPUB must be normalized, or a Kobo files highlights in "
+        "this chapter under an id no spine row carries")
+
+
+def test_ingested_epub_is_left_alone(tmp_path):
+    """Only KEPUBs go through the KEPUB normalizer."""
+    book = _make_kepub(tmp_path / "incoming.epub")
+
+    _run_add(book)
+
+    assert _ncx_sources(book) == ["chapter.xhtml#top"], (
+        "a non-KEPUB ingest must not be rewritten by the KEPUB normalizer")
+
+
+def test_normalizer_is_reachable_from_the_ingest_process():
+    """The lazy loader must actually bind it; a silent None would no-op forever."""
+    ingest_processor._load_optional_cps_modules()
+    assert ingest_processor._normalize_kepub_package is not None, (
+        "ingest_processor could not import normalize_kepub_package, so every "
+        "ingested KEPUB would silently skip normalization")


### PR DESCRIPTION
Addresses #1715, doors 2–4. Companion to #1718, which closes the web-upload door.

## The gap

`scripts/ingest_processor.py` had **no reference to `normalize_kepub_package` at all**:

```
$ grep -c normalize_kepub_package scripts/ingest_processor.py
0
```

It is a separate conversion implementation from `cps/tasks/convert.py` — it shells out to `kepubify`
itself — so every book entering the library through **auto-ingest**, CWA's primary route, was
imported un-normalized.

Three routes reach `add_book_to_library()` with a KEPUB nothing has touched:

| route | code |
|---|---|
| kepubify's own output | `convert_to_kepub()` |
| already in the target format | `if nbp.is_target_format:` → `add_book_to_library(filepath)` |
| format on the convert-ignore list | `input_format in convert_ignored_formats` → `add_book_to_library(filepath)` |

And the repair task cannot cover for them: `enqueue_startup_kepub_package_repair()` fires only while
`config_kobo_kepub_package_repair_version < REPAIR_VERSION`, and the task stamps that value on
success. Books ingested afterwards are never inspected again.

## Why it matters

A Kobo derives a chapter's id from the TOC entry verbatim, fragment included. Measured on a Clara BW
(4.45.23792): a highlight made after navigating to a fragment-bearing TOC entry is stored with
`Bookmark.ContentID` ending `...xhtml#pgepubid00038`, matches **0** rows of `ContentType=9`, and is
drawn nowhere — no error, nothing looks wrong. That is #1657, arriving through the door its fix did
not cover.

## The change

One call at `add_book_to_library()`, the single choke point all three routes land in. That method
already establishes the pattern by running the kindle-epub-fixer there and importing the *fixed*
file.

The normalizer is bound through the existing `_load_optional_cps_modules()` lazy loader, so the `cps`
package is still not imported at module load and @navels' fast-exit design is preserved.

Non-fatal by design: `normalize_kepub_package` logs and returns `None` with the archive untouched,
and the call is additionally wrapped — importing an un-normalized KEPUB beats failing an ingest.

## Tests

Three, in `tests/unit/test_1715_ingest_normalizes_kepub.py`, driving the real
`add_book_to_library` with a stub `self` (normalization is the first thing it does):

- an ingested `.kepub` has its redundant fragment stripped;
- an ingested `.epub` is left byte-for-byte alone;
- **the lazy import actually binds** — a silent `None` would no-op forever, which is the failure mode
  that would make this fix invisible.

Red/green: removing the block fails `test_ingested_kepub_has_its_redundant_fragment_stripped`
(1 failed, 2 passed); restored, 3 passed.

## Verification

- Existing ingest tests unaffected: **99 passed, 7 skipped, exit 0**.
- Full suite: **6378 passed, 100 skipped, exit 0**.
- Ruff: **9 errors in this file both with and without the change** — all pre-existing, none
  introduced here.