### PR TITLE
docs(changelog): say which files the #1657 figures were counted on, and report the real repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,17 @@ is for things you can see or feel when running the app.
   you make in that chapter under a name nothing on the device answers to, so the
   marks are saved and drawn nowhere. Nothing looks wrong and no error appears;
   the highlights simply never show up. On one 212-book library this affected 57
-  books. Where the anchor sits at the very top of the chapter it points at it
+  books. (Those two figures were counted on the library's source EPUBs; a Kobo is
+  served the converted copy. The two carry the same table of contents, so the
+  counts match, but the repair itself was measured directly and is reported at
+  the end of this entry.) Where the anchor sits at the very top of the chapter it points at it
   says nothing the file path does not already say, so conversion now drops it:
   517 such targets across 25 of those books, with every table-of-contents entry
   kept exactly as it was. Books already in your library are repaired on the first
   restart after upgrading, not only newly converted ones — each one is copied and
-  hash-checked before it is touched. Chapter files themselves are left byte-for-byte
+  hash-checked before it is touched. Measured on the reference instance after this
+  shipped: 37 books repaired, every one completed, and no converted copy left
+  needing work. Chapter files themselves are left byte-for-byte
   alone, so highlights you already hold keep their positions. In a few books the
   contents page is part of the reading order and so is rewritten too — five of
   the twenty-five here — but only its links change, and it carries none of the


### PR DESCRIPTION
Re #1657. Documentation only.

## Two corrections to the entry merged in #1709

**1. The figures were a proxy measurement, and did not say so.**

My verification harness filtered on `.lower().endswith('.epub')` — which does **not** match `.kepub`.
So "57 books" and "517 targets" were counted on the library's **source EPUBs**, while the file a Kobo
actually downloads is the converted copy.

The counts are equivalent — kepubify carries the table of contents through unchanged, measured
earlier at 883 fragment-bearing targets in and 883 out — so the entry is not misleading about scale.
But it presented a proxy as a direct measurement, and that is worth stating rather than leaving for
someone to rediscover.

**2. "Books already in your library are repaired" is no longer a forward-looking claim.**

The release deployed to the reference instance at 02:26Z and the startup repair ran. Observed:

```
config_kobo_kepub_package_repair_version : 1 -> 2   (stamped only on success)
kepub_package_repair rows                : 37, all status=completed, all version 2
converted copies still needing work      : 0
```

Including one book (*The Poppy War*) whose malformed navigation document logs
`XML declaration allowed only at the start of the document` and is **skipped cleanly rather than
retried** — the #1696 loop this release exists to avoid, visibly not happening.

Numbers a reader can check on that instance: **217** converted copies, **46** still carrying
fragment-anchored targets, **1,224** such targets remaining. Those are the mid-document case the
entry already names as its honest limit.

No code change.