### PR TITLE
test: point CONFIG_DIR at a temp directory so the suite stops writing into the checkout

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -30,12 +30,29 @@ SQLAlchemy / scheduler heavy startup that import-time test code can't afford.
 """
 
 import importlib.util
+import os
 import sys
+import tempfile
 import types
 from pathlib import Path
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Point CONFIG_DIR somewhere disposable before cps.constants is ever imported
+# (#1712). constants.py resolves CONFIG_DIR = os.environ.get('CALIBRE_DBPATH',
+# BASE_DIR) at import time, so under pytest it was the checkout itself, and
+# production write paths deposited production artifacts into the source tree --
+# annotation_backup.get_backup_root() left real gzipped highlight payloads at
+# <repo>/annotation-backups/<user>/<book>/, untracked, on every full run.
+#
+# Set here rather than in a fixture because _preload_real_constants() below
+# imports constants during collection, long before any fixture runs. Tests that
+# care about this value (test_1474_cwa_db_config_dir_ssot.py) monkeypatch
+# CALIBRE_DBPATH themselves and are unaffected; an explicit value already in the
+# environment is left alone so a caller can still choose one.
+if not os.environ.get("CALIBRE_DBPATH"):
+    os.environ["CALIBRE_DBPATH"] = tempfile.mkdtemp(prefix="cwng-test-config-")
 
 
 def _preload_real_constants() -> None:


### PR DESCRIPTION
Re #1712. Partial fix — the issue stays open, see the last section.

## What was happening

`cps/constants.py` resolves `CONFIG_DIR = os.environ.get('CALIBRE_DBPATH', BASE_DIR)` **at import
time**. Under pytest that is the checkout, so production write paths deposit production artifacts
into the source tree — annotation-backup payloads, `app.db`, `convert-library.log` and others.

#1714 stopped the dangerous consequence by ignoring `annotation-backups/`, but the writes themselves
carried on, and the other artifacts were not addressed at all.

## The change

One assignment at `tests/unit/conftest.py` module level, before `cps.constants` can be imported:

```python
if not os.environ.get("CALIBRE_DBPATH"):
    os.environ["CALIBRE_DBPATH"] = tempfile.mkdtemp(prefix="cwng-test-config-")
```

Module level rather than a fixture is deliberate — `_preload_real_constants()` imports constants
during **collection**, long before any fixture runs. An explicit value already in the environment is
left alone so a caller can still choose one.

## I was wrong to decline this earlier

In #1714 I said this needed its own change because `test_1474_cwa_db_config_dir_ssot.py`
monkeypatches `CALIBRE_DBPATH` per test and reasons about `CONFIG_DIR`. That was over-cautious: those
tests set the variable themselves and are unaffected. Measured instead of assumed.

## Verification

```
full suite            : 6378 passed, 100 skipped, exit 0   (no failures)
files moved out of the checkout : 47
annotation-backup residue       : 37 files -> 11
```

## Why #1712 stays open

Eleven files still reach `<repo>/annotation-backups/`. The obvious candidates all monkeypatch
`CONFIG_DIR` to tmp paths of their own, so it is something subtler — plausibly a background worker
flushing after a fixture has reverted. The `.gitignore` entry from #1714 still covers the commit
hazard for those, so the remaining residue is untidy rather than dangerous.