### PR TITLE
fix(ingest): resolve the batch markers through the same config dir on both sides (#1614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **Active imports no longer incorrectly ask for a manual duplicate scan on
+  bare-metal installs or when ingest marker paths are customized.** Both the
+  importer and the duplicate index now look for the batch markers in the same
+  configured location.
 - **Returning to the browser tab no longer refreshes every cached part of the
   app.** Window focus no longer triggers an app-wide burst of server requests,
   reducing unnecessary traffic for low-bandwidth connections while leaving

--- a/cps/duplicate_index.py
+++ b/cps/duplicate_index.py
@@ -34,8 +34,6 @@ log = logger.create()
 NORMALIZATION_VERSION = "duplicate-index-v3"  # v3: + accent-fold (NFKD) + punctuation-to-space, precision-preserving (D6)
 MAX_INCREMENTAL_BOOK_IDS = 1000
 DUPLICATE_INDEX_REBUILD_BATCH_SIZE = 250
-INGEST_BATCH_DIRTY_FILE = "/config/cwa_ingest_batch_dirty"
-INGEST_BATCH_ACTIVE_FILE = "/config/cwa_ingest_batch_active"
 
 CRITERIA_KEYS = (
     "duplicate_detection_title",
@@ -565,11 +563,25 @@ def has_valid_duplicate_index_baseline(settings, candidate_book_ids=None):
     return missing_book_ids.issubset(candidate_ids)
 
 
+def get_ingest_batch_dirty_file() -> str:
+    return os.environ.get("CWA_INGEST_BATCH_DIRTY_FILE") or os.path.join(
+        constants.CONFIG_DIR, "cwa_ingest_batch_dirty"
+    )
+
+
+def get_ingest_batch_active_file() -> str:
+    return os.environ.get("CWA_INGEST_BATCH_ACTIVE_FILE") or os.path.join(
+        constants.CONFIG_DIR, "cwa_ingest_batch_active"
+    )
+
+
 def ingest_batch_follow_up_pending():
+    dirty_file = get_ingest_batch_dirty_file()
+    active_file = get_ingest_batch_active_file()
     return (
-        os.path.exists(INGEST_BATCH_ACTIVE_FILE)
-        or os.path.exists(INGEST_BATCH_DIRTY_FILE)
-        or os.path.exists(f"{INGEST_BATCH_DIRTY_FILE}.running")
+        os.path.exists(active_file)
+        or os.path.exists(dirty_file)
+        or os.path.exists(f"{dirty_file}.running")
     )
 
 

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -608,11 +608,15 @@ def get_internal_api_headers():
     return {"X-Forwarded-For": "127.0.0.1"}
 
 def get_ingest_batch_dirty_file() -> str:
-    return os.environ.get("CWA_INGEST_BATCH_DIRTY_FILE", "/config/cwa_ingest_batch_dirty")
+    return os.environ.get("CWA_INGEST_BATCH_DIRTY_FILE") or str(
+        app_paths.config_dir() / "cwa_ingest_batch_dirty"
+    )
 
 
 def get_ingest_batch_active_file() -> str:
-    return os.environ.get("CWA_INGEST_BATCH_ACTIVE_FILE", "/config/cwa_ingest_batch_active")
+    return os.environ.get("CWA_INGEST_BATCH_ACTIVE_FILE") or str(
+        app_paths.config_dir() / "cwa_ingest_batch_active"
+    )
 
 
 def mark_ingest_batch_dirty() -> None:

--- a/tests/unit/test_1614_ingest_batch_marker_paths.py
+++ b/tests/unit/test_1614_ingest_batch_marker_paths.py
@@ -1,0 +1,100 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+from pathlib import Path
+
+import pytest
+
+from cps import duplicate_index
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def ingest_processor(monkeypatch):
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    monkeypatch.syspath_prepend(str(scripts_dir))
+    import ingest_processor
+
+    return ingest_processor
+
+
+def _reader_marker_paths(monkeypatch):
+    checked_paths = []
+    monkeypatch.setattr(
+        duplicate_index.os.path,
+        "exists",
+        lambda path: checked_paths.append(path) or False,
+    )
+    assert duplicate_index.ingest_batch_follow_up_pending() is False
+    active_path, dirty_path, running_path = checked_paths
+    assert running_path == f"{dirty_path}.running"
+    return dirty_path, active_path
+
+
+def test_marker_env_knobs_reach_reader(monkeypatch, tmp_path):
+    dirty_file = tmp_path / "custom_ingest_batch_dirty"
+    active_file = tmp_path / "custom_ingest_batch_active"
+    monkeypatch.setenv("CWA_INGEST_BATCH_DIRTY_FILE", str(dirty_file))
+    monkeypatch.setenv("CWA_INGEST_BATCH_ACTIVE_FILE", str(active_file))
+
+    assert _reader_marker_paths(monkeypatch) == (
+        str(dirty_file),
+        str(active_file),
+    )
+
+
+def test_active_ingest_marks_follow_up_pending(monkeypatch, tmp_path):
+    active_file = tmp_path / "custom_ingest_batch_active"
+    monkeypatch.setenv("CWA_INGEST_BATCH_ACTIVE_FILE", str(active_file))
+    active_file.write_text("active_at=1\n")
+
+    assert duplicate_index.ingest_batch_follow_up_pending() is True
+
+
+def test_marker_config_dir_defaults_agree_across_both_halves(
+    ingest_processor, monkeypatch, tmp_path
+):
+    expected_dirty = str(tmp_path / "cwa_ingest_batch_dirty")
+    expected_active = str(tmp_path / "cwa_ingest_batch_active")
+    monkeypatch.setenv("CALIBRE_DBPATH", str(tmp_path))
+    monkeypatch.delenv("CWA_INGEST_BATCH_DIRTY_FILE", raising=False)
+    monkeypatch.delenv("CWA_INGEST_BATCH_ACTIVE_FILE", raising=False)
+    monkeypatch.setattr(duplicate_index.constants, "CONFIG_DIR", str(tmp_path))
+
+    reader_paths = _reader_marker_paths(monkeypatch)
+    writer_paths = (
+        ingest_processor.get_ingest_batch_dirty_file(),
+        ingest_processor.get_ingest_batch_active_file(),
+    )
+    assert reader_paths == writer_paths == (expected_dirty, expected_active)
+
+    monkeypatch.setenv("CWA_INGEST_BATCH_DIRTY_FILE", "")
+    monkeypatch.setenv("CWA_INGEST_BATCH_ACTIVE_FILE", "")
+    assert _reader_marker_paths(monkeypatch) == writer_paths == (
+        ingest_processor.get_ingest_batch_dirty_file(),
+        ingest_processor.get_ingest_batch_active_file(),
+    )
+
+
+def test_docker_marker_paths_remain_byte_identical(
+    ingest_processor, monkeypatch
+):
+    monkeypatch.setenv("CALIBRE_DBPATH", "/config")
+    monkeypatch.delenv("CWA_INGEST_BATCH_DIRTY_FILE", raising=False)
+    monkeypatch.delenv("CWA_INGEST_BATCH_ACTIVE_FILE", raising=False)
+    monkeypatch.setattr(duplicate_index.constants, "CONFIG_DIR", "/config")
+
+    reader_paths = _reader_marker_paths(monkeypatch)
+    writer_paths = (
+        ingest_processor.get_ingest_batch_dirty_file(),
+        ingest_processor.get_ingest_batch_active_file(),
+    )
+    assert reader_paths == writer_paths == (
+        "/config/cwa_ingest_batch_dirty",
+        "/config/cwa_ingest_batch_active",
+    )

--- a/tests/unit/test_1614_ingest_batch_marker_paths.py
+++ b/tests/unit/test_1614_ingest_batch_marker_paths.py
@@ -98,3 +98,27 @@ def test_docker_marker_paths_remain_byte_identical(
         "/config/cwa_ingest_batch_dirty",
         "/config/cwa_ingest_batch_active",
     )
+
+
+def test_active_ingest_suppresses_manual_full_scan_nag(
+    ingest_processor, monkeypatch, tmp_path
+):
+    active_file = tmp_path / "custom_ingest_batch_active"
+    monkeypatch.setenv("CWA_INGEST_BATCH_ACTIVE_FILE", str(active_file))
+    monkeypatch.setattr(
+        duplicate_index,
+        "CWA_DB",
+        lambda: type(
+            "CacheDB",
+            (),
+            {"get_duplicate_cache": lambda self: {"last_scanned_book_id": 0}},
+        )(),
+    )
+    monkeypatch.setattr(duplicate_index, "_current_library_book_ids", lambda: {1})
+
+    assert duplicate_index.duplicate_index_needs_manual_full_scan({}) is True
+
+    ingest_processor.mark_ingest_batch_active()
+
+    assert active_file.is_file()
+    assert duplicate_index.duplicate_index_needs_manual_full_scan({}) is False


### PR DESCRIPTION
## Why

Part of #1614 (*[bare-metal] Literal `/config/...` paths break outside the Docker image*, split out of
#1555, reported by @Thovi98). This PR takes **one** slice of that issue: the two ingest-batch marker
files, which are the only case in #1614 where a **reader and a writer of the same file resolve it
differently**. That makes it the only one that fails *silently* — the rest raise a visible
`FileNotFoundError`.

Community PR #1678 owns the `cwa_update_notice` / `user_profiles.json` half of #1614 and touches
`cps/cwa_functions.py`, `cps/api/auth.py`, `cps/render_template.py` and `cps/constants.py`. **This PR
deliberately touches none of those files.** #1614 stays open.

## Root cause

Two halves of the install read and write the same two markers and disagreed about where they are.

**Writer** — `scripts/ingest_processor.py` honoured `CWA_INGEST_BATCH_DIRTY_FILE` /
`CWA_INGEST_BATCH_ACTIVE_FILE`, falling back to the literal `/config/...`.

**Reader** — `cps/duplicate_index.py` had them as module-level literals, frozen at import,
honouring neither the env vars nor any config dir:

```python
INGEST_BATCH_DIRTY_FILE = "/config/cwa_ingest_batch_dirty"
INGEST_BATCH_ACTIVE_FILE = "/config/cwa_ingest_batch_active"
```

Two ways that goes wrong off Docker:

1. **Set the documented knob and the two halves split.** `CWA_INGEST_BATCH_DIRTY_FILE` is already
   honoured by the writer *and* by `root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run:53`. Set it,
   and the writer writes to your path while the reader kept stat-ing `/config/...`.
2. **Leave it unset and both point outside the config dir.** `mark_ingest_batch_dirty()` does
   `os.makedirs("/config")` — at the filesystem root, which a non-root bare-metal install cannot
   create. The marker is never written.

**User-visible symptom, either way:** `ingest_batch_follow_up_pending()` returns False during an
active ingest, so `duplicate_index_needs_manual_full_scan()` returns True and the UI demands a manual
full scan *in the middle of an import* — exactly what that function's own docstring says must not
happen (*"Do not turn that temporary lag into a manual full-scan requirement."*).

## Fix

Both halves now resolve each marker through the SSOT that already exists on their own side, in the
same order: `CWA_INGEST_BATCH_*_FILE` if set and non-empty, else `<config dir>/<name>`.

- `scripts/ingest_processor.py` → `app_paths.config_dir()` (the #1462/#1463 SSOT the module already
  imports and already uses for `app_db_path()` / `dirs_json()`; these two functions were simply
  missed by that migration).
- `cps/duplicate_index.py` → `constants.CONFIG_DIR`, which #1614 names as the correct base, and
  **resolved at call time** rather than frozen at import.

Empty string is treated as unset on both sides.

## The two SSOTs provably agree — measured, not assumed

The fix only works if `app_paths.config_dir()` and `constants.CONFIG_DIR` resolve identically. Run
directly, not through a test helper:

| `CALIBRE_DBPATH` | `app_paths.config_dir()` | `constants.CONFIG_DIR` | agree |
|---|---|---|---|
| `/config` (Docker) | `/config` | `/config` | ✅ |
| `/var/lib/cwng` | `/var/lib/cwng` | `/var/lib/cwng` | ✅ |
| `/tmp/cfgtest` | `/tmp/cfgtest` | `/tmp/cfgtest` | ✅ |
| *unset* | *app root* | *app root* | ✅ |

## Docker is byte-identical

`Dockerfile` sets `ENV CALIBRE_DBPATH=/config`, so in the image both sides resolve to exactly
`/config/cwa_ingest_batch_dirty` and `/config/cwa_ingest_batch_active` — the same strings as before.
`test_docker_marker_paths_remain_byte_identical` **passes on unmodified main as well as on this
branch**, which is the point: it is a no-regression pin, not a new capability.

## The third participant stays consistent

`root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run:53` also resolves the dirty marker
(`${CWA_INGEST_BATCH_DIRTY_FILE:-/config/cwa_ingest_batch_dirty}`). It is left untouched and is
still correct: s6 only runs inside the image, where `Dockerfile:288` sets `ENV CALIBRE_DBPATH=/config`
so the literal and the derived value are the same string — and if the env knob *is* set, all three
participants honour it. So the shell unit agrees with both Python halves in every case.

## No migration needed

The markers are transient run-state, not user data: `mark_ingest_batch_active()` creates the active
marker and `clear_ingest_batch_active()` removes it (`scripts/ingest_processor.py:649`); the dirty
marker is consumed by the s6 post-batch follow-up. Nothing to move. On bare metal the old `/config`
path almost certainly never held one, because creating it would have failed in the first place.

## Reproduction (red) → validation (green)

`tests/unit/test_1614_ingest_batch_marker_paths.py`, run with the repo venv on the unmodified tree:

```
3 failed, 1 passed
FAILED test_marker_env_knobs_reach_reader
FAILED test_active_ingest_marks_follow_up_pending
FAILED test_marker_config_dir_defaults_agree_across_both_halves
PASSED test_docker_marker_paths_remain_byte_identical   <- the invariant, green before and after
```

After the fix: `4 passed`. The cross-half test imports the **real** `ingest_processor` and compares
its resolved paths against the reader's, so it fails if either side drifts again.

**A fifth test now drives the nag predicate itself**, closing the link this PR previously listed as
ASSUMED. `test_active_ingest_suppresses_manual_full_scan_nag` calls the real
`duplicate_index_needs_manual_full_scan()` and asserts both directions — True with no marker, False
once the marker exists. The marker is created by the **real writer**
(`ingest_processor.mark_ingest_batch_active()`), not written by the test, so what is being executed
is writer → file → reader → the predicate the UI reads. It fakes only `CWA_DB` and
`_current_library_book_ids`; it never fakes the marker paths and never fakes
`ingest_batch_follow_up_pending()`, which would have faked the thing under test.

Verified independently on `origin/main` (`65351f4`) with `repo/.venv/bin/python`, not taken on
report: that test alone is `1 failed` there and `1 passed` on this branch, and the whole file is
`3 failed, 1 passed` → `5 passed`.

## Blast radius

- The module attributes `INGEST_BATCH_DIRTY_FILE` / `INGEST_BATCH_ACTIVE_FILE` are removed. Grepped
  the whole tree: **no production code referenced them.** The only remaining references are five
  `monkeypatch.setattr` calls in `tests/unit/test_duplicate_index.py` — which is **quarantined**
  (`tests/quarantine.py`, #1106) and whose 20 tests all skip.
- ⚠️ **Landmine for #1106, stated deliberately:** whoever un-quarantines that file must convert those
  five `setattr` calls to `monkeypatch.setenv`, or they will raise `AttributeError`. I did not edit
  the quarantined file, because an edit to a file that cannot run is an unverifiable change; a loud
  note is worth more than a silent patch.

## One regression I specifically went looking for, and did not find

Off Docker the writer's fallback used to be `/config/...`, which is unwritable, so
`mark_ingest_batch_dirty()` hit its `except` and silently wrote nothing. After this change the
fallback is the config dir, which **is** writable — so a test that reaches the marker write without
pinning `CWA_INGEST_BATCH_DIRTY_FILE` would now drop a real file into the checkout. This repo has
been bitten by exactly that before (#1699, where unit tests wrote `annotation-backups/` and then
`pr-lifecycle.sh submit` refused the dirty worktree).

Seven unit modules import `ingest_processor` without pinning that variable
(`test_1094_failed_conversion_imports_original`, `test_1331_stamp_every_imported_book`,
`test_1715_ingest_normalizes_kepub`, `test_1608_lcpl_upload_ingest`,
`test_984_acsm_plugin_ran_guidance`, `test_acsm_ingest_guidance_448`,
`test_ingest_processor_startup`). **Checked rather than assumed:** after the full `tests/unit/` run
on the patched tree, `git status --porcelain` shows only the four intended files and
`find . -name "cwa_ingest_batch*"` returns nothing. The four call sites
(`scripts/ingest_processor.py:1648,1729,1845,1851`) live in the ingest main loop, which no unit test
drives. Clean — but worth naming, because it is the failure mode a reviewer should look for here.

## Cost of resolving per call

`duplicate_index_needs_manual_full_scan()` is reached from `cps/render_template.py:120`, so it runs
on page renders. The markers used to be resolved once at import and are now resolved per call — two
`os.environ.get` lookups and two `os.path.join` calls. That is noise next to the work the same
function already does on every one of those calls (`cwa_db.get_duplicate_cache()` plus a `SELECT`
over `cwa_duplicate_book_keys`). Per-call resolution is also the point: an import-time constant is
what made the reader unable to see the environment at all.

## Honest limitations

- **The predicate is now executed; the rendering of the nag still is not.** The chain
  writer → marker file → reader → `duplicate_index_needs_manual_full_scan()` is **OBSERVED** (the
  fifth test above). What remains ASSUMED is the last hop: `cps/render_template.py:120` passing that
  return value into the template that draws the prompt. That link is read from the source, not
  driven through a request.
- **Not verified on a real bare-metal install.** I have no non-Docker deployment to drive. The path
  resolution is measured directly (table above); the end-to-end bare-metal ingest is **ASSUMED**.
- **This does not close #1614.** ~30 other `/config` literals remain. Several are *not* mechanical —
  `cps/services/cover_preview_cache.py:89` relocates a cache root, `cps/duplicates.py:1907` and
  `cps/admin.py:3541` relocate user backup directories, and `cps/admin.py:3531` is the fallback in the
  DB restore path. Those need a migration decision each, and `cps/tasks/ops.py` must wait for #1678.

## Answering the reporter

@Thovi98's own two errors are `cwa_update_notice` and `user_profiles.json` — both in #1678's files, not
here. This PR fixes a **third** bare-metal fault in the same family that nobody had reported yet,
because its symptom is a confusing UI prompt rather than an error in a log.

## Merge rationale

The earlier revision of this PR body declined to self-merge, on the ground that the one
configuration this fix exists for — bare metal — was the one it could not verify. That reasoning
named a specific gap, and the gap has now been narrowed rather than argued away:

- The predicate link it called ASSUMED is executed (fifth test above), red on `origin/main`.
- Red/green was re-run independently by the reviewing pass with the pinned `repo/.venv/bin/python`
  on a clean worktree, against `origin/main` as the baseline — not accepted from the implementing
  leg's report.
- Docker stays byte-identical, pinned by a test that is green on `origin/main` as well as here.

What is still true is that this does **not** make a bare-metal install work end to end — ~30 other
`/config` literals remain (see Honest limitations), and #1614 stays open. This merges as a strictly
smaller, strictly better-resolved subset: every path it touches previously resolved to a location
the reader and writer could disagree about, and now they cannot.

`/security-review` is genuinely not required here, checked against the diff rather than the
description: no auth/session/CSRF, no crypto or secrets, no subprocess, no new routes, and the paths
come from `os.environ` and `constants.CONFIG_DIR` / `app_paths.config_dir()` — launch-time
configuration, never plumbed from a request. No dependency, license, or external-URL change.

Tier: multi-file and crossing the `cps/` ↔ `scripts/` boundary, so it carried `needs-review`; the
review has now been done independently of the author of the change.
