### PR TITLE
fix(kobo): accept a LastModified with milliseconds instead of failing the sync

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1732,8 +1732,7 @@ def HandleStateRequest(book_uuid):
             # Use the device's own timestamp so the GET response mirrors it back,
             # preventing the "newer PT" conflict popup. Official Kobo cloud does the same.
             lm_str = request_reading_state.get("LastModified")
-            request_lm = (datetime.strptime(lm_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
-                          if lm_str else datetime.now(timezone.utc))
+            request_lm = parse_kobo_timestamp(lm_str) or datetime.now(timezone.utc)
             g.kobo_reading_state_lm = request_lm
 
             request_bookmark = request_reading_state["CurrentBookmark"]
@@ -1888,6 +1887,37 @@ def get_ub_read_status(kobo_read_status):
         "Reading": ub.ReadBook.STATUS_IN_PROGRESS,
     }
     return string_to_enum_map[kobo_read_status]
+
+
+def parse_kobo_timestamp(value):
+    """Parse a Kobo ``LastModified`` into an aware UTC datetime, or ``None``.
+
+    Kobo sends ISO-8601 UTC, but **not** always to whole seconds: a Libra Colour
+    on 5.10.226356 sends ``2026-08-17T17:56:53.254Z`` (#1706). The previous
+    ``strptime(value, "%Y-%m-%dT%H:%M:%SZ")`` raised ValueError on the
+    fractional part, which the caller's ``except`` turned into a 400 -- so one
+    unexpected millisecond field failed the whole reading-state sync, and the
+    error text blamed a missing ``ReadingStates`` key.
+
+    Returns ``None`` rather than raising: this timestamp exists only to mirror
+    the device's own value back so it does not raise a "newer progress" popup.
+    Losing it costs a popup; failing the request costs the sync.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    # fromisoformat only learned to accept a trailing "Z" in 3.11.
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def get_or_create_reading_state(book_id):

--- a/tests/unit/test_1706_kobo_lastmodified_milliseconds.py
+++ b/tests/unit/test_1706_kobo_lastmodified_milliseconds.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""A Kobo LastModified with milliseconds must not fail the whole sync (#1706).
+
+25e16f83 began parsing the device's ``LastModified`` with
+``strptime(value, "%Y-%m-%dT%H:%M:%SZ")`` so the GET response could mirror it
+back and avoid a "newer progress" popup. A Libra Colour on firmware 5.10.226356
+sends ``2026-08-17T17:56:53.254Z`` -- with milliseconds -- and strptime raised
+ValueError, which the caller's except turned into ``abort(400)``. The whole
+reading-state sync failed, and the error text blamed a missing ``ReadingStates``
+key, which was not the problem.
+
+Reported with a full payload capture by a user on v4.1.37.
+"""
+from datetime import datetime, timezone
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _parse(value):
+    from cps.kobo import parse_kobo_timestamp
+    return parse_kobo_timestamp(value)
+
+
+def test_milliseconds_are_accepted():
+    """The exact string from the #1706 report."""
+    got = _parse("2026-08-17T17:56:53.254Z")
+    assert got == datetime(2026, 8, 17, 17, 56, 53, 254000, tzinfo=timezone.utc)
+
+
+def test_whole_seconds_still_work():
+    """The shape the original strptime handled must not regress."""
+    got = _parse("2026-08-17T17:56:53Z")
+    assert got == datetime(2026, 8, 17, 17, 56, 53, tzinfo=timezone.utc)
+
+
+def test_microseconds_are_accepted():
+    got = _parse("2026-08-17T17:56:53.254321Z")
+    assert got == datetime(2026, 8, 17, 17, 56, 53, 254321, tzinfo=timezone.utc)
+
+
+def test_explicit_offset_is_normalised_to_utc():
+    got = _parse("2026-08-17T19:56:53.254+02:00")
+    assert got == datetime(2026, 8, 17, 17, 56, 53, 254000, tzinfo=timezone.utc)
+
+
+def test_naive_timestamp_is_treated_as_utc():
+    got = _parse("2026-08-17T17:56:53")
+    assert got == datetime(2026, 8, 17, 17, 56, 53, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize("value", [None, "", "   ", "not a date", 12345, {}, "2026-13-45T99:99:99Z"])
+def test_unparseable_returns_none_instead_of_raising(value):
+    """The caller falls back to now(); it must never abort the sync (#1706)."""
+    assert _parse(value) is None
+
+
+def test_result_is_always_timezone_aware():
+    for value in ("2026-08-17T17:56:53.254Z", "2026-08-17T17:56:53", "2026-08-17T19:56:53+02:00"):
+        got = _parse(value)
+        assert got is not None and got.tzinfo is not None


### PR DESCRIPTION
Addresses #1706.

## The bug

A Kobo Libra Colour on firmware 5.10.226356 sends:

```json
"LastModified": "2026-08-17T17:56:53.254Z"
```

and **every reading-state sync from it returns 400**.

`25e16f834` began parsing that field so the GET response could mirror the device's own timestamp
back and avoid a "newer progress" popup — using:

```python
datetime.strptime(lm_str, "%Y-%m-%dT%H:%M:%SZ")
```

which raises `ValueError` on the fractional seconds. The enclosing `except` catches `ValueError` and
calls:

```python
abort(400, description="Malformed request data is missing 'ReadingStates' key")
```

So one unexpected millisecond field fails the entire request, **and the error names a key that was
present and correct** — anyone debugging it would look in the wrong place. The reporter had to read
the source to find the real cause.

## The fix

`parse_kobo_timestamp()` accepts whole seconds, milliseconds, microseconds, an explicit UTC offset,
and a naive value (treated as UTC), always returning an aware UTC datetime. It strips a trailing
`Z` before `fromisoformat`, because that spelling was only accepted from Python 3.11.

It **returns `None` rather than raising**, and the caller falls back to `datetime.now(timezone.utc)`.
That is deliberate: this timestamp exists solely to mirror the device's value back and suppress a
popup. Losing it costs a popup; failing the request costs the sync — which is what shipped.

## Tests

13 in `tests/unit/test_1706_kobo_lastmodified_milliseconds.py`, including the exact string from the
report, and a parametrised case pinning that garbage input returns `None` instead of aborting.

Red/green: restoring the original `strptime` fails **5 of 13**; restored, 13 pass.

## Verification

```
full suite : 6391 passed, 100 skipped, exit 0
ruff       : 8 errors in cps/kobo.py both with and without this change (pre-existing)
```

Credit to the reporter, who included a full payload capture and correctly identified both the
offending commit and the fix.