### PR TITLE
fix(kobo): re-stat data.uncompressed_size after metadata enforcement rewrites a file

### DIFF
--- a/scripts/cover_enforcer.py
+++ b/scripts/cover_enforcer.py
@@ -476,6 +476,51 @@ class Enforcer:
         return dirs['calibre_library_dir'] # Returns without / on the end
 
 
+    def _restat_format_size_after_modification(self, book_id: str, file_format: str, file_path: str) -> None:
+        """Re-stat data.uncompressed_size after rewriting a format in place (#1711).
+
+        cps/kobo.py advertises this column to a paired device verbatim as
+        ``"Size"``, and the device stores it (``content.___FileSize``). Rewriting
+        the file with ebook-polish or ebook-meta changes the byte count, so
+        leaving the column alone advertises a size the server will not serve.
+        Measured on a live library: 8 of 435 format rows stale, and the three
+        stale KEPUB rows were exactly the three books enforced in one pass.
+
+        The two other in-place writers already do this --
+        kepub_package_repair.py sets it from os.path.getsize, and
+        editbooks._refresh_format_sizes re-stats every format inside the same
+        commit boundary. The enforcer was the one that did not.
+
+        Best-effort: a failure here must not fail an enforcement pass that has
+        already written the file correctly.
+        """
+        try:
+            size = os.path.getsize(file_path)
+        except OSError as e:
+            print(f"[cover-metadata-enforcer] Warning: could not stat {file_path} "
+                  f"to refresh its size: {e}", flush=True)
+            return
+        try:
+            metadb_path = os.path.join(
+                (self.split_library or {}).get("db_path", self.calibre_library),
+                "metadata.db"
+            )
+            con = sqlite3.connect(metadb_path, timeout=60)
+            try:
+                cur = con.execute(
+                    "UPDATE data SET uncompressed_size=? WHERE book=? AND format=?",
+                    (size, int(book_id), file_format.upper()),
+                )
+                con.commit()
+                if cur.rowcount:
+                    print(f"[cover-metadata-enforcer] Refreshed size for book {book_id} "
+                          f"format {file_format.upper()} -> {size} bytes", flush=True)
+            finally:
+                con.close()
+        except Exception as e:
+            print(f"[cover-metadata-enforcer] Warning: Failed to refresh format size "
+                  f"for book {book_id}: {e}", flush=True)
+
     def _recalculate_checksum_after_modification(self, book_id: str, file_format: str, file_path: str) -> None:
         """Calculate and store new checksum after modifying a book file."""
         try:
@@ -960,6 +1005,9 @@ class Enforcer:
 
                     # Calculate and store new checksum after modification
                     self._recalculate_checksum_after_modification(book.book_id, book.file_format, file)
+                    # The bytes on disk just changed; the size Kobo is told must
+                    # change with them (#1711).
+                    self._restat_format_size_after_modification(book.book_id, book.file_format, file)
 
                 book_objects.append(book)
 

--- a/tests/unit/test_1711_enforcer_restats_format_size.py
+++ b/tests/unit/test_1711_enforcer_restats_format_size.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Metadata enforcement must re-stat data.uncompressed_size (#1711).
+
+`cps/kobo.py` advertises that column to a paired device verbatim as "Size", and
+the device stores it in `content.___FileSize`. `cover_enforcer.py` rewrites format
+files in place (ebook-polish / ebook-meta), so leaving the column alone advertises
+a byte count the server will not serve. Measured on a live library: 8 of 435
+format rows stale, and the three stale KEPUB rows were exactly the three books
+enforced in one pass.
+
+These tests EXECUTE the real method body against a real SQLite database rather
+than asserting on its source text, so they fail if the SQL is wrong, not merely
+if the wording changes.
+"""
+import ast
+import os
+import sqlite3
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "cover_enforcer.py"
+METHOD = "_restat_format_size_after_modification"
+
+
+def _method_source(name):
+    source = SCRIPT.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return ast.get_source_segment(source, node) or ""
+    pytest.fail("%s not found in cover_enforcer.py" % name)
+
+
+def _enforcer(library):
+    """Build a stub carrying just the attributes the method touches."""
+    src = _method_source(METHOD)
+    ns = {"os": os, "sqlite3": sqlite3, "print": lambda *a, **k: None}
+    exec("class _Stub:\n" + textwrap.indent(src, "    "), ns)          # noqa: S102
+    obj = ns["_Stub"]()
+    obj.split_library = None
+    obj.calibre_library = str(library)
+    return obj
+
+
+def _library(tmp_path, recorded_size):
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    con = sqlite3.connect(str(lib / "metadata.db"))
+    con.execute("CREATE TABLE data (id INTEGER PRIMARY KEY, book INTEGER, format TEXT, "
+                "uncompressed_size INTEGER, name TEXT)")
+    con.execute("INSERT INTO data (book, format, uncompressed_size, name) VALUES (?,?,?,?)",
+                (1, "KEPUB", recorded_size, "book"))
+    con.commit(); con.close()
+    book = lib / "book.kepub"
+    book.write_bytes(b"x" * 4096)          # the real, post-rewrite size
+    return lib, book
+
+
+def _recorded(lib):
+    con = sqlite3.connect(str(lib / "metadata.db"))
+    try:
+        return con.execute("SELECT uncompressed_size FROM data WHERE book=1 AND format='KEPUB'").fetchone()[0]
+    finally:
+        con.close()
+
+
+def test_stale_size_is_corrected_to_the_bytes_on_disk(tmp_path):
+    lib, book = _library(tmp_path, recorded_size=608670)      # the #1711 delta
+    assert _recorded(lib) == 608670
+
+    _enforcer(lib)._restat_format_size_after_modification("1", "kepub", str(book))
+
+    assert _recorded(lib) == 4096 == os.path.getsize(str(book))
+
+
+def test_format_is_matched_case_insensitively(tmp_path):
+    """The enforcer passes book.file_format, which is lower case."""
+    lib, book = _library(tmp_path, recorded_size=1)
+    _enforcer(lib)._restat_format_size_after_modification("1", "kepub", str(book))
+    assert _recorded(lib) == 4096
+
+
+def test_a_missing_file_leaves_the_row_alone(tmp_path):
+    lib, _book = _library(tmp_path, recorded_size=1234)
+    _enforcer(lib)._restat_format_size_after_modification("1", "kepub", str(tmp_path / "gone.kepub"))
+    assert _recorded(lib) == 1234, "a stat failure must not clear or corrupt the row"
+
+
+def test_a_broken_database_does_not_raise(tmp_path):
+    """An enforcement pass that already wrote the file must not fail here."""
+    lib, book = _library(tmp_path, recorded_size=1)
+    (lib / "metadata.db").write_bytes(b"not a database")
+    _enforcer(lib)._restat_format_size_after_modification("1", "kepub", str(book))  # must not raise
+
+
+def test_other_books_are_untouched(tmp_path):
+    lib, book = _library(tmp_path, recorded_size=1)
+    con = sqlite3.connect(str(lib / "metadata.db"))
+    con.execute("INSERT INTO data (book, format, uncompressed_size, name) VALUES (2,'KEPUB',999,'other')")
+    con.commit(); con.close()
+
+    _enforcer(lib)._restat_format_size_after_modification("1", "kepub", str(book))
+
+    con = sqlite3.connect(str(lib / "metadata.db"))
+    try:
+        assert con.execute("SELECT uncompressed_size FROM data WHERE book=2").fetchone()[0] == 999
+    finally:
+        con.close()
+
+
+def test_the_enforcer_actually_calls_it_after_a_write():
+    """Guards the wiring: the helper is useless if nothing invokes it."""
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert "self.%s(book.book_id, book.file_format, file)" % METHOD in source


### PR DESCRIPTION
Addresses #1711.

## The bug

`scripts/cover_enforcer.py` rewrites format files **in place** (`ebook-polish` for `.epub`/`.azw3`,
`ebook-meta --from-opf` then `os.replace` for `.kepub`) and recalculates the KOReader partial-MD5
afterwards. It never re-stated `data.uncompressed_size`, so Calibre kept the byte count from before
the rewrite.

`cps/kobo.py` advertises that column to the device verbatim:

```python
"Size": book_data.uncompressed_size,     # cps/kobo.py:1264
```

so a paired Kobo is told a size the server will not serve, and stores it in
`content.___FileSize`.

Measured on a live library — 435 format rows, **427 exact, 8 stale** — and the three stale KEPUB rows
were exactly the three books that went through a single enforcement pass:

```
book 317 KEPUB  db=608670  disk=608438  delta=-232
book 319 KEPUB  db=265093  disk=265077  delta= -16
book 347 KEPUB  db=732357  disk=732563  delta=+206
```

## Why this shape of fix

The codebase already treats re-stating as required after an in-place write:

- `cps/tasks/kepub_package_repair.py` — `data.uncompressed_size = os.path.getsize(path)`
- `cps/editbooks.py::_refresh_format_sizes` — re-stats every format in the same commit boundary,
  with a comment explaining exactly this hazard

The enforcer was the one in-place writer that didn't. The new helper mirrors
`_recalculate_checksum_after_modification`, which runs immediately before it on the same file — same
`metadata.db` path resolution, same best-effort posture. A failure must not fail an enforcement pass
that already wrote the file correctly, so it logs and returns.

## Deliberately not addressed

The reporter notes the download endpoint doesn't serve the file byte-for-byte anyway (cover padding
the suspect), so an advertised size can never be exactly right without either re-stating what is
actually *sent* or dropping the claim. **That is a design decision and is left open on #1711.** This
change only stops the column drifting from the bytes on disk.

## Tests

Six, in `tests/unit/test_1711_enforcer_restats_format_size.py`. They **execute the real method body**
against a real SQLite database rather than asserting on source text — the existing enforcer tests
source-pin, which cannot catch wrong SQL.

Covered: a stale row is corrected to the on-disk size; the lower-case `book.file_format` the caller
passes still matches the upper-case `data.format`; a missing file leaves the row alone; a corrupt
database does not raise; other books are untouched; and the call site exists.

Red/green on two axes:

| mutation | result |
|---|---|
| remove the call site | wiring test fails |
| pass `file_format` verbatim (case no longer matches) | **2 failed** |
| restored | 6 passed |

Worth recording: my *first* mutation — moving `.upper()` from Python into SQL as `upper(?)` — failed
to fail, because the two are equivalent. It nearly went down as a passing red/green for a case that
was in fact untested.

## Verification

```
full suite : 6384 passed, 100 skipped, exit 0
ruff       : unchanged on this file with and without the change
```