### PR TITLE
ci: fail the summary when a PR's Fast Tests job is cancelled, not only when it fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1003,31 +1003,44 @@ jobs:
           echo "Is frontend PR:    $IS_FRONTEND_PR"
           echo "Is main push:      $IS_MAIN_PUSH"
 
-          # A required summary must positively prove that every hard-gated
-          # main-push lane completed. Reject skipped/cancelled as well as
-          # failure; otherwise a later broken job condition silently turns
-          # coverage off while this required check stays green.
+          # A required summary must positively prove that every hard-gated lane
+          # completed. Reject skipped/cancelled as well as failure; otherwise a
+          # later broken job condition silently turns coverage off while this
+          # required check stays green.
+          #
+          # `fast-tests` and `frontend-build` carry no `if:`, so they run on
+          # EVERY trigger of this workflow. Any result other than success means
+          # the lane vouched for nothing, and neither can this summary.
+          #
+          # `cancelled` is the state that actually bites, and it is not
+          # hypothetical: a job killed by its own `timeout-minutes` is reported
+          # as **cancelled**, never as `failure`. OBSERVED 2026-08-18 on #1725 —
+          # the `Install system dependencies` apt step stalled for 24m46s, the
+          # job's 25-minute cap fired, `Fast Tests` came back `cancelled`, and
+          # this summary exited 0 having executed no tests at all. This
+          # strictness already existed but was scoped to IS_MAIN_PUSH, so it
+          # never covered the pull-request path — which is where every merge is
+          # gated. Scoping a gate to the rarer event is how it goes unnoticed.
+          if [[ "${{ needs.fast-tests.result }}" != "success" ]]; then
+            echo "❌ Fast tests did not succeed"
+            echo "   Actual result: ${{ needs.fast-tests.result }}"
+            exit 1
+          fi
+
+          # The SPA bundle is a hard gate: a broken TypeScript/Vite build ships
+          # an empty/broken frontend, so it blocks the merge like fast-tests.
+          if [[ "${{ needs.frontend-build.result }}" != "success" ]]; then
+            echo "❌ Frontend build did not succeed"
+            echo "   Actual result: ${{ needs.frontend-build.result }}"
+            exit 1
+          fi
+
           if [[ "$IS_MAIN_PUSH" == "true" ]]; then
-            if [[ "${{ needs.fast-tests.result }}" != "success" ]]; then
-              echo "❌ Fast tests did not succeed on a push to main"
-              echo "   Actual result: ${{ needs.fast-tests.result }}"
-              exit 1
-            fi
-            if [[ "${{ needs.frontend-build.result }}" != "success" ]]; then
-              echo "❌ Frontend build did not succeed on a push to main"
-              echo "   Actual result: ${{ needs.frontend-build.result }}"
-              exit 1
-            fi
             if [[ "${{ needs.e2e-tests.result }}" != "success" ]]; then
               echo "❌ SPA e2e suite did not succeed on a push to main"
               echo "   Actual result: ${{ needs.e2e-tests.result }}"
               exit 1
             fi
-          fi
-
-          if [[ "${{ needs.fast-tests.result }}" == "failure" ]]; then
-            echo "❌ Fast tests failed"
-            exit 1
           fi
 
           # Both path-derived gates read changed_paths outputs: IS_BUILD_PR
@@ -1038,17 +1051,11 @@ jobs:
           # #1130 is about, one level up. Fail loudly instead of inferring
           # "nothing changed" from "we could not tell what changed".
           if [[ "${{ github.event_name }}" == "pull_request" \
-                && "${{ needs.changed_paths.result }}" == "failure" ]]; then
-            echo "❌ Detect changed paths failed — the build and SPA e2e gates"
-            echo "   are both derived from its outputs, so neither can be"
-            echo "   trusted on this run."
-            exit 1
-          fi
-
-          # The SPA bundle is a hard gate: a broken TypeScript/Vite build ships
-          # an empty/broken frontend, so it blocks the merge like fast-tests.
-          if [[ "${{ needs.frontend-build.result }}" == "failure" ]]; then
-            echo "❌ Frontend build failed"
+                && "${{ needs.changed_paths.result }}" != "success" ]]; then
+            echo "❌ Detect changed paths did not succeed — the build and SPA"
+            echo "   e2e gates are both derived from its outputs, so neither"
+            echo "   can be trusted on this run."
+            echo "   Actual result: ${{ needs.changed_paths.result }}"
             exit 1
           fi
 

--- a/tests/unit/test_summary_gate_requires_success.py
+++ b/tests/unit/test_summary_gate_requires_success.py
@@ -119,6 +119,58 @@ def test_integration_stays_advisory_on_main():
     assert rc == 0
 
 
+@pytest.mark.parametrize("result", ["failure", "skipped", "cancelled"])
+def test_pull_request_requires_fast_tests_success(result):
+    """The PR path must reject every non-success fast-tests result, not just
+    `failure`.
+
+    `cancelled` is not a hypothetical. A job killed by its own
+    `timeout-minutes` is reported as **cancelled**, never as failure. OBSERVED
+    2026-08-18 on #1725: the `Install system dependencies` apt step stalled for
+    24m46s, the job's 25-minute cap fired, `Fast Tests` came back `cancelled`,
+    and this summary — the single required check branch protection reads —
+    exited 0 having run no tests at all.
+
+    The strictness already existed for pushes to main and was never extended to
+    pull requests, which is where essentially every merge is gated.
+    """
+    rc, out = _run(event="pull_request", ref="refs/heads/topic",
+                   fast=result, build="success", integration="skipped",
+                   e2e="skipped")
+    assert rc == 1, (
+        f"pull request with fast-tests={result} must fail the summary; got rc=0\n{out}"
+    )
+    assert result in out, "the summary should name the actual result it rejected"
+
+
+@pytest.mark.parametrize("result", ["failure", "skipped", "cancelled"])
+def test_pull_request_requires_frontend_build_success(result):
+    """Same reasoning for the SPA bundle: it has no `if:`, so it runs on every
+    PR, and any result other than success means it did not vouch for anything.
+    """
+    rc, out = _run(event="pull_request", ref="refs/heads/topic",
+                   fast="success", build=result, integration="skipped",
+                   e2e="skipped")
+    assert rc == 1, (
+        f"pull request with frontend-build={result} must fail the summary; got rc=0\n{out}"
+    )
+
+
+@pytest.mark.parametrize("result", ["skipped", "cancelled"])
+def test_pull_request_requires_changed_paths_success(result):
+    """`changed_paths` feeds BOTH path-derived gates. The workflow already
+    rejects its `failure`; a cancelled or skipped run leaves its outputs just as
+    empty, so both gates silently read "not applicable" and this summary would
+    vouch for a run that gated nothing.
+    """
+    rc, out = _run(event="pull_request", ref="refs/heads/topic",
+                   fast="success", build="success", integration="skipped",
+                   e2e="skipped", changed_paths=result)
+    assert rc == 1, (
+        f"pull request with changed_paths={result} must fail the summary; got rc=0\n{out}"
+    )
+
+
 def test_non_frontend_pr_still_passes_with_e2e_skipped():
     """The PR path is deliberately path-gated: a backend-only PR skips the SPA
     suite by design and must not be blocked by this change."""


### PR DESCRIPTION
Addresses #1726.

## The defect

A job killed by its own `timeout-minutes` is reported as **`cancelled`**, never as `failure`. The
`test-summary` gate rejected every non-success state only under `IS_MAIN_PUSH`; on the pull-request
path it tested `== "failure"` alone, so `cancelled` and `skipped` fell through to `exit 0`.

OBSERVED on #1725, run `32097088589`:

| step of `Fast Tests (Smoke + Unit)` | result | duration |
|---|---|---|
| Install system dependencies | **cancelled** | **24m 46s** |
| Run smoke and unit tests | skipped | — |

The apt step stalled — the stall the job's own comment already documents (*"Twice observed stalling
in the apt step"*), now a third time. The 25-minute cap added in #1710 fired. `Fast Tests` came back
`cancelled`, and the summary logged:

```
Fast Tests:        cancelled
✅ Test suite completed
```

`Test Suite Summary` is the single required check branch protection reads, and the check
`auto-merge.yml` fires on. The rollup was green with zero tests executed.

## The change

`fast-tests` and `frontend-build` carry no `if:` — they run on **every** trigger of this workflow —
so any result other than `success` means the lane vouched for nothing, and neither can this summary.
Both are now required unconditionally, which also removes the duplicated `IS_MAIN_PUSH` branch.
`changed_paths` moves from `== "failure"` to `!= "success"` on pull requests: a cancelled run leaves
its outputs just as empty, and both path-derived gates are derived from them.

Deliberately unchanged: `e2e-tests` stays main-push-scoped, and `integration-tests` stays advisory
outside tier-2/build PRs. The existing tests covering both carve-outs still pass.

## Why the existing test missed it, and the red/green

`tests/unit/test_summary_gate_requires_success.py` is the right instrument — it extracts the real
`run:` block and *executes* it under substituted results, with a positive control. Its blind spot was
scope: **every non-success case it exercised was a main push.** The pull-request path appeared once,
all-green. The suite could not have detected this.

Added the pull-request cases. Verified against the unfixed workflow first:

```
FAILED  test_pull_request_requires_fast_tests_success[skipped]
FAILED  test_pull_request_requires_fast_tests_success[cancelled]
FAILED  test_pull_request_requires_frontend_build_success[skipped]
FAILED  test_pull_request_requires_frontend_build_success[cancelled]
FAILED  test_pull_request_requires_changed_paths_success[skipped]
FAILED  test_pull_request_requires_changed_paths_success[cancelled]
6 failed, 10 passed
```

Exactly the six states that were falling through — and the `[failure]` variants passed, which is
what proves the harness was not simply rejecting everything. After the change: **16 passed**.

Full suite on this branch: **6495 passed, 105 skipped, exit 0**.

## What this does not fix

The apt stall itself. This PR makes it visible instead of silently green; the underlying flake is
still there and is worth its own issue if it recurs.
