### PR TITLE
fix(kobo): isolate the sync-target INSERT in a savepoint so losing the race stops destroying the annotation

### DIFF
--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -403,7 +403,21 @@ def _apply_result(st, result):
 
 def _upsert_sync_target(session, annotation, target_name, result):
     """Find-or-create the (annotation_id, target) row, race-safe under
-    concurrent INSERT via IntegrityError recovery."""
+    concurrent INSERT via IntegrityError recovery.
+
+    The INSERT is isolated behind a SAVEPOINT, and that is load-bearing rather
+    than tidiness. This runs BEFORE ``ub.session_commit()`` and in the same
+    transaction as the annotation ``_upsert_annotation`` has just flushed but
+    not committed, so recovering from the race with a bare
+    ``session.rollback()`` discarded the user's annotation along with the
+    losing target row — after which the caller committed, logged no failure,
+    and the device was told its upload succeeded. Since the device only ever
+    uploads a delta, that content had nothing left to recover it from.
+
+    A SAVEPOINT contains only what is flushed after it, which is exactly the
+    precondition ``cps/kobo.py`` documents for #1318: the annotation is already
+    flushed, so it survives the savepoint being rolled back.
+    """
     from cps import ub
     st = (
         session.query(ub.AnnotationSyncTarget)
@@ -425,12 +439,14 @@ def _upsert_sync_target(session, annotation, target_name, result):
             created_at=_now(),
             updated_at=_now(),
         )
-        session.add(st)
         try:
-            session.flush()
+            with session.begin_nested():
+                session.add(st)
+                session.flush()
         except IntegrityError:
-            # Concurrent INSERT — recover by re-reading + applying result.
-            session.rollback()
+            # Concurrent INSERT — the savepoint (and only the savepoint) is
+            # rolled back, so the flushed annotation is still staged. Recover
+            # by re-reading + applying result.
             st = (
                 session.query(ub.AnnotationSyncTarget)
                 .filter(

--- a/tests/unit/test_annotation_sync_dispatcher.py
+++ b/tests/unit/test_annotation_sync_dispatcher.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import pytest
 from datetime import datetime, timezone
 from sqlalchemy import create_engine, text
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import sessionmaker
 
 from cps import ub
@@ -258,3 +258,103 @@ def test_database_failure_rolls_back_only_that_member_and_later_members_continue
     assert [row.annotation_id for row in s.query(ub.Annotation).order_by(ub.Annotation.id)] == [
         "uuid-before", "uuid-after",
     ]
+
+
+def test_sync_target_insert_race_does_not_discard_the_annotation(
+    patched_session, monkeypatch,
+):
+    """A losing race on the (annotation_id, target) INSERT must not take the
+    user's annotation with it.
+
+    ``_upsert_sync_target`` runs BEFORE ``ub.session_commit()`` and in the same
+    transaction as the annotation ``_upsert_annotation`` has flushed but not
+    committed. Recovering from the concurrent INSERT with a bare
+    ``session.rollback()`` therefore discards the annotation as well — and the
+    dispatcher then commits, reports no failure, and the device is told its
+    upload succeeded. The content is gone with nothing to recover it from,
+    because the device only ever uploads a delta.
+
+    Same precondition ``cps/kobo.py`` already documents for #1318: a SAVEPOINT
+    contains only what is flushed after it, so isolating just the target INSERT
+    leaves the annotation intact.
+    """
+    s, user = patched_session
+    register_handler(StubHandler())
+    original_flush = s.flush
+    raced = {"done": False}
+
+    def flush_losing_the_target_race(*args, **kwargs):
+        if not raced["done"] and any(
+            isinstance(obj, ub.AnnotationSyncTarget) for obj in s.new
+        ):
+            raced["done"] = True
+            raise IntegrityError(
+                "INSERT INTO annotation_sync_target", {},
+                RuntimeError("UNIQUE constraint failed"),
+            )
+        return original_flush(*args, **kwargs)
+
+    monkeypatch.setattr(s, "flush", flush_losing_the_target_race)
+
+    dispatch_annotation_sync(
+        [_payload("uuid-race", text_="must survive the target race")], _book(), user,
+    )
+
+    assert raced["done"], "the test did not actually exercise the INSERT race"
+    rows = s.query(ub.Annotation).all()
+    assert [r.annotation_id for r in rows] == ["uuid-race"], (
+        "the annotation was discarded by the sync-target race recovery"
+    )
+    assert rows[0].highlighted_text == "must survive the target race"
+
+
+def test_sync_target_insert_race_still_applies_the_result_to_the_winning_row(
+    patched_session, monkeypatch,
+):
+    """Positive control for the savepoint. Isolating the INSERT must not cost
+    the recovery: when a genuine competing row exists, the loser still has to
+    find it and apply its result. Without this, a change that simply stopped
+    inserting would satisfy the loss test above and quietly break the race
+    handling it exists to preserve.
+    """
+    s, user = patched_session
+    register_handler(StubHandler())
+
+    # Give the competing INSERT a valid annotation to reference, then clear the
+    # target row so the next dispatch takes the create path again.
+    dispatch_annotation_sync([_payload("uuid-a", text_="v1")], _book(), user)
+    annotation_id = s.query(ub.Annotation).one().id
+    s.query(ub.AnnotationSyncTarget).delete()
+    s.commit()
+
+    original_begin_nested = s.begin_nested
+    injected = {"done": False}
+
+    def begin_nested_after_a_competitor_commits(*args, **kwargs):
+        # Land the competing row in the OUTER transaction, i.e. before the
+        # savepoint opens — which is where another session's committed INSERT
+        # would already be by the time we lose to it.
+        if not injected["done"]:
+            injected["done"] = True
+            now = datetime.now(timezone.utc)
+            s.execute(
+                text(
+                    "INSERT INTO annotation_sync_target "
+                    "(annotation_id, target, status, created_at, updated_at) "
+                    "VALUES (:a, 'stub', 'pending', :t, :t)"
+                ),
+                {"a": annotation_id, "t": now},
+            )
+        return original_begin_nested(*args, **kwargs)
+
+    monkeypatch.setattr(s, "begin_nested", begin_nested_after_a_competitor_commits)
+
+    dispatch_annotation_sync([_payload("uuid-a", text_="v2")], _book(), user)
+
+    assert injected["done"], "the test did not actually exercise the INSERT race"
+    targets = s.query(ub.AnnotationSyncTarget).all()
+    assert len(targets) == 1, "the race must converge on exactly one target row"
+    assert targets[0].status == "synced", (
+        "the loser must apply its result to the winning row"
+    )
+    assert s.query(ub.Annotation).one().highlighted_text == "v2"


### PR DESCRIPTION
## The defect

`_upsert_sync_target()` recovered from a concurrent `(annotation_id, target)` INSERT like this:

```python
        session.add(st)
        try:
            session.flush()
        except IntegrityError:
            # Concurrent INSERT — recover by re-reading + applying result.
            session.rollback()
```

`session.rollback()` is not scoped to the failed flush — it discards the **whole** transaction. And
this runs *before* `ub.session_commit()`, in the same transaction as the annotation that
`_upsert_annotation()` has flushed but not committed (`dispatch_annotation_sync` calls
`_mark_pending` → `_upsert_sync_target`, and only then `ub.session_commit()`).

So the writer that loses the race destroys **the user's annotation** along with its own target row.
The dispatcher then commits, sees no exception, logs nothing, and the route proxies the PATCH so the
**device is told its upload succeeded**.

That is unrecoverable rather than merely wrong:

- the Kobo uploads a **delta**, so it never re-offers the annotation;
- `checkforchanges` containment deliberately keeps an owned book out of the Kobo-cloud download that
  might otherwise have healed it.

The highlight is simply gone, and nothing anywhere reports it.

The docstring called the recovery `race-safe`, which is presumably how it survived review — a claim
about concurrency that nothing executes.

## The fix

Isolate the INSERT behind a SAVEPOINT. `cps/kobo.py` already documents the identical precondition
for **#1318**:

> A SAVEPOINT only contains what is flushed after it, so the Kobo's own bookmark, statistics and
> status writes have to be settled first or a rollback here would take them with it

The annotation is already flushed by `_upsert_annotation()`, so it survives the savepoint being
rolled back. `begin_nested()` is the established pattern in this codebase — `_store_raw_materialization`
in this same module, `share_kobo_progress_with_koreader`, and `services/reading_position` all use it —
so this introduces no new mechanism.

## Verification

**Red/green**, driving the real dispatcher and losing the real INSERT race:

```
FAILED test_sync_target_insert_race_does_not_discard_the_annotation
E   AssertionError: the annotation was discarded by the sync-target race recovery
E   assert [] == ['uuid-race']
```

The annotation table came back **empty**. After the change the row is intact with its text.

**Positive control** — `test_sync_target_insert_race_still_applies_the_result_to_the_winning_row`.
A genuine competing row is committed into the outer transaction ahead of the savepoint; the loser
must still converge on exactly one target row and apply its result to the winner. Without this test,
a change that simply stopped inserting would satisfy the loss test while silently breaking the race
handling the function exists to provide.

Both tests assert the race was actually exercised, so neither can pass vacuously.

Full suite: **6506 passed, 102 skipped, exit 0**.

## Provenance

Found by an adversarial pass over the annotation subsystem (Sol). I verified the claim against the
code before acting on it — the ordering of `_upsert_annotation` → `_upsert_sync_target` →
`session_commit`, that `_upsert_annotation` ends in `session.flush()` and not a commit, and that
`begin_nested` is already used successfully in this file — rather than taking the report at face
value. Other findings from the same pass are being filed separately with their verification status.
