### PR TITLE
fix(kobo): stop answering a rolled-back reading-state PUT with RequestResult Success

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1782,7 +1782,14 @@ def HandleStateRequest(book_uuid):
                 current_user.id, book.id, request_bookmark["ProgressPercent"])
 
         ub.session.merge(kobo_reading_state)
-        ub.session_commit()
+        # #1318 again, on the reading-state path: ``session_commit()`` returns
+        # False when it caught an OperationalError/InvalidRequestError and
+        # rolled back, and its docstring is explicit that callers whose answer
+        # depends on the write landing MUST check it. Answering "Success" for a
+        # rolled-back write makes the device clear its queue and keeps the
+        # server on the older position, with nothing anywhere reporting it.
+        if not ub.session_commit():
+            return "", 500
         return jsonify({
             "RequestResult": "Success",
             "UpdateResults": [update_results_response],

--- a/tests/unit/test_1425_kobo_to_koreader.py
+++ b/tests/unit/test_1425_kobo_to_koreader.py
@@ -237,7 +237,15 @@ def kobo_put(monkeypatch):
 
     kobo_ub = MagicMock(session=_SessionProxy())
     kobo_ub.session_flush = lambda *a, **k: session.flush()
-    kobo_ub.session_commit = lambda *a, **k: session.commit()
+    def _session_commit(*_a, **_k):
+        # Mirror the real ``ub.session_commit`` contract: True when the write
+        # landed. The old stub returned ``session.commit()``, i.e. None — so
+        # any caller that correctly checked the result would have looked broken
+        # here, which is part of why the unchecked commit survived.
+        session.commit()
+        return True
+
+    kobo_ub.session_commit = _session_commit
     kobo_ub.ReadBook = SimpleNamespace(STATUS_UNREAD=0, STATUS_IN_PROGRESS=1, STATUS_FINISHED=2)
 
     monkeypatch.setattr(kobo_module, "ub", kobo_ub)
@@ -375,3 +383,39 @@ def test_settles_pending_writes_before_opening_the_savepoint():
     src = inspect.getsource(share_kobo_progress_with_koreader)
     assert "session_flush()" in src
     assert src.index("session_flush()") < src.index("begin_nested()")
+
+
+@pytest.mark.unit
+def test_state_put_does_not_report_success_when_the_commit_rolled_back(
+    kobo_put, monkeypatch,
+):
+    """A rolled-back reading state must not be answered ``Success``.
+
+    ``ub.session_commit()`` returns ``False`` when it caught an
+    ``OperationalError``/``InvalidRequestError`` and rolled back, and its own
+    docstring says callers whose answer to the user depends on the write
+    landing MUST check it — citing #1318, which is precisely "a rolled-back
+    bookmark was still answered 201".
+
+    This handler ignored the result and returned ``RequestResult: Success``
+    unconditionally, so a device whose progress was NOT stored was told it was,
+    cleared its queue, and the server kept the older position.
+    """
+    kobo_module, app, _session = kobo_put
+    monkeypatch.setattr(kobo_module.ub, "session_commit", lambda *a, **k: False)
+
+    with app.test_request_context(json=_state_put_payload(63.5), method="PUT"):
+        response = _handler(kobo_module)("uuid-under-test")
+
+    if isinstance(response, tuple):
+        body, status = response[0], response[1]
+        body = body if isinstance(body, str) else body.get_data(as_text=True)
+    else:
+        body, status = response.get_data(as_text=True), response.status_code
+
+    assert status >= 500, (
+        f"a rolled-back state write must not be answered {status}"
+    )
+    assert "Success" not in body, (
+        "the device must not be told the write landed when it was rolled back"
+    )


### PR DESCRIPTION
## The defect

`ub.session_commit()` returns `False` when it caught an `OperationalError`/`InvalidRequestError` and
rolled back. Its own docstring is unambiguous about the obligation:

> callers whose answer to the user depends on the write actually landing **MUST** check it (#1318 —
> the previous `""` return could not express failure, so a rolled-back bookmark was still answered
> 201 …)

`HandleStateRequest`'s PUT branch called it and threw the result away:

```python
        ub.session.merge(kobo_reading_state)
        ub.session_commit()
        return jsonify({"RequestResult": "Success", ...})
```

A device whose reading position was **not** stored is told it was. It clears its queue, the server
keeps the older position, and nothing anywhere reports it. This is #1318 in a sibling endpoint.

## The fix

Exactly the pattern this repo already used for the same class, twice — `cps/web.py` `set_bookmark`
and `cps/kobo_auth.py` token revocation:

```python
        if not ub.session_commit():
            return "", 500
```

## The fixture was part of the reason this survived

The reading-state test stubbed the collaborator as `lambda *a, **k: session.commit()` — which
returns **`None`**. Under that stub any caller that *correctly* checked the result looks broken: the
existing `test_real_kobo_state_put_writes_the_koreader_carrier` went red the instant the check was
added, and the naive reading of that would have been "the fix is wrong". The stub now mirrors the
real contract and returns `True`.

A test double that contradicts the contract of the thing it doubles doesn't just fail to catch the
bug — it actively argues for the bug.

## Verification

Red/green with `session_commit` forced to `False`:

```
E   AssertionError: a rolled-back state write must not be answered 200
E   assert 200 >= 500
```

After: 500, and the body carries no success claim. Full suite **6505 passed, 102 skipped, exit 0**.

## One link is ASSUMED, and I would rather say so than gloss it

How a Kobo reacts to a 500 on *this* endpoint is not directly observed. Measured hardware behaviour
exists for a 503 on the annotations **GET** — it makes the device empty its local annotation set —
and I deliberately do **not** assume that transfers here: this endpoint carries reading position,
not annotations, and the destructive path documented for the GET has no counterpart on a state PUT.

What is certain is that the current answer is wrong, and that a retryable failure is what both
in-repo precedents chose for precisely this situation. If someone wants the device-side reaction
measured before this ships, that is a reasonable ask and the harness can do it.
