### PR TITLE
fix(annotations): make the KoboReader.sqlite import honest about its commit and dedup on the canonical key

### DIFF
--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -348,8 +348,14 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
     are explicit so this function is unit-testable without a Flask app.
 
     The annotation-backup hook fires automatically on commit so the
-    user already has a recoverable snapshot before the next import
-    overwrites anything.
+    user already has a recoverable snapshot.
+
+    NOTE: this import is INSERT-ONLY. An annotation the server already holds
+    for that (user, book) is skipped without comparing DateModified, text,
+    note, colour, position or hidden state, so re-importing a newer device
+    database cannot apply an edit or a device-side deletion. The previous
+    wording here described an "overwrite" the code has never performed
+    (findings F-e628c6).
 
     Returns a counts dict the JSON endpoint hands back to the browser.
     """
@@ -387,10 +393,14 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
             skipped_orphan += 1
             continue
 
-        # Dedup: (user_id, annotation_id) is already indexed; one
-        # SELECT covers the existence check.
+        # Dedup on the CANONICAL key. `uq_annotation_user_book_annotation` is
+        # (user_id, book_id, annotation_id) and the live PATCH dispatcher
+        # upserts on that same triple; checking only (user_id, annotation_id)
+        # made one book's row suppress a row the schema explicitly permits in
+        # another book. `ix_annotation_user_book` covers this lookup.
         existing = session.query(ub.Annotation.id).filter(
             ub.Annotation.user_id == user_id,
+            ub.Annotation.book_id == book_id,
             ub.Annotation.annotation_id == bm.bookmark_id,
         ).first()
         if existing is not None:
@@ -430,7 +440,12 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
         imported += 1
 
     try:
-        commit()
+        # `_commit_required` is this module's own guard for exactly this: CWNG's
+        # commit wrapper signals a rolled-back write by RETURNING False, not by
+        # raising, so a bare `commit()` reported rows as imported after writing
+        # nothing. Routing through the helper makes both failure shapes take
+        # the same path.
+        _commit_required(commit)
     except Exception as e:
         log.error("annotations: import commit failed: %s", e)
         session.rollback()

--- a/tests/unit/test_annotations_import_endpoint.py
+++ b/tests/unit/test_annotations_import_endpoint.py
@@ -281,3 +281,73 @@ class TestCommitFailure:
         # what would have been imported if the commit had succeeded.
         assert result["skipped_orphan"] == 2
         assert result["skipped_hidden"] == 1
+
+
+@pytest.mark.unit
+class TestImportHonestyAndIdentity:
+    """Two ways the import misreports what it actually did."""
+
+    def test_commit_returning_false_reports_imported_zero(self, memory_db, synthetic_db):
+        """The production commit signals failure by RETURNING False, not by raising.
+
+        ``ub.session_commit`` catches OperationalError/InvalidRequestError,
+        rolls back, and returns False — the sibling test above only covers a
+        commit that raises, which is the path production does not take. With
+        only that coverage the endpoint answers HTTP 200 and ``imported: N``
+        after writing nothing at all.
+        """
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        book_lookup = _make_book_lookup({
+            "b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348,
+        })
+
+        result = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=book_lookup, commit=lambda: False,
+        )
+
+        assert result["imported"] == 0, (
+            "a rolled-back import must not report rows as imported"
+        )
+        assert session.query(ub.Annotation).filter_by(user_id=7).count() == 0
+        # The other counts stay honest, as with a raising commit.
+        assert result["skipped_orphan"] == 2
+        assert result["skipped_hidden"] == 1
+
+    def test_same_annotation_id_against_a_different_book_is_not_skipped(
+        self, memory_db, synthetic_db,
+    ):
+        """Dedup must use the canonical key, which includes the book.
+
+        ``uq_annotation_user_book_annotation`` is on
+        ``(user_id, book_id, annotation_id)`` and the live PATCH dispatcher
+        upserts on that triple. The import checked only
+        ``(user_id, annotation_id)``, so one book's row suppressed a row the
+        schema explicitly permits in another book.
+        """
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        uuid = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+
+        first = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=_make_book_lookup({uuid: 348}), commit=session.commit,
+        )
+        assert first["imported"] == 3
+
+        # Same bookmark ids, resolved to a DIFFERENT book.
+        second = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=_make_book_lookup({uuid: 349}), commit=session.commit,
+        )
+
+        assert second["imported"] == 3, (
+            "rows for a different book were suppressed by the wrong dedup key"
+        )
+        assert session.query(ub.Annotation).filter_by(user_id=7, book_id=348).count() == 3
+        assert session.query(ub.Annotation).filter_by(user_id=7, book_id=349).count() == 3


### PR DESCRIPTION
Fixes **F-e4e119**, and the identity half of **F-e628c6**.

The `/annotations/import` path is the **only** recovery route for annotations the live delta sync
never carried — the Kobo uploads a delta and never re-offers an annotation, so if the server missed
one, this upload is how it comes back. Both defects below make that recovery lie about itself.

## 1. It reported rows as imported after a rolled-back commit

```python
    try:
        commit()
    except Exception as e:
        ... imported = 0
```

Only a **raised** exception was handled. The production `commit` is `ub.session_commit`, whose
contract is to catch `OperationalError`/`InvalidRequestError`, roll back, and **return `False`**.
That path left `imported` at its pre-commit count, so the endpoint answered **HTTP 200** with
`{"imported": N}` after writing nothing.

This module already owns the guard for precisely this — `_commit_required`, used by four other
callers in the same file — and this one didn't use it. Routing through it makes both failure shapes
take the same path.

The existing `TestCommitFailure` covers only a commit that **raises**, i.e. the case production does
not take. The suite was structurally unable to see this.

## 2. It deduplicated on the wrong key

```python
            ub.Annotation.user_id == user_id,
            ub.Annotation.annotation_id == bm.bookmark_id,
```

The canonical uniqueness is `uq_annotation_user_book_annotation` on
`(user_id, book_id, annotation_id)`, and the live PATCH dispatcher upserts on that same triple. So
one book's row suppressed a row the schema **explicitly permits** in another book, and the import
counted it as `skipped_existing` — indistinguishable, in the summary the user reads, from "you
already have this". `ix_annotation_user_book` already covers the corrected lookup.

## Verification

Red/green against the real function:

```
assert 3 == 0   # rolled-back import reported 3 rows imported
assert 0 == 3   # rows for a different book suppressed by the wrong key
```

Both green after. Full suite **6508 passed, 102 skipped, exit 0**.

## A docstring corrected, and what is deliberately left

The docstring promised a backup taken "before the next import overwrites anything". The import
overwrites nothing: an annotation the server already holds for that `(user, book)` is skipped with
no comparison of `DateModified`, text, note, colour, position or hidden state. So re-importing a
**newer** device database cannot apply an edit, and a device-side deletion is invisible twice over.

Saying so in the docstring is not a fix for that, and I'm not claiming it is — the remaining
insert-only limitation stays open as **F-e628c6**. But a comment promising behaviour the code lacks
is how the gap stayed invisible in the first place, so it should not keep promising it.

Related, still open and recorded rather than smuggled in here: **F-b1004e** — the import's SQL filter
(`WHERE Text IS NOT NULL AND Text != ''`) drops every dogear and note-only bookmark before they are
even counted, while the live path stores them. Measured on a Clara BW: all 13 dogear rows have empty
`Text`.
