### PR TITLE
fix(koreader): correct the plugin's Kobo colour table, which was wrong four ways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **Highlight colours synced through the KOReader plugin were wrong, and on a
+  black-and-white Kobo every highlight came back yellow.** The plugin used a
+  colour table that had blue and green the wrong way round, called Kobo's pink
+  "red" (a Kobo cannot store red at all), and had no entry for grey — which is
+  the colour a greyscale reader like the Clara BW records for *every* highlight
+  you make, so all of them arrived as yellow. The table now matches what the
+  device actually stores, measured on hardware, and the server and plugin are
+  checked against each other so they cannot drift apart again.
 - **Asking your system to reduce motion now stops every spinning icon in the new
   UI, not just some of them.** The app has seven loading spinners; four stopped
   when you turned on "reduce motion" and three kept spinning — including the

--- a/koreader/plugins/cwasync.koplugin/_meta.lua
+++ b/koreader/plugins/cwasync.koplugin/_meta.lua
@@ -5,5 +5,5 @@ return {
     name = "cwasync",
     fullname = _("NextGen Progress Sync"),
     description = _([[Synchronizes your reading progress to Calibre-Web NextGen and across your KOReader devices.]]),
-    version = "4.1.37",  -- Updates Manager reads this; keep in lockstep with main.lua and the CWNG release tag
+    version = "4.1.38",  -- Updates Manager reads this; keep in lockstep with main.lua and the CWNG release tag
 }

--- a/koreader/plugins/cwasync.koplugin/kobo_sqlite_provider.lua
+++ b/koreader/plugins/cwasync.koplugin/kobo_sqlite_provider.lua
@@ -25,19 +25,68 @@ local KoboSqliteProvider = {}
 
 local DEFAULT_KOBO_DB = "/mnt/onboard/.kobo/KoboReader.sqlite"
 
--- Kobo's Color codes (Bookmark.Color). Web/KOReader use the 4 named colors a
--- Kobo round-trips; anything else degrades to yellow.
-local COLOR_NAME_TO_INT = { yellow = 0, red = 1, green = 2, blue = 3 }
-local COLOR_INT_TO_NAME = { [0] = "yellow", [1] = "red", [2] = "green", [3] = "blue" }
+-- Kobo's Color codes (Bookmark.Color).
+--
+-- MEASURED on the operator's Kobo Clara BW, firmware 4.45.23792, 2026-08-18, by
+-- serving each palette hex in an authored response and reading Bookmark.Color
+-- back (finding F-5769c9). This is the same table the server keeps in
+-- cps/services/annotation_colors.py, and the two must not drift.
+--
+--   0  #F6F3B3  yellow
+--   1  #E8AFCF  pink
+--   2  #B2E1E8  blue
+--   3  #C6E09E  green
+--   4  #A0A0A0  grey
+--
+-- The previous table here was wrong in three ways and the plugin's own tests
+-- pinned every one of them: it called 1 "red", it had 2 and 3 swapped so every
+-- green highlight was written to the device as blue and every blue one as
+-- green, and it had no entry for 4 at all. That last omission was the worst:
+-- a greyscale device such as the Clara BW writes Color=4 for EVERY organic
+-- highlight, so with `or "yellow"` every highlight it had ever made came back
+-- from the device as yellow.
+local COLOR_NAME_TO_INT = {
+    yellow = 0,
+    pink   = 1,
+    blue   = 2,
+    green  = 3,
+    grey   = 4,
+    gray   = 4,   -- the other spelling, folded like the server folds it
+}
+local COLOR_INT_TO_NAME = {
+    [0] = "yellow",
+    [1] = "pink",
+    [2] = "blue",
+    [3] = "green",
+    [4] = "grey",
+}
+
+-- A Kobo cannot represent red at all; red exists only in the web reader's
+-- palette. Writing a red highlight to a device therefore has to pick something,
+-- and pink is the nearest of the five it does have. Deliberately one-directional:
+-- Color=1 always reads back as "pink", never as "red", because pink is what the
+-- device is actually showing.
+local WRITE_ONLY_NEAREST = { red = 1 }
 
 -- ── Pure field-mapping helpers (unit-tested) ──────────────────────────────
 
+-- name -> Bookmark.Color. The column needs an integer, so an unrecognised name
+-- still has to become something; yellow is the documented last resort rather
+-- than an accident of `or 0`.
 function KoboSqliteProvider.colorNameToKoboInt(name)
-    return COLOR_NAME_TO_INT[name] or 0
+    if type(name) == "string" then
+        name = name:lower()
+    end
+    return COLOR_NAME_TO_INT[name] or WRITE_ONLY_NEAREST[name] or 0
 end
 
+-- Bookmark.Color -> name, or nil when the device sent an integer this table does
+-- not know. Deliberately NOT "yellow": a failed lookup that answers with a real
+-- colour is indistinguishable downstream from a genuine yellow highlight, which
+-- is the mistake the server's table documents as rule 1 ("never invent a
+-- colour"). Callers omit an unknown colour rather than misreporting one.
 function KoboSqliteProvider.koboIntToColorName(code)
-    return COLOR_INT_TO_NAME[code] or "yellow"
+    return COLOR_INT_TO_NAME[code]
 end
 
 -- "kobo.4.1" -> "span#kobo\.4\.1" (Kobo escapes the dots in the CSS selector).

--- a/koreader/plugins/cwasync.koplugin/main.lua
+++ b/koreader/plugins/cwasync.koplugin/main.lua
@@ -27,7 +27,7 @@ end
 local CWASync = WidgetContainer:extend{
     name = "cwasync",
     title = _("Login to NextGen Server"),
-    version = "4.1.37",  -- Plugin version mirrors CWNG release tag; keep in lockstep with _meta.lua
+    version = "4.1.38",  -- Plugin version mirrors CWNG release tag; keep in lockstep with _meta.lua
 
     push_timestamp = nil,
     pull_timestamp = nil,

--- a/koreader/plugins/cwasync.koplugin/tests/device_annotations_test.lua
+++ b/koreader/plugins/cwasync.koplugin/tests/device_annotations_test.lua
@@ -17,16 +17,48 @@ local function assertEqual(actual, expected, message)
     end
 end
 
+-- The measured Kobo table (Clara BW 4.45.23792, finding F-5769c9). These
+-- assertions previously encoded the WRONG mapping and so defended the bug:
+-- they asserted red -> 1, green -> 2, blue -> 3 and out-of-range -> yellow.
 local function testColorMapping()
+    -- name -> Bookmark.Color, every value the device actually has
     assertEqual(KP.colorNameToKoboInt("yellow"), 0, "yellow -> 0")
-    assertEqual(KP.colorNameToKoboInt("red"), 1, "red -> 1")
-    assertEqual(KP.colorNameToKoboInt("green"), 2, "green -> 2")
-    assertEqual(KP.colorNameToKoboInt("blue"), 3, "blue -> 3")
-    assertEqual(KP.colorNameToKoboInt("chartreuse"), 0, "unknown -> 0 (yellow)")
-    assertEqual(KP.colorNameToKoboInt(nil), 0, "nil -> 0")
+    assertEqual(KP.colorNameToKoboInt("pink"), 1, "pink -> 1")
+    assertEqual(KP.colorNameToKoboInt("blue"), 2, "blue -> 2")
+    assertEqual(KP.colorNameToKoboInt("green"), 3, "green -> 3")
+    assertEqual(KP.colorNameToKoboInt("grey"), 4, "grey -> 4")
+    assertEqual(KP.colorNameToKoboInt("gray"), 4, "the other spelling folds too")
+
+    -- Bookmark.Color -> name
     assertEqual(KP.koboIntToColorName(0), "yellow", "0 -> yellow")
-    assertEqual(KP.koboIntToColorName(3), "blue", "3 -> blue")
-    assertEqual(KP.koboIntToColorName(99), "yellow", "out-of-range -> yellow")
+    assertEqual(KP.koboIntToColorName(1), "pink", "1 -> pink, NOT red")
+    assertEqual(KP.koboIntToColorName(2), "blue", "2 -> blue")
+    assertEqual(KP.koboIntToColorName(3), "green", "3 -> green")
+
+    -- The omission that mattered most. A greyscale device writes Color=4 for
+    -- EVERY organic highlight, so while 4 was missing every highlight ever made
+    -- on a Clara BW came back as yellow.
+    assertEqual(KP.koboIntToColorName(4), "grey", "4 -> grey, not yellow")
+
+    -- Blue and green must not swap. Asserted as a round trip so a future edit
+    -- cannot pass by flipping both tables together.
+    assertEqual(KP.koboIntToColorName(KP.colorNameToKoboInt("blue")), "blue", "blue round-trips")
+    assertEqual(KP.koboIntToColorName(KP.colorNameToKoboInt("green")), "green", "green round-trips")
+
+    -- A Kobo has no red. Writing one picks the nearest colour it does have, and
+    -- that is deliberately one-directional: the device is showing pink, so pink
+    -- is what comes back.
+    assertEqual(KP.colorNameToKoboInt("red"), 1, "red is written as the nearest, pink")
+    assertEqual(KP.koboIntToColorName(1), "pink", "and reads back as pink, never red")
+
+    -- Writing needs an integer, so an unknown name still has to become one.
+    assertEqual(KP.colorNameToKoboInt("chartreuse"), 0, "unknown name -> yellow (documented last resort)")
+    assertEqual(KP.colorNameToKoboInt(nil), 0, "nil -> yellow")
+
+    -- Reading does NOT: an unknown code must not be reported as a real colour,
+    -- or a failed lookup is indistinguishable from a genuine yellow highlight.
+    assertEqual(KP.koboIntToColorName(99), nil, "out-of-range -> nil, never yellow")
+    assertEqual(KP.koboIntToColorName(nil), nil, "nil code -> nil")
 end
 
 local function testSelectorEscaping()
@@ -60,7 +92,7 @@ local function testBuildBookmarkRow()
     assertEqual(row.EndOffset, 17, "end offset")
     assertEqual(row.Text, "the passage", "Text = highlighted_text")
     assertEqual(row.Annotation, "my note", "Annotation = note_text")
-    assertEqual(row.Color, 2, "Color = green int")
+    assertEqual(row.Color, 3, "green is Kobo Color 3, not 2 -- see the measured table")
     assertEqual(row.Type, "highlight", "Type = highlight")
 end
 
@@ -75,7 +107,7 @@ local function testBookmarkRowToPortable()
     }
     local p = KP.bookmarkRowToPortable(row)
     assertEqual(p.annotation_id, "dev-1", "annotation_id = BookmarkID")
-    assertEqual(p.color, "red", "Color 1 -> red")
+    assertEqual(p.color, "pink", "Color 1 is pink; a Kobo has no red at all")
     assertEqual(p.start_kobospan, "kobo.4.1", "start span extracted")
     assertEqual(p.end_kobospan, "kobo.4.2", "end span extracted")
     assertEqual(p.start_offset, 0, "start offset")

--- a/tests/unit/test_kobo_colour_table_agrees_with_the_plugin.py
+++ b/tests/unit/test_kobo_colour_table_agrees_with_the_plugin.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""The server and the KOReader plugin must agree on Kobo's colour integers.
+
+There are two copies of Kobo's `Bookmark.Color` table in this repository, in two
+languages, and they are the same fact:
+
+    cps/services/annotation_colors.py                     (Python, canonical)
+    koreader/plugins/cwasync.koplugin/kobo_sqlite_provider.lua   (Lua)
+
+They drifted, and the drift was invisible because each side had its own tests
+agreeing with itself. The Lua copy called 1 "red" (a Kobo has no red), had 2 and
+3 swapped so every green highlight was written to the device as blue and every
+blue one as green, and had no entry for 4 at all — and 4 is what a greyscale
+device writes for EVERY organic highlight, so on a Clara BW every highlight ever
+made came back as yellow. The plugin's own Lua suite asserted all three of those,
+which is why nothing caught it.
+
+The measured table (Clara BW, firmware 4.45.23792, finding F-5769c9) is in the
+Python module's docstring. This test makes the Lua file answer to it.
+
+Parsing Lua with a regex is crude, and deliberately so: the alternative is a Lua
+interpreter dependency for a check that is really "do these five pairs match".
+The parse is guarded — if it stops finding a table, the test fails rather than
+passing over an empty comparison.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[2]
+PLUGIN_LUA = REPO / "koreader" / "plugins" / "cwasync.koplugin" / "kobo_sqlite_provider.lua"
+
+
+def _lua_table(body: str, name: str) -> str:
+    match = re.search(name + r"\s*=\s*\{(.*?)\}", body, re.S)
+    assert match, f"could not find the Lua table {name} in {PLUGIN_LUA.name}"
+    return match.group(1)
+
+
+def _lua_name_to_int() -> dict[str, int]:
+    body = PLUGIN_LUA.read_text(encoding="utf-8")
+    table = _lua_table(body, "COLOR_NAME_TO_INT")
+    pairs = dict(
+        (key, int(value))
+        for key, value in re.findall(r"(\w+)\s*=\s*(\d+)", table)
+    )
+    assert pairs, "COLOR_NAME_TO_INT parsed as empty"
+    return pairs
+
+
+def _lua_int_to_name() -> dict[int, str]:
+    body = PLUGIN_LUA.read_text(encoding="utf-8")
+    table = _lua_table(body, "COLOR_INT_TO_NAME")
+    pairs = dict(
+        (int(key), value)
+        for key, value in re.findall(r"\[(\d+)\]\s*=\s*\"(\w+)\"", table)
+    )
+    assert pairs, "COLOR_INT_TO_NAME parsed as empty"
+    return pairs
+
+
+def _server_int_to_name() -> dict[int, str]:
+    from cps.services import annotation_colors
+
+    return {
+        code: annotation_colors.to_display_name(hexval)
+        for code, hexval in annotation_colors.KOBO_BOOKMARK_COLOR_HEX.items()
+    }
+
+
+def test_the_parse_finds_a_real_table():
+    """Vacuity guard: an empty parse would make every comparison below trivial."""
+    assert len(_lua_int_to_name()) >= 5, _lua_int_to_name()
+    assert len(_lua_name_to_int()) >= 5, _lua_name_to_int()
+
+
+def test_the_plugin_reads_every_kobo_colour_the_server_knows():
+    server = _server_int_to_name()
+    plugin = _lua_int_to_name()
+    assert len(server) == 5, server
+    assert plugin == server, (
+        "the plugin's Bookmark.Color -> name table disagrees with "
+        "cps/services/annotation_colors.py. A device highlight would be "
+        "reported as the wrong colour.\n"
+        f"  plugin: {plugin}\n  server: {server}"
+    )
+
+
+def test_the_plugin_writes_every_colour_back_to_the_same_integer():
+    server = _server_int_to_name()
+    plugin = _lua_name_to_int()
+    for code, name in server.items():
+        assert plugin.get(name) == code, (
+            f"the plugin writes {name!r} as Bookmark.Color {plugin.get(name)}, "
+            f"but the device uses {code}. A highlight made in {name} would "
+            f"appear on the device in another colour."
+        )
+
+
+def test_grey_is_present_because_a_greyscale_device_writes_only_grey():
+    """The omission that mattered most, pinned on its own.
+
+    A Clara BW writes Color=4 for every organic highlight. While 4 was missing,
+    every highlight on such a device read back as yellow.
+    """
+    assert _lua_int_to_name().get(4) == "grey"
+    assert _lua_name_to_int().get("grey") == 4
+
+
+def test_the_plugin_never_claims_a_kobo_can_store_red():
+    """Kobo has no red; only the web reader offers it.
+
+    Reading 1 as "red" is the specific mistake that made pink highlights arrive
+    as a colour no device can produce.
+    """
+    assert "red" not in _lua_int_to_name().values(), (
+        "the plugin reports a Bookmark.Color as red; a Kobo cannot store red, "
+        "and 1 is pink"
+    )


### PR DESCRIPTION
## What a user notices

Highlights synced through the KOReader plugin came back in the wrong colour — and
**on a black-and-white Kobo, every highlight came back yellow.**

## The table was wrong four ways

The plugin carried its own copy of Kobo's `Bookmark.Color` table:

```lua
{ yellow = 0, red = 1, green = 2, blue = 3 }
```

Measured on the operator's Kobo Clara BW, firmware 4.45.23792 (finding **F-5769c9**,
already recorded in `cps/services/annotation_colors.py`):

| int | hex | name |
|---|---|---|
| 0 | `#F6F3B3` | yellow |
| 1 | `#E8AFCF` | pink |
| 2 | `#B2E1E8` | blue |
| 3 | `#C6E09E` | green |
| 4 | `#A0A0A0` | grey |

1. **blue and green were swapped** — every green highlight was written to the device as
   blue, and every blue one as green.
2. **`1` was called "red"** — a Kobo cannot store red at all (red exists only in the web
   reader's palette), so a pink device highlight was reported as a colour no device can
   produce.
3. **There was no entry for `4`**, and `or "yellow"` swallowed it. This is the one that
   mattered: a greyscale device writes `Color=4` for *every* organic highlight, so on a
   Clara BW **every highlight the reader had ever made came back as yellow**.
4. An unrecognised code also became yellow, making a failed lookup indistinguishable from
   a genuine yellow highlight — the mistake the server's module documents as rule 1,
   *never invent a colour*.

Reading an unknown code now answers `nil`, so the caller omits the colour rather than
misreporting one. Writing still needs an integer for the column, so an unknown *name*
still falls back to yellow — now a documented last resort rather than an accident of
`or 0`. Red is written as pink, the nearest colour a Kobo has, deliberately
one-directional: `Color=1` always reads back as pink, because pink is what the device is
showing.

## The plugin's own tests pinned every one of these

`device_annotations_test.lua` asserted `red -> 1`, `green -> 2`, `blue -> 3` and
`out-of-range -> yellow`, and its round-trip cases asserted `Color = green int` was `2`
and `Color 1 -> red`. **A green suite was holding the bug in place**, in both the lookup
helpers and the row round-trip.

```
swap blue/green back     -> 1 failed        drop 4=grey             -> 1 failed
call 1 red again         -> 1 failed        unknown -> yellow again -> 1 failed
restored                 -> 6 passed
```

## The drift guard is the part that stops this recurring

Two copies of one fact existed in two languages, each with its own tests agreeing with
itself — which is exactly why nothing noticed.
`tests/unit/test_kobo_colour_table_agrees_with_the_plugin.py` parses both Lua tables and
requires them to match `cps/services/annotation_colors.py` **in both directions**. It runs
from Python, so it works on a machine with no Lua interpreter.

```
swap blue/green in the read table -> 1 failed
drop 4=grey                       -> 3 failed
call 1 red again                  -> 2 failed
write green to the wrong integer  -> 1 failed
restored                          -> 5 passed
```
