### PR TITLE
fix(kobo): record what the device said an annotation IS when importing it (F-7e418c)

### DIFF
--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -437,6 +437,12 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
             end_offset=bm.end_offset,
             context_string=bm.context_string,
             chapter_progress=bm.chapter_progress,
+            # The device's own word for what this row is, carried through
+            # unchanged (F-7e418c). The live PATCH path stores the same
+            # vocabulary from `payload["type"]`, so a row recovered from
+            # KoboReader.sqlite and the same annotation arriving over the wire
+            # now agree instead of one of them being NULL.
+            annotation_type=getattr(bm, "annotation_type", None),
             source="kobo",
             origin_device_id=origin_device_id,
             hidden=False,

--- a/cps/services/kobo_import.py
+++ b/cps/services/kobo_import.py
@@ -90,6 +90,10 @@ class ParsedBookmark:
     hidden: bool
     date_created: Optional[str]    # ISO-8601 strings as stored by Kobo
     date_modified: Optional[str]
+    annotation_type: Optional[str] = None
+    # Bookmark.Type verbatim — the device's own word, normally "highlight".
+    # None when the column is absent (older firmware) so a missing value is
+    # never confused with a device that said something.
 
 
 @dataclass(frozen=True)
@@ -295,16 +299,26 @@ def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
             log.info("kobo_import: %s has no Bookmark table — skipping", sqlite_path)
             return
 
+        # Bookmark.Type is the device's own word for what a row is
+        # ("highlight"; a Kobo also uses "dogear", which cannot reach us because
+        # of the Text filter below). Selected conditionally: naming a column an
+        # older firmware lacks would fail the whole query and lose every
+        # annotation on the device, which is a far worse outcome than importing
+        # them untyped.
+        has_type = any(
+            row[1] == "Type"
+            for row in conn.execute("PRAGMA table_info(Bookmark)").fetchall()
+        )
         rows = conn.execute("""
             SELECT
                 BookmarkID, VolumeID, ContentID,
                 StartContainerPath, StartContainerChildIndex, StartOffset,
                 EndContainerPath, EndContainerChildIndex, EndOffset,
                 Text, Annotation, Color, ContextString,
-                ChapterProgress, DateCreated, DateModified, Hidden
+                ChapterProgress, DateCreated, DateModified, Hidden, {type_column}
             FROM Bookmark
             WHERE Text IS NOT NULL AND Text != ''
-        """).fetchall()
+        """.format(type_column="Type" if has_type else "NULL")).fetchall()
     except sqlite3.DatabaseError as e:
         log.warning("kobo_import: SQL error on %s: %s", sqlite_path, e)
         return
@@ -315,7 +329,7 @@ def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
         (bm_id, volume_id, content_id,
          sp, sci, so, ep, eci, eo,
          text, annotation, color, ctx,
-         chapter_progress, dcreated, dmod, hidden) = r
+         chapter_progress, dcreated, dmod, hidden, bm_type) = r
         if not bm_id or not volume_id:
             # Malformed row — Kobo doesn't normally emit these. Skip
             # rather than abort the whole import.
@@ -338,6 +352,14 @@ def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
             # specific colour. A default here is what made every greyscale
             # device's highlights indistinguishable from real yellow ones.
             color=hex_for_bookmark_color(color),
+            # Stored verbatim, not derived. The device's vocabulary and the
+            # live PATCH path's `payload["type"]` are the same word — the
+            # KOReader plugin both writes `Type = "highlight"` and selects
+            # `WHERE Type = 'highlight'` — so preserving it keeps the two
+            # writers to this column speaking one language instead of
+            # inventing a third (the mistake annotation_colors.py exists to
+            # undo for highlight_color).
+            annotation_type=(bm_type if isinstance(bm_type, str) and bm_type else None),
             hidden=bool(hidden),
             date_created=dcreated,
             date_modified=dmod,

--- a/tests/fixtures/kobo_reader_sqlite.py
+++ b/tests/fixtures/kobo_reader_sqlite.py
@@ -170,3 +170,69 @@ def build_not_sqlite(path: Path) -> Path:
     """Not a SQLite file at all — exercises the magic-bytes rejection."""
     path.write_bytes(b"This is not a sqlite file. " * 100)
     return path
+
+
+def build_kobo_db_with_bookmark_type(
+    path: Path,
+    book_uuid: str = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04",
+) -> Path:
+    """A Bookmark table that carries the ``Type`` column, as current firmware does.
+
+    ``build_synthetic_kobo_db`` above deliberately omits ``Type`` — it models an
+    older schema, and the importer must keep working there. This one models the
+    schema a current device actually has, so the two together cover both sides of
+    the capability check in ``parse_kobo_bookmarks``.
+
+    ``dogear`` rows carry no ``Text`` on a real device and so cannot reach the
+    importer, whose SELECT filters them out. One is included anyway, with text,
+    precisely so a test can prove the importer stores whatever word the device
+    used rather than assuming everything it sees is a highlight.
+    """
+    import sqlite3
+
+    conn = sqlite3.connect(path)
+    conn.execute("""
+        CREATE TABLE Bookmark (
+            BookmarkID TEXT PRIMARY KEY,
+            VolumeID TEXT,
+            ContentID TEXT,
+            StartContainerPath TEXT,
+            StartContainerChildIndex INTEGER,
+            StartOffset INTEGER,
+            EndContainerPath TEXT,
+            EndContainerChildIndex INTEGER,
+            EndOffset INTEGER,
+            Text TEXT,
+            Annotation TEXT,
+            Color INTEGER,
+            ContextString TEXT,
+            ChapterProgress REAL,
+            DateCreated TEXT,
+            DateModified TEXT,
+            Hidden INTEGER DEFAULT 0,
+            Type TEXT
+        )
+    """)
+    chapter1 = "{}!!chapter1.html".format(book_uuid)
+    chapter2 = "{}!!chapter2.html".format(book_uuid)
+    rows = [
+        ("bt-001", book_uuid, chapter1, "span#kobo\\.1\\.1", -99, 0,
+         "span#kobo\\.1\\.2", -99, 5, "a highlight", None, 0, "ctx", 0.1,
+         "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0, "highlight"),
+        ("bt-002", book_uuid, chapter1, "span#kobo\\.2\\.1", -99, 0,
+         "span#kobo\\.2\\.2", -99, 5, "with a note", "my note", 1, "ctx", 0.2,
+         "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0, "highlight"),
+        ("bt-003", book_uuid, chapter2, "span#kobo\\.3\\.1", -99, 0,
+         "span#kobo\\.3\\.2", -99, 5, "a dogear with text", None, 4, "ctx", 0.3,
+         "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0, "dogear"),
+        ("bt-004", book_uuid, chapter2, "span#kobo\\.4\\.1", -99, 0,
+         "span#kobo\\.4\\.2", -99, 5, "type is empty", None, 0, "ctx", 0.4,
+         "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0, ""),
+    ]
+    conn.executemany(
+        "INSERT INTO Bookmark VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+    return path

--- a/tests/unit/test_imported_annotation_records_its_type.py
+++ b/tests/unit/test_imported_annotation_records_its_type.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""F-7e418c, end of the path: the STORED row must carry the device's type.
+
+Reading `Bookmark.Type` in the parser is only half the fix. If `ingest_bookmarks`
+does not pass it into the `ub.Annotation` it builds, the column stays NULL and
+nothing downstream can tell a recovered highlight from a recovered anything-else.
+
+That half was genuinely uncovered: deleting the `annotation_type=` argument from
+the row construction left 394 tests green. This file is the test that fails.
+
+Why the column matters: `cps/services/annotation_sync/__init__.py` stores
+`payload["type"]` for an annotation arriving over the wire, so without this the
+same highlight has a type when it syncs live and NULL when it is recovered from
+the device's own sqlite — two writers to one column, disagreeing, which is the
+shape that produced the highlight_color mess `annotation_colors.py` exists to
+undo.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from tests.fixtures.kobo_reader_sqlite import (
+    build_kobo_db_with_bookmark_type,
+    build_synthetic_kobo_db,
+)
+
+pytestmark = pytest.mark.unit
+
+BOOK_ID = 42
+BOOK_UUID = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+
+
+@pytest.fixture
+def memory_db(tmp_path, monkeypatch):
+    from cps import ub, constants
+    from cps.services import annotation_backup
+
+    annotation_backup.reset_for_tests()
+    monkeypatch.setattr(annotation_backup, "WORKER_AUTOSTART", False)
+
+    engine = create_engine("sqlite:///:memory:", future=True)
+    with engine.connect() as conn:
+        conn.exec_driver_sql("PRAGMA foreign_keys = OFF")
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine, future=True)()
+
+    monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path))
+    yield session
+    session.close()
+    annotation_backup.reset_for_tests()
+
+
+def _book_lookup(uuid):
+    return SimpleNamespace(id=BOOK_ID) if uuid == BOOK_UUID else None
+
+
+def _import(session, db_path):
+    from cps import ub
+    from cps.annotations import ingest_bookmarks
+
+    ingest_bookmarks(db_path, user_id=7, session=session,
+                     book_lookup=_book_lookup, commit=session.commit)
+    return {r.annotation_id: r for r in
+            session.query(ub.Annotation).filter_by(user_id=7).all()}
+
+
+def test_the_stored_row_carries_the_device_word(memory_db, tmp_path):
+    rows = _import(memory_db, build_kobo_db_with_bookmark_type(tmp_path / "k.sqlite"))
+    assert rows, "nothing was imported; the assertions below would be vacuous"
+    assert rows["bt-001"].annotation_type == "highlight"
+    assert rows["bt-002"].annotation_type == "highlight"
+
+
+def test_a_non_highlight_word_survives_into_storage(memory_db, tmp_path):
+    """Preserve, don't classify — the same rule the colour table follows."""
+    rows = _import(memory_db, build_kobo_db_with_bookmark_type(tmp_path / "k.sqlite"))
+    assert rows["bt-003"].annotation_type == "dogear"
+
+
+def test_an_empty_device_word_is_stored_as_null(memory_db, tmp_path):
+    rows = _import(memory_db, build_kobo_db_with_bookmark_type(tmp_path / "k.sqlite"))
+    assert rows["bt-004"].annotation_type is None
+
+
+def test_an_older_schema_still_imports_and_stores_null(memory_db, tmp_path):
+    """No Type column on the device is not an error, and must not lose rows."""
+    rows = _import(memory_db, build_synthetic_kobo_db(tmp_path / "old.sqlite"))
+    assert len(rows) >= 3, "the older-schema import lost rows"
+    assert {r.annotation_type for r in rows.values()} == {None}
+
+
+def test_the_two_schemas_produce_different_stored_types(memory_db, tmp_path):
+    """Vacuity guard.
+
+    Each assertion above would also hold if `annotation_type` were always None
+    and the fixture happened to agree. Pin that the typed schema and the untyped
+    one actually differ once stored.
+    """
+    typed = _import(memory_db, build_kobo_db_with_bookmark_type(tmp_path / "k.sqlite"))
+    typed_values = {r.annotation_type for r in typed.values()}
+    assert typed_values != {None}, typed_values
+    assert "highlight" in typed_values

--- a/tests/unit/test_kobo_import_parser.py
+++ b/tests/unit/test_kobo_import_parser.py
@@ -156,3 +156,95 @@ class TestParserEdgeCases:
         from cps.services.kobo_import import parse_kobo_bookmarks
 
         assert list(parse_kobo_bookmarks(tmp_path / "nope.sqlite")) == []
+
+
+@pytest.mark.unit
+class TestBookmarkTypeIsRecovered:
+    """F-7e418c: the importer never recorded what the device said a row WAS.
+
+    `cps/services/annotation_sync/__init__.py` stores `payload["type"]` for an
+    annotation arriving over the wire, so the same highlight recovered from
+    KoboReader.sqlite used to land with `annotation_type` NULL while its live
+    twin carried a value. Two writers to one column, disagreeing.
+
+    The value is taken from `Bookmark.Type` verbatim rather than derived. That is
+    not a guess about the device's vocabulary: the KOReader plugin both writes
+    `Type = "highlight"` and selects `WHERE Type = 'highlight'`
+    (koreader/plugins/cwasync.koplugin/kobo_sqlite_provider.lua), and the wire
+    payload uses the same word. Deriving one instead would have invented a third
+    vocabulary for this column — exactly what cps/services/annotation_colors.py
+    exists to undo for highlight_color.
+    """
+
+    def test_the_device_word_is_stored_verbatim(self, tmp_path):
+        from cps.services.kobo_import import parse_kobo_bookmarks
+        from tests.fixtures.kobo_reader_sqlite import build_kobo_db_with_bookmark_type
+
+        p = build_kobo_db_with_bookmark_type(tmp_path / "typed.sqlite")
+        by_id = {r.bookmark_id: r for r in parse_kobo_bookmarks(p)}
+
+        assert by_id["bt-001"].annotation_type == "highlight"
+        assert by_id["bt-002"].annotation_type == "highlight"
+
+    def test_a_word_that_is_not_highlight_is_not_rewritten_to_one(self, tmp_path):
+        """Preserve, don't classify.
+
+        A row whose Type is "dogear" must arrive as "dogear". Normalising it to
+        "highlight" would be the same class of mistake as the colour table that
+        answered "yellow" for every code it did not know.
+        """
+        from cps.services.kobo_import import parse_kobo_bookmarks
+        from tests.fixtures.kobo_reader_sqlite import build_kobo_db_with_bookmark_type
+
+        p = build_kobo_db_with_bookmark_type(tmp_path / "typed.sqlite")
+        by_id = {r.bookmark_id: r for r in parse_kobo_bookmarks(p)}
+        assert by_id["bt-003"].annotation_type == "dogear"
+
+    def test_an_empty_type_becomes_none_not_an_empty_string(self, tmp_path):
+        """"" and NULL both mean "the device did not say"."""
+        from cps.services.kobo_import import parse_kobo_bookmarks
+        from tests.fixtures.kobo_reader_sqlite import build_kobo_db_with_bookmark_type
+
+        p = build_kobo_db_with_bookmark_type(tmp_path / "typed.sqlite")
+        by_id = {r.bookmark_id: r for r in parse_kobo_bookmarks(p)}
+        assert by_id["bt-004"].annotation_type is None
+
+    def test_a_schema_without_the_type_column_still_imports_everything(self, tmp_path):
+        """The capability check is the point.
+
+        Naming a column an older firmware lacks would fail the whole query and
+        lose EVERY annotation on that device — far worse than importing them
+        untyped. The long-standing synthetic fixture has no Type column, so it is
+        the older-schema case; assert both that it still yields its rows and that
+        their type is None rather than a fabricated default.
+        """
+        from cps.services.kobo_import import parse_kobo_bookmarks
+        from tests.fixtures.kobo_reader_sqlite import build_synthetic_kobo_db
+
+        p = build_synthetic_kobo_db(tmp_path / "old.sqlite")
+        rows = list(parse_kobo_bookmarks(p))
+        assert len(rows) >= 6, "the older-schema import lost rows"
+        assert {r.annotation_type for r in rows} == {None}
+
+    def test_the_two_fixtures_really_differ(self, tmp_path):
+        """Vacuity guard.
+
+        If both fixtures lacked the Type column, every assertion above would pass
+        while testing one branch twice.
+        """
+        import sqlite3
+
+        from tests.fixtures.kobo_reader_sqlite import (
+            build_kobo_db_with_bookmark_type,
+            build_synthetic_kobo_db,
+        )
+
+        def columns(path):
+            conn = sqlite3.connect(path)
+            try:
+                return {row[1] for row in conn.execute("PRAGMA table_info(Bookmark)")}
+            finally:
+                conn.close()
+
+        assert "Type" in columns(build_kobo_db_with_bookmark_type(tmp_path / "new.sqlite"))
+        assert "Type" not in columns(build_synthetic_kobo_db(tmp_path / "old.sqlite"))


### PR DESCRIPTION
`ingest_bookmarks` built its `ub.Annotation` from fifteen fields and `annotation_type` was
not among them, while the live PATCH path stores `payload["type"]`. So the same highlight
carried a type when it synced live and NULL when it was recovered from `KoboReader.sqlite`
— **two writers to one column, disagreeing**, which is the shape that produced the
`highlight_color` mess `cps/services/annotation_colors.py` exists to undo.

The importer *could not* have set it: `ParsedBookmark` had no such field and the Bookmark
SELECT never read `Type`. Both are fixed here.

## The value is the device's own word, stored verbatim

I had earlier stopped on this saying the vocabulary was unobservable with the Kobo asleep.
**That was wrong — it is observable from this repository.**
`koreader/plugins/cwasync.koplugin/kobo_sqlite_provider.lua` both *writes*
`Type = "highlight"` and *selects* `WHERE Type = 'highlight'`, and the wire payload uses the
same word in two fixtures (`test_1660_kobo_checkforchanges_filter.py:324`,
`test_kobo_annotation_stage0.py:267`). Device SQLite and protocol already agree, so carrying
the value through keeps both writers speaking one language. Deriving one — say, from whether
`Annotation` is populated — would have invented a third.

`Type` is selected only when the column exists (`PRAGMA table_info`). Naming a column an
older firmware lacks would fail the whole query and **lose every annotation on that device**,
much worse than importing them untyped. The long-standing synthetic fixture has no `Type`
column, so it *is* the older-schema case and is now asserted as such rather than incidentally
covered.

An empty `Type` stores as NULL, so `""` and NULL both mean "the device did not say". A word
that is not `highlight` survives unchanged: **preserve, don't classify** — the same rule the
colour table follows after F-5769c9.

## Mutations, parser

```
annotation_type never set (the original bug)  -> 2 failed
classify everything as "highlight"            -> 3 failed
keep "" instead of normalising to None        -> 1 failed
drop the capability check                     -> 8 failed
```

That last one is the point: without it the older schema loses everything.

## The row-level half was genuinely uncovered

Deleting the `annotation_type=` argument from the row construction in `cps/annotations.py`
left **394 tests green** — the parser can read the type and the column still ends up NULL if
nothing passes it on. `tests/unit/test_imported_annotation_records_its_type.py` drives
`ingest_bookmarks` against a real in-memory store and asserts the **stored** row:

```
row no longer receives annotation_type  -> 3 failed
everything classified as "highlight"    -> 3 failed
restored                                -> 5 passed
```

Both new suites carry a vacuity guard, and one pins that the typed and untyped fixtures
actually differ — otherwise every assertion would hold with the column permanently None.

This is the **forward** half of F-7e418c. Rows imported before this still carry NULL; a
backfill is a separate decision and is not attempted here.
