### PR TITLE
tools(kobo): arm the annotations PATCH failure experiment

### DIFF
--- a/scripts/measure_kobo_patch_failure.py
+++ b/scripts/measure_kobo_patch_failure.py
@@ -1,0 +1,783 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Measure what Nickel does after one annotations PATCH receives HTTP 503.
+
+This is a disposable-book hardware experiment for finding F-5c1146. It does
+not change CWNG's live PATCH handler. Instead, while this process is running,
+it is a narrowly-scoped reverse proxy which refuses exactly one well-formed
+PATCH for exactly one explicitly named ContentId. Every other request is
+forwarded to ``--upstream`` unchanged.
+
+Safety model
+------------
+* dry-run by default; no SSH, listener, prompt, or local write without --go;
+* the Calibre book id must resolve to the exact --content-id;
+* the book must have zero server annotations across all users;
+* KoboReader.sqlite is copied off-device before each read and opened locally
+  with SQLite mode=ro + query_only; no command ever writes the device;
+* the first device snapshot must contain zero Bookmark rows for the book;
+* after the operator creates the sacrificial highlight, exactly one active
+  highlight row must exist before the failure proxy is armed;
+* only one updated annotation, with no deletion delta, is eligible for the
+  one-shot 503. GET, DELETE, other books, malformed bodies, and batches pass
+  through unchanged.
+
+The operator can leave scripts/measure_kobo_redelivery.py waiting at its
+"SYNC THE DEVICE NOW" prompt. The same physical wake and sync then measures
+F-3e383a and this experiment together.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import dataclasses
+import gzip
+import hashlib
+import http.client
+import http.server
+import json
+import os
+import shlex
+import sqlite3
+import ssl
+import subprocess
+import sys
+import threading
+import urllib.parse
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SSHPASS = "/opt/homebrew/bin/sshpass"
+DEVICE_DB_BEGIN = "__CWNG_KOBO_DB_BEGIN__"
+DEVICE_DB_END = "__CWNG_KOBO_DB_END__"
+HOP_BY_HOP = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+class SafetyRefusal(SystemExit):
+    """The experiment did not arm because a fail-closed safety gate fired."""
+
+
+@dataclasses.dataclass(frozen=True)
+class DeviceAnnotation:
+    bookmark_id: str
+    annotation_type: str
+    hidden: str
+
+
+@dataclasses.dataclass
+class PatchState:
+    failed_annotation_id: str | None = None
+    failure_count: int = 0
+    retry_count: int = 0
+    unsafe_target_patch_count: int = 0
+
+
+def canonical_content_id(value):
+    try:
+        return str(uuid.UUID(str(value).strip().strip("{}")))
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise SafetyRefusal(f"REFUSING: invalid ContentId UUID: {value!r}") from exc
+
+
+def _sqlite_ro(path):
+    uri = Path(path).resolve().as_uri() + "?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.execute("PRAGMA query_only = ON")
+    return conn
+
+
+def server_annotation_count(app_db, book_id):
+    """Count this book's annotations across every user, read-only."""
+    conn = _sqlite_ro(app_db)
+    try:
+        return conn.execute(
+            "SELECT COUNT(*) FROM annotation WHERE book_id = ?", (book_id,)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def metadata_content_id(metadata_db, book_id):
+    """Resolve the selected Calibre row to its UUID, read-only."""
+    conn = _sqlite_ro(metadata_db)
+    try:
+        row = conn.execute("SELECT uuid FROM books WHERE id = ?", (book_id,)).fetchone()
+    finally:
+        conn.close()
+    if row is None or not row[0]:
+        raise SafetyRefusal(f"REFUSING: metadata book {book_id} has no UUID")
+    return canonical_content_id(row[0])
+
+
+def metadata_book_ids_for_content(metadata_db, content_id):
+    """Require the proxy UUID to name one Calibre row, not an ambiguous set."""
+    conn = _sqlite_ro(metadata_db)
+    try:
+        rows = conn.execute(
+            "SELECT id FROM books WHERE lower(trim(uuid, '{} ')) = ? ORDER BY id",
+            (content_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [int(row[0]) for row in rows]
+
+
+def require_safe_server_book(app_db, metadata_db, book_id, content_id):
+    actual = metadata_content_id(metadata_db, book_id)
+    if actual != content_id:
+        raise SafetyRefusal(
+            f"REFUSING: metadata book {book_id} is {actual}, not requested {content_id}"
+        )
+    matching_ids = metadata_book_ids_for_content(metadata_db, content_id)
+    if matching_ids != [book_id]:
+        raise SafetyRefusal(
+            f"REFUSING: ContentId {content_id} maps to metadata book ids {matching_ids}, "
+            f"not uniquely to {book_id}"
+        )
+    count = server_annotation_count(app_db, book_id)
+    if count:
+        raise SafetyRefusal(
+            f"REFUSING: book {book_id} has {count} server annotation(s) across all users; "
+            "only a disposable annotation-free book is authorized"
+        )
+    return count
+
+
+def _credential():
+    raw = os.environ.get("SECRET", "")
+    try:
+        parsed = json.loads(raw)
+        return (
+            parsed.get("username") or parsed.get("user") or "root",
+            parsed.get("password") or parsed.get("secret") or parsed.get("value") or "",
+        )
+    except Exception:
+        return "root", raw.strip()
+
+
+def _known_hosts_path():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), ".kobo_known_hosts")
+
+
+def _device_backup_command(device_db):
+    quoted = shlex.quote(device_db)
+    return (
+        f"printf '{DEVICE_DB_BEGIN}\\n'; "
+        f"gzip -c < {quoted} | base64; "
+        f"printf '\\n{DEVICE_DB_END}\\n'; exit\n"
+    )
+
+
+def _decode_device_backup(output):
+    normalized = output.replace("\r", "")
+    # dropbear's forced TTY may echo the command, including both marker
+    # literals, before printing the command's actual output. The final begin
+    # marker is therefore the only safe delimiter.
+    start = normalized.rfind(DEVICE_DB_BEGIN)
+    end = normalized.find(DEVICE_DB_END, start + len(DEVICE_DB_BEGIN))
+    if start < 0 or end < 0:
+        raise SafetyRefusal(
+            "REFUSING: device database backup markers were not returned"
+        )
+    encoded = normalized[start + len(DEVICE_DB_BEGIN) : end]
+    compact = "".join(encoded.split())
+    try:
+        compressed = base64.b64decode(compact, validate=True)
+        data = gzip.decompress(compressed)
+    except Exception as exc:
+        raise SafetyRefusal(
+            "REFUSING: device database backup was not valid gzip/base64"
+        ) from exc
+    if not data.startswith(b"SQLite format 3\x00"):
+        raise SafetyRefusal("REFUSING: backed-up device file is not a SQLite database")
+    return data
+
+
+def backup_device_db(host, device_db, backup_dir):
+    """Copy KoboReader.sqlite off-device using read-only device commands."""
+    user, password = _credential()
+    if not password:
+        raise SafetyRefusal("no credential in $SECRET — run this under `secret exec`")
+
+    child_env = dict(os.environ)
+    child_env["SSHPASS"] = password
+    command = _device_backup_command(device_db)
+    try:
+        result = subprocess.run(
+            [
+                SSHPASS,
+                "-e",
+                "ssh",
+                "-tt",
+                "-o",
+                "StrictHostKeyChecking=accept-new",
+                "-o",
+                f"UserKnownHostsFile={_known_hosts_path()}",
+                "-o",
+                "ConnectTimeout=8",
+                "-o",
+                "LogLevel=ERROR",
+                f"{user}@{host}",
+            ],
+            input=command,
+            capture_output=True,
+            text=True,
+            timeout=90,
+            env=child_env,
+        )
+    except subprocess.TimeoutExpired:
+        raise SafetyRefusal(
+            f"device database backup timed out against {host}"
+        ) from None
+    if result.returncode != 0:
+        raise SafetyRefusal(
+            f"device database backup failed against {host} (ssh exit {result.returncode})"
+        )
+    data = _decode_device_backup((result.stdout or "") + (result.stderr or ""))
+
+    directory = Path(backup_dir).resolve()
+    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    destination = (
+        directory / f"KoboReader.{stamp}.{hashlib.sha256(data).hexdigest()[:12]}.sqlite"
+    )
+    fd = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except Exception:
+        try:
+            destination.unlink()
+        except OSError:
+            pass
+        raise
+    return destination
+
+
+def device_annotations_from_backup(backup, content_id):
+    """Read only the already-created local backup; never the live device DB."""
+    conn = _sqlite_ro(backup)
+    try:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(Bookmark)").fetchall()
+        }
+        required = {"BookmarkID", "VolumeID", "Type", "Hidden"}
+        if not required.issubset(columns):
+            raise SafetyRefusal(
+                f"REFUSING: device Bookmark schema lacks {sorted(required - columns)}"
+            )
+        rows = conn.execute(
+            """
+            SELECT BookmarkID, Type, Hidden
+              FROM Bookmark
+             WHERE instr(lower(coalesce(VolumeID, '')), ?) > 0
+             ORDER BY BookmarkID
+            """,
+            (content_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        DeviceAnnotation(str(row[0] or ""), str(row[1] or ""), str(row[2] or ""))
+        for row in rows
+    ]
+
+
+def capture_device_snapshot(host, device_db, backup_dir, content_id):
+    """Back up first, then query that immutable local copy in read-only mode."""
+    backup = backup_device_db(host, device_db, backup_dir)
+    rows = device_annotations_from_backup(backup, content_id)
+    return backup, rows
+
+
+def require_clean_device_baseline(rows):
+    if rows:
+        raise SafetyRefusal(
+            f"REFUSING: disposable book already has {len(rows)} device Bookmark row(s); "
+            "the baseline must be empty before the sacrificial highlight is created"
+        )
+
+
+def _is_hidden(value):
+    return str(value).strip().casefold() not in {"", "0", "false", "none", "null"}
+
+
+def require_one_sacrificial_highlight(rows):
+    if len(rows) != 1:
+        raise SafetyRefusal(
+            f"REFUSING: expected exactly one newly-created sacrificial highlight, found {len(rows)} rows"
+        )
+    row = rows[0]
+    if (
+        not row.bookmark_id
+        or row.annotation_type.casefold() != "highlight"
+        or _is_hidden(row.hidden)
+    ):
+        raise SafetyRefusal(
+            "REFUSING: the one sacrificial row must be an active highlight with a BookmarkID"
+        )
+    return row
+
+
+def _connection_tokens(headers):
+    tokens = set()
+    for name, value in headers:
+        if name.lower() == "connection":
+            tokens.update(
+                part.strip().lower() for part in value.split(",") if part.strip()
+            )
+    return tokens
+
+
+def _end_to_end_headers(headers):
+    blocked = HOP_BY_HOP | _connection_tokens(headers)
+    return [(name, value) for name, value in headers if name.lower() not in blocked]
+
+
+def _target_annotation_path(raw_path, content_id):
+    path = urllib.parse.urlsplit(raw_path).path
+    parts = path.split("/")
+    if (
+        len(parts) != 7
+        or parts[1:4] != ["api", "v3", "content"]
+        or parts[5:] != ["annotations", ""]
+    ):
+        # Accept the ordinary no-trailing-slash route below. Keeping this branch
+        # explicit prevents substring matches against a different endpoint.
+        if (
+            len(parts) != 6
+            or parts[1:4] != ["api", "v3", "content"]
+            or parts[5] != "annotations"
+        ):
+            return False
+    try:
+        return canonical_content_id(urllib.parse.unquote(parts[4])) == content_id
+    except SafetyRefusal:
+        return False
+
+
+def _eligible_single_update(body):
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    updated = payload.get("updatedAnnotations")
+    deleted = payload.get("deletedAnnotationIds")
+    if not isinstance(updated, list) or len(updated) != 1 or deleted not in (None, []):
+        return None
+    annotation = updated[0]
+    if not isinstance(annotation, dict) or not isinstance(annotation.get("id"), str):
+        return None
+    annotation_id = annotation["id"].strip()
+    return annotation_id or None
+
+
+class PatchFailureHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = ""
+    sys_version = ""
+
+    def log_message(self, _fmt, *_args):
+        pass
+
+    def _request_body(self):
+        if "chunked" in self.headers.get("Transfer-Encoding", "").lower():
+            chunks = []
+            while True:
+                line = self.rfile.readline(65537)
+                if not line or len(line) > 65536:
+                    raise ValueError("invalid chunked request")
+                size = int(line.split(b";", 1)[0].strip(), 16)
+                if size == 0:
+                    while self.rfile.readline(65537) not in (b"\r\n", b"\n", b""):
+                        pass
+                    return b"".join(chunks)
+                chunk = self.rfile.read(size)
+                if len(chunk) != size or self.rfile.read(2) != b"\r\n":
+                    raise ValueError("truncated chunked request")
+                chunks.append(chunk)
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        body = self.rfile.read(length)
+        if len(body) != length:
+            raise ValueError("truncated request body")
+        return body
+
+    def _send_experiment_503(self):
+        body = json.dumps(
+            {"error": "controlled disposable-book PATCH failure"}, separators=(",", ":")
+        ).encode()
+        self.send_response_only(503)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Retry-After", "30")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+        self.close_connection = True
+
+    def _forward(self, body):
+        upstream = self.server.upstream
+        connection_cls = (
+            http.client.HTTPSConnection
+            if upstream.scheme == "https"
+            else http.client.HTTPConnection
+        )
+        connection = connection_cls(
+            upstream.hostname, upstream.port, timeout=self.server.timeout
+        )
+        try:
+            path = self.path if self.path.startswith("/") else "/" + self.path
+            if upstream.path and upstream.path != "/":
+                path = upstream.path.rstrip("/") + path
+            connection.putrequest(
+                self.command, path, skip_host=True, skip_accept_encoding=True
+            )
+            incoming = list(self.headers.raw_items())
+            saw_length = False
+            for name, value in _end_to_end_headers(incoming):
+                lower = name.lower()
+                if lower == "host":
+                    continue
+                if lower == "content-length":
+                    value = str(len(body))
+                    saw_length = True
+                connection.putheader(name, value)
+            host = upstream.hostname
+            default_port = 443 if upstream.scheme == "https" else 80
+            if upstream.port and upstream.port != default_port:
+                host = f"{host}:{upstream.port}"
+            connection.putheader("Host", host)
+            if body and not saw_length:
+                connection.putheader("Content-Length", str(len(body)))
+            connection.endheaders(body if body else None)
+            response = connection.getresponse()
+            response_body = response.read()
+            response_headers = _end_to_end_headers(list(response.getheaders()))
+            self.send_response_only(response.status, response.reason)
+            for name, value in response_headers:
+                self.send_header(name, value)
+            self.end_headers()
+            self.wfile.write(response_body)
+            self.wfile.flush()
+        except Exception:
+            body = b'{"error":"upstream unavailable"}'
+            self.send_response_only(503)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Retry-After", "30")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(body)
+            self.close_connection = True
+        finally:
+            connection.close()
+
+    def _proxy(self):
+        try:
+            body = self._request_body()
+        except Exception:
+            self.send_error(400)
+            return
+
+        is_target_patch = self.command == "PATCH" and _target_annotation_path(
+            self.path, self.server.content_id
+        )
+        if is_target_patch:
+            annotation_id = _eligible_single_update(body)
+            with self.server.state_lock:
+                state = self.server.patch_state
+                if annotation_id is None or (
+                    self.server.expected_annotation_id is not None
+                    and annotation_id != self.server.expected_annotation_id
+                ):
+                    state.unsafe_target_patch_count += 1
+                elif state.failure_count == 0:
+                    state.failed_annotation_id = annotation_id
+                    state.failure_count = 1
+                    self.server.events.append(
+                        {
+                            "event": "failed_once",
+                            "annotation_id": annotation_id,
+                        }
+                    )
+                    self._send_experiment_503()
+                    return
+                elif annotation_id == state.failed_annotation_id:
+                    state.retry_count += 1
+                    self.server.events.append(
+                        {
+                            "event": "retry_seen",
+                            "annotation_id": annotation_id,
+                        }
+                    )
+                else:
+                    state.unsafe_target_patch_count += 1
+        self._forward(body)
+
+    do_GET = _proxy
+    do_POST = _proxy
+    do_PUT = _proxy
+    do_PATCH = _proxy
+    do_DELETE = _proxy
+    do_HEAD = _proxy
+    do_OPTIONS = _proxy
+
+
+class PatchFailureServer(http.server.ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(
+        self,
+        address,
+        *,
+        upstream,
+        content_id,
+        expected_annotation_id=None,
+        timeout=15.0,
+    ):
+        super().__init__(address, PatchFailureHandler)
+        self.upstream = urllib.parse.urlsplit(upstream)
+        if self.upstream.scheme not in {"http", "https"} or not self.upstream.hostname:
+            raise SafetyRefusal("REFUSING: --upstream must be an absolute HTTP(S) URL")
+        self.content_id = canonical_content_id(content_id)
+        self.expected_annotation_id = expected_annotation_id
+        self.timeout = timeout
+        self.patch_state = PatchState()
+        self.state_lock = threading.Lock()
+        self.events = []
+
+
+def print_decision_table():
+    print("\nDECISION TABLE — what the device outcome means for F-5c1146")
+    print("  RETRIED + ROW PRESENT:")
+    print(
+        "    A transient non-success preserves and re-offers the delta. The fix may return 503"
+    )
+    print("    when local capture is lost; the device supplies the retry path.")
+    print("  ROW PRESENT, NO RETRY AFTER AN EXPLICIT SECOND SYNC:")
+    print(
+        "    503 preserves the device copy but does not heal CWNG. The fix needs durable staging/"
+    )
+    print("    replay; changing the status alone is insufficient.")
+    print("  ROW MISSING AFTER 503:")
+    print(
+        "    Do NOT ship a non-success response for capture loss. The fix must durably capture"
+    )
+    print(
+        "    before answering success (or use another proven mechanism), because 503 loses data."
+    )
+    print("  NO ELIGIBLE PATCH / MULTIPLE OR CHANGED ROWS / DB UNREADABLE:")
+    print(
+        "    INCONCLUSIVE. Do not change the live handler; repeat only with a clean disposable book."
+    )
+
+
+def classify_result(state, rows, expected_annotation_id=None):
+    if state.failure_count != 1 or state.unsafe_target_patch_count:
+        return "INCONCLUSIVE"
+    if not rows:
+        return "ROW_MISSING_AFTER_503"
+    if len(rows) != 1:
+        return "INCONCLUSIVE"
+    row = rows[0]
+    if isinstance(row, DeviceAnnotation):
+        if _is_hidden(row.hidden):
+            return "ROW_MISSING_AFTER_503"
+        if (
+            expected_annotation_id is not None
+            and row.bookmark_id != expected_annotation_id
+        ):
+            return "INCONCLUSIVE"
+        if row.annotation_type.casefold() != "highlight":
+            return "INCONCLUSIVE"
+    if state.retry_count:
+        return "RETRIED_AND_PRESENT"
+    return "PRESENT_NOT_RETRIED"
+
+
+def _parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--book-id", type=int, required=True)
+    parser.add_argument(
+        "--content-id", required=True, help="exact disposable Calibre/Kobo UUID"
+    )
+    parser.add_argument("--app-db", required=True, help="CWNG app.db")
+    parser.add_argument("--metadata-db", required=True, help="Calibre metadata.db")
+    parser.add_argument("--device-host", default="10.0.20.250")
+    parser.add_argument("--device-db", default="/mnt/onboard/.kobo/KoboReader.sqlite")
+    parser.add_argument(
+        "--backup-dir", required=True, help="persistent local directory for DB backups"
+    )
+    parser.add_argument("--listen", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8081)
+    parser.add_argument(
+        "--upstream", required=True, help="the ordinary CWNG reading-services origin"
+    )
+    parser.add_argument("--timeout", type=float, default=15.0)
+    parser.add_argument("--tls-cert")
+    parser.add_argument("--tls-key")
+    parser.add_argument(
+        "--go", action="store_true", help="arm the device/proxy experiment"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    content_id = canonical_content_id(args.content_id)
+    if bool(args.tls_cert) != bool(args.tls_key):
+        raise SafetyRefusal(
+            "REFUSING: --tls-cert and --tls-key must be supplied together"
+        )
+
+    print(
+        "Kobo annotations PATCH failure measurement"
+        + ("" if args.go else "  [DRY RUN]")
+    )
+    print(f"  disposable book {args.book_id}, ContentId {content_id}")
+    print_decision_table()
+
+    require_safe_server_book(
+        args.app_db,
+        args.metadata_db,
+        args.book_id,
+        content_id,
+    )
+    print("\n1. server gate: exact metadata UUID, zero annotations across all users")
+
+    if not args.go:
+        print(
+            "2. [dry run] would back up KoboReader.sqlite off-device, then read the backup mode=ro"
+        )
+        print("3. [dry run] would refuse any pre-existing Bookmark row for this book")
+        print(
+            "4. [dry run] would require exactly one newly-created sacrificial highlight"
+        )
+        print(
+            "5. [dry run] would listen only while running and fail one exact one-update PATCH"
+        )
+        print(
+            "\n[DRY RUN] no SSH, listener, prompt, backup, or mutation occurred. Re-run with --go."
+        )
+        return 0
+
+    baseline_backup, baseline_rows = capture_device_snapshot(
+        args.device_host,
+        args.device_db,
+        args.backup_dir,
+        content_id,
+    )
+    require_clean_device_baseline(baseline_rows)
+    print(f"2. device gate: backup {baseline_backup} contains zero rows for this book")
+
+    input(
+        "\nCreate ONE sacrificial highlight in the disposable book WITHOUT syncing, then press Enter. "
+    )
+    staged_backup, staged_rows = capture_device_snapshot(
+        args.device_host,
+        args.device_db,
+        args.backup_dir,
+        content_id,
+    )
+    sacrificial = require_one_sacrificial_highlight(staged_rows)
+    # Recheck after the human pause. An accidental sync must not turn a stale
+    # preflight into permission to experiment on a now-populated server book.
+    require_safe_server_book(args.app_db, args.metadata_db, args.book_id, content_id)
+    print(
+        f"3. staged gate: backup {staged_backup} contains only {sacrificial.bookmark_id}"
+    )
+
+    server = PatchFailureServer(
+        (args.listen, args.port),
+        upstream=args.upstream,
+        content_id=content_id,
+        expected_annotation_id=sacrificial.bookmark_id,
+        timeout=args.timeout,
+    )
+    if args.tls_cert:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(args.tls_cert, args.tls_key)
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    scheme = "https" if args.tls_cert else "http"
+    print(f"4. ARMED: {scheme}://{args.listen}:{server.server_port}")
+    print(
+        "   Only the first exact one-update PATCH for this ContentId can receive 503."
+    )
+    print(
+        "   Leave measure_kobo_redelivery.py at its SYNC prompt; this same sync settles both."
+    )
+
+    try:
+        input(
+            "\nRoute the existing experiment endpoint here, SYNC ONCE, then press Enter. "
+        )
+        after_one_backup, after_one_rows = capture_device_snapshot(
+            args.device_host,
+            args.device_db,
+            args.backup_dir,
+            content_id,
+        )
+        print(f"5. first post-sync backup: {after_one_backup}")
+
+        state = server.patch_state
+        first_result = classify_result(
+            state,
+            after_one_rows,
+            expected_annotation_id=sacrificial.bookmark_id,
+        )
+        final_rows = after_one_rows
+        final_backup = after_one_backup
+        if first_result == "PRESENT_NOT_RETRIED":
+            input(
+                "No retry observed yet. SYNC ONCE MORE during this same wake, then press Enter. "
+            )
+            final_backup, final_rows = capture_device_snapshot(
+                args.device_host,
+                args.device_db,
+                args.backup_dir,
+                content_id,
+            )
+        result = classify_result(
+            server.patch_state,
+            final_rows,
+            expected_annotation_id=sacrificial.bookmark_id,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    print("\nRESULT: " + result)
+    print(f"  final device backup: {final_backup}")
+    print(f"  failed PATCH count: {server.patch_state.failure_count}")
+    print(f"  matching retry count: {server.patch_state.retry_count}")
+    print(
+        f"  unsafe/multi/different target PATCH count: {server.patch_state.unsafe_target_patch_count}"
+    )
+    print(f"  final target Bookmark rows: {len(final_rows)}")
+    print_decision_table()
+    return 0 if result != "INCONCLUSIVE" else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure_kobo_patch_failure.py
+++ b/scripts/measure_kobo_patch_failure.py
@@ -26,6 +26,10 @@ Safety model
 The operator can leave scripts/measure_kobo_redelivery.py waiting at its
 "SYNC THE DEVICE NOW" prompt. The same physical wake and sync then measures
 F-3e383a and this experiment together.
+
+Routing is network-level only: the proxy must listen at the address the Kobo
+already believes is CWNG, while ``--upstream`` names the real CWNG origin.
+Never edit the device's ``reading_services_host`` or production CWNG config.
 """
 
 from __future__ import annotations
@@ -472,9 +476,16 @@ class PatchFailureHandler(http.server.BaseHTTPRequestHandler):
             response_headers = _end_to_end_headers(list(response.getheaders()))
             self.send_response_only(response.status, response.reason)
             for name, value in response_headers:
+                if name.lower() == "content-length":
+                    continue
                 self.send_header(name, value)
+            # The upstream body is fully buffered, so frame the exact bytes this
+            # handler will emit. Transfer-Encoding was removed with the other
+            # hop-by-hop headers above; never forward its now-invalid framing.
+            emitted_body = b"" if self.command == "HEAD" else response_body
+            self.send_header("Content-Length", str(len(emitted_body)))
             self.end_headers()
-            self.wfile.write(response_body)
+            self.wfile.write(emitted_body)
             self.wfile.flush()
         except Exception:
             body = b'{"error":"upstream unavailable"}'
@@ -590,6 +601,18 @@ def print_decision_table():
     )
 
 
+def print_routing_constraint():
+    print("\nROUTING SAFETY — NETWORK LEVEL ONLY")
+    print("  Annotations use reading_services_host, not api_endpoint.")
+    print(
+        "  Run this proxy on the address the Kobo already believes is CWNG, and point"
+    )
+    print("  --upstream at the real CWNG origin.")
+    print("  Kobo Clara BW firmware 4.42.23291 was measured to stop syncing after a")
+    print("  device-side reading_services_host edit.")
+    print("  DO NOT edit the device or production CWNG configuration.")
+
+
 def classify_result(state, rows, expected_annotation_id=None):
     if state.failure_count != 1 or state.unsafe_target_patch_count:
         return "INCONCLUSIVE"
@@ -653,6 +676,7 @@ def main(argv=None):
         + ("" if args.go else "  [DRY RUN]")
     )
     print(f"  disposable book {args.book_id}, ContentId {content_id}")
+    print_routing_constraint()
     print_decision_table()
 
     require_safe_server_book(
@@ -726,10 +750,11 @@ def main(argv=None):
     print(
         "   Leave measure_kobo_redelivery.py at its SYNC prompt; this same sync settles both."
     )
+    print_routing_constraint()
 
     try:
         input(
-            "\nRoute the existing experiment endpoint here, SYNC ONCE, then press Enter. "
+            "\nWith the network-level route already in place, SYNC ONCE, then press Enter. "
         )
         after_one_backup, after_one_rows = capture_device_snapshot(
             args.device_host,

--- a/tests/unit/test_measure_kobo_patch_failure_is_safe.py
+++ b/tests/unit/test_measure_kobo_patch_failure_is_safe.py
@@ -359,9 +359,33 @@ class _Upstream(http.server.BaseHTTPRequestHandler):
     do_DELETE = _reply
 
 
+class _FramingUpstream(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    reply = b'{"chunked":true}'
+
+    def log_message(self, _fmt, *_args):
+        pass
+
+    def do_GET(self):
+        self.send_response_only(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        self.wfile.write(f"{len(self.reply):x}\r\n".encode())
+        self.wfile.write(self.reply + b"\r\n0\r\n\r\n")
+
+    def do_HEAD(self):
+        self.send_response_only(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(self.reply)))
+        self.end_headers()
+
+
 class _RunningProxy:
-    def __init__(self, module, expected="ann-1"):
-        self.upstream = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Upstream)
+    def __init__(self, module, expected="ann-1", upstream_handler=_Upstream):
+        self.upstream = http.server.ThreadingHTTPServer(
+            ("127.0.0.1", 0), upstream_handler
+        )
         self.upstream.seen = []
         self.up_thread = threading.Thread(
             target=self.upstream.serve_forever, daemon=True
@@ -463,6 +487,72 @@ def test_only_the_exact_disposable_single_update_can_receive_503():
         assert len(running.upstream.seen) == len(cases) + 1
     finally:
         running.close()
+
+
+def test_relayed_responses_are_reframed_to_the_exact_emitted_bytes():
+    module = _module()
+    running = _RunningProxy(module, upstream_handler=_FramingUpstream)
+    try:
+        status, body, headers = running.request("GET", "/chunked")
+        assert status == 200
+        assert headers["Content-Length"] == str(len(_FramingUpstream.reply))
+        assert "Transfer-Encoding" not in headers
+        assert body == _FramingUpstream.reply
+
+        status, body, headers = running.request("HEAD", "/head")
+        assert status == 200
+        assert headers["Content-Length"] == "0"
+        assert "Transfer-Encoding" not in headers
+        assert body == b""
+    finally:
+        running.close()
+
+
+def test_routing_correction_is_printed_at_startup_and_immediately_before_sync(
+    tmp_path, monkeypatch, capsys
+):
+    module = _module()
+    row = module.DeviceAnnotation("ann-1", "highlight", "0")
+    snapshots = iter(
+        [
+            (tmp_path / "baseline.gz", []),
+            (tmp_path / "staged.gz", [row]),
+            (tmp_path / "after.gz", [row]),
+        ]
+    )
+    monkeypatch.setattr(
+        module,
+        "capture_device_snapshot",
+        lambda *_args, **_kwargs: next(snapshots),
+    )
+    output_before_prompts = []
+
+    def answer_prompt(_prompt):
+        output_before_prompts.append(capsys.readouterr().out)
+        return ""
+
+    monkeypatch.setattr("builtins.input", answer_prompt)
+    args = _main_args(tmp_path, go=True) + ["--port", "0"]
+    assert module.main(args) == 2
+    final_output = capsys.readouterr().out
+    all_output = "".join(output_before_prompts) + final_output
+    warning = "ROUTING SAFETY — NETWORK LEVEL ONLY"
+
+    assert all_output.count(warning) == 2
+    startup_output = output_before_prompts[0]
+    assert startup_output.index(warning) < startup_output.index("DECISION TABLE")
+    before_sync_output = output_before_prompts[1]
+    assert before_sync_output.rstrip().endswith(
+        "DO NOT edit the device or production CWNG configuration."
+    )
+    for phrase in (
+        "reading_services_host, not api_endpoint",
+        "address the Kobo already believes is CWNG",
+        "--upstream at the real CWNG origin",
+        "Kobo Clara BW firmware 4.42.23291",
+        "measured to stop syncing",
+    ):
+        assert phrase in startup_output
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_measure_kobo_patch_failure_is_safe.py
+++ b/tests/unit/test_measure_kobo_patch_failure_is_safe.py
@@ -411,7 +411,7 @@ class _RunningProxy:
             method, path, body=body, headers={"Content-Type": "application/json"}
         )
         response = conn.getresponse()
-        result = (response.status, response.read(), dict(response.getheaders()))
+        result = (response.status, response.read(), response.headers)
         conn.close()
         return result
 
@@ -495,13 +495,13 @@ def test_relayed_responses_are_reframed_to_the_exact_emitted_bytes():
     try:
         status, body, headers = running.request("GET", "/chunked")
         assert status == 200
-        assert headers["Content-Length"] == str(len(_FramingUpstream.reply))
+        assert headers.get_all("Content-Length") == [str(len(_FramingUpstream.reply))]
         assert "Transfer-Encoding" not in headers
         assert body == _FramingUpstream.reply
 
         status, body, headers = running.request("HEAD", "/head")
         assert status == 200
-        assert headers["Content-Length"] == "0"
+        assert headers.get_all("Content-Length") == ["0"]
         assert "Transfer-Encoding" not in headers
         assert body == b""
     finally:

--- a/tests/unit/test_measure_kobo_patch_failure_is_safe.py
+++ b/tests/unit/test_measure_kobo_patch_failure_is_safe.py
@@ -1,0 +1,533 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Safety contract for the disposable-book Kobo PATCH experiment."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import hashlib
+import http.client
+import http.server
+import importlib.util
+import inspect
+import json
+import sqlite3
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "measure_kobo_patch_failure.py"
+TARGET = "11111111-2222-4333-8444-555555555555"
+OTHER = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("measure_kobo_patch_failure", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _app_db(tmp_path, count=0):
+    path = tmp_path / "app.db"
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE annotation (id INTEGER PRIMARY KEY, book_id INTEGER)")
+    conn.executemany("INSERT INTO annotation (book_id) VALUES (?)", [(7,)] * count)
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _metadata_db(tmp_path, content_id=TARGET):
+    path = tmp_path / "metadata.db"
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE books (id INTEGER PRIMARY KEY, uuid TEXT)")
+    conn.execute("INSERT INTO books (id, uuid) VALUES (?, ?)", (7, content_id))
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _device_db(path, rows=()):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE Bookmark (BookmarkID TEXT, VolumeID TEXT, Type TEXT, Hidden TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO Bookmark (BookmarkID, VolumeID, Type, Hidden) VALUES (?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _main_args(tmp_path, *, go=False, content_id=TARGET, annotations=0):
+    args = [
+        "--book-id",
+        "7",
+        "--content-id",
+        content_id,
+        "--app-db",
+        str(_app_db(tmp_path, annotations)),
+        "--metadata-db",
+        str(_metadata_db(tmp_path, TARGET)),
+        "--backup-dir",
+        str(tmp_path / "backups"),
+        "--upstream",
+        "http://127.0.0.1:9",
+    ]
+    if go:
+        args.append("--go")
+    return args
+
+
+def test_the_script_exists_and_loads():
+    assert SCRIPT.is_file(), SCRIPT
+    assert callable(_module().main)
+
+
+def test_no_go_means_no_device_listener_prompt_or_local_write(tmp_path, monkeypatch):
+    module = _module()
+    reached = []
+
+    def forbidden(*_args, **_kwargs):
+        reached.append(True)
+        raise AssertionError("dry run crossed into an active surface")
+
+    monkeypatch.setattr(module, "capture_device_snapshot", forbidden)
+    monkeypatch.setattr(module, "PatchFailureServer", forbidden)
+    monkeypatch.setattr("builtins.input", forbidden)
+
+    assert module.main(_main_args(tmp_path)) == 0
+    assert reached == []
+    assert not (tmp_path / "backups").exists()
+
+
+def test_it_refuses_any_server_annotation_before_device_access(tmp_path, monkeypatch):
+    module = _module()
+    reached = []
+    monkeypatch.setattr(
+        module,
+        "capture_device_snapshot",
+        lambda *_args, **_kwargs: reached.append(True),
+    )
+
+    with pytest.raises(module.SafetyRefusal, match="server annotation"):
+        module.main(_main_args(tmp_path, go=True, annotations=1))
+    assert reached == []
+
+
+def test_it_refuses_a_metadata_uuid_mismatch_before_device_access(
+    tmp_path, monkeypatch
+):
+    module = _module()
+    reached = []
+    monkeypatch.setattr(
+        module,
+        "capture_device_snapshot",
+        lambda *_args, **_kwargs: reached.append(True),
+    )
+
+    with pytest.raises(module.SafetyRefusal, match="not requested"):
+        module.main(_main_args(tmp_path, go=True, content_id=OTHER))
+    assert reached == []
+
+
+def test_it_refuses_a_duplicate_metadata_uuid(tmp_path):
+    module = _module()
+    app_db = _app_db(tmp_path)
+    metadata_db = _metadata_db(tmp_path)
+    conn = sqlite3.connect(metadata_db)
+    conn.execute("INSERT INTO books (id, uuid) VALUES (?, ?)", (8, TARGET.upper()))
+    conn.commit()
+    conn.close()
+    with pytest.raises(module.SafetyRefusal, match="not uniquely"):
+        module.require_safe_server_book(app_db, metadata_db, 7, TARGET)
+
+
+def test_it_refuses_any_preexisting_device_row():
+    module = _module()
+    dirty = [module.DeviceAnnotation("old", "highlight", "0")]
+    with pytest.raises(module.SafetyRefusal, match="baseline must be empty"):
+        module.require_clean_device_baseline(dirty)
+    assert module.require_clean_device_baseline([]) is None
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [],
+        [
+            ("new-1", "highlight", "0"),
+            ("new-2", "highlight", "0"),
+        ],
+        [("", "highlight", "0")],
+        [("new-1", "note", "0")],
+        [("new-1", "highlight", "1")],
+    ],
+)
+def test_only_one_new_active_highlight_can_be_sacrificed(rows):
+    module = _module()
+    materialized = [module.DeviceAnnotation(*row) for row in rows]
+    with pytest.raises(module.SafetyRefusal):
+        module.require_one_sacrificial_highlight(materialized)
+
+
+def test_the_single_sacrificial_highlight_case_is_not_vacuous():
+    module = _module()
+    row = module.DeviceAnnotation("new-1", "highlight", "0")
+    assert module.require_one_sacrificial_highlight([row]) == row
+
+
+def test_server_queries_are_bound_and_both_databases_are_read_only(tmp_path):
+    module = _module()
+    app_db = _app_db(tmp_path, 0)
+    metadata_db = _metadata_db(tmp_path)
+    before = {
+        app_db: hashlib.sha256(app_db.read_bytes()).digest(),
+        metadata_db: hashlib.sha256(metadata_db.read_bytes()).digest(),
+    }
+    assert module.require_safe_server_book(app_db, metadata_db, 7, TARGET) == 0
+    assert before == {
+        app_db: hashlib.sha256(app_db.read_bytes()).digest(),
+        metadata_db: hashlib.sha256(metadata_db.read_bytes()).digest(),
+    }
+    source = (
+        inspect.getsource(module.server_annotation_count)
+        + inspect.getsource(module.metadata_content_id)
+        + inspect.getsource(module.metadata_book_ids_for_content)
+    )
+    assert "WHERE book_id = ?" in source and "WHERE id = ?" in source
+    assert "(book_id,)" in source
+
+
+def test_every_sqlite_connection_is_forced_read_only_twice():
+    module = _module()
+    source = inspect.getsource(module._sqlite_ro)
+    assert "?mode=ro" in source, "the OS-level SQLite open must be read-only"
+    assert "PRAGMA query_only = ON" in source, (
+        "SQLite must also reject writes at the connection"
+    )
+
+
+def test_device_sqlite_is_queried_only_after_backup_and_never_changes(tmp_path):
+    module = _module()
+    backup = _device_db(
+        tmp_path / "KoboReader.backup.sqlite",
+        [
+            (
+                "ann-1",
+                "file:///mnt/onboard/urn:uuid:{" + TARGET.upper() + "}",
+                "highlight",
+                "0",
+            )
+        ],
+    )
+    before = hashlib.sha256(backup.read_bytes()).digest()
+    rows = module.device_annotations_from_backup(backup, TARGET)
+    assert rows == [module.DeviceAnnotation("ann-1", "highlight", "0")]
+    assert hashlib.sha256(backup.read_bytes()).digest() == before
+    source = inspect.getsource(module.device_annotations_from_backup).upper()
+    assert (
+        "UPDATE " not in source and "DELETE " not in source and "INSERT " not in source
+    )
+    assert "?" in source, "the ContentId must remain a bound SQL parameter"
+
+
+def test_snapshot_creates_the_backup_before_opening_sqlite(tmp_path, monkeypatch):
+    module = _module()
+    backup = tmp_path / "persisted.sqlite"
+    order = []
+
+    def make_backup(*_args):
+        order.append("backup")
+        _device_db(backup)
+        return backup
+
+    def read_backup(path, _content_id):
+        assert path == backup and path.exists()
+        order.append("read")
+        return []
+
+    monkeypatch.setattr(module, "backup_device_db", make_backup)
+    monkeypatch.setattr(module, "device_annotations_from_backup", read_backup)
+    assert module.capture_device_snapshot("host", "/db", tmp_path, TARGET) == (
+        backup,
+        [],
+    )
+    assert order == ["backup", "read"]
+
+
+class _RunResult:
+    returncode = 0
+    stderr = ""
+
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+def test_device_backup_uses_read_only_commands_and_keeps_password_out_of_argv(
+    tmp_path,
+    monkeypatch,
+):
+    module = _module()
+    source_db = _device_db(tmp_path / "source.sqlite")
+    encoded = base64.b64encode(gzip.compress(source_db.read_bytes())).decode("ascii")
+    echo = module._device_backup_command("/mnt/onboard/.kobo/KoboReader.sqlite")
+    output = (
+        f"{echo}\r\n{module.DEVICE_DB_BEGIN}\r\n{encoded}\r\n{module.DEVICE_DB_END}\r\n"
+    )
+    captured = []
+
+    def run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _RunResult(output)
+
+    monkeypatch.setenv("SECRET", '{"username":"root","password":"device-secret"}')
+    monkeypatch.setattr(module.subprocess, "run", run)
+    backup = module.backup_device_db(
+        "10.0.0.9",
+        "/mnt/onboard/.kobo/KoboReader.sqlite",
+        tmp_path / "backups",
+    )
+
+    assert backup.is_file() and backup.read_bytes() == source_db.read_bytes()
+    ((cmd, kwargs),) = captured
+    joined = " ".join(str(part) for part in cmd)
+    assert "device-secret" not in joined
+    assert "-p" not in cmd and "-e" in cmd
+    assert kwargs["env"]["SSHPASS"] == "device-secret"
+    assert "StrictHostKeyChecking=accept-new" in joined
+    assert ".kobo_known_hosts" in joined
+    sent = kwargs["input"]
+    assert "gzip -c <" in sent and "| base64" in sent
+    for mutator in ("sqlite3", "cp ", "mv ", "rm ", "> ", ">>"):
+        assert mutator not in sent, sent
+
+
+def test_device_path_is_shell_quoted():
+    module = _module()
+    command = module._device_backup_command("/mnt/onboard/x; rm -rf /mnt/onboard")
+    quoted = "'/mnt/onboard/x; rm -rf /mnt/onboard'"
+    assert quoted in command
+    assert "rm -rf" not in command.replace(quoted, "")
+
+
+def test_timeout_hides_the_subprocess_command(tmp_path, monkeypatch):
+    module = _module()
+    monkeypatch.setenv("SECRET", "device-secret")
+
+    def run(cmd, **_kwargs):
+        raise module.subprocess.TimeoutExpired(cmd, 90)
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+    with pytest.raises(module.SafetyRefusal) as excinfo:
+        module.backup_device_db("host", "/db", tmp_path)
+    assert "device-secret" not in str(excinfo.value)
+    assert excinfo.value.__suppress_context__
+
+
+class _Upstream(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, _fmt, *_args):
+        pass
+
+    def _reply(self):
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        body = self.rfile.read(length)
+        self.server.seen.append((self.command, self.path, body))
+        reply = b'{"upstream":true}'
+        self.send_response_only(207, "Multi-Status")
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(reply)))
+        self.send_header("ETag", 'W/"test"')
+        self.end_headers()
+        self.wfile.write(reply)
+
+    do_GET = _reply
+    do_PATCH = _reply
+    do_DELETE = _reply
+
+
+class _RunningProxy:
+    def __init__(self, module, expected="ann-1"):
+        self.upstream = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Upstream)
+        self.upstream.seen = []
+        self.up_thread = threading.Thread(
+            target=self.upstream.serve_forever, daemon=True
+        )
+        self.up_thread.start()
+        self.proxy = module.PatchFailureServer(
+            ("127.0.0.1", 0),
+            upstream=f"http://127.0.0.1:{self.upstream.server_port}",
+            content_id=TARGET,
+            expected_annotation_id=expected,
+        )
+        self.proxy_thread = threading.Thread(
+            target=self.proxy.serve_forever, daemon=True
+        )
+        self.proxy_thread.start()
+
+    def request(self, method, path, payload=None):
+        body = b"" if payload is None else json.dumps(payload).encode()
+        conn = http.client.HTTPConnection(
+            "127.0.0.1", self.proxy.server_port, timeout=3
+        )
+        conn.request(
+            method, path, body=body, headers={"Content-Type": "application/json"}
+        )
+        response = conn.getresponse()
+        result = (response.status, response.read(), dict(response.getheaders()))
+        conn.close()
+        return result
+
+    def close(self):
+        self.proxy.shutdown()
+        self.proxy.server_close()
+        self.upstream.shutdown()
+        self.upstream.server_close()
+        self.proxy_thread.join(timeout=3)
+        self.up_thread.join(timeout=3)
+
+
+def _single(annotation_id="ann-1"):
+    return {
+        "updatedAnnotations": [{"id": annotation_id, "highlightedText": "sacrificial"}],
+        "deletedAnnotationIds": [],
+    }
+
+
+def test_only_the_exact_disposable_single_update_can_receive_503():
+    module = _module()
+    running = _RunningProxy(module)
+    try:
+        cases = [
+            ("GET", f"/api/v3/content/{TARGET}/annotations", None),
+            ("PATCH", f"/api/v3/content/{OTHER}/annotations", _single()),
+            ("PATCH", f"/api/v3/content/{TARGET}/annotations-extra", _single()),
+            (
+                "PATCH",
+                f"/api/v3/content/{TARGET}/annotations",
+                {
+                    "updatedAnnotations": [{"id": "a"}, {"id": "b"}],
+                    "deletedAnnotationIds": [],
+                },
+            ),
+            (
+                "PATCH",
+                f"/api/v3/content/{TARGET}/annotations",
+                {
+                    "updatedAnnotations": [{"id": "ann-1"}],
+                    "deletedAnnotationIds": ["old"],
+                },
+            ),
+            ("PATCH", f"/api/v3/content/{TARGET}/annotations", _single("different-id")),
+        ]
+        for method, path, payload in cases:
+            status, _body, _headers = running.request(method, path, payload)
+            assert status == 207, (method, path, payload)
+        assert running.proxy.patch_state.failure_count == 0
+        assert len(running.upstream.seen) == len(cases)
+
+        status, body, headers = running.request(
+            "PATCH",
+            f"/api/v3/content/{TARGET}/annotations",
+            _single(),
+        )
+        assert status == 503 and headers["Retry-After"] == "30"
+        assert b"controlled disposable-book" in body
+        assert running.proxy.patch_state.failure_count == 1
+        assert len(running.upstream.seen) == len(cases), (
+            "the failed PATCH leaked upstream"
+        )
+
+        status, body, headers = running.request(
+            "PATCH",
+            f"/api/v3/content/{TARGET}/annotations",
+            _single(),
+        )
+        assert status == 207 and body == b'{"upstream":true}'
+        assert headers["ETag"] == 'W/"test"'
+        assert running.proxy.patch_state.failure_count == 1
+        assert running.proxy.patch_state.retry_count == 1
+        assert len(running.upstream.seen) == len(cases) + 1
+    finally:
+        running.close()
+
+
+@pytest.mark.parametrize(
+    "state, rows, expected",
+    [
+        ("none", [], "INCONCLUSIVE"),
+        ("failed", [], "ROW_MISSING_AFTER_503"),
+        ("failed", ["row"], "PRESENT_NOT_RETRIED"),
+        ("retried", ["row"], "RETRIED_AND_PRESENT"),
+        ("unsafe", ["row"], "INCONCLUSIVE"),
+    ],
+)
+def test_every_device_outcome_has_a_decision(state, rows, expected):
+    module = _module()
+    patch = module.PatchState()
+    if state in {"failed", "retried", "unsafe"}:
+        patch.failure_count = 1
+    if state == "retried":
+        patch.retry_count = 1
+    if state == "unsafe":
+        patch.unsafe_target_patch_count = 1
+    assert module.classify_result(patch, rows) == expected
+
+
+def test_hidden_or_changed_sacrificial_row_cannot_be_misclassified_as_preserved():
+    module = _module()
+    patch = module.PatchState(failure_count=1)
+    hidden = module.DeviceAnnotation("ann-1", "highlight", "1")
+    changed = module.DeviceAnnotation("ann-2", "highlight", "0")
+    assert (
+        module.classify_result(
+            patch,
+            [hidden],
+            expected_annotation_id="ann-1",
+        )
+        == "ROW_MISSING_AFTER_503"
+    )
+    assert (
+        module.classify_result(
+            patch,
+            [changed],
+            expected_annotation_id="ann-1",
+        )
+        == "INCONCLUSIVE"
+    )
+
+
+def test_the_script_prints_what_every_outcome_means(capsys):
+    module = _module()
+    module.print_decision_table()
+    output = capsys.readouterr().out
+    for phrase in (
+        "RETRIED + ROW PRESENT",
+        "ROW PRESENT, NO RETRY",
+        "ROW MISSING AFTER 503",
+        "INCONCLUSIVE",
+        "fix may return 503",
+        "durable staging",
+        "Do NOT ship a non-success",
+        "Do not change the live handler",
+    ):
+        assert phrase in output
+
+
+def test_live_patch_handler_has_no_experiment_bypass():
+    source = (REPO / "cps" / "readingservices.py").read_text(encoding="utf-8")
+    for needle in ("F-5c1146", "measure_kobo_patch", "PATCH_EXPERIMENT", "failed_once"):
+        assert needle not in source


### PR DESCRIPTION
## Why

F-5c1146 establishes that CWNG can lose a Kobo annotation locally and still proxy an upstream-success PATCH response. The device sends deltas, so the missing row is not automatically re-offered. Before changing that response, we need the hardware answer to one question: what does Nickel do when an annotations PATCH receives a non-success response?

This PR arms that measurement. It deliberately does **not** change the live PATCH handler and it does **not** run the device experiment.

## What this adds

- `scripts/measure_kobo_patch_failure.py`: a dry-run-by-default, standalone fail-once reverse proxy.
- `tests/unit/test_measure_kobo_patch_failure_is_safe.py`: behavioral and source-level safety coverage.

OBSERVED: the proxy can return 503 only for one exact ContentId, one exact staged BookmarkID, and a PATCH containing exactly one updated annotation and no deletion delta. GET, other methods, other UUIDs, malformed JSON, batches, deletes, and different annotation IDs pass through unchanged.

OBSERVED: the experiment has no hook, flag, or bypass in `cps/readingservices.py`. The non-success mechanism exists only while this separate process is running with `--go`; the listener defaults to loopback.

OBSERVED: before the listener starts, the script requires all of the following:

1. the requested Calibre id resolves uniquely to the requested UUID;
2. zero server annotations for that book across all users;
3. a persisted off-device backup of `KoboReader.sqlite`;
4. zero pre-existing device `Bookmark` rows containing that UUID, across brace/URN/file-URI representations;
5. after the operator creates the sacrificial highlight, exactly one active `highlight` row with the expected BookmarkID;
6. a second server annotation-free check after the human pause.

OBSERVED: every SQLite connection uses `mode=ro` plus `PRAGMA query_only = ON`; every SQL value is bound. The only device command is a shell-quoted `gzip -c < KoboReader.sqlite | base64` read. SSH uses `sshpass -e`, a persistent known-hosts file, and `StrictHostKeyChecking=accept-new`.

## Decision output

OBSERVED: the script prints the fix decision for every possible outcome before and after the run:

- row present + matching retry: a transient non-success can preserve and re-offer the delta;
- row present + no retry after an explicit second sync: status alone is insufficient; the fix needs durable staging/replay;
- row missing/hidden after 503: do not ship non-success on capture loss; capture durably before answering success or use another proven mechanism;
- no eligible PATCH, changed/multiple rows, or unreadable DB: inconclusive; do not change the live handler.

ASSUMED: the existing experiment endpoint can be routed to this standalone listener during the authorized hardware window, as it was for earlier reading-services captures. That routing was not exercised here because the device is off-network and the instruction was to arm, not run.

## Mutation proof

OBSERVED: the complete new safety suite was run after deleting or weakening each gate, one mutant at a time. Every mutant made the suite red; the gate was restored immediately after its run.

| Removed/weakened gate | Failing tests |
|---|---:|
| `--go` requirement | 1 |
| exact book-id → UUID identity | 1 |
| unique UUID → one metadata row | 1 |
| zero server annotations | 1 |
| zero pre-existing device rows | 1 |
| exactly one sacrificial row | 2 |
| sacrificial ID/type/visibility | 3 |
| backup-before-SQLite-read ordering | 1 |
| read-only device command | 1 |
| exact PATCH method/path/UUID scope | 1 |
| exact staged BookmarkID | 1 |
| bound metadata SQL | 1 |
| bound annotation SQL | 1 |
| password kept out of argv | 1 |
| persistent host-key pinning | 1 |
| device-path shell quoting | 1 |
| SQLite `mode=ro` | 1 |
| SQLite `query_only` | 1 |

## Validation

OBSERVED on rebased head `70947646b`:

- `ruff check ...` — pass
- `ruff format --check ...` — pass
- focused experiment + F-3e383a precedent: **43 passed**
- full unit suite with an isolated `TMPDIR`: **6,727 passed, 103 skipped, 0 failed** in 158.05s

OBSERVED test-environment note: one standard-temp full run was green (6,727 passed), a later run saw one unrelated `/tmp/ingest_processor.lock` appearance, and another saw 12 unrelated `ingest_processor` lock-acquisition failures (`NoneType.fileno`). The isolated failing import test passed immediately by itself. Running the same complete suite with an isolated `TMPDIR` removed the cross-process temp-lock collision and was fully green. Neither changed file imports or modifies `ingest_processor`.

## Scope / release

- No production behavior, schema, dependency, external URL, translation, changelog, or release-note change.
- Tier: `needs-review` (subprocess/shell + local proxy listener; hardware experiment tool).
- Hardware execution: **not performed**. This PR only arms it.
