### PR TITLE
test(kobo): pin conversion discrimination and repair notice copy

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -2131,8 +2131,10 @@ def upload_book_formats(requested_files, book, book_id, no_cover=True):
                 # KEPUB is strictly better than refusing the upload, which is
                 # the same trade-off convert.py makes.
                 #
-                # Splitting is opted into only when the book carries no
-                # annotations. This route is reached from EDIT BOOK, so
+                # Splitting is withheld for an annotated book unless the stored
+                # KEPUB was already split by us; _may_split_replacement explains
+                # why re-splitting is then the anchor-preserving choice. This
+                # route is reached from EDIT BOOK, so
                 # `book_id` can be a book that has been in the library for
                 # years: a split renames its spine documents, and a Kobo matches
                 # its stored Bookmark rows by ContentID, so it would keep the

--- a/frontend/e2e/user-notices.spec.ts
+++ b/frontend/e2e/user-notices.spec.ts
@@ -39,6 +39,18 @@ async function json(route: Route, body: unknown) {
   });
 }
 
+test('shows the complete singular repair instruction for one affected book', async ({ page }) => {
+  await serveCurrentSpaBuild(page);
+  const repaired = [notice(100, 1, 'One repaired book')];
+  await page.route(/\/api\/v1\/notices(?:\/[^?]*)?(?:\?.*)?$/, async (route) => json(route, {
+    notices: repaired,
+    summary: { count: repaired.length },
+  }));
+
+  await page.goto('/app');
+  await expect(page.getByText('We repaired this book for your Kobo. If you were having trouble highlighting, try after sync — and if it still doesn’t work, remove the book from your Kobo and let it download again.', { exact: true })).toBeVisible();
+});
+
 test('aggregates repaired books and permanently bulk-dismisses explicit occurrences', async ({ page }) => {
   await serveCurrentSpaBuild(page);
   const repaired = [notice(101, 1, 'First repaired book'), notice(102, 2, 'Second repaired book')];
@@ -59,7 +71,7 @@ test('aggregates repaired books and permanently bulk-dismisses explicit occurren
   });
 
   await page.goto('/app');
-  await expect(page.getByText('We repaired 2 books for your Kobo.', { exact: false })).toBeVisible();
+  await expect(page.getByText('We repaired 2 books for your Kobo. If you were having trouble highlighting, try after sync — and if it still doesn’t work, remove them from your Kobo and let them download again.', { exact: true })).toBeVisible();
   const accessibility = await new AxeBuilder({ page }).analyze();
   expect(accessibility.violations.filter(
     (violation) => violation.impact === 'critical' || violation.impact === 'serious',
@@ -99,9 +111,9 @@ test('book detail presents and independently dismisses its book-scoped occurrenc
   });
 
   await page.goto(`/app/book/${book!.id}`);
-  await expect(page.getByText('We repaired this book for your Kobo.', { exact: false })).toBeVisible();
+  await expect(page.getByText('We repaired this book for your Kobo. If you were having trouble highlighting, try after sync — and if it still doesn’t work, remove the book from your Kobo and let it download again. If you read it some other way, download it again to get the repaired copy.', { exact: true })).toBeVisible();
   await page.getByRole('button', { name: 'Dismiss permanently' }).click();
 
-  await expect(page.getByText('We repaired this book for your Kobo.', { exact: false })).toHaveCount(0);
+  await expect(page.getByText('We repaired this book for your Kobo. If you were having trouble highlighting, try after sync — and if it still doesn’t work, remove the book from your Kobo and let it download again. If you read it some other way, download it again to get the repaired copy.', { exact: true })).toHaveCount(0);
   expect(dismissedId).toBe(201);
 });

--- a/frontend/src/components/UserNotices.tsx
+++ b/frontend/src/components/UserNotices.tsx
@@ -39,6 +39,14 @@ function BookLinks({ notices }: { notices: UserNotice[] }) {
   );
 }
 
+/*
+ * #1748 final invariant: the repair instructions below are the operator-chosen
+ * copy. They lead with sync, retain the remove-and-download fallback, and
+ * deliberately omit the superseded pre-repair-highlight warning.
+ * The squash message records intermediate drafts; these exact literals are the
+ * final decision and are pinned by the unit and end-to-end tests.
+ */
+
 export function UserNoticeBanner() {
   const t = useT();
   const announce = useAnnouncer();

--- a/tests/unit/test_1715_uploaded_kepub_is_normalized.py
+++ b/tests/unit/test_1715_uploaded_kepub_is_normalized.py
@@ -14,6 +14,7 @@ collaborators, so they exercise the actual code path rather than pinning source.
 """
 import os
 import zipfile
+from pathlib import Path
 
 import pytest
 
@@ -352,3 +353,24 @@ def test_the_decision_rule_itself(monkeypatch):
                         raising=False)
     assert editbooks._may_split_replacement(1, False) is False
     assert editbooks._may_split_replacement(1, True) is True
+
+
+def test_upload_comment_describes_the_annotated_replacement_exception():
+    """The call-site prose must not contradict the decision directly below it.
+
+    The stale wording said splitting happened only without annotations, hiding
+    the already-split exception this suite exists to protect. Pin both the
+    removal and the corrected rule because a wrong comment disables review of
+    the real branch even while behavioural tests remain green.
+    """
+    from cps import editbooks
+
+    source = Path(editbooks.__file__).read_text(encoding="utf-8")
+    stale = "Splitting is opted into only when the book carries no"
+    corrected = (
+        "Splitting is withheld for an annotated book unless the stored\n"
+        "                # KEPUB was already split by us"
+    )
+
+    assert stale not in source
+    assert corrected in source

--- a/tests/unit/test_kepub_package_normalizer.py
+++ b/tests/unit/test_kepub_package_normalizer.py
@@ -749,3 +749,66 @@ def test_kepubify_conversion_RE_splits_an_annotated_book_that_was_already_split(
     ], ("an annotated book whose stored KEPUB was already split came back "
         "unsplit; the chapter files its highlights are anchored to no longer "
         "exist, so they would stop rendering on the device")
+
+
+@pytest.mark.unit
+def test_kepubify_conversion_keeps_an_existing_UNSPLIT_annotated_book_unsplit(
+        tmp_path, monkeypatch):
+    """The convert boundary must use the detector's False result, not existence.
+
+    The positive partner above proves a real splitter output is accepted. This
+    case supplies the missing other half: the destination exists, but its spine
+    is ordinary and unsplit. Merely checking ``os.path.exists(destination)`` --
+    or replacing ``package_was_split_by_us`` with an always-True predicate --
+    would split the replacement and strand annotations anchored to
+    ``chapter.xhtml``.
+
+    Wrap the real detector and record its argument so the assertion proves the
+    decision was made at the conversion boundary, against the stored package.
+    """
+    from types import SimpleNamespace
+
+    import cps.helper  # noqa: F401 - establish the application's normal import order
+    from cps.services import kepub_spine_splitter
+    from cps.tasks import convert
+
+    book_path = tmp_path / "book"
+    (tmp_path / "book.epub").write_bytes(b"source")
+    _write_splittable_package(tmp_path / "book.kepub.epub")
+
+    destination = tmp_path / "book.kepub"
+    _write_splittable_package(destination)
+    assert _ncx_sources(destination) == [
+        "chapter.xhtml#one",
+        "chapter.xhtml#two",
+    ], "fixture is wrong: the stored package is not an ordinary unsplit KEPUB"
+
+    real_detector = kepub_spine_splitter.package_was_split_by_us
+    detector_calls = []
+
+    def record_detector_call(path):
+        detector_calls.append(path)
+        return real_detector(path)
+
+    monkeypatch.setattr(
+        kepub_spine_splitter, "package_was_split_by_us", record_detector_call)
+
+    process = SimpleNamespace(returncode=0)
+    monkeypatch.setattr(convert.config, "config_embed_metadata", False, raising=False)
+    monkeypatch.setattr(convert.config, "config_binariesdir", "", raising=False)
+    monkeypatch.setattr(convert.config, "config_kepubifypath", "/bin/kepubify", raising=False)
+    monkeypatch.setattr(convert, "process_open", lambda *_args, **_kwargs: process)
+    monkeypatch.setattr(convert, "stream_process_output", lambda *_args, **_kwargs: [])
+    _patch_annotation_store(monkeypatch, convert, annotations=1)
+    task = convert.TaskConvert(str(book_path), 1, "convert", {}, None)
+
+    check, error = task._convert_kepubify(str(book_path), ".epub", ".kepub")
+
+    assert check == 0, error
+    assert detector_calls == [str(destination)], (
+        "conversion did not ask the real detector about the stored package")
+    assert _ncx_sources(destination) == [
+        "chapter.xhtml#one",
+        "chapter.xhtml#two",
+    ], ("an annotated book whose stored KEPUB was unsplit came back split; "
+        "its highlights were anchored to the chapter.xhtml spine document")

--- a/tests/unit/test_spa_strings_anchored.py
+++ b/tests/unit/test_spa_strings_anchored.py
@@ -28,6 +28,21 @@ pytestmark = pytest.mark.unit
 _REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _SCRIPT = os.path.join(_REPO, "scripts", "extract_spa_strings.py")
 _FUZZY_SCRIPT = os.path.join(_REPO, "scripts", "check_spa_fuzzy.py")
+_USER_NOTICES = os.path.join(_REPO, "frontend", "src", "components", "UserNotices.tsx")
+
+_KOBO_REPAIR_NOTICE_MSGIDS = (
+    "We repaired this book for your Kobo. If you were having trouble highlighting, try after sync — and if it still doesn’t work, remove the book from your Kobo and let it download again.",
+    "We repaired this book for your Kobo. If you were having trouble highlighting, try after sync — and if it still doesn’t work, remove the book from your Kobo and let it download again. If you read it some other way, download it again to get the repaired copy.",
+    "We repaired {count} books for your Kobo. If you were having trouble highlighting, try after sync — and if it still doesn’t work, remove them from your Kobo and let them download again.",
+)
+
+_SUPERSEDED_KOBO_REPAIR_CAVEATS = (
+    "Older highlights may still need to be recreated",
+    "Highlights you made before the repair may not come back",
+    "highlights created before the repair may remain invisible",
+    "highlights may not come back",
+    "highlights may not return",
+)
 
 
 def _load_extractor():
@@ -51,6 +66,37 @@ def test_every_static_spa_translation_key_is_anchored():
         f"and will render untranslated (issue #719). Run "
         f"`python scripts/extract_spa_strings.py --write`. Missing: {missing[:20]}"
     )
+
+
+def test_operator_chosen_kobo_repair_notices_are_exact_and_anchored():
+    """#1748's final English is a fixed invariant, not editable chrome.
+
+    The generic extraction gate follows whatever the frontend currently says,
+    so it cannot reject a coordinated reword. Pin each exact call and anchor;
+    the e2e coverage separately proves each complete sentence is rendered.
+    """
+    with open(_USER_NOTICES, encoding="utf-8") as source_file:
+        frontend = source_file.read()
+    with open(extractor.SPA_STRINGS, encoding="utf-8") as source_file:
+        anchors = source_file.read()
+
+    for msgid in _KOBO_REPAIR_NOTICE_MSGIDS:
+        assert frontend.count(f"t('{msgid}'") == 1, (
+            f"operator-chosen Kobo repair notice changed or is not a single t() call: {msgid!r}")
+        assert anchors.count(f'_("{msgid}")') == 1, (
+            f"operator-chosen Kobo repair notice lacks its exact extraction anchor: {msgid!r}")
+
+
+def test_operator_chosen_kobo_repair_notices_omit_superseded_caveats():
+    """The final #1748 decision deliberately removed every earlier caveat."""
+    with open(_USER_NOTICES, encoding="utf-8") as source_file:
+        frontend = source_file.read()
+    with open(extractor.SPA_STRINGS, encoding="utf-8") as source_file:
+        active_copy = frontend + source_file.read()
+
+    for caveat in _SUPERSEDED_KOBO_REPAIR_CAVEATS:
+        assert caveat.casefold() not in active_copy.casefold(), (
+            f"superseded Kobo repair caveat returned: {caveat!r}")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Late proof of #1768 found that its positive conversion fixture proved only that a real splitter output is accepted. It did not prove conversion depends on `package_was_split_by_us` discriminating an existing unsplit package from an existing split package. The same review found that #1748's final operator-chosen copy was only prefix-tested and that one upload-path comment contradicted the decision directly beneath it.

## Results

1. Adds the conversion-boundary negative partner: an annotated book with an existing ordinary unsplit KEPUB calls the real detector against that stored destination and keeps the generated replacement unsplit.
2. Corrects the upload-path comment to document the already-split annotated-book exception, with a source pin so the false statement cannot silently return.
3. Pins the three operator-chosen #1748 English literals at their `UserNotices.tsx` call sites and `spa_strings.py` anchors, rejects the superseded caveat formulations, and makes the e2e checks assert complete rendered sentences. Adds the missing one-notice aggregate case.
4. Records the corrected final #1748 invariant beside the notice call sites: sync first, retain the remove-and-download fallback, deliberately omit the superseded pre-repair-highlight warning. The note explains that the squash message contains intermediate drafts.

No runtime behavior changes. The only production-file changes are comments.

## Independent mutation evidence

- Forced `package_was_split_by_us` always true: new conversion negative test **1 failed, 0 passed**, on the split output.
- Restored the false `editbooks.py` comment in memory: comment guard **1 failed, 0 passed**.
- Changed one byte sequence in the chosen English in memory: exact-copy guard **1 failed, 0 passed**.
- Reintroduced the old highlight-loss caveat in memory: caveat-absence guard **1 failed, 0 passed**.

All mutations were in-memory pytest plugins; the worktree stayed on the committed implementation.

## Validation

- Focused affected files: **86 passed, 0 failed**.
- Full unit suite with isolated no-space `TMPDIR`: **6742 passed, 95 skipped, 0 failed** in 163.64s.
- `npm ci && npm run build`: production frontend build and TypeScript compilation passed.
- Playwright discovery: **7 tests in 2 files**, including the singular/plural/book-detail notice cases for desktop and mobile.
- The live Playwright flow was not run locally because the required authenticated fixture backend on port 8086 was not running; PR CI owns that execution.
- `git diff --check`: clean.

## Scope

No dependencies, schema, routes, auth, subprocess, file-handling behavior, or user-visible copy changed. No changelog entry is appropriate because this PR changes proof and comments only.
