### PR TITLE
fix(kobo): split nested TOC chapter groups so inner chapters become anchorable

### DIFF
--- a/cps/services/kepub_spine_splitter.py
+++ b/cps/services/kepub_spine_splitter.py
@@ -281,13 +281,19 @@ def _project_anchor(anchor, container):
     return cut
 
 
-def _descended_cut_plan(source, container, bounds, anchors, elements, ranges):
+def _has_nested_cut(nested_cuts):
+    """True when an outer TOC anchor can own a piece before an inner cut."""
+    return bool(nested_cuts)
+
+
+def _descended_cut_plan(source, container, anchors, elements, ranges):
     """Prove and plan the single supported nested-anchor descent.
 
     The ordinary NCA projection may collapse every target onto one child.  We
-    descend into that child only when it is itself exactly one TOC target and
-    the original container contains no content outside it.  The outer target
-    then owns the bytes before the first nested boundary.
+    descend into that child only when it is itself exactly one TOC target.  The
+    outer target owns the bytes before the first nested boundary; surrounding
+    sibling content is assigned to the natural edge pieces by the nested
+    partitioner rather than copied into every piece.
     """
     children = {
         _project_anchor(anchor, container) for anchor in anchors.values()
@@ -308,15 +314,8 @@ def _descended_cut_plan(source, container, bounds, anchors, elements, ranges):
 
     descended_bounds = _container_bounds(
         source, descended_container, elements, ranges)
-    _container_start, container_inner_start, container_inner_end, _container_end = bounds
-    descended_start, descended_inner_start, _descended_inner_end, descended_end = (
+    _descended_start, descended_inner_start, _descended_inner_end, _descended_end = (
         descended_bounds)
-    # Prefix/suffix slicing repeats everything outside the selected container.
-    # Permit that only for whitespace inside the original NCA; elements,
-    # comments, text, and other meaningful bytes make descent unsafe.
-    if (source[container_inner_start:descended_start].strip()
-            or source[descended_end:container_inner_end].strip()):
-        return None
 
     nested_cuts = {
         ranges[elements.index(_project_anchor(anchor, descended_container))][0]
@@ -325,7 +324,7 @@ def _descended_cut_plan(source, container, bounds, anchors, elements, ranges):
     # This is deliberately one level only.  If the nested targets still
     # collapse into one child, arbitrary recursive shell construction would be
     # required and the document remains in its current graceful grouping.
-    if len(nested_cuts) < 2 or min(nested_cuts) <= descended_inner_start:
+    if not _has_nested_cut(nested_cuts) or min(nested_cuts) <= descended_inner_start:
         return None
     boundaries = [descended_inner_start, *sorted(nested_cuts)]
     return descended_bounds, boundaries
@@ -351,6 +350,7 @@ def _anchor_cut_plan(source, document, fragments, elements, ranges):
     if container is not body and body not in container.iterancestors():
         raise _UnsafeSplit("TOC anchor common ancestor is outside the content body")
     bounds = _container_bounds(source, container, elements, ranges)
+    nested_partition = False
     anchor_positions = {}
     cut_positions = {}
     for fragment, anchor in anchors.items():
@@ -360,10 +360,11 @@ def _anchor_cut_plan(source, document, fragments, elements, ranges):
     boundaries = sorted(set(cut_positions.values()))
     if len(boundaries) == 1:
         descended = _descended_cut_plan(
-            source, container, bounds, anchors, elements, ranges)
+            source, container, anchors, elements, ranges)
         if descended is not None:
             bounds, boundaries = descended
-    return bounds, boundaries, anchor_positions
+            nested_partition = True
+    return bounds, boundaries, anchor_positions, nested_partition
 
 
 def _partition_document(source, boundaries, container_bounds):
@@ -402,6 +403,72 @@ def _partition_document(source, boundaries, container_bounds):
     return pieces
 
 
+def _partition_nested_document(
+        source, boundaries, container_bounds, container, elements, ranges):
+    """Partition a nested group without copying its surrounding content.
+
+    The ordinary partition duplicates a full prefix and suffix.  During a
+    second pass those shells can contain sibling prose or KoboSpans inherited
+    from the first-pass piece.  Keep that content on the natural edge piece and
+    build middle shells only from exact lexical ancestor tags.
+    """
+    body = _body_element(container.getroottree().getroot())
+    body_bounds = _container_bounds(source, body, elements, ranges)
+    _body_start, body_inner_start, body_inner_end, _body_end = body_bounds
+    chain = []
+    current = container
+    while current is not body:
+        chain.append(current)
+        current = current.getparent()
+        if current is None:
+            raise _UnsafeSplit("nested split container is outside the content body")
+    chain.reverse()
+
+    element_bounds = {
+        element: _container_bounds(source, element, elements, ranges)
+        for element in chain
+    }
+    minimal_prefix = source[:body_inner_start] + b"".join(
+        source[element_bounds[element][0]:element_bounds[element][1]]
+        for element in chain
+    )
+    minimal_suffix = b"".join(
+        source[element_bounds[element][2]:element_bounds[element][3]]
+        for element in reversed(chain)
+    ) + source[body_inner_end:]
+
+    _container_start, container_inner_start, container_inner_end, _container_end = (
+        container_bounds)
+    full_prefix = source[:container_inner_start]
+    full_suffix = source[container_inner_end:]
+    starts = [container_inner_start] + boundaries[1:]
+    ends = boundaries[1:] + [container_inner_end]
+    projected = sum(
+        (len(full_prefix) if index == 0 else len(minimal_prefix))
+        + (end - start)
+        + (len(full_suffix) if index == len(starts) - 1 else len(minimal_suffix))
+        for index, (start, end) in enumerate(zip(starts, ends))
+    )
+    if len(starts) > MAX_SPLIT_PIECES or projected > MAX_SPLIT_PEAK_BYTES:
+        raise _UnsafeSplit(
+            "nested split would allocate {} bytes across {} pieces, over the "
+            "{}-byte / {}-piece budget".format(
+                projected, len(starts), MAX_SPLIT_PEAK_BYTES, MAX_SPLIT_PIECES))
+
+    pieces = []
+    for index, (start, end) in enumerate(zip(starts, ends)):
+        prefix = full_prefix if index == 0 else minimal_prefix
+        suffix = full_suffix if index == len(starts) - 1 else minimal_suffix
+        piece = prefix + source[start:end] + suffix
+        try:
+            etree.fromstring(piece, parser=_XML_PARSER)
+        except etree.XMLSyntaxError as error:
+            raise _UnsafeSplit(
+                "nested chapter boundary would create malformed XML") from error
+        pieces.append(piece)
+    return pieces
+
+
 def _piece_for_position(boundaries, position):
     return max(0, bisect_right(boundaries, position) - 1)
 
@@ -431,6 +498,85 @@ def _fragment_piece_map(
     # piece one and cannot be overwritten by a repeated shell id.
     return _prefer_explicit_anchor_pieces(
         mapping, anchor_positions, boundaries, piece_names)
+
+
+def _should_refine_nested_piece(fragments):
+    """True when one first-pass piece still owns multiple TOC chapters."""
+    return len(fragments) >= 2
+
+
+def _refine_nested_pieces(pieces, fragments, fragment_indexes):
+    """Split chapter groups left together by the first lexical partition.
+
+    The first NCA partition remains authoritative for piece order.  A resulting
+    piece that still owns multiple explicit TOC fragments gets one more lexical
+    planning pass against its own well-formed XML.  This handles a nested group
+    beside ordinary top-level chapters without mixing cut containers or
+    synthesizing ancestor tags.
+    """
+    refinements = {}
+    for piece_index, piece in enumerate(pieces):
+        owned = {
+            fragment for fragment in fragments
+            if fragment_indexes[fragment] == piece_index
+        }
+        if not _should_refine_nested_piece(owned):
+            continue
+        document = etree.fromstring(piece, parser=_XML_PARSER)
+        elements, ranges = _element_positions(piece, document)
+        container_bounds, boundaries, anchor_positions, _nested_partition = _anchor_cut_plan(
+            piece, document, owned, elements, ranges)
+        if len(boundaries) < 2:
+            continue
+        container_start = container_bounds[0]
+        container = next(
+            (element for element, (start, _end) in zip(elements, ranges)
+             if start == container_start), None)
+        if container is None:
+            raise _UnsafeSplit("nested split container has no lexical element")
+        refined = _partition_nested_document(
+            piece, boundaries, container_bounds, container, elements, ranges)
+        local_indexes = _fragment_piece_map(
+            document, elements, ranges, boundaries,
+            list(range(len(refined))), anchor_positions)
+        refinements[piece_index] = refined, local_indexes
+
+    if not refinements:
+        return pieces, fragment_indexes, list(range(len(pieces)))
+
+    flattened = []
+    name_slots = []
+    first_indexes = {}
+    next_extra_slot = len(pieces)
+    for piece_index, piece in enumerate(pieces):
+        first_indexes[piece_index] = len(flattened)
+        refinement = refinements.get(piece_index)
+        if refinement is None:
+            flattened.append(piece)
+            name_slots.append(piece_index)
+            continue
+        flattened.extend(refinement[0])
+        # The first refined child retains the name this first-pass piece had.
+        # Extra children use names after every first-pass name, so refining an
+        # early group cannot rename later chapters that already split safely.
+        name_slots.append(piece_index)
+        extra_count = len(refinement[0]) - 1
+        name_slots.extend(range(next_extra_slot, next_extra_slot + extra_count))
+        next_extra_slot += extra_count
+    if (len(flattened) > MAX_SPLIT_PIECES
+            or sum(map(len, flattened)) > MAX_SPLIT_PEAK_BYTES):
+        raise _UnsafeSplit(
+            "nested split exceeds the {}-byte / {}-piece budget".format(
+                MAX_SPLIT_PEAK_BYTES, MAX_SPLIT_PIECES))
+
+    final_indexes = {}
+    for fragment, piece_index in fragment_indexes.items():
+        destination = first_indexes[piece_index]
+        refinement = refinements.get(piece_index)
+        if refinement is not None:
+            destination += refinement[1].get(fragment, 0)
+        final_indexes[fragment] = destination
+    return flattened, final_indexes, name_slots
 
 
 def _replacement_for_reference(value, document_path, split_plans):
@@ -650,18 +796,37 @@ def _plan_splits(archive, opf_path, opf_bytes, candidates, archive_names):
         if document.xpath("//*[local-name()='base'][@href]"):
             raise _UnsafeSplit("HTML base href prevents reference-safe splitting")
         elements, ranges = _element_positions(source, document)
-        container_bounds, boundaries, anchor_positions = _anchor_cut_plan(
+        container_bounds, boundaries, anchor_positions, nested_partition = _anchor_cut_plan(
             source, document, fragments, elements, ranges)
         # Several TOC anchors may live in one direct child of the common
-        # ancestor. They are inseparable by lexical slicing, but every other
-        # distinct child remains a safe split boundary.
+        # ancestor. Preserve every distinct first-pass boundary, then refine
+        # any still-collapsed piece with its own lexical container below.
         if len(boundaries) < 2:
             continue
         ordered_fragments = sorted(fragments, key=anchor_positions.__getitem__)
-        piece_names = _unique_piece_names(document_path, len(boundaries), occupied_names)
-        pieces = _partition_document(source, boundaries, container_bounds)
-        fragment_pieces = _fragment_piece_map(
-            document, elements, ranges, boundaries, piece_names, anchor_positions)
+        if nested_partition:
+            container_start = container_bounds[0]
+            container = next(
+                (element for element, (start, _end) in zip(elements, ranges)
+                 if start == container_start), None)
+            if container is None:
+                raise _UnsafeSplit("nested split container has no lexical element")
+            pieces = _partition_nested_document(
+                source, boundaries, container_bounds, container, elements, ranges)
+        else:
+            pieces = _partition_document(source, boundaries, container_bounds)
+        fragment_indexes = _fragment_piece_map(
+            document, elements, ranges, boundaries,
+            list(range(len(pieces))), anchor_positions)
+        pieces, fragment_indexes, name_slots = _refine_nested_pieces(
+            pieces, fragments, fragment_indexes)
+        allocated_names = _unique_piece_names(
+            document_path, len(pieces), occupied_names)
+        piece_names = [allocated_names[slot] for slot in name_slots]
+        fragment_pieces = {
+            fragment: piece_names[index]
+            for fragment, index in fragment_indexes.items()
+        }
         plans[document_path] = {
             "source": source,
             "manifest_id": item_id,

--- a/tests/unit/test_1657_spine_splitter.py
+++ b/tests/unit/test_1657_spine_splitter.py
@@ -214,7 +214,7 @@ def test_real_kepub_shape_preserves_every_kobo_span_lexeme_byte_exact(tmp_path):
 
 
 @pytest.mark.unit
-def test_shared_cut_element_keeps_anchors_together_without_aborting_other_splits(tmp_path):
+def test_shared_wrapper_is_refined_without_renaming_later_first_pass_piece(tmp_path):
     chapter = (
         b'<html xmlns="http://www.w3.org/1999/xhtml"><body class="calibre">'
         b'<div id="book-columns"><div id="book-inner">'
@@ -239,17 +239,71 @@ def test_shared_cut_element_keeps_anchors_together_without_aborting_other_splits
     assert _split(book) is True
 
     contents, _manifest, spine, targets = _package_state(book)
-    assert spine == ["chapter", "chapter-split"]
+    assert spine == ["chapter", "chapter-split", "chapter-split-1"]
     assert targets == [
         "chapter-split-1.xhtml",
-        "chapter-split-1.xhtml",
+        "chapter-split-3.xhtml",
         "chapter-split-2.xhtml",
     ]
     first = contents["OPS/chapter-split-1.xhtml"]
     second = contents["OPS/chapter-split-2.xhtml"]
-    assert b'id="ch1"' in first and b'id="ch1b"' in first
+    third = contents["OPS/chapter-split-3.xhtml"]
+    assert b'id="ch1"' in first and b'id="ch1b"' not in first
+    assert b'id="ch1b"' in third
     assert b'id="ch2"' not in first
     assert b'id="ch2"' in second
+
+
+@pytest.mark.unit
+def test_mixed_top_level_and_nested_groups_refine_in_place(tmp_path):
+    chapter = (
+        b'<html xmlns="http://www.w3.org/1999/xhtml"><body><div id="book-columns">'
+        b'<div id="book-inner">'
+        b'<h1 id="front"><i id="ch2"></i>'
+        b'<span class="koboSpan" id="kobo.1.1">front</span></h1>'
+        b'<div class="header-wrapper">'
+        b'<h2 id="nested-1"><span class="koboSpan" id="kobo.2.1">one</span></h2>'
+        b'<h2 id="nested-2"><span class="koboSpan" id="kobo.3.1">two</span></h2>'
+        b'<h2 id="nested-3"><span class="koboSpan" id="kobo.4.1">three</span></h2>'
+        b'<h2 id="nested-4"><span class="koboSpan" id="kobo.5.1">four</span></h2>'
+        b'</div>'
+        b'<p><span class="koboSpan" id="kobo.5.2">trailing wrapper content</span></p>'
+        b'<h1 id="later"><span class="koboSpan" id="kobo.6.1">later</span></h1>'
+        b'</div></div></body></html>')
+    book = _book(
+        tmp_path,
+        targets=(
+            "chapter.xhtml#front",
+            "chapter.xhtml#nested-1",
+            "chapter.xhtml#nested-2",
+            "chapter.xhtml#nested-3",
+            "chapter.xhtml#nested-4",
+            "chapter.xhtml#later",
+        ),
+        chapter=chapter,
+    )
+
+    assert _split(book) is True
+
+    contents, _manifest, spine, targets = _package_state(book)
+    assert len(spine) == 6
+    assert targets == [
+        "chapter-split-1.xhtml",
+        "chapter-split-2.xhtml",
+        "chapter-split-4.xhtml",
+        "chapter-split-5.xhtml",
+        "chapter-split-6.xhtml",
+        "chapter-split-3.xhtml",
+    ]
+    # The already-correct later first-pass chapter keeps split-3; only the
+    # newly separated nested chapters consume names from the numeric tail.
+    assert b'id="later"' in contents["OPS/chapter-split-3.xhtml"]
+    assert b'id="nested-2"' in contents["OPS/chapter-split-4.xhtml"]
+    assert sum(
+        content.count(b'id="kobo.5.2"')
+        for name, content in contents.items() if "chapter-split-" in name
+    ) == 1
+    assert b'id="kobo.5.2"' in contents["OPS/chapter-split-6.xhtml"]
 
 
 @pytest.mark.unit
@@ -379,21 +433,25 @@ def test_meaningful_content_outside_descent_container_is_not_duplicated(tmp_path
     )
     _add_spine_document(book, "nested.xhtml", "nested", nested)
 
-    # The ordinary chapter proves planning and writing actually proceed; the
-    # unsafe nested candidate must remain byte-exact instead of being copied
-    # around each descended piece.
+    # The sibling paragraph belongs only to the first descended piece; later
+    # pieces receive lexical ancestor tags, not a copy of surrounding content.
     assert _split(book) is True
 
     contents, _manifest, spine, targets = _package_state(book)
-    assert spine == ["chapter", "chapter-split", "nested"]
-    assert contents["OPS/nested.xhtml"] == nested
-    assert contents["OPS/nested.xhtml"].count(b"Meaningful sibling content") == 1
+    assert spine == [
+        "chapter", "chapter-split", "nested", "nested-split", "nested-split-1"]
+    nested_pieces = [
+        contents["OPS/nested-split-{}.xhtml".format(index)]
+        for index in range(1, 4)
+    ]
+    assert sum(piece.count(b"Meaningful sibling content") for piece in nested_pieces) == 1
+    assert b"Meaningful sibling content" in nested_pieces[0]
     assert targets == [
         "chapter-split-1.xhtml",
         "chapter-split-2.xhtml",
-        "nested.xhtml#outer",
-        "nested.xhtml#nested-1",
-        "nested.xhtml#nested-2",
+        "nested-split-1.xhtml",
+        "nested-split-2.xhtml",
+        "nested-split-3.xhtml",
     ]
 
 
@@ -573,7 +631,7 @@ def test_unsupported_reference_attribute_causes_a_byte_identical_noop(tmp_path):
 
 
 @pytest.mark.unit
-def test_nested_boundary_that_cannot_form_valid_documents_is_left_untouched(tmp_path):
+def test_outer_anchor_and_one_inner_anchor_form_two_valid_documents(tmp_path):
     chapter = (
         b'<html xmlns="http://www.w3.org/1999/xhtml"><body><div id="ch1">'
         b'<span class="koboSpan" id="kobo.1.1">one</span>'
@@ -581,10 +639,38 @@ def test_nested_boundary_that_cannot_form_valid_documents_is_left_untouched(tmp_
         b'</section></div></body></html>'
     )
     book = _book(tmp_path, chapter=chapter)
-    before = book.read_bytes()
+    assert _split(book) is True
 
-    assert _split(book) is False
-    assert book.read_bytes() == before
+    contents, _manifest, spine, targets = _package_state(book)
+    assert spine == ["chapter", "chapter-split"]
+    assert targets == ["chapter-split-1.xhtml", "chapter-split-2.xhtml"]
+    assert b'id="ch1"' in contents["OPS/chapter-split-1.xhtml"]
+    assert b'id="ch2"' not in contents["OPS/chapter-split-1.xhtml"]
+    assert b'id="ch1"' in contents["OPS/chapter-split-2.xhtml"]
+    assert b'id="ch2"' in contents["OPS/chapter-split-2.xhtml"]
+
+
+@pytest.mark.unit
+def test_ncx_page_list_anchor_is_rebased_but_never_becomes_a_cut(tmp_path):
+    chapter = _chapter().replace(
+        b'<p><span class="koboSpan" id="kobo.1.1">First</span>',
+        b'<p id="page-1"><span class="koboSpan" id="kobo.1.1">First</span>',
+    )
+    ncx = _ncx(("chapter.xhtml#ch1", "chapter.xhtml#ch2")).replace(
+        b"</ncx>",
+        b'<pageList><pageTarget id="page"><navLabel><text>1</text></navLabel>'
+        b'<content src="chapter.xhtml#page-1"/></pageTarget></pageList></ncx>',
+    )
+    book = _book(tmp_path, chapter=chapter, ncx=ncx)
+
+    assert _split(book) is True
+
+    contents, _manifest, spine, targets = _package_state(book)
+    assert spine == ["chapter", "chapter-split"]
+    assert targets == ["chapter-split-1.xhtml", "chapter-split-2.xhtml"]
+    toc = etree.fromstring(contents["OPS/toc.ncx"])
+    assert toc.xpath("string(//*[local-name()='pageTarget']/*[local-name()='content']/@src)") == (
+        "chapter-split-1.xhtml#page-1")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes the last structural pattern blocking Kobo highlight anchoring (finding **F-178d9a**).

## The shape

The NCA partition projects every chapter anchor up to the child of their nearest common ancestor and
cuts there. When one TOC entry is an **ancestor of the others**, all anchors project onto that single
child, collapse to one cut point, and the document is left whole — correct and safe, but every inner
chapter stays unreachable. Don Quixote is the canonical case: 11 anchors, all inside
`div#pgepubid00010`.

A second sub-shape turned up during implementation and is not in the finding: documents with an outer
anchor plus **exactly one** inner anchor, which the "two inner cut points" predicate excluded.

## Measured, on the 41-book reference library

| | anchorable / total |
|---|---|
| merged-main baseline | 1584 / 1653 |
| this branch | **1610 / 1653** |

+26 chapters. Per book: Importance of Being Earnest +6; Crime and Punishment x3 +3 each;
Moby Dick +3; Don Quixote x2 +2 each; The Prince +2; Meditations +2. The other 32 books are
byte-identical before and after.

**What the total actually means.** Of the 43 remaining entries, **35 are `#pg-footer-heading`** —
Project Gutenberg's licence footer, a TOC entry but not a chapter and not a thing anyone highlights.
Excluding those, this is **1610 of 1618 (99.5%)**, with 8 real unreachable chapters left.

## Deterministic naming is preserved

Piece names are load-bearing: `package_was_split_by_us` and the annotation-preserving re-split guard
in `cps/tasks/convert.py` depend on them, so a rename would strand existing highlights. First-pass
filename slots are reserved before nested pieces are allocated, so refining `split2` yields
`split1, split2, split4, split5, split6, split3` and the later first-pass piece keeps its name.
A regression test pins exactly that.

## Mutation evidence — independently re-run by the reviewer, not taken on report

| mutation (degrade, not delete) | splitter suite |
|---|---|
| `_has_nested_cut` -> constant False | **6 failed**, 45 passed |
| `_has_nested_cut` -> constant True | 51 passed — *equivalent mutant*, 1610 unchanged on all 41 books |
| `_should_refine_nested_piece` -> constant False | **2 failed**, 49 passed |
| `_should_refine_nested_piece` -> constant True | 51 passed — *equivalent mutant*, 1610 unchanged on all 41 books |

Stated plainly: both predicates are guards whose True direction is redundant on real input — the
discrimination is in the False direction, and the suite catches both. The True rows were measured
against the full library rather than assumed equivalent.

## Safety

- `pageList` anchors never become split boundaries (they are page numbers pointing into a chapter);
  a test proves one is rebased but creates no piece.
- A document that cannot be split correctly is left untouched — no split, no rewrite.
- The existing KoboSpan multiset validator caught a real defect during development (duplicated
  trailing content in Moby Dick) and refused the rewrite; the final edge-aware shell fixes it.
- All 41 source KEPUBs SHA-256 verified unchanged after measurement.
- No new dependencies.