### PR TITLE
fix(kobo): close the two holes in the KoboReader.sqlite annotation recovery path

### DIFF
--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -295,12 +295,11 @@ def annotations_import_form():
 @user_login_required
 def annotations_import_submit():
     """Accept an uploaded ``KoboReader.sqlite``, parse the Bookmark
-    table, and INSERT each highlight into ``kobo_annotation_sync``
+    table, and merge each recoverable annotation into ``kobo_annotation_sync``
     for the current user.
 
-    Returns a JSON summary: ``{imported, skipped_existing, skipped_orphan,
-    skipped_hidden, total_seen}`` — the upload form swaps to a result
-    pane without a page reload.
+    Returns a JSON summary with new/updated and reasoned skip counts; the
+    upload form swaps to a result pane without a page reload.
     """
     try:
         with temporary_kobo_database(
@@ -350,29 +349,163 @@ def _ingest_bookmarks(sqlite_path: str) -> dict:
     )
 
 
+def _bookmark_has_recoverable_content(text, note, annotation_type) -> bool:
+    """Whether a device row carries evidence of an annotation.
+
+    Kobo stores highlights in ``Text``, attached/note-only writing in
+    ``Annotation``, and dogears (whose text is empty) in ``Type``. Keep all
+    three inputs explicit: reducing this to the historical ``bool(Text)`` gate
+    makes dogears and note-only rows disappear again.
+    """
+    return any(
+        isinstance(value, str) and bool(value.strip())
+        for value in (text, note, annotation_type)
+    )
+
+
+def _parse_kobo_datetime(value):
+    """Parse a Kobo ISO-8601 clock into the DB's naive-UTC convention."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def _naive_utc(value):
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def _device_edit_is_newer(device_modified_at, existing) -> bool:
+    """Return whether an imported device edit may replace ``existing``.
+
+    The device must supply a valid clock later than *every* clock recording an
+    accepted state on the server. Comparing only to ``client_modified_at``
+    would let an older snapshot overwrite a later server/web edit; comparing
+    only to server receipt time would ignore the device's edit ordering. The
+    maximum is deliberately conservative because recovery must prefer a
+    reported conflict over silent loss of newer server state.
+    """
+    if device_modified_at is None:
+        return False
+    accepted_clocks = [
+        _naive_utc(getattr(existing, name, None))
+        for name in (
+            "client_modified_at", "server_modified_at", "last_synced", "created_at",
+        )
+    ]
+    watermark = max((clock for clock in accepted_clocks if clock is not None), default=None)
+    return watermark is None or device_modified_at > watermark
+
+
+def _bookmark_values(bm, content_id):
+    return (
+        bm.text,
+        bm.annotation,
+        bm.color,
+        content_id,
+        bm.start_container_path,
+        bm.start_container_child_index,
+        bm.start_offset,
+        bm.end_container_path,
+        bm.end_container_child_index,
+        bm.end_offset,
+        bm.context_string,
+        bm.chapter_progress,
+        to_storage_type(bm.annotation_type),
+    )
+
+
+def _annotation_values(row):
+    return (
+        row.highlighted_text,
+        row.note_text,
+        to_storage_color(row.highlight_color),
+        row.content_id,
+        row.start_container_path,
+        row.start_container_child_index,
+        row.start_offset,
+        row.end_container_path,
+        row.end_container_child_index,
+        row.end_offset,
+        row.context_string,
+        row.chapter_progress,
+        to_storage_type(row.annotation_type),
+    )
+
+
+def _bookmark_matches_annotation(bm, content_id, row) -> bool:
+    return not bool(row.hidden) and _bookmark_values(bm, content_id) == _annotation_values(row)
+
+
+def _apply_imported_bookmark(row, bm, content_id, *, device_modified_at,
+                             origin_device_id):
+    """Apply the content half of an already-authorised newer device edit."""
+    (
+        row.highlighted_text,
+        row.note_text,
+        row.highlight_color,
+        row.content_id,
+        row.start_container_path,
+        row.start_container_child_index,
+        row.start_offset,
+        row.end_container_path,
+        row.end_container_child_index,
+        row.end_offset,
+        row.context_string,
+        row.chapter_progress,
+        row.annotation_type,
+    ) = _bookmark_values(bm, content_id)
+    row.client_modified_at = device_modified_at
+    row.server_modified_at = datetime.now(timezone.utc)
+    row.last_synced = datetime.now(timezone.utc)
+    row.last_editor_device_id = origin_device_id
+    row.content_revision = (row.content_revision or 1) + 1
+    # Deliberately do not assign ``hidden``. Device-side deletion is not an
+    # import authority, and a recovery upload must never hide a server row.
+
+
 def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
                      origin_device_id=None) -> dict:
     """Walk the parsed bookmarks, resolve VolumeIDs via ``book_lookup``,
-    INSERT new highlights into ``kobo_annotation_sync``. Dependencies
+    merge annotations into ``kobo_annotation_sync``. Dependencies
     are explicit so this function is unit-testable without a Flask app.
 
     The annotation-backup hook fires automatically on commit so the
     user already has a recoverable snapshot.
 
-    NOTE: this import is INSERT-ONLY. An annotation the server already holds
-    for that (user, book) is skipped without comparing DateModified, text,
-    note, colour, position or hidden state, so re-importing a newer device
-    database cannot apply an edit or a device-side deletion. The previous
-    wording here described an "overwrite" the code has never performed
-    (findings F-e628c6).
+    Existing rows are updated only when the device's valid ``DateModified`` is
+    later than every accepted server/client modification clock on the row.
+    This deliberately favours the server on missing, malformed, equal, or
+    older device clocks: an import is a recovery operation and must not silently
+    overwrite state that may have been edited after the device snapshot.
+
+    Hidden device rows are counted but never applied. Importing device-side
+    deletion is intentionally outside this recovery path's authority.
 
     Returns a counts dict the JSON endpoint hands back to the browser.
     """
     imported = 0
+    updated = 0
     skipped_existing = 0
     skipped_orphan = 0
     skipped_hidden = 0
+    skipped_empty = 0
+    skipped_invalid = 0
+    skipped_newer_server = 0
     skipped_invalid_content_id = 0
+    failed = 0
     total_seen = 0
 
     # Cache: VolumeID -> CW book_id (or None for not-in-library).
@@ -383,6 +516,17 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
         total_seen += 1
         if bm.hidden:
             skipped_hidden += 1
+            continue
+        if not _bookmark_has_recoverable_content(
+                bm.text, bm.annotation, bm.annotation_type):
+            skipped_empty += 1
+            continue
+        if not bm.bookmark_id or not bm.volume_id:
+            skipped_invalid += 1
+            continue
+        normalized_type = to_storage_type(bm.annotation_type)
+        if normalized_type is not None and len(normalized_type) > 32:
+            skipped_invalid += 1
             continue
 
         # Resolve VolumeID -> CW book.id. Kobo writes either a UUID or
@@ -407,15 +551,11 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
         # upserts on that same triple; checking only (user_id, annotation_id)
         # made one book's row suppress a row the schema explicitly permits in
         # another book. `ix_annotation_user_book` covers this lookup.
-        existing = session.query(ub.Annotation.id).filter(
+        existing = session.query(ub.Annotation).filter(
             ub.Annotation.user_id == user_id,
             ub.Annotation.book_id == book_id,
             ub.Annotation.annotation_id == bm.bookmark_id,
         ).first()
-        if existing is not None:
-            skipped_existing += 1
-            continue
-
         from .services.annotation_content_id import normalize_content_id, ContentIdError
         try:
             content_id = normalize_content_id(
@@ -423,6 +563,22 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
             )
         except ContentIdError:
             skipped_invalid_content_id += 1
+            continue
+
+        device_modified_at = _parse_kobo_datetime(bm.date_modified)
+        if existing is not None:
+            if not _device_edit_is_newer(device_modified_at, existing):
+                if _bookmark_matches_annotation(bm, content_id, existing):
+                    skipped_existing += 1
+                else:
+                    skipped_newer_server += 1
+                continue
+            _apply_imported_bookmark(
+                existing, bm, content_id,
+                device_modified_at=device_modified_at,
+                origin_device_id=origin_device_id,
+            )
+            updated += 1
             continue
 
         row = ub.Annotation(
@@ -450,6 +606,8 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
             source="kobo",
             origin_device_id=origin_device_id,
             hidden=False,
+            client_modified_at=device_modified_at,
+            server_modified_at=datetime.now(timezone.utc),
         )
         session.add(row)
         imported += 1
@@ -464,14 +622,21 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
     except Exception as e:
         log.error("annotations: import commit failed: %s", e)
         session.rollback()
+        failed = imported + updated
         imported = 0
+        updated = 0
 
     return {
         "imported": imported,
+        "updated": updated,
         "skipped_existing": skipped_existing,
         "skipped_orphan": skipped_orphan,
         "skipped_hidden": skipped_hidden,
+        "skipped_empty": skipped_empty,
+        "skipped_invalid": skipped_invalid,
+        "skipped_newer_server": skipped_newer_server,
         "skipped_invalid_content_id": skipped_invalid_content_id,
+        "failed": failed,
         "total_seen": total_seen,
     }
 

--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -372,11 +372,11 @@ def _parse_kobo_datetime(value):
         raw = raw[:-1] + "+00:00"
     try:
         parsed = datetime.fromisoformat(raw)
-    except ValueError:
+        if parsed.tzinfo is None:
+            return None
+        return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    except (ValueError, OverflowError):
         return None
-    if parsed.tzinfo is None:
-        return None
-    return parsed.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 def _naive_utc(value):

--- a/cps/services/kobo_import.py
+++ b/cps/services/kobo_import.py
@@ -71,8 +71,8 @@ class ParsedBookmark:
     book-id (typically the EPUB UUID); the caller maps it to a CW
     ``books.id`` separately."""
 
-    bookmark_id: str               # Bookmark.BookmarkID (UUID)
-    volume_id: str                 # Bookmark.VolumeID — match against Books.uuid
+    bookmark_id: Optional[str]     # Bookmark.BookmarkID (UUID)
+    volume_id: Optional[str]       # Bookmark.VolumeID — match against Books.uuid
     content_id: Optional[str]      # Bookmark.ContentID — chapter pointer
     start_container_path: Optional[str]
     start_container_child_index: Optional[int]
@@ -80,7 +80,7 @@ class ParsedBookmark:
     end_container_path: Optional[str]
     end_container_child_index: Optional[int]
     end_offset: Optional[int]
-    text: str                      # Bookmark.Text (the highlighted passage)
+    text: Optional[str]            # Bookmark.Text (the highlighted passage)
     annotation: Optional[str]      # Bookmark.Annotation (user's typed note)
     context_string: Optional[str]
     chapter_progress: Optional[float]
@@ -162,6 +162,7 @@ def parse_kobo_device_books(sqlite_path):
         raise KoboContentDatabaseError("Could not open the device database") from error
 
     try:
+        connection.execute("PRAGMA query_only = ON")
         table = connection.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='content'"
         ).fetchone()
@@ -266,14 +267,11 @@ def looks_like_sqlite(blob_or_path) -> bool:
 
 
 def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
-    """Open ``sqlite_path`` read-only, walk every Bookmark row whose
-    ``Text`` is non-empty, yield :class:`ParsedBookmark` instances.
+    """Open ``sqlite_path`` read-only and yield every ``Bookmark`` row.
 
-    Yields nothing if the file is not SQLite, the Bookmark table
-    doesn't exist, or the table is empty — never raises on a
-    malformed payload. Callers test the iterator for emptiness to
-    distinguish "no annotations" from "import failed for a real
-    reason" (which we log).
+    Yields nothing if the file is not SQLite, the Bookmark table doesn't exist,
+    the table is empty, or a read fails. Read failures are logged; this iterator
+    deliberately has no separate error channel.
     """
     if not isinstance(sqlite_path, Path):
         sqlite_path = Path(sqlite_path)
@@ -292,6 +290,10 @@ def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
         return
 
     try:
+        # Keep the connection non-writing at both layers. ``mode=ro`` is the
+        # filesystem boundary; query_only also prevents a future refactor from
+        # accidentally issuing a write through this already-open connection.
+        conn.execute("PRAGMA query_only = ON")
         cur = conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='Bookmark'"
         )
@@ -300,11 +302,10 @@ def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
             return
 
         # Bookmark.Type is the device's own word for what a row is
-        # ("highlight"; a Kobo also uses "dogear", which cannot reach us because
-        # of the Text filter below). Selected conditionally: naming a column an
-        # older firmware lacks would fail the whole query and lose every
-        # annotation on the device, which is a far worse outcome than importing
-        # them untyped.
+        # (normally "highlight" or "dogear"). Selected conditionally: naming a
+        # column an older firmware lacks would fail the whole query and lose
+        # every annotation on the device, which is a far worse outcome than
+        # importing them untyped.
         has_type = any(
             row[1] == "Type"
             for row in conn.execute("PRAGMA table_info(Bookmark)").fetchall()
@@ -317,7 +318,6 @@ def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
                 Text, Annotation, Color, ContextString,
                 ChapterProgress, DateCreated, DateModified, Hidden, {type_column}
             FROM Bookmark
-            WHERE Text IS NOT NULL AND Text != ''
         """.format(type_column="Type" if has_type else "NULL")).fetchall()
     except sqlite3.DatabaseError as e:
         log.warning("kobo_import: SQL error on %s: %s", sqlite_path, e)
@@ -330,10 +330,6 @@ def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
          sp, sci, so, ep, eci, eo,
          text, annotation, color, ctx,
          chapter_progress, dcreated, dmod, hidden, bm_type) = r
-        if not bm_id or not volume_id:
-            # Malformed row — Kobo doesn't normally emit these. Skip
-            # rather than abort the whole import.
-            continue
         yield ParsedBookmark(
             bookmark_id=bm_id,
             volume_id=volume_id,

--- a/cps/templates/annotations_import.html
+++ b/cps/templates/annotations_import.html
@@ -22,10 +22,16 @@
   <div id="annotations-import-result" style="margin-top: 1.5em; display: none;">
     <h3>{{ _('Import summary') }}</h3>
     <ul>
-      <li><strong id="result-imported">0</strong> {{ _('new highlights imported') }}</li>
+      <li><strong id="result-imported">0</strong> {{ _('new annotations imported') }}</li>
+      <li><strong id="result-updated">0</strong> {{ _('existing annotations updated from a newer device copy') }}</li>
       <li><strong id="result-existing">0</strong> {{ _('already imported (skipped)') }}</li>
+      <li><strong id="result-newer-server">0</strong> {{ _('different or undated device entries older than server state (skipped)') }}</li>
       <li><strong id="result-orphan">0</strong> {{ _('for books not in this library (skipped)') }}</li>
-      <li><strong id="result-hidden">0</strong> {{ _('hidden on device (skipped)') }}</li>
+      <li><strong id="result-hidden">0</strong> {{ _('hidden on device (reported, not applied)') }}</li>
+      <li><strong id="result-empty">0</strong> {{ _('empty bookmark rows with no annotation content (skipped)') }}</li>
+      <li><strong id="result-invalid">0</strong> {{ _('invalid bookmark rows (skipped)') }}</li>
+      <li><strong id="result-invalid-content">0</strong> {{ _('entries with invalid book positions (skipped)') }}</li>
+      <li><strong id="result-failed">0</strong> {{ _('entries not saved because the import transaction failed') }}</li>
       <li><strong id="result-total">0</strong> {{ _('total entries seen') }}</li>
     </ul>
   </div>
@@ -60,9 +66,15 @@
       statusEl.textContent = '';
       if (res.ok) {
         document.getElementById('result-imported').textContent = res.body.imported || 0;
+        document.getElementById('result-updated').textContent = res.body.updated || 0;
         document.getElementById('result-existing').textContent = res.body.skipped_existing || 0;
+        document.getElementById('result-newer-server').textContent = res.body.skipped_newer_server || 0;
         document.getElementById('result-orphan').textContent = res.body.skipped_orphan || 0;
         document.getElementById('result-hidden').textContent = res.body.skipped_hidden || 0;
+        document.getElementById('result-empty').textContent = res.body.skipped_empty || 0;
+        document.getElementById('result-invalid').textContent = res.body.skipped_invalid || 0;
+        document.getElementById('result-invalid-content').textContent = res.body.skipped_invalid_content_id || 0;
+        document.getElementById('result-failed').textContent = res.body.failed || 0;
         document.getElementById('result-total').textContent = res.body.total_seen || 0;
         resultEl.style.display = 'block';
       } else {

--- a/tests/fixtures/kobo_reader_sqlite.py
+++ b/tests/fixtures/kobo_reader_sqlite.py
@@ -40,6 +40,11 @@ CREATE TABLE Bookmark (
 )
 """
 
+BOOKMARK_DDL_WITH_TYPE = BOOKMARK_DDL.replace(
+    "Hidden INTEGER DEFAULT 0\n)",
+    "Hidden INTEGER DEFAULT 0,\n    Type TEXT\n)",
+)
+
 
 def build_synthetic_kobo_db(
     path: Path,
@@ -191,28 +196,7 @@ def build_kobo_db_with_bookmark_type(
     import sqlite3
 
     conn = sqlite3.connect(path)
-    conn.execute("""
-        CREATE TABLE Bookmark (
-            BookmarkID TEXT PRIMARY KEY,
-            VolumeID TEXT,
-            ContentID TEXT,
-            StartContainerPath TEXT,
-            StartContainerChildIndex INTEGER,
-            StartOffset INTEGER,
-            EndContainerPath TEXT,
-            EndContainerChildIndex INTEGER,
-            EndOffset INTEGER,
-            Text TEXT,
-            Annotation TEXT,
-            Color INTEGER,
-            ContextString TEXT,
-            ChapterProgress REAL,
-            DateCreated TEXT,
-            DateModified TEXT,
-            Hidden INTEGER DEFAULT 0,
-            Type TEXT
-        )
-    """)
+    conn.executescript(BOOKMARK_DDL_WITH_TYPE)
     chapter1 = "{}!!chapter1.html".format(book_uuid)
     chapter2 = "{}!!chapter2.html".format(book_uuid)
     rows = [
@@ -228,6 +212,54 @@ def build_kobo_db_with_bookmark_type(
         ("bt-004", book_uuid, chapter2, "span#kobo\\.4\\.1", -99, 0,
          "span#kobo\\.4\\.2", -99, 5, "type is empty", None, 0, "ctx", 0.4,
          "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0, ""),
+    ]
+    conn.executemany(
+        "INSERT INTO Bookmark VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def build_kobo_db_with_recovery_rows(
+    path: Path,
+    book_uuid: str = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04",
+) -> Path:
+    """Current-device shapes that the old ``Text`` SQL gate made invisible.
+
+    A dogear has empty ``Text`` and identifies itself through ``Type``. A Kobo
+    highlight with only a typed note keeps ``Type='highlight'`` and puts the
+    user's writing in ``Annotation``. The final fully-empty row is a vacuity
+    guard: widening the old gate must not turn a row with no annotation evidence
+    into an imported annotation, but it must still be counted with a reason.
+    """
+    if not isinstance(path, Path):
+        path = Path(path)
+    if path.exists():
+        path.unlink()
+    conn = sqlite3.connect(path)
+    conn.executescript(BOOKMARK_DDL_WITH_TYPE)
+    chapter = f"{book_uuid}!!chapter1.html"
+    rows = [
+        (
+            "recover-dogear", book_uuid, chapter,
+            "span#kobo\\.7\\.1", -99, 0, "span#kobo\\.7\\.1", -99, 0,
+            "", None, None, None, 0.7,
+            "2026-08-18T12:00:00Z", "2026-08-18T12:00:00Z", 0, "dogear",
+        ),
+        (
+            "recover-note-only", book_uuid, chapter,
+            "span#kobo\\.8\\.1", -99, 3, "span#kobo\\.8\\.1", -99, 3,
+            "", "remember this", 4, "near the end", 0.8,
+            "2026-08-18T12:01:00Z", "2026-08-18T12:02:00Z", 0, "highlight",
+        ),
+        (
+            "recover-empty", book_uuid, chapter,
+            None, None, None, None, None, None,
+            "", None, None, None, None,
+            "2026-08-18T12:03:00Z", "2026-08-18T12:03:00Z", 0, None,
+        ),
     ]
     conn.executemany(
         "INSERT INTO Bookmark VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",

--- a/tests/unit/test_annotations_import_endpoint.py
+++ b/tests/unit/test_annotations_import_endpoint.py
@@ -42,6 +42,12 @@ from tests.fixtures.kobo_reader_sqlite import (
 )
 
 
+OVERFLOWING_KOBO_CLOCKS = (
+    pytest.param("9999-12-31T23:59:59-23:59", id="above-maxyear"),
+    pytest.param("0001-01-01T00:00:00+23:59", id="below-minyear"),
+)
+
+
 @pytest.fixture
 def memory_db(tmp_path, monkeypatch):
     """Same shape as the backup-feature fixture — full ub.Base schema
@@ -258,6 +264,56 @@ class TestPreviouslyInvisibleDeviceRows:
         assert result["skipped_hidden"] == 1, result
         assert row.hidden is False
         assert row.highlighted_text == "server copy stays visible"
+
+
+@pytest.mark.unit
+class TestOutOfRangeDeviceClock:
+    @pytest.mark.parametrize("clock", OVERFLOWING_KOBO_CLOCKS)
+    def test_parser_rejects_both_utc_overflows(self, clock):
+        from cps.annotations import _parse_kobo_datetime
+
+        assert _parse_kobo_datetime(clock) is None
+
+    @pytest.mark.parametrize("clock", OVERFLOWING_KOBO_CLOCKS)
+    def test_row_with_overflowing_clock_is_imported_and_accounted(
+        self, memory_db, synthetic_db, clock,
+    ):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        connection = sqlite3.connect(synthetic_db)
+        try:
+            connection.execute(
+                "UPDATE Bookmark SET DateModified = ? WHERE BookmarkID = 'bm-001'",
+                (clock,),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+        session, _, _ = memory_db
+        result = ingest_bookmarks(
+            synthetic_db,
+            user_id=7,
+            session=session,
+            book_lookup=_make_book_lookup({
+                "b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348,
+            }),
+            commit=session.commit,
+        )
+
+        row = session.query(ub.Annotation).filter_by(annotation_id="bm-001").one()
+        assert result["imported"] == 3, result
+        assert result["total_seen"] == 8, result
+        assert _accounted(result) == result["total_seen"]
+        assert row.client_modified_at is None
+
+    def test_valid_clock_keeps_its_existing_naive_utc_value(self):
+        from cps.annotations import _parse_kobo_datetime
+
+        assert _parse_kobo_datetime(
+            "2026-08-20T15:30:45.123456+02:30"
+        ) == datetime(2026, 8, 20, 13, 0, 45, 123456)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_annotations_import_endpoint.py
+++ b/tests/unit/test_annotations_import_endpoint.py
@@ -27,14 +27,19 @@ Coverage:
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
+import sqlite3
 from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from tests.fixtures.kobo_reader_sqlite import build_synthetic_kobo_db
+from tests.fixtures.kobo_reader_sqlite import (
+    build_kobo_db_with_recovery_rows,
+    build_synthetic_kobo_db,
+)
 
 
 @pytest.fixture
@@ -73,6 +78,14 @@ def _make_book_lookup(uuid_to_book_id: dict[str, int]):
     return lookup
 
 
+def _accounted(summary):
+    return sum(summary[key] for key in (
+        "imported", "updated", "skipped_existing", "skipped_orphan",
+        "skipped_hidden", "skipped_empty", "skipped_invalid",
+        "skipped_newer_server", "skipped_invalid_content_id", "failed",
+    ))
+
+
 @pytest.fixture
 def synthetic_db(tmp_path):
     return build_synthetic_kobo_db(tmp_path / "kr.sqlite")
@@ -103,9 +116,10 @@ class TestIngestCounts:
         assert result["skipped_hidden"] == 1, result
         assert result["skipped_orphan"] == 2, result    # bm-004 sideloaded + bm-006 unknown UUID
         assert result["skipped_existing"] == 0, result
-        # total_seen excludes empty BookmarkID + empty Text rows
-        # (filtered at the parser SQL level).
-        assert result["total_seen"] == 6, result
+        assert result["skipped_invalid"] == 1, result
+        assert result["skipped_empty"] == 1, result
+        assert result["total_seen"] == 8, result
+        assert _accounted(result) == result["total_seen"]
 
     def test_inserted_rows_carry_full_h1_payload(self, memory_db, synthetic_db):
         from cps import ub
@@ -174,6 +188,183 @@ class TestIngestCounts:
         assert displayed["bm-001"] == "yellow"
         assert displayed["bm-002"] == "pink"
         assert displayed["bm-003"] == "blue"
+
+
+@pytest.mark.unit
+class TestPreviouslyInvisibleDeviceRows:
+    def test_dogear_and_note_only_row_import_and_every_row_is_accounted(
+        self, memory_db, tmp_path,
+    ):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        book_uuid = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+        device_db = build_kobo_db_with_recovery_rows(tmp_path / "recovery.sqlite")
+
+        result = ingest_bookmarks(
+            device_db, user_id=7, session=session,
+            book_lookup=_make_book_lookup({book_uuid: 348}), commit=session.commit,
+        )
+        rows = {
+            row.annotation_id: row
+            for row in session.query(ub.Annotation).filter_by(user_id=7).all()
+        }
+
+        assert result["imported"] == 2, result
+        assert result["skipped_empty"] == 1, result
+        assert result["total_seen"] == 3, result
+        assert _accounted(result) == result["total_seen"]
+        assert set(rows) == {"recover-dogear", "recover-note-only"}
+        assert rows["recover-dogear"].highlighted_text == ""
+        assert rows["recover-dogear"].annotation_type == "dogear"
+        assert rows["recover-note-only"].highlighted_text == ""
+        assert rows["recover-note-only"].note_text == "remember this"
+        assert rows["recover-note-only"].annotation_type == "highlight"
+
+    def test_every_returned_count_is_presented_in_the_user_summary(self):
+        template = (
+            Path(__file__).parents[2] / "cps" / "templates" / "annotations_import.html"
+        ).read_text(encoding="utf-8")
+        for key in (
+            "imported", "updated", "skipped_existing", "skipped_orphan",
+            "skipped_hidden", "skipped_empty", "skipped_invalid",
+            "skipped_newer_server", "skipped_invalid_content_id", "failed",
+            "total_seen",
+        ):
+            assert f"res.body.{key}" in template
+
+    def test_hidden_device_row_is_reported_without_hiding_server_state(
+        self, memory_db, synthetic_db,
+    ):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        book_uuid = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+        session.add(ub.Annotation(
+            user_id=7, book_id=348, annotation_id="bm-005",
+            highlighted_text="server copy stays visible", hidden=False,
+            source="kobo", server_modified_at=datetime(2099, 1, 1),
+        ))
+        session.commit()
+
+        result = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=_make_book_lookup({book_uuid: 348}), commit=session.commit,
+        )
+        row = session.query(ub.Annotation).filter_by(annotation_id="bm-005").one()
+
+        assert result["skipped_hidden"] == 1, result
+        assert row.hidden is False
+        assert row.highlighted_text == "server copy stays visible"
+
+
+@pytest.mark.unit
+class TestNewerDeviceMerge:
+    BOOK_UUID = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+
+    @staticmethod
+    def _edit_fixture(path, *, modified, text, note, color=3):
+        connection = sqlite3.connect(path)
+        try:
+            connection.execute(
+                """
+                UPDATE Bookmark
+                SET Text = ?, Annotation = ?, Color = ?,
+                    ContentID = ?,
+                    StartContainerPath = ?, StartContainerChildIndex = ?, StartOffset = ?,
+                    EndContainerPath = ?, EndContainerChildIndex = ?, EndOffset = ?,
+                    ContextString = ?, ChapterProgress = ?, DateModified = ?
+                WHERE BookmarkID = 'bm-002'
+                """,
+                (
+                    text, note, color, f"{TestNewerDeviceMerge.BOOK_UUID}!!chapter9.html",
+                    "span#kobo\\.9\\.1", -99, 4,
+                    "span#kobo\\.9\\.2", -99, 17,
+                    "replacement context", 0.91, modified,
+                ),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+    def test_reimport_applies_every_field_from_a_newer_device_database(
+        self, memory_db, synthetic_db,
+    ):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        lookup = _make_book_lookup({self.BOOK_UUID: 348})
+        ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=lookup, commit=session.commit,
+        )
+        before = session.query(ub.Annotation).filter_by(annotation_id="bm-002").one()
+        before_revision = before.content_revision
+        self._edit_fixture(
+            synthetic_db, modified="2099-01-01T00:00:00Z",
+            text="edited passage", note="edited note", color=3,
+        )
+
+        result = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=lookup, commit=session.commit,
+        )
+        row = session.query(ub.Annotation).filter_by(annotation_id="bm-002").one()
+
+        assert result["updated"] == 1, result
+        assert result["skipped_existing"] == 2, result
+        assert _accounted(result) == result["total_seen"]
+        assert row.highlighted_text == "edited passage"
+        assert row.note_text == "edited note"
+        assert row.highlight_color == "#C6E09E"
+        assert row.content_id == f"{self.BOOK_UUID}!!chapter9.html"
+        assert row.start_container_path == "span#kobo\\.9\\.1"
+        assert row.start_container_child_index == -99
+        assert row.start_offset == 4
+        assert row.end_container_path == "span#kobo\\.9\\.2"
+        assert row.end_container_child_index == -99
+        assert row.end_offset == 17
+        assert row.context_string == "replacement context"
+        assert row.chapter_progress == 0.91
+        assert row.client_modified_at == datetime(2099, 1, 1)
+        assert row.content_revision == before_revision + 1
+
+    def test_older_device_copy_reports_conflict_without_overwriting_server(
+        self, memory_db, synthetic_db,
+    ):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        lookup = _make_book_lookup({self.BOOK_UUID: 348})
+        ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=lookup, commit=session.commit,
+        )
+        row = session.query(ub.Annotation).filter_by(annotation_id="bm-002").one()
+        row.note_text = "newer server note"
+        row.server_modified_at = datetime(2098, 1, 1)
+        session.commit()
+        self._edit_fixture(
+            synthetic_db, modified="2097-01-01T00:00:00Z",
+            text="stale device passage", note="stale device note",
+        )
+
+        result = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=lookup, commit=session.commit,
+        )
+        row = session.query(ub.Annotation).filter_by(annotation_id="bm-002").one()
+
+        assert result["updated"] == 0, result
+        assert result["skipped_newer_server"] == 1, result
+        assert _accounted(result) == result["total_seen"]
+        assert row.highlighted_text == "Four legs good, two legs bad."
+        assert row.note_text == "newer server note"
+        assert row.highlight_color == "#E8AFCF"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_kobo_import_parser.py
+++ b/tests/unit/test_kobo_import_parser.py
@@ -8,8 +8,8 @@
 Coverage:
 
 1. ``looks_like_sqlite`` accepts a real sqlite, rejects garbage.
-2. Parser yields one ``ParsedBookmark`` per valid Bookmark row.
-3. Hidden rows + empty-text rows + empty-BookmarkID rows are filtered.
+2. Parser yields one ``ParsedBookmark`` per Bookmark row so the ingest summary
+   can account for malformed, hidden, and empty rows itself.
 4. Color integers map to the MEASURED wire hex (finding F-5769c9).
 5. Multi-span highlight preserves both start + end fields.
 6. Note (Annotation) field round-trips.
@@ -20,6 +20,7 @@ Coverage:
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 
 import pytest
@@ -60,24 +61,30 @@ class TestLooksLikeSqlite:
 
 @pytest.mark.unit
 class TestParseKoboBookmarks:
-    def test_yields_one_per_valid_row(self, tmp_path):
+    def test_parser_keeps_both_read_only_sqlite_guards(self):
+        from cps.services.kobo_import import parse_kobo_bookmarks
+
+        source = inspect.getsource(parse_kobo_bookmarks)
+        assert "mode=ro&immutable=1" in source
+        assert 'conn.execute("PRAGMA query_only = ON")' in source
+
+    def test_yields_every_row_for_downstream_accounting(self, tmp_path):
         from cps.services.kobo_import import parse_kobo_bookmarks
 
         p = build_synthetic_kobo_db(tmp_path / "k.sqlite")
         rows = list(parse_kobo_bookmarks(p))
-        # Fixture has 6 valid-text rows (bm-001..006); bm-007 has empty
-        # BookmarkID + bm-008 has empty Text — both filtered.
+        # The parser classifies nothing: all eight SQL rows reach the caller,
+        # including the malformed id and empty-content row.
         bm_ids = {r.bookmark_id for r in rows}
+        assert len(rows) == 8
         assert "bm-001" in bm_ids
         assert "bm-002" in bm_ids
         assert "bm-003" in bm_ids
         assert "bm-004" in bm_ids  # sideloaded — yielded; caller decides
         assert "bm-005" in bm_ids  # hidden — yielded with hidden=True; caller filters
         assert "bm-006" in bm_ids
-        # malformed (empty BookmarkID) — filtered
-        assert "" not in bm_ids
-        # empty-Text — filtered at SQL level
-        assert "bm-008" not in bm_ids
+        assert "" in bm_ids
+        assert "bm-008" in bm_ids
 
     def test_color_map_normalized(self, tmp_path):
         from cps.services.kobo_import import parse_kobo_bookmarks


### PR DESCRIPTION
Closes **F-b1004e** and the open half of **F-e628c6**.

## Why this is data-integrity, not polish

The Kobo uploads a **delta**, so an annotation created while CWNG was not capturing is never
re-offered by the device, and `checkforchanges` containment (correctly) keeps the book out of the
Kobo-cloud download that could otherwise heal it. The `KoboReader.sqlite` import is therefore the
**only** recovery path that exists. F-a66189 measured 10 device-only highlights on real hardware.

That recovery path had two holes:

1. **Dogears and note-only rows were dropped in SQL** — `WHERE Text IS NOT NULL AND Text != ''`.
   A Kobo dogear is a `Bookmark` row with **empty `Text`** (13 measured on a Clara BW at 4.45.23792).
   They were not skipped-with-a-reason; they never reached `ingest_bookmarks`, were excluded from
   `total_seen`, and so could not appear in the summary the user reads. Meanwhile the *live* PATCH
   path stores them as `annotation_type='dogear'` — the two ingest routes disagreed about what an
   annotation is, and the recovery tool was the wrong one.
2. **Insert-only** — an existing row hit `skipped_existing; continue` with no comparison, so
   re-importing a **newer** device database could never apply an edit.

## What changed

Every `Bookmark` row is now selected and classified explicitly across all three device fields
(`Text`, `Annotation`, `Type`), and every row takes exactly one accounted-for path — the tests assert
the buckets **sum to `total_seen`**. The merge rule is explicit: an existing row changes only when the
imported, valid `DateModified` is strictly later than the max of `client_modified_at`,
`server_modified_at`, `last_synced`, `created_at`. Missing, malformed, equal or older device clocks
never overwrite; divergence is reported as `skipped_newer_server` rather than silently resolved.

## Deletion is deliberately out of scope

Hidden device rows stay **report-only** and never hide a server row — an uploaded recovery database
has no deletion authority. Annotation writeback is data-loss-class (F-3b565b) and operator-gated.
A test starts with a visible server row matching a hidden device row and proves it stays visible.

## Mutation evidence — the critical row independently re-run by the reviewer

| mutation (degrade, not delete) | result |
|---|---|
| content predicate -> **only `bool(Text)`** (recreates F-b1004e exactly) | **1 failed** — `test_dogear_and_note_only_row_import_and_every_row_is_accounted` |
| content predicate -> constant True | 7 failed, 8 passed |
| content predicate -> constant False | 13 failed, 2 passed |
| newer-device predicate -> constant True | 3 failed, 12 passed |
| newer-device predicate -> constant False | 1 failed, 14 passed |
| newer-device predicate -> ignores existing row | 3 failed, 12 passed |

The historical-bug row is the one that matters and was re-run independently: it fails the right
test for the right reason.

## Safety

- The upload is still opened `mode=ro&immutable=1`, now **also** with `PRAGMA query_only = ON`,
  pinned by a test at the parser boundary. The sibling uploaded-device scanner got the same guard.
- SQLite header validation and the size cap are unchanged.
- No path writes to the uploaded file.
- No new dependencies.

⚠️ Clock-skew caveat, disclosed: taking the max across device and server clocks is conservative.
Significant Kobo clock skew can turn a genuinely newer device edit into a reported conflict. It
cannot cause a silent overwrite of a server state whose recorded clock is later.