### PR TITLE
tools(kobo): make the anchorability measure name its residue, and make it testable

### DIFF
--- a/scripts/measure_kobo_anchorable_chapters.py
+++ b/scripts/measure_kobo_anchorable_chapters.py
@@ -11,13 +11,42 @@ fragment. So the test of the fix is not "were files split" but: does every
 chapter-TOC entry derive an identity that (a) carries no fragment and (b) matches
 exactly one spine document?
 """
-import os, sys, re, zipfile, collections, shutil, tempfile, posixpath
+import collections
+import os
+import posixpath
+import re
+import shutil
+import sys
+import tempfile
+import zipfile
 from urllib.parse import unquote
-sys.path.insert(0, os.getcwd())
+
 from lxml import etree
-from cps.services.kepub_package_normalizer import normalize_kepub_package
 
 P = etree.XMLParser(resolve_entities=False, recover=False)
+
+
+def _normalizer():
+    """Load the application normalizer only when the instrument is executed."""
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+    from cps.services.kepub_package_normalizer import normalize_kepub_package
+
+    return normalize_kepub_package
+
+
+def _is_anchorable(identity, chapter_rows):
+    return "#" not in identity and identity in chapter_rows
+
+
+def _duplicate_excess(count):
+    return count - 1 if count > 1 else 0
+
+
+def _is_footer_fragment(fragment):
+    return "footer" in fragment.lower()
+
 
 def package(z):
     c = etree.fromstring(z.read("META-INF/container.xml"), parser=P)
@@ -40,104 +69,124 @@ def analyse(path):
             if low.endswith(".ncx"):
                 d = z.read(n).decode("utf-8", "replace")
                 m = re.search(r"<navMap\b", d)
-                if not m: continue
+                if not m:
+                    continue
                 end = d.find("</navMap>", m.start())
                 targets += re.findall(r'<content\s+src="([^"]+)"', d[m.start():end])
             elif low.endswith("nav.xhtml"):
                 d = z.read(n).decode("utf-8", "replace")
                 for m in re.finditer(r'<nav\b[^>]*epub:type="([^"]*)"[^>]*>', d):
-                    if "toc" not in m.group(1).split(): continue
+                    if "toc" not in m.group(1).split():
+                        continue
                     end = d.find("</nav>", m.start())
                     targets += re.findall(r'href="([^"]+)"', d[m.start():end])
     derived = ["%s!%s!%s" % (uuid, opf_dir, unquote(t)) for t in targets]
-    anchored = [d for d in derived if "#" not in d and d in chapter_rows]
+    anchored = [d for d in derived if _is_anchorable(d, chapter_rows)]
     fragmented = [d for d in derived if "#" in d]
     counts = collections.Counter(anchored)
     # two TOC entries deriving the SAME identity = only one chapter is reachable
-    duplicated = sum(c - 1 for c in counts.values() if c > 1)
+    duplicated = sum(_duplicate_excess(c) for c in counts.values())
     # the fragment NAMES, so --residue can say WHICH targets are still unreachable
     frag_names = [d.split("#", 1)[1] for d in fragmented]
     return len(derived), len(anchored) - duplicated, len(fragmented), duplicated, frag_names
 
-LIB = sys.argv[1]
-#: `--no-split` runs the normalize-only control, which is what attributes the
-#: splitter's share instead of crediting it with normalization's work too.
-SPLIT = "--no-split" not in sys.argv[2:]
-#: `--residue` explains the leftovers instead of only counting them.
-RESIDUE = "--residue" in sys.argv[2:]
-rows = []
-with tempfile.TemporaryDirectory(prefix="cid-") as tmp:
-    for root, _, files in os.walk(LIB):
-        for f in files:
-            if not f.lower().endswith(".kepub"): continue
-            src = os.path.join(root, f)
-            try:
-                before = analyse(src)
-            except Exception as e:
-                continue
-            cp = os.path.join(tmp, "w.kepub"); shutil.copy2(src, cp)
-            try:
-                normalize_kepub_package(cp, split_chapters=SPLIT)
-                after = analyse(cp)
-            except Exception:
-                after = before
-            os.remove(cp)
-            rows.append((os.path.basename(root)[:36], before, after))
 
-print(f"{'book':38}{'BEFORE anchorable/total':>26}{'AFTER anchorable/total':>25}")
-tb=ta=tt=0
-for name,b,a in sorted(rows, key=lambda r: r[1][1]-r[1][0]):
-    if b[0]==0: continue
-    tb+=b[1]; ta+=a[1]; tt+=b[0]
-    if b[1]!=a[1]:
-        print(f"{name:38}{f'{b[1]}/{b[0]}':>26}{f'{a[1]}/{a[0]}':>25}")
-print(f"\nCHAPTERS A KOBO COULD ANCHOR A HIGHLIGHT IN, across {len(rows)} books:")
-print(f"  before: {tb} of {tt}    after: {ta} of {tt}")
-
-# The residue is worth naming rather than leaving as a number. Measured
-# 2026-08-19 on the 41-book library: of 69 remaining, 35 were
-# `#pg-footer-heading` — Project Gutenberg's licence footer, which is a TOC
-# entry but not a chapter and not a thing anyone highlights. Reporting the
-# total alone overstates how much reading material is still unreachable.
-print("\n  Of what remains, a TOC entry is not necessarily a chapter: run this")
-print("  with --residue to break it down by fragment name.")
-
-
-if RESIDUE:
-    import collections as _collections
-
-    kinds = _collections.Counter()
-    fragments = _collections.Counter()
-    with tempfile.TemporaryDirectory(prefix="residue-") as _tmp:
-        for _root, _dirs, _files in os.walk(LIB):
-            for _f in _files:
-                if not _f.lower().endswith(".kepub"):
+def main(argv=None):
+    args = sys.argv[1:] if argv is None else argv
+    lib = args[0]
+    # `--no-split` runs the normalize-only control, which is what attributes the
+    # splitter's share instead of crediting it with normalization's work too.
+    split = "--no-split" not in args[1:]
+    # `--residue` explains the leftovers instead of only counting them.
+    residue = "--residue" in args[1:]
+    normalize_kepub_package = _normalizer()
+    rows = []
+    with tempfile.TemporaryDirectory(prefix="cid-") as tmp:
+        for root, _, files in os.walk(lib):
+            for f in files:
+                if not f.lower().endswith(".kepub"):
                     continue
-                _cp = os.path.join(_tmp, "r.kepub")
-                shutil.copy2(os.path.join(_root, _f), _cp)
+                src = os.path.join(root, f)
                 try:
-                    normalize_kepub_package(_cp, split_chapters=SPLIT)
-                    with zipfile.ZipFile(_cp) as _z:
-                        _names = set(_z.namelist())
-                    _total, _anchored, _fragmented, _dup, _fnames = analyse(_cp)
+                    before = analyse(src)
                 except Exception:
-                    os.remove(_cp)
                     continue
-                os.remove(_cp)
-                kinds["still carries a #fragment"] += _fragmented
-                kinds["two TOC entries share one document"] += _dup
-                fragments.update(_fnames)
+                cp = os.path.join(tmp, "w.kepub")
+                shutil.copy2(src, cp)
+                try:
+                    normalize_kepub_package(cp, split_chapters=split)
+                    after = analyse(cp)
+                except Exception:
+                    after = before
+                os.remove(cp)
+                rows.append((os.path.basename(root)[:36], before, after))
 
-    print("\nRESIDUE BY KIND")
-    for _kind, _n in kinds.most_common():
-        print(f"  {_n:4}  {_kind}")
-    print("\nRESIDUE BY FRAGMENT NAME")
-    for _frag, _n in fragments.most_common(15):
-        print(f"  {_n:4}  #{_frag}")
-    _footer = sum(_n for _f, _n in fragments.items() if "footer" in _f.lower())
-    if _footer:
-        print(f"\n  {_footer} of {sum(fragments.values())} fragmented targets are a licence footer,")
-        print("  not a chapter. The real unreachable-chapter count is the remainder.")
-    print("\n  A `#pg-footer-heading` target is Project Gutenberg's licence")
-    print("  footer — a TOC entry, but not a chapter and not something a reader")
-    print("  highlights. Counting it as an unreachable chapter overstates the gap.")
+    print(f"{'book':38}{'BEFORE anchorable/total':>26}{'AFTER anchorable/total':>25}")
+    tb = ta = tt = 0
+    for name, before, after in sorted(rows, key=lambda row: row[1][1] - row[1][0]):
+        if before[0] == 0:
+            continue
+        tb += before[1]
+        ta += after[1]
+        tt += before[0]
+        if before[1] != after[1]:
+            print(
+                f"{name:38}{f'{before[1]}/{before[0]}':>26}"
+                f"{f'{after[1]}/{after[0]}':>25}"
+            )
+    print(f"\nCHAPTERS A KOBO COULD ANCHOR A HIGHLIGHT IN, across {len(rows)} books:")
+    print(f"  before: {tb} of {tt}    after: {ta} of {tt}")
+
+    # The residue is worth naming rather than leaving as a number. Measured
+    # 2026-08-19 on the 41-book library: of 69 remaining, 35 were
+    # `#pg-footer-heading` — Project Gutenberg's licence footer, which is a TOC
+    # entry but not a chapter and not a thing anyone highlights. Reporting the
+    # total alone overstates how much reading material is still unreachable.
+    print("\n  Of what remains, a TOC entry is not necessarily a chapter: run this")
+    print("  with --residue to break it down by fragment name.")
+
+    if residue:
+        kinds = collections.Counter()
+        fragments = collections.Counter()
+        with tempfile.TemporaryDirectory(prefix="residue-") as tmp:
+            for root, _dirs, files in os.walk(lib):
+                for f in files:
+                    if not f.lower().endswith(".kepub"):
+                        continue
+                    cp = os.path.join(tmp, "r.kepub")
+                    shutil.copy2(os.path.join(root, f), cp)
+                    try:
+                        normalize_kepub_package(cp, split_chapters=split)
+                        total, anchored, fragmented, duplicate, fragment_names = analyse(cp)
+                    except Exception:
+                        os.remove(cp)
+                        continue
+                    os.remove(cp)
+                    kinds["still carries a #fragment"] += fragmented
+                    kinds["two TOC entries share one document"] += duplicate
+                    fragments.update(fragment_names)
+
+        print("\nRESIDUE BY KIND")
+        for kind, count in kinds.most_common():
+            print(f"  {count:4}  {kind}")
+        print("\nRESIDUE BY FRAGMENT NAME")
+        for fragment, count in fragments.most_common(15):
+            print(f"  {count:4}  #{fragment}")
+        footer = sum(
+            count for fragment, count in fragments.items()
+            if _is_footer_fragment(fragment)
+        )
+        if footer:
+            print(
+                f"\n  {footer} of {sum(fragments.values())} fragmented targets "
+                "are a licence footer,"
+            )
+            print("  not a chapter. The real unreachable-chapter count is the remainder.")
+        print("\n  A `#pg-footer-heading` target is Project Gutenberg's licence")
+        print("  footer — a TOC entry, but not a chapter and not something a reader")
+        print("  highlights. Counting it as an unreachable chapter overstates the gap.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure_kobo_anchorable_chapters.py
+++ b/scripts/measure_kobo_anchorable_chapters.py
@@ -55,7 +55,9 @@ def analyse(path):
     counts = collections.Counter(anchored)
     # two TOC entries deriving the SAME identity = only one chapter is reachable
     duplicated = sum(c - 1 for c in counts.values() if c > 1)
-    return len(derived), len(anchored) - duplicated, len(fragmented), duplicated
+    # the fragment NAMES, so --residue can say WHICH targets are still unreachable
+    frag_names = [d.split("#", 1)[1] for d in fragmented]
+    return len(derived), len(anchored) - duplicated, len(fragmented), duplicated, frag_names
 
 LIB = sys.argv[1]
 #: `--no-split` runs the normalize-only control, which is what attributes the
@@ -117,17 +119,25 @@ if RESIDUE:
                     normalize_kepub_package(_cp, split_chapters=SPLIT)
                     with zipfile.ZipFile(_cp) as _z:
                         _names = set(_z.namelist())
-                    _total, _anchored, _fragmented, _dup = analyse(_cp)
+                    _total, _anchored, _fragmented, _dup, _fnames = analyse(_cp)
                 except Exception:
                     os.remove(_cp)
                     continue
                 os.remove(_cp)
                 kinds["still carries a #fragment"] += _fragmented
                 kinds["two TOC entries share one document"] += _dup
+                fragments.update(_fnames)
 
     print("\nRESIDUE BY KIND")
     for _kind, _n in kinds.most_common():
         print(f"  {_n:4}  {_kind}")
+    print("\nRESIDUE BY FRAGMENT NAME")
+    for _frag, _n in fragments.most_common(15):
+        print(f"  {_n:4}  #{_frag}")
+    _footer = sum(_n for _f, _n in fragments.items() if "footer" in _f.lower())
+    if _footer:
+        print(f"\n  {_footer} of {sum(fragments.values())} fragmented targets are a licence footer,")
+        print("  not a chapter. The real unreachable-chapter count is the remainder.")
     print("\n  A `#pg-footer-heading` target is Project Gutenberg's licence")
     print("  footer — a TOC entry, but not a chapter and not something a reader")
     print("  highlights. Counting it as an unreachable chapter overstates the gap.")

--- a/tests/unit/test_measure_kobo_anchorable_chapters.py
+++ b/tests/unit/test_measure_kobo_anchorable_chapters.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Behavioural coverage for the Kobo chapter-anchorability instrument."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "measure_kobo_anchorable_chapters.py"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location(
+        "measure_kobo_anchorable_chapters", SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _kepub(tmp_path, targets, *, name="Synthetic Book (1)"):
+    book_dir = tmp_path / name
+    book_dir.mkdir()
+    path = book_dir / "book.kepub"
+    links = "".join(
+        f'<li><a href="{target}">Chapter {index}</a></li>'
+        for index, target in enumerate(targets, 1)
+    )
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("mimetype", "application/epub+zip")
+        archive.writestr(
+            "META-INF/container.xml",
+            """<?xml version="1.0"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+  <rootfiles><rootfile full-path="OEBPS/content.opf"
+      media-type="application/oebps-package+xml"/></rootfiles>
+</container>""",
+        )
+        archive.writestr(
+            "OEBPS/content.opf",
+            """<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <manifest>
+    <item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml"
+          properties="nav"/>
+  </manifest>
+  <spine><itemref idref="chapter"/></spine>
+</package>""",
+        )
+        archive.writestr(
+            "OEBPS/chapter.xhtml",
+            """<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <h1 id="chapter-two">Chapter</h1><footer id="pg-footer-heading">Licence</footer>
+</body></html>""",
+        )
+        archive.writestr(
+            "OEBPS/nav.xhtml",
+            f"""<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:epub="http://www.idpf.org/2007/ops"><body>
+  <nav epub:type="toc"><ol>{links}</ol></nav>
+</body></html>""",
+        )
+    return path
+
+
+def test_import_with_no_argv_has_no_output_or_global_side_effects(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT)])
+    original_path = list(sys.path)
+
+    module = _module()
+
+    assert callable(module.main)
+    assert sys.path == original_path
+    assert capsys.readouterr() == ("", "")
+
+
+def test_an_unfragmented_unique_spine_target_is_anchorable(tmp_path):
+    module = _module()
+    path = _kepub(tmp_path, ["chapter.xhtml"])
+
+    assert module.analyse(path) == (1, 1, 0, 0, [])
+
+
+def test_a_fragmented_target_is_not_anchorable(tmp_path):
+    module = _module()
+    path = _kepub(tmp_path, ["chapter.xhtml#chapter-two"])
+
+    assert module.analyse(path) == (1, 0, 1, 0, ["chapter-two"])
+
+
+def test_two_toc_entries_colliding_on_one_document_reach_only_one_chapter(tmp_path):
+    module = _module()
+    path = _kepub(tmp_path, ["chapter.xhtml", "chapter.xhtml"])
+
+    assert module.analyse(path) == (2, 1, 0, 1, [])
+
+
+def test_residue_names_separate_a_licence_footer_from_real_chapters(
+    tmp_path, monkeypatch, capsys
+):
+    module = _module()
+    _kepub(
+        tmp_path,
+        ["chapter.xhtml", "chapter.xhtml#chapter-two", "chapter.xhtml#pg-footer-heading"],
+    )
+    calls = []
+
+    def normalize(path, *, split_chapters):
+        calls.append((Path(path).name, split_chapters))
+
+    monkeypatch.setattr(module, "_normalizer", lambda: normalize)
+
+    assert module.main([str(tmp_path), "--no-split", "--residue"]) == 0
+
+    output = capsys.readouterr().out
+    assert "before: 1 of 3    after: 1 of 3" in output
+    assert "     2  still carries a #fragment" in output
+    assert "     1  #chapter-two" in output
+    assert "     1  #pg-footer-heading" in output
+    assert "1 of 2 fragmented targets are a licence footer" in output
+    assert calls == [("w.kepub", False), ("r.kepub", False)]
+
+
+def test_default_measurement_keeps_the_splitter_enabled(tmp_path, monkeypatch, capsys):
+    module = _module()
+    _kepub(tmp_path, ["chapter.xhtml"])
+    split_values = []
+
+    def normalize(_path, *, split_chapters):
+        split_values.append(split_chapters)
+
+    monkeypatch.setattr(module, "_normalizer", lambda: normalize)
+
+    assert module.main([str(tmp_path)]) == 0
+    capsys.readouterr()
+    assert split_values == [True]


### PR DESCRIPTION
Two commits on the instrument this repo uses to justify its Kobo-anchoring claims.

## 1. `--residue` now names the fragments it counts (`cff48d0e8`)

The script's own comment asserted *"of 69 remaining, 35 were `#pg-footer-heading`"*, and its closing
line told the reader to run `--residue` to *"break it down by fragment name"*. **Neither was
reachable**: the `fragments` Counter was constructed, never populated, never printed. The instrument
could not reproduce the one claim its own output made about its own residue.

OBSERVED on the 41-book reference library:

```
RESIDUE BY KIND          65  still carries a #fragment
                          4  two TOC entries share one document
RESIDUE BY FRAGMENT      35  #pg-footer-heading
                         30  #pgepubid000XX
```

**This changes what the headline means.** 35 of the 69 "unreachable chapters" are Project Gutenberg's
licence footer — a TOC entry, but not a chapter and not a thing anyone highlights. Excluding them, the
figure was **1584 of 1618 (97.9%)**, not 1584 of 1653 (95.8%), and the real remainder was one
structural shape rather than a long tail. Reporting the total alone overstated the gap by roughly half,
which is a roadmap-level distortion: a 69-item long tail reads as diminishing returns, a 34-item single
shape reads as one more fix.

## 2. The script is now importable, and therefore tested (`4034cf2bb`)

This was the only `scripts/measure_*` tool with **no test**, and the reason was structural: it executed
at import (`LIB = sys.argv[1]` at module level), so the convention the other two use —
`importlib.util.spec_from_file_location` + `exec_module`, per `test_measure_kobo_redelivery_is_safe.py`
— crashed on it. It now has `main(argv=None)` + a `__main__` guard, the normalizer loads lazily, and
the import-time `sys.path.insert(0, os.getcwd())` is gone in favour of deriving the repo root from
`__file__`.

Tests pin the instrument's load-bearing definition — anchorable = no fragment AND matches exactly one
spine document, duplicates subtracted — plus a chapter that anchors, one that stays fragmented, two TOC
entries colliding on one document, and the `#pg-footer-heading` split-out. Synthetic KEPUB fixtures; no
reference-library book was copied into the repo.

Written test-first: before the implementation the new test module was **3 failed, 3 passed**, failing
precisely at the module-level `sys.argv[1]`, while the three direct `analyse()` semantic tests already
passed — which is what proves the red was the import defect and not malformed fixtures.

## Output compatibility — verified on the FULL library, not a sample

This tool's numbers are cited in findings and commit messages, so a silent formatting change would
invalidate that history. The full 41-book `--residue` run before and after is **byte-identical except
for the timestamp in one `ProxyFix` log line**; every measurement line matches.

No new dependencies. No production code touched.