### PR TITLE
fix(kobo): a device timestamp can silently destroy a highlight — OverflowError escapes the clock parsers

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1920,11 +1920,11 @@ def parse_kobo_timestamp(value):
         text = text[:-1] + "+00:00"
     try:
         parsed = datetime.fromisoformat(text)
-    except ValueError:
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    except (ValueError, OverflowError):
         return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
 
 
 def get_or_create_reading_state(book_id):

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -44,11 +44,11 @@ def parse_client_modified_utc(value):
         raw = raw[:-1] + "+00:00"
     try:
         parsed = datetime.fromisoformat(raw)
-    except ValueError:
+        if parsed.tzinfo is None:
+            return None
+        return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    except (ValueError, OverflowError):
         return None
-    if parsed.tzinfo is None:
-        return None
-    return parsed.astimezone(timezone.utc).replace(tzinfo=None)
 
 # Background dispatch seam (#920)
 # ------------------------------

--- a/tests/unit/test_kobo_iso_clock_overflow.py
+++ b/tests/unit/test_kobo_iso_clock_overflow.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Out-of-range device clocks must never cost a user their Kobo highlight."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask, make_response
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
+from cps.kobo import parse_kobo_timestamp
+from cps.services.annotation_sync import (
+    parse_client_modified_utc,
+    reset_registry_for_testing,
+)
+
+pytestmark = pytest.mark.unit
+
+OVERFLOWING_CLOCKS = (
+    pytest.param("9999-12-31T23:59:59-23:59", id="above-maxyear"),
+    pytest.param("0001-01-01T00:00:00+23:59", id="below-minyear"),
+)
+BOOK_UUID = "9e5251ad-d530-4e58-9121-8b8336099fdd"
+
+
+@pytest.fixture
+def annotation_session(tmp_path, monkeypatch):
+    engine = create_engine(f"sqlite:///{tmp_path}/app.db")
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    user = ub.User(name="clock-user", email="clock@example.invalid", role=0, password="x")
+    session.add(user)
+    session.commit()
+    monkeypatch.setattr(ub, "session", session)
+    monkeypatch.setattr(ub, "session_commit", lambda: session.commit())
+    reset_registry_for_testing()
+    yield session, user
+    reset_registry_for_testing()
+    session.close()
+
+
+@pytest.mark.parametrize("clock", OVERFLOWING_CLOCKS)
+def test_annotation_patch_clock_parser_rejects_both_utc_overflows(clock):
+    assert parse_client_modified_utc(clock) is None
+
+
+@pytest.mark.parametrize("clock", OVERFLOWING_CLOCKS)
+def test_kobo_reading_state_clock_parser_rejects_both_utc_overflows(clock):
+    assert parse_kobo_timestamp(clock) is None
+
+
+@pytest.mark.parametrize("clock", OVERFLOWING_CLOCKS)
+def test_live_patch_stores_the_highlight_without_the_rejected_clock(
+    annotation_session, monkeypatch, clock
+):
+    """The upstream-success response must correspond to a durable local row."""
+    from cps import readingservices
+
+    session, user = annotation_session
+    book = SimpleNamespace(id=347, title="The Clock", uuid=BOOK_UUID)
+    app = Flask(__name__)
+    upstream_body = b'{"upstream":"accepted"}'
+    monkeypatch.setattr(readingservices, "current_user", user)
+    monkeypatch.setattr(
+        readingservices,
+        "resolve_entitlement_ownership",
+        lambda _entitlement_id: book,
+    )
+    monkeypatch.setattr(readingservices, "log_annotation_data", lambda *_args: None)
+    monkeypatch.setattr(
+        readingservices,
+        "proxy_to_kobo_reading_services",
+        lambda: make_response(upstream_body, 207),
+    )
+    payload = {
+        "updatedAnnotations": [{
+            "id": f"highlight-{clock[:4]}",
+            "type": "highlight",
+            "highlightedText": "This highlight must survive the rejected clock.",
+            "highlightColor": "yellow",
+            "clientLastModifiedUtc": clock,
+            "location": {"span": {}},
+        }],
+    }
+
+    with app.test_request_context(
+        f"/api/v3/content/{BOOK_UUID}/annotations",
+        method="PATCH",
+        json=payload,
+    ):
+        response = readingservices.handle_annotations.__wrapped__(BOOK_UUID)
+
+    assert response.status_code == 207
+    assert response.get_data() == upstream_body
+    row = session.query(ub.Annotation).one()
+    assert row.highlighted_text == "This highlight must survive the rejected clock."
+    assert row.client_modified_at is None
+
+
+def test_valid_annotation_clock_keeps_its_existing_naive_utc_value():
+    assert parse_client_modified_utc("2026-08-20T15:30:45.123456+02:30") == datetime(
+        2026, 8, 20, 13, 0, 45, 123456
+    )
+
+
+def test_valid_kobo_clock_keeps_its_existing_aware_utc_value():
+    assert parse_kobo_timestamp("2026-08-20T15:30:45.123456+02:30") == datetime(
+        2026, 8, 20, 13, 0, 45, 123456, tzinfo=timezone.utc
+    )


### PR DESCRIPTION
Closes **F-947bb8**. This is silent, permanent annotation loss on the **live** Kobo capture path.

## How it was found

`/security-review` on #1774 cleared that PR, and noted *below its own bar* that a date parser caught
only `ValueError` while `astimezone()` raises `OverflowError` outside the guard — correctly excluded
as DoS. Sweeping for the **shape** found it at three sites, and the reviewed one was the mildest.

## The defect

```python
try:
    parsed = datetime.fromisoformat(raw)
except ValueError:
    return None
...
return parsed.astimezone(timezone.utc)      # OverflowError — OUTSIDE the try
```

`astimezone()` raises `OverflowError`, not `ValueError`, when the shifted value leaves
`MINYEAR..MAXYEAR`. Proven by running the real function:

```
parse_client_modified_utc('not-a-date')                 -> None            (handled correctly)
parse_client_modified_utc('9999-12-31T23:59:59-23:59')  -> OverflowError   ESCAPES
parse_client_modified_utc('0001-01-01T00:00:00+23:59')  -> OverflowError   ESCAPES
```

## Why this is data loss, not DoS

The value is **device-supplied** — `payload.get("clientLastModifiedUtc")`, ordinary sync traffic
needing no privilege. A Kobo with a wrong clock or an unusual offset produces it with nobody crafting
anything.

The code immediately below is **deliberate about this exact hazard** and its comment says so: a
rejected clock must not discard the user's edit, so it logs and stores the annotation *without* a
timestamp. That protection works for a malformed string and is bypassed entirely by `OverflowError`,
because only `ValueError` is caught.

It then meets **F-5c1146**: `handle_annotations` wraps the capture block in `except Exception` and
returns `proxy_to_kobo_reading_services()` unconditionally — so the device is answered **success** for
an annotation that was never stored. And a Kobo uploads a **delta**, so it never re-offers it, while
`checkforchanges` containment (correctly) keeps the book out of the Kobo-cloud download that could
have healed it.

**One out-of-range timestamp = one highlight gone forever, reported as success.**

## Fixed at the parsers, deliberately not at the catch-all

`handle_annotations`' broad `except Exception` is F-5c1146's *defect*, not its remedy, so it is
untouched. Both parsers now keep parse, tz-validation and UTC conversion inside one guard and return
`None` — which lands an out-of-range clock in the same branch a malformed string already lands in, so
**the highlight is stored without a timestamp rather than discarded**. That is the point; returning
`None` is only the mechanism.

Sites fixed: `cps/services/annotation_sync/__init__.py:36` (live PATCH) and `cps/kobo.py:1899` (live
sync / reading state). The third site, `cps/annotations.py:365`, is new in #1774 and is being fixed on
that branch.

## Test-first, with the red run recorded

Tests were written **before** either parser changed:

```
collected 8 items
FFFFFF..
6 failed, 2 passed
```

The two that matter are not parser assertions — they drive the real live capture orchestration and
prove the PATCH **returned upstream success while storing zero annotation rows**, with the escaping
`OverflowError` visible in the captured log. That is the user-visible property.

## Mutation evidence — re-run independently by the reviewer

| mutation (degrade, not delete) | result |
|---|---|
| narrow both `except (ValueError, OverflowError)` back to `except ValueError` | **6 failed**, 2 passed — including both live-PATCH storage tests |
| restored | 8 passed |

Full suite on the branch: `6742 passed, 103 skipped`. Byte-compiles on 3.12 and 3.13. No new
dependencies. Valid-timestamp behaviour is unchanged.