### PR TITLE
fix(kobo): derive annotation_type for legacy rows where the row itself proves it

### DIFF
--- a/cps/services/annotation_types.py
+++ b/cps/services/annotation_types.py
@@ -20,10 +20,10 @@ payload happened to carry a ``type`` key (finding ``F-9de049``):
 
 That is the same shape ``annotation_colors`` was created to undo for
 ``highlight_color``, where three vocabularies accumulated in one column and had
-to be reconciled after the fact. Doing it here now is cheap precisely because
-nothing user-visible reads the column yet — only a field list in
-``cps/services/kobo_annotation_stage0.py``. After two-way sync ships it is a
-migration.
+to be reconciled after the fact. The column now crosses the portable annotation
+boundary in ``cps/services/annotation_portable.py`` and is also named by the
+field list in ``cps/services/kobo_annotation_stage0.py``; no frontend code reads
+it directly.
 
 THE VOCABULARY, AND WHERE EACH WORD COMES FROM
 ----------------------------------------------
@@ -138,3 +138,33 @@ def type_for_webreader_annotation(*, has_anchor: bool) -> str:
     reclassify it the moment someone typed into it.
     """
     return "highlight" if has_anchor else "note"
+
+
+def _is_derivable_legacy_position_type(position_type) -> bool:
+    """Whether a legacy row retains a complete web-reader branch decision.
+
+    Only the direct web-reader constructors assign either token. Portable
+    updates may later rewrite ``source``, but they cannot create these position
+    types, so provenance is deliberately not part of this predicate.
+    """
+    return position_type in ("unanchored", "cfi")
+
+
+def derive_legacy_annotation_type(*, position_type) -> Optional[str]:
+    """Reproduce today's type only from a legacy row's recorded writer input.
+
+    The direct web-reader constructors persist the exact discriminator passed
+    to :func:`type_for_webreader_annotation`: ``unanchored`` means no anchor,
+    while ``cfi`` means an anchor. Those two cases are derivations, not
+    classifications inferred from content. ``source`` is not consulted because
+    portable updates can rewrite it without changing ``position_type``.
+
+    Every other shape remains unknown. In particular, a legacy KoboSpan row
+    has no ``position_type`` value, and the same stored selector shape can
+    arrive through portable import. Inspecting its text or selector would
+    therefore guess which writer and input produced it, violating the rule
+    that an unrecognised type resolves to ``None``.
+    """
+    if not _is_derivable_legacy_position_type(position_type):
+        return None
+    return type_for_webreader_annotation(has_anchor=position_type == "cfi")

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -3498,11 +3498,97 @@ def _ensure_kobo_opaque_present_guards(engine):
     _run_ddl_with_retry(engine, statements)
 
 
+def backfill_legacy_annotation_types(engine):
+    """Fill only NULL types derivable from a recorded web-reader branch.
+
+    The scan and its complete counts are logged before a write transaction is
+    opened. Existing values, including future vocabulary this version does not
+    know, always win: the candidate scan ignores them and the UPDATE repeats an
+    ``annotation_type IS NULL`` guard in case a concurrent writer supplies a
+    value after the scan. Rows without a recorded web-reader branch discriminator
+    remain NULL, where NULL deliberately means unknown.
+
+    Re-running is safe: after a derived value is stored it is no longer a
+    candidate, and no non-NULL value is ever overwritten.
+    """
+    from .services.annotation_types import derive_legacy_annotation_type
+
+    counts = {
+        "total": 0,
+        "already_typed": 0,
+        "null": 0,
+        "derived_note": 0,
+        "derived_highlight": 0,
+        "unknown": 0,
+        "would_update": 0,
+        "updated": 0,
+    }
+    required_columns = {"id", "position_type", "annotation_type"}
+    annotation_columns = _table_columns(engine, "annotation")
+    if annotation_columns is None or not required_columns.issubset(annotation_columns):
+        log.info(
+            "[annotation-type-backfill] scan total=0 already_typed=0 null=0 "
+            "derived_note=0 derived_highlight=0 unknown=0 would_update=0; "
+            "annotation schema is not eligible"
+        )
+        return counts
+
+    candidates = []
+    with engine.connect() as conn:
+        rows = conn.execute(text(
+            "SELECT id, position_type, annotation_type "
+            "FROM annotation ORDER BY id"
+        )).fetchall()
+
+    counts["total"] = len(rows)
+    for row_id, position_type, annotation_type in rows:
+        if annotation_type is not None:
+            counts["already_typed"] += 1
+            continue
+        counts["null"] += 1
+        derived = derive_legacy_annotation_type(
+            position_type=position_type,
+        )
+        if derived is None:
+            counts["unknown"] += 1
+            continue
+        counts[f"derived_{derived}"] += 1
+        candidates.append({"row_id": row_id, "annotation_type": derived})
+
+    counts["would_update"] = len(candidates)
+    log.info(
+        "[annotation-type-backfill] scan total=%d already_typed=%d null=%d "
+        "derived_note=%d derived_highlight=%d unknown=%d would_update=%d",
+        counts["total"],
+        counts["already_typed"],
+        counts["null"],
+        counts["derived_note"],
+        counts["derived_highlight"],
+        counts["unknown"],
+        counts["would_update"],
+    )
+
+    if candidates:
+        with engine.begin() as conn:
+            for candidate in candidates:
+                result = conn.execute(text(
+                    "UPDATE annotation SET annotation_type=:annotation_type "
+                    "WHERE id=:row_id AND annotation_type IS NULL"
+                ), candidate)
+                counts["updated"] += result.rowcount
+    log.info(
+        "[annotation-type-backfill] applied=%d planned=%d",
+        counts["updated"], counts["would_update"],
+    )
+    return counts
+
+
 def migrate_kobo_two_way_annotation_sync(engine, _session):
     """Stage 0 additive schema and conservative legacy-state backfill.
 
-    This migration never updates a pre-existing annotation column.  The only
-    annotation backfills target newly-added columns, and every legacy book is
+    Existing annotation values are preserved. The only legacy type values
+    filled are NULLs whose recorded web-reader branch reproduces today's exact
+    writer decision; all other types remain unknown. Every legacy book is
     represented as unseeded/unknown rather than being promoted to authority.
     """
     # Capture existing Stage 0-scoped violations so a repeated or partially
@@ -3534,6 +3620,8 @@ def migrate_kobo_two_way_annotation_sync(engine, _session):
         )
         for column_name, ddl in additions:
             _add_column_if_missing(engine, "annotation", column_name, ddl)
+
+        backfill_legacy_annotation_types(engine)
 
         with engine.begin() as conn:
             row_count_before = conn.execute(text("SELECT COUNT(*) FROM annotation")).scalar_one()

--- a/tests/unit/test_annotation_type_legacy_backfill.py
+++ b/tests/unit/test_annotation_type_legacy_backfill.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Proof boundary for deriving legacy ``annotation_type`` values.
+
+The migration may reproduce a value only when the legacy row retains the exact
+branch discriminator used by today's writer. Similar-looking content is not a
+substitute for that discriminator: NULL is the honest result when provenance is
+ambiguous.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("position_type", "expected"),
+    (
+        ("unanchored", "note"),
+        ("cfi", "highlight"),
+        # Legacy KoboSpan web-reader rows retain the resulting selector, but
+        # not an explicit position_type branch discriminator.
+        (None, None),
+        ("koreader_xpointer", None),
+        ("pdf_quad", None),
+        ("comic_page", None),
+    ),
+)
+def test_legacy_type_is_derived_only_from_a_recorded_webreader_branch(
+    position_type, expected,
+):
+    from cps.services.annotation_types import derive_legacy_annotation_type
+
+    assert derive_legacy_annotation_type(position_type=position_type) == expected
+
+
+@pytest.fixture
+def legacy_engine(tmp_path, monkeypatch):
+    from cps import ub
+    from cps.services import annotation_backup
+
+    annotation_backup.reset_for_tests()
+    monkeypatch.setattr(annotation_backup, "WORKER_AUTOSTART", False)
+
+    engine = create_engine(
+        "sqlite:///{}".format(tmp_path / "legacy-annotation-types.sqlite"),
+        future=True,
+    )
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine, future=True)()
+    rows = (
+        ub.Annotation(
+            # Portable import can rewrite source on an existing row. That does
+            # not erase the unanchored branch recorded in position_type.
+            user_id=7, book_id=1, annotation_id="web-note", source="koreader",
+            position_type="unanchored", note_text="standalone thought",
+            annotation_type=None,
+        ),
+        ub.Annotation(
+            user_id=7, book_id=1, annotation_id="web-cfi", source="webreader",
+            position_type="cfi", cfi_range="epubcfi(/6/2!/4/2:0)",
+            annotation_type=None,
+        ),
+        ub.Annotation(
+            user_id=7, book_id=1, annotation_id="web-kobospan", source="webreader",
+            position_type=None, start_container_path="span#kobo.4.1",
+            highlighted_text="anchored, but writer is not provable", annotation_type=None,
+        ),
+        ub.Annotation(
+            # As above, a rewritten source does not invalidate the cfi branch
+            # token: no other writer can create that position_type.
+            user_id=7, book_id=1, annotation_id="kobo-highlight", source="kobo",
+            position_type="cfi", highlighted_text="looks like a highlight",
+            annotation_type=None,
+        ),
+        ub.Annotation(
+            user_id=7, book_id=1, annotation_id="kobo-dogear", source="kobo",
+            position_type=None, highlighted_text="", annotation_type=None,
+        ),
+        ub.Annotation(
+            user_id=7, book_id=1, annotation_id="koreader", source="koreader",
+            position_type="koreader_xpointer", start_xpointer="/body/DocFragment[1]",
+            annotation_type=None,
+        ),
+        ub.Annotation(
+            user_id=7, book_id=1, annotation_id="known", source="webreader",
+            position_type="unanchored", annotation_type="dogear",
+        ),
+        ub.Annotation(
+            user_id=7, book_id=1, annotation_id="future", source="webreader",
+            position_type="cfi", annotation_type="markup",
+        ),
+    )
+    session.add_all(rows)
+    session.commit()
+    session.close()
+    yield engine
+    engine.dispose()
+    annotation_backup.reset_for_tests()
+
+
+def _stored_types(engine):
+    with engine.connect() as connection:
+        rows = connection.execute(text(
+            "SELECT annotation_id, annotation_type FROM annotation ORDER BY annotation_id"
+        )).all()
+        return {annotation_id: annotation_type for annotation_id, annotation_type in rows}
+
+
+def test_backfill_reports_the_complete_plan_before_writing_and_preserves_unknowns(
+    legacy_engine,
+):
+    from cps import ub
+
+    types_when_reported = []
+
+    def observe_report(message, *args, **_kwargs):
+        rendered = message % args if args else message
+        if "[annotation-type-backfill] scan" in rendered:
+            types_when_reported.append(_stored_types(legacy_engine))
+
+    with patch.object(ub.log, "info", side_effect=observe_report):
+        counts = ub.backfill_legacy_annotation_types(legacy_engine)
+
+    assert counts == {
+        "total": 8,
+        "already_typed": 2,
+        "null": 6,
+        "derived_note": 1,
+        "derived_highlight": 2,
+        "unknown": 3,
+        "would_update": 3,
+        "updated": 3,
+    }
+    assert len(types_when_reported) == 1
+    assert types_when_reported[0]["web-note"] is None
+    assert types_when_reported[0]["web-cfi"] is None
+    assert types_when_reported[0]["kobo-highlight"] is None
+
+    after = _stored_types(legacy_engine)
+    assert after["web-note"] == "note"
+    assert after["web-cfi"] == "highlight"
+    assert after["web-kobospan"] is None
+    assert after["kobo-highlight"] == "highlight"
+    assert after["kobo-dogear"] is None
+    assert after["koreader"] is None
+    assert after["known"] == "dogear"
+    assert after["future"] == "markup"
+
+
+def test_backfill_is_idempotent_and_the_second_scan_reports_no_candidates(
+    legacy_engine,
+):
+    from cps import ub
+
+    first = ub.backfill_legacy_annotation_types(legacy_engine)
+    snapshot = _stored_types(legacy_engine)
+    second = ub.backfill_legacy_annotation_types(legacy_engine)
+
+    assert first["updated"] == 3
+    assert second == {
+        "total": 8,
+        "already_typed": 5,
+        "null": 3,
+        "derived_note": 0,
+        "derived_highlight": 0,
+        "unknown": 3,
+        "would_update": 0,
+        "updated": 0,
+    }
+    assert _stored_types(legacy_engine) == snapshot
+
+
+def test_value_written_after_scan_wins_over_the_legacy_derivation(legacy_engine):
+    from cps import ub
+
+    wrote_concurrent_value = False
+
+    def write_after_report(message, *_args, **_kwargs):
+        nonlocal wrote_concurrent_value
+        if "[annotation-type-backfill] scan" not in message or wrote_concurrent_value:
+            return
+        # The scan has completed and been reported, but the migration's write
+        # transaction has not started. Model a live writer winning that race.
+        with legacy_engine.begin() as connection:
+            connection.execute(text(
+                "UPDATE annotation SET annotation_type='markup' "
+                "WHERE annotation_id='web-note'"
+            ))
+        wrote_concurrent_value = True
+
+    with patch.object(ub.log, "info", side_effect=write_after_report):
+        counts = ub.backfill_legacy_annotation_types(legacy_engine)
+
+    assert wrote_concurrent_value is True
+    assert counts["would_update"] == 3
+    assert counts["updated"] == 2
+    assert _stored_types(legacy_engine)["web-note"] == "markup"
+
+
+def test_stage0_startup_migration_runs_the_legacy_type_backfill(legacy_engine):
+    from cps import ub
+
+    ub.migrate_kobo_two_way_annotation_sync(legacy_engine, None)
+
+    after = _stored_types(legacy_engine)
+    assert after["web-note"] == "note"
+    assert after["web-cfi"] == "highlight"
+    assert after["web-kobospan"] is None
+    assert after["kobo-highlight"] == "highlight"


### PR DESCRIPTION
Closes the backfill half of **F-9de049**. ⚠️ **This writes to existing annotation rows** — see the
blast-radius note at the end.

## The question, and who answered it

`annotation_type` is NULL on every row written before #1760 established the vocabulary. The open
question was whether those rows could be backfilled without violating `annotation_types.py`'s **rule
1 — never invent a type**, since a default there makes a failed lookup indistinguishable from a real
observation.

This was worked test-first with the decision itself delegated, and explicit permission to come back
with "needs the operator" as a valid answer. It came back **partly derivable**, and it corrected the
starting hypothesis on the way.

## Verdict: partly derivable

`position_type` records the exact discriminator the live constructors pass to
`type_for_webreader_annotation(has_anchor=...)`. So for a legacy row:

```
position_type == 'unanchored'  ->  note        (has_anchor=False)
position_type == 'cfi'         ->  highlight   (has_anchor=True)
everything else                ->  stays NULL
```

This is a **derivation, not a classification**: it calls the same function today's writers call, and
inspects no text, note, colour, selector, path or offset. Rule 1 holds — NULL keeps meaning unknown.
Left NULL on purpose: legacy KoboSpan rows, Kobo-origin rows, dogears, KOReader xpointer rows, PDF and
comic annotations, and any unrecognised position type.

## The hypothesis that was disproved, test-first

The obvious rule is "web-reader rows only", gated on `source='webreader'`. **That is wrong**, and the
tests caught it before the implementation was corrected: portable updates can later rewrite `source`,
but they can only ever create `position_type='koreader_xpointer'` — never `unanchored` or `cfi`. So a
source gate would strand rows whose `position_type` still proves the original branch. Against the
source-gated implementation the corrected boundary produced `6 failed, 4 passed`, catching exactly
those source-rewritten rows. Provenance is therefore deliberately **not** part of the predicate.

Legacy KoboSpan rows stay NULL for the mirror-image reason: the same stored selector shape can arrive
through portable import, so reading it would guess which writer produced it.

## Migration safety

- **Reports before it writes.** Logs `total, already_typed, null, derived_note, derived_highlight,
  unknown, would_update`, then `applied` after the transaction.
- **Existing values always win**, including future vocabulary this version does not know. The scan
  skips non-NULL rows and the UPDATE independently repeats `annotation_type IS NULL`, so a value
  written between scan and write is preserved. A test writes `markup` in that window: 3 planned, 2
  applied, `markup` preserved.
- **Idempotent** (not claimed reversible). On the 8-row fixture: first run
  `null=6 derived_note=1 derived_highlight=2 unknown=3 updated=3`; second run `would_update=0 updated=0`.
- Fully parameterized UPDATE, single transaction, degrades cleanly if the schema is not eligible.

## Mutation evidence — re-run independently by the reviewer

| mutation (degrade, not delete) | result |
|---|---|
| derivability predicate -> constant True | **8 failed**, 24 passed |
| derivability predicate -> constant False | **6 failed**, 26 passed |
| restored | 32 passed |
| type mapping ignores `position_type`, always `has_anchor=True` | 3 failed, 7 passed |
| pre-existing-value scan gate -> constant false | 3 failed, 7 passed |
| SQL NULL guard -> constant true (`AND 1=1`) | 1 failed, 9 passed |

Both directions of the load-bearing predicate are caught, so there is no equivalent-mutant gap here.
Pre-implementation red run: `10 failed`.

## Blast radius, stated plainly

On next startup this fills `annotation_type` on existing rows where `position_type` is `unanchored`
or `cfi` and the type is currently NULL. It never overwrites a non-NULL value and never deletes
anything. Nothing user-visible reads the column yet — only the portable export and a Stage-0 field
list — so a wrong derivation would be low-impact and correctable, but it is still a write to real
annotation data and is called out here rather than buried.