### PR TITLE
chore(findings): resolve the four findings shipped tonight

### DIFF
--- a/findings/items/F-178d9a.json
+++ b/findings/items/F-178d9a.json
@@ -4,8 +4,14 @@
   "created": "2026-08-19",
   "id": "F-178d9a",
   "refs": [],
+  "resolution": {
+    "commit": "b0fb9749e",
+    "date": "2026-08-21",
+    "note": "Fixed in #1773. Bounded two-stage refinement: the NCA partition runs first, then any resulting piece still owning >=2 chapter-TOC targets gets exactly one refinement pass. Also covers a sub-shape this finding did not name -- an outer anchor plus exactly ONE inner anchor, which a two-inner-cut-point predicate excluded. Measured on the 41-book library: 1584 -> 1610 of 1653 anchorable, no book regressed, all 41 source KEPUBs SHA-256 unchanged. Residue then read at the source: 35 licence footers, 5 title pages, 1 Contents, 1 part divider whose chapter is reachable anyway, and exactly ONE real chapter (Pride and Prejudice, CHAPTER LXI).",
+    "release": ""
+  },
   "severity": "correctness",
   "source": "audit",
-  "status": "open",
+  "status": "resolved",
   "title": "Spine splitter cannot separate chapters whose TOC anchors nest inside one another"
 }

--- a/findings/items/F-947bb8.json
+++ b/findings/items/F-947bb8.json
@@ -6,8 +6,14 @@
   "refs": [
     "#1774"
   ],
+  "resolution": {
+    "commit": "4e8e68814",
+    "date": "2026-08-21",
+    "note": "Fixed across #1776 (the two LIVE sites: annotation_sync parse_client_modified_utc and kobo.py parse_kobo_timestamp) and #1774 (the import site, cps/annotations.py). All three now keep parse, tz-validation and UTC conversion inside one guard catching (ValueError, OverflowError). The behaviour that matters is not 'returns None' -- an out-of-range clock now lands in the same branch a malformed one already did, so the highlight is STORED without a timestamp rather than destroyed. Live-PATCH storage property proven by a test that drives the real capture orchestration, red before the fix. NOTE: this widened F-4bb29a's reachability by one input class, recorded on that finding.",
+    "release": ""
+  },
   "severity": "data-integrity",
   "source": "audit",
-  "status": "open",
+  "status": "resolved",
   "title": "A device-supplied timestamp can silently destroy a highlight: OverflowError escapes every ISO clock parser"
 }

--- a/findings/items/F-b1004e.json
+++ b/findings/items/F-b1004e.json
@@ -4,8 +4,14 @@
   "created": "2026-08-18",
   "id": "F-b1004e",
   "refs": [],
+  "resolution": {
+    "commit": "d8fa66267",
+    "date": "2026-08-21",
+    "note": "Fixed in #1774. The lossy 'WHERE Text IS NOT NULL AND Text != \"\"' predicate is gone; every Bookmark row is selected and classified explicitly across Text, Annotation and Type, and every row takes exactly one accounted-for path -- tests assert the buckets sum to total_seen. Dogears and note-only rows now import with the correct annotation_type and appear in the user-visible summary. Mutation re-verified independently: reducing the content predicate to the historical bool(Text) gate fails exactly test_dogear_and_note_only_row_import_and_every_row_is_accounted.",
+    "release": ""
+  },
   "severity": "data-integrity",
   "source": "audit",
-  "status": "open",
+  "status": "resolved",
   "title": "The KoboReader.sqlite import drops every dogear and note-only bookmark before it is counted"
 }

--- a/findings/items/F-e628c6.json
+++ b/findings/items/F-e628c6.json
@@ -6,8 +6,14 @@
   "refs": [
     "#1731"
   ],
+  "resolution": {
+    "commit": "d8fa66267",
+    "date": "2026-08-21",
+    "note": "Both halves now closed. The WRONG IDENTITY half was fixed in #1731 (existence check includes book_id, matching uq_annotation_user_book_annotation). The INSERT-ONLY half -- the substantive one -- is fixed in #1774: the existing-row lookup now retrieves the full canonical row instead of just its id, and the merge is explicit -- an existing row changes only when the imported valid DateModified is strictly later than max(client_modified_at, server_modified_at, last_synced, created_at). Missing, malformed, equal or older device clocks never overwrite; divergence is reported as skipped_newer_server rather than silently resolved. Device-side DELETION remains deliberately out of scope: hidden device rows stay report-only and an uploaded recovery database has no deletion authority (annotation writeback is data-loss-class, F-3b565b, operator-gated). Disclosed caveat: taking the max across device and server clocks is conservative, so significant Kobo clock skew can turn a genuinely newer device edit into a reported conflict -- it cannot cause a silent overwrite of newer server state.",
+    "release": ""
+  },
   "severity": "correctness",
   "source": "audit",
-  "status": "open",
+  "status": "resolved",
   "title": "The KoboReader.sqlite import is insert-only and dedups on the wrong key"
 }


### PR DESCRIPTION
Ledger only, no production code. Closes out what #1773, #1774 and #1776 actually fixed.

| finding | shipped in | what closed |
|---|---|---|
| **F-178d9a** | #1773 | nested TOC anchors now split; 1584 -> 1610 of 1653 |
| **F-b1004e** | #1774 | dogears and note-only rows are no longer dropped in SQL before being counted |
| **F-e628c6** | #1774 | the insert-only half — a newer device DB can finally apply an edit |
| **F-947bb8** | #1774 + #1776 | `OverflowError` no longer escapes the ISO clock parsers |

Each note records the evidence, **and the caveats that survive the fix** rather than only the good
news:

- **F-947bb8** widened **F-4bb29a**'s reachability by one input class. An out-of-range clock used to
  escape the reading-state handler entirely; it now returns `None` and falls into
  `or datetime.now(timezone.utc)`, inventing a clock. Net better, and it makes out-of-range behave
  like malformed — which always took that path — but F-4bb29a is worth more than it was, and that is
  written on the finding.
- **F-e628c6** keeps a disclosed clock-skew caveat: taking the max across device and server clocks is
  conservative, so real skew can turn a genuinely newer device edit into a *reported conflict*. It
  cannot cause a silent overwrite of newer server state.
- **F-178d9a**'s residue was read at the source rather than trusted from a comment: of 43 remaining
  entries, 35 are licence footers, 5 title pages, 1 a Contents entry, 1 a part divider whose chapter
  is reachable anyway — and **exactly one is a real chapter** (Pride and Prejudice, "CHAPTER LXI").

Still open and deliberately untouched: **F-a66189** (no automatic recovery for annotations the delta
never carried) and **F-5c1146** (the PATCH answers success even when a member failed to commit) — both
need the device experiment that is armed and waiting on one Kobo wake-up.