### PR TITLE
fix(kobo): three silent failures in the annotation path, plus F-4bb29a

### DIFF
--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -309,6 +309,7 @@ def annotations_import_submit():
         messages = {
             "no_file": _("No file uploaded."),
             "not_sqlite": _("Uploaded file is not a SQLite database."),
+            "not_kobo": _("Uploaded database has no readable Kobo Bookmark table."),
             "too_large": _(
                 "File exceeds %(max)d MB.",
                 max=MAX_UPLOAD_BYTES // (1024 * 1024),

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1732,8 +1732,15 @@ def HandleStateRequest(book_uuid):
             # Use the device's own timestamp so the GET response mirrors it back,
             # preventing the "newer PT" conflict popup. Official Kobo cloud does the same.
             lm_str = request_reading_state.get("LastModified")
-            request_lm = parse_kobo_timestamp(lm_str) or datetime.now(timezone.utc)
+            request_lm = parse_kobo_timestamp(lm_str)
             g.kobo_reading_state_lm = request_lm
+            if request_lm is None:
+                # ``None`` is an observation rejection, not permission to
+                # manufacture an ordering clock. Keep the parent's last
+                # accepted clock so the before_flush hook does not replace it
+                # with server ``now`` while the position itself is preserved.
+                g.kobo_reading_state_lm = getattr(
+                    kobo_reading_state, "last_modified", None)
 
             request_bookmark = request_reading_state["CurrentBookmark"]
             if request_bookmark:
@@ -1745,7 +1752,7 @@ def HandleStateRequest(book_uuid):
                     current_bookmark.location_value = location["Value"]
                     current_bookmark.location_type = location["Type"]
                     current_bookmark.location_source = location["Source"]
-                current_bookmark.last_modified = request_lm
+                _apply_kobo_last_modified(current_bookmark, request_lm)
                 update_results_response["CurrentBookmarkResult"] = {"Result": "Success"}
 
             request_statistics = request_reading_state["Statistics"]
@@ -1757,7 +1764,7 @@ def HandleStateRequest(book_uuid):
                 remaining = request_statistics.get("RemainingTimeMinutes")
                 if remaining is not None:
                     statistics.remaining_time_minutes = int(remaining)
-                statistics.last_modified = request_lm
+                _apply_kobo_last_modified(statistics, request_lm)
                 update_results_response["StatisticsResult"] = {"Result": "Success"}
 
             request_status_info = request_reading_state["StatusInfo"]
@@ -1769,7 +1776,7 @@ def HandleStateRequest(book_uuid):
                         book_read.times_started_reading += 1
                         book_read.last_time_started_reading = datetime.now(timezone.utc)
                     book_read.read_status = new_book_read_status
-                    book_read.last_modified = request_lm
+                    _apply_kobo_last_modified(book_read, request_lm)
                 update_results_response["StatusInfoResult"] = {"Result": "Success"}
         except (KeyError, TypeError, ValueError, StatementError):
             log.debug("Received malformed v1/library/<book_uuid>/state request.")
@@ -1925,6 +1932,27 @@ def parse_kobo_timestamp(value):
         return parsed.astimezone(timezone.utc)
     except (ValueError, OverflowError):
         return None
+
+
+def _apply_kobo_last_modified(target, observed_clock):
+    """Apply a valid device clock, or retain the row's accepted clock.
+
+    The Kobo state columns have SQLAlchemy ``onupdate=now`` defaults. Merely
+    declining to assign ``last_modified`` on a rejected clock is insufficient:
+    changing another field would still replace it with server time. Marking the
+    loaded value as explicitly supplied keeps that real stored observation in
+    the UPDATE instead. Test doubles have no SQLAlchemy state and need no such
+    handling.
+    """
+    if observed_clock is not None:
+        target.last_modified = observed_clock
+        return
+    if hasattr(target, "_sa_instance_state"):
+        from sqlalchemy.orm.attributes import flag_modified
+        # Load an expired value before flagging it, then make SQLAlchemy include
+        # that value instead of firing the column's ``onupdate`` default.
+        target.last_modified
+        flag_modified(target, "last_modified")
 
 
 def get_or_create_reading_state(book_id):

--- a/cps/services/annotation_portable.py
+++ b/cps/services/annotation_portable.py
@@ -35,6 +35,8 @@ def validate_portable_payload(payload, *, book_uuid=None) -> Optional[str]:
     """Return a validation error for fields that would make an upsert unsafe."""
     if not isinstance(payload, dict):
         return None  # non-object entries are deliberately counted as skipped
+    if "source" in payload and payload.get("source") not in _VALID_SOURCES:
+        return "source must be one of: " + ", ".join(sorted(_VALID_SOURCES))
     for field in ("annotation_id", "highlighted_text", "note_text", "color",
                   "content_id", "context_string", "position_type",
                   "start_xpointer", "end_xpointer", "device_origin_id"):
@@ -120,6 +122,13 @@ def apply_portable(payload, *, user_id, book, session, commit,
     if not isinstance(annotation_id, str) or not annotation_id.strip():
         return None, "skipped"
     annotation_id = annotation_id.strip()
+    source = payload.get("source", "koreader")
+    if source not in _VALID_SOURCES:
+        # The HTTP boundary rejects this with a reason. Keep the core helper
+        # defensive as well: coercing an unrecognised observation to
+        # ``koreader`` invents provenance and grants KOReader delete authority
+        # over a row whose origin it did not establish.
+        return None, "skipped"
 
     row = (
         session.query(ub.Annotation)
@@ -130,9 +139,6 @@ def apply_portable(payload, *, user_id, book, session, commit,
     )
     created = False
     if row is None:
-        source = payload.get("source")
-        if source not in _VALID_SOURCES:
-            source = "koreader"
         row = ub.Annotation(
             user_id=user_id, annotation_id=annotation_id,
             book_id=book.id, source=source, origin_device_id=origin_device_id,

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -717,6 +717,13 @@ def dispatch_annotation_deletes(deleted_ids, user, book_id=None) -> None:
         return
     jobs = []
     for annotation_id in deleted_ids:
+        if not isinstance(annotation_id, str) or not annotation_id:
+            # A malformed member has no addressable annotation identity. Skip
+            # only that member: letting it reach SQL can poison the session and
+            # prevent later, valid deletions in the same device delta from
+            # being applied before the outer route proxies success.
+            log.warning("Skipping malformed deletedAnnotationIds member %r", annotation_id)
+            continue
         query = ub.session.query(ub.Annotation).filter(
             ub.Annotation.user_id == user.id,
             ub.Annotation.annotation_id == annotation_id,

--- a/cps/services/kobo_import.py
+++ b/cps/services/kobo_import.py
@@ -64,6 +64,15 @@ class KoboContentDatabaseError(ValueError):
     pass
 
 
+class KoboBookmarkDatabaseError(KoboUploadError):
+    """The upload is SQLite, but not a readable Kobo annotation source."""
+
+    def __init__(self, detail="Could not read the Kobo Bookmark table"):
+        super().__init__("not_kobo", 400)
+        self.detail = detail
+        self.args = (detail,)
+
+
 @dataclass(frozen=True)
 class ParsedBookmark:
     """One row from a Kobo Bookmark table, plus the bits we derive
@@ -269,9 +278,10 @@ def looks_like_sqlite(blob_or_path) -> bool:
 def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
     """Open ``sqlite_path`` read-only and yield every ``Bookmark`` row.
 
-    Yields nothing if the file is not SQLite, the Bookmark table doesn't exist,
-    the table is empty, or a read fails. Read failures are logged; this iterator
-    deliberately has no separate error channel.
+    Yields nothing if the file is not SQLite or does not exist (the upload
+    boundary rejects those before calling this parser). A valid empty Bookmark
+    table yields nothing. A missing or unreadable Bookmark table raises so the
+    import cannot misreport a failed recovery as a successful zero-row scan.
     """
     if not isinstance(sqlite_path, Path):
         sqlite_path = Path(sqlite_path)
@@ -287,7 +297,7 @@ def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
         conn = sqlite3.connect(uri, uri=True)
     except sqlite3.OperationalError as e:
         log.warning("kobo_import: cannot open %s read-only: %s", sqlite_path, e)
-        return
+        raise KoboBookmarkDatabaseError("Could not open the Kobo database read-only") from e
 
     try:
         # Keep the connection non-writing at both layers. ``mode=ro`` is the
@@ -298,8 +308,7 @@ def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
             "SELECT name FROM sqlite_master WHERE type='table' AND name='Bookmark'"
         )
         if cur.fetchone() is None:
-            log.info("kobo_import: %s has no Bookmark table — skipping", sqlite_path)
-            return
+            raise KoboBookmarkDatabaseError("Kobo database has no Bookmark table")
 
         # Bookmark.Type is the device's own word for what a row is
         # (normally "highlight" or "dogear"). Selected conditionally: naming a
@@ -321,7 +330,7 @@ def parse_kobo_bookmarks(sqlite_path: Path) -> Iterator[ParsedBookmark]:
         """.format(type_column="Type" if has_type else "NULL")).fetchall()
     except sqlite3.DatabaseError as e:
         log.warning("kobo_import: SQL error on %s: %s", sqlite_path, e)
-        return
+        raise KoboBookmarkDatabaseError() from e
     finally:
         conn.close()
 

--- a/tests/unit/test_1425_kobo_to_koreader.py
+++ b/tests/unit/test_1425_kobo_to_koreader.py
@@ -321,6 +321,48 @@ def test_bookmark_only_put_still_records_the_devices_own_state(kobo_put):
     assert bookmark.location_value == "kobo.6.1", "the KoboSpan the device seeks to is still stored"
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize("clock", [
+    "not-a-clock",
+    "9999-12-31T23:59:59-23:59",
+    "0001-01-01T00:00:00+23:59",
+])
+def test_state_put_preserves_stored_clocks_when_device_clock_is_rejected(kobo_put, clock):
+    """A rejected device observation must not be replaced with server ``now``."""
+    from datetime import datetime, timezone
+
+    kobo_module, app, _session = kobo_put
+    reading_state = kobo_module.get_or_create_reading_state(BOOK_ID)
+    old_bookmark_clock = datetime(2020, 1, 2, tzinfo=timezone.utc)
+    reading_state.current_bookmark.last_modified = old_bookmark_clock
+    payload = _state_put_payload(64.5)
+    payload["ReadingStates"][0]["LastModified"] = clock
+
+    with app.test_request_context(json=payload, method="PUT"):
+        response = _handler(kobo_module)("uuid-under-test")
+
+    assert response.get_json()["RequestResult"] == "Success"
+    assert reading_state.current_bookmark.progress_percent == 64.5
+    assert reading_state.current_bookmark.last_modified == old_bookmark_clock
+
+
+@pytest.mark.unit
+def test_state_put_still_applies_a_valid_device_clock(kobo_put):
+    """The rejected-clock branch must not change valid-input behaviour."""
+    from datetime import datetime, timezone
+
+    kobo_module, app, _session = kobo_put
+    reading_state = kobo_module.get_or_create_reading_state(BOOK_ID)
+
+    with app.test_request_context(json=_state_put_payload(65.5), method="PUT"):
+        response = _handler(kobo_module)("uuid-under-test")
+
+    assert response.get_json()["RequestResult"] == "Success"
+    assert reading_state.current_bookmark.last_modified == datetime(
+        2026, 8, 14, 6, 0, tzinfo=timezone.utc,
+    )
+
+
 # ── the call site, because the bug was a call that was never made ────────────
 
 @pytest.mark.unit

--- a/tests/unit/test_annotation_portable.py
+++ b/tests/unit/test_annotation_portable.py
@@ -94,13 +94,23 @@ def test_apply_passthrough_source_kobo(session):
     assert row.source == "kobo"
 
 
-def test_apply_invalid_source_coerced(session):
-    row, _ = apply_portable(
+def test_apply_invalid_source_is_rejected_instead_of_inventing_koreader(session):
+    row, action = apply_portable(
         {"annotation_id": "dev-c", "source": "bogus", "start_kobospan": "kobo.1.1",
          "start_offset": 0, "end_kobospan": "kobo.1.1", "end_offset": 3},
         user_id=9, book=_book(), session=session, commit=session.commit,
     )
-    assert row.source == "koreader"
+    assert row is None
+    assert action == "skipped"
+    assert session.query(ub.Annotation).count() == 0
+
+
+def test_portable_boundary_rejects_an_unrecognised_source():
+    from cps.services.annotation_portable import validate_portable_payload
+
+    error = validate_portable_payload({"annotation_id": "dev-c", "source": "bogus"})
+
+    assert error == "source must be one of: kobo, koreader, webreader"
 
 
 def test_apply_portable_sets_origin_only_when_creating(session):

--- a/tests/unit/test_annotation_sync_dispatcher.py
+++ b/tests/unit/test_annotation_sync_dispatcher.py
@@ -169,6 +169,20 @@ def test_dispatch_delete_skips_tombstoned(patched_session):
     assert h.calls == []  # handler.delete NOT called twice
 
 
+def test_malformed_delete_member_cannot_block_a_later_valid_delete(patched_session):
+    """One unaddressable member must not turn the rest of the delta into a no-op."""
+    s, user = patched_session
+    dispatch_annotation_sync([_payload("uuid-keep"), _payload("uuid-delete")], _book(), user)
+
+    dispatch_annotation_deletes([{"not": "an id"}, "uuid-delete"], user, book_id=7)
+
+    rows = {
+        row.annotation_id: row.hidden
+        for row in s.query(ub.Annotation).order_by(ub.Annotation.id).all()
+    }
+    assert rows == {"uuid-keep": False, "uuid-delete": True}
+
+
 def test_tombstone_is_terminal_against_repeat_push(patched_session):
     s, user = patched_session
     register_handler(StubHandler())

--- a/tests/unit/test_kobo_import_parser.py
+++ b/tests/unit/test_kobo_import_parser.py
@@ -147,11 +147,15 @@ class TestParseKoboBookmarks:
 
 @pytest.mark.unit
 class TestParserEdgeCases:
-    def test_no_bookmark_table_yields_empty(self, tmp_path):
-        from cps.services.kobo_import import parse_kobo_bookmarks
+    def test_no_bookmark_table_is_not_reported_as_an_empty_success(self, tmp_path):
+        from cps.services.kobo_import import (
+            KoboBookmarkDatabaseError,
+            parse_kobo_bookmarks,
+        )
 
         p = build_empty_sqlite_no_bookmark_table(tmp_path / "empty.sqlite")
-        assert list(parse_kobo_bookmarks(p)) == []
+        with pytest.raises(KoboBookmarkDatabaseError, match="Bookmark table"):
+            list(parse_kobo_bookmarks(p))
 
     def test_not_sqlite_yields_empty(self, tmp_path):
         from cps.services.kobo_import import parse_kobo_bookmarks

--- a/tests/unit/test_kobo_state_put_robustness.py
+++ b/tests/unit/test_kobo_state_put_robustness.py
@@ -29,6 +29,10 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
 
 
 def _make_statistics(spent_reading_minutes=None,
@@ -69,6 +73,31 @@ class TestStatisticsResponseFalsyCheck:
         ))
         assert "SpentReadingMinutes" not in resp
         assert "RemainingTimeMinutes" not in resp
+
+
+@pytest.mark.unit
+def test_rejected_clock_defeats_the_real_onupdate_default():
+    """Changing progress must not let SQLAlchemy manufacture a newer clock."""
+    from cps.kobo import _apply_kobo_last_modified
+
+    engine = create_engine("sqlite:///:memory:")
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    old_clock = datetime(2020, 1, 2)
+    state = ub.KoboReadingState(user_id=1, book_id=2)
+    state.current_bookmark = ub.KoboBookmark(
+        progress_percent=1.0, last_modified=old_clock,
+    )
+    session.add(state)
+    session.commit()
+
+    state.current_bookmark.progress_percent = 2.0
+    _apply_kobo_last_modified(state.current_bookmark, None)
+    session.commit()
+
+    assert state.current_bookmark.progress_percent == 2.0
+    assert state.current_bookmark.last_modified == old_clock
+    session.close()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Same class as F-947bb8, found by sweeping for the **shape** rather than waiting for a report: a failure
reachable from untrusted or device-supplied input that is converted into a success, a default, or a
swallowed exception, so the user loses data with no signal.

## 1. An unrecognised `source` was coerced to `koreader` — and that grants delete authority

`cps/services/annotation_portable.py`. An unknown `source` on a portable payload silently became
`"koreader"`. That **invents provenance**, and provenance is not cosmetic here: it grants KOReader
delete authority over a row whose origin was never established. Now rejected at the HTTP boundary with
a reason, and the core helper stays defensive rather than trusting its caller.

This is precisely what `annotation_colors.py` and `annotation_types.py` were created to stop — their
docstrings both state the rule, "never invent", and this call site was breaking it.

## 2. One malformed delete member could block every later valid delete in the same batch

`cps/services/annotation_sync/__init__.py`. A non-string or empty `deletedAnnotationIds` member reached
SQL, where it can poison the session — so later, **valid** deletions in the same device delta never
applied, and the outer route proxied success anyway. Skip only the malformed member, log it, continue.
Same terminal shape as F-5c1146: the device is told everything worked.

## 3. An unreadable Bookmark table reported a successful zero-row recovery

`cps/services/kobo_import.py`. A missing or unreadable `Bookmark` table yielded nothing, which the
import reported as "imported 0 annotations" — indistinguishable from a genuinely empty device. On the
**only** recovery path that exists (F-a66189), telling someone their recovery succeeded when it never
read anything is the worst possible answer. It now raises, and the upload boundary returns a reason.

## 4. F-4bb29a — a rejected clock no longer manufactures one

`cps/kobo.py`. `parse_kobo_timestamp(lm_str) or datetime.now(timezone.utc)` replaced an unparseable
device clock with server `now` and **stored it as the ordering clock** later conflict resolution
trusts. `None` is an observation rejection, not permission to invent.

⚠️ **The subtlety that makes the naive fix wrong, and I verified it in `cps/ub.py` myself:** these
`last_modified` columns carry `onupdate=lambda: datetime.now(timezone.utc)`. Merely *declining to
assign* is insufficient — updating any other field on the row still stamps server time. The fix marks
the loaded value as explicitly supplied so the real stored observation survives the UPDATE.

## Mutation evidence — every row re-run independently by me

| mutation (degrade, not delete) | result |
|---|---|
| portable `source` guard -> never triggers | **1 failed** |
| delete malformed-member guard -> never triggers | **1 failed** |
| restore `parse_kobo_timestamp(...) or datetime.now()` | **3 failed** |
| `_apply_kobo_last_modified` assigns unconditionally | **4 failed** |
| *(my first attempt)* `if request_lm is None:` -> `if False:` | 76 passed — **weak mutation point**, disabled only the response-mirroring `g` assignment, not the behaviour |

That last row is reported rather than dropped: I aimed a mutation at the wrong place first, and it
looked like blind tests until I moved it to the load-bearing predicates. The suite does detect.

Full unit suite on this branch: **6778 passed, 103 skipped** (baseline 6742 — +36 tests).
No new dependencies.