### PR TITLE
docs: state the AI authorship disclosure up front in the README (#1631)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@
 [![Open issues](https://img.shields.io/github/issues/new-usemame/Calibre-Web-NextGen)](https://github.com/new-usemame/Calibre-Web-NextGen/issues)
 [![Sponsor](https://img.shields.io/badge/Sponsor-nothing%20paywalled-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/new-usemame)
 
+> ### 🤖 Most of the code in this fork is written by AI
+>
+> Not a footnote: the majority of this fork's own fixes, their regression tests, the changelog and
+> most issue replies are produced by an AI assistant working from a written brief. Merges are gated
+> on CI and on a regression test that is verified to fail without the fix, and anything adding a
+> dependency, changing a licence or introducing an external URL is merged by a person — but a human
+> does not read every line. The shipped application itself contains no AI: no model dependency, no
+> inference call, no telemetry, and your library is not sent anywhere.
+>
+> Decide for yourself whether that is a project you want running your library.
+> **[Read the full disclosure →](docs/AI-USAGE.md)**
+
 ---
 
 ## Switch from upstream CWA
@@ -29,7 +41,6 @@ Library, settings, users, OAuth tokens, and KOReader sync state are preserved. S
 - **New here?** See [Quick start](#quick-start) below.
 - **Want to back the work?** [**Sponsor on GitHub**](https://github.com/sponsors/new-usemame) — no rewards, no paywalled features, one-time or monthly. [Here's what it actually pays for.](#supporting-the-project)
 - **Setting up with an AI assistant** (Claude, ChatGPT, etc.)? Point it at [`AI_README.md`](AI_README.md) — a setup guide written for the assistant to follow, verify, and hand back to you working.
-- **Wondering how AI is used here?** [`docs/AI-USAGE.md`](docs/AI-USAGE.md) — used heavily to develop this fork, not at all in the software you run, and what gates it.
 
 ---
 

--- a/docs/AI-USAGE.md
+++ b/docs/AI-USAGE.md
@@ -3,7 +3,13 @@
 Asked for in [#1631](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1631). It's a fair
 question and it deserves a permanent answer rather than a reply buried in a thread.
 
-**Short version: AI is used heavily to develop this fork, and not at all in the software you run.**
+**Short version: most of the code you run was written by AI; none of it calls one at runtime.**
+
+Those are two different questions and it is worth keeping them apart, because answering only the
+second one is misleading. *Authorship*: the majority of this fork's own code, tests and prose are
+AI-written. *Runtime*: the shipped application has no model dependency, makes no inference call, and
+sends your library nowhere. If AI-authored code is the thing you are worried about, the runtime
+answer is not a reassurance and is not offered as one.
 
 ## In the software you run: none
 


### PR DESCRIPTION
## What the person asked for

@TangentFoxy, on #1631, after `docs/AI-USAGE.md` landed:

> Saying there's no AI in production when it writes the code is extremely misleading.

> Burying this instead of putting it in the ReadMe is also misleading. Users need to know immediately that this project is fully automated.

Both are fair, and both are about framing rather than facts. This changes the framing.

## What changed

**`README.md`** — the disclosure moves from the sixth bullet in a link list to a callout directly under the badges, above "Switch from upstream CWA", so it is the first prose a visitor reads. It leads with authorship (*most of the code in this fork is written by AI*), states the gates including the part where a human does not read every line, and says plainly that the reader should decide whether that is a project they want running their library. The old bullet is removed rather than left to duplicate it.

**`docs/AI-USAGE.md`** — the short version previously read "used heavily to develop this fork, and not at all in the software you run", which is the exact construction the reporter objected to: it answers the runtime question and lets the authorship question ride along under the same "no AI" heading. It now separates the two explicitly and says the runtime answer is not offered as reassurance about authorship.

## What this deliberately does not claim

"Fully automated" is the reporter's phrase and it is not quite right, so it is not adopted: community PRs are merged by a person, and dependency/licence/external-URL changes cannot merge without one. The callout says what is actually true instead of either inflating or minimising it.

## Verification

Documentation only — no code, no tests, no behaviour change. The claims in the callout are the ones already substantiated in `docs/AI-USAGE.md`, restated more prominently. Rendered link target (`docs/AI-USAGE.md`) exists at this head.

Addresses #1631.
