### PR TITLE
fix(kobo): enforce provenance authority on annotation deletes

### DIFF
--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -1533,6 +1533,9 @@ def annotations_delete(book_id, annotation_id):
         from .services import annotation_sync
         annotation_sync.dispatch_annotation_deletes(
             [annotation_id], current_user, book_id=book_id,
+            # This is an authenticated user's explicit delete, so it is
+            # authoritative across provenance rather than device-scoped.
+            deletable_sources=None,
         )
     except Exception as e:  # pragma: no cover - defensive
         log.warning("annotations: delete fan-out failed: %s", e)

--- a/cps/progress_syncing/protocols/koreader_annotations.py
+++ b/cps/progress_syncing/protocols/koreader_annotations.py
@@ -125,6 +125,7 @@ def apply_push(annotations, *, user, book, session, commit,
             if action == "deleted":
                 annotation_sync.dispatch_annotation_deletes(
                     [row.annotation_id], user, book_id=book.id,
+                    deletable_sources=_DELETABLE_SOURCES,
                 )
             else:
                 annotation_sync.dispatch_existing_annotation_sync(row, book, user)
@@ -189,6 +190,7 @@ def _apply_deletes(deleted_ids, *, user, book, session, commit, source) -> int:
         try:
             annotation_sync.dispatch_annotation_deletes(
                 [row.annotation_id], user, book_id=book.id,
+                deletable_sources=_DELETABLE_SOURCES,
             )
         except Exception:  # pragma: no cover - fan-out must never fail the push
             log.exception("koreader annotation delete fan-out failed for %s", row.annotation_id)

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -533,8 +533,12 @@ def handle_annotations(entitlement_id):
                         entitlement_id,
                     )
                 elif deleted:
+                    # Nickel can only name annotations Kobo created: CWNG has
+                    # no annotation writeback to Kobo. If F-3b565b implements
+                    # writeback, this provenance authority must be revisited.
                     annotation_sync.dispatch_annotation_deletes(
                         deleted, current_user, book_id=book.id,
+                        deletable_sources={"kobo"},
                     )
         except Exception:
             log.exception("Error processing PATCH annotations")

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -740,7 +740,10 @@ def dispatch_annotation_deletes(
         ann = query.first()
         if ann is None:
             continue
-        if deletable_sources is not None and ann.source not in deletable_sources:
+        delete_authorized = (
+            deletable_sources is None or ann.source in deletable_sources
+        )
+        if not delete_authorized:
             # Keep device transports successful for compatibility, but never
             # let a refused destructive request disappear without provenance
             # details that identify the authority mismatch.

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -6,7 +6,7 @@ Public API:
   - register_handler(handler): plug in a new target
   - available_targets(): list registered target names
   - dispatch_annotation_sync(payload_annotations, book, user): push every annotation
-  - dispatch_annotation_deletes(deleted_ids, user, book_id): delete scoped annotations
+  - dispatch_annotation_deletes(..., deletable_sources=...): delete scoped annotations
 
 The dispatcher owns all DB persistence — Annotation rows + AnnotationSyncTarget
 rows + the status state machine. Handlers are stateless: they make remote
@@ -702,15 +702,22 @@ def dispatch_existing_annotation_sync(annotation, book, user) -> None:
     _enqueue(user, jobs, book=book)
 
 
-def dispatch_annotation_deletes(deleted_ids, user, book_id=None) -> None:
+def dispatch_annotation_deletes(
+    deleted_ids, user, book_id=None, *, deletable_sources,
+) -> None:
     """For each annotation_id, transition non-tombstone sync_targets via
     handler.delete AND soft-delete the local Annotation row by setting
     ``hidden=True``.
 
-    Sub-project (2): local soft-delete happens unconditionally — independent
-    of any enabled sync target. Recovery is symmetric: a subsequent
-    create/update PATCH for the same annotation_id un-hides it via
-    ``_upsert_annotation``.
+    ``deletable_sources`` is the caller's provenance authority. Device bridges
+    pass the sources that device can honestly name; a direct user action passes
+    ``None`` to declare authority across sources. Requiring the keyword makes a
+    new bridge choose an authority model instead of inheriting an unsafe
+    default.
+
+    Once authorised, local soft-delete happens independently of any enabled
+    sync target. Recovery is symmetric: a subsequent create/update PATCH for
+    the same annotation_id un-hides it via ``_upsert_annotation``.
     """
     from cps import ub
     if not deleted_ids:
@@ -732,6 +739,17 @@ def dispatch_annotation_deletes(deleted_ids, user, book_id=None) -> None:
             query = query.filter(ub.Annotation.book_id == book_id)
         ann = query.first()
         if ann is None:
+            continue
+        if deletable_sources is not None and ann.source not in deletable_sources:
+            # Keep device transports successful for compatibility, but never
+            # let a refused destructive request disappear without provenance
+            # details that identify the authority mismatch.
+            log.warning(
+                "Annotation delete refused: user=%s book=%s annotation_id=%r "
+                "stored_source=%r deletable_sources=%s",
+                user.id, ann.book_id, annotation_id, ann.source,
+                sorted(deletable_sources),
+            )
             continue
         # Push delete through any non-tombstone sync targets.
         for st in list(ann.sync_targets):

--- a/tests/unit/test_1660_kobo_checkforchanges_filter.py
+++ b/tests/unit/test_1660_kobo_checkforchanges_filter.py
@@ -339,6 +339,34 @@ def test_patch_captures_updated_annotations_before_proxying(app, monkeypatch):
     assert dispatched == [(([annotation], book, user), {"origin_device_id": None})]
 
 
+def test_patch_declares_kobo_delete_authority_before_proxying(app, monkeypatch):
+    from cps.services import annotation_sync
+
+    sentinel = object()
+    book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
+    user = SimpleNamespace(id=7, name="test-user", is_authenticated=True)
+    dispatched = []
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "current_user", user)
+    monkeypatch.setattr(
+        annotation_sync, "dispatch_annotation_deletes",
+        lambda *args, **kwargs: dispatched.append((args, kwargs)),
+    )
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations", method="PATCH",
+        json={"deletedAnnotationIds": ["annotation-1"]},
+    ):
+        assert _view(rs.handle_annotations)(OWNED) is sentinel
+
+    assert dispatched == [(
+        (["annotation-1"], user),
+        {"book_id": book.id, "deletable_sources": {"kobo"}},
+    )]
+
+
 def test_patch_ownership_unknown_is_visible_and_not_proxied(app, monkeypatch, caplog):
     monkeypatch.setattr(
         rs, "resolve_entitlement_ownership", lambda _content_id: rs.OWNERSHIP_UNKNOWN,

--- a/tests/unit/test_annotation_sync_background_920.py
+++ b/tests/unit/test_annotation_sync_background_920.py
@@ -194,7 +194,9 @@ def test_delete_hides_locally_immediately_and_queues_the_remote(patched_session,
     queue.clear()
     handler.calls.clear()
 
-    dispatch_annotation_deletes(["uuid-a"], user, book_id=book.id)
+    dispatch_annotation_deletes(
+        ["uuid-a"], user, book_id=book.id, deletable_sources={"kobo"},
+    )
 
     ann = s.query(ub.Annotation).one()
     assert ann.hidden is True, "local soft-delete must not wait on the remote"
@@ -214,7 +216,9 @@ def test_tombstoned_target_is_never_requeued(patched_session, queue):
     book = _book()
     dispatch_annotation_sync([_payload("uuid-a")], book, user)
     _run(s, user, queue, book)
-    dispatch_annotation_deletes(["uuid-a"], user, book_id=book.id)
+    dispatch_annotation_deletes(
+        ["uuid-a"], user, book_id=book.id, deletable_sources={"kobo"},
+    )
     _run(s, user, queue, book)
     queue.clear()
 

--- a/tests/unit/test_annotation_sync_dispatcher.py
+++ b/tests/unit/test_annotation_sync_dispatcher.py
@@ -158,6 +158,57 @@ def test_dispatch_delete_transitions_to_tombstone(patched_session):
     assert s.query(ub.AnnotationSyncTarget).one().status == "tombstone"
 
 
+def test_kobo_delete_authority_refuses_foreign_sources_and_fans_out_owned(
+    patched_session, caplog,
+):
+    """A Kobo delete may affect only rows a Kobo device could have held."""
+    s, user = patched_session
+    handler = StubHandler()
+    register_handler(handler)
+    dispatch_annotation_sync([_payload("kobo-owned")], _book(), user)
+
+    for annotation_id, source in (
+        ("webreader-foreign", "webreader"),
+        ("koreader-foreign", "koreader"),
+    ):
+        row = ub.Annotation(
+            user_id=user.id,
+            annotation_id=annotation_id,
+            book_id=7,
+            source=source,
+            hidden=False,
+        )
+        row.sync_targets.append(ub.AnnotationSyncTarget(
+            target="stub",
+            target_record_id=f"{source}-remote",
+            status="synced",
+        ))
+        s.add(row)
+    s.commit()
+    handler.calls.clear()
+    caplog.set_level("WARNING", logger="cps.services.annotation_sync")
+
+    dispatch_annotation_deletes(
+        ["kobo-owned", "webreader-foreign", "koreader-foreign"],
+        user,
+        book_id=7,
+        deletable_sources={"kobo"},
+    )
+
+    rows = {
+        row.annotation_id: bool(row.hidden)
+        for row in s.query(ub.Annotation).order_by(ub.Annotation.id)
+    }
+    assert rows == {
+        "kobo-owned": True,
+        "webreader-foreign": False,
+        "koreader-foreign": False,
+    }
+    assert handler.calls == [("delete", "r1")]
+    assert "annotation_id='webreader-foreign' stored_source='webreader'" in caplog.text
+    assert "annotation_id='koreader-foreign' stored_source='koreader'" in caplog.text
+
+
 def test_dispatch_delete_skips_tombstoned(patched_session):
     s, user = patched_session
     h = StubHandler()

--- a/tests/unit/test_annotation_sync_dispatcher.py
+++ b/tests/unit/test_annotation_sync_dispatcher.py
@@ -154,7 +154,7 @@ def test_dispatch_delete_transitions_to_tombstone(patched_session):
     register_handler(StubHandler())
     dispatch_annotation_sync([_payload("uuid-x")], _book(), user)
     assert s.query(ub.AnnotationSyncTarget).one().status == "synced"
-    dispatch_annotation_deletes(["uuid-x"], user)
+    dispatch_annotation_deletes(["uuid-x"], user, deletable_sources={"kobo"})
     assert s.query(ub.AnnotationSyncTarget).one().status == "tombstone"
 
 
@@ -214,9 +214,11 @@ def test_dispatch_delete_skips_tombstoned(patched_session):
     h = StubHandler()
     register_handler(h)
     dispatch_annotation_sync([_payload("uuid-x")], _book(), user)
-    dispatch_annotation_deletes(["uuid-x"], user)
+    dispatch_annotation_deletes(["uuid-x"], user, deletable_sources={"kobo"})
     h.calls.clear()
-    dispatch_annotation_deletes(["uuid-x"], user)  # second delete attempt
+    dispatch_annotation_deletes(
+        ["uuid-x"], user, deletable_sources={"kobo"},
+    )  # second delete attempt
     assert h.calls == []  # handler.delete NOT called twice
 
 
@@ -225,7 +227,10 @@ def test_malformed_delete_member_cannot_block_a_later_valid_delete(patched_sessi
     s, user = patched_session
     dispatch_annotation_sync([_payload("uuid-keep"), _payload("uuid-delete")], _book(), user)
 
-    dispatch_annotation_deletes([{"not": "an id"}, "uuid-delete"], user, book_id=7)
+    dispatch_annotation_deletes(
+        [{"not": "an id"}, "uuid-delete"], user, book_id=7,
+        deletable_sources={"kobo"},
+    )
 
     rows = {
         row.annotation_id: row.hidden
@@ -239,7 +244,7 @@ def test_tombstone_is_terminal_against_repeat_push(patched_session):
     register_handler(StubHandler())
     payload = _payload("uuid-x")
     dispatch_annotation_sync([payload], _book(), user)
-    dispatch_annotation_deletes(["uuid-x"], user)
+    dispatch_annotation_deletes(["uuid-x"], user, deletable_sources={"kobo"})
     dispatch_annotation_sync([payload], _book(), user)  # re-push
     st = s.query(ub.AnnotationSyncTarget).one()
     assert st.status == "tombstone"  # NOT resurrected

--- a/tests/unit/test_annotations_webreader_hardcover_fanout.py
+++ b/tests/unit/test_annotations_webreader_hardcover_fanout.py
@@ -158,7 +158,9 @@ def test_real_hardcover_handler_gates_then_tombstones_without_repush(patched_ses
     assert client.calls[0][0] == "add"
 
     from cps.services.annotation_sync import dispatch_annotation_deletes
-    dispatch_annotation_deletes([row.annotation_id], user)
+    dispatch_annotation_deletes(
+        [row.annotation_id], user, deletable_sources=None,
+    )
     assert client.calls[1] == ("delete", 91)
 
     dispatch_existing_annotation_sync(row, _book(), user)

--- a/tests/unit/test_kobo_annotation_stage0.py
+++ b/tests/unit/test_kobo_annotation_stage0.py
@@ -516,7 +516,9 @@ def test_dispatch_persists_raw_sidecar_without_rewriting_parsed_location(monkeyp
     assert materialization.provenance == "kobo_patch"
     assert materialization.attachments_state == "empty"
     assert materialization.serveable is False
-    annotation_sync.dispatch_annotation_deletes(["ann-1"], user, book_id=348)
+    annotation_sync.dispatch_annotation_deletes(
+        ["ann-1"], user, book_id=348, deletable_sources={"kobo"},
+    )
     session.refresh(ann)
     assert ann.hidden is True
     assert ann.content_revision == 2

--- a/tests/unit/test_koreader_annotations_endpoints.py
+++ b/tests/unit/test_koreader_annotations_endpoints.py
@@ -170,7 +170,7 @@ def test_delete_fanout_is_scoped_to_book(env):
     _seed(s, user, "shared", book_id=7)
     _seed(s, user, "shared", book_id=8)
     dispatch_annotation_deletes(
-        ["shared"], user, book_id=8, deletable_sources={"koreader"},
+        ["shared"], user, book_id=8, deletable_sources={"kobo"},
     )
     assert s.query(ub.Annotation).filter_by(book_id=7, annotation_id="shared").one().hidden is False
     assert s.query(ub.Annotation).filter_by(book_id=8, annotation_id="shared").one().hidden is True

--- a/tests/unit/test_koreader_annotations_endpoints.py
+++ b/tests/unit/test_koreader_annotations_endpoints.py
@@ -169,7 +169,9 @@ def test_delete_fanout_is_scoped_to_book(env):
     s, user = env
     _seed(s, user, "shared", book_id=7)
     _seed(s, user, "shared", book_id=8)
-    dispatch_annotation_deletes(["shared"], user, book_id=8)
+    dispatch_annotation_deletes(
+        ["shared"], user, book_id=8, deletable_sources={"koreader"},
+    )
     assert s.query(ub.Annotation).filter_by(book_id=7, annotation_id="shared").one().hidden is False
     assert s.query(ub.Annotation).filter_by(book_id=8, annotation_id="shared").one().hidden is True
 

--- a/tests/unit/test_sp2_live_kobo_capture.py
+++ b/tests/unit/test_sp2_live_kobo_capture.py
@@ -141,7 +141,7 @@ def test_delete_soft_deletes_local_row_with_no_handler(session):
     dispatch_annotation_sync([_full_payload("kobo-1")], _book(), user)
     ann = s.query(ub.Annotation).one()
     assert ann.hidden is False or ann.hidden is None
-    dispatch_annotation_deletes(["kobo-1"], user)
+    dispatch_annotation_deletes(["kobo-1"], user, deletable_sources={"kobo"})
     s.refresh(ann)
     assert ann.hidden is True
 
@@ -155,14 +155,16 @@ def test_delete_soft_deletes_locally_even_when_handler_disabled(session):
         def delete(self, *a, **kw): return SyncResult(status="tombstone")
     register_handler(DisabledHandler())
     dispatch_annotation_sync([_full_payload("kobo-1")], _book(), user)
-    dispatch_annotation_deletes(["kobo-1"], user)
+    dispatch_annotation_deletes(["kobo-1"], user, deletable_sources={"kobo"})
     ann = s.query(ub.Annotation).one()
     assert ann.hidden is True
 
 
 def test_delete_nonexistent_annotation_is_noop(session):
     s, user = session
-    dispatch_annotation_deletes(["never-existed"], user)
+    dispatch_annotation_deletes(
+        ["never-existed"], user, deletable_sources={"kobo"},
+    )
     assert s.query(ub.Annotation).count() == 0
 
 
@@ -173,7 +175,7 @@ def test_recreate_unhides_previously_deleted_annotation(session):
     the local row comes back to life rather than staying hidden."""
     s, user = session
     dispatch_annotation_sync([_full_payload("kobo-1")], _book(), user)
-    dispatch_annotation_deletes(["kobo-1"], user)
+    dispatch_annotation_deletes(["kobo-1"], user, deletable_sources={"kobo"})
     ann = s.query(ub.Annotation).one()
     assert ann.hidden is True
     # PATCH the same annotation_id again with new text.


### PR DESCRIPTION
## Summary

- require every shared annotation-delete caller to declare its provenance authority
- limit Kobo PATCH deletes to `source="kobo"`, while preserving KOReader's existing `{"koreader"}` authority and explicit authenticated web-UI authority across sources
- refuse foreign-source deletes before local mutation or sync-target fan-out, with diagnostic user/book/annotation/source logging
- record at the Kobo call site that F-3b565b writeback would require revisiting this authority model

## Compatibility decision

A refused Kobo delete remains silent to the device: the local mutation is skipped and logged, while the PATCH continues through the existing Kobo proxy and returns its normal response. Introducing a new error response risks firmware retry or destructive reconciliation behavior that is not established as safe. Since the device could never have held the refused foreign-source row, there is nothing honest for it to retry locally.

The shared dispatcher uses a required keyword parameter rather than a hardcoded Kobo set. That makes every current and future caller choose an authority model explicitly; a new device bridge cannot accidentally inherit unrestricted deletion.

Honest Kobo deletes still soft-delete locally, fan out to non-tombstoned sync targets, and un-hide on a later recreate PATCH.

## Verification

- fail-first regression: `1 failed` on the pre-fix dispatcher (`unexpected keyword argument 'deletable_sources'`)
- guard mutation (`delete_authorized = True`): `1 failed`; both foreign-source rows were incorrectly hidden
- focused affected suites: `252 passed, 46 warnings`

References F-a54711 and #1790.
