### PR TITLE
fix: preserve newest annotation during duplicate merge

### DIFF
--- a/cps/user_book_data.py
+++ b/cps/user_book_data.py
@@ -45,6 +45,40 @@ def _newer(a, b):
         b = b.replace(tzinfo=None)
     return a > b
 
+
+def _annotation_is_newer(candidate, current):
+    """Whether ``candidate`` is the newer coherent annotation version.
+
+    Server and client clocks both record accepted edits, so the newest
+    available clock on each row is authoritative.  Revisions break equal or
+    absent-clock ties.  A complete tie returns False, deterministically
+    retaining ``current`` (the row already attached to the destination book).
+    """
+    candidate_modified = None
+    current_modified = None
+    for timestamp in (candidate.server_modified_at,
+                      candidate.client_modified_at):
+        if _newer(timestamp, candidate_modified):
+            candidate_modified = timestamp
+    for timestamp in (current.server_modified_at,
+                      current.client_modified_at):
+        if _newer(timestamp, current_modified):
+            current_modified = timestamp
+
+    if _newer(candidate_modified, current_modified):
+        return True
+    if _newer(current_modified, candidate_modified):
+        return False
+    return (candidate.content_revision or 0) > (current.content_revision or 0)
+
+
+def _delete_annotation(session, annotation):
+    """Delete an annotation and children SQLite will not cascade itself."""
+    session.query(ub.AnnotationSyncTarget).filter(
+        ub.AnnotationSyncTarget.annotation_id == annotation.id,
+    ).delete(synchronize_session=False)
+    session.delete(annotation)
+
 # Models keyed (user_id, book_id) handled by this module, with merge
 # semantics for migrate. BookShelf has no user_id (shelf-scoped) and
 # KoboBookmark/KoboStatistics/AnnotationSyncTarget are children reached
@@ -78,9 +112,9 @@ def migrate_user_book_data(from_book_id, to_book_id, session=None):
         return
 
     # Annotations: re-point, but a user may already have the same
-    # annotation_id on the kept book (e.g. the device synced both copies) —
-    # there only the loser row is dropped (ORM delete so sync-target
-    # children go with it).
+    # annotation_id on the kept book (e.g. the device synced both copies).
+    # Keep the newer coherent row; field-level synthesis could combine content,
+    # anchors and lifecycle metadata into a version no client ever authored.
     for ann in session.query(ub.Annotation).filter(
             ub.Annotation.book_id == from_book_id).all():
         clash = session.query(ub.Annotation).filter(
@@ -88,13 +122,12 @@ def migrate_user_book_data(from_book_id, to_book_id, session=None):
             ub.Annotation.annotation_id == ann.annotation_id,
             ub.Annotation.book_id == to_book_id).first()
         if clash is not None:
-            # sync_targets declares passive_deletes=True (expects DB-level
-            # ON DELETE CASCADE), but SQLite FK enforcement is off — delete
-            # the children explicitly.
-            session.query(ub.AnnotationSyncTarget).filter(
-                ub.AnnotationSyncTarget.annotation_id == ann.id).delete(
-                synchronize_session=False)
-            session.delete(ann)
+            if _annotation_is_newer(ann, clash):
+                _delete_annotation(session, clash)
+                session.flush()  # clear the UNIQUE slot before re-pointing
+                ann.book_id = to_book_id
+            else:
+                _delete_annotation(session, ann)
         else:
             ann.book_id = to_book_id
     session.flush()

--- a/tests/unit/test_user_book_data_d4.py
+++ b/tests/unit/test_user_book_data_d4.py
@@ -102,11 +102,20 @@ class TestMigrate:
         assert moved.highlighted_text == "hl"
         assert session.query(ub.AnnotationSyncTarget).count() == 1
 
-    def test_annotation_clash_keeps_winner_row(self, session):
+    def test_annotation_clash_keeps_newer_destination_row(self, session):
         from cps import ub
         from cps.user_book_data import migrate_user_book_data
-        keep = _annotation(ub, WINNER, text="winner-copy")
-        lose = _annotation(ub, LOSER, text="loser-copy")
+        keep = _annotation(
+            ub, WINNER, text="newer-destination-copy", note_text="keep me",
+            server_modified_at=datetime(2026, 7, 20), content_revision=9,
+        )
+        lose = _annotation(
+            ub, LOSER, text="stale-source-copy",
+            server_modified_at=datetime(2026, 1, 1), content_revision=1,
+        )
+        keep.sync_targets.append(
+            ub.AnnotationSyncTarget(target="readwise", status="synced")
+        )
         lose.sync_targets.append(ub.AnnotationSyncTarget(target="hardcover", status="pending"))
         session.add_all([keep, lose])
         session.commit()
@@ -115,9 +124,106 @@ class TestMigrate:
         session.commit()
 
         rows = session.query(ub.Annotation).all()
-        assert len(rows) == 1 and rows[0].highlighted_text == "winner-copy"
-        # the dropped loser row's sync-target child went with it
-        assert session.query(ub.AnnotationSyncTarget).count() == 0
+        assert len(rows) == 1
+        assert rows[0].book_id == WINNER
+        assert rows[0].highlighted_text == "newer-destination-copy"
+        assert rows[0].note_text == "keep me"
+        # Only the dropped source row's sync-target child is removed.
+        targets = session.query(ub.AnnotationSyncTarget).all()
+        assert len(targets) == 1
+        assert targets[0].annotation_id == rows[0].id
+        assert targets[0].target == "readwise"
+
+    def test_annotation_clash_moves_newer_source_row_and_drops_destination_children(
+        self, session,
+    ):
+        from cps import ub
+        from cps.user_book_data import migrate_user_book_data
+        keep = _annotation(
+            ub, WINNER, text="stale-destination-copy", note_text=None,
+            server_modified_at=datetime(2026, 1, 1), content_revision=1,
+        )
+        lose = _annotation(
+            ub, LOSER, text="newer-source-copy", note_text="recent note",
+            server_modified_at=datetime(2026, 7, 20), content_revision=9,
+        )
+        keep.sync_targets.append(
+            ub.AnnotationSyncTarget(target="hardcover", status="synced")
+        )
+        lose.sync_targets.append(
+            ub.AnnotationSyncTarget(target="readwise", status="pending")
+        )
+        session.add_all([keep, lose])
+        session.commit()
+        source_id = lose.id
+
+        migrate_user_book_data(LOSER, WINNER, session=session)
+        session.commit()
+
+        row = session.query(ub.Annotation).one()
+        assert row.id == source_id
+        assert row.book_id == WINNER
+        assert row.highlighted_text == "newer-source-copy"
+        assert row.note_text == "recent note"
+        assert row.content_revision == 9
+        targets = session.query(ub.AnnotationSyncTarget).all()
+        assert len(targets) == 1
+        assert targets[0].annotation_id == row.id
+        assert targets[0].target == "readwise"
+
+    def test_annotation_clash_uses_client_clock_when_server_clocks_are_null(
+        self, session,
+    ):
+        from cps import ub
+        from cps.user_book_data import migrate_user_book_data
+        session.add_all([
+            _annotation(
+                ub, WINNER, text="stale-destination-copy",
+                client_modified_at=datetime(2026, 1, 1), content_revision=9,
+            ),
+            _annotation(
+                ub, LOSER, text="newer-source-copy",
+                client_modified_at=datetime(2026, 7, 20), content_revision=1,
+            ),
+        ])
+        session.commit()
+
+        migrate_user_book_data(LOSER, WINNER, session=session)
+        session.commit()
+
+        row = session.query(ub.Annotation).one()
+        assert row.book_id == WINNER
+        assert row.highlighted_text == "newer-source-copy"
+
+    def test_annotation_clash_null_clocks_use_revision_then_destination_tie_break(
+        self, session,
+    ):
+        from cps import ub
+        from cps.user_book_data import migrate_user_book_data
+        session.add_all([
+            _annotation(ub, WINNER, annotation_id="revision", text="revision-2",
+                        content_revision=2),
+            _annotation(ub, LOSER, annotation_id="revision", text="revision-7",
+                        content_revision=7),
+            _annotation(ub, WINNER, annotation_id="tie", text="destination-tie",
+                        content_revision=4),
+            _annotation(ub, LOSER, annotation_id="tie", text="source-tie",
+                        content_revision=4),
+        ])
+        session.commit()
+
+        migrate_user_book_data(LOSER, WINNER, session=session)
+        session.commit()
+
+        rows = {
+            row.annotation_id: row
+            for row in session.query(ub.Annotation).order_by(ub.Annotation.annotation_id)
+        }
+        assert set(rows) == {"revision", "tie"}
+        assert rows["revision"].book_id == WINNER
+        assert rows["revision"].highlighted_text == "revision-7"
+        assert rows["tie"].book_id == WINNER
+        assert rows["tie"].highlighted_text == "destination-tie"
 
     def test_kobo_reading_state_newer_loser_wins(self, session):
         from cps import ub


### PR DESCRIPTION
## Summary

- choose the newer coherent annotation row when duplicate-book migration finds the same `(user_id, annotation_id)` on both books
- compare the newest available `server_modified_at` / `client_modified_at` clock first, then `content_revision`; if all recency signals tie or are null/equal, deterministically keep the destination-book row
- explicitly delete `AnnotationSyncTarget` children for whichever annotation loses, and flush a deleted destination row before moving the source into the unique `(user_id, book_id, annotation_id)` slot
- leave `KoboReadingState` and `ReadBook` merge behavior unchanged

## Design decision

This deliberately selects one whole annotation row rather than synthesizing fields. Annotation content, anchor/location, lifecycle state, editor/device metadata, and revision describe one coherent version. Field-level merging could produce a state no client authored—for example, a newer note combined with a stale anchor or lifecycle value—so it is too risky for this targeted data-loss fix.

Null timestamps are handled explicitly: a present effective clock outranks no clock; when both effective clocks are absent or equal, the higher content revision wins; an exact tie retains the destination row.

## Verification

- Red before production change: `python -m pytest tests/unit/test_user_book_data_d4.py -k annotation --tb=short` → **3 failed, 3 passed, 15 deselected**
- Fixed annotation subset: same command → **6 passed, 15 deselected**
- Full per-user-book module: `python -m pytest tests/unit/test_user_book_data_d4.py --tb=short` → **21 passed**
- Required broader unit selection: `python -m pytest tests/unit -k 'user_book_data or annotation or kobo' --tb=short -q` → **1189 passed, 3 skipped, 5713 deselected**
- Degrade mutation: forced `_annotation_is_newer` to return `False`; the annotation subset returned **3 failed, 3 passed, 15 deselected**, proving the new tests execute the recency decision. Mutation removed and the subset re-ran **6 passed**.

References F-a7b6b2.
