### PR TITLE
fix(koreader): bound the annotation-delete query to the ids actually requested

### DIFF
--- a/cps/progress_syncing/protocols/koreader_annotations.py
+++ b/cps/progress_syncing/protocols/koreader_annotations.py
@@ -66,6 +66,10 @@ log = logger.create()
 # highlight.
 _DELETABLE_SOURCES = {"koreader"}
 
+# Keep ``annotation_id IN (...)`` below SQLite's historical 999-variable
+# ceiling after the user/book/source predicates take their own bind slots.
+_DELETE_ID_CHUNK_SIZE = 900
+
 
 def _now():
     return datetime.now(timezone.utc)
@@ -167,17 +171,21 @@ def _apply_deletes(deleted_ids, *, user, book, session, commit, source) -> int:
     if not wanted:
         return 0
 
-    stale = [
-        row for row in session.query(ub.Annotation).filter(
-            ub.Annotation.user_id == user.id,
-            ub.Annotation.book_id == book.id,
-            ub.Annotation.source == source,
-        ).filter(
-            (ub.Annotation.hidden.is_(None))
-            | (ub.Annotation.hidden == False)  # noqa: E712 — SQLA needs ==
-        ).all()
-        if row.annotation_id in wanted
-    ]
+    base_query = session.query(ub.Annotation).filter(
+        ub.Annotation.user_id == user.id,
+        ub.Annotation.book_id == book.id,
+        ub.Annotation.source == source,
+    ).filter(
+        (ub.Annotation.hidden.is_(None))
+        | (ub.Annotation.hidden == False)  # noqa: E712 — SQLA needs ==
+    )
+    wanted_ids = sorted(wanted)
+    stale = []
+    for start in range(0, len(wanted_ids), _DELETE_ID_CHUNK_SIZE):
+        chunk = wanted_ids[start:start + _DELETE_ID_CHUNK_SIZE]
+        stale.extend(
+            base_query.filter(ub.Annotation.annotation_id.in_(chunk)).all()
+        )
     if not stale:
         return 0
 

--- a/tests/unit/test_koreader_annotation_delete_reap.py
+++ b/tests/unit/test_koreader_annotation_delete_reap.py
@@ -27,7 +27,7 @@ itself (an omission never deletes) lives in
 from __future__ import annotations
 
 import pytest
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, event, text
 from sqlalchemy.orm import sessionmaker
 from types import SimpleNamespace
 
@@ -155,6 +155,79 @@ def test_deleted_row_dispatches_delete_fanout(env):
                deleted_ids=["fanout-me"])
 
     assert handler.deletes == ["r1"]
+
+
+def test_delete_query_materializes_only_requested_ids_in_bounded_chunks(
+    env, monkeypatch,
+):
+    """Deleting N ids must not load every highlight in the scoped book.
+
+    The request is deliberately larger than SQLite's historical 999-variable
+    ceiling.  This catches both failure modes: filtering the whole book in
+    Python, and replacing that scan with one unbounded ``IN (...)`` clause.
+    """
+    s, user = env
+    user_id = user.id
+    requested = [f"delete-{index}" for index in range(1001)]
+    unrelated = [f"keep-{index}" for index in range(25)]
+    s.add_all([
+        ub.Annotation(
+            user_id=user_id, annotation_id=aid, book_id=7, source="koreader",
+            highlighted_text="t", highlight_color="yellow",
+            start_container_path="span#kobo.1.1", start_offset=0,
+            end_container_path="span#kobo.1.1", end_offset=4, hidden=False,
+        )
+        for aid in requested + unrelated
+    ])
+    s.commit()
+    s.expunge_all()
+
+    loaded_ids = []
+    in_query_bind_counts = []
+
+    def _record_load(row, _context):
+        loaded_ids.append(row.annotation_id)
+
+    def _record_query(_conn, _cursor, statement, parameters, _context, _many):
+        if "annotation.annotation_id IN (" in statement:
+            in_query_bind_counts.append(len(parameters))
+
+    fanout_calls = []
+
+    def _record_fanout(ids, fanout_user, **kwargs):
+        fanout_calls.append((ids, fanout_user.id, kwargs))
+
+    from cps.services import annotation_sync
+    monkeypatch.setattr(
+        annotation_sync, "dispatch_annotation_deletes", _record_fanout,
+    )
+    event.listen(ub.Annotation, "load", _record_load)
+    event.listen(s.get_bind(), "before_cursor_execute", _record_query)
+    try:
+        summary = apply_push(
+            [], user=SimpleNamespace(id=user_id), book=_book(),
+            session=s, commit=s.commit, deleted_ids=requested,
+        )
+    finally:
+        event.remove(ub.Annotation, "load", _record_load)
+        event.remove(s.get_bind(), "before_cursor_execute", _record_query)
+
+    assert len(loaded_ids) == len(requested), (
+        f"delete of {len(requested)} ids materialized {len(loaded_ids)} live "
+        "rows from the scoped book; work must scale with requested deletions, "
+        "not total highlights"
+    )
+    assert set(loaded_ids) == set(requested)
+    assert len(in_query_bind_counts) >= 2
+    assert max(in_query_bind_counts) <= 904
+    assert summary["deleted"] == len(requested)
+    assert len(fanout_calls) == len(requested)
+    assert {call[0][0] for call in fanout_calls} == set(requested)
+    assert all(call[0] and len(call[0]) == 1 for call in fanout_calls)
+    assert all(call[1] == user_id for call in fanout_calls)
+    assert all(call[2] == {
+        "book_id": 7, "deletable_sources": {"koreader"},
+    } for call in fanout_calls)
 
 
 # --- over the wire ---------------------------------------------------------


### PR DESCRIPTION
Server half of **F-e4da4d** (#1239).

`_apply_deletes` materialized **every** live KOReader annotation for the user/book/source with `.all()`, then filtered in Python against the wanted set. So deleting *n* highlights did work proportional to the user's **total** highlight count for that book. The path only became reachable with #1238 and was never exercised at scale.

The ids now go into the query as `annotation_id IN (...)`, chunked at 900 so the fix doesn't just move the cliff to SQLite's variable ceiling.

**Semantics unchanged:** same rows selected, per-row fan-out through `dispatch_annotation_deletes` still one call per row with `deletable_sources={'koreader'}` (#1793), and the "fan-out must never fail the push" handling untouched. The test asserts all of that explicitly.

### Evidence (OBSERVED)

The test measures the property, not a proxy: it counts ORM rows actually loaded and the bind count of each `IN` query, keeps 25 unrelated rows in the same scoped book as a control, and requests 1001 ids so it fails **both** ways — a Python-side scan *and* a single unbounded `IN`.

Red on `origin/main` for a behavioural reason:

```
AssertionError: delete of 1001 ids materialized 1026 live rows from the scoped book;
work must scale with requested deletions, not total highlights
assert 1026 == 1001
```

**Mutation:** reverting only `koreader_annotations.py` to `origin/main` and keeping the test fails **exactly 1** test.

**Full unit suite on the branch:** `6835 passed, 104 skipped`.

### What this does NOT do

The client half — `CWASyncClient.lua:303` sending the complete id list in one request under a 15s timeout, unbatched and uncapped — is untouched, and **F-e4da4d stays open for it**. That half is what actually bounds request *size* against a slow reader or a reverse-proxy body limit; this half removes the "scales with total highlights" property.