### PR TITLE
fix(spa): the expanded desktop sidebar no longer swallows clicks on the page you just opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ is for things you can see or feel when running the app.
 
 ### Fixed
 
+- **After opening a sidebar destination, the expanded desktop navigation could
+  stay over the new page and block its left-side controls simply because the
+  pointer was still resting over the item that was clicked.** The rail now
+  stays collapsed while the pointer travels out toward the page; deliberately
+  returning to the rail or focusing it with the keyboard still expands it
+  without shifting the page content.
+
 - **Smart shelves and other library activity now keep recording statistics when
   source-tree and container installs launch outside the application directory.**
   Those launches could not find the CWA settings database module, which filled

--- a/frontend/e2e/sidebar-retained-hover.spec.ts
+++ b/frontend/e2e/sidebar-retained-hover.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test';
+
+test('desktop sidebar releases hover retained across navigation', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop', 'desktop fine-pointer rail only');
+
+  await page.goto('/app/');
+  const firstBook = page.locator('main a[href*="/book/"]').first();
+  await expect(firstBook).toBeVisible({ timeout: 20_000 });
+  await firstBook.click();
+  await expect(page).toHaveURL(/\/book\/\d+(?:\?.*)?$/);
+  const bookUrl = page.url();
+
+  // Enter the expandable rail as a user does, then leave the pointer parked on
+  // the clicked item while navigation changes the page beneath it.
+  const nav = page.getByRole('navigation', { name: 'Browse' });
+  const tagsLink = nav.getByRole('link', { name: 'Tags', exact: true });
+  await tagsLink.hover();
+  await expect.poll(() => nav.evaluate((element) => getComputedStyle(element).width))
+    .toBe('220px');
+  const navBox = await nav.boundingBox();
+  const tagsBox = await tagsLink.boundingBox();
+  expect(navBox).not.toBeNull();
+  expect(tagsBox).not.toBeNull();
+  const parkedX = navBox!.x + 48;
+  await tagsLink.click({
+    position: { x: parkedX - tagsBox!.x, y: tagsBox!.height / 2 },
+  });
+  await expect(page).toHaveURL(/\/tags\/?(?:\?.*)?$/);
+  await expect.poll(() => nav.evaluate((element) =>
+    element.getAnimations().filter((animation) => animation.playState === 'running').length,
+  )).toBe(0);
+
+  // Suppressing stale hover must never defeat keyboard expansion. Route focus
+  // starts at main; Shift+Tab enters the preceding sidebar control.
+  await expect.poll(() => page.evaluate(() => document.activeElement?.id)).toBe('main');
+  await page.keyboard.press('Shift+Tab');
+  expect(await nav.evaluate((element) => element.contains(document.activeElement)))
+    .toBe(true);
+  await expect.poll(() => nav.evaluate((element) => getComputedStyle(element).width))
+    .toBe('220px');
+
+  // Returning to the book does not move the pointer. The newly landed page's
+  // back link is inside the 156px overlay strip formerly retained by :hover.
+  await page.goBack();
+  await expect(page).toHaveURL(bookUrl);
+  const backLink = page.getByRole('link', { name: '← Library', exact: true });
+  await expect(backLink).toBeVisible();
+  await expect.poll(() => nav.evaluate((element) =>
+    element.getAnimations().filter((animation) => animation.playState === 'running').length,
+  )).toBe(0);
+
+  const box = await backLink.boundingBox();
+  expect(box, 'book back link has a rendered box').not.toBeNull();
+  const centre = { x: box!.x + box!.width / 2, y: box!.y + box!.height / 2 };
+  expect(centre.x, 'regression control sits inside the rail\'s 156px overlay strip')
+    .toBeLessThan(156);
+
+  const hitAtCentre = () => backLink.evaluate((target, point) => {
+    const element = document.elementFromPoint(point.x, point.y);
+    return {
+      targetOwnsHit: element === target || target.contains(element),
+      hitTag: element?.tagName ?? null,
+      hitText: element?.textContent?.trim() ?? null,
+      hitHref: element instanceof HTMLAnchorElement ? element.getAttribute('href') : null,
+      hitInsideNav: !!element?.closest('nav[aria-label="Browse"]'),
+    };
+  }, centre);
+
+  // Follow a human mouse path from the icon-side click point to the page
+  // control. Every intermediate move must keep stale hover suppressed; if the
+  // rail expands under the travelling pointer, it captures the destination.
+  const parkedY = tagsBox!.y + tagsBox!.height / 2;
+  for (let step = 1; step <= 12; step += 1) {
+    const point = {
+      x: parkedX + ((centre.x - parkedX) * step) / 12,
+      y: parkedY + ((centre.y - parkedY) * step) / 12,
+    };
+    await page.mouse.move(point.x, point.y);
+    await page.waitForTimeout(50);
+    expect(await nav.evaluate((element) => getComputedStyle(element).width),
+      `rail width after traversal step ${step}`).toBe('64px');
+    const hit = await hitAtCentre();
+    expect(hit.targetOwnsHit,
+      `step ${step}: back-link centre ${JSON.stringify(centre)} hit ${JSON.stringify(hit)}`)
+      .toBe(true);
+  }
+
+  await page.mouse.down();
+  await page.mouse.up();
+  await expect(page).toHaveURL(/\/app\/?(?:\?.*)?$/);
+
+  // Once the pointer has completed its journey out, deliberately returning to
+  // the collapsed rail is new hover intent and must expand it again.
+  await page.mouse.move(navBox!.x + 32, navBox!.y + 32, { steps: 12 });
+  await expect.poll(() => nav.evaluate((element) => getComputedStyle(element).width))
+    .toBe('220px');
+});

--- a/frontend/src/components/Sidebar.module.css
+++ b/frontend/src/components/Sidebar.module.css
@@ -157,7 +157,7 @@
       margin-right var(--dur-base) var(--ease-out);
   }
 
-  :is(.nav, .navOpen):is(:hover, :focus-within) {
+  :is(.nav, .navOpen):is(:hover:not(.hoverSuppressed), :focus-within) {
     width: 220px;
     margin-right: -156px;
   }
@@ -187,14 +187,14 @@
     padding-left: calc(18px + var(--sp-2));
   }
 
-  :is(.nav, .navOpen):is(:hover, :focus-within)
+  :is(.nav, .navOpen):is(:hover:not(.hoverSuppressed), :focus-within)
     :is(.item > span, .itemActive > span, .sectionTitle > span, .sectionTitleActive > span, .customizeBtn > span, .shelfName, .magicShelfName),
-  :is(.nav, .navOpen):is(:hover, :focus-within)
+  :is(.nav, .navOpen):is(:hover:not(.hoverSuppressed), :focus-within)
     :is(.shelfItem, .shelfItemActive) {
     opacity: 1;
   }
 
-  :is(.nav, .navOpen):is(:hover, :focus-within) .magicShelfIcon {
+  :is(.nav, .navOpen):is(:hover:not(.hoverSuppressed), :focus-within) .magicShelfIcon {
     left: calc(var(--sp-3) + 18px + var(--sp-3));
   }
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -41,6 +41,8 @@ export function Sidebar({ open, onClose, onNavigate }: SidebarProps) {
   const announce = useAnnouncer();
   const navRef = useRef<HTMLElement>(null);
   const update = useUpdateSidebar();
+  const [hoverSuppressed, setHoverSuppressed] = useState(false);
+  const hoverExitObserved = useRef(false);
 
   // #585 v3: inline sidebar edit mode (toggled by the Customize capsule).
   const [editMode, setEditMode] = useState(false);
@@ -65,6 +67,30 @@ export function Sidebar({ open, onClose, onNavigate }: SidebarProps) {
     if (isMobile && !open) node.setAttribute('inert', '');
     else node.removeAttribute('inert');
   }, [isMobile, open]);
+
+  useEffect(() => {
+    if (!hoverSuppressed) return;
+
+    // A route click can leave the pointer either inside the 64px rail or over
+    // the overlay strip that is about to disappear. Keep stale hover suppressed
+    // for the pointer's whole journey out; only a later return to the nav is
+    // fresh hover intent. A layout-induced pointerleave is deliberately ignored.
+    const trackPointerJourney = (event: PointerEvent) => {
+      const node = navRef.current;
+      if (!node) return;
+      const pointerInsideNav = event.composedPath().includes(node);
+
+      if (!hoverExitObserved.current) {
+        if (!pointerInsideNav) hoverExitObserved.current = true;
+        return;
+      }
+
+      if (pointerInsideNav) setHoverSuppressed(false);
+    };
+
+    window.addEventListener('pointermove', trackPointerJourney, true);
+    return () => window.removeEventListener('pointermove', trackPointerJourney, true);
+  }, [hoverSuppressed]);
 
   useFocusTrap(navRef, { onClose, active: isMobile && open });
   const { data: shelvesData } = useShelves();
@@ -193,9 +219,15 @@ export function Sidebar({ open, onClose, onNavigate }: SidebarProps) {
       {open && <div className={styles.scrim} onClick={onClose} aria-hidden="true" />}
       <nav
         ref={navRef}
-        className={open ? styles.navOpen : styles.nav}
+        className={`${open ? styles.navOpen : styles.nav}${hoverSuppressed ? ` ${styles.hoverSuppressed}` : ''}`}
         aria-label={t('Browse')}
         tabIndex={-1}
+        onClickCapture={(event) => {
+          if (event.target instanceof Element && event.target.closest('a[href]')) {
+            hoverExitObserved.current = false;
+            setHoverSuppressed(true);
+          }
+        }}
       >
         {/* Mobile-only close affordance (labelled); hidden on the desktop rail. */}
         <button type="button" className={styles.drawerClose} onClick={onClose} aria-label={t('Close menu')}>


### PR DESCRIPTION
## What was broken

On desktop the navigation rail is 64px wide and expands to 220px on hover — and it expands by
*overlaying* the page (`margin-right: -156px`) rather than pushing it, so the page never reflows.

Click something in that rail and the mouse is left sitting inside it. The page changes underneath the
pointer, the rail is still hovered, and it is now covering the leftmost 156px of the page you just
landed on. Everything in that strip belongs to the sidebar instead: the book page's back link is at
x≈96–141, so clicking it navigated to whatever nav item happened to be under the cursor.

Measured on the pre-fix build, doing exactly what a person does — click a sidebar item, then move the
mouse to the back link:

```
back-link centre (124.77, 137.21)  ->  elementFromPoint = <a href="/app/rated">Top Rated</a>
click:  /app/book/182  ->  /app/rated
```

The user asked to go back to their list and silently landed on Top Rated. This is a live defect on
`main`, introduced with the expandable sidebar in 6a765542d (#1652 / #1019). It is also why
[#1742](https://github.com/new-usemame/Calibre-Web-NextGen/pull/1742)'s CI has been red: its spec is
the first one that clicks that element, and the sidebar was eating the click. Its `href` assertions
passed the whole time — the back-link fix under test was always correct.

## What changes

A rail that is expanded *only* because the pointer was parked there when the page changed stops
covering the page. On a sidebar link activation the rail drops back to 64px, and it stays there for
the whole of the pointer's journey out — every intermediate mouse position, not just the first.
Deliberately moving back into the rail is fresh intent and expands it again.

Keyboard `:focus-within` is deliberately outside this state machine, so tabbing into the rail still
expands it. The overlay geometry (`width: 220px; margin-right: -156px`) is untouched, so page content
still does not reflow. The mobile / coarse-pointer block is untouched.

The release signal is a real `pointermove`, never `pointerleave`: collapsing 220px→64px under a
stationary pointer emits a spurious leave event, which would have looked like the user moving away.

## Evidence

All OBSERVED against `cwn-local` with the bundle built into the container's bind-mounted
`cps/static/app`, so the browser ran the build under test rather than a stale one.

**Red on `origin/main` fcb692b02**, `sidebar-retained-hover.spec.ts --project=desktop`:

```
Error: back-link centre {"x":124.765625,"y":137.2109375} hit
  {"targetOwnsHit":false,"hitTag":"A","hitText":"Top Rated","hitHref":"/app/rated","hitInsideNav":true}
```

**Green on this branch:** `2 passed (20.9s)`.

**An intermediate version of this fix released the suppression on the first pointer movement, and
that was not enough** — the first move still happens inside the 64px rail, so the rail re-expanded at
traversal step 3 and swallowed the click again (`afterClickUrl: /app/rated`). The spec now asserts the
rail width and the hit-test at all 12 interpolated steps, so that regression cannot come back.

The spec covers, in one flow: deliberate hover expands (220px) · click Tags at x=48, inside the rail ·
pointer parked through navigation · Shift+Tab expands to 220px while suppression is active · browser
Back without moving the pointer · 12-step human mouse traversal, rail 64px and back link owning its own
centre at every step · raw mouse down/up lands on `/app/` · moving back into the rail re-expands to 220px.

**#1742 cross-check** — this fix applied on top of that branch (d50420123), combined tree built and run:

```
4 passed (21.3s)   (all three book-detail-back-origin cases, including the one CI fails today)
```

## Fix the intent

1. **What was the person trying to do?** Go back to the list they came from — or, more generally, click
   anything on the left edge of a page they reached from the sidebar.
2. **Can they now?** Yes, observed: the raw click lands on `/app/`, at every point along the path a
   real mouse takes.
3. **Whole ask or a slice?** The whole of this defect. The rail still overlays content while
   deliberately hovered — that is the design of #1652 and is not changed here.
4. **Other symptoms of the same cause?** Any page whose first control sits within 156px of the left
   edge, reached via the sidebar. The fix is at the rail, so all of them are covered at once.
5. **Would they recognise it as an answer?** "Clicking the back link goes back instead of jumping to
   Top Rated" needs no mechanism to explain.

## Notes

No new dependencies, no license changes, no new external URLs. Frontend-only; no auth, session, CSRF,
subprocess, file-path or route surface is touched, so `/security-review` does not apply.

Consumes pending finding `PF-2026-08-23T00-00-04Z-43924`, whose one open question — retained hover vs
`:focus-within` — is settled here as retained hover; `:focus-within` was falsified by measurement.
