### PR TITLE
perf(thumbnails): index the cover lookup and stop querying it twice per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cover thumbnails load faster, and the gap widens the bigger your library
+  gets.** Every cover request searched the whole thumbnail table instead of
+  going straight to the row it wanted, and the book grid asked for each cover
+  twice — once for the WebP version and once for the JPEG. Both are fixed, so a
+  page of covers now costs a fraction of the database work it used to. Reported
+  by @ericsilberberg on Discord, who was running NextGen and stock Calibre-Web
+  side by side and noticed pages populating more slowly here
+  ([#1571](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1571)).
+
 ## [v4.1.40] - 2026-08-23
 
 ### Added

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -1593,8 +1593,11 @@ def get_book_cover_internal(book, resolution=None):
         if resolution:
             cache = fs.FileSystem()
             # Check for both webp and jpg thumbnails, generate missing ones
-            webp_thumb = get_book_cover_thumbnail_by_format(book, resolution, 'webp')
-            jpg_thumb = get_book_cover_thumbnail_by_format(book, resolution, 'jpg')
+            thumbnails = get_book_cover_thumbnails_by_formats(
+                book, resolution, ('webp', 'jpg')
+            )
+            webp_thumb = thumbnails.get('webp')
+            jpg_thumb = thumbnails.get('jpg')
 
             # CWA #1339 (@Altycoder): treat content-stale thumbnails as
             # missing. The Thumbnail table keys on `entity_id = book.id`,
@@ -1793,6 +1796,27 @@ def get_book_cover_thumbnail_by_format(book, resolution, format):
                 .filter(ub.Thumbnail.format == format)
                 .filter(or_(ub.Thumbnail.expiration.is_(None), ub.Thumbnail.expiration > datetime.now(timezone.utc)))
                 .first())
+
+
+def get_book_cover_thumbnails_by_formats(book, resolution, formats):
+    """Get the first non-expired cover thumbnail for each requested format."""
+    if not book or not book.has_cover:
+        return {}
+
+    thumbnails = (ub.session
+                  .query(ub.Thumbnail)
+                  .filter(ub.Thumbnail.type == THUMBNAIL_TYPE_COVER)
+                  .filter(ub.Thumbnail.entity_id == book.id)
+                  .filter(ub.Thumbnail.resolution == resolution)
+                  .filter(ub.Thumbnail.format.in_(formats))
+                  .filter(or_(ub.Thumbnail.expiration.is_(None),
+                              ub.Thumbnail.expiration > datetime.now(timezone.utc)))
+                  .order_by(ub.Thumbnail.format.asc(), ub.Thumbnail.id.asc())
+                  .all())
+    first_by_format = {}
+    for thumbnail in thumbnails:
+        first_by_format.setdefault(thumbnail.format, thumbnail)
+    return first_by_format
 
 
 def get_series_thumbnail_on_failure(series_id, resolution):

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1781,6 +1781,9 @@ def filename(context):
 
 class Thumbnail(Base):
     __tablename__ = 'thumbnail'
+    __table_args__ = (
+        Index('ix_thumbnail_cover_lookup', 'type', 'entity_id', 'resolution', 'format'),
+    )
 
     id = Column(Integer, primary_key=True)
     entity_id = Column(Integer)
@@ -3995,9 +3998,45 @@ def migrate_bookmark_format_lowercase(engine, _session):
             log.info("[bookmark-format-migration] merged %d rows; lowercased %d rows", merged, updated)
 
 
+def migrate_thumbnail_lookup_index(engine, _session):
+    """Add the composite index used by cover-thumbnail lookups."""
+    marker_path = os.path.join(
+        constants.CONFIG_DIR,
+        ".cwa_migrations",
+        "thumbnail_lookup_index_v1",
+    )
+    if os.path.isfile(marker_path):
+        return
+
+    try:
+        _run_ddl_with_retry(
+            engine,
+            "CREATE INDEX IF NOT EXISTS ix_thumbnail_cover_lookup "
+            "ON thumbnail(type, entity_id, resolution, format)",
+        )
+    except Exception as error:
+        log.warning(
+            "[thumbnail-lookup-index-migration] index creation failed: %s",
+            error,
+        )
+        return
+
+    try:
+        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+        with open(marker_path, "w", encoding="utf-8") as marker:
+            marker.write(datetime.now(timezone.utc).isoformat())
+    except OSError as error:
+        log.warning(
+            "[thumbnail-lookup-index-migration] could not write marker %s: %s",
+            marker_path,
+            error,
+        )
+
+
 def migrate_Database(_session):
     engine = _session.bind
     add_missing_tables(engine, _session)
+    migrate_thumbnail_lookup_index(engine, _session)
     migrate_registration_table(engine, _session)
     migrate_user_session_table(engine, _session)
     migrate_user_table(engine, _session)

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -3999,15 +3999,12 @@ def migrate_bookmark_format_lowercase(engine, _session):
 
 
 def migrate_thumbnail_lookup_index(engine, _session):
-    """Add the composite index used by cover-thumbnail lookups."""
-    marker_path = os.path.join(
-        constants.CONFIG_DIR,
-        ".cwa_migrations",
-        "thumbnail_lookup_index_v1",
-    )
-    if os.path.isfile(marker_path):
-        return
+    """Ensure the current app.db has the cover-thumbnail lookup index.
 
+    Do not gate this on a CONFIG_DIR marker: callers can select or restore a
+    different app.db while keeping the same config directory. The database-
+    scoped ``IF NOT EXISTS`` is the idempotency guard.
+    """
     try:
         _run_ddl_with_retry(
             engine,
@@ -4017,18 +4014,6 @@ def migrate_thumbnail_lookup_index(engine, _session):
     except Exception as error:
         log.warning(
             "[thumbnail-lookup-index-migration] index creation failed: %s",
-            error,
-        )
-        return
-
-    try:
-        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
-        with open(marker_path, "w", encoding="utf-8") as marker:
-            marker.write(datetime.now(timezone.utc).isoformat())
-    except OSError as error:
-        log.warning(
-            "[thumbnail-lookup-index-migration] could not write marker %s: %s",
-            marker_path,
             error,
         )
 

--- a/tests/unit/test_1571_thumbnail_lookup_uses_index.py
+++ b/tests/unit/test_1571_thumbnail_lookup_uses_index.py
@@ -1,0 +1,271 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression coverage for the thumbnail lookup slowdown in issue #1571."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.orm import sessionmaker
+
+pytestmark = pytest.mark.unit
+
+INDEX_NAME = "ix_thumbnail_cover_lookup"
+
+
+def test_thumbnail_model_defines_cover_lookup_index():
+    from cps import ub
+
+    index = next(
+        (item for item in ub.Thumbnail.__table__.indexes if item.name == INDEX_NAME),
+        None,
+    )
+    assert index is not None
+    assert tuple(column.name for column in index.columns) == (
+        "type",
+        "entity_id",
+        "resolution",
+        "format",
+    )
+
+
+def _legacy_app_db(tmp_path, monkeypatch):
+    """Build an app.db in the pre-#1571 shape, then run the real migrator."""
+    from cps import config_sql, constants, ub
+
+    monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path), raising=False)
+    engine = create_engine(f"sqlite:///{tmp_path / 'app.db'}", future=True)
+    ub.Base.metadata.create_all(engine)
+    config_sql._Settings.__table__.create(engine, checkfirst=True)
+    with engine.begin() as connection:
+        connection.execute(text(f"DROP INDEX IF EXISTS {INDEX_NAME}"))
+
+    Session = sessionmaker(bind=engine, future=True)
+    db_session = Session()
+    ub.migrate_Database(db_session)
+    return engine, db_session
+
+
+def _thumbnail_query_plan(engine):
+    with engine.connect() as connection:
+        rows = connection.execute(
+            text(
+                "EXPLAIN QUERY PLAN "
+                "SELECT * FROM thumbnail "
+                "WHERE type = :type AND entity_id = :entity_id "
+                "AND resolution = :resolution "
+                "AND format IN (:webp, :jpg) "
+                "AND (expiration IS NULL OR expiration > :now) "
+                "ORDER BY format ASC, id ASC"
+            ),
+            {
+                "type": 1,
+                "entity_id": 123,
+                "resolution": 2,
+                "webp": "webp",
+                "jpg": "jpg",
+                "now": datetime.now(timezone.utc),
+            },
+        ).fetchall()
+    return " | ".join(str(row[3]) for row in rows)
+
+
+def test_existing_app_db_migration_adds_thumbnail_lookup_index(tmp_path, monkeypatch):
+    engine, db_session = _legacy_app_db(tmp_path, monkeypatch)
+    try:
+        plan = _thumbnail_query_plan(engine)
+        assert f"USING INDEX {INDEX_NAME}" in plan, plan
+        assert "SCAN thumbnail" not in plan, plan
+    finally:
+        db_session.close()
+        engine.dispose()
+
+
+def test_thumbnail_lookup_index_migration_is_idempotent(tmp_path, monkeypatch):
+    from cps import ub
+
+    engine, db_session = _legacy_app_db(tmp_path, monkeypatch)
+    try:
+        marker = tmp_path / ".cwa_migrations" / "thumbnail_lookup_index_v1"
+        assert marker.is_file()
+
+        monkeypatch.setattr(
+            ub,
+            "_run_ddl_with_retry",
+            lambda *args, **kwargs: pytest.fail("second migration run issued DDL"),
+        )
+        ub.migrate_thumbnail_lookup_index(engine, db_session)
+    finally:
+        db_session.close()
+        engine.dispose()
+
+
+def test_thumbnail_lookup_index_failure_does_not_break_startup(
+    tmp_path, monkeypatch, caplog
+):
+    from cps import constants, ub
+
+    monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(
+        ub,
+        "_run_ddl_with_retry",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("read only")),
+    )
+
+    ub.migrate_thumbnail_lookup_index(None, None)
+
+    assert "index creation failed: read only" in caplog.text
+    assert not (
+        tmp_path / ".cwa_migrations" / "thumbnail_lookup_index_v1"
+    ).exists()
+
+
+def _thumbnail_session():
+    from cps import ub
+
+    engine = create_engine("sqlite://", future=True)
+    ub.Thumbnail.__table__.create(engine)
+    Session = sessionmaker(bind=engine, future=True)
+    return engine, Session()
+
+
+def test_collapsed_lookup_keeps_has_cover_guard(monkeypatch):
+    from cps import helper, ub
+
+    class QueryForbidden:
+        @staticmethod
+        def query(*args, **kwargs):
+            pytest.fail("cover-less book queried the thumbnail table")
+
+    monkeypatch.setattr(ub, "session", QueryForbidden())
+    assert helper.get_book_cover_thumbnails_by_formats(None, 2, ("webp", "jpg")) == {}
+    assert helper.get_book_cover_thumbnails_by_formats(
+        SimpleNamespace(id=123, has_cover=False), 2, ("webp", "jpg")
+    ) == {}
+
+
+def test_collapsed_lookup_uses_lowest_id_per_format_and_ignores_expired(monkeypatch):
+    from cps import helper, ub
+
+    engine, db_session = _thumbnail_session()
+    now = datetime.now(timezone.utc)
+    db_session.add_all(
+        [
+            ub.Thumbnail(
+                id=30,
+                entity_id=123,
+                format="webp",
+                type=helper.THUMBNAIL_TYPE_COVER,
+                resolution=2,
+                filename="later.webp",
+            ),
+            ub.Thumbnail(
+                id=10,
+                entity_id=123,
+                format="webp",
+                type=helper.THUMBNAIL_TYPE_COVER,
+                resolution=2,
+                filename="earlier.webp",
+            ),
+            ub.Thumbnail(
+                id=5,
+                entity_id=123,
+                format="jpg",
+                type=helper.THUMBNAIL_TYPE_COVER,
+                resolution=2,
+                filename="expired.jpg",
+                expiration=now - timedelta(seconds=1),
+            ),
+            ub.Thumbnail(
+                id=20,
+                entity_id=123,
+                format="jpg",
+                type=helper.THUMBNAIL_TYPE_COVER,
+                resolution=2,
+                filename="current.jpg",
+            ),
+        ]
+    )
+    db_session.commit()
+    monkeypatch.setattr(ub, "session", db_session)
+
+    try:
+        result = helper.get_book_cover_thumbnails_by_formats(
+            SimpleNamespace(id=123, has_cover=True), 2, ("webp", "jpg")
+        )
+        assert result["webp"].id == 10
+        assert result["jpg"].id == 20
+    finally:
+        db_session.close()
+        engine.dispose()
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_filename"),
+    [("/books/123", "cover.webp"), ("/kobo/123/cover", "cover.jpg")],
+)
+def test_collapsed_lookup_preserves_request_format_preference(
+    tmp_path, monkeypatch, path, expected_filename
+):
+    from cps import helper, ub
+
+    engine, db_session = _thumbnail_session()
+    generated_at = datetime.now(timezone.utc)
+    db_session.add_all(
+        [
+            ub.Thumbnail(
+                entity_id=123,
+                format="webp",
+                type=helper.THUMBNAIL_TYPE_COVER,
+                resolution=2,
+                filename="cover.webp",
+                generated_at=generated_at,
+            ),
+            ub.Thumbnail(
+                entity_id=123,
+                format="jpg",
+                type=helper.THUMBNAIL_TYPE_COVER,
+                resolution=2,
+                filename="cover.jpg",
+                generated_at=generated_at,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    class Cache:
+        @staticmethod
+        def get_cache_file_exists(filename, cache_type):
+            return True
+
+        @staticmethod
+        def get_cache_file_dir(filename, cache_type):
+            return str(tmp_path)
+
+    monkeypatch.setattr(ub, "session", db_session)
+    monkeypatch.setattr(helper.fs, "FileSystem", Cache)
+    monkeypatch.setattr(helper, "send_from_directory", lambda directory, filename: filename)
+
+    thumbnail_selects = []
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _count_thumbnail_selects(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT") and "FROM thumbnail" in statement:
+            thumbnail_selects.append(statement)
+
+    book = SimpleNamespace(id=123, has_cover=True, last_modified=generated_at)
+    app = Flask(__name__)
+    try:
+        with app.test_request_context(path):
+            assert helper.get_book_cover_internal(book, resolution=2) == expected_filename
+        assert len(thumbnail_selects) == 1, thumbnail_selects
+    finally:
+        db_session.close()
+        engine.dispose()

--- a/tests/unit/test_1571_thumbnail_lookup_uses_index.py
+++ b/tests/unit/test_1571_thumbnail_lookup_uses_index.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 from flask import Flask
-from sqlalchemy import create_engine, event, text
+from sqlalchemy import create_engine, event, inspect, text
 from sqlalchemy.orm import sessionmaker
 
 pytestmark = pytest.mark.unit
@@ -53,26 +53,33 @@ def _legacy_app_db(tmp_path, monkeypatch):
     return engine, db_session
 
 
-def _thumbnail_query_plan(engine):
+def _actual_thumbnail_query_plan(engine, db_session, monkeypatch):
+    """EXPLAIN the statement and parameters emitted by the production helper."""
+    from cps import helper, ub
+
+    captured = []
+
+    def capture_thumbnail_select(
+        conn, cursor, statement, parameters, context, executemany
+    ):
+        if statement.lstrip().upper().startswith("SELECT") and "FROM thumbnail" in statement:
+            captured.append((statement, parameters))
+
+    event.listen(engine, "before_cursor_execute", capture_thumbnail_select)
+    monkeypatch.setattr(ub, "session", db_session)
+    try:
+        helper.get_book_cover_thumbnails_by_formats(
+            SimpleNamespace(id=123, has_cover=True), 2, ("webp", "jpg")
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", capture_thumbnail_select)
+
+    assert len(captured) == 1, captured
+    statement, parameters = captured[0]
     with engine.connect() as connection:
-        rows = connection.execute(
-            text(
-                "EXPLAIN QUERY PLAN "
-                "SELECT * FROM thumbnail "
-                "WHERE type = :type AND entity_id = :entity_id "
-                "AND resolution = :resolution "
-                "AND format IN (:webp, :jpg) "
-                "AND (expiration IS NULL OR expiration > :now) "
-                "ORDER BY format ASC, id ASC"
-            ),
-            {
-                "type": 1,
-                "entity_id": 123,
-                "resolution": 2,
-                "webp": "webp",
-                "jpg": "jpg",
-                "now": datetime.now(timezone.utc),
-            },
+        rows = connection.exec_driver_sql(
+            "EXPLAIN QUERY PLAN " + statement,
+            parameters,
         ).fetchall()
     return " | ".join(str(row[3]) for row in rows)
 
@@ -80,8 +87,11 @@ def _thumbnail_query_plan(engine):
 def test_existing_app_db_migration_adds_thumbnail_lookup_index(tmp_path, monkeypatch):
     engine, db_session = _legacy_app_db(tmp_path, monkeypatch)
     try:
-        plan = _thumbnail_query_plan(engine)
-        assert f"USING INDEX {INDEX_NAME}" in plan, plan
+        plan = _actual_thumbnail_query_plan(engine, db_session, monkeypatch)
+        assert (
+            f"USING INDEX {INDEX_NAME} "
+            "(type=? AND entity_id=? AND resolution=? AND format=?)"
+        ) in plan, plan
         assert "SCAN thumbnail" not in plan, plan
     finally:
         db_session.close()
@@ -93,26 +103,45 @@ def test_thumbnail_lookup_index_migration_is_idempotent(tmp_path, monkeypatch):
 
     engine, db_session = _legacy_app_db(tmp_path, monkeypatch)
     try:
-        marker = tmp_path / ".cwa_migrations" / "thumbnail_lookup_index_v1"
-        assert marker.is_file()
-
-        monkeypatch.setattr(
-            ub,
-            "_run_ddl_with_retry",
-            lambda *args, **kwargs: pytest.fail("second migration run issued DDL"),
-        )
         ub.migrate_thumbnail_lookup_index(engine, db_session)
+        ub.migrate_thumbnail_lookup_index(engine, db_session)
+        indexes = [
+            item["name"]
+            for item in inspect(engine).get_indexes("thumbnail")
+            if item["name"] == INDEX_NAME
+        ]
+        assert indexes == [INDEX_NAME]
     finally:
         db_session.close()
         engine.dispose()
 
 
-def test_thumbnail_lookup_index_failure_does_not_break_startup(
-    tmp_path, monkeypatch, caplog
+def test_existing_marker_cannot_skip_index_for_a_different_database(
+    tmp_path, monkeypatch
 ):
     from cps import constants, ub
 
     monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path), raising=False)
+    marker = tmp_path / ".cwa_migrations" / "thumbnail_lookup_index_v1"
+    marker.parent.mkdir()
+    marker.write_text("marker from another app.db")
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'restored-app.db'}", future=True)
+    ub.Thumbnail.__table__.create(engine)
+    with engine.begin() as connection:
+        connection.execute(text(f"DROP INDEX {INDEX_NAME}"))
+
+    try:
+        ub.migrate_thumbnail_lookup_index(engine, None)
+        names = {item["name"] for item in inspect(engine).get_indexes("thumbnail")}
+        assert INDEX_NAME in names
+    finally:
+        engine.dispose()
+
+
+def test_thumbnail_lookup_index_failure_does_not_break_startup(monkeypatch, caplog):
+    from cps import ub
+
     monkeypatch.setattr(
         ub,
         "_run_ddl_with_retry",
@@ -122,9 +151,6 @@ def test_thumbnail_lookup_index_failure_does_not_break_startup(
     ub.migrate_thumbnail_lookup_index(None, None)
 
     assert "index creation failed: read only" in caplog.text
-    assert not (
-        tmp_path / ".cwa_migrations" / "thumbnail_lookup_index_v1"
-    ).exists()
 
 
 def _thumbnail_session():

--- a/tests/unit/test_cover_and_static_cache_headers.py
+++ b/tests/unit/test_cover_and_static_cache_headers.py
@@ -299,8 +299,12 @@ def _thumbnail_app(monkeypatch, tmp_path, have_webp, have_jpg, generated_at=LAST
         "jpg": SimpleNamespace(filename="book_42_r2.jpg", generated_at=generated_at),
     }
     present = {"webp": have_webp, "jpg": have_jpg}
-    monkeypatch.setattr(helper, "get_book_cover_thumbnail_by_format",
-                        lambda book, res, fmt: thumbs[fmt], raising=False)
+    monkeypatch.setattr(
+        helper,
+        "get_book_cover_thumbnails_by_formats",
+        lambda book, res, formats: {fmt: thumbs[fmt] for fmt in formats},
+        raising=False,
+    )
 
     class _Cache:
         def get_cache_file_exists(self, filename, _type):
@@ -366,8 +370,12 @@ def test_a_resized_request_falling_back_to_the_original_is_not_immutable(monkeyp
     monkeypatch.setattr(helper.config, "get_book_path", lambda: str(tmp_path), raising=False)
     monkeypatch.setattr(helper.config, "config_use_google_drive", False, raising=False)
     # No thumbnail rows, and no ImageMagick, so nothing is queued either.
-    monkeypatch.setattr(helper, "get_book_cover_thumbnail_by_format",
-                        lambda *a, **kw: None, raising=False)
+    monkeypatch.setattr(
+        helper,
+        "get_book_cover_thumbnails_by_formats",
+        lambda *args, **kwargs: {},
+        raising=False,
+    )
     monkeypatch.setattr(helper, "use_IM", False, raising=False)
 
     book = SimpleNamespace(id=42, has_cover=1, path="Some Author/Some Book (42)",


### PR DESCRIPTION
Fixes #1571.

`@ericsilberberg` reported on Discord that cover thumbnails populate a page noticeably
slower here than on `lscr.io/linuxserver/calibre-web` running side by side, in the classic
UI as well as the new one. That is accurate, and the cause is in our schema rather than in
the image pipeline — nothing about generating a thumbnail got slower; looking one up did.

**Root cause.** `ub.Thumbnail` has no index covering the lookup the cover route actually
performs. Every other hot table in `cps/ub.py` has one; this table was added without it.
So each cover request table-scans `thumbnail`, and the scan grows with the library. On top
of that, `get_book_cover_internal` ran the query twice per request — once for `webp` and
once for `jpg` — so a 100-cover page paid 200 scans.

**Fix.** Add the composite index on `(type, entity_id, resolution, format)`, with an
idempotent migration for existing `app.db` files, and collapse the two per-request lookups
into one.

Measured on the real model shape at 5000 books / 30000 thumbnail rows:
`EXPLAIN QUERY PLAN` moves from SCAN to SEARCH, per-cover lookup drops from ~4.3ms to
~0.04ms, and a 100-cover page goes from ~432ms of database time to ~4ms.

Behaviour is unchanged: the `has_cover` guard, the expiry filter, and which row wins are
all preserved.

---

### Verification

Red/green re-derived independently of the implementation leg, against a clean
`origin/main` worktree with only the new test file added:

- **Red** (`origin/main`): `8 failed` in `tests/unit/test_1571_thumbnail_lookup_uses_index.py`
- **Green** (this branch): `41 passed` across the #1571 regression file plus the
  existing cover-cache-header and #1339 thumbnail-staleness coverage

### Review gate

An independent reviewer (fresh context, told to refute rather than approve) returned
DO-NOT-SHIP with three findings. Two were real and are fixed in `6fefdc0ae`:

- **The migration was gated on a marker file in `CONFIG_DIR`, not on the database.** Point
  the app at another `app.db` with `-p`, or restore a pre-upgrade `app.db` while keeping
  `/config`, and startup would see the old marker and skip the migration forever — that
  database silently stays unindexed with no recovery short of deleting a hidden file. The
  marker bought nothing, since `CREATE INDEX IF NOT EXISTS` is already idempotent and
  effectively free on a database that has the index. It is gone; the database-scoped DDL is
  the idempotency guard.
- **The regression test could not detect the bug it exists for.** It ran EXPLAIN over a
  hand-written ideal SQL string rather than the statement the helper actually emits, so
  breaking the helper's ability to use the index left the whole file green. It now captures
  the real emitted statement and its bound parameters. Verified by deliberately breaking the
  production choke point two different ways — `func.abs(entity_id)` and `resolution + 0` —
  and confirming the file goes red both times, then green again on restore.

The third finding is accepted deliberately and not fixed: the collapsed query evaluates
`now` once for both formats where the old code evaluated it separately per format, so a
thumbnail expiring inside that sub-millisecond window could be served where it previously
would not have been. The boundary was already arbitrary and the window is smaller than the
one it replaces.

Practical, user-visible verification on a real container (`calibre-web-nextgen:local`,
disposable instance on :18086, bind-mounting this branch, pointed at a **copy of a real
existing `app.db`** so the upgrade path is what actually ran):

- App booted healthy and the migration created `ix_thumbnail_cover_lookup` on the existing
  database — with a **stale marker file deliberately planted first**, which is precisely the
  state that would have skipped the migration before the review fix, and the index genuinely
  absent beforehand.
- Real HTTP against the real cover routes: `/cover/3/sm` → `200 image/webp` 3740 bytes
  (the resized path that goes through the collapsed lookup, correctly preferring WebP for
  a web request); `/cover/3/og` → `200 image/jpeg` 80055 bytes.
- `EXPLAIN QUERY PLAN` on that same live `app.db`, for the exact collapsed query:
  `SEARCH thumbnail USING INDEX ix_thumbnail_cover_lookup (type=? AND entity_id=? AND resolution=? AND format=?)`,
  and with the index dropped, `SCAN thumbnail | USE TEMP B-TREE FOR ORDER BY`.

Independent benchmark at the reported scale (5000 books / 30000 thumbnail rows):
SCAN → SEARCH, ~1.5ms → ~0.027ms per lookup.

Known limitations, stated plainly:

- Three `tests/unit/test_s6_ingest_service_shutdown.py` cases fail on this macOS host.
  Confirmed **pre-existing** by running that file against a clean `origin/main` worktree
  (`3 failed, 7 passed`) — unrelated to this change, and deliberately not touched.
- Which row wins when a book somehow has duplicate thumbnail rows for one format is now
  deterministic (lowest `id`). The previous unordered `.first()` made no guarantee, so
  this pins behaviour rather than preserving an existing one.

No new dependencies, no license changes, no new external service URLs. No auth, session,
CSRF, subprocess, user-controlled path or new-route surface is touched, so
`/security-review` does not apply.
