### PR TITLE
fix(kobo): stop acknowledging annotation PATCHes we did not store

### DIFF
--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -57,6 +57,16 @@ def _is_check_for_changes_path(path):
     return normalized_parts == ["api", "v3", "content", "checkforchanges"]
 
 
+def _is_annotation_path(path):
+    """Recognize the one reading-services route whose PATCH carries user data."""
+    normalized_parts = [part.casefold() for part in path.split("/") if part]
+    return (
+        len(normalized_parts) == 5
+        and normalized_parts[:3] == ["api", "v3", "content"]
+        and normalized_parts[-1] == "annotations"
+    )
+
+
 def redact_headers(headers):
     """Redact sensitive headers from the headers dictionary.
     
@@ -143,9 +153,10 @@ def requires_reading_services_auth_and_config(f):
 
     Authentication uses the existing Flask session, whether it came from a
     Kobo-sync handshake or a browser login. If Kobo sync is off OR the user
-    isn't logged in, we normally proxy through to Kobo untouched. The
-    checkforchanges trigger is the exception: its ownership containment must
-    run even during those two transition windows.
+    isn't logged in, we normally proxy through to Kobo untouched. Two routes
+    are exceptions: checkforchanges must still run ownership containment, and
+    an annotation PATCH must fail authentication instead of forwarding a
+    success that would make Nickel forget an upload CWNG did not capture.
     """
     @wraps(f)
     def decorated_function(*args, **kwargs):
@@ -165,6 +176,11 @@ def requires_reading_services_auth_and_config(f):
             return f(*args, **kwargs)
         if contains_check_for_changes:
             return f(*args, **kwargs)
+        if request.method == "PATCH" and _is_annotation_path(request.path):
+            log.warning(
+                "Refusing unauthenticated annotation PATCH so the device can retry"
+            )
+            return make_response(jsonify({"error": "Authentication required"}), 401)
         log.debug("Reading services request without auth, proxying to Kobo")
         return proxy_to_kobo_reading_services()
     return decorated_function
@@ -537,9 +553,19 @@ def handle_annotations(entitlement_id):
                             raw_materializations=raw_materializations,
                             trace_id=trace_id,
                         )
-                    annotation_sync.dispatch_annotation_sync(
+                    persisted = annotation_sync.dispatch_annotation_sync(
                         updated, book, current_user, **dispatch_kwargs,
                     )
+                    if persisted is False:
+                        log.error(
+                            "Kobo annotation PATCH was not fully persisted for "
+                            "user_id=%s book_id=%s; refusing to acknowledge it upstream",
+                            getattr(current_user, "id", None), book.id,
+                        )
+                        return make_response(
+                            jsonify({"error": "Annotation capture temporarily unavailable"}),
+                            503,
+                        )
                 if deleted is not None and not isinstance(deleted, list):
                     log.warning(
                         "Ignoring deletedAnnotationIds for entitlement %s: expected a list",
@@ -555,6 +581,9 @@ def handle_annotations(entitlement_id):
                     )
         except Exception:
             log.exception("Error processing PATCH annotations")
+            return make_response(
+                jsonify({"error": "Annotation capture temporarily unavailable"}), 503,
+            )
     # Proxy both GET + PATCH. Do not refuse GET: hardware testing showed that a
     # 503 (or a hung request) makes Nickel empty its local annotations. The safe
     # containment point is checkforchanges, before Nickel decides to GET.

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -611,25 +611,32 @@ def _mark_pending(session, annotation, user):
 
 
 def dispatch_annotation_sync(payload_annotations, book, user, *, origin_device_id=None,
-                             raw_materializations=None, trace_id=None) -> None:
+                             raw_materializations=None, trace_id=None) -> bool:
     """Persist each valid annotation independently, then fan it out.
 
     Device batches are a transport convenience, not a transaction boundary: one
     malformed member or failed write must not roll back already-preserved user
     data or prevent later members from being attempted.
+
+    Return ``True`` only when every addressable member was persisted (or was an
+    idempotent/stale no-op).  ``False`` is transport-significant: the Reading
+    Services route must not proxy a success to Kobo, because Nickel uploads
+    deltas and may never offer an acknowledged member again.
     """
     from cps import ub
     if not payload_annotations:
-        return
+        return True
     if not isinstance(payload_annotations, list):
         log.warning("Skipping annotation batch because updatedAnnotations is not a list")
-        return
+        return False
     jobs = []
+    all_persisted = True
     for index, payload in enumerate(payload_annotations):
         if not isinstance(payload, dict):
             log.warning(
                 "Skipping non-object annotation member at updatedAnnotations[%d]", index,
             )
+            all_persisted = False
             continue
         pending_job = None
         try:
@@ -652,6 +659,7 @@ def dispatch_annotation_sync(payload_annotations, book, user, *, origin_device_i
                 push_annotation_to_handlers(ub.session, ann, book, user, payload=payload)
             committed = ub.session_commit()
             if committed is False:
+                all_persisted = False
                 log.error(
                     "Annotation %s could not be committed; continuing with the batch",
                     payload.get("id"),
@@ -665,6 +673,7 @@ def dispatch_annotation_sync(payload_annotations, book, user, *, origin_device_i
                     annotation_count=1,
                 )
         except Exception:
+            all_persisted = False
             # A failed SQLAlchemy transaction poisons the scoped session until an
             # explicit rollback. Do that here, then continue: prior annotations
             # were committed independently and later annotations still deserve a
@@ -678,6 +687,7 @@ def dispatch_annotation_sync(payload_annotations, book, user, *, origin_device_i
         if pending_job is not None:
             jobs.append(pending_job)
     _enqueue(user, jobs, book=book)
+    return all_persisted
 
 
 def dispatch_existing_annotation_sync(annotation, book, user) -> None:

--- a/tests/unit/test_1660_kobo_checkforchanges_filter.py
+++ b/tests/unit/test_1660_kobo_checkforchanges_filter.py
@@ -302,6 +302,28 @@ def test_unauthenticated_annotation_get_does_not_resolve_ownership(app, monkeypa
         assert decorated() is sentinel
 
 
+def test_unauthenticated_annotation_patch_is_not_acknowledged_upstream(app, monkeypatch):
+    monkeypatch.setattr(rs.config, "config_kobo_sync", True, raising=False)
+    monkeypatch.setattr(
+        rs, "current_user", SimpleNamespace(is_authenticated=False, id=None),
+    )
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("an uncaptured PATCH must not be acknowledged upstream"),
+    )
+    decorated = rs.requires_reading_services_auth_and_config(
+        lambda: pytest.fail("unauthenticated request must not reach the handler")
+    )
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations", method="PATCH",
+        json={"updatedAnnotations": [{"id": "annotation-1"}]},
+    ):
+        response = decorated()
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Authentication required"}
+
+
 def test_empty_patch_for_unowned_content_still_proxies(app, monkeypatch):
     sentinel = object()
     monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: None)
@@ -337,6 +359,33 @@ def test_patch_captures_updated_annotations_before_proxying(app, monkeypatch):
         assert _view(rs.handle_annotations)(OWNED) is sentinel
 
     assert dispatched == [(([annotation], book, user), {"origin_device_id": None})]
+
+
+def test_patch_persistence_failure_is_not_acknowledged_upstream(
+    app, monkeypatch, caplog,
+):
+    from cps.services import annotation_sync
+
+    book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
+    user = SimpleNamespace(id=7, name="test-user", is_authenticated=True)
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "current_user", user)
+    monkeypatch.setattr(annotation_sync, "dispatch_annotation_sync", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("a failed local write must not be acknowledged upstream"),
+    )
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations", method="PATCH",
+        json={"updatedAnnotations": [{"id": "annotation-1"}]},
+    ), caplog.at_level("ERROR"):
+        response = _view(rs.handle_annotations)(OWNED)
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "Annotation capture temporarily unavailable"}
+    assert "not fully persisted" in caplog.text
 
 
 def test_patch_declares_kobo_delete_authority_before_proxying(app, monkeypatch):

--- a/tests/unit/test_annotation_sync_dispatcher.py
+++ b/tests/unit/test_annotation_sync_dispatcher.py
@@ -318,12 +318,13 @@ def test_database_failure_rolls_back_only_that_member_and_later_members_continue
     monkeypatch.setattr(s, "rollback", recording_rollback)
     monkeypatch.setattr(annotation_sync, "_upsert_annotation", fail_one)
 
-    dispatch_annotation_sync([
+    result = dispatch_annotation_sync([
         _payload("uuid-before", text_="before"),
         _payload("uuid-db-failure", text_="lost only with failed write"),
         _payload("uuid-after", text_="after"),
     ], _book(), user)
 
+    assert result is False
     assert rollback_calls == [True]
     assert [row.annotation_id for row in s.query(ub.Annotation).order_by(ub.Annotation.id)] == [
         "uuid-before", "uuid-after",


### PR DESCRIPTION
## The bug

The device-to-server annotation path was **fail-open**. A Kobo annotation `PATCH` that failed to persist locally — or arrived in an unauthenticated window — was still proxied upstream, and we returned upstream's `204 NO CONTENT`.

Nickel uploads **deltas**. An acknowledged member is settled permanently and is never offered again, so the acknowledgment itself destroyed the annotation. The transport was working the whole time.

## Evidence, from a real reader's data

Three annotations PATCHed in one batch received `204` and appear nowhere in `annotation`, including hidden rows.

One highlight supplies a natural control:

| time | event |
|---|---|
| 12:10:42 | `PATCH` → **500** |
| 12:13:03 | device **retried the same annotation** |
| 12:13:04 | retry → **204**, retries stop |
| — | row absent from `annotation` |

Withholding success retained the delta; granting it lost the data. A failure response was strictly safer than a success response.

Not a unique-index collision — the key is correctly scoped to `(user_id, book_id, annotation_id)` and none of the ids exists for that user.

## The fix

- `dispatch_annotation_sync` returns `bool` — `True` only when every addressable member was persisted or was an idempotent no-op. "Did not raise" is no longer read as "stored".
- The route returns **503** without contacting upstream when an authenticated batch was not fully persisted, and on an unexpected PATCH exception rather than falling through to the proxy.
- An unauthenticated annotation `PATCH` gets **401** instead of being transparently proxied, so the device re-authenticates and retries.

## Scope — deliberately PATCH-only

Annotation `GET` and `checkforchanges` containment are **unchanged**. On the download side a 503 or a hang makes Nickel *empty* its local annotations (#1660 / #1679). Same status code, opposite consequence depending on direction — so the remedy is scoped to the verb.

## Verification

- Regression tests against **unpatched** source: **3 failed / 65 passed** — they detect the defect rather than pin it.
- With the fix: **68 passed**.
- Full kobo + annotation surface (95 files): **1122 passed, 1 skipped, 0 failed**.
- One production caller of the changed function; updated.

## Known limit

The exact historical branch that skipped each insert is **not recoverable** — those requests predate the `raw_capture` telemetry and the period included several experimental deployments. An unauthenticated session window is the leading explanation and is tagged **ASSUMED**. The failure *mechanism* — false success acknowledgment — is **OBSERVED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7rUYq8zL3mqWecnnDV7wT