### PR TITLE
test: cover partial bulk delete failures

### DIFF
--- a/frontend/e2e/bulk-delete-partial-failure.spec.ts
+++ b/frontend/e2e/bulk-delete-partial-failure.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type SelectedBook = {
+  id: number;
+  title: string;
+};
+
+function libraryBookLinks(page: Page) {
+  // Quick-edit links end in /edit. The remaining book links are the cards whose
+  // accessible names become "Select <title>" when multi-select mode is active.
+  return page.locator('main a[href*="/book/"]:not([href$="/edit"])');
+}
+
+test('bulk delete reports and renders the exact partial-failure split (F-567c75, #1831)', async ({ page }) => {
+  // Discover can repeat library books outside the catalog grid. Keeping it out
+  // makes every captured accessible name belong to exactly one selectable card.
+  await page.addInitScript(() => localStorage.setItem('cwng_discover_hidden_v1', '1'));
+
+  const simulatedDeletedIds = new Set<number>();
+  await page.route('**/api/v1/books?**', async (route) => {
+    const requestUrl = new URL(route.request().url());
+    if (route.request().method() !== 'GET' || requestUrl.pathname !== '/api/v1/books') {
+      await route.continue();
+      return;
+    }
+
+    const response = await route.fetch();
+    if (!response.ok() || simulatedDeletedIds.size === 0) {
+      await route.fulfill({ response });
+      return;
+    }
+
+    const body = await response.json() as {
+      items?: Array<{ id: number }>;
+      total?: number;
+    };
+    const removedFromPage = (body.items ?? []).filter((book) => simulatedDeletedIds.has(book.id)).length;
+    body.items = (body.items ?? []).filter((book) => !simulatedDeletedIds.has(book.id));
+    if (typeof body.total === 'number') body.total = Math.max(0, body.total - removedFromPage);
+    await route.fulfill({ response, json: body });
+  });
+
+  await page.goto('/app');
+  const links = libraryBookLinks(page);
+  await expect(links.first()).toBeVisible();
+
+  const visibleBooks = await links.evaluateAll((bookLinks) => bookLinks.map((link) => {
+    const href = (link as HTMLAnchorElement).getAttribute('href') ?? '';
+    const id = Number(href.match(/\/book\/(\d+)/)?.[1]);
+    const accessibleName = link.getAttribute('aria-label') ?? '';
+    return { id, title: accessibleName.replace(/^Open details for /, '') };
+  }).filter((book) => Number.isInteger(book.id) && book.title));
+
+  // Prefer three books, but do not pin the spec to a seed's total book count.
+  // Repeated titles are excluded because their role/name selector is ambiguous.
+  const titleCounts = new Map<string, number>();
+  for (const book of visibleBooks) titleCounts.set(book.title, (titleCounts.get(book.title) ?? 0) + 1);
+  const selectedBooks = visibleBooks.filter((book) => titleCounts.get(book.title) === 1).slice(0, 3);
+  test.skip(selectedBooks.length < 2, 'the seed needs at least two uniquely named visible books');
+
+  await page.getByRole('button', { name: 'Select', exact: true }).click();
+  for (const book of selectedBooks) {
+    await page.getByRole('button', { name: `Select ${book.title}`, exact: true }).click();
+  }
+  await expect(page.getByRole('region', { name: `${selectedBooks.length} selected` })).toBeVisible();
+
+  const failedBook = selectedBooks[1];
+  const succeededBooks = selectedBooks.filter((book) => book.id !== failedBook.id);
+  const deleteCallIds: number[] = [];
+  await page.route('**/api/v1/books/*/delete', async (route) => {
+    const id = Number(new URL(route.request().url()).pathname.match(/\/books\/(\d+)\/delete$/)?.[1]);
+    if (route.request().method() !== 'POST' || !selectedBooks.some((book) => book.id === id)) {
+      await route.continue();
+      return;
+    }
+
+    deleteCallIds.push(id);
+    if (id === failedBook.id) {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Injected partial bulk-delete failure' }),
+      });
+      return;
+    }
+
+    simulatedDeletedIds.add(id);
+    await route.fulfill({ status: 204, body: '' });
+  });
+
+  page.once('dialog', (dialog) => void dialog.accept());
+  await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+  await expect
+    .poll(() => deleteCallIds.length, { message: 'one delete request is issued for every selected book' })
+    .toBe(selectedBooks.length);
+  expect(new Set(deleteCallIds), 'each selected book is attempted exactly once').toEqual(
+    new Set(selectedBooks.map((book) => book.id)),
+  );
+
+  const deleteAnnouncement = page.locator('[aria-live]').filter({ hasText: /book\(s\) deleted/ });
+  await expect(deleteAnnouncement).toHaveText(
+    `${succeededBooks.length} book(s) deleted; 1 failed.`,
+  );
+
+  // The failed card remains selected in the current list. Successful cards are
+  // absent from that same live view; no page reload is used to reach this state.
+  await expect(page.getByRole('button', { name: `Deselect ${failedBook.title}`, exact: true })).toBeVisible();
+  for (const book of succeededBooks) {
+    await expect(page.getByRole('button', { name: `Select ${book.title}`, exact: true })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: `Deselect ${book.title}`, exact: true })).toHaveCount(0);
+  }
+});

--- a/tests/unit/test_bulk_action_accounting.py
+++ b/tests/unit/test_bulk_action_accounting.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).parents[2]
+
+
+@pytest.mark.unit
+def test_settle_by_id_reports_exact_successes_and_failures():
+    helper = (ROOT / "frontend" / "src" / "lib" / "bulkResults.ts").as_uri()
+    script = f"""
+      import assert from 'node:assert/strict';
+      import {{ settleById }} from '{helper}';
+      const result = await settleById([223, 222, 221], (id) =>
+        id === 222 ? Promise.reject(new Error('injected')) : Promise.resolve(id));
+      assert.deepEqual(result, {{ succeededIds: [223, 221], failedIds: [222] }});
+    """
+    completed = subprocess.run(
+        ["node", "--experimental-strip-types", "--input-type=module", "--eval", script],
+        text=True, capture_output=True, check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.unit
+def test_every_bulk_caller_uses_accounting_and_delete_evicts_only_successes():
+    """Pin source wiring only; this does not execute a bulk caller or prove UI behavior.
+
+    The partial-failure user contract is exercised by
+    frontend/e2e/bulk-delete-partial-failure.spec.ts.
+    """
+    queries = (ROOT / "frontend" / "src" / "lib" / "queries.ts").read_text()
+    bulk_bar = (ROOT / "frontend" / "src" / "components" / "BulkBar.tsx").read_text()
+    assert queries.count("settleById(") == 4
+    assert "succeededIds.forEach(removeBookFromCache)" in queries
+    assert "err instanceof ApiError && err.status === 409" in queries
+    assert bulk_bar.count("result.failedIds.length") >= 4
+    assert "result.succeededIds.length" in bulk_bar


### PR DESCRIPTION
## Summary

- add a Playwright regression spec for partial bulk-delete failures
- intercept every delete so exactly one fails and no seed book is actually removed
- assert the truthful success/failure announcement and the live catalog contents
- preserve #1831 accounting coverage while documenting that its structural source pin does not execute the UI

Tracks F-567c75 and complements #1831.

## Verification

- pre-fix image: fails at the result-summary assertion, receiving `3 book(s) deleted.` instead of `2 book(s) deleted; 1 failed.`
- throwaway merge with `origin/fix/ledger-f567c75-bulk-accounting`: desktop and mobile pass
- accounting unit tests: 2 passed
- isolated seed total after the Playwright run: 5