### PR TITLE
Fix Tasks failure details and SPA book links

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -2169,7 +2169,7 @@ def upload_book_formats(requested_files, book, book_id, no_cover=True):
             # Queue uploader info
             link = '<a href="{}">{}</a>'.format(url_for('web.show_book', book_id=book.id), escape(book.title))
             upload_text = N_("File format %(ext)s added to %(book)s", ext=file_ext.upper(), book=link)
-            WorkerThread.add(current_user.name, TaskUpload(upload_text, escape(book.title)))
+            WorkerThread.add(current_user.name, TaskUpload(upload_text, book.title, book_id=book.id))
             meta = uploader.process(
                 saved_filename,
                 *os.path.splitext(current_filename),

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -516,7 +516,8 @@ def send_mail(book_id, book_format, convert, ereader_mail, calibrepath, user_id,
                 email = strip_whitespaces(email)
                 WorkerThread.add(user_id, TaskEmail(subject, book.path, converted_file_name,
                                                     config.get_mail_settings(), email,
-                                                    email_text, get_email_body_text(), book.id))
+                                                    email_text, get_email_body_text(), book.id,
+                                                    book_title=book.title))
             return None
     return _("The requested file could not be read. Maybe wrong permissions?")
 

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -381,7 +381,7 @@ def convert_book_format(book_id, calibre_path, old_book_format, new_book_format,
            link)
     settings['old_book_format'] = old_book_format
     settings['new_book_format'] = new_book_format
-    task = TaskConvert(file_path, book.id, txt, settings, ereader_mail, user_id)
+    task = TaskConvert(file_path, book.id, txt, settings, ereader_mail, user_id, book_title=book.title)
     WorkerThread.add(user_id, task)
     if blocking:
         # Only the context-free Event wait crosses onto the bounded native

--- a/cps/services/worker.py
+++ b/cps/services/worker.py
@@ -199,13 +199,19 @@ class WorkerThread(threading.Thread):
 class CalibreTask:
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, message):
+    def __init__(self, message, book_id=None, book_title=None):
         self._progress = 0
         self.stat = STAT_WAITING
         self.error = None
         self.start_time = None
         self.end_time = None
         self.message = message
+        # Tasks keep their Classic HTML message for bootstrap-table. When a
+        # message contains a linked book, these fields give other serializers
+        # enough structure to render their own native link without trusting
+        # that HTML. Non-book tasks leave both fields unset.
+        self.book_id = book_id
+        self.book_title = book_title
         self.id = uuid.uuid4()
         self.self_cleanup = False
         self._scheduled = False

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -63,11 +63,11 @@ current_milli_time = lambda: int(round(time() * 1000))
 
 
 class TaskConvert(CalibreTask):
-    def __init__(self, file_path, book_id, task_message, settings, ereader_mail, user=None):
-        super(TaskConvert, self).__init__(task_message)
+    def __init__(self, file_path, book_id, task_message, settings, ereader_mail,
+                 user=None, book_title=None):
+        super(TaskConvert, self).__init__(task_message, book_id=book_id, book_title=book_title)
         self.worker_thread = None
         self.file_path = file_path
-        self.book_id = book_id
         self.title = ""
         self.settings = settings
         self.ereader_mail = ereader_mail

--- a/cps/tasks/mail.py
+++ b/cps/tasks/mail.py
@@ -30,6 +30,7 @@ import uuid
 log = logger.create()
 
 CHUNKSIZE = 8192
+TASK_BOOK_TOKEN = "__CWNG_TASK_BOOK__"
 
 
 # Class for sending email with ability to get current progress
@@ -101,7 +102,7 @@ class EmailSSL(EmailBase, smtplib.SMTP_SSL):
 
 class TaskEmail(CalibreTask):
     def __init__(self, subject, filepath, attachment, settings, recipient, task_message, text, id=0, internal=False,
-                 html=None):
+                 html=None, book_title=None):
         super(TaskEmail, self).__init__(task_message)
         self.subject = subject
         self.attachment = attachment
@@ -117,6 +118,15 @@ class TaskEmail(CalibreTask):
         self.html = html
         self.asyncSMTP = None
         self.book_id = id
+        # ``task_message`` stays HTML for the Classic bootstrap-table contract.
+        # The SPA receives this separate, tokenized representation and composes
+        # its own safe in-app link instead of interpreting server HTML.
+        self.book_title = book_title
+        self.spa_message_token = TASK_BOOK_TOKEN if book_title and id else None
+        self.spa_message_template = (
+            N_("%(book)s send to eReader", book=TASK_BOOK_TOKEN)
+            if self.spa_message_token else None
+        )
         self.results = dict()
 
     # from calibre code:

--- a/cps/tasks/mail.py
+++ b/cps/tasks/mail.py
@@ -30,7 +30,6 @@ import uuid
 log = logger.create()
 
 CHUNKSIZE = 8192
-TASK_BOOK_TOKEN = "__CWNG_TASK_BOOK__"
 
 
 # Class for sending email with ability to get current progress
@@ -103,7 +102,7 @@ class EmailSSL(EmailBase, smtplib.SMTP_SSL):
 class TaskEmail(CalibreTask):
     def __init__(self, subject, filepath, attachment, settings, recipient, task_message, text, id=0, internal=False,
                  html=None, book_title=None):
-        super(TaskEmail, self).__init__(task_message)
+        super(TaskEmail, self).__init__(task_message, book_id=id or None, book_title=book_title)
         self.subject = subject
         self.attachment = attachment
         self.settings = settings
@@ -117,16 +116,6 @@ class TaskEmail(CalibreTask):
         # registration, test mail) is unchanged single-part text/plain.
         self.html = html
         self.asyncSMTP = None
-        self.book_id = id
-        # ``task_message`` stays HTML for the Classic bootstrap-table contract.
-        # The SPA receives this separate, tokenized representation and composes
-        # its own safe in-app link instead of interpreting server HTML.
-        self.book_title = book_title
-        self.spa_message_token = TASK_BOOK_TOKEN if book_title and id else None
-        self.spa_message_template = (
-            N_("%(book)s send to eReader", book=TASK_BOOK_TOKEN)
-            if self.spa_message_token else None
-        )
         self.results = dict()
 
     # from calibre code:

--- a/cps/tasks/upload.py
+++ b/cps/tasks/upload.py
@@ -13,8 +13,12 @@ from cps.services.worker import CalibreTask, STAT_FINISH_SUCCESS
 
 
 class TaskUpload(CalibreTask):
-    def __init__(self, task_message, book_title):
-        super(TaskUpload, self).__init__(task_message)
+    def __init__(self, task_message, book_title, book_id=None):
+        super(TaskUpload, self).__init__(
+            task_message,
+            book_id=book_id,
+            book_title=book_title if book_id else None,
+        )
         self.start_time = self.end_time = datetime.now()
         self.stat = STAT_FINISH_SUCCESS
         self.progress = 1

--- a/cps/tasks_status.py
+++ b/cps/tasks_status.py
@@ -66,6 +66,18 @@ def render_task_status(tasklist):
                     ret['status'] = _('Unknown Status')
 
             ret['taskMessage'] = "{}: {}".format(task.name, task.message) if task.message else task.name
+            message_template = getattr(task, 'spa_message_template', None)
+            message_token = getattr(task, 'spa_message_token', None)
+            book_title = getattr(task, 'book_title', None)
+            book_id = getattr(task, 'book_id', None)
+            if message_template and message_token and book_title and book_id:
+                prefix, token, suffix = str(message_template).partition(message_token)
+                if token:
+                    ret['taskMessageParts'] = {
+                        'prefix': "{}: {}".format(task.name, prefix),
+                        'book': {'id': book_id, 'title': str(book_title)},
+                        'suffix': suffix,
+                    }
             ret['progress'] = "{} %".format(int(task.progress * 100))
             ret['user'] = escape(user)  # prevent xss
 

--- a/cps/tasks_status.py
+++ b/cps/tasks_status.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # See CONTRIBUTORS for full list of authors.
 
+import re
+
 from markupsafe import escape
 
 from flask import Blueprint, jsonify
@@ -65,18 +67,28 @@ def render_task_status(tasklist):
                 else:
                     ret['status'] = _('Unknown Status')
 
-            ret['taskMessage'] = "{}: {}".format(task.name, task.message) if task.message else task.name
-            message_template = getattr(task, 'spa_message_template', None)
-            message_token = getattr(task, 'spa_message_token', None)
+            task_name = str(task.name)
+            message = str(task.message) if task.message else ''
+            ret['taskMessage'] = "{}: {}".format(task_name, message) if message else task_name
             book_title = getattr(task, 'book_title', None)
             book_id = getattr(task, 'book_id', None)
-            if message_template and message_token and book_title and book_id:
-                prefix, token, suffix = str(message_template).partition(message_token)
-                if token:
+            if book_title is not None and book_id is not None:
+                # Classic task messages intentionally contain an anchor. Match
+                # only the anchor for this task's known book pair, then expose
+                # plain message segments so the SPA can build its own in-app
+                # link. Any unrelated markup remains text in the SPA.
+                anchor = re.search(
+                    r'<a href="/(?:[^"<>:/]+/)*book/{}">{}</a>'.format(
+                        re.escape(str(book_id)),
+                        re.escape(str(escape(book_title))),
+                    ),
+                    message,
+                )
+                if anchor:
                     ret['taskMessageParts'] = {
-                        'prefix': "{}: {}".format(task.name, prefix),
+                        'prefix': "{}: {}".format(task_name, message[:anchor.start()]),
                         'book': {'id': book_id, 'title': str(book_title)},
-                        'suffix': suffix,
+                        'suffix': message[anchor.end():],
                     }
             ret['progress'] = "{} %".format(int(task.progress * 100))
             ret['user'] = escape(user)  # prevent xss

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -140,16 +140,24 @@ test('convert and failed send expose SPA-native book links in both task UIs', as
     const sendClassicRow = page.locator('#tasktable tbody tr').filter({ hasText: 'Failed' }).last();
     await expect(convertClassicRow).toBeVisible();
     await expect(sendClassicRow).toBeVisible();
-    await expect(convertClassicRow.getByRole('link', { name: book!.title })).toHaveAttribute(
-      'href',
-      `/book/${book!.id}`,
-    );
-    await expect(sendClassicRow.getByRole('link', { name: book!.title })).toHaveAttribute(
-      'href',
-      `/book/${book!.id}`,
-    );
+    const convertClassicLink = convertClassicRow.getByRole('link', { name: book!.title });
+    const sendClassicLink = sendClassicRow.getByRole('link', { name: book!.title });
+    await expect(convertClassicLink).toHaveAttribute('href', `/book/${book!.id}`);
+    await expect(sendClassicLink).toHaveAttribute('href', `/book/${book!.id}`);
     await expect(sendClassicRow).toContainText(failedTask!.starttime!);
     await expect(sendClassicRow).toContainText(failedTask!.error!);
+
+    await convertClassicLink.click();
+    await expect(page).toHaveURL(new RegExp(`/book/${book!.id}$`));
+    await expect(page.getByText(book!.title, { exact: true }).first()).toBeVisible();
+    await page.waitForLoadState('networkidle');
+
+    await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
+    await page.locator('#tasktable tbody tr').filter({ hasText: 'Failed' }).last()
+      .getByRole('link', { name: book!.title }).click();
+    await expect(page).toHaveURL(new RegExp(`/book/${book!.id}$`));
+    await expect(page.getByText(book!.title, { exact: true }).first()).toBeVisible();
+    await page.waitForLoadState('networkidle');
 
     assertNoPageErrors(errors);
   } finally {

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -28,12 +28,12 @@ async function csrfToken(page: Page): Promise<string> {
 
 /**
  * F-57c90e / F-b19131 — this is deliberately one real, serial flow. It changes
- * SMTP settings, queues a genuine send, waits for the worker's DNS failure,
- * then renders that same task in both UIs. Running one copy avoids racing the
- * shared seeded admin's settings between Playwright projects.
+ * SMTP settings, queues a genuine conversion and send, waits for both workers,
+ * then renders those same tasks in both UIs. Running one copy avoids racing the
+ * shared seeded admin's settings and formats between Playwright projects.
  */
-test('failed send exposes its reason, start time, and SPA-native book link in both task UIs', async ({ page }, testInfo) => {
-  test.skip(testInfo.project.name !== 'desktop', 'one real failed-send flow covers both UIs and the 375px viewport');
+test('convert and failed send expose SPA-native book links in both task UIs', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop', 'one real worker flow covers both UIs and the 375px viewport');
 
   await page.goto('/app');
   const errors = collectPageErrors(page);
@@ -43,6 +43,7 @@ test('failed send exposes its reason, start time, and SPA-native book link in bo
   const originalResponse = await page.request.get('/api/v1/admin/mailsettings');
   expect(originalResponse.ok(), 'reading the original SMTP settings should succeed').toBeTruthy();
   const original = (await originalResponse.json()) as MailSettings;
+  let convertedBookId: number | undefined;
 
   try {
     const configure = await page.request.post('/api/v1/admin/mailsettings', {
@@ -64,9 +65,18 @@ test('failed send exposes its reason, start time, and SPA-native book link in bo
     const books = (await booksResponse.json()) as {
       items: Array<{ id: number; title: string; formats: string[] }>;
     };
-    const book = books.items.find((item) =>
-      item.formats.some((format) => format.toLowerCase() === 'epub'));
-    expect(book, 'the e2e seed must contain an EPUB book for the real send failure').toBeTruthy();
+    const book = books.items.find((item) => {
+      const formats = item.formats.map((format) => format.toLowerCase());
+      return formats.includes('epub') && !formats.includes('mobi');
+    });
+    expect(book, 'the e2e seed must contain an EPUB-only book for the real conversion').toBeTruthy();
+    convertedBookId = book!.id;
+
+    const convert = await page.request.post(`/api/v1/books/${book!.id}/convert`, {
+      headers,
+      data: { from: 'EPUB', to: 'MOBI' },
+    });
+    expect(convert.ok(), await convert.text()).toBeTruthy();
 
     const queued = await page.request.post(`/api/v1/books/${book!.id}/send`, {
       headers,
@@ -74,39 +84,48 @@ test('failed send exposes its reason, start time, and SPA-native book link in bo
     });
     expect(queued.ok(), await queued.text()).toBeTruthy();
 
+    let convertTask: TaskItem | undefined;
     let failedTask: TaskItem | undefined;
     await expect.poll(async () => {
       const response = await page.request.get('/api/v1/tasks');
       if (!response.ok()) return `HTTP ${response.status()}`;
       const body = (await response.json()) as { items: TaskItem[] };
-      failedTask = body.items.find((item) => item.taskMessage.includes(`/book/${book!.id}`));
-      return failedTask?.status;
+      convertTask = body.items.find((item) =>
+        item.taskMessage.includes('EPUB -> MOBI') && item.taskMessage.includes(`/book/${book!.id}`));
+      failedTask = body.items.find((item) =>
+        item.taskMessage.includes('send to eReader') && item.taskMessage.includes(`/book/${book!.id}`));
+      return `${convertTask?.status}/${failedTask?.status}`;
     }, {
-      message: 'the real SMTP task should fail in the worker',
-      timeout: 20_000,
+      message: 'the real conversion should finish and SMTP task should fail in the worker',
+      timeout: 30_000,
       intervals: [250, 500, 1_000],
-    }).toBe('Failed');
+    }).toBe('Finished/Failed');
 
     expect(failedTask?.starttime, 'failed task payload should carry its start time').toBeTruthy();
     expect(failedTask?.error, 'failed task payload should carry its failure reason')
       .toMatch(/Socket Error sending e-mail:.*(Name or service not known|nodename nor servname)/i);
 
     await page.goto('/app/tasks');
-    const spaRow = page.getByRole('row').filter({ hasText: 'Failed' }).last();
-    await expect(spaRow).toBeVisible();
-    const bookLink = spaRow.getByRole('link', { name: book!.title });
-    await expect(bookLink).toBeVisible();
-    await expect(bookLink).toHaveAttribute('href', new RegExp(`/app/book/${book!.id}$`));
-    await expect(spaRow).toContainText(failedTask!.starttime!);
-    await expect(spaRow).toContainText(failedTask!.error!);
-    await expect(spaRow).not.toContainText('<a href=');
+    const convertSpaRow = page.getByRole('row').filter({ hasText: 'EPUB -> MOBI' }).last();
+    const sendSpaRow = page.getByRole('row').filter({ hasText: 'Failed' }).last();
+    await expect(convertSpaRow).toBeVisible();
+    await expect(sendSpaRow).toBeVisible();
+    const convertBookLink = convertSpaRow.getByRole('link', { name: book!.title });
+    const sendBookLink = sendSpaRow.getByRole('link', { name: book!.title });
+    await expect(convertBookLink).toHaveAttribute('href', new RegExp(`/app/book/${book!.id}$`));
+    await expect(sendBookLink).toHaveAttribute('href', new RegExp(`/app/book/${book!.id}$`));
+    await expect(sendSpaRow).toContainText(failedTask!.starttime!);
+    await expect(sendSpaRow).toContainText(failedTask!.error!);
+    await expect(convertSpaRow).not.toContainText('<a href=');
+    await expect(sendSpaRow).not.toContainText('<a href=');
 
-    await bookLink.click();
+    await convertBookLink.click();
     await expect(page).toHaveURL(new RegExp(`/app/book/${book!.id}$`));
     await expect(page.getByRole('heading', { name: book!.title }).first()).toBeVisible();
 
     await page.setViewportSize({ width: 375, height: 667 });
     await page.goto('/app/tasks');
+    await expect(page.getByRole('row').filter({ hasText: 'EPUB -> MOBI' }).last()).toBeVisible();
     await expect(page.getByRole('row').filter({ hasText: 'Failed' }).last()).toBeVisible();
     await assertNoHorizontalOverflow(page);
 
@@ -117,17 +136,26 @@ test('failed send exposes its reason, start time, and SPA-native book link in bo
     }]);
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
-    const classicRow = page.locator('#tasktable tbody tr').filter({ hasText: book!.title });
-    await expect(classicRow).toBeVisible();
-    await expect(classicRow.getByRole('link', { name: book!.title })).toHaveAttribute(
+    const convertClassicRow = page.locator('#tasktable tbody tr').filter({ hasText: 'EPUB -> MOBI' }).last();
+    const sendClassicRow = page.locator('#tasktable tbody tr').filter({ hasText: 'Failed' }).last();
+    await expect(convertClassicRow).toBeVisible();
+    await expect(sendClassicRow).toBeVisible();
+    await expect(convertClassicRow.getByRole('link', { name: book!.title })).toHaveAttribute(
       'href',
       `/book/${book!.id}`,
     );
-    await expect(classicRow).toContainText(failedTask!.starttime!);
-    await expect(classicRow).toContainText(failedTask!.error!);
+    await expect(sendClassicRow.getByRole('link', { name: book!.title })).toHaveAttribute(
+      'href',
+      `/book/${book!.id}`,
+    );
+    await expect(sendClassicRow).toContainText(failedTask!.starttime!);
+    await expect(sendClassicRow).toContainText(failedTask!.error!);
 
     assertNoPageErrors(errors);
   } finally {
+    if (convertedBookId !== undefined) {
+      await page.request.post(`/api/v1/books/${convertedBookId}/formats/MOBI/delete`, { headers });
+    }
     await page.request.post('/api/v1/admin/mailsettings', {
       headers,
       data: {

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test, type Page } from '@playwright/test';
+import { assertNoHorizontalOverflow, assertNoPageErrors, collectPageErrors } from './utils';
+
+interface MailSettings {
+  mail_server: string;
+  mail_port: number;
+  mail_use_ssl: number;
+  mail_login: string;
+  mail_from: string;
+  mail_size_mb: number;
+  mail_server_type: number;
+  has_password: boolean;
+}
+
+interface TaskItem {
+  task_id: string;
+  taskMessage: string;
+  status?: string;
+  starttime?: string;
+  error?: string | null;
+}
+
+async function csrfToken(page: Page): Promise<string> {
+  const response = await page.request.get('/api/v1/auth/csrf');
+  expect(response.ok(), 'CSRF token request should succeed').toBeTruthy();
+  return ((await response.json()) as { csrf_token: string }).csrf_token;
+}
+
+/**
+ * F-57c90e / F-b19131 — this is deliberately one real, serial flow. It changes
+ * SMTP settings, queues a genuine send, waits for the worker's DNS failure,
+ * then renders that same task in both UIs. Running one copy avoids racing the
+ * shared seeded admin's settings between Playwright projects.
+ */
+test('failed send exposes its reason, start time, and SPA-native book link in both task UIs', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop', 'one real failed-send flow covers both UIs and the 375px viewport');
+
+  await page.goto('/app');
+  const errors = collectPageErrors(page);
+  const csrf = await csrfToken(page);
+  const headers = { 'X-CSRFToken': csrf };
+
+  const originalResponse = await page.request.get('/api/v1/admin/mailsettings');
+  expect(originalResponse.ok(), 'reading the original SMTP settings should succeed').toBeTruthy();
+  const original = (await originalResponse.json()) as MailSettings;
+
+  try {
+    const configure = await page.request.post('/api/v1/admin/mailsettings', {
+      headers,
+      data: {
+        mail_server: 'smtp-probe.invalid',
+        mail_port: 25,
+        mail_use_ssl: 0,
+        mail_login: '',
+        mail_from: 'probe@example.invalid',
+        mail_size_mb: original.mail_size_mb,
+        mail_server_type: 0,
+      },
+    });
+    expect(configure.ok(), await configure.text()).toBeTruthy();
+
+    const booksResponse = await page.request.get('/api/v1/books?per_page=200');
+    expect(booksResponse.ok(), 'book seed request should succeed').toBeTruthy();
+    const books = (await booksResponse.json()) as {
+      items: Array<{ id: number; title: string; formats: string[] }>;
+    };
+    const book = books.items.find((item) =>
+      item.formats.some((format) => format.toLowerCase() === 'epub'));
+    expect(book, 'the e2e seed must contain an EPUB book for the real send failure').toBeTruthy();
+
+    const queued = await page.request.post(`/api/v1/books/${book!.id}/send`, {
+      headers,
+      data: { format: 'epub', emails: 'probe@example.invalid' },
+    });
+    expect(queued.ok(), await queued.text()).toBeTruthy();
+
+    let failedTask: TaskItem | undefined;
+    await expect.poll(async () => {
+      const response = await page.request.get('/api/v1/tasks');
+      if (!response.ok()) return `HTTP ${response.status()}`;
+      const body = (await response.json()) as { items: TaskItem[] };
+      failedTask = body.items.find((item) => item.taskMessage.includes(`/book/${book!.id}`));
+      return failedTask?.status;
+    }, {
+      message: 'the real SMTP task should fail in the worker',
+      timeout: 20_000,
+      intervals: [250, 500, 1_000],
+    }).toBe('Failed');
+
+    expect(failedTask?.starttime, 'failed task payload should carry its start time').toBeTruthy();
+    expect(failedTask?.error, 'failed task payload should carry its failure reason')
+      .toMatch(/Socket Error sending e-mail:.*(Name or service not known|nodename nor servname)/i);
+
+    await page.goto('/app/tasks');
+    const spaRow = page.getByRole('row').filter({ hasText: 'Failed' }).last();
+    await expect(spaRow).toBeVisible();
+    const bookLink = spaRow.getByRole('link', { name: book!.title });
+    await expect(bookLink).toBeVisible();
+    await expect(bookLink).toHaveAttribute('href', new RegExp(`/app/book/${book!.id}$`));
+    await expect(spaRow).toContainText(failedTask!.starttime!);
+    await expect(spaRow).toContainText(failedTask!.error!);
+    await expect(spaRow).not.toContainText('<a href=');
+
+    await bookLink.click();
+    await expect(page).toHaveURL(new RegExp(`/app/book/${book!.id}$`));
+    await expect(page.getByRole('heading', { name: book!.title }).first()).toBeVisible();
+
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/app/tasks');
+    await expect(page.getByRole('row').filter({ hasText: 'Failed' }).last()).toBeVisible();
+    await assertNoHorizontalOverflow(page);
+
+    await page.context().addCookies([{
+      name: 'cwng_prefer_spa',
+      value: '0',
+      url: new URL(page.url()).origin,
+    }]);
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
+    const classicRow = page.locator('#tasktable tbody tr').filter({ hasText: book!.title });
+    await expect(classicRow).toBeVisible();
+    await expect(classicRow.getByRole('link', { name: book!.title })).toHaveAttribute(
+      'href',
+      `/book/${book!.id}`,
+    );
+    await expect(classicRow).toContainText(failedTask!.starttime!);
+    await expect(classicRow).toContainText(failedTask!.error!);
+
+    assertNoPageErrors(errors);
+  } finally {
+    await page.request.post('/api/v1/admin/mailsettings', {
+      headers,
+      data: {
+        mail_server: original.mail_server,
+        mail_port: original.mail_port,
+        mail_use_ssl: original.mail_use_ssl,
+        mail_login: original.mail_login,
+        mail_from: original.mail_from,
+        mail_size_mb: original.mail_size_mb,
+        mail_server_type: original.mail_server_type,
+      },
+    });
+  }
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -421,6 +421,11 @@ export interface AboutInfo {
 export interface TaskItem {
   task_id: number | string;
   taskMessage: string;
+  taskMessageParts?: {
+    prefix: string;
+    book: { id: number | string; title: string };
+    suffix: string;
+  };
   status?: string;
   progress: string;
   starttime?: string;
@@ -428,6 +433,7 @@ export interface TaskItem {
   user: string;
   is_cancellable: boolean;
   stat: number;
+  error?: string | null;
 }
 
 export class ApiError extends Error {

--- a/frontend/src/pages/Tasks.module.css
+++ b/frontend/src/pages/Tasks.module.css
@@ -34,9 +34,29 @@
   padding: var(--sp-3) var(--sp-3);
   border-bottom: 1px solid var(--border);
   color: var(--text);
+  overflow-wrap: anywhere;
 }
 .table tr:last-child td { border-bottom: none; }
-.taskMsg { max-width: 360px; }
+.taskCell { max-width: 420px; }
+.taskMsg { line-height: 1.45; }
+.bookLink {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.bookLink:hover { color: var(--accent-hover); }
+
+.taskDetails {
+  display: grid;
+  gap: var(--sp-1);
+  margin: var(--sp-2) 0 0;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+}
+.taskStart { font-variant-numeric: tabular-nums; }
+.taskError { color: var(--danger); }
+.mobileLabel { display: none; }
 
 .cancelBtn {
   display: inline-flex;
@@ -48,3 +68,53 @@
 }
 .cancelBtn:hover:not(:disabled) { color: var(--danger); background: var(--danger-soft); }
 .cancelBtn:disabled { opacity: 0.4; }
+
+@media (max-width: 600px) {
+  .container { padding: var(--sp-5) var(--sp-3); }
+
+  .table,
+  .table tbody { display: block; width: 100%; }
+  .table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .table tbody tr {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--sp-3) var(--sp-4);
+    padding: var(--sp-4);
+  }
+  .table tbody tr + tr { border-top: 1px solid var(--border); }
+  .table td {
+    display: block;
+    min-width: 0;
+    padding: 0;
+    border-bottom: none;
+  }
+  .taskCell {
+    grid-column: 1 / -1;
+    max-width: none;
+  }
+  .taskCellCancellable { padding-right: calc(28px + var(--sp-2)); }
+  .taskDetails { gap: var(--sp-2); }
+  .mobileLabel {
+    display: block;
+    margin-bottom: 2px;
+    color: var(--text-muted);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+  }
+  .cancelCell {
+    position: absolute;
+    top: var(--sp-3);
+    right: var(--sp-3);
+  }
+}

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -27,12 +27,13 @@ function taskMessageParts(task: TaskItem): TaskMessageParts | undefined {
   if (task.taskMessageParts) return task.taskMessageParts;
 
   // Rolling upgrades and the PR E2E rig can briefly pair this SPA with a
-  // server that only has the Classic HTML field. Accept exactly its known
-  // anchor shape; arbitrary or additional markup stays visible as plain text.
-  const match = /^([^<>]+): <a href="\/book\/(\d+)">([^<>]*)<\/a>([^<>]*)$/.exec(task.taskMessage);
+  // server that only has the Classic HTML field. Accept one known, local book
+  // anchor surrounded by plain text; arbitrary or additional markup stays
+  // visible as plain text.
+  const match = /^([^<]*)<a href="\/(?:[^"<>:/]+\/)*book\/(\d+)">([^<]*)<\/a>([^<]*)$/.exec(task.taskMessage);
   if (!match) return undefined;
   return {
-    prefix: `${decodeTaskEntities(match[1])}: `,
+    prefix: decodeTaskEntities(match[1]),
     book: { id: match[2], title: decodeTaskEntities(match[3]) },
     suffix: decodeTaskEntities(match[4]),
   };

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -1,9 +1,30 @@
 import { ListChecks, X } from 'lucide-react';
+import { Link } from 'wouter';
 import { useTasks, useCancelTask } from '../lib/queries';
+import type { TaskItem } from '../lib/api';
 import { SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import { useT } from '../lib/i18n';
 import styles from './Tasks.module.css';
+
+function taskMessageText(task: TaskItem) {
+  const parts = task.taskMessageParts;
+  return parts
+    ? `${parts.prefix}${parts.book.title}${parts.suffix}`
+    : task.taskMessage;
+}
+
+function TaskMessage({ task }: { task: TaskItem }) {
+  const parts = task.taskMessageParts;
+  if (!parts) return <>{task.taskMessage}</>;
+  return (
+    <>
+      {parts.prefix}
+      <Link href={`/book/${parts.book.id}`} className={styles.bookLink}>{parts.book.title}</Link>
+      {parts.suffix}
+    </>
+  );
+}
 
 export function Tasks() {
   const { data, isLoading, error } = useTasks();
@@ -22,7 +43,7 @@ export function Tasks() {
   return (
     <main className={styles.container}>
       <div className={styles.header}>
-        <ListChecks size={22} className={styles.headerIcon} />
+        <ListChecks size={22} className={styles.headerIcon} aria-hidden="true" focusable={false} />
         <h1 className={styles.title}>{t('Tasks')}</h1>
         <span className={styles.count}>{data.items.length}</span>
       </div>
@@ -44,18 +65,44 @@ export function Tasks() {
           <tbody>
             {data.items.map((task) => (
               <tr key={String(task.task_id)}>
-                <td className={styles.taskMsg}>{task.taskMessage}</td>
-                <td>{task.user}</td>
-                <td>{task.status ?? '—'}</td>
-                <td>{task.progress}</td>
-                <td>{task.runtime ?? '—'}</td>
-                <td>
+                <td className={`${styles.taskCell} ${task.is_cancellable ? styles.taskCellCancellable : ''}`}>
+                  <div className={styles.taskMsg}><TaskMessage task={task} /></div>
+                  {(task.starttime || task.error) && (
+                    <div className={styles.taskDetails}>
+                      {task.starttime && (
+                        <time className={styles.taskStart} dateTime={task.starttime.replace(' ', 'T')}>
+                          {task.starttime}
+                        </time>
+                      )}
+                      {task.error && (
+                        <div className={styles.taskError} role="alert">{task.error}</div>
+                      )}
+                    </div>
+                  )}
+                </td>
+                <td className={styles.metaCell}>
+                  <span className={styles.mobileLabel}>{t('User')}</span>
+                  {task.user}
+                </td>
+                <td className={styles.metaCell}>
+                  <span className={styles.mobileLabel}>{t('Status')}</span>
+                  {task.status ?? '—'}
+                </td>
+                <td className={styles.metaCell}>
+                  <span className={styles.mobileLabel}>{t('Progress')}</span>
+                  {task.progress}
+                </td>
+                <td className={styles.metaCell}>
+                  <span className={styles.mobileLabel}>{t('Run time')}</span>
+                  {task.runtime ?? '—'}
+                </td>
+                <td className={styles.cancelCell}>
                   {task.is_cancellable && (
                     <button className={styles.cancelBtn}
                       onClick={() => cancel.mutate(task.task_id)}
                       disabled={cancel.isPending}
-                      aria-label={t('Cancel {task}', { task: task.taskMessage })}>
-                      <X size={15} />
+                      aria-label={t('Cancel {task}', { task: taskMessageText(task) })}>
+                      <X size={15} aria-hidden="true" focusable={false} />
                     </button>
                   )}
                 </td>

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -7,15 +7,46 @@ import { EmptyState } from '../components/EmptyState';
 import { useT } from '../lib/i18n';
 import styles from './Tasks.module.css';
 
+type TaskMessageParts = NonNullable<TaskItem['taskMessageParts']>;
+
+function decodeTaskEntities(text: string) {
+  return text.replace(/&(#(?:x[0-9a-f]+|\d+)|amp|lt|gt|quot|apos);/gi, (entity, token: string) => {
+    if (token.startsWith('#')) {
+      const hex = token[1]?.toLowerCase() === 'x';
+      const codePoint = Number.parseInt(token.slice(hex ? 2 : 1), hex ? 16 : 10);
+      if (Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff) {
+        try { return String.fromCodePoint(codePoint); } catch { return entity; }
+      }
+      return entity;
+    }
+    return ({ amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" } as Record<string, string>)[token.toLowerCase()] ?? entity;
+  });
+}
+
+function taskMessageParts(task: TaskItem): TaskMessageParts | undefined {
+  if (task.taskMessageParts) return task.taskMessageParts;
+
+  // Rolling upgrades and the PR E2E rig can briefly pair this SPA with a
+  // server that only has the Classic HTML field. Accept exactly its known
+  // anchor shape; arbitrary or additional markup stays visible as plain text.
+  const match = /^([^<>]+): <a href="\/book\/(\d+)">([^<>]*)<\/a>([^<>]*)$/.exec(task.taskMessage);
+  if (!match) return undefined;
+  return {
+    prefix: `${decodeTaskEntities(match[1])}: `,
+    book: { id: match[2], title: decodeTaskEntities(match[3]) },
+    suffix: decodeTaskEntities(match[4]),
+  };
+}
+
 function taskMessageText(task: TaskItem) {
-  const parts = task.taskMessageParts;
+  const parts = taskMessageParts(task);
   return parts
     ? `${parts.prefix}${parts.book.title}${parts.suffix}`
     : task.taskMessage;
 }
 
 function TaskMessage({ task }: { task: TaskItem }) {
-  const parts = task.taskMessageParts;
+  const parts = taskMessageParts(task);
   if (!parts) return <>{task.taskMessage}</>;
   return (
     <>

--- a/tests/unit/test_api_v1_info.py
+++ b/tests/unit/test_api_v1_info.py
@@ -203,6 +203,58 @@ def test_tasks_uses_render_task_status():
     assert "render_task_status" in src
 
 
+def _render_book_task(message, *, task_name="Convert", book_id=197,
+                      book_title="The Enchanted & April"):
+    from cps import tasks_status
+    task = SimpleNamespace(
+        name=task_name,
+        message=message,
+        book_id=book_id,
+        book_title=book_title,
+        start_time=None,
+        stat="finished",
+        progress=1,
+        id="task-1",
+        is_cancellable=False,
+        error=None,
+    )
+    with _ctx("/api/v1/tasks", method="GET"):
+        with patch.object(tasks_status, "current_user",
+                          SimpleNamespace(name="alice", role_admin=lambda: False)):
+            return tasks_status.render_task_status([(0, "alice", 0, task, 0)])[0]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("task_name, message, expected_prefix, expected_suffix", [
+    ("Convert", 'EPUB -> MOBI: <a href="/book/197">The Enchanted &amp; April</a>',
+     "Convert: EPUB -> MOBI: ", ""),
+    ("E-mail", '<a href="/library/book/197">The Enchanted &amp; April</a> send to eReader',
+     "E-mail: ", " send to eReader"),
+])
+def test_tasks_structures_any_known_book_anchor(
+        task_name, message, expected_prefix, expected_suffix):
+    rendered = _render_book_task(message, task_name=task_name)
+
+    assert rendered["taskMessageParts"] == {
+        "prefix": expected_prefix,
+        "book": {"id": 197, "title": "The Enchanted & April"},
+        "suffix": expected_suffix,
+    }
+    assert rendered["taskMessage"] == "{}: {}".format(task_name, message)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("message", [
+    '<a href="/book/999">The Enchanted &amp; April</a>',
+    '<a href="//example.invalid/book/197">The Enchanted &amp; April</a>',
+])
+def test_tasks_does_not_structure_an_unrelated_anchor(message):
+    rendered = _render_book_task(message)
+
+    assert "taskMessageParts" not in rendered
+    assert rendered["taskMessage"] == "Convert: {}".format(message)
+
+
 @pytest.mark.unit
 def test_cancel_task_not_found_404():
     from cps.api import info as mod


### PR DESCRIPTION
## Summary

- preserve the Classic Tasks page HTML `taskMessage` contract while carrying an optional `book_id` / `book_title` pair on `CalibreTask`
- have `/api/v1/tasks` recognize the exact anchor for that known book pair and emit plain `taskMessageParts`, so every book-linked task uses one structural serializer path
- thread the book pair through send, convert, and the existing linked format-upload task producer instead of maintaining per-class SPA templates
- compose the title with a native Wouter link in the SPA; keep a strict one-local-anchor fallback for mixed-version deployments, including messages such as `EPUB -> MOBI`
- show task start timestamp and failure reason, and retain the compact mobile reflow with no 375px horizontal overflow
- extend the real-worker Playwright regression to trigger both EPUB-to-MOBI conversion and SMTP DNS failure and verify both UIs

## Runtime verification

- OBSERVED the extended Playwright spec fail against the pre-change image at the convert row because no book link was rendered
- OBSERVED real `POST /api/v1/books/<id>/convert` with `{"from":"EPUB","to":"MOBI"}` finish successfully
- OBSERVED real `POST /api/v1/books/<id>/send` with `{"format":"epub","emails":"probe@example.invalid"}` fail with `Socket Error sending e-mail: Name or service not known`
- OBSERVED the final rebuilt image emit structured book parts for both tasks while preserving each Classic HTML message
- OBSERVED the final Playwright spec verify native `/app/book/<id>` links and no visible markup for convert and send, working Classic `/book/<id>` links for both, send start time/error, and no horizontal overflow at 375px
- OBSERVED the final SPA bundle pass the same spec against the pre-change backend, exercising the rolling-upgrade fallback

## Other verification

- `npm --prefix frontend run build`
- `python3 -m pytest -q tests/unit/test_api_v1_info.py tests/unit/test_225_broadcast_email.py tests/unit/test_convert_user_plugins_env_724.py` — 55 passed
- `python3 -m pytest -q tests/unit/test_api_v1_info.py tests/unit/test_225_broadcast_email.py tests/unit/test_convert_user_plugins_env_724.py tests/unit/test_kobo_prefer_kepub.py tests/unit/test_kobo_annotations_landed_interactions.py tests/unit/test_1419_kepub_backfill_survives_one_bad_book.py` — 81 passed
- `E2E_BASE_URL=http://localhost:18089 npm run test:e2e -- tasks.spec.ts --project=desktop --workers=1` — 2 passed
- mixed-version: `E2E_BASE_URL=http://localhost:18090 npm run test:e2e -- tasks.spec.ts --project=desktop --workers=1` — 2 passed

References F-57c90e and F-b19131.