### PR TITLE
chore(findings): record the SPA delete and permission audit

### DIFF
--- a/findings/items/F-2f48b9.json
+++ b/findings/items/F-2f48b9.json
@@ -1,0 +1,11 @@
+{
+  "area": "spa",
+  "body": "OBSERVED, confirmed independently (Opus).\n\nAuthorization for Duplicates is admin-OR-edit on both the classic route\n(`cps/duplicates.py:548-551`, `admin_or_edit_required`) and the SPA's own API\n(`cps/api/duplicates.py:28-41`). Classic's sidebar matches it:\n`cps/render_template.py:202` — `if current_user.role_admin() or current_user.role_edit()`.\n\nThe SPA sidebar instead gates on upload-or-admin:\n`frontend/src/components/Sidebar.tsx:334` — `(canUpload || isAdmin) && showDuplicates`.\n\n`upload` and `edit` are distinct bits, so this is wrong in both directions:\n- an EDIT-only user is authorized by the API but never shown the link;\n- an UPLOAD-only user is shown a link whose API answers 403.\n\nFix: gate the sidebar entry on admin-or-edit to match the route and the API, and add\nedit-only and upload-only cases to the role matrix the risk register calls for\n(R13) — this finding is the concrete instance proving that matrix is not optional.",
+  "created": "2026-08-23",
+  "id": "F-2f48b9",
+  "refs": [],
+  "severity": "correctness",
+  "source": "audit",
+  "status": "open",
+  "title": "Duplicates sidebar link is gated on the wrong role bit, failing in both directions"
+}

--- a/findings/items/F-3db089.json
+++ b/findings/items/F-3db089.json
@@ -1,0 +1,11 @@
+{
+  "area": "spa",
+  "body": "OBSERVED, confirmed independently (Opus) after an adversarial audit pass (Sol refuter).\n\nClassic gates the per-format delete buttons on the book having MORE THAN ONE format:\n`cps/templates/book_edit.html:55` — `{% if book.data|length > 1 %}`.\n\nThe SPA has no equivalent guard. `frontend/src/pages/EditBook.tsx:835-850` maps every\nentry of `book.formats` and gates only on `canDelete`, so the sole remaining format\ngets a delete button. The API does not backstop it either: `cps/api/edit.py:432-442`\n(`delete_format`) checks auth, role and visibility, then calls\n`delete_book_from_table(book_id, fmt.upper(), True)` with no format-count check.\n\nResult: through the default UI a user can reduce a book to zero formats — a state\nclassic's UI is explicitly written to prevent. The book row survives with no file.\n\nFix shape: enforce the invariant in the API (the UI guard alone repeats classic's\nmistake of a client-side-only rule), and mirror it in EditBook so the control is\ndisabled-with-reason rather than absent.",
+  "created": "2026-08-23",
+  "id": "F-3db089",
+  "refs": [],
+  "severity": "data-integrity",
+  "source": "audit",
+  "status": "open",
+  "title": "New UI can delete a book's last remaining format; classic deliberately prevents it"
+}

--- a/findings/items/F-567c75.json
+++ b/findings/items/F-567c75.json
@@ -1,0 +1,11 @@
+{
+  "area": "spa",
+  "body": "OBSERVED, confirmed independently (Opus).\n\n`useBulkActions().remove` fans out per-book deletes through\n`settle = Promise.allSettled` (`frontend/src/lib/queries.ts:646,666-674`).\n`Promise.allSettled` NEVER rejects, so the mutation's `onSuccess` runs even when every\nrequest failed. `onSuccess` then evicts every requested id from cache unconditionally\n(`ids.forEach(removeBookFromCache)`), and `BulkBar.tsx:77-81` announces\n\"{n} book(s) deleted.\" using the ORIGINAL selection count.\n\nSo a bulk delete where some or all books failed to delete tells the user they were all\ndeleted and removes them from view. Reloading brings them back.\n\nThis is independent of F-c6b236: fixing the API's false 204 does not fix this, because\n`allSettled` would still resolve on genuine rejections.\n\nFix shape: inspect settlement status per item; evict only confirmed deletions; report\ntruthful succeeded/failed counts. Note the same `settle()` helper backs markRead and\naddToShelf, so audit those for the same false-success shape (compare F-a24ccb, which\nfound the equivalent bug in bulk metadata edits — this is the same defect class\nrecurring, which suggests fixing the helper rather than each caller).",
+  "created": "2026-08-23",
+  "id": "F-567c75",
+  "refs": [],
+  "severity": "data-integrity",
+  "source": "audit",
+  "status": "open",
+  "title": "Bulk delete announces every selected book deleted even when requests failed"
+}

--- a/findings/items/F-c6b236.json
+++ b/findings/items/F-c6b236.json
@@ -1,0 +1,11 @@
+{
+  "area": "api",
+  "body": "OBSERVED, confirmed independently (Opus).\n\n`delete_book_from_table()` returns a structured result describing failure:\n- `cps/editbooks.py:1615-1624` returns a `\"type\": \"danger\"` payload when\n  `helper.delete_book` fails to remove the format file;\n- `cps/editbooks.py:1596-1609` logs \"removed from the database but file ...\" on the\n  whole-book path;\n- `cps/editbooks.py:1669-1679` returns a danger payload after `session.rollback()`\n  on exception.\n\nBoth SPA endpoints throw that return value away and answer unconditionally:\n`cps/api/edit.py:423-426` (`delete_book`) and `cps/api/edit.py:438-442`\n(`delete_format`) both end `delete_book_from_table(...)` / `return \"\", 204`.\n\nSo a deletion that failed, rolled back, or orphaned a file reports HTTP 204 No Content\n— indistinguishable from success. React then treats it as a successful mutation and\nevicts the cached rows (`frontend/src/lib/queries.ts:778-795,816-826`), so the UI shows\nthe book gone whether or not it is.\n\nClassic surfaces the same conditions as a flash error. This is a strict safety\nregression in the new UI relative to the old.\n\nFix shape: translate the core's result into a non-2xx error (and an explicit warning\nresponse for the partial-success cases) rather than swallowing it.",
+  "created": "2026-08-23",
+  "id": "F-c6b236",
+  "refs": [],
+  "severity": "data-integrity",
+  "source": "audit",
+  "status": "open",
+  "title": "SPA delete endpoints discard the deletion core's result and always return 204"
+}

--- a/findings/items/F-f6a8bf.json
+++ b/findings/items/F-f6a8bf.json
@@ -1,0 +1,11 @@
+{
+  "area": "spa",
+  "body": "OBSERVED, confirmed independently (Opus).\n\nClassic requires the CONJUNCTION of both role bits before it will even render the\ndelete control: `cps/templates/detail.html:1202` —\n`delete_book(current_user.role_delete_books() and current_user.role_edit())`.\n\nThe SPA requires only one: `frontend/src/pages/BookDetail.tsx:557` —\n`me?.role?.delete_books && (...)`. The API agrees with the SPA, not with classic:\n`cps/api/edit.py:409-425` checks `current_user.role_delete_books()` alone.\n\n`edit` and `delete_books` are independently assignable bits (`cps/constants.py`),\nand the SPA's own admin UI exposes them as separate toggles\n(`frontend/src/pages/Admin.tsx:51-60`, mapped at `cps/api/admin.py:37-48`).\n\nSo an account provisioned as delete-but-not-edit is denied whole-book deletion in the\nclassic UI and granted it in the new one. Note the code comment at BookDetail.tsx:554-556\nsays \"The server still re-checks the role\" — true, but the server re-checks the WEAKER\ncondition, so the comment reads as reassurance while describing the gap.\n\nThis needs a policy decision before the SPA becomes the only UI: either classic's\nconjunction is the intended rule (then fix the API and the SPA), or the single bit is\n(then classic is over-restrictive and the intent should be written down). Do not resolve\nit by aligning the UI to the current API without deciding which is correct.",
+  "created": "2026-08-23",
+  "id": "F-f6a8bf",
+  "refs": [],
+  "severity": "security",
+  "source": "audit",
+  "status": "open",
+  "title": "New UI grants whole-book delete to delete-without-edit users; classic requires both roles"
+}


### PR DESCRIPTION
Five findings from an audit of the New UI's delete surface against classic Calibre-Web's behaviour. Ledger entries only — no code changes.

| id | severity | what |
|---|---|---|
| F-f6a8bf | security | delete-without-edit users get whole-book delete; classic requires both roles |
| F-3db089 | data-integrity | the New UI will delete a book's last remaining format, which classic deliberately prevents |
| F-c6b236 | data-integrity | SPA delete endpoints discard the deletion core's result and always return 204, so partial failures read as success |
| F-567c75 | data-integrity | bulk delete announces every selected book deleted even when individual requests failed |
| F-2f48b9 | correctness | the Duplicates sidebar link is gated on the wrong role bit and fails in both directions |

All five are recorded `open`; fixes land separately.