### PR TITLE
docs(kobo): mark the 2026-05-25 design superseded on Edge 4

### DIFF
--- a/notes/2026-05-25-annotation-two-way-phase1-phase2-DESIGN.md
+++ b/notes/2026-05-25-annotation-two-way-phase1-phase2-DESIGN.md
@@ -1,6 +1,17 @@
 # Annotation two-way sync — Phase 1 (web-reader create) + Phase 2 (KOReader bridge)
 
-Status: design — awaiting operator approval before implementation
+> **⚠️ SUPERSEDED on the Edge 4 question (2026-08-23).** This document states below that
+> Edge 4 — server → stock Nickel — is impossible and "permanently out (protocol)". That
+> claim is **wrong** and was written before anyone measured the protocol on hardware.
+> `notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md` (2026-08-16, Clara BW firmware
+> 4.45.23792) is the **authority** on Edge 4 and supersedes every statement here about
+> it. Stage 0 of that design is merged.
+>
+> Everything else in this document — the Phase 1 web-reader create path and the Phase 2
+> KOReader bridge — still stands and is unaffected.
+
+
+Status: design — Phase 1/2 stand; **Edge 4 claims superseded, see the banner above**
 Author: new-usemame
 Date: 2026-05-25
 Parents:
@@ -23,9 +34,15 @@ Two edges of the 5-edge matrix are still open:
 | 1 | Web reader → Server (create) | ❌ render-only, no create endpoint | **Phase 1** |
 | 5 | Server ↔ KOReader-on-Kobo (→ Nickel) | ❌ plugin is progress-only | **Phase 2** |
 
-Edge 4 (Server → stock Nickel directly) stays out of scope — Kobo's closed
-protocol blocks it; Phase 2's KoboReader.sqlite bridge is the sanctioned path
-to get a server/web highlight onto a Kobo.
+~~Edge 4 (Server → stock Nickel directly) stays out of scope — Kobo's closed
+protocol blocks it~~ — **superseded, and it was never measured.** Firmware
+4.45.23792 fetches `GET /api/v3/content/<uuid>/annotations` after
+`checkforchanges` names the content ID, and treats that response as an
+**authoritative replacement set**: a row added to it is created on-device.
+That is Edge 4, and it is the mechanism
+`notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md` builds on. Phase 2's
+`KoboReader.sqlite` bridge remains a valid path for KOReader users; it is no
+longer the *only* one.
 
 This is two independent sub-projects sharing one data model. They can ship in
 either order. Phase 1 is self-contained and lower-risk; Phase 2 touches a
@@ -351,7 +368,7 @@ checklist), plus the one nullable column + its migration.
 Out of scope (later, behind the seams built here): KOReader-native `.sdr`
 provider (cross-engine xpointer mapping); device-side deletes of Nickel rows;
 async background sync worker; sharing annotations between users; Readwise/Notion
-targets. Edge 4 (direct server→Nickel) remains permanently out (protocol).
+targets. ~~Edge 4 (direct server→Nickel) remains permanently out (protocol).~~ **Wrong — see the banner at the top.** Edge 4 is reachable on firmware 4.45.23792 and is designed in `notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md`.
 
 ## 7. Acceptance criteria
 

--- a/notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md
+++ b/notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md
@@ -1,6 +1,13 @@
 # Kobo two-way annotation sync — authoritative-set design
 
-**Status:** design only; no production implementation is authorized by this document
+**Status:** the **authority** on Kobo two-way annotation sync. Stage 0 (§10) is merged —
+schema, preference API and SPA controls, with both gates default-off so nothing syncs.
+**Stages 1–5 are not authorized by this document** and each remains hardware-gated.
+
+**Supersedes:** `notes/2026-05-25-annotation-two-way-phase1-phase2-DESIGN.md` on the
+Edge 4 question only. That document states server → stock Nickel is "permanently out
+(protocol)"; it predates any hardware measurement and is wrong. Its Phase 1 and Phase 2
+content is unaffected.
 
 **Date:** 2026-08-16
 


### PR DESCRIPTION
## What

`notes/2026-05-25-annotation-two-way-phase1-phase2-DESIGN.md` asserts that Edge 4 — server → stock Nickel — is impossible:

> Edge 4 (Server → stock Nickel directly) stays out of scope — Kobo's closed protocol blocks it

and §6 hardens it to *"remains permanently out (protocol)"*.

**That is wrong, and it was never measured.** `notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md` (2026-08-16, Clara BW firmware 4.45.23792) records the opposite from hardware: the device issues `GET /api/v3/content/<uuid>/annotations` once `checkforchanges` names the content ID, and treats the response as an **authoritative replacement set** — a row added to it is created on-device. Stage 0 of that design is merged (#1841).

## Why it matters

Nothing linked the two documents, so **search order decided which answer a reader got**, and the wrong one wins on filename recency for "annotation two-way". A session answered the operator's *"is there any way for us to natively do two-way annotations and notes sync to Kobos?"* out of the superseded doc and had to be corrected. The doc is committed, so every future reader — human or agent — inherits the same trap.

## Changes

- **Superseded doc**: banner under the H1 naming the authority; status line updated; both Edge 4 claims struck through **in place** rather than deleted, so the history stays legible and the correction is visible where the wrong claim is.
- **Authority doc**: now names what it supersedes and on which question. Its status line said *"design only; no production implementation is authorized by this document"* — stale since Stage 0 merged, and misleading in the other direction. It now says Stage 0 is merged with both gates default-off, and that **Stages 1–5 remain unauthorized and hardware-gated**.

Phase 1 (web-reader create) and Phase 2 (KOReader bridge) in the older document are unaffected and still stand — the supersession is scoped to Edge 4.

## Verification

Docs only — no code paths touched, no tests apply. `git diff --stat`: 2 files, +30/-6, both under `notes/`.

Merge tier: `safe-tier-1` (docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1GA5qD4wtZJKYuMybVqPx