### PR TITLE
docs(kobo): the 2026-05-25 design is wrong about Edge 4 in two ways, not one

### DIFF
--- a/notes/2026-05-25-annotation-two-way-phase1-phase2-DESIGN.md
+++ b/notes/2026-05-25-annotation-two-way-phase1-phase2-DESIGN.md
@@ -7,6 +7,16 @@
 > 4.45.23792) is the **authority** on Edge 4 and supersedes every statement here about
 > it. Stage 0 of that design is merged.
 >
+> **It is wrong in two independent ways, not one.** The first is the annotation
+> fetch: the device treats `GET /api/v3/content/<uuid>/annotations` as an
+> authoritative replacement set, so a row the server adds is created on-device.
+> The second is the ETag, which is what the "closed protocol" argument really
+> rested on — Nickel accepts a **CWNG-authored** ETag, stores it byte-for-byte,
+> and echoes it back in the next `checkforchanges`. It is opaque to the device.
+> So the server does not need to synthesise anything resembling a Kobo manifest
+> to be believed, which was the assumed blocker. Measured 2026-08-23; recorded
+> as §11.2 CLOSED in the authority.
+>
 > Everything else in this document — the Phase 1 web-reader create path and the Phase 2
 > KOReader bridge — still stands and is unaffected.
 

--- a/notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md
+++ b/notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md
@@ -6,8 +6,10 @@ schema, preference API and SPA controls, with both gates default-off so nothing 
 
 **Supersedes:** `notes/2026-05-25-annotation-two-way-phase1-phase2-DESIGN.md` on the
 Edge 4 question only. That document states server → stock Nickel is "permanently out
-(protocol)"; it predates any hardware measurement and is wrong. Its Phase 1 and Phase 2
-content is unaffected.
+(protocol)"; it predates any hardware measurement and is wrong on two counts — the
+annotation GET is an authoritative replacement set (§2), and the ETag is opaque to
+Nickel (§11.2, CLOSED 2026-08-23), so no manifest synthesis is required. Its Phase 1
+and Phase 2 content is unaffected.
 
 **Date:** 2026-08-16
 


### PR DESCRIPTION
Follow-up to #1844, at the request of the session that ran the hardware experiment.

#1844's banner corrected the 2026-05-25 design on **one** count: the device treats `GET /api/v3/content/<uuid>/annotations` as an authoritative replacement set, so a row the server adds is created on-device.

But the *"Kobo's closed protocol blocks it"* argument really rested on something else — the **ETag**. Kobo's own ETag is a structured composite manifest, not an opaque token, so the assumption was that a server could not produce one Nickel would believe without synthesising a Kobo-shaped manifest.

**§11.2 of the authority closed that on 2026-08-23, on hardware:** Nickel accepts a CWNG-authored ETag that shares none of Kobo's manifest grammar, stores it byte-for-byte, and sends it back on the next `checkforchanges`. It is opaque to the device. Option B therefore needs no manifest synthesis.

Naming only half of a wrong claim leaves the other half readable as still true — which is the mechanism by which that document misled a reader in the first place, so it is worth closing properly rather than leaving the stronger objection standing unaddressed.

- Banner on the superseded doc now names both, and says which one the original argument rested on.
- The authority's `Supersedes:` note names both counts and cites §11.2.

I verified §11.2's `CLOSED 2026-08-23` marker and its `[OBSERVED]` line in the authority before asserting it here rather than taking the report on trust.

Docs only. 2 files, +14/-2, both under `notes/`. Merge tier: `safe-tier-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1GA5qD4wtZJKYuMybVqPx