### PR TITLE
feat(tasks): show scheduled sends and operations in SPA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -929,6 +929,11 @@ jobs:
         env:
           CI: 'true'
           E2E_BASE_URL: http://localhost:8083
+          # Lets the scheduled-queue spec seed the isolated cwa.db through the
+          # same CWA_DB methods production scheduling uses, then independently
+          # observe the persisted cancellation state. This is the container
+          # created by this job above — never an external/shared instance.
+          E2E_CONTAINER_NAME: cwn-e2e
         run: npm run test:e2e
 
       - name: Upload Playwright report

--- a/cps/spa_strings.py
+++ b/cps/spa_strings.py
@@ -1029,6 +1029,22 @@ _("Versions")
 _("View")
 _("View settings")
 _("Viewer")
+
+# F-f61640 — persistent scheduled queues on the SPA Tasks page. Most column
+# labels are shared with Classic; anchoring them here still matters because the
+# React source is not part of pybabel's extraction inputs.
+_("Upcoming scheduled sends")
+_("Upcoming scheduled operations")
+_("Scheduled Time")
+_("Book ID")
+_("State")
+_("Type")
+_("Convert Library")
+_("EPUB Fixer")
+_("No upcoming scheduled sends.")
+_("No upcoming scheduled operations.")
+_("Could not load scheduled tasks.")
+_("Cancel scheduled item \"{title}\"? This cannot be undone.")
 _("Waiting for you to authorise…")
 _("Warning: this highlight can’t be shown in the book")
 _("We repaired this book for your Kobo. If you were having trouble highlighting, try after sync — and if it still doesn’t work, remove the book from your Kobo and let it download again.")

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -133,7 +133,8 @@ class TaskConvert(CalibreTask):
                                                                EmailText,
                                                                self.settings['body'],
                                                                id=self.book_id,
-                                                               internal=True)
+                                                               internal=True,
+                                                               book_title=self.book_title or self.title)
                                           )
                 except Exception as ex:
                     return self._handleError(str(ex))

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -7349,7 +7349,7 @@ msgstr "Sauvegarde des métadonnées"
 msgid "Convert Library – full run"
 msgstr "Convertir la bibliothèque – exécution complète"
 
-#: cps/tasks/ops.py
+#: cps/spa_strings.py cps/tasks/ops.py
 msgid "Convert Library"
 msgstr "Convertir la bibliothèque"
 
@@ -7357,7 +7357,7 @@ msgstr "Convertir la bibliothèque"
 msgid "EPUB Fixer – full run"
 msgstr "EPUB Fixer – exécution complète"
 
-#: cps/tasks/ops.py
+#: cps/spa_strings.py cps/tasks/ops.py
 msgid "EPUB Fixer"
 msgstr "EPUB Fixer"
 
@@ -12555,15 +12555,15 @@ msgstr "Durée"
 msgid "Actions"
 msgstr "Actions"
 
-#: cps/templates/tasks.html
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
 msgstr "Prochains envois programmés"
 
-#: cps/templates/tasks.html
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Scheduled Time"
 msgstr "Heure prévue"
 
-#: cps/templates/tasks.html
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "State"
 msgstr "État"
 
@@ -12576,11 +12576,11 @@ msgstr ""
 "que tâches à l'heure prévue. Vous pouvez annuler un envoi en attente avant "
 "qu'il ne soit exécuté."
 
-#: cps/templates/tasks.html
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
 msgstr "Opérations prévues prochainement"
 
-#: cps/templates/tasks.html
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Type"
 msgstr "Type"
 
@@ -12615,6 +12615,22 @@ msgstr "Élément planifié annulé avec succès"
 #: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr "Erreur lors de l'annulation d'un élément planifié"
+
+#: cps/spa_strings.py
+msgid "No upcoming scheduled sends."
+msgstr "Aucun envoi programmé à venir."
+
+#: cps/spa_strings.py
+msgid "No upcoming scheduled operations."
+msgstr "Aucune opération programmée à venir."
+
+#: cps/spa_strings.py
+msgid "Could not load scheduled tasks."
+msgstr "Impossible de charger les tâches planifiées."
+
+#: cps/spa_strings.py
+msgid "Cancel scheduled item \"{title}\"? This cannot be undone."
+msgstr "Annuler l’élément planifié « {title} » ? Cette action est irréversible."
 
 #: cps/templates/update_now_modal.html
 #, fuzzy

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -7217,7 +7217,7 @@ msgstr "metagegevens opslaan"
 msgid "Convert Library – full run"
 msgstr ""
 
-#: cps/tasks/ops.py
+#: cps/spa_strings.py cps/tasks/ops.py
 msgid "Convert Library"
 msgstr "Omzetten bibliotheek"
 
@@ -7225,9 +7225,9 @@ msgstr "Omzetten bibliotheek"
 msgid "EPUB Fixer – full run"
 msgstr ""
 
-#: cps/tasks/ops.py
+#: cps/spa_strings.py cps/tasks/ops.py
 msgid "EPUB Fixer"
-msgstr ""
+msgstr "EPUB-reparatie"
 
 #: cps/tasks/thumbnail.py
 #, python-format
@@ -12248,18 +12248,17 @@ msgstr "Looptijd"
 msgid "Actions"
 msgstr "Acties"
 
-#: cps/templates/tasks.html
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Upcoming scheduled sends"
-msgstr ""
+msgstr "Aankomende geplande verzendingen"
 
-#: cps/templates/tasks.html
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Scheduled Time"
-msgstr ""
+msgstr "Gepland tijdstip"
 
-#: cps/templates/tasks.html
-#, fuzzy
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "State"
-msgstr "Draaien"
+msgstr "Status"
 
 #: cps/templates/tasks.html
 msgid ""
@@ -12267,13 +12266,13 @@ msgid ""
 "time. You can cancel a pending send before it runs."
 msgstr ""
 
-#: cps/templates/tasks.html
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Upcoming scheduled operations"
-msgstr ""
+msgstr "Aankomende geplande bewerkingen"
 
-#: cps/templates/tasks.html
+#: cps/spa_strings.py cps/templates/tasks.html
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 #: cps/templates/tasks.html
 msgid ""
@@ -12303,6 +12302,22 @@ msgstr "Geselecteerde dubbele boeken zijn succesvol verwijderd!"
 #: cps/templates/tasks.html
 msgid "Error cancelling scheduled item"
 msgstr ""
+
+#: cps/spa_strings.py
+msgid "No upcoming scheduled sends."
+msgstr "Geen aankomende geplande verzendingen."
+
+#: cps/spa_strings.py
+msgid "No upcoming scheduled operations."
+msgstr "Geen aankomende geplande bewerkingen."
+
+#: cps/spa_strings.py
+msgid "Could not load scheduled tasks."
+msgstr "Geplande taken konden niet worden geladen."
+
+#: cps/spa_strings.py
+msgid "Cancel scheduled item \"{title}\"? This cannot be undone."
+msgstr "Gepland item \"{title}\" annuleren? Dit kan niet ongedaan worden gemaakt."
 
 #: cps/templates/update_now_modal.html
 #, fuzzy

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -245,10 +245,22 @@ test('convert and failed send expose SPA-native book links in both task UIs', as
  * assertions go through the real HTTP/UI surfaces. The post-cancel state is
  * read independently from cwa.db so a 200 response or a filtered-out row can
  * never masquerade as proof that cancellation persisted.
+ *
+ * The docker exec is intentional fixture setup, not a product-layer shortcut.
+ * The production HTTP scheduling path is localhost-gated and is unreachable in
+ * this harness, so the spec seeds the job's own isolated container through the
+ * exact CWA_DB.scheduled_add_autosend / scheduled_add_job methods production
+ * scheduling uses. Product behaviour is still exercised through the browser
+ * and real HTTP endpoints; the matching CWA_DB read only independently proves
+ * that cancellation persisted instead of trusting a 200 or a missing row.
  */
 test('admin can inspect and cancel persisted scheduled queues; non-admin cannot', async ({ page, browser, baseURL }, testInfo) => {
   test.skip(testInfo.project.name !== 'desktop', 'one persisted scheduler flow covers desktop and 375px');
-  test.skip(!SCHEDULE_CONTAINER, 'requires E2E_CONTAINER_NAME for isolated cwa.db seeding');
+  if (!SCHEDULE_CONTAINER) {
+    const reason = 'requires E2E_CONTAINER_NAME for isolated cwa.db seeding; refusing to guess a developer container';
+    console.log(`[scheduled-queues] SKIP: ${reason}`);
+    test.skip(true, reason);
+  }
 
   await page.goto('/app');
   const errors = collectPageErrors(page);

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { execFileSync } from 'node:child_process';
 import { assertNoHorizontalOverflow, assertNoPageErrors, collectPageErrors } from './utils';
 
 interface MailSettings {
@@ -24,6 +26,64 @@ async function csrfToken(page: Page): Promise<string> {
   const response = await page.request.get('/api/v1/auth/csrf');
   expect(response.ok(), 'CSRF token request should succeed').toBeTruthy();
   return ((await response.json()) as { csrf_token: string }).csrf_token;
+}
+
+interface ScheduledSeed {
+  sendId: number;
+  operationId: number;
+}
+
+const SCHEDULE_CONTAINER = process.env.E2E_CONTAINER_NAME;
+
+function containerPython(source: string, ...args: string[]): string {
+  if (!SCHEDULE_CONTAINER) {
+    throw new Error('E2E_CONTAINER_NAME must name the isolated app container for scheduled-queue tests');
+  }
+  return execFileSync('docker', [
+    'exec', '-w', '/app/calibre-web-automated', SCHEDULE_CONTAINER,
+    'python3', '-c', source, ...args,
+  ], { encoding: 'utf8' });
+}
+
+function markedJson<T>(output: string, marker: string): T {
+  const line = output.split(/\r?\n/).find((candidate) => candidate.startsWith(marker));
+  if (!line) throw new Error(`container helper did not emit ${marker}:\n${output}`);
+  return JSON.parse(line.slice(marker.length)) as T;
+}
+
+function seedScheduledQueues(bookId: number, userId: number, username: string): ScheduledSeed {
+  const output = containerPython(`
+import json, sys
+from datetime import datetime, timedelta, timezone
+from cps.cwa_db_loader import load_cwa_db
+
+db = load_cwa_db().CWA_DB()
+run_at = (datetime.now(timezone.utc) + timedelta(minutes=55)).isoformat().replace('+00:00', 'Z')
+send_id = db.scheduled_add_autosend(int(sys.argv[1]), int(sys.argv[2]), run_at, sys.argv[3], 'Scheduled queue E2E send')
+operation_id = db.scheduled_add_job('epub_fixer', run_at, username=sys.argv[3], title='Scheduled queue E2E operation')
+print('SCHEDULE_SEED=' + json.dumps({'sendId': send_id, 'operationId': operation_id}))
+`, String(bookId), String(userId), username);
+  return markedJson<ScheduledSeed>(output, 'SCHEDULE_SEED=');
+}
+
+function scheduledState(id: number): string | null {
+  const output = containerPython(`
+import json, sys
+from cps.cwa_db_loader import load_cwa_db
+row = load_cwa_db().CWA_DB().scheduled_get_by_id(int(sys.argv[1]))
+print('SCHEDULE_STATE=' + json.dumps(None if row is None else row.get('state')))
+`, String(id));
+  return markedJson<string | null>(output, 'SCHEDULE_STATE=');
+}
+
+function removeScheduledSeeds(ids: number[]): void {
+  containerPython(`
+import sys
+from cps.cwa_db_loader import load_cwa_db
+db = load_cwa_db().CWA_DB()
+db.cur.executemany('DELETE FROM cwa_scheduled_jobs WHERE id=?', [(int(value),) for value in sys.argv[1:]])
+db.con.commit()
+`, ...ids.map(String));
 }
 
 /**
@@ -176,5 +236,155 @@ test('convert and failed send expose SPA-native book links in both task UIs', as
         mail_server_type: original.mail_server_type,
       },
     });
+  }
+});
+
+/**
+ * F-f61640 — one serial, real-stack flow owns the shared cwa.db fixture. Rows
+ * are inserted through the same CWA_DB methods used by the scheduler, then all
+ * assertions go through the real HTTP/UI surfaces. The post-cancel state is
+ * read independently from cwa.db so a 200 response or a filtered-out row can
+ * never masquerade as proof that cancellation persisted.
+ */
+test('admin can inspect and cancel persisted scheduled queues; non-admin cannot', async ({ page, browser, baseURL }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop', 'one persisted scheduler flow covers desktop and 375px');
+  test.skip(!SCHEDULE_CONTAINER, 'requires E2E_CONTAINER_NAME for isolated cwa.db seeding');
+
+  await page.goto('/app');
+  const errors = collectPageErrors(page);
+  const csrf = await csrfToken(page);
+  const headers = { 'X-CSRFToken': csrf };
+
+  const meResponse = await page.request.get('/api/v1/auth/me');
+  expect(meResponse.ok(), 'admin identity request should succeed').toBeTruthy();
+  const me = (await meResponse.json()) as { id: number; name: string; role: { admin?: boolean } };
+  expect(me.role.admin, 'the seeded Playwright account must be an admin').toBe(true);
+
+  const booksResponse = await page.request.get('/api/v1/books?per_page=1');
+  expect(booksResponse.ok(), 'book seed request should succeed').toBeTruthy();
+  const books = (await booksResponse.json()) as { items: Array<{ id: number }> };
+  expect(books.items.length, 'the e2e seed must contain a book for the scheduled send').toBeGreaterThan(0);
+
+  const username = `scheduled-e2e-${Date.now()}`;
+  const password = 'CWNG-scheduled-E2E-42!';
+  const created = await page.request.post('/api/v1/admin/users', {
+    headers,
+    data: {
+      name: username,
+      email: `${username}@example.test`,
+      password,
+      roles: { viewer: true, download: true, admin: false },
+    },
+  });
+  expect(created.ok(), await created.text()).toBeTruthy();
+  const nonAdmin = (await created.json()) as { id: number };
+
+  let seeded: ScheduledSeed | undefined;
+  let nonAdminContext: Awaited<ReturnType<typeof browser.newContext>> | undefined;
+
+  try {
+    seeded = seedScheduledQueues(books.items[0].id, me.id, me.name);
+    nonAdminContext = await browser.newContext({ baseURL });
+    const nonAdminPage = await nonAdminContext.newPage();
+
+    const sends = await page.request.get('/cwa-scheduled/upcoming');
+    const operations = await page.request.get('/cwa-scheduled/upcoming-ops');
+    expect(sends.ok(), await sends.text()).toBeTruthy();
+    expect(operations.ok(), await operations.text()).toBeTruthy();
+    expect((await sends.json()).items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: seeded.sendId, state: 'scheduled' }),
+    ]));
+    expect((await operations.json()).items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: seeded.operationId, state: 'scheduled', job_type: 'epub_fixer' }),
+    ]));
+
+    await page.goto('/app/tasks');
+    const sendsSection = page.getByRole('region', { name: 'Upcoming scheduled sends' });
+    const operationsSection = page.getByRole('region', { name: 'Upcoming scheduled operations' });
+    await expect(sendsSection).toBeVisible();
+    await expect(operationsSection).toBeVisible();
+    const sendRow = sendsSection.getByRole('row').filter({ hasText: 'Scheduled queue E2E send' });
+    const operationRow = operationsSection.getByRole('row').filter({ hasText: 'Scheduled queue E2E operation' });
+    await expect(sendRow).toContainText('scheduled');
+    await expect(operationRow).toContainText('scheduled');
+    await expect(sendRow.locator('time')).not.toHaveText('');
+    await expect(operationRow.locator('time')).not.toHaveText('');
+    const accessibility = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
+      .analyze();
+    expect(
+      accessibility.violations
+        .filter((violation) => ['critical', 'serious'].includes(violation.impact ?? ''))
+        .map((violation) => `${violation.id}: ${violation.help}`),
+      'populated scheduled queues must have no critical/serious accessibility violations',
+    ).toEqual([]);
+
+    await page.context().addCookies([{
+      name: 'cwng_prefer_spa',
+      value: '0',
+      url: new URL(page.url()).origin,
+    }]);
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#upcomingtable tbody tr').filter({ hasText: 'Scheduled queue E2E send' })).toContainText('scheduled');
+    await expect(page.locator('#upcomingopstable tbody tr').filter({ hasText: 'Scheduled queue E2E operation' })).toContainText('scheduled');
+
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/app/tasks');
+    await assertNoHorizontalOverflow(page);
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.type()).toBe('confirm');
+      expect(dialog.message()).toContain('Scheduled queue E2E send');
+      expect(dialog.message()).toContain('cannot be undone');
+      await dialog.dismiss();
+    });
+    await sendRow.getByRole('button', { name: /cancel/i }).click();
+    expect(scheduledState(seeded.sendId), 'dismissing confirmation must not mutate the row').toBe('scheduled');
+    await expect(sendRow).toContainText('scheduled');
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.type()).toBe('confirm');
+      await dialog.accept();
+    });
+    await sendRow.getByRole('button', { name: /cancel/i }).click();
+    await expect.poll(() => scheduledState(seeded.sendId), {
+      message: 'cancellation should persist the send state transition in cwa.db',
+    }).toBe('cancelled');
+    await expect(sendRow).toHaveCount(0);
+    await expect(operationRow).toContainText('scheduled');
+
+    const nonAdminCsrf = await csrfToken(nonAdminPage);
+    const login = await nonAdminPage.request.post('/api/v1/auth/login', {
+      headers: { 'X-CSRFToken': nonAdminCsrf },
+      data: { username, password },
+    });
+    expect(login.ok(), await login.text()).toBeTruthy();
+
+    const forbiddenSends = await nonAdminPage.request.get('/cwa-scheduled/upcoming');
+    const forbiddenOperations = await nonAdminPage.request.get('/cwa-scheduled/upcoming-ops');
+    expect(forbiddenSends.status(), 'non-admin scheduled-send data must be server-forbidden').toBe(403);
+    expect(forbiddenOperations.status(), 'non-admin scheduled-operation data must be server-forbidden').toBe(403);
+    const forbiddenCancel = await nonAdminPage.request.post('/cwa-scheduled/cancel', {
+      data: { id: seeded.operationId },
+    });
+    expect(forbiddenCancel.status(), 'non-admin scheduled cancellation must be server-forbidden').toBe(403);
+    expect(scheduledState(seeded.operationId), 'a forbidden cancellation must not mutate the row').toBe('scheduled');
+
+    await nonAdminPage.goto('/app/tasks');
+    await expect(nonAdminPage.getByRole('region', { name: 'Upcoming scheduled sends' })).toHaveCount(0);
+    await expect(nonAdminPage.getByRole('region', { name: 'Upcoming scheduled operations' })).toHaveCount(0);
+
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#upcomingtable tbody tr').filter({ hasText: 'Scheduled queue E2E send' })).toHaveCount(0);
+    await expect(page.locator('#upcomingopstable tbody tr').filter({ hasText: 'Scheduled queue E2E operation' })).toContainText('scheduled');
+
+    assertNoPageErrors(errors);
+  } finally {
+    await nonAdminContext?.close();
+    if (seeded) removeScheduledSeeds([seeded.sendId, seeded.operationId]);
+    const deleted = await page.request.post(`/api/v1/admin/users/${nonAdmin.id}/delete`, { headers });
+    expect(deleted.status(), await deleted.text()).toBe(204);
   }
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -436,6 +436,32 @@ export interface TaskItem {
   error?: string | null;
 }
 
+export interface ScheduledSend {
+  id: number;
+  book_id: number;
+  user_id: number;
+  username: string;
+  title: string;
+  run_at_utc: string;
+  state: string;
+}
+
+export interface ScheduledOperation {
+  id: number;
+  job_type: 'convert_library' | 'epub_fixer' | string;
+  book_id: number | null;
+  user_id: number | null;
+  username: string;
+  title: string;
+  run_at_utc: string;
+  state: string;
+}
+
+export interface ScheduledQueues {
+  sends: ScheduledSend[];
+  operations: ScheduledOperation[];
+}
+
 export class ApiError extends Error {
   status: number;
   /** The parsed `error` object from the response body, when there was one.

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -12,7 +12,7 @@ import type {
   Me, Book, BooksPage, BookDetail, EntityList, Shelf, ShelfDetail,
   SearchOptions, AdvancedSearchParams, AdvSearchResult, Account, ProfileUpdate,
   BookMetadata, MetadataUpdate, UploadResult, AdminUser, AboutInfo, TaskItem, AuthConfig,
-  NoticeInbox,
+  NoticeInbox, ScheduledSend, ScheduledOperation, ScheduledQueues,
 } from './api';
 
 /** Entity kinds the catalog can be filtered by. Singular here; the browse-list
@@ -1305,5 +1305,33 @@ export function useCancelTask() {
     mutationFn: (taskId: number | string) =>
       apiPost(`/api/v1/tasks/${encodeURIComponent(String(taskId))}/cancel`),
     onSuccess: () => void qc.invalidateQueries({ queryKey: ['tasks'] }),
+  });
+}
+
+/** Persistent scheduler queues shown in Classic. These predate /api/v1 but are
+ * already JSON, same-origin and server-gated with admin_required. Keeping the
+ * SPA on the canonical routes avoids a proxy endpoint whose only job would be
+ * to reshape two identical `{items}` responses. */
+export function useScheduledQueues(enabled: boolean) {
+  return useQuery<ScheduledQueues>({
+    queryKey: ['scheduled-queues'],
+    queryFn: async () => {
+      const [sends, operations] = await Promise.all([
+        apiGet<{ items: ScheduledSend[] }>('/cwa-scheduled/upcoming'),
+        apiGet<{ items: ScheduledOperation[] }>('/cwa-scheduled/upcoming-ops'),
+      ]);
+      return { sends: sends.items, operations: operations.items };
+    },
+    enabled,
+    refetchInterval: 4000,
+  });
+}
+
+export function useCancelScheduledItem() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => apiPost<{ status: string; id: number }>(
+      '/cwa-scheduled/cancel', { id }),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['scheduled-queues'] }),
   });
 }

--- a/frontend/src/pages/Tasks.module.css
+++ b/frontend/src/pages/Tasks.module.css
@@ -62,12 +62,60 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px; height: 28px;
+  width: 36px; height: 36px;
   border-radius: var(--r-md);
   color: var(--text-muted);
 }
 .cancelBtn:hover:not(:disabled) { color: var(--danger); background: var(--danger-soft); }
 .cancelBtn:disabled { opacity: 0.4; }
+
+.scheduledQueues {
+  display: grid;
+  gap: var(--sp-7);
+  margin-top: var(--sp-8);
+}
+.scheduledSection { min-width: 0; }
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-3);
+}
+.sectionTitle {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+}
+.scheduledEmpty {
+  margin: 0;
+  padding: var(--sp-5);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface-1);
+  color: var(--text-muted);
+  text-align: center;
+}
+.scheduledError {
+  margin: 0;
+  padding: var(--sp-3) var(--sp-4);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--r-md);
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+.scheduledTable .taskCell { min-width: 210px; }
+.scheduledTimeLabel {
+  margin-right: var(--sp-1);
+  font-weight: 600;
+}
+.state {
+  display: inline-flex;
+  padding: 2px var(--sp-2);
+  border-radius: 999px;
+  background: var(--surface-2);
+  font-size: var(--fs-xs);
+}
 
 @media (max-width: 600px) {
   .container { padding: var(--sp-5) var(--sp-3); }
@@ -103,7 +151,7 @@
     grid-column: 1 / -1;
     max-width: none;
   }
-  .taskCellCancellable { padding-right: calc(28px + var(--sp-2)); }
+  .taskCellCancellable { padding-right: calc(44px + var(--sp-2)); }
   .taskDetails { gap: var(--sp-2); }
   .mobileLabel {
     display: block;
@@ -117,4 +165,11 @@
     top: var(--sp-3);
     right: var(--sp-3);
   }
+  .cancelBtn { width: 44px; height: 44px; }
+  .scheduledQueues { gap: var(--sp-6); margin-top: var(--sp-7); }
+  .scheduledTable .taskCell {
+    grid-column: 1 / -1;
+    min-width: 0;
+  }
+  .scheduledTimeLabel { display: block; margin: 0 0 2px; }
 }

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -1,7 +1,9 @@
 import { ListChecks, X } from 'lucide-react';
 import { Link } from 'wouter';
-import { useTasks, useCancelTask } from '../lib/queries';
-import type { TaskItem } from '../lib/api';
+import {
+  useTasks, useCancelTask, useMe, useScheduledQueues, useCancelScheduledItem,
+} from '../lib/queries';
+import type { ScheduledOperation, ScheduledSend, TaskItem } from '../lib/api';
 import { SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import { useT } from '../lib/i18n';
@@ -58,10 +60,118 @@ function TaskMessage({ task }: { task: TaskItem }) {
   );
 }
 
+function scheduledTime(value: string) {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString();
+}
+
+function operationType(item: ScheduledOperation, t: ReturnType<typeof useT>) {
+  if (item.job_type === 'convert_library') return t('Convert Library');
+  if (item.job_type === 'epub_fixer') return t('EPUB Fixer');
+  return item.job_type;
+}
+
+interface ScheduledSectionProps {
+  id: string;
+  title: string;
+  items: Array<ScheduledSend | ScheduledOperation>;
+  kind: 'send' | 'operation';
+  cancelling: boolean;
+  onCancel: (item: ScheduledSend | ScheduledOperation) => void;
+}
+
+function ScheduledSection({ id, title, items, kind, cancelling, onCancel }: ScheduledSectionProps) {
+  const t = useT();
+  return (
+    <section className={styles.scheduledSection} aria-labelledby={id}>
+      <div className={styles.sectionHeader}>
+        <h2 id={id} className={styles.sectionTitle}>{title}</h2>
+        <span className={styles.count}>{items.length}</span>
+      </div>
+      {items.length === 0 ? (
+        <p className={styles.scheduledEmpty}>
+          {kind === 'send' ? t('No upcoming scheduled sends.') : t('No upcoming scheduled operations.')}
+        </p>
+      ) : (
+        <table className={`${styles.table} ${styles.scheduledTable}`}>
+          <thead>
+            <tr>
+              {kind === 'operation' && <th>{t('Type')}</th>}
+              <th>{t('Title')}</th>
+              <th>{t('User')}</th>
+              {kind === 'send' && <th>{t('Book ID')}</th>}
+              <th>{t('State')}</th>
+              <th aria-label={t('Cancel')} />
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr key={item.id}>
+                {kind === 'operation' && (
+                  <td className={styles.metaCell}>
+                    <span className={styles.mobileLabel}>{t('Type')}</span>
+                    {operationType(item as ScheduledOperation, t)}
+                  </td>
+                )}
+                <td className={`${styles.taskCell} ${styles.taskCellCancellable}`}>
+                  <div className={styles.taskMsg}>{item.title}</div>
+                  <div className={styles.taskDetails}>
+                    <span className={styles.scheduledTimeLabel}>{t('Scheduled Time')}</span>
+                    <time className={styles.taskStart} dateTime={item.run_at_utc}>
+                      {scheduledTime(item.run_at_utc)}
+                    </time>
+                  </div>
+                </td>
+                <td className={styles.metaCell}>
+                  <span className={styles.mobileLabel}>{t('User')}</span>
+                  {item.username}
+                </td>
+                {kind === 'send' && (
+                  <td className={styles.metaCell}>
+                    <span className={styles.mobileLabel}>{t('Book ID')}</span>
+                    {(item as ScheduledSend).book_id}
+                  </td>
+                )}
+                <td className={styles.metaCell}>
+                  <span className={styles.mobileLabel}>{t('State')}</span>
+                  <span className={styles.state}>{item.state}</span>
+                </td>
+                <td className={styles.cancelCell}>
+                  <button
+                    type="button"
+                    className={styles.cancelBtn}
+                    onClick={() => onCancel(item)}
+                    disabled={cancelling}
+                    aria-label={t('Cancel {task}', { task: item.title })}
+                  >
+                    <X size={15} aria-hidden="true" focusable={false} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}
+
 export function Tasks() {
   const { data, isLoading, error } = useTasks();
   const cancel = useCancelTask();
+  const { data: me } = useMe();
+  const isAdmin = !!me?.role?.admin;
+  const scheduled = useScheduledQueues(isAdmin);
+  const cancelScheduled = useCancelScheduledItem();
   const t = useT();
+  const scheduledFailure = scheduled.error ?? cancelScheduled.error;
+
+  const confirmScheduledCancel = (item: ScheduledSend | ScheduledOperation) => {
+    if (!window.confirm(t('Cancel scheduled item "{title}"? This cannot be undone.', {
+      title: item.title,
+    }))) return;
+    cancelScheduled.mutate(item.id);
+  };
 
   if (isLoading) return <SpinnerCentered size={40} />;
   if (error || !data) {
@@ -142,6 +252,39 @@ export function Tasks() {
             ))}
           </tbody>
         </table>
+      )}
+
+      {isAdmin && (
+        <div className={styles.scheduledQueues}>
+          {scheduledFailure ? (
+            <p className={styles.scheduledError} role="alert">
+              {scheduledFailure instanceof Error
+                ? scheduledFailure.message
+                : t('Could not load scheduled tasks.')}
+            </p>
+          ) : scheduled.data ? (
+            <>
+              <ScheduledSection
+                id="upcoming-scheduled-sends"
+                title={t('Upcoming scheduled sends')}
+                items={scheduled.data.sends}
+                kind="send"
+                cancelling={cancelScheduled.isPending}
+                onCancel={confirmScheduledCancel}
+              />
+              <ScheduledSection
+                id="upcoming-scheduled-operations"
+                title={t('Upcoming scheduled operations')}
+                items={scheduled.data.operations}
+                kind="operation"
+                cancelling={cancelScheduled.isPending}
+                onCancel={confirmScheduledCancel}
+              />
+            </>
+          ) : (
+            <SpinnerCentered size={28} />
+          )}
+        </div>
       )}
     </main>
   );

--- a/tests/unit/test_task_convert_email_metadata.py
+++ b/tests/unit/test_task_convert_email_metadata.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Producer-chain coverage for conversion-triggered e-reader email tasks."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "explicit_title, discovered_title, expected_title",
+    [
+        ("Queued conversion title", "Database title", "Queued conversion title"),
+        (None, "Database title", "Database title"),
+    ],
+)
+def test_convert_forwards_book_metadata_to_internal_email(
+        monkeypatch, explicit_title, discovered_title, expected_title):
+    # Production reaches TaskConvert through cps.helper; that import order also
+    # resolves convert.py's longstanding helper/convert module cycle.
+    from cps import helper
+    from cps.tasks import convert
+    from cps.tasks.mail import TaskEmail
+
+    monkeypatch.setattr(convert.config, "config_use_google_drive", False, raising=False)
+    task = helper.TaskConvert(
+        "/library/Author/Book/book",
+        1851,
+        "EPUB -> MOBI",
+        {"subject": "Converted book", "body": "Attached book"},
+        "reader@example.invalid",
+        user="alice",
+        book_title=explicit_title,
+    )
+
+    def complete_conversion():
+        task.title = discovered_title
+        task.results["path"] = "Author/Book"
+        return "book.mobi"
+
+    monkeypatch.setattr(task, "_convert_ebook_format", complete_conversion)
+    worker = MagicMock()
+
+    task.run(worker)
+
+    worker.add.assert_called_once()
+    queued_user, queued_task = worker.add.call_args.args
+    assert queued_user == "alice"
+    assert isinstance(queued_task, TaskEmail)
+    assert queued_task.book_id == 1851
+    assert queued_task.book_title == expected_title

--- a/tests/unit/test_workflow_safety_invariants.py
+++ b/tests/unit/test_workflow_safety_invariants.py
@@ -1407,3 +1407,39 @@ def test_spa_e2e_uploads_its_playwright_report():
             "the upload must run on failure — that is the only run whose "
             "evidence anyone needs"
         )
+
+
+# ─── Wall 12: scheduled-queue E2E cannot silently skip ────────────────
+#
+# The spec deliberately refuses to guess a local Docker container. That is safe
+# for a developer but dangerous in CI unless the workflow-to-spec handoff is
+# pinned: removing one env key would turn every real-stack scheduler assertion
+# into a green skip, the same unexecuted-coverage class this file guards against.
+
+
+def test_spa_e2e_runner_names_its_isolated_container():
+    """The scheduled-queue E2E must never silently skip in CI.
+
+    Its local-safe contract is to skip when E2E_CONTAINER_NAME is absent rather
+    than guessing which developer container it may mutate. The CI workflow owns
+    an isolated container named cwn-e2e, so the exact step that executes the SPA
+    harness must supply that name. Pinning the producer beside the consumer
+    means a workflow cleanup cannot turn the feature's only real-stack coverage
+    into a green skip.
+    """
+    wf = _load(WF_DIR / "tests.yml")
+    runners = [
+        (job_name, step)
+        for job_name, step in _every_step(wf)
+        if str(step.get("run") or "").strip() == "npm run test:e2e"
+    ]
+    assert runners, "tests.yml must contain the step that runs npm run test:e2e"
+
+    for job_name, step in runners:
+        container = (step.get("env") or {}).get("E2E_CONTAINER_NAME")
+        assert container == "cwn-e2e", (
+            f"tests.yml/{job_name}/{step.get('name') or 'unnamed step'} runs "
+            "npm run test:e2e without E2E_CONTAINER_NAME: cwn-e2e; "
+            "tasks.spec.ts will silently skip all persisted scheduled-queue, "
+            "non-admin 403 and cancel-state coverage"
+        )


### PR DESCRIPTION
## Summary

- add admin-only Upcoming scheduled sends and Upcoming scheduled operations sections to the SPA Tasks page
- consume the existing storage-backed, admin-gated cwa-scheduled JSON routes and confirm before cancellation
- reflow both populated queues at 375px, preserve Classic, and register/translate new SPA strings in fr and nl
- add a real-stack Playwright regression that seeds both canonical CWA_DB row types, verifies admin rendering, persisted cancellation, non-admin 403/UI absence, mobile overflow, Classic parity, and critical/serious axe results
- pin E2E_CONTAINER_NAME on the npm run test:e2e workflow step with a unit invariant, so removing the CI-to-spec container handoff fails instead of silently skipping the scheduler coverage

Ledger: F-f61640

Depends on #1837 and intentionally targets its branch; retarget to main after #1837 merges.

## Verification

- npm run build
- E2E_CONTAINER_NAME=cwng-schedq-test E2E_BASE_URL=http://localhost:18188 npx playwright test tasks.spec.ts --project desktop — 3 passed
- focused feature pytest set — 96 passed
- workflow safety + E2E reachability — 48 passed
- workflow pin with env line present — 1 passed; with only the env line removed — 1 failed with the targeted silent-skip assertion
- npm test:e2e path without E2E_CONTAINER_NAME — explicit scheduled-queues skip reason, 1 skipped / setup passed
- completed-locale SPA chrome gate — 2 passed
- msgfmt --check --check-format for fr and nl
- git diff --check