### PR TITLE
Stop CHANGELOG.md and findings/INDEX.md from serializing the merge queue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,13 @@
 Dockerfile text eol=lf
 *.yml text eol=lf
 **/run text eol=lf
+
+# Append-only bookkeeping files: every squash-merge to main re-poisons every
+# open PR at the same append point (OBSERVED 2026-08-24: one CHANGELOG commit
+# put nine PRs into CONFLICTING; 10 of 11 blocked PRs had zero code conflict).
+# `union` is git's built-in keep-both-sides driver — correct for this file
+# class because entries are an unordered set of appends with no competing line.
+# See state/rollback/FINDING-20260824-changelog-serializes-the-merge-queue.md
+# in the project tree. Undo = delete these two lines.
+CHANGELOG.md merge=union
+findings/INDEX.md merge=union


### PR DESCRIPTION
CHANGELOG.md and findings/INDEX.md get git's built-in union merge driver.

OBSERVED 2026-08-24: 11 of our 16 open PRs were CONFLICTING, and real
three-way merges (git merge-tree --write-tree) showed 10 of the 11 had ZERO
code conflict — 8 collided only on CHANGELOG.md, 2 only on findings/INDEX.md.
One CHANGELOG commit in 24h put nine PRs into CONFLICTING. At ~11 squash
merges/day, every merge re-poisoned every open PR at the same append point,
so the queue could not drain faster than one PR per rebase round.

union is correct for this file class specifically: a changelog is an
unordered set of appends, so keep-both-sides is the semantically right
resolution and no line's two versions genuinely compete. Proven locally:
git merge-file --union on #1846's three CHANGELOG versions returns rc=0 and
produces main's changelog with the PR's entry appended — no markers, no
duplication, no reordering.

Whether GitHub honours merge=union server-side (update-branch, merge button)
is the open question; the first update-branch on a CHANGELOG-only conflicting
PR after this lands is the discriminating test. If it does not, the fallback
is autopilot-side local union rebase, which the measurement above already
proves works.

Undo = delete the two attribute lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjaGwDbLyU5n4LiR6A8dJT