### PR TITLE
chore(changelog): isolate release notes into changelog.d fragments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -207,6 +207,6 @@ Pluggable providers in `cps/metadata_provider/`:
 ## Contributing Guidelines
 - Follow SPDX headers in all Python files (use `scripts/update_spdx_headers.py`)
 - Update `CONTRIBUTORS` file for new contributors
-- Changelogs in `changelogs/` directory (semver naming)
+- Add one categorized, symptom-first Markdown fragment at `changelog.d/<pr-or-slug>.md`; release preparation assembles and deletes fragments. See `changelog.d/README.md`.
 - Join Discord for feature discussions before major PRs
 - Test with both local disk and network share deployments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,9 @@ Bug reports without a version + repro are still useful — we'll just ask follow
 2. Keep PRs focused on one logical change. Explain the problem, the approach, the user-visible result, and anything deliberately left out.
 3. Include verification that traces the real trigger to the observed result. For UI work, name the browser and input modes tested; screenshots are welcome when appearance changed.
 4. Add or update tests for changed behavior. Python tests live under `tests/`; React end-to-end tests live under `frontend/e2e/`.
-5. CI must pass, including `validate-author`, `Fast Tests (Smoke + Unit)`, `Frontend Build (SPA bundle)`, and `Test Suite Summary`. Docker integration and browser E2E jobs run when the change requires them.
-6. If touching `cps/translations/`, update the relevant `.po`; CI validates translations.
+5. Add a changelog fragment at `changelog.d/<pr-or-slug>.md`; follow [`changelog.d/README.md`](changelog.d/README.md) for the category and symptom-first entry format. New PRs should not edit the shared `CHANGELOG.md` insertion point. CI accepts direct `CHANGELOG.md` edits only as a cutover compatibility path.
+6. CI must pass, including `validate-author`, `Fast Tests (Smoke + Unit)`, `Frontend Build (SPA bundle)`, and `Test Suite Summary`. Docker integration and browser E2E jobs run when the change requires them.
+7. If touching `cps/translations/`, update the relevant `.po`; CI validates translations.
 
 ### Commit identity and `validate-author`
 

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,50 @@
+# Changelog fragments
+
+Every pull request records its release-note entry in a separate Markdown file
+under this directory. That keeps concurrent branches away from the shared
+`CHANGELOG.md` insertion point.
+
+Name the file after the PR when its number is known, or use a short stable slug:
+
+```text
+changelog.d/1860.md
+changelog.d/kobo-highlight-safety.md
+```
+
+Fragments use the existing Keep a Changelog categories and house style. Each
+entry starts with a bold, plain-English description of what someone can see or
+do differently:
+
+```markdown
+### Fixed
+
+- **Books return to the list they were opened from.** The active filter is
+  preserved instead of returning to the library root. Reported by @reader.
+```
+
+The accepted categories, rendered in canonical order, are `Added`, `Changed`,
+`Deprecated`, `Removed`, `Fixed`, and `Security`. A fragment may contain more
+than one category or entry. Fragment names are ASCII letters, digits, dots,
+underscores, or hyphens and must be direct `.md` children of `changelog.d/`.
+This `README.md` is documentation and does not satisfy the CI requirement.
+
+Do not run the assembler from an ordinary PR: successful assembly consumes the
+fragment files. Release preparation runs this exact command before the release
+commit is created:
+
+```bash
+LC_ALL=C LANG=C python3 scripts/assemble_changelog.py \
+  --version vX.Y.Z --date YYYY-MM-DD
+```
+
+That command moves the current `[Unreleased]` entries and every fragment into a
+single dated version section, leaves `[Unreleased]` empty, and deletes consumed
+fragments. Files are read in C-locale filename order and entries are grouped in
+the category order above, so repeated runs produce the same bytes. Afterward,
+release preparation still updates `VERSION` and the in-app What's New data,
+runs the changelog tests, commits all of those changes together, and executes
+the existing pre-tag release gate.
+
+Direct edits to `CHANGELOG.md` remain CI-valid during the cutover and the
+`merge=union` attribute remains as a safety net for branches opened before
+fragments were adopted. New pull requests should use fragments.

--- a/changelog.d/changelog-fragments.md
+++ b/changelog.d/changelog-fragments.md
@@ -1,0 +1,5 @@
+### Changed
+
+- **Contributors no longer have to edit the same changelog insertion point in
+  every pull request.** Each change now carries an isolated `changelog.d`
+  fragment, and release preparation assembles the fragments deterministically.

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Assemble isolated changelog fragments into CHANGELOG.md.
+
+PRs write one direct child of ``changelog.d/`` instead of contending on the
+single ``CHANGELOG.md`` insertion point.  This script is the only writer which
+folds those fragments into the canonical Keep-a-Changelog sections.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import re
+import stat
+import sys
+import tempfile
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CATEGORY_ORDER = ("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security")
+CATEGORY_SET = set(CATEGORY_ORDER)
+SECTION_HEADING = re.compile(r"^## \[([^]]+)\][^\n]*$", re.MULTILINE)
+CATEGORY_HEADING = re.compile(r"^### ([A-Za-z][A-Za-z ]*)$")
+FRAGMENT_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*\.md$")
+VERSION = re.compile(r"^v\d+\.\d+\.\d+$")
+
+
+class AssemblyError(ValueError):
+    """A user-actionable fragment or changelog format error."""
+
+
+@dataclass(frozen=True)
+class Section:
+    label: str
+    heading: str
+    heading_start: int
+    body_start: int
+    end: int
+
+
+def _sections(text: str) -> list[Section]:
+    matches = list(SECTION_HEADING.finditer(text))
+    sections: list[Section] = []
+    for index, match in enumerate(matches):
+        body_start = match.end()
+        if text[body_start : body_start + 1] == "\n":
+            body_start += 1
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        sections.append(
+            Section(
+                label=match.group(1),
+                heading=match.group(0),
+                heading_start=match.start(),
+                body_start=body_start,
+                end=end,
+            )
+        )
+    return sections
+
+
+def _section(text: str, label: str) -> Section:
+    found = [section for section in _sections(text) if section.label == label]
+    if len(found) != 1:
+        raise AssemblyError(
+            f"CHANGELOG.md must contain exactly one '## [{label}]' section; found {len(found)}"
+        )
+    return found[0]
+
+
+def _entry_key(entry: str) -> str:
+    return " ".join(entry.split())
+
+
+def _parse_body(body: str, source: str) -> dict[str, list[str]]:
+    """Parse category headings and bold-lead bullets without rewording them."""
+    parsed = {category: [] for category in CATEGORY_ORDER}
+    seen_headings: set[str] = set()
+    category: str | None = None
+    entry: list[str] | None = None
+
+    def finish_entry() -> None:
+        nonlocal entry
+        if entry is None:
+            return
+        while entry and not entry[-1].strip():
+            entry.pop()
+        if not entry:
+            raise AssemblyError(f"{source}: empty changelog entry")
+        assert category is not None
+        parsed[category].append("\n".join(entry))
+        entry = None
+
+    for line_number, raw_line in enumerate(body.splitlines(), start=1):
+        line = raw_line.rstrip()
+        heading = CATEGORY_HEADING.match(line)
+        if heading:
+            finish_entry()
+            candidate = heading.group(1)
+            if candidate not in CATEGORY_SET:
+                raise AssemblyError(
+                    f"{source}:{line_number}: unsupported category '{candidate}'; "
+                    f"choose one of {', '.join(CATEGORY_ORDER)}"
+                )
+            if candidate in seen_headings:
+                raise AssemblyError(
+                    f"{source}:{line_number}: duplicate '### {candidate}' heading"
+                )
+            seen_headings.add(candidate)
+            category = candidate
+            continue
+
+        if line.startswith("### "):
+            raise AssemblyError(f"{source}:{line_number}: malformed category heading")
+        if line.startswith("## "):
+            raise AssemblyError(
+                f"{source}:{line_number}: fragments cannot contain release headings"
+            )
+        if line.startswith("- **"):
+            if category is None:
+                raise AssemblyError(
+                    f"{source}:{line_number}: entry appears before a '### <category>' heading"
+                )
+            finish_entry()
+            entry = [line]
+            continue
+        if not line:
+            if entry is not None:
+                entry.append("")
+            continue
+        if entry is not None and (
+            raw_line.startswith("  ") or raw_line.startswith("\t")
+        ):
+            entry.append(line)
+            continue
+        raise AssemblyError(
+            f"{source}:{line_number}: expected a '### <category>' heading, a '- **' entry, "
+            "or an indented continuation"
+        )
+
+    finish_entry()
+    for heading in seen_headings:
+        if not parsed[heading]:
+            raise AssemblyError(f"{source}: '### {heading}' contains no entries")
+    return parsed
+
+
+def _merge_entries(
+    base: dict[str, list[str]], additions: Iterable[dict[str, list[str]]]
+) -> dict[str, list[str]]:
+    merged = {category: list(base.get(category, [])) for category in CATEGORY_ORDER}
+    seen = {_entry_key(entry) for entries in merged.values() for entry in entries}
+    for addition in additions:
+        for category in CATEGORY_ORDER:
+            for entry in addition.get(category, []):
+                key = _entry_key(entry)
+                if key in seen:
+                    continue
+                merged[category].append(entry)
+                seen.add(key)
+    return merged
+
+
+def _has_entries(categories: dict[str, list[str]]) -> bool:
+    return any(categories[category] for category in CATEGORY_ORDER)
+
+
+def _render_body(categories: dict[str, list[str]]) -> str:
+    blocks: list[str] = []
+    for category in CATEGORY_ORDER:
+        entries = categories[category]
+        if entries:
+            blocks.append(f"### {category}\n\n" + "\n\n".join(entries))
+    if not blocks:
+        return "\n"
+    return "\n" + "\n\n".join(blocks) + "\n\n"
+
+
+def _replace_body(text: str, section: Section, body: str) -> str:
+    return text[: section.body_start] + body + text[section.end :]
+
+
+def _fragment_paths(directory: Path) -> list[Path]:
+    if not directory.exists():
+        return []
+    if not directory.is_dir():
+        raise AssemblyError(f"fragment path is not a directory: {directory}")
+    paths: list[Path] = []
+    for path in directory.iterdir():
+        if not path.is_file() or path.name == "README.md":
+            continue
+        if path.suffix != ".md":
+            continue
+        if not FRAGMENT_NAME.fullmatch(path.name):
+            raise AssemblyError(
+                f"{path}: fragment names must match {FRAGMENT_NAME.pattern} and be direct children"
+            )
+        paths.append(path)
+    # Accepted names are ASCII, so Python's stable lexical order is exactly the
+    # LC_ALL=C byte order used by the release shell.
+    return sorted(paths, key=lambda path: path.name)
+
+
+def _write_atomic(path: Path, text: str) -> None:
+    mode = stat.S_IMODE(path.stat().st_mode)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def assemble(
+    changelog: Path,
+    fragments_directory: Path,
+    *,
+    version: str | None = None,
+    release_date: str | None = None,
+) -> tuple[int, bool]:
+    """Assemble fragments, returning ``(consumed_count, changelog_changed)``."""
+    if not changelog.is_file():
+        raise AssemblyError(f"changelog does not exist: {changelog}")
+    text = changelog.read_text(encoding="utf-8")
+    unreleased = _section(text, "Unreleased")
+    unreleased_entries = _parse_body(
+        text[unreleased.body_start : unreleased.end], "CHANGELOG.md [Unreleased]"
+    )
+
+    fragment_paths = _fragment_paths(fragments_directory)
+    fragment_entries = [
+        _parse_body(path.read_text(encoding="utf-8"), path.name)
+        for path in fragment_paths
+    ]
+
+    if version is None:
+        if release_date is not None:
+            raise AssemblyError("--date requires --version")
+        if not fragment_paths:
+            return 0, False
+        merged = _merge_entries(unreleased_entries, fragment_entries)
+        updated = _replace_body(text, unreleased, _render_body(merged))
+    else:
+        if not VERSION.fullmatch(version):
+            raise AssemblyError("--version must have the form vX.Y.Z")
+        if release_date is None:
+            raise AssemblyError("--version requires --date YYYY-MM-DD")
+        try:
+            dt.date.fromisoformat(release_date)
+        except ValueError as exc:
+            raise AssemblyError(
+                "--date must be a real ISO date in YYYY-MM-DD form"
+            ) from exc
+
+        existing = [section for section in _sections(text) if section.label == version]
+        if len(existing) > 1:
+            raise AssemblyError(f"CHANGELOG.md contains duplicate [{version}] sections")
+        if existing:
+            target = existing[0]
+            expected_heading = f"## [{version}] - {release_date}"
+            if target.heading != expected_heading:
+                raise AssemblyError(
+                    f"existing [{version}] heading is '{target.heading}', expected '{expected_heading}'"
+                )
+            if _has_entries(unreleased_entries):
+                raise AssemblyError(
+                    f"[{version}] already exists while [Unreleased] still has entries; "
+                    "refusing to guess which release owns them"
+                )
+            target_entries = _parse_body(
+                text[target.body_start : target.end], f"CHANGELOG.md [{version}]"
+            )
+            merged = _merge_entries(target_entries, fragment_entries)
+            updated = _replace_body(text, target, _render_body(merged))
+        else:
+            merged = _merge_entries(unreleased_entries, fragment_entries)
+            if not _has_entries(merged):
+                raise AssemblyError(
+                    "nothing is present in [Unreleased] or changelog.d to release"
+                )
+            release = f"## [{version}] - {release_date}\n" + _render_body(merged)
+            updated = (
+                text[: unreleased.body_start] + "\n" + release + text[unreleased.end :]
+            )
+
+    changed = updated != text
+    if changed:
+        _write_atomic(changelog, updated)
+    # Delete only after the canonical write is durable. Entry-level dedupe makes
+    # rerunning safe if the process was interrupted between replace and unlink.
+    for path in fragment_paths:
+        path.unlink()
+    return len(fragment_paths), changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(
+        description="Deterministically assemble changelog.d fragments into CHANGELOG.md."
+    )
+    parser.add_argument("--changelog", type=Path, default=root / "CHANGELOG.md")
+    parser.add_argument("--fragments-dir", type=Path, default=root / "changelog.d")
+    parser.add_argument("--version", help="release section to create, in vX.Y.Z form")
+    parser.add_argument("--date", dest="release_date", help="release date, YYYY-MM-DD")
+    args = parser.parse_args(argv)
+
+    try:
+        consumed, changed = assemble(
+            args.changelog,
+            args.fragments_dir,
+            version=args.version,
+            release_date=args.release_date,
+        )
+    except (AssemblyError, OSError, UnicodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    destination = f"[{args.version}]" if args.version else "[Unreleased]"
+    if consumed == 0 and not changed:
+        print("No changelog fragments to assemble; CHANGELOG.md is unchanged.")
+    else:
+        print(
+            f"Assembled {consumed} changelog fragment(s) into {destination}; "
+            f"CHANGELOG.md {'updated' if changed else 'already contained every entry'}."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_changelog_diff.py
+++ b/scripts/check_changelog_diff.py
@@ -13,6 +13,7 @@ import sys
 # This guard cares about heading identity, not date typography.
 RELEASE_HEADING = re.compile(r"^## \[(v\d+\.\d+\.\d+)\]", re.MULTILINE)
 ENTRY_LEAD = re.compile(r"^- \*\*", re.MULTILINE)
+FRAGMENT_PATH = re.compile(r"^changelog\.d/[A-Za-z0-9][A-Za-z0-9._-]*\.md$")
 
 
 def _distinct_entries(text: str) -> set[str]:
@@ -77,6 +78,22 @@ def pull_request_regressions(
     return structural_regressions(target, proposed)
 
 
+def changelog_requirement_errors(changed_paths: list[str]) -> list[str]:
+    """Require the canonical changelog or one real fragment in every PR."""
+    if "CHANGELOG.md" in changed_paths:
+        return []
+    if any(
+        FRAGMENT_PATH.fullmatch(path) and path != "changelog.d/README.md"
+        for path in changed_paths
+    ):
+        return []
+    return [
+        "This PR changes neither CHANGELOG.md nor "
+        "changelog.d/<pr-or-slug>.md. Add a categorized changelog fragment; "
+        "changelog.d/README.md documents the format."
+    ]
+
+
 def _file_at(ref: str) -> str:
     result = subprocess.run(
         ["git", "show", f"{ref}:CHANGELOG.md"],
@@ -105,6 +122,24 @@ def _merge_base(base_ref: str, head_ref: str) -> str:
     return result.stdout.strip()
 
 
+def _changed_paths(branch_point: str, head_ref: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "-z", branch_point, head_ref],
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode:
+        detail = result.stderr.decode(errors="replace").strip() or "git diff failed"
+        raise RuntimeError(
+            f"cannot list PR paths between {branch_point} and {head_ref}: {detail}"
+        )
+    return [
+        raw.decode("utf-8", errors="surrogateescape")
+        for raw in result.stdout.split(b"\0")
+        if raw
+    ]
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Reject structural CHANGELOG.md loss between two git refs."
@@ -115,10 +150,15 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         branch_point = _merge_base(args.base_ref, args.head_ref)
-        errors = pull_request_regressions(
-            _file_at(args.base_ref),
-            _file_at(branch_point),
-            _file_at(args.head_ref),
+        errors = changelog_requirement_errors(
+            _changed_paths(branch_point, args.head_ref)
+        )
+        errors.extend(
+            pull_request_regressions(
+                _file_at(args.base_ref),
+                _file_at(branch_point),
+                _file_at(args.head_ref),
+            )
         )
     except RuntimeError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
@@ -132,7 +172,8 @@ def main(argv: list[str] | None = None) -> int:
 
     print(
         "CHANGELOG integrity guard passed: "
-        "no PR-authored release structure was lost."
+        "a canonical entry or fragment is present and no PR-authored release "
+        "structure was lost."
     )
     return 0
 

--- a/tests/unit/test_changelog_diff_guard.py
+++ b/tests/unit/test_changelog_diff_guard.py
@@ -1,19 +1,27 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Pin the PR-level guard against structural CHANGELOG loss."""
 
+import importlib.util
+import os
 from pathlib import Path
 
-from scripts.check_changelog_diff import (
-    pull_request_regressions,
-    structural_regressions,
-)
-
-
 ROOT = Path(__file__).resolve().parents[2]
+GUARD_PATH = Path(
+    os.environ.get("CWNG_CHANGELOG_GUARD", ROOT / "scripts" / "check_changelog_diff.py")
+)
+SPEC = importlib.util.spec_from_file_location("cwng_changelog_guard", GUARD_PATH)
+assert SPEC and SPEC.loader
+GUARD = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GUARD)
+changelog_requirement_errors = GUARD.changelog_requirement_errors
+pull_request_regressions = GUARD.pull_request_regressions
+structural_regressions = GUARD.structural_regressions
 
 
 def test_missing_release_heading_is_rejected():
-    base = """## [Unreleased]\n\n## [v4.1.27] - 2026-08-02\n\n### Fixed\n- **A fix.**\n"""
+    base = (
+        """## [Unreleased]\n\n## [v4.1.27] - 2026-08-02\n\n### Fixed\n- **A fix.**\n"""
+    )
     stale_branch = """## [Unreleased]\n\n### Fixed\n- **A new fix.**\n- **A fix.**\n"""
     errors = structural_regressions(base, stale_branch)
     assert any("v4.1.27" in error for error in errors)
@@ -124,10 +132,46 @@ def test_stale_pr_that_did_edit_changelog_must_preserve_current_releases():
     assert any("v4.1.27" in error for error in errors)
 
 
+def test_pr_can_satisfy_the_changelog_rule_with_a_fragment():
+    assert (
+        changelog_requirement_errors(
+            ["cps/web.py", "tests/unit/test_web.py", "changelog.d/reader-back-link.md"]
+        )
+        == []
+    )
+
+
+def test_direct_changelog_edits_remain_accepted_during_cutover():
+    assert changelog_requirement_errors(["cps/web.py", "CHANGELOG.md"]) == []
+
+
+def test_pr_cannot_satisfy_the_changelog_rule_with_neither_form():
+    errors = changelog_requirement_errors(["cps/web.py", "tests/unit/test_web.py"])
+    assert len(errors) == 1
+    assert "CHANGELOG.md" in errors[0]
+    assert "changelog.d/<pr-or-slug>.md" in errors[0]
+
+
+def test_changelog_directory_readme_is_documentation_not_a_fragment():
+    errors = changelog_requirement_errors(["CONTRIBUTING.md", "changelog.d/README.md"])
+    assert errors
+
+
+def test_fragments_are_direct_markdown_children_with_safe_names():
+    assert changelog_requirement_errors(["changelog.d/fix-123.md"]) == []
+    assert changelog_requirement_errors(["changelog.d/nested/fix.md"])
+    assert changelog_requirement_errors(["changelog.d/fix.txt"])
+
+
 def test_pr_ci_invokes_guard_with_complete_git_history():
-    workflow = (ROOT / ".github" / "workflows" / "tests.yml").read_text(encoding="utf-8")
+    workflow = (ROOT / ".github" / "workflows" / "tests.yml").read_text(
+        encoding="utf-8"
+    )
     fast_tests = workflow.split("  fast-tests:", 1)[1].split("\n  #", 1)[0]
     changed_paths = workflow.split("  changed_paths:", 1)[1].split("\n  #", 1)[0]
     assert "fetch-depth: 0" in fast_tests
     assert "fetch-depth: 0" in changed_paths
-    assert 'python3 scripts/check_changelog_diff.py "$BASE_SHA" "$HEAD_SHA"' in changed_paths
+    assert (
+        'python3 scripts/check_changelog_diff.py "$BASE_SHA" "$HEAD_SHA"'
+        in changed_paths
+    )

--- a/tests/unit/test_changelog_fragments.py
+++ b/tests/unit/test_changelog_fragments.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Behavioural coverage for deterministic changelog-fragment assembly."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import os
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = Path(
+    os.environ.get(
+        "CWNG_CHANGELOG_ASSEMBLER", ROOT / "scripts" / "assemble_changelog.py"
+    )
+)
+
+BASE_CHANGELOG = """# Changelog
+
+Project preamble.
+
+## [Unreleased]
+
+### Fixed
+
+- **Existing fix.** Existing detail.
+
+## [v1.0.0] - 2026-08-01
+
+### Added
+
+- **First release.** Initial detail.
+"""
+
+
+def _workspace(tmp_path: Path, changelog: str = BASE_CHANGELOG) -> tuple[Path, Path]:
+    changelog_path = tmp_path / "CHANGELOG.md"
+    fragments = tmp_path / "changelog.d"
+    fragments.mkdir()
+    changelog_path.write_text(changelog, encoding="utf-8")
+    return changelog_path, fragments
+
+
+def _run(
+    changelog: Path, fragments: Path, *extra: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--changelog",
+            str(changelog),
+            "--fragments-dir",
+            str(fragments),
+            *extra,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_empty_fragment_directory_is_a_byte_identical_noop(tmp_path: Path) -> None:
+    changelog, fragments = _workspace(tmp_path)
+    before = changelog.read_bytes()
+
+    result = _run(changelog, fragments)
+
+    assert result.returncode == 0, result.stderr
+    assert changelog.read_bytes() == before
+    assert list(fragments.iterdir()) == []
+    assert "unchanged" in result.stdout
+
+
+def test_one_fragment_moves_into_unreleased_and_is_deleted(tmp_path: Path) -> None:
+    changelog, fragments = _workspace(tmp_path)
+    fragment = fragments / "reader-back-link.md"
+    fragment.write_text(
+        "### Fixed\n\n- **Books return to their source list.** The filter is preserved.\n",
+        encoding="utf-8",
+    )
+
+    result = _run(changelog, fragments)
+
+    assert result.returncode == 0, result.stderr
+    text = changelog.read_text(encoding="utf-8")
+    unreleased = text.split("## [Unreleased]", 1)[1].split("\n## [", 1)[0]
+    assert "**Existing fix.**" in unreleased
+    assert "**Books return to their source list.**" in unreleased
+    assert not fragment.exists()
+
+
+def test_many_fragments_use_category_then_c_locale_filename_order(
+    tmp_path: Path,
+) -> None:
+    changelog, fragments = _workspace(tmp_path)
+    (fragments / "z-last.md").write_text(
+        "### Fixed\n\n- **Zulu fix.** Last filename.\n", encoding="utf-8"
+    )
+    (fragments / "a-first.md").write_text(
+        "### Fixed\n\n- **Alpha fix.** First filename.\n", encoding="utf-8"
+    )
+    (fragments / "m-added.md").write_text(
+        "### Added\n\n- **Middle feature.** Added category.\n", encoding="utf-8"
+    )
+
+    result = _run(changelog, fragments)
+
+    assert result.returncode == 0, result.stderr
+    text = changelog.read_text(encoding="utf-8")
+    unreleased = text.split("## [Unreleased]", 1)[1].split("\n## [", 1)[0]
+    assert unreleased.index("### Added") < unreleased.index("### Fixed")
+    assert unreleased.index("**Existing fix.**") < unreleased.index("**Alpha fix.**")
+    assert unreleased.index("**Alpha fix.**") < unreleased.index("**Zulu fix.**")
+    assert [path.name for path in fragments.iterdir()] == []
+
+
+def test_readme_is_not_a_fragment_and_survives_assembly(tmp_path: Path) -> None:
+    changelog, fragments = _workspace(tmp_path)
+    readme = fragments / "README.md"
+    readme.write_text("format documentation\n", encoding="utf-8")
+
+    result = _run(changelog, fragments)
+
+    assert result.returncode == 0, result.stderr
+    assert readme.read_text(encoding="utf-8") == "format documentation\n"
+
+
+def test_second_assembly_is_idempotent(tmp_path: Path) -> None:
+    changelog, fragments = _workspace(tmp_path)
+    (fragments / "one.md").write_text(
+        "### Changed\n\n- **One setting is clearer.** More detail.\n", encoding="utf-8"
+    )
+
+    first = _run(changelog, fragments)
+    after_first = changelog.read_bytes()
+    second = _run(changelog, fragments)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert changelog.read_bytes() == after_first
+    assert (
+        changelog.read_text(encoding="utf-8").count("**One setting is clearer.**") == 1
+    )
+
+
+def test_replayed_fragment_is_deduplicated_after_a_post_write_interruption(
+    tmp_path: Path,
+) -> None:
+    changelog, fragments = _workspace(tmp_path)
+    body = "### Fixed\n\n- **One durable fix.** More detail.\n"
+    fragment = fragments / "durable.md"
+    fragment.write_text(body, encoding="utf-8")
+    first = _run(changelog, fragments)
+    # Model a kill after CHANGELOG.md was replaced but before fragment unlink:
+    # the canonical entry exists and the same fragment is still on disk.
+    fragment.write_text(body, encoding="utf-8")
+    second = _run(changelog, fragments)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert changelog.read_text(encoding="utf-8").count("**One durable fix.**") == 1
+    assert not fragment.exists()
+
+
+def test_release_mode_drains_unreleased_and_fragments_into_one_version(
+    tmp_path: Path,
+) -> None:
+    changelog, fragments = _workspace(tmp_path)
+    fragment = fragments / "release-fix.md"
+    fragment.write_text(
+        "### Fixed\n\n- **Release fix.** Included from a fragment.\n", encoding="utf-8"
+    )
+
+    first = _run(
+        changelog,
+        fragments,
+        "--version",
+        "v1.0.1",
+        "--date",
+        "2026-08-24",
+    )
+    after_first = changelog.read_bytes()
+    second = _run(
+        changelog,
+        fragments,
+        "--version",
+        "v1.0.1",
+        "--date",
+        "2026-08-24",
+    )
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert changelog.read_bytes() == after_first
+    text = changelog.read_text(encoding="utf-8")
+    unreleased = text.split("## [Unreleased]", 1)[1].split("\n## [", 1)[0]
+    release = text.split("## [v1.0.1] - 2026-08-24", 1)[1].split("\n## [", 1)[0]
+    assert unreleased.strip() == ""
+    assert "**Existing fix.**" in release
+    assert "**Release fix.**" in release
+    assert text.count("## [v1.0.1] - 2026-08-24") == 1
+    assert not fragment.exists()
+
+
+def test_invalid_fragment_fails_without_modifying_or_consuming_files(
+    tmp_path: Path,
+) -> None:
+    changelog, fragments = _workspace(tmp_path)
+    fragment = fragments / "invalid.md"
+    fragment.write_text("- not under a category\n", encoding="utf-8")
+    before = changelog.read_bytes()
+
+    result = _run(changelog, fragments)
+
+    assert result.returncode == 2
+    assert "invalid.md" in result.stderr
+    assert changelog.read_bytes() == before
+    assert fragment.exists()
+
+
+def test_unsupported_fragment_category_is_rejected(tmp_path: Path) -> None:
+    changelog, fragments = _workspace(tmp_path)
+    fragment = fragments / "unsupported.md"
+    fragment.write_text(
+        "### Improvements\n\n- **A vague category.** This cannot be ordered.\n",
+        encoding="utf-8",
+    )
+    before = changelog.read_bytes()
+
+    result = _run(changelog, fragments)
+
+    assert result.returncode == 2
+    assert "unsupported category 'Improvements'" in result.stderr
+    assert changelog.read_bytes() == before
+    assert fragment.exists()
+
+
+def test_current_repository_changelog_shape_accepts_a_fragment(tmp_path: Path) -> None:
+    changelog, fragments = _workspace(
+        tmp_path, (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    )
+    fragment = fragments / "shape-probe.md"
+    fragment.write_text(
+        "### Fixed\n\n- **The real changelog parser remains usable.** Shape probe.\n",
+        encoding="utf-8",
+    )
+
+    result = _run(changelog, fragments)
+
+    assert result.returncode == 0, result.stderr
+    assert "**The real changelog parser remains usable.**" in changelog.read_text(
+        encoding="utf-8"
+    )
+    assert not fragment.exists()


### PR DESCRIPTION
## What this is

The `changelog.d` fragment mechanism proposed as §4 of
`state/rollback/FINDING-20260824-changelog-serializes-the-merge-queue.md`. Each PR
writes an isolated `changelog.d/<pr-or-slug>.md` instead of contending on the single
`CHANGELOG.md` insertion point; `scripts/assemble_changelog.py` is the only writer that
folds fragments into the canonical Keep-a-Changelog sections at release time.

`scripts/assemble_changelog.py` is deterministic (C-locale filename order, fixed
category order), idempotent, replay-safe after a post-write interruption, and consumes
fragments only on success. 25 unit tests pass locally
(`tests/unit/test_changelog_fragments.py` + `tests/unit/test_changelog_diff_guard.py`).

## Why this is `needs-review` and not merged

**This is a project-policy decision, not maintenance.** It changes how every contributor
writes a release note and how a release is cut. The finding above deliberately declined
to make that call unilaterally, and this PR keeps that posture — it is opened so the
decision is visible and reviewable, not to land automatically.

Note the urgency is now lower than when this was drafted. The `merge=union` attribute
from #1855 is **confirmed working server-side** (OBSERVED 2026-08-24: all ten previously
`CONFLICTING` PRs — #1745 #1816 #1829 #1830 #1831 #1832 #1833 #1834 #1842 #1846 — report
`MERGEABLE` after it landed, with no rebase). Fragments remain the better end state
because they remove the conflict *by construction*, but the queue is no longer serialized
while this waits.

## ⚠️ Known blocking defect in this branch — do not merge as-is

`changelog_requirement_errors()` in `scripts/check_changelog_diff.py` makes a changelog
entry **mandatory for every PR**. That step runs in `changed_paths`, which gates the whole
test matrix, so it is a hard CI requirement that did not previously exist. It would fail
legitimately note-free PRs, including ones open right now:

- #1836 `test: cover partial bulk delete failures` — test-only
- #1834 `chore(findings): …` — `findings/items/*.json` + `INDEX.md`, no runtime code
- translation-only `.po` PRs

Before this can merge it needs either an exemption path (test-only / findings / i18n /
docs), a `skip-changelog` label escape hatch, or the requirement dropped so the guard goes
back to only rejecting structural loss. Left unfixed here deliberately: the right answer
depends on the policy call above.

## Compatibility

Direct `CHANGELOG.md` edits stay CI-valid during the cutover, and the `merge=union`
attribute stays as the safety net for branches opened before fragments were adopted.
