### PR TITLE
fix(changelog): exempt non-shipping-only pull requests from the entry requirement

### DIFF
--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,8 +1,16 @@
 # Changelog fragments
 
-Every pull request records its release-note entry in a separate Markdown file
-under this directory. That keeps concurrent branches away from the shared
-`CHANGELOG.md` insertion point.
+Every pull request that changes shipping code or assets records its release-note
+entry in a separate Markdown file under this directory. That keeps concurrent
+branches away from the shared `CHANGELOG.md` insertion point.
+
+A fragment is not required when every changed path is confined to `findings/`,
+`notes/`, `docs/`, `tests/`, this `changelog.d/README.md` file, or the guard
+implementation itself at `scripts/check_changelog_diff.py`. Those paths contain
+evidence ledgers, working notes, documentation, verification code, or CI policy
+rather than application behavior. This is an all-paths exemption: a pull
+request that mixes any of them with shipping code or assets still needs a
+fragment. Unlisted paths require a fragment by default.
 
 Name the file after the PR when its number is known, or use a short stable slug:
 
@@ -26,7 +34,8 @@ The accepted categories, rendered in canonical order, are `Added`, `Changed`,
 `Deprecated`, `Removed`, `Fixed`, and `Security`. A fragment may contain more
 than one category or entry. Fragment names are ASCII letters, digits, dots,
 underscores, or hyphens and must be direct `.md` children of `changelog.d/`.
-This `README.md` is documentation and does not satisfy the CI requirement.
+This `README.md` is documentation and does not count as a fragment. It is only
+exempt when every other changed path is also non-shipping as described above.
 
 Do not run the assembler from an ordinary PR: successful assembly consumes the
 fragment files. Release preparation runs this exact command before the release

--- a/scripts/check_changelog_diff.py
+++ b/scripts/check_changelog_diff.py
@@ -14,6 +14,10 @@ import sys
 RELEASE_HEADING = re.compile(r"^## \[(v\d+\.\d+\.\d+)\]", re.MULTILINE)
 ENTRY_LEAD = re.compile(r"^- \*\*", re.MULTILINE)
 FRAGMENT_PATH = re.compile(r"^changelog\.d/[A-Za-z0-9][A-Za-z0-9._-]*\.md$")
+NON_SHIPPING_PATH_PREFIXES = ("docs/", "findings/", "notes/", "tests/")
+NON_SHIPPING_PATHS = frozenset(
+    {"changelog.d/README.md", "scripts/check_changelog_diff.py"}
+)
 
 
 def _distinct_entries(text: str) -> set[str]:
@@ -78,8 +82,14 @@ def pull_request_regressions(
     return structural_regressions(target, proposed)
 
 
+def _is_non_shipping_path(path: str) -> bool:
+    return path in NON_SHIPPING_PATHS or path.startswith(
+        NON_SHIPPING_PATH_PREFIXES
+    )
+
+
 def changelog_requirement_errors(changed_paths: list[str]) -> list[str]:
-    """Require the canonical changelog or one real fragment in every PR."""
+    """Require a changelog entry unless every changed path is non-shipping."""
     if "CHANGELOG.md" in changed_paths:
         return []
     if any(
@@ -87,11 +97,25 @@ def changelog_requirement_errors(changed_paths: list[str]) -> list[str]:
         for path in changed_paths
     ):
         return []
+    if changed_paths and all(_is_non_shipping_path(path) for path in changed_paths):
+        return []
     return [
-        "This PR changes neither CHANGELOG.md nor "
+        "This PR changes shipping paths but neither CHANGELOG.md nor "
         "changelog.d/<pr-or-slug>.md. Add a categorized changelog fragment; "
         "changelog.d/README.md documents the format."
     ]
+
+
+def pull_request_errors(
+    changed_paths: list[str],
+    target: str,
+    branch_point: str,
+    proposed: str,
+) -> list[str]:
+    """Return every requirement and structural error for a pull request."""
+    errors = changelog_requirement_errors(changed_paths)
+    errors.extend(pull_request_regressions(target, branch_point, proposed))
+    return errors
 
 
 def _file_at(ref: str) -> str:
@@ -150,15 +174,11 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         branch_point = _merge_base(args.base_ref, args.head_ref)
-        errors = changelog_requirement_errors(
-            _changed_paths(branch_point, args.head_ref)
-        )
-        errors.extend(
-            pull_request_regressions(
-                _file_at(args.base_ref),
-                _file_at(branch_point),
-                _file_at(args.head_ref),
-            )
+        errors = pull_request_errors(
+            _changed_paths(branch_point, args.head_ref),
+            _file_at(args.base_ref),
+            _file_at(branch_point),
+            _file_at(args.head_ref),
         )
     except RuntimeError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
@@ -172,8 +192,8 @@ def main(argv: list[str] | None = None) -> int:
 
     print(
         "CHANGELOG integrity guard passed: "
-        "a canonical entry or fragment is present and no PR-authored release "
-        "structure was lost."
+        "the entry requirement is satisfied or every changed path is "
+        "non-shipping, and no PR-authored release structure was lost."
     )
     return 0
 

--- a/tests/unit/test_changelog_diff_guard.py
+++ b/tests/unit/test_changelog_diff_guard.py
@@ -14,6 +14,7 @@ assert SPEC and SPEC.loader
 GUARD = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(GUARD)
 changelog_requirement_errors = GUARD.changelog_requirement_errors
+pull_request_errors = GUARD.pull_request_errors
 pull_request_regressions = GUARD.pull_request_regressions
 structural_regressions = GUARD.structural_regressions
 
@@ -146,15 +147,52 @@ def test_direct_changelog_edits_remain_accepted_during_cutover():
 
 
 def test_pr_cannot_satisfy_the_changelog_rule_with_neither_form():
-    errors = changelog_requirement_errors(["cps/web.py", "tests/unit/test_web.py"])
+    errors = changelog_requirement_errors(["cps/web.py"])
     assert len(errors) == 1
     assert "CHANGELOG.md" in errors[0]
     assert "changelog.d/<pr-or-slug>.md" in errors[0]
 
 
+def test_findings_ledger_only_pr_does_not_require_a_changelog_entry():
+    assert changelog_requirement_errors(["findings/kobo/F-66edbc.md"]) == []
+
+
+def test_mixing_a_findings_ledger_with_shipping_code_requires_an_entry():
+    errors = changelog_requirement_errors(
+        ["findings/kobo/F-66edbc.md", "cps/readingservices.py"]
+    )
+    assert len(errors) == 1
+    assert "shipping paths" in errors[0]
+
+
+def test_other_allowlisted_non_shipping_paths_do_not_require_an_entry():
+    for path in (
+        "notes/kobo-hardware-run.md",
+        "docs/install/compose.md",
+        "tests/unit/test_changelog_diff_guard.py",
+        "changelog.d/README.md",
+        "scripts/check_changelog_diff.py",
+    ):
+        assert changelog_requirement_errors([path]) == []
+
+
+def test_github_paths_and_top_level_dotfiles_are_not_blanket_exempt():
+    for path in (".github/workflows/tests.yml", ".dockerignore", ".editorconfig"):
+        assert changelog_requirement_errors([path])
+
+
 def test_changelog_directory_readme_is_documentation_not_a_fragment():
-    errors = changelog_requirement_errors(["CONTRIBUTING.md", "changelog.d/README.md"])
+    errors = changelog_requirement_errors(["cps/web.py", "changelog.d/README.md"])
     assert errors
+
+
+def test_non_shipping_exemption_does_not_bypass_structural_regressions():
+    base = """## [Unreleased]\n\n### Fixed\n- **First fix.**\n- **Second fix.**\n"""
+    damaged = """## [Unreleased]\n\n### Fixed\n- **First fix.**\n"""
+    errors = pull_request_errors(
+        ["findings/kobo/F-66edbc.md"], base, base, damaged
+    )
+    assert any("loses 1" in error for error in errors)
 
 
 def test_fragments_are_direct_markdown_children_with_safe_names():


### PR DESCRIPTION
The changelog-fragment guard from #1856 has no exemption: `changelog_requirement_errors()` returns clean only if the PR touched `CHANGELOG.md` or a `changelog.d/*.md`. So a findings-ledger PR, a notes-only PR, or a tests-only PR fails CI unless it invents a release note.

That is worse than an inconvenience. This repo's `CHANGELOG.md` is explicitly *"things you can see or feel when running the app"*, so satisfying the guard on such a PR means writing a **false** entry — the guard currently pressures authors into corrupting the artifact it exists to protect. #1858 is blocked on exactly this, and is the first ledger PR through since #1856 landed.

## The exemption

An **all-paths allowlist**: every changed path must be non-shipping, so a single unlisted path makes an entry mandatory again.

| exempt | why |
|---|---|
| `findings/` | evidence ledger, not a shipped change |
| `notes/` | internal working notes |
| `docs/` | repository documentation, not runtime payload |
| `tests/` | verification code — changes confidence, not behavior |
| `changelog.d/README.md` | the guard's own author-facing doc (still excluded from *fragment* recognition) |
| `scripts/check_changelog_diff.py` | this exact file implements CI changelog policy; the broader `scripts/` is **not** exempt |

**Deliberately still guarded:** `.github/` (contains container-build, release, translation and plugin-publishing workflows — a blanket exemption could let a change to the produced artifact escape), top-level dotfiles (`.dockerignore` affects the build context, `.gitattributes` affects merge/release), and any new top-level directory, which defaults to requiring an entry.

## What it does not weaken

- `pull_request_regressions()` still runs on **every** PR. The exemption governs only whether a *new* entry is required, never whether existing structure may be damaged.
- Mixed PRs stay required — the check is `all(...)`, so `findings/x.md + cps/readingservices.py` still needs an entry.
- The success message was corrected too: it previously claimed an entry was present, which would have been a false statement on an exempt PR.

## Verification

20/20 guard tests pass. Four mutations, each confirming the test is real:

| mutation | test that went red |
|---|---|
| drop `findings/` from the allowlist | `test_findings_ledger_only_pr_does_not_require_a_changelog_entry` |
| make the guarded default return `[]` | `test_pr_cannot_satisfy_the_changelog_rule_with_neither_form` |
| change `all(...)` to `any(...)` | `test_mixing_a_findings_ledger_with_shipping_code_requires_an_entry` |
| drop `pull_request_regressions()` from the aggregator | `test_non_shipping_exemption_does_not_bypass_structural_regressions` |

Full unit suite: 6,942 passed, 105 skipped, 0 failed.

**Free end-to-end test:** this PR changes only `changelog.d/README.md`, `scripts/check_changelog_diff.py` and `tests/`, so it exercises its own rule. Running the guard on this branch:

```
CHANGELOG integrity guard passed: the entry requirement is satisfied or every
changed path is non-shipping, and no PR-authored release structure was lost.
```

Rebased onto main after #1816 merged — the pre-rebase branch would have shown 896 lines of spool tests as deletions.