### PR TITLE
fix(kobo): schedule spool retention before record commit

### DIFF
--- a/changelog.d/pr-1860.md
+++ b/changelog.d/pr-1860.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Kobo PATCH recovery no longer commits a record after retention scheduling
+  has already failed.** Timer admission now happens before the durable spool
+  transaction, so a maintenance setup failure leaves the established recovery
+  record set unchanged and the annotation PATCH still fails open.

--- a/cps/services/kobo_patch_spool.py
+++ b/cps/services/kobo_patch_spool.py
@@ -529,10 +529,10 @@ def _write_new_record(spool_id, compressed, cancelled=None):
             path = root / (
                 f"patch-{time.time_ns():020d}-{spool_id}-staged.json.gz"
             )
+            _schedule_retention(root, time.time() + MAX_AGE_SECONDS)
             _install_record_locked(
                 path, compressed, victims=victims, cancelled=cancelled,
             )
-    _schedule_retention(root, time.time() + MAX_AGE_SECONDS)
     return path
 
 
@@ -561,7 +561,6 @@ def _mark_dispatch_outcome_blocking(path, status, cancelled=None):
                 replacing_path=path,
                 cancelled=cancelled,
             )
-    _schedule_retention(root, time.time() + MAX_AGE_SECONDS)
     return new_path
 
 

--- a/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
+++ b/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
@@ -303,6 +303,24 @@ def test_failed_new_write_does_not_destroy_the_existing_recovery_record(
 
 
 @pytest.mark.unit
+def test_retention_schedule_failure_happens_before_record_commit(monkeypatch, tmp_path):
+    """A post-write maintenance failure cannot create an unreported record."""
+    spool, root = _root(monkeypatch, tmp_path)
+
+    def _fail_schedule(*_args, **_kwargs):
+        raise RuntimeError("simulated timer creation failure")
+
+    monkeypatch.setattr(spool, "_schedule_retention", _fail_schedule)
+    ticket = spool.stage_patch(
+        raw_body=RAW_PATCH, entitlement_id=BOOK_UUID,
+        user_id=7, origin_device_id=None,
+    )
+
+    assert ticket is None
+    assert list(root.glob("patch-*.json.gz")) == []
+
+
+@pytest.mark.unit
 def test_cross_process_lock_contention_fails_open_without_waiting(monkeypatch, tmp_path):
     """A busy peer must not block this gevent worker's entire request hub."""
     spool, root = _root(monkeypatch, tmp_path)


### PR DESCRIPTION
Follow-up to #1816. That PR auto-merged after its green CI run while the final failure-path audit was still completing.

If retention timer creation failed after a durable stage committed, `stage_patch()` returned no ticket even though it had changed the spool, and the new record had no age timer. Schedule admission now happens before the record transaction: timer creation failure leaves the established record set unchanged, while a later record-write failure leaves only a harmless empty timer.

Verification:
- Added a focused regression test and mutation-proved it red when scheduling is moved after the durable install.
- Touched area: 30 passed.
- Full unit suite: 6,972 passed, 102 skipped.