### PR TITLE
fix(kobo): fail closed on unaddressable annotation PATCH bodies, and stop the recovery spool filling with retries (#1827, #1869)

### DIFF
--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -63,16 +63,21 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
 
 - **Kobo annotation PATCH parse failures now preserve the device retry instead
   of acknowledging an upload CWNG could not address** (fork #1827) — a
-  non-empty non-object body and any present non-list `updatedAnnotations`
+  non-empty non-object body and any non-empty non-list `updatedAnnotations`
   value now receive the same 503 refusal as a local persistence failure.
   Empty/whitespace bodies, empty objects, empty annotation/delete lists, and
-  confirmed-unowned content preserve the proxy contract. The route now sends
-  every present `updatedAnnotations` value through the dispatcher, and the
-  dispatcher's non-list defense runs before its empty-batch shortcut. The
+  confirmed-unowned content preserve the proxy contract. Falsy non-list update
+  spellings contain no annotation and are treated as empty so delete-carrying
+  batches still complete; the dispatcher's non-list defense remains the backstop
+  for non-empty malformed values. The
   unauthenticated 401 can record its exact request only under the explicit
   private-data diagnostic gate, with `authentication=unauthenticated` and no
-  user ID. Those records use a separate 32-file/8-MiB/24-hour budget, never the
-  non-evictable recovery spool, and storage runs off the gevent hub. | SHA
+  user ID. Those records use a separate 32-file/8-MiB budget and a 24-hour age
+  target enforced on the next unauthenticated capture write, never the recovery
+  spool, and storage runs off the gevent hub. Every refusal remains a protected
+  replay candidate, but retries of one exact user/entitlement/device/body
+  identity atomically refresh one record regardless of its previous outcome,
+  instead of consuming one global spool slot per retry. | SHA
   `TBD` | release `TBD`.
 
 - **Durable pre-dispatch Kobo PATCH recovery spool (finding F-5c1146 addendum

--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -61,6 +61,20 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
 
 ### Bug fixes
 
+- **Kobo annotation PATCH parse failures now preserve the device retry instead
+  of acknowledging an upload CWNG could not address** (fork #1827) — a
+  non-empty non-object body and any present non-list `updatedAnnotations`
+  value now receive the same 503 refusal as a local persistence failure.
+  Empty/whitespace bodies, empty objects, empty annotation/delete lists, and
+  confirmed-unowned content preserve the proxy contract. The route now sends
+  every present `updatedAnnotations` value through the dispatcher, and the
+  dispatcher's non-list defense runs before its empty-batch shortcut. The
+  unauthenticated 401 can record its exact request only under the explicit
+  private-data diagnostic gate, with `authentication=unauthenticated` and no
+  user ID. Those records use a separate 32-file/8-MiB/24-hour budget, never the
+  non-evictable recovery spool, and storage runs off the gevent hub. | SHA
+  `TBD` | release `TBD`.
+
 - **Durable pre-dispatch Kobo PATCH recovery spool (finding F-5c1146 addendum
   point 2)** — the Stage-0 sidecar is attached only after an Annotation row
   exists, so a parser or dispatcher exception could lose the device's delta

--- a/changelog.d/1827.md
+++ b/changelog.d/1827.md
@@ -2,8 +2,12 @@
 
 - **Kobo annotation uploads are no longer acknowledged when their JSON shape
   prevents CWNG from addressing the uploaded annotations.** Non-empty
-  non-object bodies and non-list annotation batches now receive a temporary
-  failure so the device retains the delta for retry, while legitimate empty
-  sync batches continue normally. Operators running the explicit private
+  non-object bodies and non-empty non-list annotation batches now receive a
+  temporary failure so the device retains the delta for retry, while legitimate
+  empty sync and delete-carrying batches continue normally. Operators running
+  the explicit private
   Reading Services diagnostic can also capture the body of a pre-authentication
-  401 refusal in a separate, tightly bounded unauthenticated store.
+  401 refusal in a separate, tightly bounded unauthenticated store. Repeated
+  attempts for the same unresolved upload now share one protected recovery
+  record, preventing one retrying device from exhausting the instance-wide
+  spool and denying recovery staging to other users.

--- a/changelog.d/1827.md
+++ b/changelog.d/1827.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Kobo annotation uploads are no longer acknowledged when their JSON shape
+  prevents CWNG from addressing the uploaded annotations.** Non-empty
+  non-object bodies and non-list annotation batches now receive a temporary
+  failure so the device retains the delta for retry, while legitimate empty
+  sync batches continue normally. Operators running the explicit private
+  Reading Services diagnostic can also capture the body of a pre-authentication
+  401 refusal in a separate, tightly bounded unauthenticated store.

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -202,6 +202,7 @@ def requires_reading_services_auth_and_config(f):
         if contains_check_for_changes:
             return f(*args, **kwargs)
         if request.method == "PATCH" and _is_annotation_path(request.path):
+            _capture_unauthenticated_annotation_patch()
             log.warning(
                 "Refusing unauthenticated annotation PATCH so the device can retry"
             )
@@ -303,7 +304,9 @@ def _check_for_changes_ownership_is_filtered(ownership):
     return ownership is not None
 
 
-def _begin_exchange_capture(exchange, raw_body):
+def _begin_exchange_capture(
+    exchange, raw_body, *, authentication="not_recorded", user_id=None,
+):
     """Attach a best-effort after-response observer to the current request."""
     try:
         from .services import kobo_exchange_capture
@@ -314,6 +317,8 @@ def _begin_exchange_capture(exchange, raw_body):
             query_string=request.query_string,
             headers=request.headers.items(),
             body=raw_body,
+            authentication=authentication,
+            user_id=user_id,
         )
         if capture_session is None:
             return None
@@ -339,6 +344,48 @@ def _begin_exchange_capture(exchange, raw_body):
         log.warning(
             "Kobo exchange capture could not attach exchange=%s",
             exchange, exc_info=True,
+        )
+        return None
+
+
+def _capture_unauthenticated_annotation_patch():
+    """Opt-in, separately bounded capture of a PATCH refused before auth.
+
+    The always-on recovery spool is deliberately not used here.  Without an
+    authenticated principal there is no safe replay target, and unresolved
+    spool records are protected from eviction.  Admitting them would let an
+    unauthenticated caller exhaust the recovery budget for real users.
+
+    Do not consume an unauthenticated body unless the private diagnostic is
+    explicitly enabled, and require a bounded Content-Length before reading.
+    """
+    try:
+        from .services import kobo_exchange_capture
+        if not kobo_exchange_capture.enabled():
+            return None
+        content_length = request.content_length
+        if (
+            content_length is None
+            or content_length < 0
+            or content_length > kobo_exchange_capture.UNAUTHENTICATED_MAX_BODY_BYTES
+        ):
+            log.warning(
+                "Unauthenticated Kobo annotation PATCH capture skipped: "
+                "request length is missing or outside diagnostic bound bytes=%s",
+                content_length,
+            )
+            return None
+        raw_body = request.get_data(cache=True)
+        return _begin_exchange_capture(
+            "annotations_patch_unauthenticated",
+            raw_body,
+            authentication="unauthenticated",
+            user_id=None,
+        )
+    except Exception:
+        log.warning(
+            "Unauthenticated Kobo annotation PATCH capture could not attach",
+            exc_info=True,
         )
         return None
 
@@ -621,16 +668,18 @@ def handle_annotations(entitlement_id):
     capture_session = _begin_exchange_capture(
         "annotations_patch" if request.method == "PATCH" else "annotations_get",
         raw_body,
+        authentication="authenticated",
+        user_id=getattr(current_user, "id", None),
     )
     if request.method == "PATCH":
         patch_spool_ticket = _stage_patch_for_recovery(raw_body, entitlement_id)
         try:
             data = request.get_json(silent=True)
+            nonempty_unaddressable_body = False
             if not isinstance(data, dict):
-                log.warning(
-                    "Ignoring local annotation capture for entitlement %s: "
-                    "PATCH body is not a JSON object", entitlement_id,
-                )
+                if raw_body.strip():
+                    nonempty_unaddressable_body = True
+                # A genuinely empty body is a legitimate no-op sent by Kobo.
                 data = {}
             book = resolve_entitlement_ownership(entitlement_id)
             if book is OWNERSHIP_UNKNOWN:
@@ -653,40 +702,46 @@ def handle_annotations(entitlement_id):
                     entitlement_id,
                 )
             else:
+                if nonempty_unaddressable_body:
+                    log.warning(
+                        "Refusing local annotation capture for entitlement %s: "
+                        "PATCH body is not a JSON object", entitlement_id,
+                    )
+                    return make_response(
+                        jsonify({"error": "Annotation capture temporarily unavailable"}),
+                        503,
+                    )
                 from cps.services import annotation_sync
                 updated = data.get("updatedAnnotations")
                 deleted = data.get("deletedAnnotationIds")
-                if updated is not None and not isinstance(updated, list):
-                    log.warning(
-                        "Ignoring updatedAnnotations for entitlement %s: expected a list",
-                        entitlement_id,
-                    )
-                elif updated:
-                    trace_id = secrets.token_hex(8)
+                if "updatedAnnotations" in data:
                     raw_materializations = None
-                    try:
-                        from cps.services.kobo_annotation_capture import (
-                            extract_updated_annotation_materializations,
-                        )
-                        raw_materializations = extract_updated_annotation_materializations(raw_body)
-                        from cps.services import kobo_annotation_stage0
-                        kobo_annotation_stage0.record_event(
-                            "raw_capture", "extracted", trace_id=trace_id,
-                            user_id=getattr(current_user, "id", None), book_id=book.id,
-                            annotation_count=len(raw_materializations),
-                        )
-                    except Exception:
-                        log.warning(
-                            "Kobo raw lexical capture failed trace_id=%s user_id=%s book_id=%s",
-                            trace_id, getattr(current_user, "id", None), book.id,
-                            exc_info=True,
-                        )
-                        from cps.services import kobo_annotation_stage0
-                        kobo_annotation_stage0.record_event(
-                            "raw_capture", "failed", trace_id=trace_id,
-                            user_id=getattr(current_user, "id", None), book_id=book.id,
-                            annotation_count=len(updated),
-                        )
+                    trace_id = None
+                    if isinstance(updated, list) and updated:
+                        trace_id = secrets.token_hex(8)
+                        try:
+                            from cps.services.kobo_annotation_capture import (
+                                extract_updated_annotation_materializations,
+                            )
+                            raw_materializations = extract_updated_annotation_materializations(raw_body)
+                            from cps.services import kobo_annotation_stage0
+                            kobo_annotation_stage0.record_event(
+                                "raw_capture", "extracted", trace_id=trace_id,
+                                user_id=getattr(current_user, "id", None), book_id=book.id,
+                                annotation_count=len(raw_materializations),
+                            )
+                        except Exception:
+                            log.warning(
+                                "Kobo raw lexical capture failed trace_id=%s user_id=%s book_id=%s",
+                                trace_id, getattr(current_user, "id", None), book.id,
+                                exc_info=True,
+                            )
+                            from cps.services import kobo_annotation_stage0
+                            kobo_annotation_stage0.record_event(
+                                "raw_capture", "failed", trace_id=trace_id,
+                                user_id=getattr(current_user, "id", None), book_id=book.id,
+                                annotation_count=len(updated),
+                            )
                     dispatch_kwargs = {
                         "origin_device_id": getattr(g, "annotation_origin_device_id", None),
                     }

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -629,6 +629,20 @@ class KoboAnnotation(TypedDict):
     type: str  # "note" or "highlight"
 
 
+def _dispatch_kobo_annotation_deletes(annotation_sync, deleted, entitlement_id, book):
+    if deleted is not None and not isinstance(deleted, list):
+        log.warning(
+            "Ignoring deletedAnnotationIds for entitlement %s: expected a list",
+            entitlement_id,
+        )
+    elif deleted:
+        # Nickel can only name annotations Kobo created: CWNG has no annotation
+        # writeback to Kobo. If F-3b565b implements writeback, this provenance
+        # authority must be revisited.
+        annotation_sync.dispatch_annotation_deletes(
+            deleted, current_user, book_id=book.id,
+            deletable_sources={"kobo"},
+        )
 
 
 @csrf.exempt
@@ -673,8 +687,16 @@ def handle_annotations(entitlement_id):
     )
     if request.method == "PATCH":
         patch_spool_ticket = _stage_patch_for_recovery(raw_body, entitlement_id)
+        # The conservative default is replayable. Every post-stage exit crosses
+        # the single finally block below, so a new return cannot silently leave
+        # its ticket in the ambiguous initial state. Only a completed dispatch
+        # overrides it; every refusal remains an unresolved replay candidate.
+        patch_spool_outcome = "dispatch_exception"
         try:
-            data = request.get_json(silent=True)
+            # The raw body is the authority here. A proxy or client can strip
+            # or alter Content-Type without changing whether these bytes are a
+            # valid, addressable JSON batch.
+            data = request.get_json(silent=True, force=True)
             nonempty_unaddressable_body = False
             if not isinstance(data, dict):
                 if raw_body.strip():
@@ -692,6 +714,7 @@ def handle_annotations(entitlement_id):
                 # Do not proxy: checkforchanges containment prevents an owned
                 # book from healing this local gap by downloading from Kobo.
                 # A visible PATCH failure preserves the opportunity to retry.
+                patch_spool_outcome = "dispatch_refused"
                 return make_response(
                     jsonify({"error": "Annotation capture temporarily unavailable"}), 503,
                 )
@@ -707,6 +730,7 @@ def handle_annotations(entitlement_id):
                         "Refusing local annotation capture for entitlement %s: "
                         "PATCH body is not a JSON object", entitlement_id,
                     )
+                    patch_spool_outcome = "dispatch_refused"
                     return make_response(
                         jsonify({"error": "Annotation capture temporarily unavailable"}),
                         503,
@@ -714,7 +738,19 @@ def handle_annotations(entitlement_id):
                 from cps.services import annotation_sync
                 updated = data.get("updatedAnnotations")
                 deleted = data.get("deletedAnnotationIds")
-                if "updatedAnnotations" in data:
+                deterministic_update_rejection = (
+                    bool(updated) and not isinstance(updated, list)
+                )
+                # Falsy non-list spellings cannot contain an annotation. Treat
+                # them as an empty update set so a delete-carrying batch is not
+                # trapped in a permanent retry. A truthy non-list value may be
+                # a malformed annotation and still goes through the defensive
+                # dispatcher, whose False result is refused below.
+                if deterministic_update_rejection:
+                    _dispatch_kobo_annotation_deletes(
+                        annotation_sync, deleted, entitlement_id, book,
+                    )
+                if updated:
                     raw_materializations = None
                     trace_id = None
                     if isinstance(updated, list) and updated:
@@ -754,36 +790,32 @@ def handle_annotations(entitlement_id):
                         updated, book, current_user, **dispatch_kwargs,
                     )
                     if persisted is False:
+                        # False means complete batch persistence is unproven,
+                        # not that zero rows reached SQLite. On this engine a
+                        # released SAVEPOINT can survive a later rollback, so
+                        # keep the raw body for replay/reconciliation either way.
                         log.error(
                             "Kobo annotation PATCH was not fully persisted for "
                             "user_id=%s book_id=%s; refusing to acknowledge it upstream",
                             getattr(current_user, "id", None), book.id,
                         )
+                        patch_spool_outcome = "dispatch_refused"
                         return make_response(
                             jsonify({"error": "Annotation capture temporarily unavailable"}),
                             503,
                         )
-                if deleted is not None and not isinstance(deleted, list):
-                    log.warning(
-                        "Ignoring deletedAnnotationIds for entitlement %s: expected a list",
-                        entitlement_id,
+                if not deterministic_update_rejection:
+                    _dispatch_kobo_annotation_deletes(
+                        annotation_sync, deleted, entitlement_id, book,
                     )
-                elif deleted:
-                    # Nickel can only name annotations Kobo created: CWNG has
-                    # no annotation writeback to Kobo. If F-3b565b implements
-                    # writeback, this provenance authority must be revisited.
-                    annotation_sync.dispatch_annotation_deletes(
-                        deleted, current_user, book_id=book.id,
-                        deletable_sources={"kobo"},
-                    )
+            patch_spool_outcome = "dispatch_completed"
         except Exception:
-            _mark_patch_spool_outcome(patch_spool_ticket, "dispatch_exception")
             log.exception("Error processing PATCH annotations")
             return make_response(
                 jsonify({"error": "Annotation capture temporarily unavailable"}), 503,
             )
-        else:
-            _mark_patch_spool_outcome(patch_spool_ticket, "dispatch_completed")
+        finally:
+            _mark_patch_spool_outcome(patch_spool_ticket, patch_spool_outcome)
     # Proxy both GET + PATCH. Do not refuse GET: hardware testing showed that a
     # 503 (or a hung request) makes Nickel empty its local annotations. The safe
     # containment point is checkforchanges, before Nickel decides to GET.

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -624,11 +624,11 @@ def dispatch_annotation_sync(payload_annotations, book, user, *, origin_device_i
     deltas and may never offer an acknowledged member again.
     """
     from cps import ub
-    if not payload_annotations:
-        return True
     if not isinstance(payload_annotations, list):
         log.warning("Skipping annotation batch because updatedAnnotations is not a list")
         return False
+    if not payload_annotations:
+        return True
     jobs = []
     all_persisted = True
     for index, payload in enumerate(payload_annotations):

--- a/cps/services/kobo_exchange_capture.py
+++ b/cps/services/kobo_exchange_capture.py
@@ -8,10 +8,16 @@ The observer is deliberately harder to enable than an ordinary boolean flag:
 application database in a hidden, mode-0700 directory.  They are not included
 in the annotation backup format or any repository artifact.
 
-Each gzip record contains the device request, the exact request body actually
-sent upstream, Kobo's response, and the final response returned to the device.
-Credential-bearing headers are redacted.  Annotation text remains only in the
-private record; ordinary logs contain structural counts and capture IDs only.
+Each gzip record contains explicit authentication provenance, the device
+request, the exact request body actually sent upstream, Kobo's response, and
+the final response returned to the device. Credential-bearing headers are
+redacted. Annotation text remains only in the private record; ordinary logs
+contain structural counts and capture IDs only.
+
+Unauthenticated captures are opt-in, carry no user identity, and use a tighter
+independent store so untrusted traffic cannot evict authenticated diagnostics
+or unresolved recovery records. All capture persistence runs off the gevent
+hub behind a hard request deadline.
 
 This module must never participate in request success.  All public mutators are
 best-effort, and :meth:`CaptureSession.finish` swallows storage failures.
@@ -33,6 +39,8 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from gevent import Timeout, get_hub
+
 from .. import constants
 
 
@@ -49,7 +57,31 @@ MAX_TOTAL_BYTES = 64 * 1024 * 1024
 MAX_FILES = 256
 MAX_AGE_SECONDS = 7 * 24 * 60 * 60
 
-_PROCESS_LOCK = threading.Lock()
+# An unauthenticated refusal has no replay identity and is reachable by anyone
+# who can reach the port.  Keep it out of both the recovery spool and the
+# authenticated diagnostic budget, with tighter independent bounds.
+UNAUTHENTICATED_MAX_BODY_BYTES = 1 * 1024 * 1024
+UNAUTHENTICATED_MAX_TOTAL_BYTES = 8 * 1024 * 1024
+UNAUTHENTICATED_MAX_FILES = 32
+UNAUTHENTICATED_MAX_AGE_SECONDS = 24 * 60 * 60
+REQUEST_IO_TIMEOUT_SECONDS = 0.1
+
+_PROCESS_LOCKS = {
+    "authenticated": threading.Lock(),
+    "unauthenticated": threading.Lock(),
+}
+_REQUEST_IO_GATES = {
+    "authenticated": threading.Lock(),
+    "unauthenticated": threading.Lock(),
+}
+
+
+class _CaptureDeadlineExceeded(Exception):
+    pass
+
+
+class _CaptureUnavailable(Exception):
+    pass
 
 
 def _capture_root() -> Path:
@@ -57,6 +89,14 @@ def _capture_root() -> Path:
         Path(constants.CONFIG_DIR)
         / ".cwng-private-observability"
         / "kobo-reading-services"
+    )
+
+
+def _unauthenticated_capture_root() -> Path:
+    return (
+        Path(constants.CONFIG_DIR)
+        / ".cwng-private-observability"
+        / "kobo-reading-services-unauthenticated"
     )
 
 
@@ -127,18 +167,76 @@ def _leg(*, method=None, path=None, query_string=b"", headers=(), body=b"", stat
     return value
 
 
-def _body_is_within_bound(body) -> bool:
+def _body_is_within_bound(body, *, max_bytes=MAX_BODY_BYTES) -> bool:
     try:
-        return len(body or b"") <= MAX_BODY_BYTES
+        return len(body or b"") <= max_bytes
     except TypeError:
         return False
 
 
-def begin_capture(*, exchange, method, path, query_string, headers, body):
+def _run_off_hub_bounded(scope, function):
+    """Run diagnostic storage on a native thread with a bounded greenlet wait."""
+    gate = _REQUEST_IO_GATES[scope]
+    if not gate.acquire(blocking=False):
+        raise _CaptureUnavailable("another capture storage operation is active")
+    try:
+        timeout = Timeout.start_new(REQUEST_IO_TIMEOUT_SECONDS)
+    except BaseException:
+        gate.release()
+        raise
+    try:
+        try:
+            result = get_hub().threadpool.spawn(
+                _capture_worker_result, function, gate,
+            )
+        except BaseException:
+            gate.release()
+            raise
+        value, error = result.get()
+        if error is not None:
+            raise error
+        return value
+    except Timeout as error:
+        if error is not timeout:
+            raise
+        raise _CaptureDeadlineExceeded(
+            f"Kobo exchange capture exceeded {REQUEST_IO_TIMEOUT_SECONDS:.3f}s deadline"
+        ) from None
+    finally:
+        timeout.cancel()
+
+
+def _capture_worker_result(function, gate):
+    try:
+        try:
+            return function(), None
+        except Exception as error:
+            return None, error
+    finally:
+        gate.release()
+
+
+def begin_capture(
+    *, exchange, method, path, query_string, headers, body,
+    authentication="not_recorded", user_id=None,
+):
     """Begin an exchange capture, or return ``None`` when off/out of bounds."""
     if not enabled():
         return None
-    if not _body_is_within_bound(body):
+    if authentication not in {
+        "authenticated", "unauthenticated", "not_recorded",
+    }:
+        log.warning("Kobo exchange capture skipped: invalid authentication provenance")
+        return None
+    if authentication == "unauthenticated" and user_id is not None:
+        log.warning("Kobo exchange capture skipped: unauthenticated record has a user id")
+        return None
+    max_body_bytes = (
+        UNAUTHENTICATED_MAX_BODY_BYTES
+        if authentication == "unauthenticated"
+        else MAX_BODY_BYTES
+    )
+    if not _body_is_within_bound(body, max_bytes=max_body_bytes):
         log.warning(
             "Kobo exchange capture skipped: device request exceeds body bound exchange=%s bytes=%s",
             str(exchange)[:64], len(body or b""),
@@ -152,6 +250,8 @@ def begin_capture(*, exchange, method, path, query_string, headers, body):
             query_string=query_string,
             headers=headers,
             body=body,
+            authentication=authentication,
+            user_id=user_id,
         )
     except Exception:
         log.warning(
@@ -164,15 +264,33 @@ def begin_capture(*, exchange, method, path, query_string, headers, body):
 class CaptureSession:
     """In-memory exchange envelope committed atomically after the response."""
 
-    def __init__(self, *, exchange, method, path, query_string, headers, body):
+    def __init__(
+        self, *, exchange, method, path, query_string, headers, body,
+        authentication, user_id,
+    ):
         self.capture_id = secrets.token_hex(16)
         self._invalid = False
         self._finished = False
+        self._authentication = authentication
+        self._storage_scope = (
+            "unauthenticated"
+            if authentication == "unauthenticated"
+            else "authenticated"
+        )
+        self._max_body_bytes = (
+            UNAUTHENTICATED_MAX_BODY_BYTES
+            if authentication == "unauthenticated"
+            else MAX_BODY_BYTES
+        )
         self._record = {
-            "schema_version": 1,
+            "schema_version": 2,
             "capture_id": self.capture_id,
             "captured_at": datetime.now(timezone.utc).isoformat(),
             "exchange": str(exchange)[:64],
+            "request_provenance": {
+                "authentication": authentication,
+                "user_id": user_id,
+            },
             "device_request": _leg(
                 method=method,
                 path=path,
@@ -216,7 +334,7 @@ class CaptureSession:
     def record_upstream_request(
         self, *, method, path, query_string, headers, body,
     ) -> bool:
-        if not _body_is_within_bound(body):
+        if not _body_is_within_bound(body, max_bytes=self._max_body_bytes):
             self._invalid = True
             return False
         return self._mutate(lambda: self._record.__setitem__(
@@ -231,7 +349,7 @@ class CaptureSession:
         ))
 
     def record_upstream_response(self, *, status, headers, body) -> bool:
-        if not _body_is_within_bound(body):
+        if not _body_is_within_bound(body, max_bytes=self._max_body_bytes):
             self._invalid = True
             return False
         return self._mutate(lambda: self._record.__setitem__(
@@ -249,7 +367,7 @@ class CaptureSession:
         if self._finished:
             return False
         self._finished = True
-        if not _body_is_within_bound(body):
+        if not _body_is_within_bound(body, max_bytes=self._max_body_bytes):
             self._invalid = True
         try:
             self._record["device_response"] = _leg(
@@ -261,12 +379,18 @@ class CaptureSession:
                     self.capture_id,
                 )
                 return False
-            self._persist()
+            _run_off_hub_bounded(self._storage_scope, self._persist)
             log.info(
                 "Kobo exchange captured capture_id=%s exchange=%s",
                 self.capture_id, self._record["exchange"],
             )
             return True
+        except (_CaptureDeadlineExceeded, _CaptureUnavailable):
+            log.warning(
+                "Kobo exchange capture persistence unavailable capture_id=%s scope=%s",
+                self.capture_id, self._authentication,
+            )
+            return False
         except Exception:
             log.warning(
                 "Kobo exchange capture persistence failed capture_id=%s",
@@ -280,12 +404,20 @@ class CaptureSession:
             ensure_ascii=False,
             separators=(",", ":"),
         ).encode("utf-8")
+        if self._authentication == "unauthenticated":
+            root = _unauthenticated_capture_root()
+            max_files = UNAUTHENTICATED_MAX_FILES
+            max_total_bytes = UNAUTHENTICATED_MAX_TOTAL_BYTES
+            max_age_seconds = UNAUTHENTICATED_MAX_AGE_SECONDS
+        else:
+            root = _capture_root()
+            max_files = MAX_FILES
+            max_total_bytes = MAX_TOTAL_BYTES
+            max_age_seconds = MAX_AGE_SECONDS
         compressed = gzip.compress(serialized, compresslevel=6, mtime=0)
-        if len(compressed) > MAX_TOTAL_BYTES:
+        if len(compressed) > max_total_bytes:
             raise ValueError("one compressed capture exceeds total retention bound")
-
-        root = _capture_root()
-        with _PROCESS_LOCK:
+        with _PROCESS_LOCKS[self._storage_scope]:
             # mkdir(parents=True) does NOT apply `mode` to the intermediates it
             # creates, so the private-observability parent would land at
             # 0777 & ~umask while only the leaf got 0700. Create and tighten it
@@ -299,7 +431,13 @@ class CaptureSession:
             try:
                 os.fchmod(lock_fd, 0o600)
                 fcntl.flock(lock_fd, fcntl.LOCK_EX)
-                _prune_locked(root, incoming_bytes=len(compressed))
+                _prune_locked(
+                    root,
+                    incoming_bytes=len(compressed),
+                    max_files=max_files,
+                    max_total_bytes=max_total_bytes,
+                    max_age_seconds=max_age_seconds,
+                )
                 final_path = root / (
                     f"exchange-{time.time_ns():020d}-{self.capture_id}.json.gz"
                 )
@@ -319,7 +457,13 @@ class CaptureSession:
                         os.fsync(directory_fd)
                     finally:
                         os.close(directory_fd)
-                    _prune_locked(root, incoming_bytes=0)
+                    _prune_locked(
+                        root,
+                        incoming_bytes=0,
+                        max_files=max_files,
+                        max_total_bytes=max_total_bytes,
+                        max_age_seconds=max_age_seconds,
+                    )
                 finally:
                     if temp_fd is not None:
                         os.close(temp_fd)
@@ -340,17 +484,30 @@ def _capture_paths(root: Path) -> list[Path]:
     return paths
 
 
-def _file_count_requires_prune(count: int, *, incoming: bool) -> bool:
+def _file_count_requires_prune(
+    count: int, *, incoming: bool, max_files=None,
+) -> bool:
     """Use make-room semantics before a write and hard-limit semantics after."""
-    return count >= MAX_FILES if incoming else count > MAX_FILES
+    if max_files is None:
+        max_files = MAX_FILES
+    return count >= max_files if incoming else count > max_files
 
 
-def _prune_locked(root: Path, *, incoming_bytes: int):
+def _prune_locked(
+    root: Path, *, incoming_bytes: int, max_files=None,
+    max_total_bytes=None, max_age_seconds=None,
+):
+    if max_files is None:
+        max_files = MAX_FILES
+    if max_total_bytes is None:
+        max_total_bytes = MAX_TOTAL_BYTES
+    if max_age_seconds is None:
+        max_age_seconds = MAX_AGE_SECONDS
     now = time.time()
     paths = _capture_paths(root)
     for path in list(paths):
         try:
-            if now - path.stat().st_mtime > MAX_AGE_SECONDS:
+            if now - path.stat().st_mtime > max_age_seconds:
                 path.unlink()
                 paths.remove(path)
         except FileNotFoundError:
@@ -358,8 +515,10 @@ def _prune_locked(root: Path, *, incoming_bytes: int):
 
     total = sum(path.stat().st_size for path in paths if path.exists())
     while paths and (
-        _file_count_requires_prune(len(paths), incoming=bool(incoming_bytes))
-        or total + incoming_bytes > MAX_TOTAL_BYTES
+        _file_count_requires_prune(
+            len(paths), incoming=bool(incoming_bytes), max_files=max_files,
+        )
+        or total + incoming_bytes > max_total_bytes
     ):
         oldest = paths.pop(0)
         try:
@@ -370,6 +529,6 @@ def _prune_locked(root: Path, *, incoming_bytes: int):
             pass
 
     if incoming_bytes and (
-        MAX_FILES < 1 or total + incoming_bytes > MAX_TOTAL_BYTES
+        max_files < 1 or total + incoming_bytes > max_total_bytes
     ):
         raise ValueError("capture retention bounds leave no room for exchange")

--- a/cps/services/kobo_patch_spool.py
+++ b/cps/services/kobo_patch_spool.py
@@ -9,12 +9,14 @@ Storage runs on gevent's native threadpool behind a hard request deadline: a
 busy or wedged spool returns no ticket and never blocks the worker hub without
 bound.
 
-Unresolved records (``staged`` / ``dispatch_exception``) are never evicted to
-admit a new body. Admission and outcome replacement use a small durable
-transaction journal, so a failed or interrupted write restores the prior
-record set. Successful records can be evicted within the advertised count and
-compressed-byte bounds. A deadline-driven maintenance thread enforces age
-retention even when no later PATCH arrives.
+Unresolved records (``staged`` / ``dispatch_refused`` /
+``dispatch_exception``) are never evicted to admit a new body. Repeated attempts
+for the same user, entitlement, device, and exact body refresh one record
+instead of consuming another slot, regardless of the prior attempt's outcome.
+Admission, deduplication, and outcome replacement use a small durable
+transaction journal, so a failed or interrupted write restores the prior record
+set. A deadline-driven maintenance thread enforces age retention even when no
+later PATCH arrives.
 
 The spool stores no request headers or credentials. It is a local recovery
 artifact, excluded from annotation backups and support bundles.
@@ -51,8 +53,18 @@ REQUEST_IO_TIMEOUT_SECONDS = 0.1
 
 _PROCESS_LOCK = threading.Lock()
 _REQUEST_IO_GATE = threading.Lock()
-_VALID_OUTCOMES = {"staged", "dispatch_completed", "dispatch_exception"}
-_UNRESOLVED_OUTCOMES = {"staged", "dispatch_exception"}
+_VALID_OUTCOMES = {
+    "staged", "dispatch_completed", "dispatch_exception", "dispatch_refused",
+}
+_UNRESOLVED_OUTCOMES = {"staged", "dispatch_exception", "dispatch_refused"}
+_REPLAY_IDENTITY_FIELDS = (
+    "user_id",
+    "entitlement_id",
+    "origin_device_id",
+    "body_length",
+    "body_sha256",
+    "body_base64",
+)
 _RETENTION_TIMERS_LOCK = threading.Lock()
 _RETENTION_TIMERS = {}
 _RETENTION_STARTED = False
@@ -84,6 +96,15 @@ def _spool_root() -> Path:
 
 def sha256_bytes(value: bytes) -> str:
     return hashlib.sha256(bytes(value)).hexdigest()
+
+
+def _replay_identity_sha256(record) -> str:
+    serialized = json.dumps(
+        [record.get(field) for field in _REPLAY_IDENTITY_FIELDS],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return sha256_bytes(serialized)
 
 
 def _body_within_bound(raw_body) -> bool:
@@ -152,11 +173,13 @@ def stage_patch(*, raw_body, entitlement_id, user_id, origin_device_id):
     try:
         raw_body = bytes(raw_body)
         spool_id = secrets.token_hex(16)
+        attempt_id = secrets.token_hex(16)
         now = datetime.now(timezone.utc).isoformat()
         record = {
-            "schema_version": 1,
+            "schema_version": 2,
             "spool_id": spool_id,
             "received_at": now,
+            "last_received_at": now,
             "entitlement_id": str(entitlement_id),
             "user_id": user_id,
             "origin_device_id": origin_device_id,
@@ -166,14 +189,21 @@ def stage_patch(*, raw_body, entitlement_id, user_id, origin_device_id):
             "body_base64": base64.b64encode(raw_body).decode("ascii"),
             "dispatch_status": "staged",
             "dispatch_updated_at": now,
+            "dispatch_attempt_id": attempt_id,
+            "attempt_count": 1,
         }
+        record["replay_identity_sha256"] = _replay_identity_sha256(record)
         compressed = _compress(record)
-        path = _run_off_hub_bounded(_write_new_record, spool_id, compressed)
-        log.info(
-            "Kobo PATCH recovery body staged spool_id=%s user_id=%s bytes=%s",
-            spool_id, user_id, len(raw_body),
+        spool_id, path, attempt_id, reused = _run_off_hub_bounded(
+            _write_or_reuse_record, record, compressed,
         )
-        return PatchSpoolTicket(spool_id=spool_id, path=path)
+        log.info(
+            "Kobo PATCH recovery body %s spool_id=%s user_id=%s bytes=%s",
+            "restaged" if reused else "staged", spool_id, user_id, len(raw_body),
+        )
+        return PatchSpoolTicket(
+            spool_id=spool_id, path=path, attempt_id=attempt_id,
+        )
     except _SpoolNoRoom:
         log.warning(
             "Kobo PATCH recovery spool full of established unresolved records; "
@@ -206,19 +236,30 @@ def stage_patch(*, raw_body, entitlement_id, user_id, origin_device_id):
 
 
 class PatchSpoolTicket:
-    def __init__(self, *, spool_id, path):
+    def __init__(self, *, spool_id, path, attempt_id):
         self.spool_id = spool_id
         self.path = Path(path)
+        self.attempt_id = attempt_id
 
     def mark_dispatch_outcome(self, status) -> bool:
         if status not in _VALID_OUTCOMES - {"staged"}:
             raise ValueError("invalid Kobo PATCH dispatch outcome")
         try:
-            new_path = _run_off_hub_bounded(
-                _mark_dispatch_outcome_blocking, self.path, status,
+            new_path, applied = _run_off_hub_bounded(
+                _mark_dispatch_outcome_blocking,
+                self.path,
+                self.spool_id,
+                self.attempt_id,
+                status,
             )
             self.path = Path(new_path)
-            return True
+            if not applied:
+                log.info(
+                    "Ignored stale Kobo PATCH recovery outcome spool_id=%s "
+                    "attempt_id=%s status=%s",
+                    self.spool_id, self.attempt_id, status,
+                )
+            return applied
         except (_SpoolNoRoom, _SpoolDeadlineExceeded, _SpoolUnavailable):
             log.error(
                 "Kobo PATCH recovery outcome update unavailable; preserving "
@@ -325,6 +366,36 @@ def _path_with_status(path, status):
             stem = stem[:-len(suffix)]
             break
     return path.with_name(f"{stem}-{status}.json.gz")
+
+
+def _identity_from_path(path):
+    stem = Path(path).name.removesuffix(".json.gz")
+    for status in _VALID_OUTCOMES:
+        suffix = f"-{status}"
+        if stem.endswith(suffix):
+            stem = stem[:-len(suffix)]
+            break
+    candidate = stem.rsplit("-", 1)[-1]
+    if len(candidate) != 64:
+        return None
+    try:
+        int(candidate, 16)
+    except ValueError:
+        return None
+    return candidate
+
+
+def _path_with_identity_and_status(path, identity, status):
+    path = Path(path)
+    if _identity_from_path(path) == identity:
+        return _path_with_status(path, status)
+    stem = path.name.removesuffix(".json.gz")
+    for known_status in _VALID_OUTCOMES:
+        suffix = f"-{known_status}"
+        if stem.endswith(suffix):
+            stem = stem[:-len(suffix)]
+            break
+    return path.with_name(f"{stem}-{identity}-{status}.json.gz")
 
 
 def _record_inventory(root):
@@ -514,7 +585,35 @@ def _install_record_locked(
         )
 
 
-def _write_new_record(spool_id, compressed, cancelled=None):
+def _same_replay_identity(record, incoming):
+    return all(
+        record.get(field) == incoming.get(field)
+        for field in _REPLAY_IDENTITY_FIELDS
+    )
+
+
+def _find_matching_replay_identity_locked(inventory, incoming):
+    matches = []
+    incoming_identity = incoming["replay_identity_sha256"]
+    for item in inventory:
+        disk_identity = _identity_from_path(item["path"])
+        if disk_identity is not None and disk_identity != incoming_identity:
+            continue
+        try:
+            record = _load_disk_record(item["path"])
+        except FileNotFoundError:
+            continue
+        except Exception:
+            # An unreadable record cannot be proven identical and must not
+            # absorb a different request. If unresolved, it remains protected
+            # by the normal admission policy.
+            continue
+        if _same_replay_identity(record, incoming):
+            matches.append((item["path"], record))
+    return matches
+
+
+def _write_or_reuse_record(incoming, compressed, cancelled=None):
     root = _spool_root()
     with _PROCESS_LOCK:
         _ensure_not_cancelled(cancelled)
@@ -523,20 +622,92 @@ def _write_new_record(spool_id, compressed, cancelled=None):
             _ensure_not_cancelled(cancelled)
             _recover_transactions_locked(root)
             inventory = _record_inventory(root)
-            victims = _select_victims(
-                inventory, incoming_bytes=len(compressed),
+            matches = _find_matching_replay_identity_locked(
+                inventory, incoming,
             )
-            path = root / (
-                f"patch-{time.time_ns():020d}-{spool_id}-staged.json.gz"
-            )
-            _schedule_retention(root, time.time() + MAX_AGE_SECONDS)
-            _install_record_locked(
-                path, compressed, victims=victims, cancelled=cancelled,
-            )
-    return path
+            if matches:
+                existing_path, existing = matches[0]
+                duplicate_paths = [path for path, _record in matches[1:]]
+                now = incoming["received_at"]
+                refreshed = dict(existing)
+                refreshed.update({
+                    "schema_version": max(2, int(existing.get("schema_version", 1))),
+                    "last_received_at": now,
+                    "dispatch_status": "staged",
+                    "dispatch_updated_at": now,
+                    "dispatch_attempt_id": incoming["dispatch_attempt_id"],
+                    "attempt_count": sum(
+                        int(record.get("attempt_count", 1))
+                        for _path, record in matches
+                    ) + 1,
+                    "replay_identity_sha256": incoming["replay_identity_sha256"],
+                })
+                compressed = _compress(refreshed)
+                deduplicated_inventory = [
+                    item for item in inventory
+                    if item["path"] not in duplicate_paths
+                ]
+                victims = _select_victims(
+                    deduplicated_inventory,
+                    incoming_bytes=len(compressed),
+                    replacing_path=existing_path,
+                )
+                victims = duplicate_paths + victims
+                path = _path_with_identity_and_status(
+                    existing_path,
+                    incoming["replay_identity_sha256"],
+                    "staged",
+                )
+                _schedule_retention(root, time.time() + MAX_AGE_SECONDS)
+                _install_record_locked(
+                    path,
+                    compressed,
+                    victims=victims,
+                    replacing_path=existing_path,
+                    cancelled=cancelled,
+                )
+                result = (
+                    refreshed["spool_id"],
+                    path,
+                    incoming["dispatch_attempt_id"],
+                    True,
+                )
+            else:
+                victims = _select_victims(
+                    inventory, incoming_bytes=len(compressed),
+                )
+                path = root / (
+                    f"patch-{time.time_ns():020d}-{incoming['spool_id']}-"
+                    f"{incoming['replay_identity_sha256']}-staged.json.gz"
+                )
+                _schedule_retention(root, time.time() + MAX_AGE_SECONDS)
+                _install_record_locked(
+                    path, compressed, victims=victims, cancelled=cancelled,
+                )
+                result = (
+                    incoming["spool_id"],
+                    path,
+                    incoming["dispatch_attempt_id"],
+                    False,
+                )
+    return result
 
 
-def _mark_dispatch_outcome_blocking(path, status, cancelled=None):
+def _find_record_path_by_spool_id_locked(root, spool_id):
+    for candidate in _record_paths(root):
+        try:
+            if _load_disk_record(candidate).get("spool_id") == spool_id:
+                return candidate
+        except FileNotFoundError:
+            continue
+        except Exception:
+            continue
+    return None
+
+
+def _mark_dispatch_outcome_blocking(
+    path, spool_id, attempt_id, status, cancelled=None,
+):
     path = Path(path)
     root = path.parent
     with _PROCESS_LOCK:
@@ -545,7 +716,15 @@ def _mark_dispatch_outcome_blocking(path, status, cancelled=None):
         with _locked_root(root):
             _ensure_not_cancelled(cancelled)
             _recover_transactions_locked(root)
+            if not path.exists():
+                path = _find_record_path_by_spool_id_locked(root, spool_id)
+                if path is None:
+                    raise FileNotFoundError(
+                        f"Kobo PATCH spool record not found: {spool_id}"
+                    )
             record = _load_disk_record(path)
+            if record.get("dispatch_attempt_id") != attempt_id:
+                return path, False
             record["dispatch_status"] = status
             record["dispatch_updated_at"] = datetime.now(timezone.utc).isoformat()
             compressed = _compress(record)
@@ -561,7 +740,7 @@ def _mark_dispatch_outcome_blocking(path, status, cancelled=None):
                 replacing_path=path,
                 cancelled=cancelled,
             )
-    return new_path
+    return new_path, True
 
 
 def _replace_record_locked(path, compressed, cancelled=None):

--- a/docs/kobo-reading-services-capture.md
+++ b/docs/kobo-reading-services-capture.md
@@ -64,10 +64,13 @@ This unauthenticated diagnostic has a separate directory and retention budget:
 <config>/.cwng-private-observability/kobo-reading-services-unauthenticated/
 ```
 
-It is capped at 32 records, 8 MiB compressed total, 24 hours, and 1 MiB for an
-individual body. Requests without a bounded `Content-Length` or beyond 1 MiB
-are refused normally but not read or captured. The diagnostic remains off by
-default; when it is off, the auth gate does not consume the request body.
+It is capped at 32 records, 8 MiB compressed total, and 1 MiB for an individual
+body. Records older than 24 hours are pruned when the next unauthenticated
+capture is persisted; 24 hours is therefore an age target, not a wall-clock
+maximum during a quiet period. Requests without a bounded `Content-Length` or
+beyond 1 MiB are refused normally but not read or captured. The diagnostic
+remains off by default; when it is off, the auth gate does not consume the
+request body.
 Unauthenticated churn therefore cannot evict authenticated exchange captures
 or any always-on recovery record.
 
@@ -84,11 +87,12 @@ diagnostic gate. Its records live at:
 
 The spool stores the exact raw body as base64 plus its byte length and SHA-256,
 the entitlement/user/origin-device identifiers needed to route a controlled
-replay, and one processing outcome: `staged`, `dispatch_exception`, or
-`dispatch_completed`. It never stores request headers. A completed record is
-retained too because completion of the route does not prove that every member
-commit succeeded. Replay is deliberately a server-side operator action; CWNG
-does not automatically reapply a PATCH or risk applying the same delta twice.
+replay, and one processing outcome: `staged`, `dispatch_refused`,
+`dispatch_exception`, or `dispatch_completed`. It never stores request headers.
+A completed record is retained too because completion of the route does not
+prove that every member commit succeeded. Replay is deliberately a server-side
+operator action; CWNG does not automatically reapply a PATCH or risk applying
+the same delta twice.
 `cps.services.kobo_patch_spool.iter_replay_candidates()` identifies definitely
 interrupted records and `load_spooled_patch(path)` verifies the stored length
 and digest before returning the original bytes.
@@ -100,11 +104,17 @@ the request waits at most 100 ms; timeout, lock contention, or any storage
 failure degrades to no new recovery record without changing the PATCH route.
 
 It is capped at 512 files, 64 MiB compressed total, 14 days, and 16 MiB per
-PATCH body. `staged` and `dispatch_exception` records are protected: when the
-only way to admit a new body would be to remove one, the new body is not
-staged. Evictable completed records are moved through a durable transaction so
-a failed new write restores the prior record set. A deadline-driven maintenance
-worker enforces the age limit even while no new PATCHes arrive. An oversized
+PATCH body. `staged`, `dispatch_refused`, and `dispatch_exception` records are
+protected: when the only way to admit a new body would be to remove one, the
+new body is not staged. Retries with the same user, entitlement, origin device, and exact body
+refresh one record regardless of the previous outcome; they do not consume
+additional slots. The refreshed record is protected until that attempt finishes.
+This identity rule also applies to bodies CWNG cannot parse or fully persist:
+the refusal remains replayable because complete persistence is unproven.
+Only completed records are evictable to admit distinct bodies.
+Evictable records are moved through a durable transaction so a failed new write
+restores the prior record set. A deadline-driven maintenance worker enforces
+the age limit even while no new PATCHes arrive. An oversized
 body or any storage failure is reported without body content and cannot change
 parsing, dispatch, the existing ownership-unknown 503, or the upstream response
 returned to the Kobo. The same repository, support-bundle, and external-backup

--- a/docs/kobo-reading-services-capture.md
+++ b/docs/kobo-reading-services-capture.md
@@ -26,8 +26,10 @@ a repository, issue attachment, or other shared artifact. External backup jobs
 that archive all of `/config` should explicitly exclude
 `.cwng-private-observability/`.
 
-Each schema-version-1 record contains:
+Each schema-version-2 record contains:
 
+- explicit request provenance (`authenticated`, `unauthenticated`, or
+  `not_recorded`) and a local user ID only when one was authenticated;
 - the device request body and redacted headers;
 - `checkforchanges` decisions in original array order, including ownership,
   observed authority state, and whether each ID was suppressed or proxied;
@@ -42,9 +44,32 @@ replaced with `***REDACTED***` in every leg.
 
 Retention is automatic and cross-process locked: at most 256 records, 64 MiB
 compressed total, seven days, and 16 MiB for any individual body. An exchange
-above the body limit is skipped whole rather than saved partially. Any observer
-or storage failure is logged only with structural metadata and cannot replace,
-delay with retries, or change the response being observed.
+above the body limit is skipped whole rather than saved partially. Blocking
+capture storage runs outside the gevent hub with a 100 ms request deadline.
+Any observer or storage failure is logged only with structural metadata and
+cannot replace, retry, or change the response being observed.
+
+### Unauthenticated annotation PATCH refusals
+
+When the private-data gate is enabled, an annotation PATCH refused with 401 is
+captured before the refusal. Its record is explicitly marked
+`authentication: unauthenticated` and `user_id: null`; the route does not guess
+an owner from entitlement IDs, device headers, cookies, or request metadata.
+The request is never admitted to the recovery spool because there is no safe
+replay principal and unresolved spool records are intentionally non-evictable.
+
+This unauthenticated diagnostic has a separate directory and retention budget:
+
+```text
+<config>/.cwng-private-observability/kobo-reading-services-unauthenticated/
+```
+
+It is capped at 32 records, 8 MiB compressed total, 24 hours, and 1 MiB for an
+individual body. Requests without a bounded `Content-Length` or beyond 1 MiB
+are refused normally but not read or captured. The diagnostic remains off by
+default; when it is off, the auth gate does not consume the request body.
+Unauthenticated churn therefore cannot evict authenticated exchange captures
+or any always-on recovery record.
 
 ## Annotation PATCH recovery spool
 

--- a/notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md
+++ b/notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md
@@ -618,9 +618,11 @@ on, and throwing.
 captured only while the same explicit private-data gate is enabled. The schema-version-2 record is
 marked `authentication='unauthenticated'` with `user_id=null`; CWNG does not infer an owner. These
 records never enter the always-on recovery spool. They use a separate mode-0700 directory and
-independent locks capped at 32 records, 8 MiB compressed, 24 hours, and 1 MiB per body. A missing or
-out-of-bound `Content-Length` is not read. Thus unauthenticated traffic cannot consume the
-non-evictable recovery budget or evict authenticated exchange diagnostics.
+independent locks capped at 32 records, 8 MiB compressed, and 1 MiB per body. Records older than 24
+hours are pruned on the next unauthenticated capture write, so 24 hours is an age target rather than
+a wall-clock maximum during a quiet period. A missing or out-of-bound `Content-Length` is not read.
+Thus unauthenticated traffic cannot consume the non-evictable recovery budget or evict authenticated
+exchange diagnostics.
 
 **[OBSERVED — IMPLEMENTED 2026-08-23]** Annotation PATCH has a separate always-on recovery spool.
 The exact raw request body is atomically written and fsynced before JSON parsing, ownership
@@ -629,6 +631,11 @@ changing the response sent to Nickel. Records contain no headers, use the same p
 parent and mode-0600 files, and are bounded to 512 records, 64 MiB compressed, 14 days, and 16 MiB
 per body. Normal-return records remain during retention because return from the dispatcher is not
 proof that every member committed. Replay is manual and integrity-checked; it is not automatic.
+Unresolved records are never evicted to admit a distinct body. Retries with the same user,
+entitlement, origin device, and exact raw bytes atomically refresh one record regardless of its
+previous outcome, so repeated delivery cannot consume the instance-wide spool one slot at a time.
+An unresolved outcome means complete persistence is unproven; it does not assert that SQLite
+stored nothing, because SAVEPOINT writes may survive a later outer rollback on the current engine.
 This implements F-5c1146 addendum point (2). The finding's response-code/failed-member half remains
 open until the independent PATCH failure hardware experiment completes.
 

--- a/notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md
+++ b/notes/KOBO-TWO-WAY-ANNOTATION-SYNC-DESIGN.md
@@ -610,8 +610,17 @@ annotation text exists only inside mode-0600 gzip records under the mode-0700 pr
 `<config>/.cwng-private-observability/kobo-reading-services/`. The directory is not part of the
 annotation backup format or the support debug bundle. Retention is bounded to 256 records, 64 MiB
 compressed, seven days, and 16 MiB for any one body. Capture finalization is an after-response
-observer, storage exceptions are swallowed, and executed route tests prove identical status,
-headers, and body with the gate off, on, and throwing.
+observer, storage runs off the gevent hub with a 100 ms request deadline, storage exceptions are
+swallowed, and executed route tests prove identical status, headers, and body with the gate off,
+on, and throwing.
+
+**[OBSERVED — IMPLEMENTED 2026-08-24]** An annotation PATCH refused before authentication can be
+captured only while the same explicit private-data gate is enabled. The schema-version-2 record is
+marked `authentication='unauthenticated'` with `user_id=null`; CWNG does not infer an owner. These
+records never enter the always-on recovery spool. They use a separate mode-0700 directory and
+independent locks capped at 32 records, 8 MiB compressed, 24 hours, and 1 MiB per body. A missing or
+out-of-bound `Content-Length` is not read. Thus unauthenticated traffic cannot consume the
+non-evictable recovery budget or evict authenticated exchange diagnostics.
 
 **[OBSERVED — IMPLEMENTED 2026-08-23]** Annotation PATCH has a separate always-on recovery spool.
 The exact raw request body is atomically written and fsynced before JSON parsing, ownership

--- a/tests/unit/test_1660_kobo_checkforchanges_filter.py
+++ b/tests/unit/test_1660_kobo_checkforchanges_filter.py
@@ -439,59 +439,157 @@ def test_patch_ownership_unknown_is_visible_and_not_proxied(app, monkeypatch, ca
     assert OWNED in caplog.text
 
 
-def test_patch_non_object_body_is_rejected_locally_and_still_proxies(
+def test_patch_non_object_body_is_refused_without_upstream_acknowledgement(
+    app, monkeypatch, caplog,
+):
+    monkeypatch.setattr(
+        rs, "resolve_entitlement_ownership",
+        lambda _content_id: SimpleNamespace(id=347, title="Flatland", identifiers=[]),
+    )
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("a non-object PATCH must not be acknowledged upstream"),
+    )
+    monkeypatch.setattr(
+        rs, "current_user", SimpleNamespace(id=7, name="test-user", is_authenticated=True),
+    )
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations", method="PATCH",
+        json=["not", "an", "object"],
+    ), caplog.at_level("WARNING"):
+        response = _view(rs.handle_annotations)(OWNED)
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "error": "Annotation capture temporarily unavailable",
+    }
+    assert "PATCH body is not a JSON object" in caplog.text
+
+
+def test_patch_non_object_body_for_confirmed_unowned_content_still_proxies(
+    app, monkeypatch,
+):
+    sentinel = object()
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: None)
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+
+    with app.test_request_context(
+        f"/api/v3/content/{FOREIGN}/annotations", method="PATCH",
+        json=["not", "an", "object"],
+    ):
+        assert _view(rs.handle_annotations)(FOREIGN) is sentinel
+
+
+def test_patch_non_list_annotation_batch_reaches_dispatcher_and_is_refused(
     app, monkeypatch, caplog,
 ):
     from cps.services import annotation_sync
 
-    sentinel = object()
     dispatched = []
     monkeypatch.setattr(
         rs, "resolve_entitlement_ownership",
         lambda _content_id: SimpleNamespace(id=347, title="Flatland", identifiers=[]),
     )
     monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("a non-list annotation batch must not be acknowledged upstream"),
+    )
     monkeypatch.setattr(
         rs, "current_user", SimpleNamespace(id=7, name="test-user", is_authenticated=True),
     )
     monkeypatch.setattr(
         annotation_sync, "dispatch_annotation_sync",
-        lambda *args, **kwargs: dispatched.append((args, kwargs)),
+        lambda batch, *_args, **_kwargs: dispatched.append(batch) or False,
     )
     with app.test_request_context(
         f"/api/v3/content/{OWNED}/annotations", method="PATCH",
-        json=["not", "an", "object"],
-    ), caplog.at_level("WARNING"):
-        assert _view(rs.handle_annotations)(OWNED) is sentinel
+        json={"updatedAnnotations": {"id": "not-a-list"}},
+    ), caplog.at_level("ERROR"):
+        response = _view(rs.handle_annotations)(OWNED)
 
-    assert dispatched == []
-    assert "PATCH body is not a JSON object" in caplog.text
+    assert dispatched == [{"id": "not-a-list"}]
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "error": "Annotation capture temporarily unavailable",
+    }
+    assert "not fully persisted" in caplog.text
 
 
-def test_patch_non_list_annotation_batch_is_rejected_without_breaking_proxy(
-    app, monkeypatch, caplog,
+@pytest.mark.parametrize(
+    "raw_body",
+    [
+        b'["not","an","object"]',
+        b'{"updatedAnnotations":{"id":"not-a-list"}}',
+    ],
+)
+def test_registered_annotation_patch_route_returns_retryable_refusal(
+    monkeypatch, raw_body,
 ):
-    from cps.services import annotation_sync
+    app = Flask(__name__)
+    app.register_blueprint(rs.readingservices_api_v3)
+    book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs.config, "config_kobo_sync", True, raising=False)
+    monkeypatch.setattr(
+        rs, "current_user", SimpleNamespace(
+            id=7, name="test-user", is_authenticated=True,
+        ),
+    )
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "cps.services.device_registry.register_kobo_device_best_effort",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: pytest.fail("malformed local data reached the upstream proxy"),
+    )
 
+    response = app.test_client().patch(
+        f"/api/v3/content/{OWNED}/annotations",
+        data=raw_body,
+        content_type="application/json",
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "error": "Annotation capture temporarily unavailable",
+    }
+
+
+@pytest.mark.parametrize(
+    "raw_body",
+    [
+        b"",
+        b" \r\n\t",
+        b"{}",
+        b'{"updatedAnnotations":[],"deletedAnnotationIds":[]}',
+    ],
+)
+def test_empty_and_object_noop_patch_bodies_still_proxy(
+    app, monkeypatch, raw_body,
+):
     sentinel = object()
     monkeypatch.setattr(
         rs, "resolve_entitlement_ownership",
         lambda _content_id: SimpleNamespace(id=347, title="Flatland", identifiers=[]),
     )
     monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
     monkeypatch.setattr(
         rs, "current_user", SimpleNamespace(id=7, name="test-user", is_authenticated=True),
     )
-    monkeypatch.setattr(
-        annotation_sync, "dispatch_annotation_sync",
-        lambda *_args, **_kwargs: pytest.fail("non-list batch reached dispatcher"),
-    )
+
     with app.test_request_context(
         f"/api/v3/content/{OWNED}/annotations", method="PATCH",
-        json={"updatedAnnotations": {"id": "not-a-list"}},
-    ), caplog.at_level("WARNING"):
+        data=raw_body, content_type="application/json",
+    ):
         assert _view(rs.handle_annotations)(OWNED) is sentinel
-
-    assert "expected a list" in caplog.text

--- a/tests/unit/test_1660_kobo_checkforchanges_filter.py
+++ b/tests/unit/test_1660_kobo_checkforchanges_filter.py
@@ -521,6 +521,195 @@ def test_patch_non_list_annotation_batch_reaches_dispatcher_and_is_refused(
     assert "not fully persisted" in caplog.text
 
 
+def test_null_update_batch_preserves_deletes_and_upstream_proxy(
+    app, monkeypatch,
+):
+    from cps.services import annotation_sync
+
+    book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
+    user = SimpleNamespace(id=7, name="test-user", is_authenticated=True)
+    deleted = []
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "current_user", user)
+    monkeypatch.setattr(
+        annotation_sync,
+        "dispatch_annotation_sync",
+        lambda *_args, **_kwargs: pytest.fail(
+            "a null update set contains no annotation to dispatch"
+        ),
+    )
+    monkeypatch.setattr(
+        annotation_sync,
+        "dispatch_annotation_deletes",
+        lambda *args, **kwargs: deleted.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        rs,
+        "proxy_to_kobo_reading_services",
+        lambda: make_response(jsonify({"upstream": "accepted"}), 207),
+    )
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations",
+        method="PATCH",
+        data=(
+            b'{"updatedAnnotations":null,'
+            b'"deletedAnnotationIds":["ghost-annotation-1"]}'
+        ),
+        content_type="application/json",
+    ):
+        response = _view(rs.handle_annotations)(OWNED)
+
+    assert response.status_code == 207
+    assert deleted == [(
+        (["ghost-annotation-1"], user),
+        {"book_id": book.id, "deletable_sources": {"kobo"}},
+    )]
+
+
+def test_valid_json_annotation_batch_is_parsed_without_json_content_type(
+    app, monkeypatch,
+):
+    from cps.services import annotation_sync
+
+    sentinel = object()
+    book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
+    user = SimpleNamespace(id=7, name="test-user", is_authenticated=True)
+    annotation = {"id": "annotation-1", "type": "highlight"}
+    dispatched = []
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "current_user", user)
+    monkeypatch.setattr(
+        annotation_sync,
+        "dispatch_annotation_sync",
+        lambda *args, **kwargs: dispatched.append((args, kwargs)) or True,
+    )
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations",
+        method="PATCH",
+        data=json.dumps({"updatedAnnotations": [annotation]}).encode(),
+        content_type="text/plain",
+    ):
+        assert _view(rs.handle_annotations)(OWNED) is sentinel
+
+    [(args, kwargs)] = dispatched
+    assert args == ([annotation], book, user)
+    assert kwargs["origin_device_id"] is None
+
+
+def test_valid_update_and_delete_batch_preserves_dispatch_order(app, monkeypatch):
+    from cps.services import annotation_sync
+
+    sentinel = object()
+    book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
+    events = []
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        rs, "current_user", SimpleNamespace(id=7, name="test-user", is_authenticated=True),
+    )
+    monkeypatch.setattr(
+        annotation_sync,
+        "dispatch_annotation_sync",
+        lambda *_args, **_kwargs: events.append("update") or True,
+    )
+    monkeypatch.setattr(
+        annotation_sync,
+        "dispatch_annotation_deletes",
+        lambda *_args, **_kwargs: events.append("delete"),
+    )
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations",
+        method="PATCH",
+        json={
+            "updatedAnnotations": [{"id": "annotation-1"}],
+            "deletedAnnotationIds": ["annotation-1"],
+        },
+    ):
+        assert _view(rs.handle_annotations)(OWNED) is sentinel
+
+    assert events == ["update", "delete"]
+
+
+def test_non_object_refusal_remains_one_replay_candidate_across_retries(
+    app, monkeypatch, tmp_path,
+):
+    from cps.services import kobo_patch_spool as spool
+
+    root = tmp_path / "recovery-spool"
+    book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
+    user = SimpleNamespace(id=7, name="test-user", is_authenticated=True)
+    monkeypatch.setattr(spool, "_spool_root", lambda: root)
+    monkeypatch.setattr(spool, "MAX_FILES", 2)
+    monkeypatch.setattr(spool, "MAX_TOTAL_BYTES", 1024 * 1024)
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "current_user", user)
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: object())
+
+    raw_body = b'["not","an","object"]'
+    for _attempt in range(5):
+        with app.test_request_context(
+            f"/api/v3/content/{OWNED}/annotations",
+            method="PATCH",
+            data=raw_body,
+            content_type="application/json",
+        ):
+            response = _view(rs.handle_annotations)(OWNED)
+        assert response.status_code == 503
+
+    [path] = root.glob("patch-*.json.gz")
+    record = spool.load_spooled_patch(path)
+    assert record["body"] == raw_body
+    assert record["attempt_count"] == 5
+    assert record["dispatch_status"] == "dispatch_refused"
+    assert spool.is_replay_candidate(record["dispatch_status"]) is True
+
+
+def test_unpersisted_annotation_batch_remains_replayable_after_refusal(
+    app, monkeypatch, tmp_path,
+):
+    from cps.services import annotation_sync
+    from cps.services import kobo_patch_spool as spool
+
+    root = tmp_path / "recovery-spool"
+    book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
+    monkeypatch.setattr(spool, "_spool_root", lambda: root)
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        rs, "current_user", SimpleNamespace(id=7, name="test-user", is_authenticated=True),
+    )
+    monkeypatch.setattr(annotation_sync, "dispatch_annotation_sync", lambda *_a, **_k: False)
+
+    raw_body = b'{"updatedAnnotations":[{"id":"annotation-1"}]}'
+    for _attempt in range(5):
+        with app.test_request_context(
+            f"/api/v3/content/{OWNED}/annotations",
+            method="PATCH",
+            data=raw_body,
+            content_type="application/json",
+        ):
+            response = _view(rs.handle_annotations)(OWNED)
+        assert response.status_code == 503
+
+    [path] = root.glob("patch-*.json.gz")
+    record = spool.load_spooled_patch(path)
+    assert record["body"] == raw_body
+    assert record["attempt_count"] == 5
+    assert record["dispatch_status"] == "dispatch_refused"
+    assert spool.is_replay_candidate(record["dispatch_status"]) is True
+
+
 @pytest.mark.parametrize(
     "raw_body",
     [

--- a/tests/unit/test_annotation_sync_dispatcher.py
+++ b/tests/unit/test_annotation_sync_dispatcher.py
@@ -94,6 +94,15 @@ def test_dispatch_creates_annotation_and_sync_target(patched_session):
     assert targets[0].target_record_id == "r1"
 
 
+@pytest.mark.parametrize("batch", [None, {}, {"id": "not-a-list"}, "not-a-list"])
+def test_dispatch_refuses_every_non_list_batch_before_empty_shortcut(
+    patched_session, batch,
+):
+    _session, user = patched_session
+
+    assert dispatch_annotation_sync(batch, _book(), user) is False
+
+
 def test_dispatch_updates_existing_annotation(patched_session):
     s, user = patched_session
     register_handler(StubHandler())

--- a/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
+++ b/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
@@ -776,3 +776,143 @@ def test_unreadable_patch_body_still_refuses_but_unreadable_get_body_does_not(
 
     get_response = app.test_client().get(f"/annotations/{BOOK_UUID}")
     assert get_response.status_code != 503
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("unresolved_status", ["staged", "dispatch_exception", "dispatch_refused"])
+def test_full_spool_never_evicts_any_unresolved_status(
+    monkeypatch, tmp_path, unresolved_status,
+):
+    """Eviction protection is pinned for EVERY unresolved status, not just `staged`.
+
+    Raised by the cross-family review of #1861: making `dispatch_refused`
+    evictable in `_select_victims` passed the entire suite, because the only
+    protection test staged a record and left it `staged`. That is a one-line
+    regression of this subsystem's headline invariant — a contributor
+    "relieving spool pressure" would silently collect the only copy of a body
+    the device still believes undelivered, which is the exact data-loss class
+    the spool exists to prevent.
+
+    `dispatch_refused` in particular must stay protected: it means the batch
+    was refused with nothing persisted, so the body genuinely is a replay
+    candidate (#1869).
+    """
+    spool, root = _root(monkeypatch, tmp_path)
+    monkeypatch.setattr(spool, "MAX_FILES", 1)
+    monkeypatch.setattr(spool, "MAX_TOTAL_BYTES", 1024 * 1024)
+
+    first = spool.stage_patch(
+        raw_body=b'{"updatedAnnotations":[{"id":"must-survive"}]}',
+        entitlement_id="book-first", user_id=7, origin_device_id=None,
+    )
+    assert first is not None
+    if unresolved_status != "staged":
+        # mark_dispatch_outcome rewrites the record under a new status-bearing
+        # filename and updates the ticket's own path.
+        first.mark_dispatch_outcome(unresolved_status)
+    surviving = first.path
+    assert spool.load_spooled_patch(surviving)["dispatch_status"] == unresolved_status
+
+    second = spool.stage_patch(
+        raw_body=b'{"updatedAnnotations":[{"id":"new-arrival"}]}',
+        entitlement_id="book-second", user_id=7, origin_device_id=None,
+    )
+
+    assert surviving.exists(), (
+        f"a {unresolved_status} record was evicted to admit a different body; "
+        "it is the only surviving copy of a PATCH the device believes delivered"
+    )
+    assert second is None, (
+        "the new record must fail open while only unresolved records remain"
+    )
+    assert len(list(root.glob("patch-*.json.gz"))) == 1
+
+
+@pytest.mark.unit
+def test_retention_schedule_failure_happens_before_the_REUSE_record_commit(
+    monkeypatch, tmp_path,
+):
+    """The same ordering, pinned at the reuse site rather than the new-record one.
+
+    Raised by the cross-family review of #1861: `_write_or_reuse_record` has TWO
+    `_install_record_locked` sites since the replay-identity rewrite, and the
+    existing ordering test stages only once, so it instruments the new-record
+    site alone. Moving `_schedule_retention` after the install at the *reuse*
+    site passed the whole suite.
+
+    The invariant is #1860's: a timer-creation failure must abort BEFORE the
+    record commits, or the caller is told no recovery record exists while an
+    unexpiring one sits on disk. A retry of an identical body takes the reuse
+    path, so it needs its own pin.
+    """
+    spool, root = _root(monkeypatch, tmp_path)
+
+    first = spool.stage_patch(
+        raw_body=RAW_PATCH, entitlement_id=BOOK_UUID,
+        user_id=7, origin_device_id=None,
+    )
+    assert first is not None
+    before = spool.load_spooled_patch(first.path)
+
+    def _fail_schedule(*_args, **_kwargs):
+        raise RuntimeError("simulated timer creation failure")
+
+    monkeypatch.setattr(spool, "_schedule_retention", _fail_schedule)
+    retry = spool.stage_patch(
+        raw_body=RAW_PATCH, entitlement_id=BOOK_UUID,
+        user_id=7, origin_device_id=None,
+    )
+
+    assert retry is None, "a failed retention schedule must not yield a ticket"
+    survivors = list(root.glob("patch-*.json.gz"))
+    assert len(survivors) == 1, (
+        "the reuse path committed a record despite the scheduler failing"
+    )
+    after = spool.load_spooled_patch(survivors[0])
+    assert after["attempt_count"] == before["attempt_count"], (
+        "the reuse path refreshed the record before its retention timer existed"
+    )
+
+
+@pytest.mark.unit
+def test_a_filename_digest_match_does_not_merge_a_different_body(monkeypatch, tmp_path):
+    """The filename digest is a lookup key; identity is decided on every field.
+
+    Raised by the cross-family review of #1861: skipping the
+    `_same_replay_identity` re-comparison and trusting the filename digest
+    passed the whole suite. The merge keeps the EXISTING record's body, so a
+    filename/content mismatch would silently discard the incoming one — and
+    the PR advertises "every field is compared before merging".
+
+    Only reachable through on-disk corruption that preserves a filename, or a
+    SHA-256 collision. Pinned anyway, because the guard is one `if` and the
+    thing it protects is the only copy of somebody's annotations.
+    """
+    import base64
+    import gzip
+    import json
+
+    spool, root = _root(monkeypatch, tmp_path)
+
+    first = spool.stage_patch(
+        raw_body=RAW_PATCH, entitlement_id=BOOK_UUID,
+        user_id=7, origin_device_id=None,
+    )
+    assert first is not None
+
+    # Corrupt the body in place, keeping the filename — and therefore the
+    # identity digest the lookup keys on — exactly as it was.
+    record = json.loads(gzip.decompress(first.path.read_bytes()))
+    record["body_base64"] = base64.b64encode(b'{"updatedAnnotations":[{"id":"different"}]}').decode()
+    first.path.write_bytes(spool._compress(record))
+
+    retry = spool.stage_patch(
+        raw_body=RAW_PATCH, entitlement_id=BOOK_UUID,
+        user_id=7, origin_device_id=None,
+    )
+
+    assert retry is not None, "the retry must still be staged"
+    assert len(list(root.glob("patch-*.json.gz"))) == 2, (
+        "the retry merged into a record whose body differs — the filename "
+        "digest was trusted instead of comparing the identity fields"
+    )

--- a/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
+++ b/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
@@ -120,10 +120,11 @@ def test_dispatch_exception_spools_the_body_and_still_refuses_to_acknowledge(
 ):
     """The spool must not soften the #1825 refusal.
 
-    Spooling makes a lost delta recoverable server-side, which is why the
-    response code matters less than it did.  It does not make the PATCH stored,
-    so CWNG must still answer 503 rather than let the device retire a delta it
-    will never re-send.  Asserting 207 here would silently revert F-5c1146.
+    Spooling makes an unresolved delta recoverable server-side. It does not
+    prove the whole PATCH was stored: SQLite savepoint writes may survive a
+    later rollback, while other members may still be missing. CWNG must answer
+    503 rather than let the device retire a delta that needs reconciliation.
+    Asserting 207 here would silently revert F-5c1146.
     """
     spool, root = _root(monkeypatch, tmp_path)
 
@@ -147,7 +148,7 @@ def test_dispatch_exception_spools_the_body_and_still_refuses_to_acknowledge(
 
 
 @pytest.mark.unit
-def test_parse_exception_still_leaves_staged_replay_candidate(monkeypatch, tmp_path):
+def test_parse_exception_still_leaves_replay_candidate(monkeypatch, tmp_path):
     spool, root = _root(monkeypatch, tmp_path)
     app = _app(monkeypatch, dispatch=lambda *_args, **_kwargs: None)
     original = app.request_class.get_json
@@ -162,12 +163,42 @@ def test_parse_exception_still_leaves_staged_replay_candidate(monkeypatch, tmp_p
     )
     monkeypatch.setattr(app.request_class, "get_json", original)
 
-    # Same contract as the dispatch-exception case: the body is recoverable, but
-    # nothing was stored, so the device must not be told the delta landed.
+    # Same contract as the dispatch-exception case: the body is recoverable,
+    # but complete persistence is unproven, so the device must not be told the
+    # delta landed.
     assert response.status_code == 503
     [(_path, record)] = _records(spool, root)
     assert record["body"] == RAW_PATCH
     assert record["dispatch_status"] == "dispatch_exception"
+
+
+@pytest.mark.unit
+def test_finalizer_marks_ticket_when_view_raises_past_exception_handler(
+    monkeypatch, tmp_path,
+):
+    spool, root = _root(monkeypatch, tmp_path)
+    app = _app(monkeypatch, dispatch=lambda *_args, **_kwargs: None)
+
+    class EscapesViewHandler(BaseException):
+        pass
+
+    def _escape(_content_id):
+        raise EscapesViewHandler("outside the view's Exception handler")
+
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", _escape)
+    with app.test_request_context(
+        f"/annotations/{BOOK_UUID}",
+        method="PATCH",
+        data=RAW_PATCH,
+        content_type="application/json",
+    ):
+        with pytest.raises(EscapesViewHandler):
+            rs.handle_annotations.__wrapped__(BOOK_UUID)
+
+    [(path, record)] = _records(spool, root)
+    assert record["body"] == RAW_PATCH
+    assert record["dispatch_status"] == "dispatch_exception"
+    assert list(spool.iter_replay_candidates()) == [path]
 
 
 @pytest.mark.unit
@@ -193,7 +224,7 @@ def test_spool_failure_cannot_change_patch_response_or_dispatch(monkeypatch, tmp
 
 
 @pytest.mark.unit
-def test_existing_ownership_unknown_503_is_unchanged_and_body_is_spooled(
+def test_existing_ownership_unknown_503_is_unchanged_and_body_remains_replayable(
     monkeypatch, tmp_path,
 ):
     spool, root = _root(monkeypatch, tmp_path)
@@ -213,15 +244,181 @@ def test_existing_ownership_unknown_503_is_unchanged_and_body_is_spooled(
         lambda **_kwargs: pytest.fail("the existing 503 branch must not proxy"),
     )
 
-    response = app.test_client().patch(
-        f"/annotations/{BOOK_UUID}", data=RAW_PATCH, content_type="application/json",
+    for _attempt in range(5):
+        response = app.test_client().patch(
+            f"/annotations/{BOOK_UUID}",
+            data=RAW_PATCH,
+            content_type="application/json",
+        )
+        assert response.status_code == 503
+        assert response.get_json() == {
+            "error": "Annotation capture temporarily unavailable",
+        }
+
+    records = _records(spool, root)
+    assert len(records) == 1, "one unchanged body must occupy one replay slot"
+    [(_path, record)] = records
+    assert record["body"] == RAW_PATCH
+    assert record["dispatch_status"] == "dispatch_refused"
+    assert spool.is_replay_candidate(record["dispatch_status"]) is True
+    assert record["attempt_count"] == 5
+
+
+@pytest.mark.unit
+def test_unpersisted_retry_loop_deduplicates_and_cannot_starve_another_user(
+    monkeypatch, tmp_path,
+):
+    spool, root = _root(monkeypatch, tmp_path)
+    monkeypatch.setattr(spool, "MAX_FILES", 3)
+    monkeypatch.setattr(spool, "MAX_TOTAL_BYTES", 1024 * 1024)
+    app = _app(monkeypatch, dispatch=lambda *_args, **_kwargs: False)
+
+    for _attempt in range(5):
+        response = app.test_client().patch(
+            f"/annotations/{BOOK_UUID}",
+            data=RAW_PATCH,
+            content_type="application/json",
+        )
+        assert response.status_code == 503
+
+    first_user_records = _records(spool, root)
+    assert len(first_user_records) == 1
+    assert first_user_records[0][1]["attempt_count"] == 5
+    assert first_user_records[0][1]["dispatch_status"] == "dispatch_refused"
+
+    other_body = b'{"updatedAnnotations":[{"id":"other-user"}]}'
+    other_user = spool.stage_patch(
+        raw_body=other_body,
+        entitlement_id="other-book",
+        user_id=99,
+        origin_device_id="other-device",
     )
 
-    assert response.status_code == 503
-    assert response.get_json() == {"error": "Annotation capture temporarily unavailable"}
+    assert other_user is not None, "one client's retries starved another tenant"
+    records = _records(spool, root)
+    assert len(records) == 2
+    assert {(record["user_id"], record["body"]) for _path, record in records} == {
+        (7, RAW_PATCH),
+        (99, other_body),
+    }
+
+
+@pytest.mark.unit
+def test_retry_identity_includes_scope_and_exact_body(monkeypatch, tmp_path):
+    spool, root = _root(monkeypatch, tmp_path)
+
+    first = spool.stage_patch(
+        raw_body=RAW_PATCH,
+        entitlement_id=BOOK_UUID,
+        user_id=7,
+        origin_device_id="device-a",
+    )
+    exact_retry = spool.stage_patch(
+        raw_body=RAW_PATCH,
+        entitlement_id=BOOK_UUID,
+        user_id=7,
+        origin_device_id="device-a",
+    )
+    other_user = spool.stage_patch(
+        raw_body=RAW_PATCH,
+        entitlement_id=BOOK_UUID,
+        user_id=99,
+        origin_device_id="device-a",
+    )
+    other_body = spool.stage_patch(
+        raw_body=RAW_PATCH + b" ",
+        entitlement_id=BOOK_UUID,
+        user_id=7,
+        origin_device_id="device-a",
+    )
+
+    assert all(ticket is not None for ticket in (first, exact_retry, other_user, other_body))
+    assert exact_retry.spool_id == first.spool_id
+    assert other_user.spool_id != first.spool_id
+    assert other_body.spool_id != first.spool_id
+    assert len(_records(spool, root)) == 3
+
+
+@pytest.mark.unit
+def test_same_identity_reuses_completed_record_for_a_later_attempt(
+    monkeypatch, tmp_path,
+):
+    spool, root = _root(monkeypatch, tmp_path)
+    first = spool.stage_patch(
+        raw_body=RAW_PATCH, entitlement_id=BOOK_UUID,
+        user_id=7, origin_device_id=None,
+    )
+    assert first is not None
+    assert first.mark_dispatch_outcome("dispatch_completed") is True
+
+    retry = spool.stage_patch(
+        raw_body=RAW_PATCH, entitlement_id=BOOK_UUID,
+        user_id=7, origin_device_id=None,
+    )
+
+    assert retry is not None
+    assert retry.spool_id == first.spool_id
     [(_path, record)] = _records(spool, root)
-    assert record["body"] == RAW_PATCH
     assert record["dispatch_status"] == "staged"
+    assert record["attempt_count"] == 2
+
+
+@pytest.mark.unit
+def test_retry_consolidates_legacy_duplicate_records(monkeypatch, tmp_path):
+    spool, root = _root(monkeypatch, tmp_path)
+    root.mkdir(parents=True)
+    now = spool.datetime.now(spool.timezone.utc).isoformat()
+    encoded = spool.base64.b64encode(RAW_PATCH).decode("ascii")
+    for index in range(3):
+        record = {
+            "schema_version": 1,
+            "spool_id": f"{index:032x}",
+            "received_at": now,
+            "entitlement_id": BOOK_UUID,
+            "user_id": 7,
+            "origin_device_id": None,
+            "body_encoding": "base64",
+            "body_length": len(RAW_PATCH),
+            "body_sha256": spool.sha256_bytes(RAW_PATCH),
+            "body_base64": encoded,
+            "dispatch_status": "dispatch_exception",
+            "dispatch_updated_at": now,
+        }
+        path = root / (
+            f"patch-{index:020d}-{record['spool_id']}-dispatch_exception.json.gz"
+        )
+        spool._replace_record_locked(path, spool._compress(record))
+
+    retry = spool.stage_patch(
+        raw_body=RAW_PATCH, entitlement_id=BOOK_UUID,
+        user_id=7, origin_device_id=None,
+    )
+
+    assert retry is not None
+    [(path, record)] = _records(spool, root)
+    assert spool._identity_from_path(path) == record["replay_identity_sha256"]
+    assert record["attempt_count"] == 4
+    assert record["dispatch_status"] == "staged"
+
+
+@pytest.mark.unit
+def test_older_overlapping_retry_cannot_overwrite_newer_outcome(monkeypatch, tmp_path):
+    spool, root = _root(monkeypatch, tmp_path)
+    first = spool.stage_patch(
+        raw_body=RAW_PATCH, entitlement_id=BOOK_UUID,
+        user_id=7, origin_device_id=None,
+    )
+    second = spool.stage_patch(
+        raw_body=RAW_PATCH, entitlement_id=BOOK_UUID,
+        user_id=7, origin_device_id=None,
+    )
+
+    assert first is not None and second is not None
+    assert first.spool_id == second.spool_id
+    assert first.mark_dispatch_outcome("dispatch_exception") is False
+    assert second.mark_dispatch_outcome("dispatch_completed") is True
+    [(_path, record)] = _records(spool, root)
+    assert record["dispatch_status"] == "dispatch_completed"
 
 
 @pytest.mark.unit
@@ -499,6 +696,7 @@ def test_replay_candidate_predicate_distinguishes_completed_from_lost():
     spool = _module()
     assert spool.is_replay_candidate("staged") is True
     assert spool.is_replay_candidate("dispatch_exception") is True
+    assert spool.is_replay_candidate("dispatch_refused") is True
     assert spool.is_replay_candidate("dispatch_completed") is False
 
 

--- a/tests/unit/test_kobo_reading_services_exchange_capture.py
+++ b/tests/unit/test_kobo_reading_services_exchange_capture.py
@@ -9,8 +9,10 @@ import importlib
 import json
 import os
 import stat
+import time
 from types import SimpleNamespace
 
+import gevent
 import pytest
 from flask import Flask, jsonify, request
 
@@ -282,6 +284,166 @@ def test_capture_enabled_and_capture_failure_leave_response_byte_identical(monke
     )
     failed = app.test_client().post("/api/v3/content/checkforchanges", json=payload)
     assert (failed.status_code, failed.get_data(), list(failed.headers.items())) == baseline_triplet
+
+
+@pytest.mark.unit
+def test_unauthenticated_patch_401_captures_body_with_explicit_provenance_outside_spool(
+    monkeypatch, tmp_path,
+):
+    capture = _module()
+    unauthenticated_root = tmp_path / "unauthenticated-exchange-captures"
+    recovery_spool_root = tmp_path / "recovery-spool-must-stay-empty"
+    monkeypatch.setenv(capture.ENABLE_ENV, ACK)
+    monkeypatch.setattr(
+        capture, "_unauthenticated_capture_root",
+        lambda: unauthenticated_root,
+        raising=False,
+    )
+    from cps.services import kobo_patch_spool
+    monkeypatch.setattr(kobo_patch_spool, "_spool_root", lambda: recovery_spool_root)
+    monkeypatch.setattr(rs.config, "config_kobo_sync", True, raising=False)
+    monkeypatch.setattr(
+        rs, "current_user", SimpleNamespace(is_authenticated=False, id=None),
+    )
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("the refused PATCH must not be sent upstream"),
+    )
+    raw_body = b'{"updatedAnnotations":[{"id":"annotation-1","noteText":"private"}]}'
+    app = Flask(__name__)
+
+    @app.patch("/api/v3/content/<content_id>/annotations")
+    @rs.requires_reading_services_auth_and_config
+    def annotations(content_id):
+        del content_id
+        pytest.fail("the unauthenticated PATCH must not reach the handler")
+
+    response = app.test_client().patch(
+        f"/api/v3/content/{OWNED}/annotations",
+        data=raw_body,
+        content_type="application/json",
+        headers={"Authorization": "Bearer must-be-redacted"},
+    )
+
+    assert response.status_code == 401
+    [record] = _records(unauthenticated_root)
+    assert record["schema_version"] == 2
+    assert record["exchange"] == "annotations_patch_unauthenticated"
+    assert record["request_provenance"] == {
+        "authentication": "unauthenticated",
+        "user_id": None,
+    }
+    assert record["device_request"]["body"]["data"].encode() == raw_body
+    assert dict(record["device_request"]["headers"])["Authorization"] \
+        == "***REDACTED***"
+    assert record["upstream_request"] is None
+    assert record["upstream_response"] is None
+    assert record["device_response"]["status"] == 401
+    assert record["device_response"]["body"]["data"].encode() == response.get_data()
+    assert not recovery_spool_root.exists()
+
+
+@pytest.mark.unit
+def test_unauthenticated_capture_is_off_by_default_and_does_not_read_the_body(
+    monkeypatch, tmp_path,
+):
+    capture = _module()
+    unauthenticated_root = tmp_path / "must-not-exist"
+    monkeypatch.delenv(capture.ENABLE_ENV, raising=False)
+    monkeypatch.setattr(
+        capture, "_unauthenticated_capture_root",
+        lambda: unauthenticated_root,
+        raising=False,
+    )
+    monkeypatch.setattr(rs.config, "config_kobo_sync", True, raising=False)
+    monkeypatch.setattr(
+        rs, "current_user", SimpleNamespace(is_authenticated=False, id=None),
+    )
+    app = Flask(__name__)
+
+    @app.patch("/api/v3/content/<content_id>/annotations")
+    @rs.requires_reading_services_auth_and_config
+    def annotations(content_id):
+        del content_id
+        pytest.fail("the unauthenticated PATCH must not reach the handler")
+
+    monkeypatch.setattr(
+        app.request_class,
+        "get_data",
+        lambda *_args, **_kwargs: pytest.fail(
+            "an off diagnostic must not consume an unauthenticated request body"
+        ),
+    )
+    response = app.test_client().patch(
+        f"/api/v3/content/{OWNED}/annotations",
+        data=b'{"updatedAnnotations":[{"id":"annotation-1"}]}',
+        content_type="application/json",
+    )
+
+    assert response.status_code == 401
+    assert not unauthenticated_root.exists()
+
+
+@pytest.mark.unit
+def test_unauthenticated_capture_churn_cannot_evict_authenticated_diagnostics(
+    monkeypatch, tmp_path,
+):
+    capture, authenticated_root = _enable(monkeypatch, tmp_path)
+    unauthenticated_root = tmp_path / "separate-unauthenticated-budget"
+    monkeypatch.setattr(
+        capture, "_unauthenticated_capture_root", lambda: unauthenticated_root,
+    )
+    monkeypatch.setattr(capture, "UNAUTHENTICATED_MAX_FILES", 2)
+    monkeypatch.setattr(capture, "UNAUTHENTICATED_MAX_TOTAL_BYTES", 1024 * 1024)
+
+    authenticated = capture.begin_capture(
+        exchange="annotations_patch", method="PATCH", path="/annotations/book",
+        query_string=b"", headers=[], body=b'{"updatedAnnotations":[]}',
+        authentication="authenticated", user_id=7,
+    )
+    assert _finish(authenticated) is True
+
+    for index in range(4):
+        unauthenticated = capture.begin_capture(
+            exchange="annotations_patch_unauthenticated", method="PATCH",
+            path=f"/annotations/untrusted-{index}", query_string=b"",
+            headers=[], body=str(index).encode(),
+            authentication="unauthenticated", user_id=None,
+        )
+        assert _finish(unauthenticated) is True
+
+    [authenticated_record] = _records(authenticated_root)
+    assert authenticated_record["request_provenance"]["user_id"] == 7
+    assert len(_records(unauthenticated_root)) == 2
+
+
+@pytest.mark.unit
+def test_capture_persistence_yields_to_gevent_hub(monkeypatch, tmp_path):
+    capture, _root = _enable(monkeypatch, tmp_path)
+    session = capture.begin_capture(
+        exchange="annotations_patch", method="PATCH", path="/annotations/book",
+        query_string=b"", headers=[], body=b'{"updatedAnnotations":[]}',
+        authentication="authenticated", user_id=7,
+    )
+    original_persist = session._persist
+    events = []
+
+    def slow_native_io():
+        time.sleep(0.05)
+        original_persist()
+        events.append("persisted")
+
+    def hub_ticker():
+        gevent.sleep(0.01)
+        events.append("hub-ran")
+
+    monkeypatch.setattr(session, "_persist", slow_native_io)
+    ticker = gevent.spawn(hub_ticker)
+
+    assert _finish(session) is True
+    ticker.join(timeout=1)
+
+    assert events == ["hub-ran", "persisted"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes both halves of #1827. Addresses #1827; unblocked by #1816, which landed the instruments this needed.

## 1. Parse-layer fail-open holes

Two branches still returned an upstream success for a batch CWNG captured nothing from — a non-dict JSON body (became `data={}`) and `updatedAnnotations` present but not a list. Because Nickel prunes acknowledged deltas, an ack there costs the annotation exactly as the bug #1825 fixed did.

Now a **non-empty, non-addressable** body gets the same 503 #1825 chose, so the device retains the delta and retries. **Empty and object-shaped no-op batches still proxy normally** — devices legitimately send those, and a 503 storm would have been a worse bug than the one being fixed.

The issue also flagged that the dispatcher's `return False` for non-list batches was *unreachable from the route* — "a dead defense that reads as coverage". Its type check now runs **before** the empty-batch shortcut, so it is genuinely reachable, pinned by `test_dispatch_refuses_every_non_list_batch_before_empty_shortcut`.

## 2. The pre-auth 401 captured no forensics

#1825 refuses an unauthenticated annotation PATCH with 401 so the device retries, but recorded nothing — and an unauthenticated session window is the leading ASSUMED explanation for the original data loss. The body is now capturable there.

**This is an unauthenticated write path, so it is deliberately conservative:**

- **Opt-in only** — gated behind the explicit private-diagnostic gate, never on by default.
- **It will not even read the body** unless that gate is on, and requires a bounded `Content-Length` before reading. An unauthenticated caller cannot force an unbounded read.
- **A separate store with its own bound** — explicitly *not* the always-on recovery spool. Without an authenticated principal there is no safe replay target, and unresolved spool records are protected from eviction, so admitting these would let an unauthenticated caller exhaust the recovery budget for real users.

## Verification

Full unit suite: **6,988 passed, 105 skipped, 0 failed** (+15 over main's 6,973).

Mutations run against this branch:

| mutation | went red |
|---|---|
| remove the opt-in gate on the unauthenticated capture | `test_unauthenticated_capture_is_off_by_default_and_does_not_read_the_body` |
| disable the fail-closed refusal | `test_patch_non_object_body_is_refused_without_upstream_acknowledgement` + the route-level retryable-refusal case |

Restored: 70 passed. Also covered: `test_unauthenticated_capture_churn_cannot_evict_authenticated_diagnostics`, `test_empty_and_object_noop_patch_bodies_still_proxy`, `test_capture_persistence_yields_to_gevent_hub` (the app serves greenlets without `monkey.patch_all()`).

No new dependencies, licenses, or external service URLs.

## Why this is `needs-review` and not self-merged

The delegate that wrote it was **killed before it produced its report**, so the usual per-deliverable evidence and mutation record never arrived. The commit and tests were already in place, and everything above is verification I ran myself afterwards — but a lane that died before reporting does not get the same trust as one that finished, so this wants a second pair of eyes rather than the autonomous merge gate.