### PR TITLE
fix(changelog): exempt wiki-src/ from the release-note requirement

### DIFF
--- a/scripts/check_changelog_diff.py
+++ b/scripts/check_changelog_diff.py
@@ -146,7 +146,7 @@ def _merge_base(base_ref: str, head_ref: str) -> str:
     return result.stdout.strip()
 
 
-def _changed_paths(branch_point: str, head_ref: str) -> list[str]:
+def _changed_paths(branch_point: str, head_ref: str, cwd=None) -> list[str]:
     # --no-renames, deliberately. With rename detection on, `git mv` out of a
     # shipping directory is reported by its DESTINATION only, so
     # `git mv cps/thing.py docs/thing.py` reaches the classifier as a lone
@@ -157,6 +157,10 @@ def _changed_paths(branch_point: str, head_ref: str) -> list[str]:
         ["git", "diff", "--no-renames", "--name-only", "-z", branch_point, head_ref],
         check=False,
         capture_output=True,
+        # `cwd` exists so a test can point this at a throwaway repository
+        # WITHOUT chdir()ing the process. A test-local chdir is global to the
+        # interpreter and perturbs anything running on a background thread.
+        cwd=cwd,
     )
     if result.returncode:
         detail = result.stderr.decode(errors="replace").strip() or "git diff failed"

--- a/scripts/check_changelog_diff.py
+++ b/scripts/check_changelog_diff.py
@@ -147,8 +147,14 @@ def _merge_base(base_ref: str, head_ref: str) -> str:
 
 
 def _changed_paths(branch_point: str, head_ref: str) -> list[str]:
+    # --no-renames, deliberately. With rename detection on, `git mv` out of a
+    # shipping directory is reported by its DESTINATION only, so
+    # `git mv cps/thing.py docs/thing.py` reaches the classifier as a lone
+    # `docs/` path -- non-shipping -- and a module that vanished from the
+    # application merges with no release note. Splitting the rename into its
+    # delete and its add keeps the shipping side visible to the guard.
     result = subprocess.run(
-        ["git", "diff", "--name-only", "-z", branch_point, head_ref],
+        ["git", "diff", "--no-renames", "--name-only", "-z", branch_point, head_ref],
         check=False,
         capture_output=True,
     )

--- a/scripts/check_changelog_diff.py
+++ b/scripts/check_changelog_diff.py
@@ -14,7 +14,7 @@ import sys
 RELEASE_HEADING = re.compile(r"^## \[(v\d+\.\d+\.\d+)\]", re.MULTILINE)
 ENTRY_LEAD = re.compile(r"^- \*\*", re.MULTILINE)
 FRAGMENT_PATH = re.compile(r"^changelog\.d/[A-Za-z0-9][A-Za-z0-9._-]*\.md$")
-NON_SHIPPING_PATH_PREFIXES = ("docs/", "findings/", "notes/", "tests/")
+NON_SHIPPING_PATH_PREFIXES = ("docs/", "findings/", "notes/", "tests/", "wiki-src/")
 NON_SHIPPING_PATHS = frozenset(
     {"changelog.d/README.md", "scripts/check_changelog_diff.py"}
 )

--- a/tests/unit/test_changelog_diff_guard.py
+++ b/tests/unit/test_changelog_diff_guard.py
@@ -169,6 +169,7 @@ def test_other_allowlisted_non_shipping_paths_do_not_require_an_entry():
     for path in (
         "notes/kobo-hardware-run.md",
         "docs/install/compose.md",
+        "wiki-src/Contributing.md",
         "tests/unit/test_changelog_diff_guard.py",
         "changelog.d/README.md",
         "scripts/check_changelog_diff.py",

--- a/tests/unit/test_changelog_diff_guard.py
+++ b/tests/unit/test_changelog_diff_guard.py
@@ -214,3 +214,54 @@ def test_pr_ci_invokes_guard_with_complete_git_history():
         'python3 scripts/check_changelog_diff.py "$BASE_SHA" "$HEAD_SHA"'
         in changed_paths
     )
+
+
+def test_a_rename_out_of_a_shipping_directory_still_reports_the_shipping_path(
+    tmp_path, monkeypatch
+):
+    """`git mv cps/x.py wiki-src/x.py` must not read as a wiki-only change.
+
+    With git's rename detection on, `git diff --name-only` reports a detected
+    rename by its DESTINATION alone. A module moved out of `cps/` into any
+    exempt directory would then reach the classifier as a single non-shipping
+    path, and code that vanished from the application would merge with no
+    release note -- the exact loss this guard exists to prevent.
+
+    This exercises `_changed_paths` against a real repository rather than a
+    hand-written path list, because the defect lives in how the paths are
+    OBTAINED, not in how they are classified. A test that passes both paths in
+    by hand cannot fail on it.
+    """
+    import subprocess
+
+    def git(*args):
+        subprocess.run(
+            ["git", "-C", str(tmp_path), *args],
+            check=True, capture_output=True,
+        )
+
+    git("init", "-q", ".")
+    git("config", "user.email", "guard@test.invalid")
+    git("config", "user.name", "guard-test")
+    (tmp_path / "cps").mkdir()
+    (tmp_path / "wiki-src").mkdir()
+    (tmp_path / "cps" / "shipping_module.py").write_text("VALUE = 1\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "base")
+    git("mv", "cps/shipping_module.py", "wiki-src/shipping_module.py")
+    git("commit", "-qm", "move it out of the application")
+
+    # _changed_paths shells out to git in the CURRENT directory, which is how
+    # CI invokes it. Stand in the throwaway repository so the diff is the one
+    # this test built.
+    monkeypatch.chdir(tmp_path)
+    paths = GUARD._changed_paths("HEAD~1", "HEAD")
+
+    assert "cps/shipping_module.py" in paths, (
+        "the rename's source was dropped, so the guard cannot see that a "
+        f"shipping file left the application; got {paths}"
+    )
+    assert changelog_requirement_errors(paths), (
+        "a diff that removes a module from cps/ must still require a "
+        "release-note entry"
+    )

--- a/tests/unit/test_changelog_diff_guard.py
+++ b/tests/unit/test_changelog_diff_guard.py
@@ -216,9 +216,7 @@ def test_pr_ci_invokes_guard_with_complete_git_history():
     )
 
 
-def test_a_rename_out_of_a_shipping_directory_still_reports_the_shipping_path(
-    tmp_path, monkeypatch
-):
+def test_a_rename_out_of_a_shipping_directory_still_reports_the_shipping_path(tmp_path):
     """`git mv cps/x.py wiki-src/x.py` must not read as a wiki-only change.
 
     With git's rename detection on, `git diff --name-only` reports a detected
@@ -251,11 +249,10 @@ def test_a_rename_out_of_a_shipping_directory_still_reports_the_shipping_path(
     git("mv", "cps/shipping_module.py", "wiki-src/shipping_module.py")
     git("commit", "-qm", "move it out of the application")
 
-    # _changed_paths shells out to git in the CURRENT directory, which is how
-    # CI invokes it. Stand in the throwaway repository so the diff is the one
-    # this test built.
-    monkeypatch.chdir(tmp_path)
-    paths = GUARD._changed_paths("HEAD~1", "HEAD")
+    # Pass cwd rather than chdir()ing: a test-local chdir is global to the
+    # interpreter, and this suite runs under xdist with background retention
+    # timers live in the same process.
+    paths = GUARD._changed_paths("HEAD~1", "HEAD", cwd=tmp_path)
 
     assert "cps/shipping_module.py" in paths, (
         "the rename's source was dropped, so the guard cannot see that a "


### PR DESCRIPTION
`wiki-src/` holds the templates the GitHub wiki is generated from. Nothing under it is packaged into the image, imported by the app, or visible to a user running this build — it is documentation source, exactly like `docs/`, which #1859 already exempted.

Without this, a wiki-only change has to invent a CHANGELOG entry for a file that ships nothing. That is precisely the pressure #1859 was written to remove: a guard that forces authors to corrupt the artifact it exists to protect.

## How it surfaced

`sync-wiki.sh` has been exiting non-zero on **every autopilot tick** with a live DRIFT TRIPWIRE:

```
DRIFT TRIPWIRE: source sections not mirrored into any wiki page and not on the ignore list:
  - README.md#how-ai-is-used  ("How AI is used")
```

The fix for that is a `wiki-src/` edit — which the guard would have blocked. That PR follows once this lands.

## Verification

Mutation, not assertion. Dropping `"wiki-src/"` from `NON_SHIPPING_PATH_PREFIXES`:

```
FAILED tests/unit/test_changelog_diff_guard.py::test_other_allowlisted_non_shipping_paths_do_not_require_an_entry
1 failed, 19 passed
```

Restoring it: `20 passed`.

## Labelling

Two files (the guard + its test), so **`needs-review` rather than `safe-tier-2`** — tier-2 is defined as a single file and I am not going to bend a labelled gate for a two-line change. Blast radius is CI-only: no runtime path imports this script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1GA5qD4wtZJKYuMybVqPx