### PR TITLE
fix(kobo): import annotations from books whose OPF is in a subdirectory (#1852)

### DIFF
--- a/changelog.d/pr-1852.md
+++ b/changelog.d/pr-1852.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Restoring a Kobo backup no longer drops the annotations from most of your
+  books.** The recovery importer only understood the chapter identifier that a
+  Kobo writes for books whose EPUB keeps its package file at the top level. For
+  every other book — the common case — it counted the annotations as
+  unreadable and skipped them, so a restore that reported success could bring
+  back a fraction of what the backup held. Those annotations now import.

--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -560,7 +560,10 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
         from .services.annotation_content_id import normalize_content_id, ContentIdError
         try:
             content_id = normalize_content_id(
-                bm.content_id, book_uuid=resolved_uuid, allow_legacy_file_uri=True
+                bm.content_id,
+                book_uuid=resolved_uuid,
+                allow_legacy_file_uri=True,
+                allow_kobo_device_content_id=True,
             )
         except ContentIdError:
             skipped_invalid_content_id += 1

--- a/cps/services/annotation_content_id.py
+++ b/cps/services/annotation_content_id.py
@@ -12,6 +12,7 @@ from pathlib import PurePosixPath
 MAX_CONTENT_ID_LENGTH = 2048
 _UUID = r"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
 _CANONICAL = re.compile(rf"^({_UUID})!!(.+)$")
+_KOBO_DEVICE = re.compile(rf"^({_UUID})!([^!]+)!(.+)$")
 _LEGACY_FILE = re.compile(
     r"^file:///mnt/(?:onboard|sd|sdcard)/([^?#]+)#\([0-9]{1,4}\)(.+)$"
 )
@@ -67,8 +68,14 @@ def _chapter(value: str) -> str:
     return normalized
 
 
-def normalize_content_id(value, *, book_uuid=None, allow_legacy_file_uri=False):
-    """Return canonical ``uuid!!chapter`` or reject; ``None`` remains ``None``."""
+def normalize_content_id(value, *, book_uuid=None, allow_legacy_file_uri=False,
+                         allow_kobo_device_content_id=False):
+    """Return canonical ``uuid!!chapter`` or reject; ``None`` remains ``None``.
+
+    ``allow_kobo_device_content_id`` is for KoboReader.sqlite recovery imports.
+    It admits the device-only ``uuid!opf-dir!href`` spelling without widening
+    the ordinary wire/portable grammar.
+    """
     if value is None:
         return None
     if not isinstance(value, str) or not value or len(value) > MAX_CONTENT_ID_LENGTH:
@@ -85,6 +92,17 @@ def normalize_content_id(value, *, book_uuid=None, allow_legacy_file_uri=False):
         if expected and actual != expected:
             raise ContentIdError("content_id does not belong to this book")
         return f"{actual}!!{_chapter(match.group(2))}"
+    if allow_kobo_device_content_id:
+        match = _KOBO_DEVICE.fullmatch(value)
+        if match:
+            actual = _normal_uuid(match.group(1))
+            if expected and actual != expected:
+                raise ContentIdError("content_id does not belong to this book")
+            # Validate the complete folded path. This keeps traversal, control,
+            # empty-segment, relative-path, and length checks identical to the
+            # canonical grammar instead of trusting either device segment.
+            chapter = _chapter(f"{match.group(2)}/{match.group(3)}")
+            return f"{actual}!!{chapter}"
     if allow_legacy_file_uri:
         match = _LEGACY_FILE.fullmatch(value)
         if match and expected:

--- a/tests/unit/test_annotation_portable.py
+++ b/tests/unit/test_annotation_portable.py
@@ -193,6 +193,7 @@ def test_apply_wrong_type_skipped(session):
     "../unbounded-client-shape",
     "x" * 2049,
     "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa!!chapter.xhtml",
+    "b3d1b38b-74fd-43b7-a796-996e5a6a8b04!OEBPS!chapter.xhtml",
 ])
 def test_portable_boundary_rejects_invalid_or_wrong_book_content_id(content_id):
     from cps.services.annotation_portable import validate_portable_payload

--- a/tests/unit/test_annotations_import_endpoint.py
+++ b/tests/unit/test_annotations_import_endpoint.py
@@ -197,6 +197,82 @@ class TestIngestCounts:
 
 
 @pytest.mark.unit
+class TestKoboDeviceContentId:
+    BOOK_UUID = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+
+    @staticmethod
+    def _replace_content_id(sqlite_path, content_id):
+        connection = sqlite3.connect(sqlite_path)
+        try:
+            connection.execute(
+                "UPDATE Bookmark SET ContentID = ? WHERE BookmarkID = 'bm-001'",
+                (content_id,),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+    @pytest.mark.parametrize(
+        ("device_content_id", "canonical_content_id"),
+        [
+            pytest.param(
+                f"{BOOK_UUID}!OEBPS!5974957359191092168_980-h-0.htm.xhtml",
+                f"{BOOK_UUID}!!OEBPS/5974957359191092168_980-h-0.htm.xhtml",
+                id="measured-device-shape",
+            ),
+            pytest.param(
+                f"{BOOK_UUID}!OEBPS!chapter.xhtml#pgepubid00001",
+                f"{BOOK_UUID}!!OEBPS/chapter.xhtml#pgepubid00001",
+                id="fragment",
+            ),
+            pytest.param(
+                f"{BOOK_UUID}!EPUB/package/Text!part/chapter.xhtml",
+                f"{BOOK_UUID}!!EPUB/package/Text/part/chapter.xhtml",
+                id="nested-opf-directory",
+            ),
+        ],
+    )
+    def test_import_folds_device_content_id_to_canonical_server_form(
+        self, memory_db, synthetic_db, device_content_id, canonical_content_id,
+    ):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        self._replace_content_id(synthetic_db, device_content_id)
+        session, _, _ = memory_db
+
+        result = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=_make_book_lookup({self.BOOK_UUID: 348}), commit=session.commit,
+        )
+        row = session.query(ub.Annotation).filter_by(annotation_id="bm-001").one()
+
+        assert result["imported"] == 3, result
+        assert result["skipped_invalid_content_id"] == 0, result
+        assert row.content_id == canonical_content_id
+
+    def test_import_rejects_device_content_id_that_escapes_after_folding(
+        self, memory_db, synthetic_db,
+    ):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        self._replace_content_id(
+            synthetic_db, f"{self.BOOK_UUID}!..!../outside.xhtml",
+        )
+        session, _, _ = memory_db
+
+        result = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=_make_book_lookup({self.BOOK_UUID: 348}), commit=session.commit,
+        )
+
+        assert result["imported"] == 2, result
+        assert result["skipped_invalid_content_id"] == 1, result
+        assert session.query(ub.Annotation).filter_by(annotation_id="bm-001").first() is None
+
+
+@pytest.mark.unit
 class TestPreviouslyInvisibleDeviceRows:
     def test_dogear_and_note_only_row_import_and_every_row_is_accounted(
         self, memory_db, tmp_path,

--- a/tests/unit/test_multi_device_annotations_safe_slice.py
+++ b/tests/unit/test_multi_device_annotations_safe_slice.py
@@ -109,6 +109,48 @@ def test_content_id_normalizes_both_legacy_shapes_idempotently():
     assert normalize_content_id(raw, book_uuid=book, allow_legacy_file_uri=True) == canonical
 
 
+def test_device_content_id_requires_explicit_import_opt_in():
+    from cps.services.annotation_content_id import normalize_content_id, ContentIdError
+    book = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+    device = f"{book}!OEBPS!chapter.xhtml"
+    canonical = f"{book}!!OEBPS/chapter.xhtml"
+
+    with pytest.raises(ContentIdError):
+        normalize_content_id(device, book_uuid=book)
+    assert normalize_content_id(
+        device, book_uuid=book, allow_kobo_device_content_id=True,
+    ) == canonical
+    assert normalize_content_id(
+        canonical, book_uuid=book, allow_kobo_device_content_id=True,
+    ) == canonical
+
+
+@pytest.mark.parametrize(
+    ("device_content_id", "message"),
+    [
+        pytest.param(
+            "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa!OEBPS!chapter.xhtml",
+            "content_id does not belong to this book",
+            id="wrong-book",
+        ),
+        pytest.param("{book}!..!../outside.xhtml", "escapes", id="escape"),
+        pytest.param("{book}!OEBPS//Text!chapter.xhtml", "unsafe segment", id="empty-segment"),
+        pytest.param("{book}!OEBPS!chapter\x1f.xhtml", "control character", id="control"),
+        pytest.param("{book}!OEBPS!" + "x" * 1536, "too long", id="chapter-length"),
+    ],
+)
+def test_device_content_id_is_validated_after_folding(device_content_id, message):
+    from cps.services.annotation_content_id import normalize_content_id, ContentIdError
+    book = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+
+    with pytest.raises(ContentIdError, match=message):
+        normalize_content_id(
+            device_content_id.format(book=book),
+            book_uuid=book,
+            allow_kobo_device_content_id=True,
+        )
+
+
 def test_backfill_is_conservative_and_idempotent():
     from cps import ub
     engine = create_engine("sqlite:///:memory:")
@@ -116,11 +158,12 @@ def test_backfill_is_conservative_and_idempotent():
         conn.execute(text("CREATE TABLE annotation (id INTEGER PRIMARY KEY, book_id INTEGER, content_id TEXT)"))
         uuid = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
         wrong = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
-        conn.execute(text("INSERT INTO annotation VALUES (1, 5, :v), (2, 5, :u), (3, 5, :w), (4, 99, :m)"), {
+        conn.execute(text("INSERT INTO annotation VALUES (1, 5, :v), (2, 5, :u), (3, 5, :w), (4, 99, :m), (5, 5, :d)"), {
             "v": f"file:///mnt/onboard/{uuid}.epub#(6)OEBPS/c.xhtml",
             "u": "opaque-old-value",
             "w": f"file:///mnt/onboard/{wrong}.epub#(6)OEBPS/wrong.xhtml",
             "m": f"file:///mnt/onboard/{uuid}.epub#(6)OEBPS/missing.xhtml",
+            "d": f"{uuid}!OEBPS!device-only.xhtml",
         })
     ub.migrate_multi_device_annotation_safe_slice(engine, None)
     lookup = lambda book_id: uuid if book_id == 5 else None
@@ -133,6 +176,7 @@ def test_backfill_is_conservative_and_idempotent():
     assert once[1][1] == "opaque-old-value"
     assert once[2][1] == f"file:///mnt/onboard/{wrong}.epub#(6)OEBPS/wrong.xhtml"
     assert once[3][1] == f"file:///mnt/onboard/{uuid}.epub#(6)OEBPS/missing.xhtml"
+    assert once[4][1] == f"{uuid}!OEBPS!device-only.xhtml"
 
 
 def test_backfill_repairs_journaled_wrong_book_without_overwriting_later_edits():

--- a/tests/unit/test_multi_device_annotations_safe_slice.py
+++ b/tests/unit/test_multi_device_annotations_safe_slice.py
@@ -347,3 +347,41 @@ def test_non_uuid_book_id_accepted_only_on_exact_match(value, book_uuid, accepte
     else:
         with pytest.raises(ContentIdError):
             normalize_content_id(value, book_uuid=book_uuid)
+
+
+def test_device_content_id_folds_on_the_first_bang_when_the_href_contains_one():
+    """`!` is a legal character in an EPUB path segment, so the fold must split
+    on the device grammar's separators and not on the last bang it can find.
+
+    Guards a mutation the rest of the suite does not catch: widening
+    ``_KOBO_DEVICE``'s opf-dir group from ``([^!]+)`` to ``(.+)`` makes the
+    match greedy, and ``uuid!OEBPS!ch!apter.xhtml`` folds to
+    ``OEBPS!ch/apter.xhtml`` — a silently wrong chapter path that resolves to
+    nothing, with no error for the user to see.
+    """
+    from cps.services.annotation_content_id import normalize_content_id
+
+    book = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+    assert normalize_content_id(
+        f"{book}!OEBPS!ch!apter.xhtml",
+        book_uuid=book,
+        allow_kobo_device_content_id=True,
+    ) == f"{book}!!OEBPS/ch!apter.xhtml"
+
+
+def test_device_content_id_uppercase_uuid_is_canonicalised():
+    """A device uuid in upper case belongs to the same book and must normalise.
+
+    Guards the mutation that drops ``_normal_uuid`` from the device branch:
+    without it the raw device spelling is compared against the canonical book
+    uuid, so the reader's own book is rejected as "does not belong to this
+    book" — an annotation lost to letter case.
+    """
+    from cps.services.annotation_content_id import normalize_content_id
+
+    book = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+    assert normalize_content_id(
+        f"{book.upper()}!OEBPS!chapter.xhtml",
+        book_uuid=book,
+        allow_kobo_device_content_id=True,
+    ) == f"{book}!!OEBPS/chapter.xhtml"


### PR DESCRIPTION
Closes #1852.

A Kobo identifies a chapter as `<book-uuid>!<opf-dir>!<internal-href>`. When the OPF sits at the archive root the middle segment is empty — that is what produces the familiar `!!`. `_CANONICAL` admitted only that empty case, so `<uuid>!OEBPS!chapter.xhtml` matched no grammar and `ingest_bookmarks` counted the row as `skipped_invalid_content_id`.

Measured on real hardware, same chapter / same book / same instance:

```
device KoboReader.sqlite : 812dd6be-…!OEBPS!5974957359191092168_980-h-0.htm.xhtml
server annotation row    : 812dd6be-…!!OEBPS/5974957359191092168_980-h-0.htm.xhtml
```

## Why this does not widen the wire grammar

Across **659** stored annotation rows on the reporting instance, **zero** carry the single-bang form. The live PATCH path receives `location.span.chapterFilename` with the OPF directory already slash-delimited and constructs the canonical id itself — it never sees a device ContentID. So the new grammar is opt-in (`allow_kobo_device_content_id`) and the SQLite importer is its only caller.

Ownership is checked **before** folding, and the complete folded path goes through the existing `_chapter()` validator, so traversal, control-character, empty-segment, relative-path and length rejection are byte-identical to the canonical branch rather than trusting either device segment. `<uuid>!..!../outside.xhtml` stays rejected, with a test.

## Verification — mutation, not assertion

Tests written before the implementation: `9 failed, 62 passed`.

With the fix in place, disabling only the folding branch while keeping the new signature — so the failure is a behaviour removal, not a missing-keyword error:

```
9 failed, 6 passed      # mutated
15 passed               # restored
```

The 6 survivors are the negative/preservation checks that *should* stay green: folded-input rejection, portable strictness, backfill preservation.

Full unit suite: **6987 passed, 105 skipped, 0 failed**.

End-to-end verification against the operator's real device backup follows the merge, with the prediction recorded on #1852 **before** the run — the last prediction on this feature was wrong, and that is how this bug was found.

## Same-class sweep

Each inbound path checked and deliberately left strict:

| path | verdict |
|---|---|
| `annotation_portable.py` (KOReader/portable) | not affected — exports are already canonical; new test pins `!OEBPS!` as still rejected |
| `annotation_sync/__init__.py` (live PATCH) | not applicable — consumes `chapterFilename`, builds `!!` itself |
| `ub.py` backfill + journal normalization | not affected — operates on stored server rows; verified byte-identical across two runs |
| `create_annotation` (web reader) | not affected — server-generated canonical shape |

## Scope, stated honestly

On the reporting instance this recovers **2** annotations, not 16. Fourteen of the seventeen affected device rows were already on the server via the live path — the importer was refusing rows it already had. The genuine data-loss case is the intersection of *"the live delta never landed"* with *"this book's OPF is in a subdirectory"*, which matters because Nickel prunes an acknowledged delta and never offers it again. Details and the correction to an earlier over-claim are on #1852.

Implementation by Sol (codex); brief, review, and the reconciliation measurements by the manager lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1GA5qD4wtZJKYuMybVqPx