### PR TITLE
docs(wiki): mirror the AI-usage disclosure onto the Contributing page

### DIFF
--- a/wiki-src/Contributing.md
+++ b/wiki-src/Contributing.md
@@ -16,4 +16,8 @@ To contribute a translation, edit the `.po` file under [cps/translations/](https
 
 ---
 
+{{repo:README.md#how-ai-is-used|heading}}
+
+---
+
 {{repo:README.md#credits|heading}}


### PR DESCRIPTION
The GitHub wiki has not published since **2026-08-22 10:14**. `sync-wiki.sh` has exited non-zero on every autopilot tick for three days with a live DRIFT TRIPWIRE:

```
DRIFT TRIPWIRE: source sections not mirrored into any wiki page and not on the ignore list:
  - README.md#how-ai-is-used  ("How AI is used")
```

The tripwire is doing exactly its job. The section is a transparency statement about how this fork is developed, and "the wiki is quieter about it than the README" is not a defensible reason to add it to `IGNORED_SLUGS`. So it gets mirrored.

## Placement

On **Contributing**, between "Supporting the project" and "Credits" — the README's own ordering. Contributing is where *how this project is developed* already lives, and the placement keeps the disclosure exactly as prominent on the wiki as it is in the README: no more, no less.

## What it fixes beyond the tripwire

Giving Contributing ownership of the `#how-ai-is-used` slug also repairs a **broken link on Home**. Today the Home preamble renders `[How AI is used](#how-ai-is-used)` — a same-page anchor to a section Home does not contain. After this it renders as a working cross-page link to `…/wiki/Contributing#how-ai-is-used`. Home does not receive a second copy of the section.

## Verification

Independently reviewed and returned **MERGE with no defects**. Observed:

- `origin/main` generator: **rc=1**, reporting only this tripwire. With this change: **rc=0**, 22 files rendered (20 pages + sidebar/footer).
- The authoritative outer `scripts/sync-wiki.sh` run in dry-run mode against this worktree: **rc=0**, no push.
- Rendered heading sequence is `# Contributing` / `## Supporting the project` / `## Translations` / `## How AI is used` / `## Credits` — one H1, sibling H2s, no heading-level collision, no duplicate slug.
- The section is transcluded exactly once: one `README.md#how-ai-is-used` directive in `wiki-src/`, and the body appears only in `Contributing.md`.
- The relative `docs/AI-USAGE.md` link is correctly rewritten to an absolute URL that resolves on `main`.
- The rendered disclosure is complete — lineage and contributor credit, the AI-assisted development statement, the human review gates, the explicit "the shipped application contains no AI, no inference call, no telemetry", and the full-disclosure link.

Depends on #1863, now merged — without it the changelog guard would have demanded a release note for a directory that ships nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1GA5qD4wtZJKYuMybVqPx
