### PR TITLE
feat: per-key environment overrides for the three runtime paths, with dirs.json as fallback (#1611)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Library, settings, users, OAuth tokens, and KOReader sync state are preserved. S
 - [What's included](#whats-included)
 - [Quick start](#quick-start)
 - [Full Docker Compose setup](#full-docker-compose-setup)
+- [Runtime path overrides for packagers](#runtime-path-overrides-for-packagers)
 - [First run](#first-run)
 - [Migrating](#migrating)
   - [From upstream CWA](#from-upstream-cwa)
@@ -175,6 +176,12 @@ services:
       # limit. Free; sign up at https://comicvine.gamespot.com/api/
       # - COMICVINE_API_KEY=...
 
+      # Optional: override paths inside the container. The matching
+      # volume targets below must use the same paths.
+      # - CWA_INGEST_FOLDER=/cwa-book-ingest
+      # - CWA_CALIBRE_LIBRARY_DIR=/calibre-library
+      # - CWA_TMP_CONVERSION_DIR=/config/.cwa_conversion_tmp
+
     volumes:
       # Settings, user database, logs. Empty folder for new installs;
       # for existing CWA users, point at your existing /config.
@@ -212,6 +219,42 @@ services:
 | `/cwa-book-ingest` | Drop zone for new books | Files here are **deleted** after processing. Don't park books here long-term. |
 
 > Don't nest the binds. All three should be separate top-level folders. Putting `ingest` inside `library` produces recursive ingest behavior.
+
+---
+
+## Runtime path overrides for packagers
+
+Bare-metal and distro packages can configure all three runtime paths from the
+process environment instead of editing `dirs.json` inside the installation:
+
+| Environment variable | `dirs.json` fallback | Compiled-in default |
+|---|---|---|
+| `CWA_INGEST_FOLDER` | `ingest_folder` | `/cwa-book-ingest` |
+| `CWA_CALIBRE_LIBRARY_DIR` | `calibre_library_dir` | `/calibre-library` |
+| `CWA_TMP_CONVERSION_DIR` | `tmp_conversion_dir` | `/config/.cwa_conversion_tmp` |
+
+Each non-blank environment value wins for its key. If it is unset or blank,
+CWNG reads that key from the file selected by `CWA_DIRS_JSON`; a missing,
+invalid, or blank file value falls back to the compiled-in default. Existing
+hand-edited `dirs.json` files therefore remain supported.
+
+For example, a systemd unit can load a packager-owned file:
+
+```ini
+[Service]
+EnvironmentFile=/etc/calibre-web-nextgen/paths.env
+```
+
+```bash
+CWA_INGEST_FOLDER=/srv/calibre-web-nextgen/ingest
+CWA_CALIBRE_LIBRARY_DIR=/srv/calibre/library
+CWA_TMP_CONVERSION_DIR=/var/cache/calibre-web-nextgen/conversion
+```
+
+When `CWA_CALIBRE_LIBRARY_DIR` is set, it is authoritative. Automatic library
+discovery will leave `dirs.json` unchanged; if discovery finds a different
+library, startup stops and reports both paths so the environment file can be
+corrected.
 
 ---
 

--- a/changelog.d/1611.md
+++ b/changelog.d/1611.md
@@ -1,0 +1,7 @@
+### Added
+
+- **Runtime data paths can be configured without editing the installation.**
+  Packagers can set `CWA_INGEST_FOLDER`, `CWA_CALIBRE_LIBRARY_DIR`, and
+  `CWA_TMP_CONVERSION_DIR` from the process environment while existing
+  `dirs.json` values remain supported as fallbacks. Requested with
+  @chloeroform and @Thovi98 in #1611.

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -6,8 +6,11 @@
 # See CONTRIBUTORS for full list of authors.
 
 from importlib import metadata
+import json
+import logging
 import sys
 import os
+import threading
 from collections import namedtuple
 
 from flask_babel import gettext as _
@@ -44,6 +47,66 @@ SCRIPTS_DIR         = os.path.join(BASE_DIR, 'scripts')
 _dirs_json_override = (os.environ.get('CWA_DIRS_JSON') or '').strip()
 DIRS_JSON           = (os.path.join(BASE_DIR, _dirs_json_override) if _dirs_json_override
                        else os.path.join(BASE_DIR, 'dirs.json'))
+
+DEFAULT_INGEST_FOLDER = '/cwa-book-ingest'
+DEFAULT_LIBRARY_DIR = '/calibre-library'
+DEFAULT_TMP_CONVERSION_DIR = '/config/.cwa_conversion_tmp'
+
+_DIRS_JSON_LOGGED_KEYS = set()
+_DIRS_JSON_LOG_LOCK = threading.Lock()
+_dirs_logger = logging.getLogger(__name__)
+_dirs_environ = os.environ
+
+
+def _configured_dir(key, env_name, default):
+    """Resolve one runtime directory through environment, file, then default."""
+    override = _dirs_environ.get(env_name)
+    if override is not None and override.strip():
+        return override.strip()
+
+    try:
+        with open(DIRS_JSON, 'r', encoding='utf-8') as config_file:
+            configured_dirs = json.load(config_file)
+    except (OSError, ValueError, TypeError):
+        configured_dirs = {}
+
+    configured = configured_dirs.get(key) if isinstance(configured_dirs, dict) else None
+    if isinstance(configured, str) and configured.strip():
+        configured = configured.strip()
+        with _DIRS_JSON_LOG_LOCK:
+            if key not in _DIRS_JSON_LOGGED_KEYS:
+                _DIRS_JSON_LOGGED_KEYS.add(key)
+                _dirs_logger.info(
+                    "Using dirs.json fallback %s=%s from %s",
+                    key,
+                    configured,
+                    DIRS_JSON,
+                )
+        return configured
+    return default
+
+
+def ingest_folder():
+    """Configured ingest directory, without adding a trailing separator."""
+    return _configured_dir(
+        'ingest_folder', 'CWA_INGEST_FOLDER', DEFAULT_INGEST_FOLDER
+    )
+
+
+def calibre_library_dir():
+    """Configured Calibre library directory, without a trailing separator."""
+    return _configured_dir(
+        'calibre_library_dir', 'CWA_CALIBRE_LIBRARY_DIR', DEFAULT_LIBRARY_DIR
+    )
+
+
+def tmp_conversion_dir():
+    """Configured conversion scratch directory, without a trailing separator."""
+    return _configured_dir(
+        'tmp_conversion_dir',
+        'CWA_TMP_CONVERSION_DIR',
+        DEFAULT_TMP_CONVERSION_DIR,
+    )
 
 # Cache dir - use CACHE_DIR environment variable, otherwise use the default directory: cps/cache
 DEFAULT_CACHE_DIR   = os.path.join(BASE_DIR, 'cps', 'cache')

--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -8,7 +8,7 @@ from flask import Blueprint, redirect, flash, url_for, request, send_from_direct
 from flask_babel import gettext as _, lazy_gettext as _l
 
 from . import logger, config, constants, csrf, helper, ub, calibre_db
-from .constants import DIRS_JSON, LOG_ARCHIVE
+from .constants import LOG_ARCHIVE
 from .metadata_constants import DEFAULT_METADATA_PROVIDER_HIERARCHY_JSON
 from .usermanagement import login_required_if_no_ano, user_login_required
 from .admin import admin_required
@@ -214,9 +214,7 @@ def cwa_switch_theme():
 ##————————————————————————————————————————————————————————————————————————————##
 
 def get_ingest_dir():
-    with open(DIRS_JSON, 'r') as f:
-        dirs = json.load(f)
-        return dirs['ingest_folder']
+    return constants.ingest_folder()
 
 def get_ingest_status():
     """Read the current ingest service status"""
@@ -1958,12 +1956,7 @@ def convert_library_start(queue):
     queue.put(cl_process)
 
 def get_tmp_conversion_dir() -> str:
-    dirs = {}
-    with open(DIRS_JSON, 'r') as f:
-        dirs: dict[str, str] = json.load(f)
-    tmp_conversion_dir = f"{dirs['tmp_conversion_dir']}/"
-
-    return tmp_conversion_dir
+    return f"{constants.tmp_conversion_dir()}/"
 
 def empty_tmp_con_dir(tmp_conversion_dir) -> None:
     try:

--- a/cps/web.py
+++ b/cps/web.py
@@ -31,7 +31,6 @@ from werkzeug.datastructures import Headers
 from werkzeug.security import generate_password_hash, check_password_hash
 
 from . import constants, logger, isoLanguages, services, helper, spa, oauth_auto_redirect
-from .constants import DIRS_JSON
 from . import db, ub, config, app
 from . import calibre_db, kobo_sync_status
 from .services.ereader_send import send_includes_own_address
@@ -573,11 +572,7 @@ def get_sort_function(sort_param, data):
 
 
 def cwa_get_library_location() -> str:
-    dirs = {}
-    with open(DIRS_JSON, 'r') as f:
-        dirs: dict[str, str] = json.load(f)
-    library_dir = dirs['calibre_library_dir']
-    return library_dir
+    return constants.calibre_library_dir()
 
 def cwa_get_num_books_in_library() -> int:
     try:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,11 @@ services:
       # Skip the automatic library detection/mount at startup. When enabled, the auto-library service will not run.
       # Accepts: true/yes/1 to disable auto-mount (default: false)
       # - DISABLE_LIBRARY_AUTOMOUNT=false
+      # Optional: override the paths used inside the container. If changed,
+      # update the matching volume targets below to the same paths.
+      # - CWA_INGEST_FOLDER=/cwa-book-ingest
+      # - CWA_CALIBRE_LIBRARY_DIR=/calibre-library
+      # - CWA_TMP_CONVERSION_DIR=/config/.cwa_conversion_tmp
     volumes:
       # CW users migrating should stop their existing CW instance, make a copy of the config folder, and bind that here to carry over all of their user settings etc.
       - /path/to/config/folder:/config

--- a/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
@@ -10,19 +10,8 @@
 
 echo "[cwa-checksum-backfill] Waiting for CWA service to be ready..."
 
-dirs_json="${CWA_DIRS_JSON:-/app/calibre-web-automated/dirs.json}"
-library_path="$(python3 - "$dirs_json" <<'PY'
-import json
-import sys
-
-try:
-    with open(sys.argv[1], "r", encoding="utf-8") as config_file:
-        configured = json.load(config_file).get("calibre_library_dir")
-    print(configured if isinstance(configured, str) and configured.strip() else "/calibre-library")
-except (OSError, ValueError, TypeError):
-    print("/calibre-library")
-PY
-)"
+CWA_APP_PATHS="${CWA_APP_PATHS:-/app/calibre-web-automated/scripts/app_paths.py}"
+library_path="$(python3 "${CWA_APP_PATHS}" calibre_library_dir)"
 metadata_db="${library_path%/}/metadata.db"
 metadata_uri="$(python3 - "$metadata_db" <<'PY'
 import sys

--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -2,7 +2,10 @@
 
 echo "========== STARTING CWA-INGEST SERVICE =========="
 
-WATCH_FOLDER=${WATCH_FOLDER:-$(grep -o '"ingest_folder": "[^"]*' /app/calibre-web-automated/dirs.json | grep -o '[^"]*$')}
+# CWA_INGEST_FOLDER is the public path override. WATCH_FOLDER remains a
+# backwards-compatible service-local fallback when the public knob is unset.
+CWA_APP_PATHS="${CWA_APP_PATHS:-/app/calibre-web-automated/scripts/app_paths.py}"
+WATCH_FOLDER=${CWA_INGEST_FOLDER:-${WATCH_FOLDER:-$(python3 "${CWA_APP_PATHS}" ingest_folder)}}
 echo "[cwa-ingest-service] Watching folder: $WATCH_FOLDER"
 
 # Create queue file for retry processing (persistent across restarts)

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -168,16 +168,10 @@ if [ "$(realpath -m -- "${CWA_LEGACY_TEMP_DIR}" 2>/dev/null || echo "${CWA_LEGAC
   rm -rf "${CWA_LEGACY_TEMP_DIR}" 2>/dev/null || true
 fi
 
-# Ensure ingest directory exists and is writable (matches dirs.json)
-INGEST_DIR=$(python3 - <<'PY'
-import json
-try:
-    with open('/app/calibre-web-automated/dirs.json', 'r', encoding='utf-8') as f:
-        print(json.load(f).get('ingest_folder', '').strip())
-except Exception:
-    print('')
-PY
-)
+# Ensure the resolved ingest directory exists and is writable. app_paths keeps
+# the environment -> dirs.json -> default precedence identical to Python.
+CWA_APP_PATHS="${CWA_APP_PATHS:-/app/calibre-web-automated/scripts/app_paths.py}"
+INGEST_DIR=$(python3 "${CWA_APP_PATHS}" ingest_folder)
 if [ -n "$INGEST_DIR" ]; then
   # Create directory if missing
   mkdir -p "$INGEST_DIR" 2>/dev/null || true

--- a/scripts/app_paths.py
+++ b/scripts/app_paths.py
@@ -25,20 +25,27 @@ What                 Environment override                  Default
 app root             ``CWA_APP_ROOT``                       parent of this file's dir
 config dir           ``CALIBRE_DBPATH``                     same as ``cps`` (app root)
 ``dirs.json``        ``CWA_DIRS_JSON``                      ``<app root>/dirs.json``
+ingest folder        ``CWA_INGEST_FOLDER``                  ``/cwa-book-ingest``
+library directory    ``CWA_CALIBRE_LIBRARY_DIR``            ``/calibre-library``
+conversion temp      ``CWA_TMP_CONVERSION_DIR``             ``/config/.cwa_conversion_tmp``
 ``app.db``           ``CWA_APP_DB_PATH``, ``CALIBRE_DBPATH`` ``<config dir>/app.db``
 ===================  ====================================  =========================
 
+The three runtime directories use their matching key in ``dirs.json`` between
+the environment override and the compiled-in default.
+
 Every default here has to match what ``cps`` resolves to, because the two
 halves of the install read and write the same files. Where they disagree, the
-disagreement is invisible in Docker — the image sets the environment variables
-explicitly — and silent everywhere else: scripts seed a database the app never
-opens. Both known cases were fixed together in the #1462 follow-up.
+disagreement is easy to miss in Docker — the image supplies its layout through
+environment values and the shipped ``dirs.json`` — and silent everywhere else:
+scripts seed a database the app never opens. Both known cases were fixed
+together in the #1462 follow-up.
 
 Deliberately dependency-free and free of any ``cps`` import: ``auto_library.py``
 runs before the Flask stack is usable, and ``cover_enforcer.py`` has to survive
 an environment where importing ``cps`` fails outright.
 
-**These four variables are trusted configuration, not user input.** They are read
+**These launch variables are trusted configuration, not user input.** They are read
 from the launch environment — the Dockerfile, the s6 service definitions, or a
 packager's systemd unit — and they were already trusted that way before this
 module existed. Centralising them does widen what one of them reaches:
@@ -55,8 +62,10 @@ so that default never fires there — and de-hardcoding the *app* root must not
 quietly relocate anybody's *databases*.
 """
 
+import json
 import os
 import sys
+import threading
 from pathlib import Path
 
 __all__ = [
@@ -64,12 +73,17 @@ __all__ = [
     "config_dir",
     "stray_legacy_config_dir",
     "dirs_json",
+    "ingest_folder",
+    "calibre_library_dir",
+    "tmp_conversion_dir",
     "app_db_path",
     "scripts_dir",
     "script_path",
     "ensure_app_root_on_sys_path",
     "DEFAULT_CONFIG_DIR",
+    "DEFAULT_INGEST_FOLDER",
     "DEFAULT_LIBRARY_DIR",
+    "DEFAULT_TMP_CONVERSION_DIR",
 ]
 
 #: Where the *container* keeps the writable state. The Dockerfile sets
@@ -79,8 +93,18 @@ __all__ = [
 #: puts config here" is worth being able to reference.
 DEFAULT_CONFIG_DIR = "/config"
 
+#: Container ingest mount, used when neither the environment nor dirs.json
+#: supplies a usable path.
+DEFAULT_INGEST_FOLDER = "/cwa-book-ingest"
+
 #: Legacy library root, used as a last resort by :mod:`library_paths`.
 DEFAULT_LIBRARY_DIR = "/calibre-library"
+
+#: Container conversion scratch directory, used as the final fallback.
+DEFAULT_TMP_CONVERSION_DIR = "/config/.cwa_conversion_tmp"
+
+_DIRS_JSON_LOGGED_KEYS = set()
+_DIRS_JSON_LOG_LOCK = threading.Lock()
 
 
 def _env_path(name):
@@ -243,6 +267,87 @@ def dirs_json():
     return app_root() / "dirs.json"
 
 
+def _configured_dir(key, env_name, default, dirs_json_path=None):
+    """Resolve one runtime directory through environment, file, then default."""
+    override = os.environ.get(env_name)
+    if override is not None and override.strip():
+        return override.strip()
+
+    config_path = Path(dirs_json_path) if dirs_json_path else dirs_json()
+    try:
+        with config_path.open("r", encoding="utf-8") as config_file:
+            configured_dirs = json.load(config_file)
+    except (OSError, ValueError, TypeError):
+        configured_dirs = {}
+
+    configured = configured_dirs.get(key) if isinstance(configured_dirs, dict) else None
+    if isinstance(configured, str) and configured.strip():
+        configured = configured.strip()
+        with _DIRS_JSON_LOG_LOCK:
+            if key not in _DIRS_JSON_LOGGED_KEYS:
+                _DIRS_JSON_LOGGED_KEYS.add(key)
+                print(
+                    f"[cwa-paths] Using dirs.json fallback {key}={configured} "
+                    f"from {config_path}",
+                    file=sys.stderr,
+                )
+        return configured
+    return default
+
+
+def ingest_folder(dirs_json_path=None):
+    """Configured ingest directory, without adding a trailing separator."""
+    return _configured_dir(
+        "ingest_folder",
+        "CWA_INGEST_FOLDER",
+        DEFAULT_INGEST_FOLDER,
+        dirs_json_path,
+    )
+
+
+def calibre_library_dir(dirs_json_path=None):
+    """Configured Calibre library directory, without a trailing separator."""
+    return _configured_dir(
+        "calibre_library_dir",
+        "CWA_CALIBRE_LIBRARY_DIR",
+        DEFAULT_LIBRARY_DIR,
+        dirs_json_path,
+    )
+
+
+def tmp_conversion_dir(dirs_json_path=None):
+    """Configured conversion scratch directory, without a trailing separator."""
+    return _configured_dir(
+        "tmp_conversion_dir",
+        "CWA_TMP_CONVERSION_DIR",
+        DEFAULT_TMP_CONVERSION_DIR,
+        dirs_json_path,
+    )
+
+
+def _main(argv=None):
+    """Expose the same resolver to shell-based s6 consumers."""
+    args = sys.argv[1:] if argv is None else argv
+    commands = {
+        "ingest_folder": ingest_folder,
+        "calibre_library_dir": calibre_library_dir,
+        "tmp_conversion_dir": tmp_conversion_dir,
+    }
+    if len(args) != 1 or args[0] not in {*commands, "all"}:
+        print(
+            "usage: app_paths.py "
+            "{ingest_folder|calibre_library_dir|tmp_conversion_dir|all}",
+            file=sys.stderr,
+        )
+        return 2
+    if args[0] == "all":
+        for resolver in commands.values():
+            print(resolver())
+    else:
+        print(commands[args[0]]())
+    return 0
+
+
 def ensure_app_root_on_sys_path():
     """Put the app root on ``sys.path`` so ``import cps...`` works.
 
@@ -253,3 +358,7 @@ def ensure_app_root_on_sys_path():
     if root not in sys.path:
         sys.path.insert(0, root)
     return root
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/auto_library.py
+++ b/scripts/auto_library.py
@@ -367,7 +367,7 @@ class AutoLibrary:
         else:
             return False
 
-    # Sets the library's location in both dirs.json and the CW db
+    # Persists the selected library without contradicting an environment override.
     def set_library_location(self):
         if self.metadb_path is not None and os.path.exists(self.metadb_path):
             self.update_dirs_json()
@@ -397,7 +397,26 @@ class AutoLibrary:
 
     # Update the dirs.json file with the new library location (lib_path))
     def update_dirs_json(self):
-        """Updates the location of the calibre library stored in dirs.json with the found library"""
+        """Update dirs.json unless the environment is the authoritative source."""
+        environment_library = os.environ.get("CWA_CALIBRE_LIBRARY_DIR", "").strip()
+        if environment_library:
+            if os.path.normpath(environment_library) != os.path.normpath(self.lib_path):
+                print(
+                    "[cwa-auto-library]: ERROR: discovered library "
+                    f"'{self.lib_path}' conflicts with authoritative "
+                    f"CWA_CALIBRE_LIBRARY_DIR='{environment_library}'."
+                )
+                print(
+                    "[cwa-auto-library]: dirs.json and app.db were left unchanged. "
+                    "Set CWA_CALIBRE_LIBRARY_DIR to the directory containing the "
+                    "selected metadata.db, then restart."
+                )
+                sys.exit(1)
+            print(
+                "[cwa-auto-library] CWA_CALIBRE_LIBRARY_DIR is authoritative; "
+                "leaving dirs.json unchanged."
+            )
+            return
         try:
             print("[cwa-auto-library] Updating dirs.json with new library location...")
             with open(self.dirs_path) as f:
@@ -414,10 +433,19 @@ class AutoLibrary:
     # Uses the empty metadata.db shipped in the app root to create a new library
     def make_new_library(self):
         print("[cwa-auto-library]: No existing library found. Creating new library...")
+        if os.environ.get("CWA_CALIBRE_LIBRARY_DIR", "").strip():
+            location_help = (
+                "Set CWA_CALIBRE_LIBRARY_DIR to a directory this user can write to."
+            )
+        else:
+            location_help = (
+                f"Set 'calibre_library_dir' in {self.dirs_path} to a directory "
+                "this user can write to."
+            )
         self.ensure_dir_exists(
             self.library_dir,
             "library directory",
-            f"Set 'calibre_library_dir' in {self.dirs_path} to a directory this user can write to.",
+            location_help,
         )
         self.metadb_path = os.path.join(self.library_dir, "metadata.db")
         create_metadb(self.metadb_path)

--- a/scripts/convert_library.py
+++ b/scripts/convert_library.py
@@ -168,13 +168,9 @@ class LibraryConverter:
 
 
     def get_dirs(self, dirs_json_path: str) -> tuple[str, str, str]:
-        dirs = {}
-        with open(dirs_json_path, 'r') as f:
-            dirs: dict[str, str] = json.load(f)
-
-        ingest_folder = f"{dirs['ingest_folder']}/"
-        library_dir = f"{dirs['calibre_library_dir']}/"
-        tmp_conversion_dir = f"{dirs['tmp_conversion_dir']}/"
+        ingest_folder = f"{app_paths.ingest_folder(dirs_json_path)}/"
+        library_dir = f"{app_paths.calibre_library_dir(dirs_json_path)}/"
+        tmp_conversion_dir = f"{app_paths.tmp_conversion_dir(dirs_json_path)}/"
 
         return ingest_folder, library_dir, tmp_conversion_dir
 

--- a/scripts/cover_enforcer.py
+++ b/scripts/cover_enforcer.py
@@ -300,9 +300,7 @@ class Book:
 
     def get_calibre_library(self) -> str:
         """Gets Calibre-Library location from dirs.json"""
-        with open(dirs_json, 'r') as f:
-            dirs = json.load(f)
-        return dirs['calibre_library_dir'] # Returns without / on the end
+        return app_paths.calibre_library_dir(dirs_json) # Returns without / on the end
 
 
     def get_time(self) -> str:
@@ -471,9 +469,7 @@ class Enforcer:
 
 
     def get_calibre_library(self) -> str:
-        with open(dirs_json, 'r') as f:
-            dirs = json.load(f)
-        return dirs['calibre_library_dir'] # Returns without / on the end
+        return app_paths.calibre_library_dir(dirs_json) # Returns without / on the end
 
 
     def _restat_format_size_after_modification(self, book_id: str, file_format: str, file_path: str) -> None:

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -1390,13 +1390,9 @@ class NewBookProcessor:
 
 
     def get_dirs(self, dirs_json_path: str) -> tuple[str, str, str]:
-        dirs = {}
-        with open(dirs_json_path, 'r') as f:
-            dirs: dict[str, str] = json.load(f)
-
-        ingest_folder = f"{dirs['ingest_folder']}/"
-        library_dir = f"{dirs['calibre_library_dir']}/"
-        tmp_conversion_dir = f"{dirs['tmp_conversion_dir']}/"
+        ingest_folder = f"{app_paths.ingest_folder(dirs_json_path)}/"
+        library_dir = f"{app_paths.calibre_library_dir(dirs_json_path)}/"
+        tmp_conversion_dir = f"{app_paths.tmp_conversion_dir(dirs_json_path)}/"
 
         return ingest_folder, library_dir, tmp_conversion_dir
 

--- a/scripts/kindle_epub_fixer.py
+++ b/scripts/kindle_epub_fixer.py
@@ -1243,16 +1243,11 @@ def get_library_location() -> str:
         con.close()
         return split_path
     else:
-        dirs = {}
         # The module-level `dirs_json`, not a fresh app_paths lookup: it is the
         # same value, and it is the seam the rest of this module (and its tests)
-        # already resolve through. Before #1462 this line hardcoded a path that
-        # does not exist outside the container, so it raised and the caller's
-        # `except` branch quietly did the right thing via that global.
-        with open(dirs_json, 'r') as f:
-            dirs: dict[str, str] = json.load(f)
-        library_dir = f"{dirs['calibre_library_dir']}/"
-        return library_dir
+        # already resolve through. app_paths adds the per-key environment and
+        # safe default layers while preserving this function's trailing slash.
+        return f"{app_paths.calibre_library_dir(dirs_json)}/"
 
 # Calibre's own bookkeeping directories inside the library root. Matched by
 # exact name so that a book whose author or title legitimately begins with a

--- a/scripts/library_paths.py
+++ b/scripts/library_paths.py
@@ -1,6 +1,5 @@
 """Resolve the active Calibre library without creating database files."""
 
-import json
 import os
 import sqlite3
 from pathlib import Path
@@ -14,15 +13,7 @@ DEFAULT_LIBRARY_DIR = app_paths.DEFAULT_LIBRARY_DIR
 
 def get_calibre_library_dir(dirs_json_path=None):
     """Return the configured library directory, with the legacy root as fallback."""
-    config_path = dirs_json_path or str(app_paths.dirs_json())
-    try:
-        with open(config_path, "r", encoding="utf-8") as config_file:
-            configured = json.load(config_file).get("calibre_library_dir")
-        if isinstance(configured, str) and configured.strip():
-            return configured
-    except (OSError, ValueError, TypeError):
-        pass
-    return DEFAULT_LIBRARY_DIR
+    return app_paths.calibre_library_dir(dirs_json_path)
 
 
 def get_calibre_metadata_db_path(dirs_json_path=None):

--- a/scripts/set_ownership.sh
+++ b/scripts/set_ownership.sh
@@ -4,7 +4,8 @@
 # Called by the cwa-init s6 unit at every container start.
 #
 # The list is a fixed floor (/config, plus the narrow set of app-tree dirs the
-# runtime user writes) and whatever dirs.json declares. dirs.json ships
+# runtime user writes) and the three paths resolved from environment,
+# dirs.json, or defaults. dirs.json ships
 # calibre_library_dir=/calibre-library and
 # tmp_conversion_dir=/config/.cwa_conversion_tmp, and the old inline version of
 # this logic hardcoded /calibre-library and /config on top of that -- so every
@@ -35,9 +36,9 @@
 # repeated here. The rest of the tree (dirs.json, the code) is written only by
 # root or never, so orphaned build-time ownership is harmless.
 #
-# scripts/auto_library.py also rewrites dirs.json in place at runtime, so a crash
-# mid-write can leave it unparseable -- which must not be able to silently reduce
-# this pass to nothing.
+# scripts/auto_library.py can rewrite dirs.json in place at runtime when the
+# library environment override is unset, so a crash mid-write can leave it
+# unparseable -- which must not be able to silently reduce this pass to nothing.
 #
 # Every path is env-overridable so the logic is testable without a container;
 # see tests/unit/test_set_ownership.py.
@@ -50,7 +51,10 @@ CWA_DIRS_JSON="${CWA_DIRS_JSON:-${CWA_APP_ROOT}/dirs.json}"
 CWA_OWNER_USER="${CWA_OWNER_USER:-abc}"
 CWA_CHOWN="${CWA_CHOWN:-chown}"
 CWA_PYTHON="${CWA_PYTHON:-python3}"
+CWA_SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CWA_APP_PATHS="${CWA_APP_PATHS:-${CWA_SCRIPT_DIR}/app_paths.py}"
 CWA_UID="${CWA_UID:-$(id -u)}"
+CWA_RESOLVED_DIRS=()
 
 log() { echo "[cwa-init] $*"; }
 
@@ -68,31 +72,26 @@ network_share_mode() {
 
 # Bind-mounted trees we must not touch when they live on a network share.
 share_exempt() {
+  local configured
   case "$1" in
-    "${CWA_CONFIG_ROOT}"|"${CWA_CONFIG_ROOT}"/*|/calibre-library|/calibre-library/*|/cwa-book-ingest|/cwa-book-ingest/*)
+    "${CWA_CONFIG_ROOT}"|"${CWA_CONFIG_ROOT}"/*)
       return 0 ;;
-    *) return 1 ;;
   esac
+  for configured in ${CWA_RESOLVED_DIRS[@]+"${CWA_RESOLVED_DIRS[@]}"}; do
+    configured="$(normalise "$configured")"
+    case "$1" in
+      "$configured"|"$configured"/*) return 0 ;;
+    esac
+  done
+  return 1
 }
 
-# Echo the absolute directories declared in dirs.json, one per line. A missing or
-# unparseable file yields nothing; the caller keeps its own floor.
-read_dirs_json() {
-  [ -f "${CWA_DIRS_JSON}" ] || return 0
-  "${CWA_PYTHON}" - "${CWA_DIRS_JSON}" <<'PY'
-import json
-import sys
-
-try:
-    with open(sys.argv[1], "r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    if isinstance(data, dict):
-        for value in data.values():
-            if isinstance(value, str) and value.startswith("/"):
-                print(value)
-except Exception:
-    pass
-PY
+# Echo the three resolved runtime directories, one per line. app_paths owns
+# per-key environment -> dirs.json -> compiled-default precedence for every
+# scripts/ and shell consumer.
+read_configured_dirs() {
+  CWA_APP_ROOT="${CWA_APP_ROOT}" CWA_DIRS_JSON="${CWA_DIRS_JSON}" \
+    "${CWA_PYTHON}" "${CWA_APP_PATHS}" all
 }
 
 # Strip trailing slashes so /config/ and /config compare equal.
@@ -150,8 +149,11 @@ main() {
   fi
 
   while IFS= read -r dir; do
-    [ -n "$dir" ] && candidates+=("$dir")
-  done < <(read_dirs_json)
+    if [ -n "$dir" ]; then
+      CWA_RESOLVED_DIRS+=("$dir")
+      candidates+=("$dir")
+    fi
+  done < <(read_configured_dirs)
 
   local -a requiredDirs=()
   while IFS= read -r dir; do

--- a/tests/unit/test_1436_nested_library_metadata.py
+++ b/tests/unit/test_1436_nested_library_metadata.py
@@ -99,6 +99,7 @@ def test_checksum_service_polls_and_backfills_nested_library(tmp_path):
     env = os.environ.copy()
     env.update({
         "CWA_DIRS_JSON": str(dirs_json),
+        "CWA_APP_PATHS": str(SCRIPTS_DIR / "app_paths.py"),
         "BACKFILL_ARGS": str(invocation),
         "SQLITE_ARGS": str(sqlite_invocation),
         "PATH": f"{bin_dir}:{env['PATH']}",

--- a/tests/unit/test_1438_undefined_module_globals.py
+++ b/tests/unit/test_1438_undefined_module_globals.py
@@ -142,26 +142,27 @@ def _cps_python_files():
                 yield os.path.join(dirpath, filename)
 
 
-def test_web_module_resolves_dirs_json():
-    """The exact regression: ``DIRS_JSON`` is used in web.py, so it must be bound.
+def test_web_module_resolves_library_location_through_constants():
+    """The exact regression: web.py's library resolver must use a bound SSOT.
 
     Red against the #1438 tree, where the constant was referenced but never
     imported and ``cwa_get_library_location()`` raised ``NameError`` on call.
+    Since #1611, constants owns the guarded per-key resolver as well as the
+    dirs.json path, so web.py delegates instead of binding DIRS_JSON itself.
     """
     path = os.path.join(CPS_ROOT, "web.py")
     with open(path, encoding="utf-8") as handle:
         source = handle.read()
 
-    assert "DIRS_JSON" in source, (
-        "web.py no longer references DIRS_JSON — if the path lookup moved, move "
-        "this test with it rather than deleting the guard."
+    assert "constants.calibre_library_dir()" in source, (
+        "cwa_get_library_location() bypasses cps.constants; it must use the "
+        "shared guarded resolver so environment, dirs.json and default "
+        "precedence cannot diverge."
     )
-    assert "DIRS_JSON" not in _undefined_globals(path), (
-        "cps/web.py uses DIRS_JSON without binding it. cwa_get_library_location() "
-        "will raise NameError when called, and both callers swallow it — "
-        "/health reports 'degraded' 503 forever and the library count renders 0. "
-        "Add `from .constants import DIRS_JSON` (the import cps/cwa_functions.py "
-        "already uses)."
+    assert "constants" not in _undefined_globals(path), (
+        "cps/web.py calls constants.calibre_library_dir() without binding "
+        "constants. Its callers swallow the resulting NameError, so /health "
+        "reports degraded and the library count renders 0."
     )
 
 

--- a/tests/unit/test_1611_path_env_overrides.py
+++ b/tests/unit/test_1611_path_env_overrides.py
@@ -1,0 +1,298 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for #1611 — per-key runtime path overrides."""
+
+import importlib
+import json
+import logging
+from pathlib import Path
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+S6_DIR = REPO_ROOT / "root/etc/s6-overlay/s6-rc.d"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+PATH_CASES = (
+    ("ingest_folder", "CWA_INGEST_FOLDER", "/cwa-book-ingest"),
+    ("calibre_library_dir", "CWA_CALIBRE_LIBRARY_DIR", "/calibre-library"),
+    ("tmp_conversion_dir", "CWA_TMP_CONVERSION_DIR", "/config/.cwa_conversion_tmp"),
+)
+PATH_ENV_VARS = tuple(case[1] for case in PATH_CASES)
+
+
+@pytest.fixture()
+def resolvers(monkeypatch):
+    """Return fresh scripts and cps resolvers with an isolated environment."""
+    for name in ("CWA_DIRS_JSON", *PATH_ENV_VARS):
+        monkeypatch.delenv(name, raising=False)
+
+    app_paths = importlib.reload(importlib.import_module("app_paths"))
+    from cps import constants
+
+    getattr(constants, "_DIRS_JSON_LOGGED_KEYS", set()).clear()
+    return app_paths, constants
+
+
+def _write_dirs(path, values):
+    path.write_text(json.dumps(values), encoding="utf-8")
+    return path
+
+
+def _answers(module):
+    return {key: getattr(module, key)() for key, _env, _default in PATH_CASES}
+
+
+@pytest.mark.parametrize("key,env_name,default", PATH_CASES)
+def test_each_env_var_overrides_its_file_value_on_both_sides(
+    resolvers, monkeypatch, tmp_path, key, env_name, default
+):
+    app_paths, constants = resolvers
+    values = {case_key: f"/from-file/{case_key}" for case_key, _env, _default in PATH_CASES}
+    dirs_file = _write_dirs(tmp_path / "dirs.json", values)
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+    monkeypatch.setenv(env_name, f"  /from-env/{key}  ")
+
+    assert getattr(app_paths, key)() == f"/from-env/{key}"
+    assert getattr(constants, key)() == f"/from-env/{key}"
+
+    for other_key, _other_env, _other_default in PATH_CASES:
+        if other_key != key:
+            assert getattr(app_paths, other_key)() == values[other_key]
+            assert getattr(constants, other_key)() == values[other_key]
+
+
+def test_env_unset_honours_hand_edited_dirs_json_on_both_sides(
+    resolvers, monkeypatch, tmp_path
+):
+    app_paths, constants = resolvers
+    values = {key: f"/edited/{key}" for key, _env, _default in PATH_CASES}
+    dirs_file = _write_dirs(tmp_path / "dirs.json", values)
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+
+    assert _answers(app_paths) == values
+    assert _answers(constants) == values
+
+
+def test_missing_file_yields_defaults_at_every_python_read_site(
+    resolvers, monkeypatch, tmp_path
+):
+    _app_paths, constants = resolvers
+    missing = tmp_path / "missing-dirs.json"
+    monkeypatch.setenv("CWA_DIRS_JSON", str(missing))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(missing))
+
+    from cps import cwa_functions, web
+    import convert_library
+    import cover_enforcer
+    import ingest_processor
+    import library_paths
+
+    monkeypatch.setattr(cover_enforcer, "dirs_json", str(missing))
+
+    assert web.cwa_get_library_location() == "/calibre-library"
+    assert cwa_functions.get_ingest_dir() == "/cwa-book-ingest"
+    assert cwa_functions.get_tmp_conversion_dir() == "/config/.cwa_conversion_tmp/"
+    expected_dirs = (
+        "/cwa-book-ingest/",
+        "/calibre-library/",
+        "/config/.cwa_conversion_tmp/",
+    )
+    assert convert_library.LibraryConverter.get_dirs(None, str(missing)) == expected_dirs
+    assert ingest_processor.NewBookProcessor.get_dirs(None, str(missing)) == expected_dirs
+    assert cover_enforcer.Book.get_calibre_library(None) == "/calibre-library"
+    assert cover_enforcer.Enforcer.get_calibre_library(None) == "/calibre-library"
+    assert library_paths.get_calibre_library_dir(str(missing)) == "/calibre-library"
+
+
+@pytest.mark.parametrize(
+    "contents",
+    (
+        "not JSON",
+        json.dumps(["not", "an", "object"]),
+        json.dumps({"ingest_folder": None, "calibre_library_dir": None,
+                    "tmp_conversion_dir": None}),
+        json.dumps({"ingest_folder": "", "calibre_library_dir": "   ",
+                    "tmp_conversion_dir": ""}),
+    ),
+    ids=("not-json", "json-list", "null-values", "blank-values"),
+)
+def test_corrupt_or_unusable_file_values_yield_defaults_on_both_sides(
+    resolvers, monkeypatch, tmp_path, contents
+):
+    app_paths, constants = resolvers
+    dirs_file = tmp_path / "dirs.json"
+    dirs_file.write_text(contents, encoding="utf-8")
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+
+    expected = {key: default for key, _env, default in PATH_CASES}
+    assert _answers(app_paths) == expected
+    assert _answers(constants) == expected
+
+
+def test_cps_and_scripts_resolvers_agree_for_same_env_and_file(
+    resolvers, monkeypatch, tmp_path
+):
+    app_paths, constants = resolvers
+    dirs_file = _write_dirs(
+        tmp_path / "dirs.json",
+        {
+            "ingest_folder": "/file-ingest",
+            "calibre_library_dir": "/file-library",
+            "tmp_conversion_dir": "/file-tmp",
+        },
+    )
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+    monkeypatch.setenv("CWA_INGEST_FOLDER", "/env-ingest")
+    monkeypatch.setenv("CWA_TMP_CONVERSION_DIR", "/env-tmp")
+
+    assert _answers(app_paths) == _answers(constants) == {
+        "ingest_folder": "/env-ingest",
+        "calibre_library_dir": "/file-library",
+        "tmp_conversion_dir": "/env-tmp",
+    }
+
+
+def test_read_site_trailing_separator_shapes_are_preserved(
+    resolvers, monkeypatch, tmp_path
+):
+    _app_paths, constants = resolvers
+    dirs_file = _write_dirs(
+        tmp_path / "dirs.json",
+        {
+            "ingest_folder": "/shape-ingest",
+            "calibre_library_dir": "/shape-library",
+            "tmp_conversion_dir": "/shape-tmp",
+        },
+    )
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+
+    from cps import cwa_functions, web
+    import convert_library
+    import cover_enforcer
+    import ingest_processor
+    import library_paths
+
+    monkeypatch.setattr(cover_enforcer, "dirs_json", str(dirs_file))
+
+    assert cwa_functions.get_ingest_dir() == "/shape-ingest"
+    assert web.cwa_get_library_location() == "/shape-library"
+    assert cwa_functions.get_tmp_conversion_dir() == "/shape-tmp/"
+    expected_dirs = ("/shape-ingest/", "/shape-library/", "/shape-tmp/")
+    assert convert_library.LibraryConverter.get_dirs(None, str(dirs_file)) == expected_dirs
+    assert ingest_processor.NewBookProcessor.get_dirs(None, str(dirs_file)) == expected_dirs
+    assert cover_enforcer.Book.get_calibre_library(None) == "/shape-library"
+    assert cover_enforcer.Enforcer.get_calibre_library(None) == "/shape-library"
+    assert library_paths.get_calibre_library_dir(str(dirs_file)) == "/shape-library"
+
+
+def test_file_fallback_is_reported_once_per_key_per_process(
+    resolvers, monkeypatch, tmp_path, caplog, capsys
+):
+    app_paths, constants = resolvers
+    values = {key: f"/logged/{key}" for key, _env, _default in PATH_CASES}
+    dirs_file = _write_dirs(tmp_path / "dirs.json", values)
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+
+    _answers(app_paths)
+    _answers(app_paths)
+    script_lines = [
+        line for line in capsys.readouterr().err.splitlines()
+        if line.startswith("[cwa-paths]")
+    ]
+    assert len(script_lines) == 3
+
+    caplog.set_level(logging.INFO, logger="cps.constants")
+    _answers(constants)
+    _answers(constants)
+    app_records = [r for r in caplog.records if r.name == "cps.constants"]
+    assert len(app_records) == 3
+
+    for key, _env, _default in PATH_CASES:
+        assert sum(key in line and values[key] in line for line in script_lines) == 1
+        assert sum(
+            key in record.getMessage() and values[key] in record.getMessage()
+            for record in app_records
+        ) == 1
+
+
+def _auto_library_writer(tmp_path, monkeypatch, env_value, discovered):
+    import auto_library
+
+    monkeypatch.setenv("CWA_CALIBRE_LIBRARY_DIR", env_value)
+    writer = auto_library.AutoLibrary.__new__(auto_library.AutoLibrary)
+    writer.dirs_path = str(tmp_path / "dirs.json")
+    writer.lib_path = discovered
+    original = {
+        "ingest_folder": "/file-ingest",
+        "calibre_library_dir": "/file-library",
+        "tmp_conversion_dir": "/file-tmp",
+    }
+    Path(writer.dirs_path).write_text(json.dumps(original), encoding="utf-8")
+    return writer, original
+
+
+def test_auto_library_env_override_is_visible_and_leaves_file_untouched(
+    tmp_path, monkeypatch, capsys
+):
+    writer, original = _auto_library_writer(
+        tmp_path, monkeypatch, "/env-library", "/env-library"
+    )
+
+    writer.update_dirs_json()
+
+    assert json.loads(Path(writer.dirs_path).read_text(encoding="utf-8")) == original
+    output = capsys.readouterr().out
+    assert "CWA_CALIBRE_LIBRARY_DIR" in output
+    assert "authoritative" in output
+    assert "unchanged" in output
+
+
+def test_auto_library_stops_on_discovery_conflicting_with_env_override(
+    tmp_path, monkeypatch, capsys
+):
+    writer, original = _auto_library_writer(
+        tmp_path, monkeypatch, "/env-library", "/discovered-library"
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        writer.update_dirs_json()
+
+    assert excinfo.value.code == 1
+    assert json.loads(Path(writer.dirs_path).read_text(encoding="utf-8")) == original
+    output = capsys.readouterr().out
+    assert "CWA_CALIBRE_LIBRARY_DIR" in output
+    assert "/env-library" in output
+    assert "/discovered-library" in output
+
+
+def test_shell_consumers_delegate_path_resolution_to_app_paths_cli():
+    consumers = {
+        REPO_ROOT / "scripts/set_ownership.sh": "all",
+        S6_DIR / "cwa-init/run": "ingest_folder",
+        S6_DIR / "cwa-ingest-service/run": "ingest_folder",
+        S6_DIR / "cwa-checksum-backfill/run": "calibre_library_dir",
+    }
+    for path, command in consumers.items():
+        source = path.read_text(encoding="utf-8")
+        assert "app_paths.py" in source, f"{path.relative_to(REPO_ROOT)} bypasses app_paths"
+        assert command in source, f"{path.relative_to(REPO_ROOT)} does not resolve {command}"
+
+    assert "/app/calibre-web-automated/dirs.json" not in (
+        S6_DIR / "cwa-ingest-service/run"
+    ).read_text(encoding="utf-8")
+    assert "json.load(config_file).get(\"calibre_library_dir\")" not in (
+        S6_DIR / "cwa-checksum-backfill/run"
+    ).read_text(encoding="utf-8")

--- a/tests/unit/test_set_ownership.py
+++ b/tests/unit/test_set_ownership.py
@@ -365,6 +365,27 @@ def test_falsey_network_share_mode_walks_everything(harness: Harness):
     assert str(harness.config_root) in walked
 
 
+def test_network_share_mode_skips_per_key_environment_paths(harness: Harness):
+    """#1611 custom bind targets receive the same no-chown protection."""
+    custom_library = harness.tmp / "custom-library"
+    custom_ingest = harness.tmp / "custom-ingest"
+    custom_tmp = harness.tmp / "custom-conversion"
+    for path in (custom_library, custom_ingest, custom_tmp):
+        path.mkdir()
+
+    harness.run(
+        NETWORK_SHARE_MODE="true",
+        CWA_CALIBRE_LIBRARY_DIR=custom_library,
+        CWA_INGEST_FOLDER=custom_ingest,
+        CWA_TMP_CONVERSION_DIR=custom_tmp,
+    )
+
+    walked = harness.chowned_paths()
+    assert str(custom_library) not in walked
+    assert str(custom_ingest) not in walked
+    assert str(custom_tmp) not in walked
+
+
 # --------------------------------------------------------------------------
 # The init unit must actually call the script
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1611.

`dirs.json` has been the only way to tell CWNG where the ingest folder, the Calibre library
and the conversion tmp dir live. That is fine in Docker, where the image ships the file, and
awkward everywhere else: a distro package wants to set paths from a systemd
`EnvironmentFile=`, not to patch a JSON file inside the installed tree. @chloeroform raised
that in #1611 and @Thovi98 supplied the concrete packaging constraint from
`calibreweb-nextgen_ynh`.

**What changes.** Each of the three paths gets its own environment variable, and every read
site in both halves of the install resolves through one shared accessor:

| dirs.json key | environment variable | default |
|---|---|---|
| `ingest_folder` | `CWA_INGEST_FOLDER` | `/cwa-book-ingest` |
| `calibre_library_dir` | `CWA_CALIBRE_LIBRARY_DIR` | `/calibre-library` |
| `tmp_conversion_dir` | `CWA_TMP_CONVERSION_DIR` | `/config/.cwa_conversion_tmp` |

Resolution is: the variable, then `dirs.json`, then the compiled-in default.

**Why the file is still read.** Removing it in the same change that replaces it would be a
trap. Someone who edited `dirs.json` years ago to move their ingest folder has that decision
recorded in exactly one place; if the file simply stopped being read, their setup would
revert to `/cwa-book-ingest` with nothing in the logs saying why — from the app's point of
view nothing failed. So the file stays as the fallback layer, a value that came from it is
logged once at startup, and it becomes removable later rather than in this PR.

CWNG does not read `.env` itself and gains no dotenv parser. Whoever starts the process
supplies the environment — systemd `EnvironmentFile=`, compose `environment:`, or a plain
`export`. One mechanism, no precedence rules to get wrong.
