### PR TITLE
Repair the quarantined duplicate harness, stop a failed migration deleting the book, and keep the device's DateCreated

### DIFF
--- a/changelog.d/issues-1876-1865.md
+++ b/changelog.d/issues-1876-1865.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - **Automatic duplicate resolution no longer deletes a book when its reading data could not be moved.** The duplicate remains available and the group is reported as unresolved so it can be retried safely.
-- **Annotations imported from a Kobo now retain their original creation time.** Device timestamps without an explicit offset are interpreted consistently with Kobo's UTC modification timestamps instead of being replaced by the import time.
+- **Annotations imported from a Kobo now retain their original creation time.** Kobo creation timestamps without an explicit offset are interpreted consistently with the device's paired UTC modification timestamps instead of being replaced by the import time.

--- a/changelog.d/issues-1876-1865.md
+++ b/changelog.d/issues-1876-1865.md
@@ -1,3 +1,4 @@
 ### Fixed
 
 - **Automatic duplicate resolution no longer deletes a book when its reading data could not be moved.** The duplicate remains available and the group is reported as unresolved so it can be retried safely.
+- **Annotations imported from a Kobo now retain their original creation time.** Device timestamps without an explicit offset are interpreted consistently with Kobo's UTC modification timestamps instead of being replaced by the import time.

--- a/changelog.d/issues-1876-1865.md
+++ b/changelog.d/issues-1876-1865.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Automatic duplicate resolution no longer deletes a book when its reading data could not be moved.** The duplicate remains available and the group is reported as unresolved so it can be retried safely.

--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -364,8 +364,13 @@ def _bookmark_has_recoverable_content(text, note, annotation_type) -> bool:
     )
 
 
-def _parse_kobo_datetime(value):
-    """Parse a Kobo ISO-8601 clock into the DB's naive-UTC convention."""
+def _parse_kobo_datetime(value, *, assume_naive_utc=False):
+    """Parse a Kobo ISO-8601 clock into the DB's naive-UTC convention.
+
+    Naive clocks are refused by default. Only the DateCreated import opts into
+    the measured UTC convention; a naive DateModified must never gain overwrite
+    authority by guessing which instant its device-local clock represented.
+    """
     if not isinstance(value, str) or not value.strip():
         return None
     raw = value.strip()
@@ -374,12 +379,15 @@ def _parse_kobo_datetime(value):
     try:
         parsed = datetime.fromisoformat(raw)
         if parsed.tzinfo is None:
-            # Kobo writes DateCreated without an offset even though the paired
-            # DateModified uses ``Z``. On the measured device all 31 pairs
-            # described the same instant and agreed to the second, so interpret
-            # that naive device clock as UTC. This is strong evidence, not proof:
-            # it covers one device in one time zone and should be revisited if
-            # hardware from another zone demonstrates a different convention.
+            if not assume_naive_utc:
+                return None
+            # DateCreated is descriptive: Kobo writes it without an offset even
+            # though its paired DateModified uses ``Z``. On the measured device
+            # all 31 pairs agreed to the second, so the DateCreated caller may
+            # interpret it as UTC. This is strong evidence, not proof (one device,
+            # one zone). DateModified is deliberately different: it decides
+            # whether device content may overwrite a server edit, so an ambiguous
+            # local clock must fail closed rather than be guessed into the future.
             parsed = parsed.replace(tzinfo=timezone.utc)
         return parsed.astimezone(timezone.utc).replace(tzinfo=None)
     except (ValueError, OverflowError):
@@ -575,7 +583,12 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
             skipped_invalid_content_id += 1
             continue
 
-        device_created_at = _parse_kobo_datetime(bm.date_created)
+        device_created_at = _parse_kobo_datetime(
+            bm.date_created,
+            assume_naive_utc=True,
+        )
+        # Keep the safe default for DateModified: unlike creation metadata, this
+        # clock grants overwrite authority through _device_edit_is_newer().
         device_modified_at = _parse_kobo_datetime(bm.date_modified)
         if existing is not None:
             if not _device_edit_is_newer(device_modified_at, existing):

--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -374,7 +374,13 @@ def _parse_kobo_datetime(value):
     try:
         parsed = datetime.fromisoformat(raw)
         if parsed.tzinfo is None:
-            return None
+            # Kobo writes DateCreated without an offset even though the paired
+            # DateModified uses ``Z``. On the measured device all 31 pairs
+            # described the same instant and agreed to the second, so interpret
+            # that naive device clock as UTC. This is strong evidence, not proof:
+            # it covers one device in one time zone and should be revisited if
+            # hardware from another zone demonstrates a different convention.
+            parsed = parsed.replace(tzinfo=timezone.utc)
         return parsed.astimezone(timezone.utc).replace(tzinfo=None)
     except (ValueError, OverflowError):
         return None
@@ -569,6 +575,7 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
             skipped_invalid_content_id += 1
             continue
 
+        device_created_at = _parse_kobo_datetime(bm.date_created)
         device_modified_at = _parse_kobo_datetime(bm.date_modified)
         if existing is not None:
             if not _device_edit_is_newer(device_modified_at, existing):
@@ -610,6 +617,9 @@ def ingest_bookmarks(sqlite_path, user_id, session, book_lookup, commit,
             source="kobo",
             origin_device_id=origin_device_id,
             hidden=False,
+            # Preserve the annotation's device creation time when usable;
+            # malformed/absent clocks retain the historical import-time fallback.
+            created_at=device_created_at or datetime.now(timezone.utc),
             client_modified_at=device_modified_at,
             server_modified_at=datetime.now(timezone.utc),
         )

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -1973,7 +1973,16 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
                         # not just 'merge'. A keep-newest resolution otherwise
                         # silently deletes highlights made on the older copy.
                         user_book_data.migrate_user_book_data(deleted_book_id, book_to_keep_id)
-                        ub.session_commit()
+                        # User data lives in app.db while the book row below lives
+                        # in metadata.db, so no transaction can make these writes
+                        # atomic. Fail closed at the database boundary: when the
+                        # migration rolls back, keep the loser (and its files) so
+                        # the unresolved group can be retried instead of deleting
+                        # the only row still carrying the user's annotations.
+                        if not ub.session_commit():
+                            raise RuntimeError(
+                                "user data migration commit failed; duplicate book was not deleted"
+                            )
 
                         print(f"[cwa-duplicates-auto] Cleaning up database for book {deleted_book_id}...", flush=True)
                         from cps.editbooks import delete_whole_book

--- a/tests/fixtures/kobo_reader_sqlite.py
+++ b/tests/fixtures/kobo_reader_sqlite.py
@@ -82,31 +82,31 @@ def build_synthetic_kobo_db(
         ("bm-001", book_uuid, f"{book_uuid}!!chapter1.html",
          "span#kobo\\.1\\.1", -99, 0, "span#kobo\\.1\\.1", -99, 15,
          "All animals are equal.", None, 0, "... All animals are equal. But ...",
-         0.01, "2026-01-01T10:00:00Z", "2026-01-01T10:00:00Z", "false"),
+         0.01, "2026-01-01T10:00:00.000", "2026-01-01T10:00:00Z", "false"),
         ("bm-002", book_uuid, f"{book_uuid}!!chapter1.html",
          "span#kobo\\.1\\.2", -99, 0, "span#kobo\\.1\\.3", -99, 21,
          "Four legs good, two legs bad.", "my favorite line", 1,
-         "Four legs good, two legs bad.", 0.024, "2026-01-01T10:05:00Z",
+         "Four legs good, two legs bad.", 0.024, "2026-01-01T10:05:00.123",
          "2026-01-01T10:05:00Z", "false"),
         ("bm-003", book_uuid, f"{book_uuid}!!chapter2.html",
          "span#kobo\\.2\\.1", -99, 8, "span#kobo\\.2\\.1", -99, 17,
          "Comrade Napoleon", None, 2, "...Comrade Napoleon is always right...",
-         0.5, "2026-01-02T10:00:00Z", "2026-01-02T10:00:00Z", "false"),
+         0.5, "2026-01-02T10:00:00.000", "2026-01-02T10:00:00Z", "false"),
         # sideloaded — must be skipped
         ("bm-004", sideloaded_uri, "sideloaded!!ch1.html",
          "span#kobo\\.4\\.1", -99, 0, "span#kobo\\.4\\.1", -99, 10,
          "sideloaded text", None, 0, None, 0.1,
-         "2026-01-03T10:00:00Z", "2026-01-03T10:00:00Z", "false"),
+         "2026-01-03T10:00:00.000", "2026-01-03T10:00:00Z", "false"),
         # hidden — must be skipped
         ("bm-005", book_uuid, f"{book_uuid}!!chapter1.html",
          "span#kobo\\.1\\.4", -99, 0, "span#kobo\\.1\\.4", -99, 30,
          "deleted on device", None, 0, None, 0.05,
-         "2026-01-04T10:00:00Z", "2026-01-04T10:00:00Z", "true"),
+         "2026-01-04T10:00:00.000", "2026-01-04T10:00:00Z", "true"),
         # unrelated UUID — must be skipped (no CW book matches)
         ("bm-006", extra_book_uuid, f"{extra_book_uuid}!!intro.html",
          "span#kobo\\.5\\.1", -99, 0, "span#kobo\\.5\\.1", -99, 12,
          "orphan highlight", None, 3, None, 0.0,
-         "2026-01-05T10:00:00Z", "2026-01-05T10:00:00Z", "false"),
+         "2026-01-05T10:00:00.000", "2026-01-05T10:00:00Z", "false"),
         # malformed: empty BookmarkID — must be skipped silently
         ("", book_uuid, None, None, None, None, None, None, None,
          "malformed", None, 0, None, None, None, None, "false"),
@@ -114,7 +114,7 @@ def build_synthetic_kobo_db(
         ("bm-008", book_uuid, f"{book_uuid}!!chapter1.html",
          "span#kobo\\.1\\.7", -99, 0, "span#kobo\\.1\\.7", -99, 5,
          "", None, 0, None, 0.0,
-         "2026-01-06T10:00:00Z", "2026-01-06T10:00:00Z", "false"),
+         "2026-01-06T10:00:00.000", "2026-01-06T10:00:00Z", "false"),
     ]
 
     conn.executemany(
@@ -154,7 +154,7 @@ def build_kobo_db_with_colors(
             "span#kobo\\.1\\.{}".format(index), -99, 0,
             "span#kobo\\.1\\.{}".format(index), -99, 10,
             f"passage {index}", None, color, None, 0.1,
-            "2026-01-01T10:00:00Z", "2026-01-01T10:00:00Z", 0,
+            "2026-01-01T10:00:00.000", "2026-01-01T10:00:00Z", 0,
         ))
     conn.executemany(
         "INSERT INTO Bookmark VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -208,16 +208,16 @@ def build_kobo_db_with_bookmark_type(
     rows = [
         ("bt-001", book_uuid, chapter1, "span#kobo\\.1\\.1", -99, 0,
          "span#kobo\\.1\\.2", -99, 5, "a highlight", None, 0, "ctx", 0.1,
-         "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0, "highlight"),
+         "2026-01-01T00:00:00.000", "2026-01-01T00:00:00Z", 0, "highlight"),
         ("bt-002", book_uuid, chapter1, "span#kobo\\.2\\.1", -99, 0,
          "span#kobo\\.2\\.2", -99, 5, "with a note", "my note", 1, "ctx", 0.2,
-         "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0, "highlight"),
+         "2026-01-01T00:00:00.000", "2026-01-01T00:00:00Z", 0, "highlight"),
         ("bt-003", book_uuid, chapter2, "span#kobo\\.3\\.1", -99, 0,
          "span#kobo\\.3\\.2", -99, 5, "a dogear with text", None, 4, "ctx", 0.3,
-         "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0, "dogear"),
+         "2026-01-01T00:00:00.000", "2026-01-01T00:00:00Z", 0, "dogear"),
         ("bt-004", book_uuid, chapter2, "span#kobo\\.4\\.1", -99, 0,
          "span#kobo\\.4\\.2", -99, 5, "type is empty", None, 0, "ctx", 0.4,
-         "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0, ""),
+         "2026-01-01T00:00:00.000", "2026-01-01T00:00:00Z", 0, ""),
     ]
     conn.executemany(
         "INSERT INTO Bookmark VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -252,19 +252,19 @@ def build_kobo_db_with_recovery_rows(
             "recover-dogear", book_uuid, chapter,
             "span#kobo\\.7\\.1", -99, 0, "span#kobo\\.7\\.1", -99, 0,
             "", None, None, None, 0.7,
-            "2026-08-18T12:00:00Z", "2026-08-18T12:00:00Z", 0, "dogear",
+            "2026-08-18T12:00:00.000", "2026-08-18T12:00:00Z", 0, "dogear",
         ),
         (
             "recover-note-only", book_uuid, chapter,
             "span#kobo\\.8\\.1", -99, 3, "span#kobo\\.8\\.1", -99, 3,
             "", "remember this", 4, "near the end", 0.8,
-            "2026-08-18T12:01:00Z", "2026-08-18T12:02:00Z", 0, "highlight",
+            "2026-08-18T12:01:00.000", "2026-08-18T12:02:00Z", 0, "highlight",
         ),
         (
             "recover-empty", book_uuid, chapter,
             None, None, None, None, None, None,
             "", None, None, None, None,
-            "2026-08-18T12:03:00Z", "2026-08-18T12:03:00Z", 0, None,
+            "2026-08-18T12:03:00.000", "2026-08-18T12:03:00Z", 0, None,
         ),
     ]
     conn.executemany(

--- a/tests/quarantine.py
+++ b/tests/quarantine.py
@@ -31,6 +31,12 @@ _SHIM_ROT = (
     "went unseen for as long as the test was deselected. " + TRIAGE_ISSUE
 )
 
+_EDITBOOKS_SHIM_ROT = (
+    "spec_from_file_location editbooks shim is stale: its Flask stub does not "
+    "provide copy_current_request_context, so cps/editbooks.py fails during "
+    "module import before either test can execute. " + TRIAGE_ISSUE
+)
+
 _NEVER_RAN = (
     "asserts against oauth_bb.{github,google,generic}_logged_in as module "
     "attributes, but all three are nested inside init_oauth_blueprints() "
@@ -41,10 +47,9 @@ _NEVER_RAN = (
 
 #: node id -> why it is skipped. Every reason must name an issue.
 QUARANTINED = {
-    # --- shim rot: the duplicate-detection module loaders (30) -------------
-    "tests/unit/test_duplicate_delete_index_maintenance.py::test_auto_resolve_duplicates_deletes_duplicate_keys_and_refreshes_cache": _SHIM_ROT,
-    "tests/unit/test_duplicate_delete_index_maintenance.py::test_delete_book_from_table_format_only_keeps_duplicate_keys_and_invalidates_cache": _SHIM_ROT,
-    "tests/unit/test_duplicate_delete_index_maintenance.py::test_delete_book_from_table_whole_book_deletes_duplicate_keys_and_refreshes_cache": _SHIM_ROT,
+    # --- shim rot: the duplicate-detection module loaders (29) -------------
+    "tests/unit/test_duplicate_delete_index_maintenance.py::test_delete_book_from_table_format_only_keeps_duplicate_keys_and_invalidates_cache": _EDITBOOKS_SHIM_ROT,
+    "tests/unit/test_duplicate_delete_index_maintenance.py::test_delete_book_from_table_whole_book_deletes_duplicate_keys_and_refreshes_cache": _EDITBOOKS_SHIM_ROT,
     "tests/unit/test_duplicate_index.py::test_build_book_key_parts_matches_python_duplicate_fallbacks": _SHIM_ROT,
     "tests/unit/test_duplicate_index.py::test_cache_merge_deletes_key_rows_for_missing_candidate_ids": _SHIM_ROT,
     "tests/unit/test_duplicate_index.py::test_cache_merge_keeps_serialization_shape": _SHIM_ROT,

--- a/tests/unit/test_annotations_import_endpoint.py
+++ b/tests/unit/test_annotations_import_endpoint.py
@@ -362,11 +362,14 @@ class TestPreviouslyInvisibleDeviceRows:
 
 @pytest.mark.unit
 class TestKoboDeviceClockParsing:
-    def test_real_device_naive_date_created_is_utc(self):
+    def test_naive_clock_requires_explicit_date_created_opt_in(self):
         from cps.annotations import _parse_kobo_datetime
 
+        clock = "2026-08-15T22:27:08.567"
+        assert _parse_kobo_datetime(clock) is None
         assert _parse_kobo_datetime(
-            "2026-08-15T22:27:08.567"
+            clock,
+            assume_naive_utc=True,
         ) == datetime(2026, 8, 15, 22, 27, 8, 567000)
 
 
@@ -511,6 +514,46 @@ class TestNewerDeviceMerge:
         self._edit_fixture(
             synthetic_db, modified="2097-01-01T00:00:00Z",
             text="stale device passage", note="stale device note",
+        )
+
+        result = ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=lookup, commit=session.commit,
+        )
+        row = session.query(ub.Annotation).filter_by(annotation_id="bm-002").one()
+
+        assert result["updated"] == 0, result
+        assert result["skipped_newer_server"] == 1, result
+        assert _accounted(result) == result["total_seen"]
+        assert row.highlighted_text == "Four legs good, two legs bad."
+        assert row.note_text == "newer server note"
+        assert row.highlight_color == "#E8AFCF"
+
+    def test_naive_device_modified_clock_cannot_overwrite_server(
+        self, memory_db, synthetic_db,
+    ):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        lookup = _make_book_lookup({self.BOOK_UUID: 348})
+        ingest_bookmarks(
+            synthetic_db, user_id=7, session=session,
+            book_lookup=lookup, commit=session.commit,
+        )
+        row = session.query(ub.Annotation).filter_by(annotation_id="bm-002").one()
+        row.note_text = "newer server note"
+        row.server_modified_at = datetime(2027, 6, 1, 11, 30)
+        session.commit()
+
+        # Without an offset, noon could be a local UTC+N clock representing an
+        # instant before the 11:30 UTC server edit. Treating it as noon UTC is a
+        # fail-open guess that lets this ambiguous device snapshot overwrite.
+        self._edit_fixture(
+            synthetic_db,
+            modified="2027-06-01T12:00:00.000",
+            text="ambiguous device passage",
+            note="ambiguous device note",
         )
 
         result = ingest_bookmarks(

--- a/tests/unit/test_annotations_import_endpoint.py
+++ b/tests/unit/test_annotations_import_endpoint.py
@@ -156,6 +156,24 @@ class TestIngestCounts:
         assert row.source == "kobo"
         assert row.chapter_progress == 0.024
 
+    def test_inserted_row_keeps_device_date_created(self, memory_db, synthetic_db):
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        ingest_bookmarks(
+            synthetic_db,
+            user_id=7,
+            session=session,
+            book_lookup=_make_book_lookup({
+                "b3d1b38b-74fd-43b7-a796-996e5a6a8b04": 348,
+            }),
+            commit=session.commit,
+        )
+
+        row = session.query(ub.Annotation).filter_by(annotation_id="bm-002").one()
+        assert row.created_at == datetime(2026, 1, 1, 10, 5, 0, 123000)
+
     def test_color_round_trips(self, memory_db, synthetic_db):
         """Device integer -> what lands in the column -> what the reader is told.
 
@@ -340,6 +358,16 @@ class TestPreviouslyInvisibleDeviceRows:
         assert result["skipped_hidden"] == 1, result
         assert row.hidden is False
         assert row.highlighted_text == "server copy stays visible"
+
+
+@pytest.mark.unit
+class TestKoboDeviceClockParsing:
+    def test_real_device_naive_date_created_is_utc(self):
+        from cps.annotations import _parse_kobo_datetime
+
+        assert _parse_kobo_datetime(
+            "2026-08-15T22:27:08.567"
+        ) == datetime(2026, 8, 15, 22, 27, 8, 567000)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_duplicate_delete_index_maintenance.py
+++ b/tests/unit/test_duplicate_delete_index_maintenance.py
@@ -293,6 +293,10 @@ def _load_duplicates_module(delete_key_calls):
         {"migrate_user_book_data": lambda *a, **k: None,
          "purge_user_book_data": lambda *a, **k: None},
     )
+    _install_stub(
+        "cps.kobo_sync_status",
+        {"record_book_deletion": lambda book_id, uuid: calls.append(("tombstone", book_id))},
+    )
     _install_stub("cps.csrf", {"exempt": _decorator})
     _install_stub("cps.admin", {"admin_required": _decorator})
     _install_stub("cps.usermanagement", {"login_required_if_no_ano": _decorator})

--- a/tests/unit/test_duplicate_delete_index_maintenance.py
+++ b/tests/unit/test_duplicate_delete_index_maintenance.py
@@ -250,7 +250,7 @@ def _load_editbooks_module(delete_key_calls):
     return module, calls
 
 
-def _load_duplicates_module(delete_key_calls):
+def _load_duplicates_module(delete_key_calls, *, user_data_commit_result=True):
     _clear_modules()
     _install_common_web_stubs()
 
@@ -271,7 +271,10 @@ def _load_duplicates_module(delete_key_calls):
         "cps.constants",
         {"SCRIPTS_DIR": str(pathlib.Path(__file__).resolve().parents[2] / "scripts")},
     )
-    helper = _install_stub("cps.helper", {"delete_book": lambda *args, **kwargs: (True, None)})
+    helper = _install_stub(
+        "cps.helper",
+        {"delete_book": lambda book, *args, **kwargs: calls.append(("files", book.id)) or (True, None)},
+    )
     config = _install_stub(
         "cps.config",
         {"config_calibre_dir": "/library", "get_book_path": lambda: "/library"},
@@ -287,10 +290,10 @@ def _load_duplicates_module(delete_key_calls):
     cps.db = db
 
     _install_stub("cps.ub", {"init_db_thread": lambda: calls.append("init-db-thread"),
-                             "session_commit": lambda *a, **k: None})
+                             "session_commit": lambda *a, **k: user_data_commit_result})
     _install_stub(
         "cps.user_book_data",
-        {"migrate_user_book_data": lambda *a, **k: None,
+        {"migrate_user_book_data": lambda source, target: calls.append(("migrate", source, target)),
          "purge_user_book_data": lambda *a, **k: None},
     )
     _install_stub(
@@ -456,6 +459,53 @@ def test_auto_resolve_dry_run_does_not_invalidate_duplicate_cache():
     assert ("whole", 2) not in calls
     assert delete_key_calls == []
     assert _CwaDB.instances[-1].invalidated is False
+
+
+def test_auto_resolve_keeps_loser_when_user_data_migration_commit_fails():
+    _CwaDB.instances = []
+    delete_key_calls = []
+    module, calibre_books, calls = _load_duplicates_module(
+        delete_key_calls,
+        user_data_commit_result=False,
+    )
+    kept = SimpleNamespace(
+        id=1,
+        title="Dune",
+        timestamp=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        data=[],
+        path="Dune",
+    )
+    deleted = SimpleNamespace(
+        id=2,
+        title="Dune",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        data=[],
+        path="Dune Copy",
+    )
+    calibre_books[1] = kept
+    calibre_books[2] = deleted
+
+    with patch("os.path.exists", return_value=False), patch("os.makedirs"):
+        result = module.auto_resolve_duplicates(
+            strategy="newest",
+            duplicate_groups=[
+                {
+                    "group_hash": "abc123",
+                    "title": "Dune",
+                    "author": "Frank Herbert",
+                    "books": [kept, deleted],
+                }
+            ],
+        )
+
+    assert ("migrate", 2, 1) in calls
+    assert ("whole", 2) not in calls
+    assert ("files", 2) not in calls
+    assert delete_key_calls == []
+    assert result["success"] is False
+    assert result["resolved_count"] == 0
+    assert result["deleted_count"] == 0
+    assert any("user data migration commit failed" in error for error in result["errors"])
 
 
 _modules_snapshot: dict[str, "ModuleType"] = {}


### PR DESCRIPTION
Three diagnosed defects, one commit each, reviewable independently. Closes #1106, #1876, #1865.

Implemented by Sol. **Every claim below is my own re-verification**, not the delegate's report.

---

## 1. `99577efc7` — repair the quarantined duplicate harness (#1106)

`tests/unit/test_duplicate_delete_index_maintenance.py` ran `sss.` — three of four tests skipped for shim rot. The loader never registered a stub for `cps.kobo_sync_status`, which `cps/duplicates.py` imports inside the resolution loop.

**The quarantine was lifted for one test, not three.** The instruction was to confirm each individually, because three failures need not share one cause — and they did not. The other two fail on a *different* stub gap (`copy_current_request_context` missing from the Flask stub, so `cps/editbooks.py` dies at import) and **remain quarantined**, now with that precise reason recorded instead of the generic one.

This matters beyond tidiness: it is what unblocked #1876's regression test, which had no executing harness to live in.

## 2. `608f21f47` — a failed migration commit no longer deletes the book (#1876)

`auto_resolve_duplicates` migrated the loser's annotations, reading progress, Kobo state and shelf membership to the winner, **discarded the commit's return value**, and deleted the loser from the database and from disk regardless.

Two databases are involved and nothing can make them atomic — `ub.session_commit()` writes `app.db`, `calibre_db.session.commit()` writes `metadata.db`. **Checking that return value is not the cheapest protection available at this site; it is the only one.**

Measured before the fix, with a positive control:

```
[CONTROL commit=True ] deleted=1 whole-delete=True migrated=[(2,1)] files_deleted=[ref]
[RED     commit=False] deleted=1 whole-delete=True migrated=[(2,1)] files_deleted=[ref]
```

Identical — and `success=True` was returned, so nothing upstream could retry or warn. The failure was not merely unhandled, it was reported as a success. Both halves are fixed: the loser survives, **and** the group is reported unresolved.

**Independently mutation-proved** (by me, not from the report): deleting the guard reds `test_auto_resolve_keeps_loser_when_user_data_migration_commit_fails`; restoring it gives `3 passed, 2 skipped`.

The test **executes** the path. `test_duplicate_resolution_safety.py` and `test_user_book_data_d4.py` already guard this ordering with source-text assertions (`src.find(A) < src.find(B)`), which pass identically with or without the check — an unchecked return value sitting between two correctly-ordered calls is exactly what a string-order assertion cannot see.

## 3. `83a91704e` — the device's `DateCreated` is no longer discarded (#1865)

Two defects, the second hiding the first: `date_created` was parsed and never consumed, and `_parse_kobo_datetime` rejected the format every real device writes.

Not a parsing gap — `fromisoformat` handles the fraction fine. `annotations.py:377` refused *naive* input on purpose, so this was a **timezone decision**, not a lenience change, which is why the obvious one-liner ships and does nothing.

The decision is evidence-backed: on the measured device, `DateCreated` (naive) and `DateModified` (`Z`) describe the same instant and agree to the second on 31/31 rows, so a naive device clock is already UTC. **The caveat is carried in the code comment** — one device, one zone, so this is strong evidence rather than proof.

The fixture now writes what a device writes: `DateCreated` naive-with-millis, `DateModified` with `Z`, instead of `Z` for both. That is the #1866 class — a fixture modelling a device that does not exist — and it is why this was never exercised.

---

## Verification

| check | result |
|---|---|
| `test_duplicate_delete_index_maintenance.py` | 3 passed, 2 skipped |
| guard removed (my mutation) | 1 failed — the regression, specifically |
| guard restored | 3 passed, 2 skipped |
| `test_annotations_import_endpoint.py` + `test_kobo_import_parser.py` | 46 passed |
| changelog guard | passed |

**Pre-existing failures, not from this branch.** A full unit run shows failures in `tests/unit/test_1094_failed_conversion_imports_original.py`. Confirmed unrelated: that file is byte-identical to `origin/main` here, it fails **3 under `-n 4`** and passes **69/69 serially** in this same tree, and it is the xdist temp-dir collision fixed by #1877.
